### PR TITLE
feat: add dynamic window titles based on user messages

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -450,6 +450,36 @@ export namespace Server {
         },
       )
       .post(
+        "/session_generate_title",
+        describeRoute({
+          description: "Generate a concise title for a message",
+          responses: {
+            200: {
+              description: "Generated title",
+              content: {
+                "application/json": {
+                  schema: resolver(z.object({
+                    title: z.string(),
+                  })),
+                },
+              },
+            },
+          },
+        }),
+        zValidator(
+          "json",
+          z.object({
+            text: z.string(),
+            providerID: z.string(),
+          }),
+        ),
+        async (c) => {
+          const body = c.req.valid("json")
+          const title = await Session.generateTitle(body.text, body.providerID)
+          return c.json({ title })
+        },
+      )
+      .post(
         "/provider_list",
         describeRoute({
           description: "List all providers",

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -223,6 +223,64 @@ export namespace Session {
     })
   }
 
+  export async function generateTitle(userMessage: string, providerID: string): Promise<string> {
+    const log = Log.create({ service: "title-generator" })
+    const fallback = userMessage.split('\n')[0].slice(0, 40) + (userMessage.length > 40 ? '...' : '')
+    try {
+      let titleModelID: string | undefined
+      let titleProviderID: string | undefined
+      switch (providerID) {
+        case "anthropic":
+          titleModelID = "claude-3-5-haiku-20241022"
+          titleProviderID = "anthropic"
+          break
+        case "openai":
+          titleModelID = "gpt-4o-mini"
+          titleProviderID = "openai"
+          break
+        default:
+      }
+
+      if (!titleModelID || !titleProviderID) {
+        return fallback
+      }
+
+      try {
+        await Provider.getModel(titleProviderID, titleModelID)
+      } catch {
+        return fallback
+      }
+
+      const model = await Provider.getModel(titleProviderID, titleModelID)
+
+      const result = await generateText({
+        model: model.language,
+        messages: [
+          {
+            role: "system",
+            content: SystemPrompt.windowTitle()
+          },
+          {
+            role: "user",
+            content: userMessage
+          }],
+        maxTokens: 20,
+        temperature: 0,
+      })
+
+      const title = result.text?.trim() || fallback
+      
+      // Ensure title is not too long
+      if (title.length > 40) {
+        return title.slice(0, 37) + '...'
+      }
+
+      return title
+    } catch (error) {
+      log.error("Failed to generate title", { error })
+      return fallback
+    }
+  }
   export async function chat(input: {
     sessionID: string
     providerID: string

--- a/packages/opencode/src/session/prompt/title-window.txt
+++ b/packages/opencode/src/session/prompt/title-window.txt
@@ -1,0 +1,1 @@
+Summarize this coding conversation and generate a concise title (under 50 characters) for this message. Focus on the main action or intent. nCapture the main task, key files, problems addressed, and current status. Use active verbs when possible. Omit articles and unnecessary words. Output only the title, nothing else.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -9,6 +9,7 @@ import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
 import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 import PROMPT_SUMMARIZE from "./prompt/summarize.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import PROMPT_TITLE_WINDOW from "./prompt/title-window.txt"
 
 export namespace SystemPrompt {
   export function provider(providerID: string) {
@@ -133,5 +134,9 @@ export namespace SystemPrompt {
       default:
         return [PROMPT_TITLE]
     }
+  }
+
+  export function windowTitle() {
+    return PROMPT_TITLE_WINDOW
   }
 }

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -44,6 +44,9 @@ type SendMsg struct {
 	Text        string
 	Attachments []Attachment
 }
+type WindowTitleMsg struct {
+	Title string
+}
 type CompletionDialogTriggerdMsg struct {
 	InitialValue string
 }
@@ -387,6 +390,28 @@ func (a *App) ListProviders(ctx context.Context) ([]client.ProviderInfo, error) 
 
 	providers := *resp.JSON200
 	return providers.Providers, nil
+}
+
+func (a *App) GenerateWindowTitle(ctx context.Context, text string) (string, error) {
+	if a.Provider == nil {
+		return "", fmt.Errorf("no provider configured")
+	}
+
+	requestBody := client.PostSessionGenerateTitleJSONRequestBody{
+		Text:       text,
+		ProviderID: a.Provider.Id,
+	}
+
+	response, err := a.Client.PostSessionGenerateTitleWithResponse(ctx, requestBody)
+	if err != nil {
+		return "", err
+	}
+
+	if response.StatusCode() != 200 || response.JSON200 == nil {
+		return "", fmt.Errorf("failed to generate title: status %d", response.StatusCode())
+	}
+
+	return response.JSON200.Title, nil
 }
 
 // func (a *App) loadCustomKeybinds() {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -40,6 +40,26 @@ type appModel struct {
 	leaderBinding        *key.Binding
 	isLeaderSequence     bool
 	toastManager         *toast.ToastManager
+	lastSubmittedMessage string
+	wasProcessing        bool
+}
+
+func formatWindowTitle(message string) string {
+	if message == "" {
+		return "opencode"
+	}
+
+	// Take first line only
+	lines := strings.Split(message, "\n")
+	title := strings.TrimSpace(lines[0])
+
+	// Truncate if too long
+	maxLen := 50
+	if len(title) > maxLen {
+		title = title[:maxLen-3] + "..."
+	}
+
+	return "opencode: " + title
 }
 
 func (a appModel) Init() tea.Cmd {
@@ -55,6 +75,9 @@ func (a appModel) Init() tea.Cmd {
 	cmds = append(cmds, a.status.Init())
 	cmds = append(cmds, a.completions.Init())
 	cmds = append(cmds, a.toastManager.Init())
+
+	// Set initial window title
+	cmds = append(cmds, tea.SetWindowTitle("opencode"))
 
 	// Check if we should show the init dialog
 	cmds = append(cmds, func() tea.Msg {
@@ -208,8 +231,10 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case app.SendMsg:
 		a.showCompletionDialog = false
+		a.lastSubmittedMessage = msg.Text
 		cmd := a.app.SendChatMessage(context.Background(), msg.Text, msg.Attachments)
-		cmds = append(cmds, cmd)
+		titleCmd := tea.SetWindowTitle(formatWindowTitle(msg.Text))
+		cmds = append(cmds, cmd, titleCmd)
 	case dialog.CompletionDialogCloseMsg:
 		a.showCompletionDialog = false
 	case client.EventInstallationUpdated:
@@ -261,6 +286,8 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.app.Session = msg
 		a.app.Messages = messages
+		a.lastSubmittedMessage = ""
+		cmds = append(cmds, tea.SetWindowTitle("opencode"))
 	case app.ModelSelectedMsg:
 		a.app.Provider = &msg.Provider
 		a.app.Model = &msg.Model
@@ -307,6 +334,14 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.completions = u.(dialog.CompletionDialog)
 		cmds = append(cmds, cmd)
 	}
+
+	// Check if AI finished processing and reset title
+	isProcessing := a.app.IsBusy()
+	if a.wasProcessing && !isProcessing && a.lastSubmittedMessage != "" {
+		a.lastSubmittedMessage = ""
+		cmds = append(cmds, tea.SetWindowTitle("opencode"))
+	}
+	a.wasProcessing = isProcessing
 
 	return a, tea.Batch(cmds...)
 }
@@ -415,7 +450,9 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 		}
 		a.app.Session = &client.SessionInfo{}
 		a.app.Messages = []client.MessageInfo{}
+		a.lastSubmittedMessage = ""
 		cmds = append(cmds, util.CmdHandler(app.SessionClearedMsg{}))
+		cmds = append(cmds, tea.SetWindowTitle("opencode"))
 	case commands.SessionListCommand:
 		sessionDialog := dialog.NewSessionDialog(a.app)
 		a.modal = sessionDialog
@@ -443,7 +480,8 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 			return a, nil
 		}
 		a.app.Cancel(context.Background(), a.app.Session.Id)
-		return a, nil
+		a.lastSubmittedMessage = ""
+		return a, tea.SetWindowTitle("opencode")
 	case commands.SessionCompactCommand:
 		if a.app.Session.Id == "" {
 			return a, nil

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -233,8 +233,21 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.showCompletionDialog = false
 		a.lastSubmittedMessage = msg.Text
 		cmd := a.app.SendChatMessage(context.Background(), msg.Text, msg.Attachments)
-		titleCmd := tea.SetWindowTitle(formatWindowTitle(msg.Text))
-		cmds = append(cmds, cmd, titleCmd)
+		cmds = append(cmds, cmd)
+		
+		// Generate title asynchronously
+		cmds = append(cmds, func() tea.Msg {
+			title, err := a.app.GenerateWindowTitle(context.Background(), msg.Text)
+			if err != nil {
+				slog.Debug("Failed to generate window title", "error", err)
+				// Fall back to truncated message
+				title = formatWindowTitle(msg.Text)
+			} else {
+				// Prepend "opencode: " to AI-generated title
+				title = "opencode: " + title
+			}
+			return app.WindowTitleMsg{Title: title}
+		})
 	case dialog.CompletionDialogCloseMsg:
 		a.showCompletionDialog = false
 	case client.EventInstallationUpdated:
@@ -288,6 +301,8 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.app.Messages = messages
 		a.lastSubmittedMessage = ""
 		cmds = append(cmds, tea.SetWindowTitle("opencode"))
+	case app.WindowTitleMsg:
+		return a, tea.SetWindowTitle(msg.Title)
 	case app.ModelSelectedMsg:
 		a.app.Provider = &msg.Provider
 		a.app.Model = &msg.Model

--- a/packages/tui/pkg/client/gen/openapi.json
+++ b/packages/tui/pkg/client/gen/openapi.json
@@ -230,6 +230,42 @@
         }
       }
     },
