### PR TITLE
fix: only slash-escape HTML tag angle brackets outside of code sections

### DIFF
--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -22,21 +22,18 @@ import (
 	"golang.org/x/text/language"
 )
 
-// processInlineCode handles escaping of angle brackets outside of inline code blocks
 func processInlineCode(line string) string {
 	var result strings.Builder
 	inCode := false
 	
 	for i := 0; i < len(line); i++ {
 		if i < len(line)-1 && line[i] == '`' && line[i+1] != '`' {
-			// Toggle inline code state
+			// Switching in or out of inline code
 			inCode = !inCode
 			result.WriteByte('`')
 		} else if line[i] == '<' && !inCode {
-			// Escape < only if not in inline code
 			result.WriteString("\\<")
 		} else if line[i] == '>' && !inCode {
-			// Escape > only if not in inline code
 			result.WriteString("\\>")
 		} else {
 			result.WriteByte(line[i])
@@ -46,35 +43,27 @@ func processInlineCode(line string) string {
 	return result.String()
 }
 
-func toMarkdown(content string, width int, backgroundColor compat.AdaptiveColor) string {
-	r := styles.GetMarkdownRenderer(width, backgroundColor)
-	content = strings.ReplaceAll(content, app.RootPath+"/", "")
-	
-	// Process content to escape HTML tags only outside of code blocks
+func processContentForAngleBrackets(content string) string {
 	var processed strings.Builder
 	inCodeBlock := false
 	codeBlockMarker := ""
 	
-	// Split content by lines to process code blocks
 	contentLines := strings.Split(content, "\n")
 	for i, line := range contentLines {
 		// Check for code block markers (``` or ~~~)
 		if strings.HasPrefix(strings.TrimSpace(line), "```") || strings.HasPrefix(strings.TrimSpace(line), "~~~") {
 			marker := line[:3]
 			if !inCodeBlock {
-				// Start of code block
 				inCodeBlock = true
 				codeBlockMarker = marker
 			} else if strings.HasPrefix(strings.TrimSpace(line), codeBlockMarker) {
-				// End of code block
 				inCodeBlock = false
 			}
 			processed.WriteString(line)
 		} else if inCodeBlock {
-			// Inside code block - don't escape angle brackets
 			processed.WriteString(line)
 		} else {
-			// Outside code block - handle inline code and escape angle brackets
+			// Outside code block - handle inline code and escape any non-backticked-enclosed angle brackets
 			processedLine := processInlineCode(line)
 			processed.WriteString(processedLine)
 		}
@@ -85,7 +74,14 @@ func toMarkdown(content string, width int, backgroundColor compat.AdaptiveColor)
 		}
 	}
 	
-	content = processed.String()
+	return processed.String()
+}
+
+func toMarkdown(content string, width int, backgroundColor compat.AdaptiveColor) string {
+	r := styles.GetMarkdownRenderer(width, backgroundColor)
+	content = strings.ReplaceAll(content, app.RootPath+"/", "")
+	content = processContentForAngleBrackets(content)
+	
 	rendered, _ := r.Render(content)
 	lines := strings.Split(rendered, "\n")
 

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -22,11 +22,70 @@ import (
 	"golang.org/x/text/language"
 )
 
+// processInlineCode handles escaping of angle brackets outside of inline code blocks
+func processInlineCode(line string) string {
+	var result strings.Builder
+	inCode := false
+	
+	for i := 0; i < len(line); i++ {
+		if i < len(line)-1 && line[i] == '`' && line[i+1] != '`' {
+			// Toggle inline code state
+			inCode = !inCode
+			result.WriteByte('`')
+		} else if line[i] == '<' && !inCode {
+			// Escape < only if not in inline code
+			result.WriteString("\\<")
+		} else if line[i] == '>' && !inCode {
+			// Escape > only if not in inline code
+			result.WriteString("\\>")
+		} else {
+			result.WriteByte(line[i])
+		}
+	}
+	
+	return result.String()
+}
+
 func toMarkdown(content string, width int, backgroundColor compat.AdaptiveColor) string {
 	r := styles.GetMarkdownRenderer(width, backgroundColor)
 	content = strings.ReplaceAll(content, app.RootPath+"/", "")
-	content = strings.ReplaceAll(content, "<", "\\<")
-	content = strings.ReplaceAll(content, ">", "\\>")
+	
+	// Process content to escape HTML tags only outside of code blocks
+	var processed strings.Builder
+	inCodeBlock := false
+	codeBlockMarker := ""
+	
+	// Split content by lines to process code blocks
+	contentLines := strings.Split(content, "\n")
+	for i, line := range contentLines {
+		// Check for code block markers (``` or ~~~)
+		if strings.HasPrefix(strings.TrimSpace(line), "```") || strings.HasPrefix(strings.TrimSpace(line), "~~~") {
+			marker := line[:3]
+			if !inCodeBlock {
+				// Start of code block
+				inCodeBlock = true
+				codeBlockMarker = marker
+			} else if strings.HasPrefix(strings.TrimSpace(line), codeBlockMarker) {
+				// End of code block
+				inCodeBlock = false
+			}
+			processed.WriteString(line)
+		} else if inCodeBlock {
+			// Inside code block - don't escape angle brackets
+			processed.WriteString(line)
+		} else {
+			// Outside code block - handle inline code and escape angle brackets
+			processedLine := processInlineCode(line)
+			processed.WriteString(processedLine)
+		}
+		
+		// Add newline unless it's the last line
+		if i < len(contentLines)-1 {
+			processed.WriteString("\n")
+		}
+	}
+	
+	content = processed.String()
 	rendered, _ := r.Render(content)
 	lines := strings.Split(rendered, "\n")
 

--- a/packages/tui/internal/components/chat/message_test.go
+++ b/packages/tui/internal/components/chat/message_test.go
@@ -1,0 +1,158 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProcessInlineCode verifies that the processInlineCode function correctly
+// escapes angle brackets in plain text while preserving them in inline code segments.
+func TestProcessInlineCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "plain text with angle brackets",
+			input:    "This is <some> text with <angle brackets>",
+			expected: "This is \\<some\\> text with \\<angle brackets\\>",
+		},
+		{
+			name:     "inline code with angle brackets",
+			input:    "This is `<some>` code with angle brackets",
+			expected: "This is `<some>` code with angle brackets",
+		},
+		{
+			name:     "multiple inline code segments",
+			input:    "Text with `<code>` and more `<brackets>` in different segments",
+			expected: "Text with `<code>` and more `<brackets>` in different segments",
+		},
+		{
+			name:     "mixed content",
+			input:    "Normal <tag> with `<code>` and then <another> tag",
+			expected: "Normal \\<tag\\> with `<code>` and then \\<another\\> tag",
+		},
+		{
+			name:     "angle bracket at end of line",
+			input:    "Text ending with <",
+			expected: "Text ending with \\<",
+		},
+		{
+			name:     "unclosed inline code",
+			input:    "This has unclosed `<code>",
+			expected: "This has unclosed `<code>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := processInlineCode(tt.input)
+			if result != tt.expected {
+				t.Errorf("processInlineCode() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestCodeBlockAngleBrackets tests the code block detection logic to ensure
+// that angle brackets are escaped in plain text but preserved in code blocks.
+func TestCodeBlockAngleBrackets(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		shouldEscape []bool // For each line, should angle brackets be escaped?
+	}{
+		{
+			name:         "plain text outside code block",
+			input:        "This is <some> text",
+			shouldEscape: []bool{true},
+		},
+		{
+			name:         "text inside code block",
+			input:        "```\n<html>\n</html>\n```",
+			shouldEscape: []bool{false, false, false, false},
+		},
+		{
+			name:         "text with inline code",
+			input:        "Text with `<code>` segment",
+			shouldEscape: []bool{true}, // The line will be processed by processInlineCode which handles inline code
+		},
+		{
+			name:         "mixed content",
+			input:        "Text before\n```\n<div>\n  <p>Content</p>\n</div>\n```\nText after",
+			shouldEscape: []bool{true, false, false, false, false, false, true},
+		},
+		{
+			name:         "nested angle brackets",
+			input:        "Text <outer <inner> outer>\n```\n<outer <inner> outer>\n```",
+			shouldEscape: []bool{true, false, false, false},
+		},
+		{
+			name:         "tilde code blocks",
+			input:        "Text before\n~~~\n<div>\n  <p>Content</p>\n</div>\n~~~\nText after",
+			shouldEscape: []bool{true, false, false, false, false, false, true},
+		},
+		{
+			name:         "code blocks with language specifier",
+			input:        "Text before\n```html\n<div>\n  <p>Content</p>\n</div>\n```\nText after",
+			shouldEscape: []bool{true, false, false, false, false, false, true},
+		},
+		{
+			name:         "code blocks with complex language specifier",
+			input:        "Text before\n```javascript {.line-numbers}\n<div>\n  const element = document.createElement('<p>');\n</div>\n```\nText after",
+			shouldEscape: []bool{true, false, false, false, false, false, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the code block detection logic from toMarkdown
+			lines := strings.Split(tt.input, "\n")
+			inCodeBlock := false
+			codeBlockMarker := ""
+
+			for i, line := range lines {
+				// Check if we should be escaping this line based on test case
+				expectedEscape := tt.shouldEscape[i]
+
+				// Check for code block markers (``` or ~~~)
+				if strings.HasPrefix(strings.TrimSpace(line), "```") || strings.HasPrefix(strings.TrimSpace(line), "~~~") {
+					marker := line[:3]
+					if !inCodeBlock {
+						// Start of code block
+						inCodeBlock = true
+						codeBlockMarker = marker
+					} else if strings.HasPrefix(strings.TrimSpace(line), codeBlockMarker) {
+						// End of code block
+						inCodeBlock = false
+					}
+				}
+
+				// Verify our code block detection matches expected behavior
+				if inCodeBlock || strings.HasPrefix(strings.TrimSpace(line), "```") || strings.HasPrefix(strings.TrimSpace(line), "~~~") {
+					// Inside code block or marker line - should not escape
+					if expectedEscape {
+						t.Errorf("Line %d should not be in a code block, but was detected as such: %q", i, line)
+					}
+				} else {
+					// Outside code block - should escape
+					if !expectedEscape {
+						t.Errorf("Line %d should be in a code block, but was not detected as such: %q", i, line)
+					}
+
+					// If the line contains angle brackets, verify processInlineCode escapes them
+					if strings.Contains(line, "<") || strings.Contains(line, ">") {
+						processed := processInlineCode(line)
+						// Check that angle brackets are escaped, but not those in inline code
+						if !strings.Contains(processed, "\\<") && !strings.Contains(processed, "\\>") &&
+							(strings.Contains(line, "<") || strings.Contains(line, ">")) &&
+							!strings.Contains(line, "`") {
+							t.Errorf("Angle brackets should be escaped in line: %q, got: %q", line, processed)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
fixes #320

Added unit tests because this is the kind of twitchy text-parsing that really benefits from it.

What I don't know is if there is a better library to use that can do the "are we in a code block" parsing in a definitely-spec-compliant way. This way is pretty brute force and naive.