### PR TITLE
fix: disable history navigation when filepicker is open

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,6 +40,9 @@ type App struct {
 	watcherCancelFuncs []context.CancelFunc
 	cancelFuncsMutex   sync.Mutex
 	watcherWG          sync.WaitGroup
+	
+	// UI state
+	filepickerOpen bool
 }
 
 func New(ctx context.Context, conn *sql.DB) (*App, error) {
@@ -126,6 +129,16 @@ func (app *App) initTheme() {
 	} else {
 		slog.Debug("Set theme from config", "theme", cfg.TUI.Theme)
 	}
+}
+
+// IsFilepickerOpen returns whether the filepicker is currently open
+func (app *App) IsFilepickerOpen() bool {
+	return app.filepickerOpen
+}
+
+// SetFilepickerOpen sets the state of the filepicker
+func (app *App) SetFilepickerOpen(open bool) {
+	app.filepickerOpen = open
 }
 
 // Shutdown performs a clean shutdown of the application

--- a/internal/tui/components/chat/editor.go
+++ b/internal/tui/components/chat/editor.go
@@ -247,7 +247,8 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Handle history navigation with up/down arrow keys
-		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryUp) {
+		// Only handle history navigation if the filepicker is not open
+		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryUp) && !m.app.IsFilepickerOpen() {
 			// Get the current line number
 			currentLine := m.textarea.Line()
 			
@@ -267,7 +268,7 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		
-		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryDown) {
+		if m.textarea.Focused() && key.Matches(msg, editorMaps.HistoryDown) && !m.app.IsFilepickerOpen() {
 			// Get the current line number and total lines
 			currentLine := m.textarea.Line()
 			value := m.textarea.Value()

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -417,6 +417,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if a.showFilepicker {
 				a.showFilepicker = false
 				a.filepicker.ToggleFilepicker(a.showFilepicker)
+				a.app.SetFilepickerOpen(a.showFilepicker)
 			}
 			if a.showModelDialog {
 				a.showModelDialog = false
@@ -539,6 +540,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if a.showFilepicker {
 					a.showFilepicker = false
 					a.filepicker.ToggleFilepicker(a.showFilepicker)
+					a.app.SetFilepickerOpen(a.showFilepicker)
 					return a, nil
 				}
 				if a.currentPage == page.LogsPage {
@@ -571,6 +573,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Toggle filepicker
 			a.showFilepicker = !a.showFilepicker
 			a.filepicker.ToggleFilepicker(a.showFilepicker)
+			a.app.SetFilepickerOpen(a.showFilepicker)
 			
 			// Close other dialogs if opening filepicker
 			if a.showFilepicker {


### PR DESCRIPTION
## Summary
- Disables up/down arrow key history navigation when the filepicker is open
- Fixes issue #37 where history navigation would interfere with filepicker navigation

## Test plan
- Open the filepicker with Ctrl+F
- Verify that up/down arrow keys navigate the filepicker and don't affect the message history
- Close the filepicker and verify that history navigation works as expected

🤖 Generated with opencode