### PR TITLE
fix: improve browser opening error handling in AuthLoginCommand

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -111,8 +111,12 @@ export const AuthLoginCommand = cmd({
         // some weird bug where program exits without this
         await new Promise((resolve) => setTimeout(resolve, 10))
         const { url, verifier } = await AuthAnthropic.authorize()
-        prompts.note("Opening browser...")
-        await open(url)
+        prompts.note("Trying to open browser...")
+        try {
+          await open(url)
+        } catch (e) {
+          prompts.log.error("Failed to open browser perhaps you are running without a display or X server, please open the following URL in your browser:")
+        }
         prompts.log.info(url)
 
         const code = await prompts.text({


### PR DESCRIPTION
In my newly installed setup in a Hetzner cloud VPS I encountered this error that doesn't let me get through the setup intuitively. (I can paste the code next to the error so it's non blocking but looks bad).

Of course I can just copy paste the config from my home machine to it, but since it's an obstacle new folk configuring it the server might encounter I figured I open a PR. 

Feel free to suggest new wording as I'm not familiar with the tone of the repo log messages yet. 


