### PR TITLE
fix: session title generation

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1,4 +1,4 @@
-import type { CoreMessage, LanguageModelV1Prompt } from "ai"
+import type { LanguageModelV1Prompt } from "ai"
 import { unique } from "remeda"
 
 export namespace ProviderTransform {

--- a/packages/opencode/src/session/prompt/title.txt
+++ b/packages/opencode/src/session/prompt/title.txt
@@ -1,7 +1,11 @@
-You will generate a short title based on the first message a user begins a conversation with
-- ensure it is not more than 50 characters long
-- the title should be a summary of the user's message
-- it should be one line long
-- do not use quotes or colons
-- the entire text you return will be used as the title
-- never return anything that is more than one sentence (one line) long
+Generate a short title based on the first message a user begins a conversation with. CRITICAL: Your response must be EXACTLY one line with NO line breaks, newlines, or multiple sentences.
+
+Requirements:
+- Maximum 50 characters
+- Single line only - NO newlines or line breaks
+- Summary of the user's message
+- No quotes, colons, or special formatting
+- Do not include explanatory text like "summary:" or similar
+- Your entire response becomes the title
+
+IMPORTANT: Return only the title text on a single line. Do not add any explanations, formatting, or additional text.


### PR DESCRIPTION
With the original prompt, AI felt too generous about generating session titles. It generated stuff like this, especially on the first `/init` command:
```
Codebase analysis and AGENTS. md creation\n\nI'd be happy to help you create
```
```
Codebase analysis and AGENTS.md creation guide\n\nI'd be happy to help you
```

With this new version this issue should be fixed - or at least improved, as I can't reproduce this issue anymore.

For reproduction, I used opencode's repository itself as the base for the `/init` command.