### PR TITLE
feat(providers): use env variable instead of hardcoded api key in auth.json

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -16,7 +16,12 @@ export namespace Auth {
     key: z.string(),
   })
 
-  export const Info = z.discriminatedUnion("type", [Oauth, Api])
+  export const Env = z.object({
+    type: z.literal("env"),
+    env: z.string(),
+  })
+
+  export const Info = z.discriminatedUnion("type", [Oauth, Api, Env])
   export type Info = z.infer<typeof Info>
 
   const filepath = path.join(Global.Path.data, "auth.json")

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -241,6 +241,12 @@ export namespace Provider {
       if (provider.type === "api") {
         mergeProvider(providerID, { apiKey: provider.key }, "api")
       }
+      if (provider.type === "env") {
+        const envValue = process.env[provider.env]
+        if (envValue) {
+          mergeProvider(providerID, { apiKey: envValue }, "env")
+        }
+      }
     }
 
     // load custom


### PR DESCRIPTION
I am doing this specifically for Gemini (Google), but this should work with any provider.

This is NOT available in the UI of `opencode auth login` because I am not sure what the UX there should be like, so instead you can just "manually" update your opencode `auth.json` to something like the following:

```json
{
  "google": {
    "type": "env",
    "env": "GEMINI_API_KEY"
  }
}
```

This allows you to have opencode leverage an environment variable for an API Key instead of having to "hardcode" it into the opencode `auth.json`.

This should somewhat resolve #318