### PR TITLE
fix: invalidate provider state when OAuth tokens are refreshed

### DIFF
--- a/packages/opencode/src/auth/anthropic.ts
+++ b/packages/opencode/src/auth/anthropic.ts
@@ -76,6 +76,11 @@ export namespace AuthAnthropic {
       refresh: json.refresh_token as string,
       expires: Date.now() + json.expires_in * 1000,
     })
+    
+    // Invalidate provider state when token is refreshed
+    const { Provider } = await import("../provider/provider")
+    Provider.invalidateState()
+    
     return json.access_token as string
   }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -178,6 +178,24 @@ export namespace Provider {
     }
   })
 
+  export function invalidateState() {
+    log.info("invalidating provider state")
+    // Force re-initialization by clearing the cached state
+    try {
+      const { App } = require("../app/app")
+      const ctx = (App as any).ctx
+      if (ctx) {
+        const appInstance = ctx.use()
+        if (appInstance?.services?.has("provider")) {
+          log.info("clearing cached provider state")
+          appInstance.services.delete("provider")
+        }
+      }
+    } catch (error) {
+      log.warn("failed to invalidate provider state", { error })
+    }
+  }
+
   export async function list() {
     return state().then((state) => state.providers)
   }


### PR DESCRIPTION
## Summary
- Fixes "OAuth token has been revoked" errors when multiple opencode instances are running
- Invalidates cached provider state when OAuth tokens are refreshed to ensure all instances use fresh tokens

## Test plan
- [ ] Test with multiple opencode instances running simultaneously
- [ ] Verify OAuth token refresh works without requiring re-authentication
- [ ] Confirm no regression in single-instance usage

🤖 Generated with [opencode](https://opencode.ai)