### PR TITLE
Adding "ignore folder" configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ You can configure OpenCode using environment variables:
     "args": ["-l"]
   },
   "debug": false,
-  "debugLSP": false
+  "debugLSP": false,
+  "ignore": {
+    "folders": ["path/to/ignored-folder"]
+  }
 }
 ```
 
@@ -229,7 +232,7 @@ To use bedrock models with OpenCode you need three things.
   },
 }
 ```
- 
+
 ## Interactive Mode Usage
 
 ```bash

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,12 @@ type ShellConfig struct {
 	Args []string `json:"args,omitempty"`
 }
 
+// IgnoreConfig defines which folders to ignore while grepping
+// through the codebase
+type IgnoreConfig struct {
+	Folders []string `json:"folders,omitempty"`
+}
+
 // Config is the main configuration structure for the application.
 type Config struct {
 	Data         Data                              `json:"data"`
@@ -92,6 +98,7 @@ type Config struct {
 	ContextPaths []string                          `json:"contextPaths,omitempty"`
 	TUI          TUIConfig                         `json:"tui"`
 	Shell        ShellConfig                       `json:"shell,omitempty"`
+	Ignore		 	 IgnoreConfig											 `json:"ignore,omitempty"`
 }
 
 // Application constants

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ type Config struct {
 	ContextPaths []string                          `json:"contextPaths,omitempty"`
 	TUI          TUIConfig                         `json:"tui"`
 	Shell        ShellConfig                       `json:"shell,omitempty"`
-	Ignore		 	 IgnoreConfig											 `json:"ignore,omitempty"`
+	Ignore       IgnoreConfig                      `json:"ignore,omitempty"`
 }
 
 // Application constants

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/sst/opencode/internal/config"
 	"github.com/sst/opencode/internal/status"
 )
 
@@ -80,6 +81,7 @@ func SkipHidden(path string) bool {
 		return true
 	}
 
+	cfg := config.Get()
 	commonIgnoredDirs := map[string]bool{
 		".opencode":        true,
 		"node_modules":     true,
@@ -101,6 +103,10 @@ func SkipHidden(path string) bool {
 		"generated":        true,
 		"bower_components": true,
 		"jspm_packages":    true,
+	}
+
+	for _, element := range cfg.Ignore.Folders {
+		commonIgnoredDirs[element] = true
 	}
 
 	parts := strings.Split(path, string(os.PathSeparator))


### PR DESCRIPTION
Today,`opencode` has a hard coded list of "common" folders that it skips when greping a code base. This PR exposes "ignored" folders as a configuration so users can have control over which folders `opencode` skips.

### Configuration 

```json
{
  "ignore": {
    "folders": ["path/to/ignored-folder"]
  }
}
```

There doesn't seem to be any tests for this, so I didn't add any but I did verify that the configuration is being loaded correctly.

If this is accepted, it would probably be desirable to move `commonIgnoredDirs` closer to the configuration parsing.