### PR TITLE
Add `--permission-prompt-tool` to match claude code format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,8 +115,9 @@ to assist developers in writing, debugging, and understanding code directly from
 			// Get tool restriction flags
 			allowedTools, _ := cmd.Flags().GetStringSlice("allowedTools")
 			excludedTools, _ := cmd.Flags().GetStringSlice("excludedTools")
+			permissionPromptTool, _ := cmd.Flags().GetString("permission-prompt-tool")
 
-			return handleNonInteractiveMode(cmd.Context(), prompt, outputFormat, quiet, verbose, allowedTools, excludedTools)
+			return handleNonInteractiveMode(cmd.Context(), prompt, outputFormat, quiet, verbose, allowedTools, excludedTools, permissionPromptTool)
 		}
 
 		// Run LSP auto-discovery
@@ -352,6 +353,7 @@ func init() {
 	rootCmd.Flags().BoolP("verbose", "", false, "Display logs to stderr in non-interactive mode")
 	rootCmd.Flags().StringSlice("allowedTools", nil, "Restrict the agent to only use the specified tools in non-interactive mode (comma-separated list)")
 	rootCmd.Flags().StringSlice("excludedTools", nil, "Prevent the agent from using the specified tools in non-interactive mode (comma-separated list)")
+	rootCmd.Flags().String("permission-prompt-tool", "", "MCP tool for handling permission prompts in non-interactive mode")
 
 	// Make allowedTools and excludedTools mutually exclusive
 	rootCmd.MarkFlagsMutuallyExclusive("allowedTools", "excludedTools")

--- a/internal/llm/models/anthropic.go
+++ b/internal/llm/models/anthropic.go
@@ -10,6 +10,7 @@ const (
 	Claude35Haiku  ModelID = "claude-3.5-haiku"
 	Claude3Opus    ModelID = "claude-3-opus"
 	Claude4Sonnet  ModelID = "claude-4-sonnet"
+	Claude4Opus    ModelID = "claude-4-opus"
 )
 
 // https://docs.anthropic.com/en/docs/about-claude/models/all-models
@@ -65,6 +66,20 @@ var AnthropicModels = map[ModelID]Model{
 		CostPer1MOut:        15.0,
 		ContextWindow:       200000,
 		DefaultMaxTokens:    50000,
+		CanReason:           true,
+		SupportsAttachments: true,
+	},
+	Claude4Opus: {
+		ID:                  Claude4Opus,
+		Name:                "Claude 4 Opus",
+		Provider:            ProviderAnthropic,
+		APIModel:            "claude-opus-4-20250514",
+		CostPer1MIn:         15.0,
+		CostPer1MInCached:   18.75,
+		CostPer1MOutCached:  1.50,
+		CostPer1MOut:        75.0,
+		ContextWindow:       200000,
+		DefaultMaxTokens:    32000,
 		CanReason:           true,
 		SupportsAttachments: true,
 	},

--- a/internal/llm/models/bedrock.go
+++ b/internal/llm/models/bedrock.go
@@ -5,6 +5,8 @@ const (
 
 	// Models
 	BedrockClaude37Sonnet ModelID = "bedrock.claude-3.7-sonnet"
+	BedrockClaude4Sonnet  ModelID = "bedrock.claude-4.0-sonnet"
+	BedrockClaude4Opus    ModelID = "bedrock.claude-4.0-opus"
 )
 
 var BedrockModels = map[ModelID]Model{
@@ -17,6 +19,34 @@ var BedrockModels = map[ModelID]Model{
 		CostPer1MInCached:   3.75,
 		CostPer1MOutCached:  0.30,
 		CostPer1MOut:        15.0,
+		ContextWindow:       200_000,
+		DefaultMaxTokens:    50_000,
+		CanReason:           true,
+		SupportsAttachments: true,
+	},
+	BedrockClaude4Sonnet: {
+		ID:                  BedrockClaude4Sonnet,
+		Name:                "Bedrock: Claude 4 Sonnet",
+		Provider:            ProviderBedrock,
+		APIModel:            "anthropic.claude-sonnet-4-20250514-v1:0",
+		CostPer1MIn:         3.0,
+		CostPer1MInCached:   3.75,
+		CostPer1MOutCached:  0.30,
+		CostPer1MOut:        15.0,
+		ContextWindow:       200_000,
+		DefaultMaxTokens:    50_000,
+		CanReason:           true,
+		SupportsAttachments: true,
+	},
+	BedrockClaude4Opus: {
+		ID:                  BedrockClaude4Opus,
+		Name:                "Bedrock: Claude 4 Opus",
+		Provider:            ProviderBedrock,
+		APIModel:            "anthropic.claude-opus-4-20250514-v1:0",
+		CostPer1MIn:         15.0,
+		CostPer1MInCached:   18.75,
+		CostPer1MOutCached:  1.50,
+		CostPer1MOut:        75.0,
 		ContextWindow:       200_000,
 		DefaultMaxTokens:    50_000,
 		CanReason:           true,

--- a/internal/tui/theme/nord.go
+++ b/internal/tui/theme/nord.go
@@ -1,0 +1,107 @@
+package theme
+
+import (
+	"github.com/charmbracelet/lipgloss"
+)
+
+// NordTheme implements the Theme interface with Nord colors.
+// It provides both list and dark variants based on the Nord palette.
+type NordTheme struct {
+	BaseTheme
+}
+
+// NewNordTheme creates a new instance of the Nord theme.
+func NewNordTheme() *NordTheme {
+	// Nord color palette from https://www.nordtheme.com/docs/colors-and-palettes
+	polarNight0 := "#2E3440"
+	polarNight1 := "#3B4252"
+	polarNight2 := "#434C5E"
+	polarNight3 := "#4C566A"
+	snowStorm0 := "#D8DEE9"
+	snowStorm1 := "#E5E9F0"
+	snowStorm2 := "#ECEFF4"
+	frost0 := "#8FBCBB"
+	frost1 := "#88C0D0"
+	frost2 := "#81A1C1"
+	frost3 := "#5E81AC"
+	aurora0 := "#BF616A"
+	// aurora1 := "#D08770"
+	aurora2 := "#EBCB8B"
+	aurora3 := "#A3BE8C"
+	aurora4 := "#B48EAD"
+
+	theme := &NordTheme{}
+
+	// Base colors
+	theme.PrimaryColor = lipgloss.AdaptiveColor{Dark: frost1, Light: frost1}
+	theme.SecondaryColor = lipgloss.AdaptiveColor{Dark: frost2, Light: frost2}
+	theme.AccentColor = lipgloss.AdaptiveColor{Dark: frost0, Light: frost0}
+
+	// Status colors
+	theme.ErrorColor = lipgloss.AdaptiveColor{Dark: aurora0, Light: aurora0}
+	theme.WarningColor = lipgloss.AdaptiveColor{Dark: aurora2, Light: aurora2}
+	theme.SuccessColor = lipgloss.AdaptiveColor{Dark: aurora3, Light: aurora3}
+	theme.InfoColor = lipgloss.AdaptiveColor{Dark: frost0, Light: frost0}
+
+	// Text colors
+	theme.TextColor = lipgloss.AdaptiveColor{Dark: snowStorm2, Light: polarNight0}
+	theme.TextMutedColor = lipgloss.AdaptiveColor{Dark: snowStorm0, Light: polarNight3}
+	theme.TextEmphasizedColor = lipgloss.AdaptiveColor{Dark: aurora2, Light: aurora2}
+
+	// Background colors
+	theme.BackgroundColor = lipgloss.AdaptiveColor{Dark: polarNight0, Light: snowStorm2}
+	theme.BackgroundSecondaryColor = lipgloss.AdaptiveColor{Dark: polarNight1, Light: snowStorm1}
+	theme.BackgroundDarkerColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+
+	// Border colors
+	theme.BorderNormalColor = lipgloss.AdaptiveColor{Dark: polarNight3, Light: snowStorm1}
+	theme.BorderFocusedColor = lipgloss.AdaptiveColor{Dark: frost3, Light: frost3}
+	theme.BorderDimColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+
+	// Diff view colors
+	theme.DiffAddedColor = lipgloss.AdaptiveColor{Dark: aurora3, Light: aurora3}
+	theme.DiffRemovedColor = lipgloss.AdaptiveColor{Dark: aurora0, Light: aurora0}
+	theme.DiffContextColor = lipgloss.AdaptiveColor{Dark: polarNight3, Light: snowStorm0}
+	theme.DiffHunkHeaderColor = lipgloss.AdaptiveColor{Dark: frost3, Light: frost3}
+	theme.DiffHighlightAddedColor = lipgloss.AdaptiveColor{Dark: frost3, Light: frost3}
+	theme.DiffHighlightRemovedColor = lipgloss.AdaptiveColor{Dark: aurora0, Light: aurora0}
+	theme.DiffAddedBgColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+	theme.DiffRemovedBgColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+	theme.DiffContextBgColor = lipgloss.AdaptiveColor{Dark: polarNight1, Light: snowStorm1}
+	theme.DiffLineNumberColor = lipgloss.AdaptiveColor{Dark: polarNight3, Light: snowStorm1}
+	theme.DiffAddedLineNumberBgColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+	theme.DiffRemovedLineNumberBgColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+
+	// Markdown colors
+	theme.MarkdownTextColor = lipgloss.AdaptiveColor{Dark: snowStorm2, Light: polarNight0}
+	theme.MarkdownHeadingColor = lipgloss.AdaptiveColor{Dark: frost3, Light: frost3}
+	theme.MarkdownLinkColor = lipgloss.AdaptiveColor{Dark: frost0, Light: frost0}
+	theme.MarkdownLinkTextColor = lipgloss.AdaptiveColor{Dark: frost1, Light: frost1}
+	theme.MarkdownCodeColor = lipgloss.AdaptiveColor{Dark: aurora3, Light: aurora3}
+	theme.MarkdownBlockQuoteColor = lipgloss.AdaptiveColor{Dark: aurora2, Light: aurora2}
+	theme.MarkdownEmphColor = lipgloss.AdaptiveColor{Dark: aurora2, Light: aurora2}
+	theme.MarkdownStrongColor = lipgloss.AdaptiveColor{Dark: aurora0, Light: aurora0}
+	theme.MarkdownHorizontalRuleColor = lipgloss.AdaptiveColor{Dark: polarNight3, Light: snowStorm1}
+	theme.MarkdownListItemColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm1}
+	theme.MarkdownListEnumerationColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm1}
+	theme.MarkdownImageColor = lipgloss.AdaptiveColor{Dark: frost1, Light: frost1}
+	theme.MarkdownImageTextColor = lipgloss.AdaptiveColor{Dark: frost1, Light: frost1}
+	theme.MarkdownCodeBlockColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm0}
+
+	// Syntax highsnowStorming colors
+	theme.SyntaxCommentColor = lipgloss.AdaptiveColor{Dark: polarNight3, Light: snowStorm2}
+	theme.SyntaxKeywordColor = lipgloss.AdaptiveColor{Dark: aurora4, Light: aurora4}
+	theme.SyntaxFunctionColor = lipgloss.AdaptiveColor{Dark: frost1, Light: frost1}
+	theme.SyntaxVariableColor = lipgloss.AdaptiveColor{Dark: frost0, Light: frost0}
+	theme.SyntaxStringColor = lipgloss.AdaptiveColor{Dark: aurora2, Light: aurora2}
+	theme.SyntaxNumberColor = lipgloss.AdaptiveColor{Dark: aurora2, Light: aurora2}
+	theme.SyntaxTypeColor = lipgloss.AdaptiveColor{Dark: aurora3, Light: aurora3}
+	theme.SyntaxOperatorColor = lipgloss.AdaptiveColor{Dark: aurora4, Light: aurora4}
+	theme.SyntaxPunctuationColor = lipgloss.AdaptiveColor{Dark: polarNight2, Light: snowStorm2}
+
+	return theme
+}
+
+func init() {
+	RegisterTheme("nord", NewNordTheme())
+}

