### PR TITLE
Fixes tool tip layering

### DIFF
--- a/packages/web/src/components/share.module.css
+++ b/packages/web/src/components/share.module.css
@@ -194,6 +194,7 @@
           border-radius: 7px;
           white-space: nowrap;
 
+          z-index: 1;
           opacity: 0;
           visibility: hidden;
 


### PR DESCRIPTION
Noticed this layering with the "Copied" tool tip, adding a small z-index resolved it

| Before | After |
|--------|--------|
| <img width="89" alt="image" src="https://github.com/user-attachments/assets/74a6da59-8e2e-404b-87eb-c026a390f43e" /> | <img width="99" alt="image" src="https://github.com/user-attachments/assets/0f86af6c-a30a-434b-a7aa-770dc0f53195" /> | 


