### PR TITLE
fix: spelling, grammar and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI coding agent, built for the terminal.
 
-⚠️ **Note:** version 0.1.x is a full rewrite and we do not have proper documentation for it yet. Should have this out week of June 17th 2025 📚
+⚠️ **Note:** version 0.1.x is a full rewrite, and we do not have proper documentation for it yet. Should have this out week of June 17th 2025 📚
 
 ### Installation
 
@@ -20,9 +20,9 @@ paru -S opencode-bin               # Arch Linux
 
 ### Providers
 
-The recommended approach is to sign up for claude pro or max and do `opencode auth login` and select Anthropic. It is the most cost effective way to use this tool.
+The recommended approach is to sign up for claude pro or max and do `opencode auth login` and select Anthropic. It is the most cost-effective way to use this tool.
 
-Additionally opencode is powered by the provider list at [models.dev](https://models.dev) so you can use `opencode auth login` to configure api keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`
+Additionally, OpenCode is powered by the provider list at [models.dev](https://models.dev) so you can use `opencode auth login` to configure api keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`
 
 ```bash
 $ opencode auth login
@@ -47,7 +47,7 @@ If there are additional providers you want to use you can submit a PR to the [mo
 
 ### Project Config
 
-Project configuration is optional. You can place an `opencode.json` file in the root of your repo and it will be loaded.
+Project configuration is optional. You can place an `opencode.json` file in the root of your repo, and it will be loaded.
 
 ```json title="opencode.json"
 {
@@ -78,7 +78,7 @@ Project configuration is optional. You can place an `opencode.json` file in the 
 
 #### Providers
 
-You can use opencode with any provider listed at [here](https://ai-sdk.dev/providers/ai-sdk-providers). Use the npm package name as the key in your config. Note we use v5 of the ai-sdk and not all providers support that yet.
+You can use OpenCode with any provider listed at [here](https://ai-sdk.dev/providers/ai-sdk-providers). Use the npm package name as the key in your config. Note we use v5 of the ai-sdk and not all providers support that yet.
 
 ```json title="opencode.json"
 {
@@ -101,7 +101,7 @@ You can use opencode with any provider listed at [here](https://ai-sdk.dev/provi
 
 ### Contributing
 
-To run opencode locally you need
+To run OpenCode locally you need
 
 - bun
 - golang 1.24.x
@@ -118,7 +118,7 @@ $ bun run src/index.ts
 
 #### How do I use this with OpenRouter
 
-OpenRouter is not yet in the models.dev database but you can configure it manually.
+OpenRouter is not yet in the models.dev database, but you can configure it manually.
 
 ```json title="opencode.json"
 {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ paru -S opencode-bin               # Arch Linux
 
 The recommended approach is to sign up for claude pro or max and do `opencode auth login` and select Anthropic. It is the most cost-effective way to use this tool.
 
-Additionally, OpenCode is powered by the provider list at [models.dev](https://models.dev) so you can use `opencode auth login` to configure api keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`
+Additionally, opencode is powered by the provider list at [models.dev](https://models.dev) so you can use `opencode auth login` to configure api keys for any provider you'd like to use. This is stored in `~/.local/share/opencode/auth.json`
 
 ```bash
 $ opencode auth login
@@ -78,7 +78,7 @@ Project configuration is optional. You can place an `opencode.json` file in the 
 
 #### Providers
 
-You can use OpenCode with any provider listed at [here](https://ai-sdk.dev/providers/ai-sdk-providers). Use the npm package name as the key in your config. Note we use v5 of the ai-sdk and not all providers support that yet.
+You can use opencode with any provider listed at [here](https://ai-sdk.dev/providers/ai-sdk-providers). Use the npm package name as the key in your config. Note we use v5 of the ai-sdk and not all providers support that yet.
 
 ```json title="opencode.json"
 {
@@ -101,7 +101,7 @@ You can use OpenCode with any provider listed at [here](https://ai-sdk.dev/provi
 
 ### Contributing
 
-To run OpenCode locally you need
+To run opencode locally you need
 
 - bun
 - golang 1.24.x


### PR DESCRIPTION
Some small fixes for grammatical errors and typos on the README.

It appears that we use `opencode` instead of `OpenCode`. I believe the correct spelling is `OpenCode` like `OpenRouter`?

Please correct me if I'm wrong.