### PR TITLE
Docs update mcp models

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ paru -S opencode-bin               # Arch Linux
 
 ### Documentation
 
-For more info on how to configure opencode [**head over to our docs**](https://opencode.ai/docs).
+For more info on how to configure opencode, including details on providers, models, MCP servers, and more, [**head over to our docs**](https://opencode.ai/docs).
 
 ### Contributing
 

--- a/packages/web/src/content/docs/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/docs/mcp-servers.mdx
@@ -11,17 +11,76 @@ Once added, MCP tools are automatically available to the LLM alongside built-in 
 
 ---
 
-## Configure
+## Configuring MCP Servers
 
 You can define MCP servers in your opencode config under `mcp`. The `opencode.json` file can be placed in your project root (this is useful for project-specific tools and can be checked into Git) or globally at `~/.config/opencode/config.json` (for tools you want to use across all projects).
 
 If both files exist, opencode will use the configuration from the project root.
 
-Here are examples of how to configure local and remote MCP servers:
+Below is a comprehensive example of an `opencode.json` file configuring both local and remote MCP servers. You can adapt this structure for your specific needs.
 
-### Local
+```json title="opencode.json (Example with multiple MCPs)"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "my-local-tool": {
+      "type": "local",
+      "command": ["python", "path/to/my/local_tool_server.py"],
+      "environment": {
+        "TOOL_API_KEY": "your_local_tool_api_key"
+      }
+    },
+    "my-remote-service": {
+      "type": "remote",
+      "url": "https://api.myremoteservice.com/mcp"
+    }
+  }
+}
+```
 
-Add a local MCP servers under `mcp.localmcp`.
+---
+
+## Example: Configuring MetaMCP
+
+[MetaMCP](https://github.com/metatool-ai/metatool-app) is a unified middleware MCP that allows you to manage multiple MCP servers through a GUI application and a local MCP proxy.
+
+To use MetaMCP with opencode, you'll typically configure it as a local MCP server. First, ensure you have MetaMCP installed and running. You can usually start its proxy server using an npx command.
+
+Here's how you can configure it in your `opencode.json`:
+
+```json title="opencode.json (with MetaMCP)"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "metamcp": {
+      "type": "local",
+      "command": ["npx", "-y", "@metamcp/mcp-server-metamcp@latest"],
+      "environment": {
+        "METAMCP_API_KEY": "your_metamcp_api_key",
+        "METAMCP_API_BASE_URL": "http://localhost:12005"
+      }
+    }
+  }
+}
+```
+
+**Explanation:**
+
+- `"metamcp"`: This is the identifier for your MetaMCP server within opencode. You can name it anything you like.
+- `"type": "local"`:  Indicates this is a locally running MCP server.
+- `"command": ["npx", "-y", "@metamcp/mcp-server-metamcp@latest"]`: This is the command opencode will use to start the MetaMCP proxy.
+    - `npx -y @metamcp/mcp-server-metamcp@latest` ensures you're using the latest version of the MetaMCP server.
+- `"environment"`: This object allows you to set environment variables required by the MetaMCP server.
+    - `METAMCP_API_KEY`: You'll need to replace `"your_metamcp_api_key"` with your actual API key obtained from the MetaMCP App.
+    - `METAMCP_API_BASE_URL`: This is typically the URL where your MetaMCP App is running (default is `http://localhost:12005`).
+
+After configuring, opencode will be able to communicate with your MetaMCP instance, allowing you to access any tools or resources managed by MetaMCP.
+
+Refer to the [MetaMCP documentation](https://github.com/metatool-ai/metatool-app) for more details on obtaining API keys and other configuration options.
+
+### Local Servers
+
+Add local MCP servers by defining them within the `mcp` object. Each key under `mcp` will be the identifier for that server.
 
 ```json title="opencode.json"
 {
@@ -38,9 +97,9 @@ Add a local MCP servers under `mcp.localmcp`.
 }
 ```
 
-### Remote
+### Remote Servers
 
-Add a remote MCP servers under `mcp.remotemcp`.
+Add remote MCP servers similarly by defining them within the `mcp` object.
 
 ```json title="opencode.json"
 {

--- a/packages/web/src/content/docs/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/docs/mcp-servers.mdx
@@ -13,7 +13,11 @@ Once added, MCP tools are automatically available to the LLM alongside built-in 
 
 ## Configure
 
-You can define MCP servers in your opencode config under `mcp`.
+You can define MCP servers in your opencode config under `mcp`. The `opencode.json` file can be placed in your project root (this is useful for project-specific tools and can be checked into Git) or globally at `~/.config/opencode/config.json` (for tools you want to use across all projects).
+
+If both files exist, opencode will use the configuration from the project root.
+
+Here are examples of how to configure local and remote MCP servers:
 
 ### Local
 

--- a/packages/web/src/content/docs/docs/models.mdx
+++ b/packages/web/src/content/docs/docs/models.mdx
@@ -36,6 +36,33 @@ You can add custom providers by specifying the npm package for the provider and 
 }
 ```
 
+### Google Gemini
+
+To configure Google Gemini models, such as Gemini 2.5-flash, you'll need to ensure you have authenticated with Google Cloud CLI and set up the necessary environment variables. Typically, this involves setting `GOOGLE_API_KEY` or `GOOGLE_APPLICATION_CREDENTIALS`.
+
+Here's an example of how to configure Gemini 2.5-flash in your `opencode.json`:
+
+```json title="opencode.json" {5,9-11}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "google": {
+      "npm": "@ai-sdk/google",
+      "name": "Google",
+      "options": {},
+      "models": {
+        "gemini-2.5-flash": {
+          "name": "Gemini 2.5 Flash"
+        }
+      }
+    }
+  },
+  "model": "google/gemini-2.5-flash"
+}
+```
+
+Make sure to replace `"google/gemini-2.5-flash"` with the specific model ID if you're using a different Gemini model. You can find more information about available models and authentication in the [official Google AI documentation](https://ai.google.dev/docs).
+
 ### Local
 
 To configure a local model, specify the npm package to use and the `baseURL`.


### PR DESCRIPTION
docs: improve documentation for models and MCP servers

Updated README.md to better direct users to the detailed documentation.

Enhanced models.mdx with instructions and examples for configuring Google Gemini 2.5-flash.

Improved mcp-servers.mdx by clarifying the placement of opencode.json and ensuring comprehensive examples for local and remote
- Added a comprehensive opencode.json example to mcp-servers.mdx, showcasing configuration for both local and remote MCP servers.
- Added a new section to mcp-servers.mdx detailing how to configure MetaMCP, including a specific opencode.json example and explanation of necessary environment variables. MetaMCP can suggest other MPC servers to actual application.
- Restructured mcp-servers.mdx slightly for better flow and clarity between generic examples and the specific MetaMCP example.