+    "/session_unshare": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Successfully unshared session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/session.info"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postSession_unshare",
+        "parameters": [],
+        "description": "Unshare the session",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sessionID": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "sessionID"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/session_messages": {
       "post": {
         "responses": {
@@ -415,6 +451,54 @@
                   "providerID",
                   "modelID",
                   "parts"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/session_generate_title": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Generated title",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "title"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postSession_generate_title",
+        "parameters": [],
+        "description": "Generate a concise title for a message",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "providerID": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "text",
+                  "providerID"
                 ]
               }
             }
@@ -1461,6 +1545,9 @@
                       "temperature": {
                         "type": "boolean"
                       },
+                      "tool_call": {
+                        "type": "boolean"
+                      },
                       "cost": {
                         "type": "object",
                         "properties": {
@@ -1499,6 +1586,10 @@
                       },
                       "id": {
                         "type": "string"
+                      },
+                      "options": {
+                        "type": "object",
+                        "additionalProperties": {}
                       }
                     }
                   }
@@ -1535,7 +1626,8 @@
             },
             "description": "MCP (Model Context Protocol) server configurations"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "Config.Keybinds": {
         "type": "object",
@@ -1648,7 +1740,8 @@
             "type": "string",
             "description": "Exit the application"
           }
-        }
+        },
+        "additionalProperties": false
       },
       "Provider.Info": {
         "type": "object",
@@ -1700,6 +1793,9 @@
           "temperature": {
             "type": "boolean"
           },
+          "tool_call": {
+            "type": "boolean"
+          },
           "cost": {
             "type": "object",
             "properties": {
@@ -1738,6 +1834,10 @@
           },
           "id": {
             "type": "string"
+          },
+          "options": {
+            "type": "object",
+            "additionalProperties": {}
           }
         },
         "required": [
@@ -1745,9 +1845,11 @@
           "attachment",
           "reasoning",
           "temperature",
+          "tool_call",
           "cost",
           "limit",
-          "id"
+          "id",
+          "options"
         ]
       },
       "Config.McpLocal": {
@@ -1776,7 +1878,8 @@
         "required": [
           "type",
           "command"
-        ]
+        ],
+        "additionalProperties": false
       },
       "Config.McpRemote": {
         "type": "object",
@@ -1794,7 +1897,8 @@
         "required": [
           "type",
           "url"
-        ]
+        ],
+        "additionalProperties": false
       },
       "Error": {
         "type": "object",

--- a/packages/tui/pkg/client/generated-client.go
+++ b/packages/tui/pkg/client/generated-client.go
@@ -78,9 +78,11 @@ type ConfigInfo struct {
 				Context float32 `json:"context"`
 				Output  float32 `json:"output"`
 			} `json:"limit,omitempty"`
-			Name        *string `json:"name,omitempty"`
-			Reasoning   *bool   `json:"reasoning,omitempty"`
-			Temperature *bool   `json:"temperature,omitempty"`
+			Name        *string                 `json:"name,omitempty"`
+			Options     *map[string]interface{} `json:"options,omitempty"`
+			Reasoning   *bool                   `json:"reasoning,omitempty"`
+			Temperature *bool                   `json:"temperature,omitempty"`
+			ToolCall    *bool                   `json:"tool_call,omitempty"`
 		} `json:"models"`
 		Name    *string                 `json:"name,omitempty"`
 		Npm     *string                 `json:"npm,omitempty"`
