### PR TITLE
fix(install): check if the path export command already exists

### DIFF
--- a/install
+++ b/install
@@ -101,7 +101,9 @@ add_to_path() {
     local config_file=$1
     local command=$2
 
-    if [[ -w $config_file ]]; then
+    if grep -Fxq "$command" "$config_file"; then
+        print_message info "Command already exists in $config_file, skipping write."
+    elif [[ -w $config_file ]]; then
         echo -e "\n# opencode" >> "$config_file"
         echo "$command" >> "$config_file"
         print_message info "Successfully added ${ORANGE}opencode ${GREEN}to \$PATH in $config_file"
@@ -167,6 +169,7 @@ if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
             add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
         ;;
         *)
+            export PATH=$INSTALL_DIR:$PATH
             print_message warning "Manually add the directory to $config_file (or similar):"
             print_message info "  export PATH=$INSTALL_DIR:\$PATH"
         ;;


### PR DESCRIPTION
Install script will add the export statement every time you run it.
I added a simple condition to check if the full command already exists in the config file and skip writing it.