### PR TITLE
fix: return false for missing AWS_PROFILE in amazon-bedrock provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -75,7 +75,7 @@ export namespace Provider {
       }
     },
     "amazon-bedrock": async () => {
-      if (!process.env["AWS_PROFILE"]) false
+      if (!process.env["AWS_PROFILE"]) return false
 
       const region = process.env["AWS_REGION"] ?? "us-east-1"
 


### PR DESCRIPTION
#241 had a small syntax error. this fixes it

Error: Unexpected error, check log file at /Users/aryasaatvik/.local/share/opencode/log/2025-06-20T20:22:42.log for more details

```
INFO  2025-06-20T20:22:42 +11ms service=default version=dev args= opencode
INFO  2025-06-20T20:22:42 +1ms service=app cwd=/Users/aryasaatvik/Developer/opencode/packages/opencode creating
INFO  2025-06-20T20:22:42 +0ms service=app git=/Users/aryasaatvik/Developer/opencode git
INFO  2025-06-20T20:22:42 +1ms service=app name=provider registering service
INFO  2025-06-20T20:22:42 +0ms service=app name=config registering service
INFO  2025-06-20T20:22:42 +1ms service=config $schema=https://opencode.ai/config.json loaded
INFO  2025-06-20T20:22:42 +0ms service=models.dev refreshing
INFO  2025-06-20T20:22:42 +0ms service=provider init
ERROR 2025-06-20T20:22:42 +1ms service=default fatal
```