### PR TITLE
add support to preview webp images and paste file paths

### DIFF
--- a/internal/tui/image/images.go
+++ b/internal/tui/image/images.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/disintegration/imaging"
 	"github.com/lucasb-eyer/go-colorful"
+	_ "golang.org/x/image/webp"
 )
 
 func ValidateFileSize(filePath string, sizeLimit int64) (bool, error) {


### PR DESCRIPTION
I missed testing pasting file paths and webp previews when i added filepicker and I just noticed they don't work. This should fix the two issues