### PR TITLE
feat: implement /unshare functionality in the tui

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -161,11 +161,12 @@ export namespace Session {
   }
 
   export async function unshare(id: string) {
+    const share = await Storage.readJSON<ShareInfo>("session/share/" + id)
     await Storage.remove("session/share/" + id)
     await update(id, (draft) => {
       draft.share = undefined
     })
-    await Share.remove(id)
+    await Share.remove(id, share.secret)
   }
 
   export async function update(id: string, editor: (session: Info) => void) {

--- a/packages/opencode/src/share/share.ts
+++ b/packages/opencode/src/share/share.ts
@@ -71,10 +71,10 @@ export namespace Share {
       .then((x) => x as { url: string; secret: string })
   }
 
-  export async function remove(id: string) {
+  export async function remove(id: string, secret: string) {
     return fetch(`${URL}/share_delete`, {
       method: "POST",
-      body: JSON.stringify({ id }),
+      body: JSON.stringify({ id, secret }),
     }).then((x) => x.json())
   }
 }

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -75,6 +75,7 @@ const (
 	SessionNewCommand           CommandName = "session_new"
 	SessionListCommand          CommandName = "session_list"
 	SessionShareCommand         CommandName = "session_share"
+	SessionUnshareCommand       CommandName = "session_unshare"
 	SessionInterruptCommand     CommandName = "session_interrupt"
 	SessionCompactCommand       CommandName = "session_compact"
 	ToolDetailsCommand          CommandName = "tool_details"
@@ -154,6 +155,12 @@ func LoadFromConfig(config *client.ConfigInfo) CommandRegistry {
 			Description: "share session",
 			Keybindings: parseBindings("<leader>s"),
 			Trigger:     "share",
+		},
+		{
+			Name:        SessionUnshareCommand,
+			Description: "unshare session",
+			Keybindings: parseBindings("<leader>u"),
+			Trigger:     "unshare",
 		},
 		{
 			Name:        SessionInterruptCommand,

--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -266,7 +266,6 @@ func (m *messagesComponent) header() string {
 	headerLines = append(headerLines, toMarkdown("# "+m.app.Session.Title, width-6, t.Background()))
 	if m.app.Session.Share != nil && m.app.Session.Share.Url != "" {
 		headerLines = append(headerLines, muted(m.app.Session.Share.Url))
-		headerLines = append(headerLines, base("/unshare")+muted(" to stop sharing"))
 	} else {
 		headerLines = append(headerLines, base("/share")+muted(" to create a shareable link"))
 	}

--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -266,6 +266,7 @@ func (m *messagesComponent) header() string {
 	headerLines = append(headerLines, toMarkdown("# "+m.app.Session.Title, width-6, t.Background()))
 	if m.app.Session.Share != nil && m.app.Session.Share.Url != "" {
 		headerLines = append(headerLines, muted(m.app.Session.Share.Url))
+		headerLines = append(headerLines, base("/unshare")+muted(" to stop sharing"))
 	} else {
 		headerLines = append(headerLines, base("/share")+muted(" to create a shareable link"))
 	}
@@ -357,14 +358,14 @@ func (m *messagesComponent) home() string {
 		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(t.Background())),
 	)
 
-	lines := []string{}
-	lines = append(lines, logoAndVersion)
-	lines = append(lines, "")
-	lines = append(lines, "")
-	// lines = append(lines, base("cwd ")+muted(cwd))
-	// lines = append(lines, base("config ")+muted(config))
-	// lines = append(lines, "")
-	lines = append(lines, commands)
+	lines := []string{
+		logoAndVersion,
+		"",
+		"",
+		//base("cwd ")+muted(cwd),
+		//base("config ")+muted(config)
+		commands,
+	}
 
 	return lipgloss.Place(
 		m.width,

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -465,6 +465,24 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 			cmds = append(cmds, tea.SetClipboard(shareUrl))
 			cmds = append(cmds, toast.NewSuccessToast("Share URL copied to clipboard!"))
 		}
+	case commands.SessionUnshareCommand:
+		if a.app.Session.Id == "" {
+			return a, nil
+		}
+		response, err := a.app.Client.PostSessionUnshareWithResponse(
+			context.Background(),
+			client.PostSessionUnshareJSONRequestBody{
+				SessionID: a.app.Session.Id,
+			},
+		)
+		if err != nil {
+			slog.Error("Failed to unshare session", "error", err)
+			return a, toast.NewErrorToast("Failed to unshare session")
+		}
+		if response.JSON200 != nil && response.StatusCode() != 200 {
+			return a, toast.NewErrorToast("Failed to unshare session: " + string(response.Body))
+		}
+		cmds = append(cmds, toast.NewSuccessToast("Unshared the current session"))
 	case commands.SessionInterruptCommand:
 		if a.app.Session.Id == "" {
 			return a, nil


### PR DESCRIPTION
This PR updates the generated client code to make the unshare endpoint available and implements the `/unshare` command. See issue #271 