### PR TITLE
feat: forward provider options from model config

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -12,6 +12,7 @@ export namespace ModelsDev {
       name: z.string(),
       attachment: z.boolean(),
       reasoning: z.boolean(),
+      tools: z.boolean().optional(),
       temperature: z.boolean(),
       cost: z.object({
         input: z.number(),
@@ -24,6 +25,7 @@ export namespace ModelsDev {
         output: z.number(),
       }),
       id: z.string(),
+      providerOptions: z.record(z.string(), z.any()).optional()
     })
     .openapi({
       ref: "Model.Info",

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -13,6 +13,7 @@ export namespace ModelsDev {
       attachment: z.boolean(),
       reasoning: z.boolean(),
       temperature: z.boolean(),
+      tool_call: z.boolean(),
       cost: z.object({
         input: z.number(),
         output: z.number(),
@@ -24,10 +25,7 @@ export namespace ModelsDev {
         output: z.number(),
       }),
       id: z.string(),
-      options: z.object({
-        providerOptions: z.record(z.string(), z.any()).optional(),
-        tools: z.boolean().optional(),
-      }),
+      options: z.record(z.any()),
     })
     .openapi({
       ref: "Model.Info",
@@ -51,7 +49,7 @@ export namespace ModelsDev {
 
   export async function get() {
     const file = Bun.file(filepath)
-    const result = await file.json().catch(() => { })
+    const result = await file.json().catch(() => {})
     if (result) {
       refresh()
       return result as Record<string, Provider>

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -12,7 +12,6 @@ export namespace ModelsDev {
       name: z.string(),
       attachment: z.boolean(),
       reasoning: z.boolean(),
-      tools: z.boolean().optional(),
       temperature: z.boolean(),
       cost: z.object({
         input: z.number(),
@@ -25,7 +24,10 @@ export namespace ModelsDev {
         output: z.number(),
       }),
       id: z.string(),
-      providerOptions: z.record(z.string(), z.any()).optional()
+      options: z.object({
+        providerOptions: z.record(z.string(), z.any()).optional(),
+        tools: z.boolean().optional(),
+      }),
     })
     .openapi({
       ref: "Model.Info",
@@ -49,7 +51,7 @@ export namespace ModelsDev {
 
   export async function get() {
     const file = Bun.file(filepath)
-    const result = await file.json().catch(() => {})
+    const result = await file.json().catch(() => { })
     if (result) {
       refresh()
       return result as Record<string, Provider>

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -161,7 +161,6 @@ export namespace Provider {
           attachment: model.attachment ?? existing?.attachment ?? false,
           reasoning: model.reasoning ?? existing?.reasoning ?? false,
           temperature: model.temperature ?? existing?.temperature ?? false,
-          tools: model.tools,
           cost: model.cost ??
             existing?.cost ?? {
               input: 0,
@@ -169,7 +168,10 @@ export namespace Provider {
               inputCached: 0,
               outputCached: 0,
             },
-          providerOptions: model.providerOptions,
+          options: {
+            tools: model.options?.tools,
+            providerOptions: model.options?.providerOptions,
+          },
           limit: model.limit ??
             existing?.limit ?? {
               context: 0,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -161,16 +161,18 @@ export namespace Provider {
           attachment: model.attachment ?? existing?.attachment ?? false,
           reasoning: model.reasoning ?? existing?.reasoning ?? false,
           temperature: model.temperature ?? existing?.temperature ?? false,
-          cost: model.cost ??
-            existing?.cost ?? {
-              input: 0,
-              output: 0,
-              inputCached: 0,
-              outputCached: 0,
-            },
+          tool_call: model.tool_call ?? existing?.tool_call ?? true,
+          cost: {
+            ...existing?.cost,
+            ...model.cost,
+            input: 0,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
+          },
           options: {
-            tools: model.options?.tools,
-            providerOptions: model.options?.providerOptions,
+            ...existing?.options,
+            ...model.options,
           },
           limit: model.limit ??
             existing?.limit ?? {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -161,6 +161,7 @@ export namespace Provider {
           attachment: model.attachment ?? existing?.attachment ?? false,
           reasoning: model.reasoning ?? existing?.reasoning ?? false,
           temperature: model.temperature ?? existing?.temperature ?? false,
+          tools: model.tools,
           cost: model.cost ??
             existing?.cost ?? {
               input: 0,
@@ -168,6 +169,7 @@ export namespace Provider {
               inputCached: 0,
               outputCached: 0,
             },
+          providerOptions: model.providerOptions,
           limit: model.limit ??
             existing?.limit ?? {
               context: 0,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -260,7 +260,7 @@ export namespace Session {
     if (msgs.length === 0 && !session.parentID) {
       generateText({
         maxTokens: input.providerID === "google" ? 1024 : 20,
-        providerOptions: model.info.options.providerOptions,
+        providerOptions: model.info.options,
         messages: [
           ...SystemPrompt.title(input.providerID).map(
             (x): CoreMessage => ({
@@ -513,7 +513,7 @@ export namespace Session {
       toolCallStreaming: true,
       abortSignal: abort.signal,
       maxSteps: 1000,
-      providerOptions: model.info.options.providerOptions,
+      providerOptions: model.info.options,
       messages: [
         ...system.map(
           (x, index): CoreMessage => ({
@@ -535,9 +535,7 @@ export namespace Session {
         ),
       ],
       temperature: model.info.temperature ? 0 : undefined,
-      tools: model.info.options.tools === false ? undefined : {
-        ...tools,
-      },
+      tools: model.info.tool_call === false ? undefined : tools,
       model: model.language,
     })
     try {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -260,7 +260,7 @@ export namespace Session {
     if (msgs.length === 0 && !session.parentID) {
       generateText({
         maxTokens: input.providerID === "google" ? 1024 : 20,
-        providerOptions: model.info.providerOptions,
+        providerOptions: model.info.options.providerOptions,
         messages: [
           ...SystemPrompt.title(input.providerID).map(
             (x): CoreMessage => ({
@@ -513,7 +513,7 @@ export namespace Session {
       toolCallStreaming: true,
       abortSignal: abort.signal,
       maxSteps: 1000,
-      providerOptions: model.info.providerOptions,
+      providerOptions: model.info.options.providerOptions,
       messages: [
         ...system.map(
           (x, index): CoreMessage => ({
@@ -535,7 +535,7 @@ export namespace Session {
         ),
       ],
       temperature: model.info.temperature ? 0 : undefined,
-      tools: model.info.tools === false ? undefined : {
+      tools: model.info.options.tools === false ? undefined : {
         ...tools,
       },
       model: model.language,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -260,6 +260,7 @@ export namespace Session {
     if (msgs.length === 0 && !session.parentID) {
       generateText({
         maxTokens: input.providerID === "google" ? 1024 : 20,
+        providerOptions: model.info.providerOptions,
         messages: [
           ...SystemPrompt.title(input.providerID).map(
             (x): CoreMessage => ({
@@ -512,6 +513,7 @@ export namespace Session {
       toolCallStreaming: true,
       abortSignal: abort.signal,
       maxSteps: 1000,
+      providerOptions: model.info.providerOptions,
       messages: [
         ...system.map(
           (x, index): CoreMessage => ({
@@ -533,7 +535,7 @@ export namespace Session {
         ),
       ],
       temperature: model.info.temperature ? 0 : undefined,
-      tools: {
+      tools: model.info.tools === false ? undefined : {
         ...tools,
       },
       model: model.language,


### PR DESCRIPTION
Allows users to forward `providerOptions` to Vercel's `ai` package. This is
particularly useful for `openrouter` when needing to select specific providers.

This allows the user to follow the documentation on `providerOptions` 1:1 with a
given providers sdk.

### Example

Following [this](https://openrouter.ai/docs/features/provider-routing) documentation for adding `provider` options to the body of a request, we can use
the following `opencode.json` to select a specific provider

```json
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "openrouter": {
      "npm": "@openrouter/ai-sdk-provider",
      "name": "OpenRouter",
      "options": {},
      "models": {
        "deepseek/deepseek-r1:free": {
          "tools": false,
          "id": "deepseek/deepseek-r1:free",
          "name": "DeepSeek: R1 (free)",
          "providerOptions": {
            "openrouter": {
              "provider": {
                "allow_fallbacks": false,
                "only": [
                  "targon"
                ]
              }
            }
          }
        }
      }
    }
  }
}
```

### Notes

I added the `tools` field to the model info as an optional bool, since
openrouter providers may or may not support tools (in my case, Targon does not
yet support tool calling), so this needs to be dynamic per model. Maybe it makes
sense to name this something closer to `disableTools`?

Closes #186
