### PR TITLE
fix: contribution setup

### DIFF
--- a/packages/tui/internal/components/commands/commands.go
+++ b/packages/tui/internal/components/commands/commands.go
@@ -106,7 +106,7 @@ func (c *commandsComponent) View() string {
 		var keybindStrs []string
 		if c.showKeybinds {
 			for _, kb := range cmd.Keybindings {
-				if kb.RequiresLeader {
+				if kb.RequiresLeader && c.app.Config.Keybinds.Leader != nil {
 					keybindStrs = append(keybindStrs, *c.app.Config.Keybinds.Leader+" "+kb.Key)
 				} else {
 					keybindStrs = append(keybindStrs, kb.Key)


### PR DESCRIPTION
On fresh clone when following the [Contributing](https://github.com/sst/opencode?tab=readme-ov-file#contributing) section of the README `bun run packages/opencode/src/index.ts` fails with:

```bash
╰─❯ bun run packages/opencode/src/index.ts
Caught panic:

runtime error: invalid memory address or nil pointer dereference

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:18 +0x1c
github.com/charmbracelet/bubbletea/v2.(*Program).recoverFromPanic(0x140001a3200, {0x10396b0c0, 0x103f35c70})
        /Users/dizzzmas/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.3/tea.go:1134 +0xb0
github.com/charmbracelet/bubbletea/v2.(*Program).Run.func2()
        /Users/dizzzmas/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.3/tea.go:871 +0xdc
panic({0x10396b0c0?, 0x103f35c70?})
        /usr/local/go/src/runtime/panic.go:792 +0x124
github.com/sst/opencode/internal/components/commands.(*commandsComponent).View(0x1400033c3c0)
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/internal/components/commands/commands.go:110 +0xdf8
github.com/sst/opencode/internal/components/chat.(*messagesComponent).home(0x14000989508)
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/internal/components/chat/messages.go:352 +0x758
github.com/sst/opencode/internal/components/chat.(*messagesComponent).View(0x14000a79848?)
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/internal/components/chat/messages.go:288 +0x258
github.com/sst/opencode/internal/layout.(*container).View(0x1400099c000)
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/internal/layout/container.go:103 +0x6f8
github.com/sst/opencode/internal/layout.(*flexLayout).View(0x140001bbe50)
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/internal/layout/flex.go:79 +0x378
github.com/sst/opencode/internal/tui.appModel.View({0x0, 0x0, 0x140004442a0, {0x0, 0x0}, {0x103a30800, 0x1400045ec40}, {0x103a368c0, 0x14000996008}, {0x103a35528, ...}, ...})
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/internal/tui/tui.go:319 +0x2c
github.com/charmbracelet/bubbletea/v2.(*Program).render(0x140001a3200, {0x103a2e858?, 0x140001344d0?})
        /Users/dizzzmas/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.3/tea.go:795 +0x13c
github.com/charmbracelet/bubbletea/v2.(*Program).Run(0x140001a3200)
        /Users/dizzzmas/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.3/tea.go:1013 +0xac8
main.main()
        /Users/dizzzmas/Projects/oss/opencode/packages/tui/cmd/opencode/main.go:89 +0x70c
```

This seems to happen because of `opencode.json` in the root of the repo having empty `keybinds` object:
```json
{
  "$schema": "https://opencode.ai/config.json",
  "keybinds": {},
  "mcp": {}
}
```

Another way to fix it would be to change that json structure, but wasn't sure what the change should be there, so went with checking for null pointer