### PR TITLE
fix: combine stdout and stderr in bash tool output

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -66,6 +66,7 @@ export const BashTool = Tool.define({
       metadata: {
         stderr,
         stdout,
+        exitCode: process.exitCode,
         description: params.description,
         title: params.command,
       },

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -59,6 +59,9 @@ export const BashTool = Tool.define({
     const stdout = await new Response(process.stdout).text()
     const stderr = await new Response(process.stderr).text()
 
+    // Combine stdout and stderr, with stderr appearing after stdout
+    const combinedOutput = stdout + (stderr ? stderr : "")
+    
     return {
       metadata: {
         stderr,
@@ -66,7 +69,7 @@ export const BashTool = Tool.define({
         description: params.description,
         title: params.command,
       },
-      output: stdout.replaceAll(/\x1b\[[0-9;]*m/g, ""),
+      output: combinedOutput.replaceAll(/\x1b\[[0-9;]*m/g, ""),
     }
   },
 })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -59,18 +59,22 @@ export const BashTool = Tool.define({
     const stdout = await new Response(process.stdout).text()
     const stderr = await new Response(process.stderr).text()
 
-    // Combine stdout and stderr, with stderr appearing after stdout
-    const combinedOutput = stdout + (stderr ? stderr : "")
-    
     return {
       metadata: {
         stderr,
         stdout,
-        exitCode: process.exitCode,
+        exit: process.exitCode,
         description: params.description,
         title: params.command,
       },
-      output: combinedOutput.replaceAll(/\x1b\[[0-9;]*m/g, ""),
+      output: [
+        `<stdout>`,
+        stdout ?? "",
+        `</stdout>`,
+        `<stderr>`,
+        stderr ?? "",
+        `</stderr>`,
+      ].join("\n"),
     }
   },
 })


### PR DESCRIPTION
## Summary
- Fix bash tool to combine stdout and stderr in output, ensuring commands like `bun test` that output to stderr are visible to users
- Stderr is still preserved separately in metadata for backward compatibility

## Test plan
- [x] Test with commands that output to stderr (e.g., `echo "test" >&2`)
- [x] Verify stderr is still available in metadata
- [x] Confirm existing functionality remains intact

Fixes #291

🤖 Generated with [opencode](https://opencode.ai)