--- a/internal/tui/theme/theme_test.go
+++ b/internal/tui/theme/theme_test.go
@@ -47,6 +47,18 @@ func TestThemeRegistration(t *testing.T) {
 		t.Errorf("Monokai theme is not registered")
 	}
 
+	// Check if "nord" theme is registered
+	nordFound := false
+	for _, themeName := range availableThemes {
+		if themeName == "nord" {
+			nordFound = true
+			break
+		}
+	}
+	if !nordFound {
+		t.Errorf("Nord theme is not registered")
+	}
+
 	// Try to get the themes and make sure they're not nil
 	catppuccin := GetTheme("catppuccin")
 	if catppuccin == nil {

--- a/www/src/content/docs/docs/themes.mdx
+++ b/www/src/content/docs/docs/themes.mdx
@@ -14,6 +14,7 @@ The following predefined themes are available:
 - `flexoki`
 - `gruvbox`
 - `monokai`
+- `nord`
 - `onedark`
 - `tokyonight`
 - `tron`


### PR DESCRIPTION
In non interactive mode you can pass an MCP server tool to claude code in order to get custom permission approval responses. This isn't super well documented at the current moment, but it is working in a way that is described here: https://github.com/anthropics/claude-code/issues/1175#issuecomment-2927478549

This PR aims to support the same standard format/functionality that claude code exposes via the same command. This is a little messy at time of creating PR, and I will clean up, write tests, test manually, and ensure it's written in a way that I'm happy with before moving from draft status. Just wanted to get it up early (the PR) to show interest in getting the feature. 

Here is the comment from the above issue that highlights the format that claude code expects the MCP server to respond in:
https://github.com/anthropics/claude-code/issues/1175#issuecomment-2908916791