### PR TITLE
feat(cli): add git-commit-msg command for conventional commits

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -458,7 +458,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
 
-    "@types/bun": ["@types/bun@1.2.16", "", { "dependencies": { "bun-types": "1.2.16" } }, "sha512-1aCZJ/6nSiViw339RsaNhkNoEloLaPzZhxMOYEa7OzRzO41IGg5n/7I43/ZIAW/c+Q6cT12Vf7fOZOoVIzb5BQ=="],
+    "@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
@@ -596,7 +596,7 @@
 
     "buffer": ["buffer@4.9.2", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4", "isarray": "^1.0.0" } }, "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg=="],
 
-    "bun-types": ["bun-types@1.2.16", "", { "dependencies": { "@types/node": "*" } }, "sha512-ciXLrHV4PXax9vHvUrkvun9VPVGOVwbbbBF/Ev1cXz12lyEZMoJpIJABOfPcN9gDJRaiKF9MVbSygLg4NXu3/A=="],
+    "bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/packages/opencode/src/cli/cmd/git-commit-msg.ts
+++ b/packages/opencode/src/cli/cmd/git-commit-msg.ts
@@ -1,0 +1,166 @@
+import type { Argv } from "yargs"
+import { App } from "../../app/app"
+import { Provider } from "../../provider/provider"
+import { Session } from "../../session"
+import { Share } from "../../share/share"
+import { Message } from "../../session/message"
+import { Bus } from "../../bus"
+import { UI } from "../ui"
+import { cmd } from "./cmd"
+import { exec } from "child_process"
+import { promisify } from "util"
+
+const execAsync = promisify(exec)
+
+export const GitCommitMsgCommand = cmd({
+  command: "git-commit-msg",
+  describe: "Generate a conventional commit message from staged changes",
+  builder: (yargs: Argv) => {
+    return yargs
+      .option("model", {
+        type: "string",
+        alias: ["m"],
+        describe: "Model to use in the format of provider/model",
+      })
+      .option("copy", {
+        type: "boolean",
+        alias: ["c"],
+        describe: "Copy the generated commit message to clipboard",
+        default: false,
+      })
+  },
+  handler: async (args) => {
+    await App.provide(
+      {
+        cwd: process.cwd(),
+      },
+      async () => {
+        try {
+          // check if we're in a git repository
+          await execAsync("git rev-parse --git-dir")
+        } catch (error) {
+          UI.error("Not in a git repository")
+          return
+        }
+
+        // get git diff for staged changes (what will be committed)
+        let gitDiff: string
+
+        try {
+          const { stdout } = await execAsync("git diff --cached")
+          gitDiff = stdout.trim()
+
+          if (!gitDiff) {
+            UI.error("No staged changes found. Run 'git add' first.")
+            return
+          }
+        } catch (error) {
+          UI.error("Failed to get git diff")
+          return
+        }
+
+        await Share.init()
+        const session = await Session.create()
+
+        UI.empty()
+        UI.println(UI.logo())
+        UI.empty()
+        UI.println(UI.Style.TEXT_NORMAL_BOLD + "> ", "Generating conventional commit message...")
+        UI.empty()
+
+        const { providerID, modelID } = args.model
+          ? Provider.parseModel(args.model)
+          : await Provider.defaultModel()
+
+        UI.println(
+          UI.Style.TEXT_NORMAL_BOLD + "@ ",
+          UI.Style.TEXT_NORMAL + `${providerID}/${modelID}`,
+        )
+        UI.empty()
+
+        const prompt = `You are an expert at following the Conventional Commit specification. Based on the following git diff, generate a conventional commit message that follows the format:
+
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+
+Types: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert
+
+Rules:
+- Use lowercase for type and description
+- Keep description under 50 characters
+- Use imperative mood (e.g., "add" not "added")
+- Include scope if changes are focused on a specific area
+- Add body if more context is needed
+- Only return the commit message, no additional text
+
+Git diff:
+${gitDiff}`
+
+        let commitMessage = ""
+
+        Bus.subscribe(Message.Event.PartUpdated, async (evt) => {
+          if (evt.properties.sessionID !== session.id) return
+          const part = evt.properties.part
+
+          if (part.type === "text") {
+            commitMessage += part.text
+          }
+        })
+
+        await Session.chat({
+          sessionID: session.id,
+          providerID,
+          modelID,
+          parts: [
+            {
+              type: "text",
+              text: prompt,
+            },
+          ],
+        })
+
+        if (commitMessage.trim()) {
+          const cleanMessage = commitMessage.trim()
+
+          UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Generated commit message:")
+          UI.empty()
+          UI.println(cleanMessage)
+          UI.empty()
+
+          if (args.copy) {
+            try {
+              // try different clipboard commands based on platform
+              const platform = process.platform
+              let copyCommand: string
+
+              if (platform === "darwin") {
+                copyCommand = "pbcopy"
+              } else if (platform === "linux") {
+                copyCommand = "xclip -selection clipboard"
+              } else if (platform === "win32") {
+                copyCommand = "clip"
+              } else {
+                throw new Error("Unsupported platform")
+              }
+
+              await execAsync(`echo "${cleanMessage.replace(/"/g, '\\"')}" | ${copyCommand}`)
+              UI.println(UI.Style.TEXT_SUCCESS_BOLD + "✓ Copied to clipboard!")
+              UI.empty()
+            } catch (error) {
+              UI.println(UI.Style.TEXT_WARNING_BOLD + "⚠ Failed to copy to clipboard")
+              UI.empty()
+            }
+          }
+
+          UI.println(UI.Style.TEXT_INFO + "To use this message, run:")
+          UI.println(UI.Style.TEXT_INFO + `git commit -m "${cleanMessage.replace(/"/g, '\\"')}"`)
+        }
+
+        UI.empty()
+      },
+    )
+  },
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -10,6 +10,7 @@ import { hideBin } from "yargs/helpers"
 import { RunCommand } from "./cli/cmd/run"
 import { GenerateCommand } from "./cli/cmd/generate"
 import { ScrapCommand } from "./cli/cmd/scrap"
+import { GitCommitMsgCommand } from "./cli/cmd/git-commit-msg"
 import { Log } from "./util/log"
 import { AuthCommand, AuthLoginCommand } from "./cli/cmd/auth"
 import { UpgradeCommand } from "./cli/cmd/upgrade"
@@ -120,6 +121,7 @@ const cli = yargs(hideBin(process.argv))
   .command(RunCommand)
   .command(GenerateCommand)
   .command(ScrapCommand)
+  .command(GitCommitMsgCommand)
   .command(AuthCommand)
   .command(UpgradeCommand)
   .fail((msg) => {


### PR DESCRIPTION
Add new command to generate conventional commit messages from git diffs and copy to clipboard.

```bash
$ bun run packages/opencode/src/index.ts git-commit-msg -c
```
```console
█▀▀█ █▀▀█ █▀▀ █▀▀▄ █▀▀ █▀▀█ █▀▀▄ █▀▀
█░░█ █░░█ █▀▀ █░░█ █░░ █░░█ █░░█ █▀▀
▀▀▀▀ █▀▀▀ ▀▀▀ ▀  ▀ ▀▀▀ ▀▀▀▀ ▀▀▀  ▀▀▀

>  Generating conventional commit message...

@  amazon-bedrock/anthropic.claude-sonnet-4-20250514-v1:0

Generated commit message:

fix(cli): did something useful...maybe

✓ Copied to clipboard!

To use this message, run:
git commit -m "fix(cli): did something useful...maybe"
```

Not sure if this fits with the TUI, but I find this feature super-useful with another tool I use and wondering if it could be added with some more work/tests? Looking for any advice on current implementation and if the code owners like the idea for me to spend more time on it