### PR TITLE
feat(copilot): edit headers for better rate limit avoidance

### DIFF
--- a/packages/opencode/src/auth/github-copilot.ts
+++ b/packages/opencode/src/auth/github-copilot.ts
@@ -37,7 +37,7 @@ export namespace AuthGithubCopilot {
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
-        "User-Agent": "GithubCopilot/1.155.0",
+        "User-Agent": "GitHubCopilotChat/0.26.7",
       },
       body: JSON.stringify({
         client_id: CLIENT_ID,
@@ -60,7 +60,7 @@ export namespace AuthGithubCopilot {
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
-        "User-Agent": "GithubCopilot/1.155.0",
+        "User-Agent": "GitHubCopilotChat/0.26.7",
       },
       body: JSON.stringify({
         client_id: CLIENT_ID,
@@ -101,9 +101,9 @@ export namespace AuthGithubCopilot {
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${info.refresh}`,
-        "User-Agent": "GithubCopilot/1.155.0",
-        "Editor-Version": "vscode/1.85.1",
-        "Editor-Plugin-Version": "copilot/1.155.0",
+        "User-Agent": "GitHubCopilotChat/0.26.7",
+        "Editor-Version": "vscode/1.99.3",
+        "Editor-Plugin-Version": "copilot-chat/0.26.7",
       },
     })
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -89,9 +89,11 @@ export namespace Provider {
             const headers = {
               ...init.headers,
               Authorization: `Bearer ${token}`,
-              "User-Agent": "GithubCopilot/1.155.0",
-              "Editor-Version": "vscode/1.85.1",
-              "Editor-Plugin-Version": "copilot/1.155.0",
+              "User-Agent": "GitHubCopilotChat/0.26.7",
+              "Editor-Version": "vscode/1.99.3",
+              "Editor-Plugin-Version": "copilot-chat/0.26.7",
+              "Copilot-Integration-Id": "vscode-chat",
+              "Openai-Intent": "conversation-edits",
             }
             delete headers["x-api-key"]
             return fetch(input, {


### PR DESCRIPTION
- add additional headers and modify user-agent for better rate limiting success
- GitHub Copilot chat and agent mode has notoriously been bad about rate limiting recently in vscode and anywhere else really that uses copilot sub for agentic coding.
- These headers are ones I gathered from other projects and have tested myself to the most success for avoiding rate limiting as much as possible.