### PR TITLE
feat: Add message history navigation with arrow keys

### DIFF
--- a/internal/tui/components/chat/editor.go
+++ b/internal/tui/components/chat/editor.go
@@ -248,11 +248,11 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Handle history navigation with up/down arrow keys
 		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryUp) {
-			// Check if we're at the top line of a multi-line message
-			lineInfo := m.textarea.LineInfo()
+			// Get the current line number
+			currentLine := m.textarea.Line()
 			
 			// Only navigate history if we're at the first line
-			if lineInfo.RowOffset == 0 && len(m.history) > 0 {
+			if currentLine == 0 && len(m.history) > 0 {
 				// Save current message if we're just starting to navigate
 				if m.historyIndex == len(m.history) {
 					m.currentMessage = m.textarea.Value()
@@ -268,12 +268,14 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		
 		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryDown) {
-			// Check if we're at the bottom line of a multi-line message
-			lineInfo := m.textarea.LineInfo()
-			lineCount := m.textarea.LineCount()
+			// Get the current line number and total lines
+			currentLine := m.textarea.Line()
+			value := m.textarea.Value()
+			lines := strings.Split(value, "\n")
+			totalLines := len(lines)
 			
 			// Only navigate history if we're at the last line
-			if lineInfo.RowOffset == lineCount-1 {
+			if currentLine == totalLines-1 {
 				if m.historyIndex < len(m.history)-1 {
 					// Go to next message in history
 					m.historyIndex++

--- a/internal/tui/components/chat/editor.go
+++ b/internal/tui/components/chat/editor.go
@@ -25,18 +25,23 @@ import (
 )
 
 type editorCmp struct {
-	width       int
-	height      int
-	app         *app.App
-	textarea    textarea.Model
-	attachments []message.Attachment
-	deleteMode  bool
+	width          int
+	height         int
+	app            *app.App
+	textarea       textarea.Model
+	attachments    []message.Attachment
+	deleteMode     bool
+	history        []string
+	historyIndex   int
+	currentMessage string
 }
 
 type EditorKeyMaps struct {
 	Send       key.Binding
 	OpenEditor key.Binding
 	Paste      key.Binding
+	HistoryUp  key.Binding
+	HistoryDown key.Binding
 }
 
 type bluredEditorKeyMaps struct {
@@ -62,6 +67,14 @@ var editorMaps = EditorKeyMaps{
 	Paste: key.NewBinding(
 		key.WithKeys("ctrl+v"),
 		key.WithHelp("ctrl+v", "paste content"),
+	),
+	HistoryUp: key.NewBinding(
+		key.WithKeys("up"),
+		key.WithHelp("up", "previous message"),
+	),
+	HistoryDown: key.NewBinding(
+		key.WithKeys("down"),
+		key.WithHelp("down", "next message"),
 	),
 }
 
@@ -138,6 +151,15 @@ func (m *editorCmp) send() tea.Cmd {
 	value := m.textarea.Value()
 	m.textarea.Reset()
 	attachments := m.attachments
+
+	// Save to history if not empty and not a duplicate of the last entry
+	if value != "" {
+		if len(m.history) == 0 || m.history[len(m.history)-1] != value {
+			m.history = append(m.history, value)
+		}
+		m.historyIndex = len(m.history)
+		m.currentMessage = ""
+	}
 
 	m.attachments = nil
 	if value == "" {
@@ -223,6 +245,48 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
+
+		// Handle history navigation with up/down arrow keys
+		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryUp) {
+			// Check if we're at the top line of a multi-line message
+			lineInfo := m.textarea.LineInfo()
+			
+			// Only navigate history if we're at the first line
+			if lineInfo.RowOffset == 0 && len(m.history) > 0 {
+				// Save current message if we're just starting to navigate
+				if m.historyIndex == len(m.history) {
+					m.currentMessage = m.textarea.Value()
+				}
+				
+				// Go to previous message in history
+				if m.historyIndex > 0 {
+					m.historyIndex--
+					m.textarea.SetValue(m.history[m.historyIndex])
+				}
+				return m, nil
+			}
+		}
+		
+		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryDown) {
+			// Check if we're at the bottom line of a multi-line message
+			lineInfo := m.textarea.LineInfo()
+			lineCount := m.textarea.LineCount()
+			
+			// Only navigate history if we're at the last line
+			if lineInfo.RowOffset == lineCount-1 {
+				if m.historyIndex < len(m.history)-1 {
+					// Go to next message in history
+					m.historyIndex++
+					m.textarea.SetValue(m.history[m.historyIndex])
+				} else if m.historyIndex == len(m.history)-1 {
+					// Return to the current message being composed
+					m.historyIndex = len(m.history)
+					m.textarea.SetValue(m.currentMessage)
+				}
+				return m, nil
+			}
+		}
+
 		// Handle Enter key
 		if m.textarea.Focused() && key.Matches(msg, editorMaps.Send) {
 			value := m.textarea.Value()
@@ -336,7 +400,10 @@ func CreateTextArea(existing *textarea.Model) textarea.Model {
 func NewEditorCmp(app *app.App) tea.Model {
 	ta := CreateTextArea(nil)
 	return &editorCmp{
-		app:      app,
-		textarea: ta,
+		app:          app,
+		textarea:     ta,
+		history:      []string{},
+		historyIndex: 0,
+		currentMessage: "",
 	}
 }

--- a/internal/tui/components/chat/messages.go
+++ b/internal/tui/components/chat/messages.go
@@ -386,6 +386,8 @@ func (m *messagesCmp) help() string {
 			baseStyle.Foreground(t.TextMuted()).Bold(true).Render("+"),
 			baseStyle.Foreground(t.Text()).Bold(true).Render("enter"),
 			baseStyle.Foreground(t.TextMuted()).Bold(true).Render(" for newline,"),
+			baseStyle.Foreground(t.Text()).Bold(true).Render(" ↑↓"),
+			baseStyle.Foreground(t.TextMuted()).Bold(true).Render(" for history,"),
 			baseStyle.Foreground(t.Text()).Bold(true).Render(" ctrl+h"),
 			baseStyle.Foreground(t.TextMuted()).Bold(true).Render(" to toggle tool messages"),
 		)


### PR DESCRIPTION
## Summary
- Added message history navigation using up/down arrow keys
- Up arrow navigates to previous messages when cursor is on the first line
- Down arrow navigates to next messages when cursor is on the last line
- Preserves normal arrow key functionality for editing multi-line messages

## Test plan
1. Type a message and send it
2. Type another message and send it
3. Press up arrow to navigate to previous message
4. Press down arrow to navigate back
5. Type a multi-line message using backslash+enter
6. Verify that arrow keys work normally for editing within the message
7. Verify that up arrow only navigates to history when on the first line
8. Verify that down arrow only navigates to history when on the last line

🤖 Generated with opencode