### PR TITLE
fix: phantom input bug on wsl

### DIFF
--- a/packages/tui/internal/styles/background.go
+++ b/packages/tui/internal/styles/background.go
@@ -8,6 +8,6 @@ var Terminal *TerminalInfo
 
 func init() {
 	Terminal = &TerminalInfo{
-		BackgroundIsDark: false,
+		BackgroundIsDark: true,
 	}
 }

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -42,7 +42,11 @@ type appModel struct {
 
 func (a appModel) Init() tea.Cmd {
 	var cmds []tea.Cmd
-	cmds = append(cmds, tea.RequestBackgroundColor)
+	// https://github.com/charmbracelet/bubbletea/issues/1440
+	// https://github.com/sst/opencode/issues/127
+	if !util.IsWsl() {
+		cmds = append(cmds, tea.RequestBackgroundColor)
+	}
 	cmds = append(cmds, a.app.InitializeProvider())
 	cmds = append(cmds, a.editor.Init())
 	cmds = append(cmds, a.messages.Init())

--- a/packages/tui/internal/util/util.go
+++ b/packages/tui/internal/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"os"
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea/v2"
 )
 
@@ -16,4 +19,19 @@ func Clamp(v, low, high int) int {
 		low, high = high, low
 	}
 	return min(high, max(low, v))
+}
+
+func IsWsl() bool {
+	// Check for WSL environment variables
+	if os.Getenv("WSL_DISTRO_NAME") != "" {
+		return true
+	}
+
+	// Check /proc/version for WSL signature
+	if data, err := os.ReadFile("/proc/version"); err == nil {
+		version := strings.ToLower(string(data))
+		return strings.Contains(version, "microsoft") || strings.Contains(version, "wsl")
+	}
+
+	return false
 }


### PR DESCRIPTION
this is basically just working around the issue. wsl users will be defaulted to dark mode no matter what settings are.

will test this on my work laptop tomorrow. related: #127 