### PR TITLE
feat(tui): theme switcher with preview

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -77,8 +77,9 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch keyString {
 			// Escape always closes current modal
 			case "esc", "ctrl+c":
+				cmd := a.modal.Close()
 				a.modal = nil
-				return a, nil
+				return a, cmd
 			}
 
 			// Pass all other key presses to the modal
@@ -194,8 +195,12 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		slog.Debug("Background color", "isDark", msg.IsDark())
 	case modal.CloseModalMsg:
+		var cmd tea.Cmd
+		if a.modal != nil {
+			cmd = a.modal.Close()
+		}
 		a.modal = nil
-		return a, nil
+		return a, cmd
 	case commands.ExecuteCommandMsg:
 		updated, cmd := a.executeCommand(commands.Command(msg))
 		return updated, cmd


### PR DESCRIPTION
Previously, to see a theme in action, you had to do this:

1. `/themes`
2. Select a new theme
3. Save with `Enter`
4. Decide whether you like it or not
5. If you like it, profit, if you don't, go back to step 1

After this PR, the new behavior is this:
1. `/themes`
2. Preview the available themes via the up and down arrow keys
3. Press `Enter` if you like a theme to save it or `Esc` to discard the selection and close the modal