### PR TITLE
fix: typo and literal wording in packages/opencode/AGENTS.md

### DIFF
--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -19,14 +19,14 @@
 
 ## IMPORTANT
 
-- Try to keep things in one function unless composable or reusablte
+- Try to keep things in one function unless composable or reusable
 - DO NOT do unnecessary destructuring of variables
-- DO NOT use else statements unless necessary
-- DO NOT use try catch if it can be avoided
-- AVOID try catch where possible
-- AVOID else statements
+- DO NOT use `else` statements unless necessary
+- DO NOT use `try`/`catch` if it can be avoided
+- AVOID `try`/`catch` where possible
+- AVOID `else` statements
 - AVOID using `any` type
-- AVOID let statements
+- AVOID `let` statements
 - PREFER single word variable names where possible
 - Use as many bun apis as possible like Bun.file()
 


### PR DESCRIPTION
this PR inline-codes literals and fixes a typo in AGENTS.md