### PR TITLE
Fix: Improve Help UI Readability (Issue #99)

### DIFF
--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -3,9 +3,9 @@ import { NamedError } from "../util/error"
 
 export namespace UI {
   const LOGO = [
-    `█▀▀█ █▀▀█ █▀▀ █▀▀▄ █▀▀ █▀▀█ █▀▀▄ █▀▀`,
-    `█░░█ █░░█ █▀▀ █░░█ █░░ █░░█ █░░█ █▀▀`,
-    `▀▀▀▀ █▀▀▀ ▀▀▀ ▀  ▀ ▀▀▀ ▀▀▀▀ ▀▀▀  ▀▀▀`,
+    [`█▀▀█ █▀▀█ █▀▀ █▀▀▄ `, `█▀▀ █▀▀█ █▀▀▄ █▀▀`],
+    [`█░░█ █░░█ █▀▀ █░░█ `, `█░░ █░░█ █░░█ █▀▀`],
+    [`▀▀▀▀ █▀▀▀ ▀▀▀ ▀  ▀ `, `▀▀▀ ▀▀▀▀ ▀▀▀  ▀▀▀`],
   ]
 
   export const CancelledError = NamedError.create("UICancelledError", z.void())
@@ -48,12 +48,10 @@ export namespace UI {
     const result = []
     for (const row of LOGO) {
       if (pad) result.push(pad)
-      for (let i = 0; i < row.length; i++) {
-        const color =
-          i > 18 ? Bun.color("white", "ansi") : Bun.color("gray", "ansi")
-        const char = row[i]
-        result.push(color + char)
-      }
+      result.push(Bun.color("gray", "ansi"))
+      result.push(row[0])
+      result.push("\x1b[0m")
+      result.push(row[1])
       result.push("\n")
     }
     return result.join("").trimEnd()


### PR DESCRIPTION
This is a little fix for the following issue: https://github.com/sst/opencode/issues/99.

Unfortunately, I couldn't find any consistent way to request for the terminal's theme mode across different applications; none of the methods I tried worked in my iTerm2 terminal. Also, because sending ASCII codes for colors isn't consistent, the white color may differ from the default foreground color.

Here are a few screenshots of the changes:

Before:
<img width="976" alt="Screenshot 2025-06-15 at 14 42 30" src="https://github.com/user-attachments/assets/36ed0946-9990-4271-9e4c-4e1b16924224" />
<img width="973" alt="Screenshot 2025-06-15 at 14 43 20" src="https://github.com/user-attachments/assets/fdb2df88-1b87-48bc-b5a8-28dc3ab1d13a" />

With changes:
<img width="968" alt="Screenshot 2025-06-15 at 15 07 34" src="https://github.com/user-attachments/assets/d68a27aa-2efc-4c35-8df5-0643c8e99f68" />
<img width="967" alt="Screenshot 2025-06-15 at 15 08 05" src="https://github.com/user-attachments/assets/7d6b4ff1-0633-4b1b-a875-80913fc3a9e6" />