### PR TITLE
Fix project folder name starting with "-" in data

### DIFF
--- a/packages/opencode/src/app/app.ts
+++ b/packages/opencode/src/app/app.ts
@@ -46,7 +46,7 @@ export namespace App {
     const data = path.join(
       Global.Path.data,
       "project",
-      git ? git.split(path.sep).join("-") : "global",
+      git ? git.split(path.sep).filter(Boolean).join("-") : "global",
     )
     const stateFile = Bun.file(path.join(data, APP_JSON))
     const state = (await stateFile.json().catch(() => ({}))) as {


### PR DESCRIPTION
When starting new session in a project with `.git` folder the path created in data storage starts with a hyphen on linux. E.g.:

Actual path: `/path/to/my/amazing-project`
It becomes: `~/.local/share/opencode/project/-path-to-my-amazing-project`

This causes issues when trying to change to that directory when one is in `~/.local/share/opencode/` as the first letter is interpreted as option passed to cd command. 

This PR attempts to fix it by filtering out "falsy" values from the array before joining it with the hyphens.