### PR TITLE
docs: add API client generation instructions to README and AGENTS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ $ bun install
 $ bun run packages/opencode/src/index.ts
 ```
 
+#### Development Notes
+
+**API Client Generation**: After making changes to the TypeScript API endpoints in `packages/opencode/src/server/server.ts`, you need to regenerate the Go client and OpenAPI specification:
+
+```bash
+$ cd packages/tui
+$ go generate ./pkg/client/
+```
+
+This updates the generated Go client code that the TUI uses to communicate with the backend server.
+
 ### FAQ
 
 #### How do I use this with OpenRouter?

--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -7,6 +7,7 @@
 - **Typecheck**: `bun run typecheck` (npm run typecheck)
 - **Test**: `bun test` (runs all tests)
 - **Single test**: `bun test test/tool/tool.test.ts` (specific test file)
+- **API Client Generation**: `cd packages/tui && go generate ./pkg/client/` (after changes to server endpoints)
 
 ## Code Style
 
@@ -37,3 +38,4 @@
 - **Validation**: All inputs validated with Zod schemas
 - **Logging**: Use `Log.create({ service: "name" })` pattern
 - **Storage**: Use `Storage` namespace for persistence
+- **API Client**: Go TUI communicates with TypeScript server via generated client. When adding/modifying server endpoints in `packages/opencode/src/server/server.ts`, run `cd packages/tui && go generate ./pkg/client/` to update the Go client code and OpenAPI spec.


### PR DESCRIPTION
add API client generation instructions to README and AGENTS.md