### PR TITLE
fix: log pane text wrapping

### DIFF
--- a/internal/tui/components/logs/details.go
+++ b/internal/tui/components/logs/details.go
@@ -84,7 +84,7 @@ func (i *detailCmp) updateContent() {
 	messageStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Text())
 	content.WriteString(messageStyle.Render("Message:"))
 	content.WriteString("\n")
-	content.WriteString(lipgloss.NewStyle().Padding(0, 2).Render(i.currentLog.Message))
+	content.WriteString(lipgloss.NewStyle().Padding(0, 2).Width(i.width).Render(i.currentLog.Message))
 	content.WriteString("\n\n")
 
 	// Attributes section
@@ -112,7 +112,7 @@ func (i *detailCmp) updateContent() {
 				valueStyle.Render(value),
 			)
 
-			content.WriteString(lipgloss.NewStyle().Padding(0, 2).Render(attrLine))
+			content.WriteString(lipgloss.NewStyle().Padding(0, 2).Width(i.width).Render(attrLine))
 			content.WriteString("\n")
 		}
 	}
@@ -123,7 +123,7 @@ func (i *detailCmp) updateContent() {
 		content.WriteString("\n")
 		content.WriteString(sessionStyle.Render("Session:"))
 		content.WriteString("\n")
-		content.WriteString(lipgloss.NewStyle().Padding(0, 2).Render(i.currentLog.SessionID))
+		content.WriteString(lipgloss.NewStyle().Padding(0, 2).Width(i.width).Render(i.currentLog.SessionID))
 	}
 
 	i.viewport.SetContent(content.String())


### PR DESCRIPTION
Partly addresses #12 

The log pane text does not wrap when it's too long.

**Before:**
![CleanShot 2025-05-17 at 12 12 24@2x](https://github.com/user-attachments/assets/f9ce8df1-da3f-45c7-b7df-d55aba40ecf5)

**After:**
![CleanShot 2025-05-17 at 12 13 09@2x](https://github.com/user-attachments/assets/bea6348f-3895-48c8-a422-40ca5973284a)