@@ -435,9 +437,11 @@ type ModelInfo struct {
 		Context float32 `json:"context"`
 		Output  float32 `json:"output"`
 	} `json:"limit"`
-	Name        string `json:"name"`
-	Reasoning   bool   `json:"reasoning"`
-	Temperature bool   `json:"temperature"`
+	Name        string                 `json:"name"`
+	Options     map[string]interface{} `json:"options"`
+	Reasoning   bool                   `json:"reasoning"`
+	Temperature bool                   `json:"temperature"`
+	ToolCall    bool                   `json:"tool_call"`
 }
 
 // ProviderInfo defines model for Provider.Info.
@@ -511,6 +515,12 @@ type PostSessionChatJSONBody struct {
 	SessionID  string        `json:"sessionID"`
 }
 
+// PostSessionGenerateTitleJSONBody defines parameters for PostSessionGenerateTitle.
+type PostSessionGenerateTitleJSONBody struct {
+	ProviderID string `json:"providerID"`
+	Text       string `json:"text"`
+}
+
 // PostSessionInitializeJSONBody defines parameters for PostSessionInitialize.
 type PostSessionInitializeJSONBody struct {
 	ModelID    string `json:"modelID"`
@@ -535,6 +545,11 @@ type PostSessionSummarizeJSONBody struct {
 	SessionID  string `json:"sessionID"`
 }
 
+// PostSessionUnshareJSONBody defines parameters for PostSessionUnshare.
+type PostSessionUnshareJSONBody struct {
+	SessionID string `json:"sessionID"`
+}
+
 // PostFileSearchJSONRequestBody defines body for PostFileSearch for application/json ContentType.
 type PostFileSearchJSONRequestBody PostFileSearchJSONBody
 
@@ -543,6 +558,9 @@ type PostSessionAbortJSONRequestBody PostSessionAbortJSONBody
 
 // PostSessionChatJSONRequestBody defines body for PostSessionChat for application/json ContentType.
 type PostSessionChatJSONRequestBody PostSessionChatJSONBody
+
+// PostSessionGenerateTitleJSONRequestBody defines body for PostSessionGenerateTitle for application/json ContentType.
+type PostSessionGenerateTitleJSONRequestBody PostSessionGenerateTitleJSONBody
 
 // PostSessionInitializeJSONRequestBody defines body for PostSessionInitialize for application/json ContentType.
 type PostSessionInitializeJSONRequestBody PostSessionInitializeJSONBody
@@ -555,6 +573,9 @@ type PostSessionShareJSONRequestBody PostSessionShareJSONBody
 
 // PostSessionSummarizeJSONRequestBody defines body for PostSessionSummarize for application/json ContentType.
 type PostSessionSummarizeJSONRequestBody PostSessionSummarizeJSONBody
+
+// PostSessionUnshareJSONRequestBody defines body for PostSessionUnshare for application/json ContentType.
+type PostSessionUnshareJSONRequestBody PostSessionUnshareJSONBody
 
 // Getter for additional properties for MessageInfo_Metadata_Tool_AdditionalProperties. Returns the specified
 // element and whether it was found
@@ -1611,6 +1632,11 @@ type ClientInterface interface {
 	// PostSessionCreate request
 	PostSessionCreate(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostSessionGenerateTitleWithBody request with any body
+	PostSessionGenerateTitleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostSessionGenerateTitle(ctx context.Context, body PostSessionGenerateTitleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostSessionInitializeWithBody request with any body
 	PostSessionInitializeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1633,6 +1659,11 @@ type ClientInterface interface {
 	PostSessionSummarizeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	PostSessionSummarize(ctx context.Context, body PostSessionSummarizeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostSessionUnshareWithBody request with any body
+	PostSessionUnshareWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostSessionUnshare(ctx context.Context, body PostSessionUnshareJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) PostAppInfo(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -1803,6 +1834,30 @@ func (c *Client) PostSessionCreate(ctx context.Context, reqEditors ...RequestEdi
 	return c.Client.Do(req)
 }
 
+func (c *Client) PostSessionGenerateTitleWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostSessionGenerateTitleRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostSessionGenerateTitle(ctx context.Context, body PostSessionGenerateTitleJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostSessionGenerateTitleRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) PostSessionInitializeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostSessionInitializeRequestWithBody(c.Server, contentType, body)
 	if err != nil {
@@ -1901,6 +1956,30 @@ func (c *Client) PostSessionSummarizeWithBody(ctx context.Context, contentType s
 
 func (c *Client) PostSessionSummarize(ctx context.Context, body PostSessionSummarizeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostSessionSummarizeRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostSessionUnshareWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostSessionUnshareRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostSessionUnshare(ctx context.Context, body PostSessionUnshareJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostSessionUnshareRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2247,6 +2326,46 @@ func NewPostSessionCreateRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewPostSessionGenerateTitleRequest calls the generic PostSessionGenerateTitle builder with application/json body
+func NewPostSessionGenerateTitleRequest(server string, body PostSessionGenerateTitleJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostSessionGenerateTitleRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostSessionGenerateTitleRequestWithBody generates requests for PostSessionGenerateTitle with any type of body
+func NewPostSessionGenerateTitleRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/session_generate_title")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewPostSessionInitializeRequest calls the generic PostSessionInitialize builder with application/json body
 func NewPostSessionInitializeRequest(server string, body PostSessionInitializeJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -2434,6 +2553,46 @@ func NewPostSessionSummarizeRequestWithBody(server string, contentType string, b
 	return req, nil
 }
 
+// NewPostSessionUnshareRequest calls the generic PostSessionUnshare builder with application/json body
+func NewPostSessionUnshareRequest(server string, body PostSessionUnshareJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostSessionUnshareRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostSessionUnshareRequestWithBody generates requests for PostSessionUnshare with any type of body
+func NewPostSessionUnshareRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/session_unshare")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -2516,6 +2675,11 @@ type ClientWithResponsesInterface interface {
 	// PostSessionCreateWithResponse request
 	PostSessionCreateWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostSessionCreateResponse, error)
 
+	// PostSessionGenerateTitleWithBodyWithResponse request with any body
+	PostSessionGenerateTitleWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionGenerateTitleResponse, error)
+
+	PostSessionGenerateTitleWithResponse(ctx context.Context, body PostSessionGenerateTitleJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSessionGenerateTitleResponse, error)
+
 	// PostSessionInitializeWithBodyWithResponse request with any body
 	PostSessionInitializeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionInitializeResponse, error)
 
@@ -2538,6 +2702,11 @@ type ClientWithResponsesInterface interface {
 	PostSessionSummarizeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionSummarizeResponse, error)
 
 	PostSessionSummarizeWithResponse(ctx context.Context, body PostSessionSummarizeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSessionSummarizeResponse, error)
+
+	// PostSessionUnshareWithBodyWithResponse request with any body
+	PostSessionUnshareWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionUnshareResponse, error)
+
+	PostSessionUnshareWithResponse(ctx context.Context, body PostSessionUnshareJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSessionUnshareResponse, error)
 }
 
 type PostAppInfoResponse struct {
@@ -2791,6 +2960,30 @@ func (r PostSessionCreateResponse) StatusCode() int {
 	return 0
 }
 
+type PostSessionGenerateTitleResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Title string `json:"title"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostSessionGenerateTitleResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostSessionGenerateTitleResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type PostSessionInitializeResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2895,6 +3088,28 @@ func (r PostSessionSummarizeResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostSessionSummarizeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostSessionUnshareResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SessionInfo
+}
+
+// Status returns HTTPResponse.Status
+func (r PostSessionUnshareResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostSessionUnshareResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3024,6 +3239,23 @@ func (c *ClientWithResponses) PostSessionCreateWithResponse(ctx context.Context,
 	return ParsePostSessionCreateResponse(rsp)
 }
 
+// PostSessionGenerateTitleWithBodyWithResponse request with arbitrary body returning *PostSessionGenerateTitleResponse
+func (c *ClientWithResponses) PostSessionGenerateTitleWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionGenerateTitleResponse, error) {
+	rsp, err := c.PostSessionGenerateTitleWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostSessionGenerateTitleResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostSessionGenerateTitleWithResponse(ctx context.Context, body PostSessionGenerateTitleJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSessionGenerateTitleResponse, error) {
+	rsp, err := c.PostSessionGenerateTitle(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostSessionGenerateTitleResponse(rsp)
+}
+
 // PostSessionInitializeWithBodyWithResponse request with arbitrary body returning *PostSessionInitializeResponse
 func (c *ClientWithResponses) PostSessionInitializeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionInitializeResponse, error) {
 	rsp, err := c.PostSessionInitializeWithBody(ctx, contentType, body, reqEditors...)
@@ -3099,6 +3331,23 @@ func (c *ClientWithResponses) PostSessionSummarizeWithResponse(ctx context.Conte
 		return nil, err
 	}
 	return ParsePostSessionSummarizeResponse(rsp)
+}
+
+// PostSessionUnshareWithBodyWithResponse request with arbitrary body returning *PostSessionUnshareResponse
+func (c *ClientWithResponses) PostSessionUnshareWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSessionUnshareResponse, error) {
+	rsp, err := c.PostSessionUnshareWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostSessionUnshareResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostSessionUnshareWithResponse(ctx context.Context, body PostSessionUnshareJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSessionUnshareResponse, error) {
+	rsp, err := c.PostSessionUnshare(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostSessionUnshareResponse(rsp)
 }
 
 // ParsePostAppInfoResponse parses an HTTP response from a PostAppInfoWithResponse call
@@ -3402,6 +3651,34 @@ func ParsePostSessionCreateResponse(rsp *http.Response) (*PostSessionCreateRespo
 	return response, nil
 }
 
+// ParsePostSessionGenerateTitleResponse parses an HTTP response from a PostSessionGenerateTitleWithResponse call
+func ParsePostSessionGenerateTitleResponse(rsp *http.Response) (*PostSessionGenerateTitleResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostSessionGenerateTitleResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Title string `json:"title"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParsePostSessionInitializeResponse parses an HTTP response from a PostSessionInitializeWithResponse call
 func ParsePostSessionInitializeResponse(rsp *http.Response) (*PostSessionInitializeResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -3522,6 +3799,32 @@ func ParsePostSessionSummarizeResponse(rsp *http.Response) (*PostSessionSummariz
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest bool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostSessionUnshareResponse parses an HTTP response from a PostSessionUnshareWithResponse call
+func ParsePostSessionUnshareResponse(rsp *http.Response) (*PostSessionUnshareResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostSessionUnshareResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SessionInfo
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- Adds dynamic window title generation that shows the user's message in the terminal title bar while AI is processing
- Implements AI-powered title generation using fast models (Haiku for Anthropic, GPT-4o-mini for OpenAI)
- Window title reverts to "opencode" when AI finishes processing or when session is interrupted

## Implementation Details
- Added `/session_generate_title` endpoint in TypeScript server
- Created `title-window.txt` prompt file for concise title generation
- Integrated window title updates in Go TUI client
- Title generation happens asynchronously without blocking message submission
- Handles edge cases like session interruption, session switching, and model selection

## Test Plan
- [x] Test window title updates when submitting messages
- [x] Verify title reverts to "opencode" when AI completes
- [x] Test title reset on session interrupt (Ctrl+C)
- [x] Verify title resets when switching sessions
- [x] Test fallback to truncated message if API fails
- [x] Ensure title generation works with different providers (Anthropic, OpenAI)

https://github.com/user-attachments/assets/32d3f521-70db-42f4-b129-71dab67be3fe

