### PR TITLE
tui: fix help dialog background

### DIFF
--- a/packages/tui/internal/components/dialog/help.go
+++ b/packages/tui/internal/components/dialog/help.go
@@ -59,6 +59,8 @@ func (h *helpDialog) View() string {
 	descStyle := lipgloss.NewStyle().
 		Background(t.BackgroundElement()).
 		Foreground(t.TextMuted())
+	contentStyle := lipgloss.NewStyle().
+		PaddingLeft(1).Background(t.BackgroundElement())
 
 	lines := []string{}
 	for _, b := range h.bindings {
@@ -74,7 +76,7 @@ func (h *helpDialog) View() string {
 			}
 		}
 
-		lines = append(lines, content)
+		lines = append(lines, contentStyle.Render(content))
 	}
 
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
just removing the / from the commands showing up behind the help menu
before:
![Screenshot 2025-06-14 at 3 32 34 PM](https://github.com/user-attachments/assets/f340670a-87db-4956-bdf7-784c7d7c3171)
after:
![Screenshot 2025-06-14 at 3 42 56 PM](https://github.com/user-attachments/assets/5864fa9c-1066-4a31-9013-a48c03ea1985)

