### PR TITLE
fix: checksum error with lipgloss

### DIFF
--- a/packages/tui/go.sum
+++ b/packages/tui/go.sum
@@ -34,7 +34,7 @@ github.com/charmbracelet/glamour v0.10.0 h1:MtZvfwsYCx8jEPFJm3rIBFIMZUfUJ765oX8V
 github.com/charmbracelet/glamour v0.10.0/go.mod h1:f+uf+I/ChNmqo087elLnVdCiVgjSKWuXa/l6NU2ndYk=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
-github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1 h1:kU4FK3BrF9yfW4P1tT1+Ag9KVckKhkUuLTwj//7SzaA=
+github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1 h1:D9AJJuYTN5pvz6mpIGO1ijLKpfTYSHOtKGgwoTQ4Gog=
 github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1/go.mod h1:tRlx/Hu0lo/j9viunCN2H+Ze6JrmdjQlXUQvvArgaOc=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
 github.com/charmbracelet/x/ansi v0.8.0/go.mod h1:wdYl/ONOLHLIVmQaxbIYEC/cRKOQyjTkowiI4blgS9Q=


### PR DESCRIPTION
`bun run src/index.ts` gave me these errors

```
go: downloading github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.1
go: downloading github.com/alecthomas/chroma/v2 v2.18.0
go: downloading golang.org/x/sys v0.32.0
go: downloading github.com/lucasb-eyer/go-colorful v1.2.0
go: downloading github.com/BurntSushi/toml v1.5.0
go: downloading github.com/rivo/uniseg v0.4.7
go: downloading github.com/atotto/clipboard v0.1.4
verifying github.com/charmbracelet/lipgloss/v2@v2.0.0-beta.1: checksum mismatch
	downloaded: h1:D9AJJuYTN5pvz6mpIGO1ijLKpfTYSHOtKGgwoTQ4Gog=
	go.sum:     h1:kU4FK3BrF9yfW4P1tT1+Ag9KVckKhkUuLTwj//7SzaA=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
```

updated the `go.sum`

related to https://github.com/sst/opencode/pull/131

