### PR TITLE
feat: open browser for github auth

### DIFF
--- a/packages/opencode/src/auth/github-copilot.ts
+++ b/packages/opencode/src/auth/github-copilot.ts
@@ -46,11 +46,11 @@ export namespace AuthGithubCopilot {
     })
     const deviceData: DeviceCodeResponse = await deviceResponse.json()
     return {
-      device: deviceData.device_code,
-      user: deviceData.user_code,
-      verification: deviceData.verification_uri,
+      deviceCode: deviceData.device_code,
+      userCode: deviceData.user_code,
+      verificationUri: deviceData.verification_uri,
       interval: deviceData.interval || 5,
-      expiry: deviceData.expires_in,
+      expiryIn: deviceData.expires_in,
     }
   }
 

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -184,20 +184,26 @@ export const AuthLoginCommand = cmd({
     const copilot = await AuthCopilot()
     if (provider === "github-copilot" && copilot) {
       await new Promise((resolve) => setTimeout(resolve, 10))
-      const deviceInfo = await copilot.authorize()
+      const { userCode, deviceCode, verificationUri, interval } =
+        await copilot.authorize()
 
-      prompts.note(
-        `Please visit: ${deviceInfo.verification}\nEnter code: ${deviceInfo.user}`,
-      )
+      prompts.note(`Enter the following code: ${userCode} when prompted`)
+      prompts.note("Trying to open browser...")
+      try {
+        await open(verificationUri)
+      } catch (e) {
+        prompts.log.error(
+          "Failed to open browser perhaps you are running without a display or X server, please open the following URL in your browser:",
+        )
+      }
+      prompts.log.info(verificationUri)
 
       const spinner = prompts.spinner()
       spinner.start("Waiting for authorization...")
 
       while (true) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, deviceInfo.interval * 1000),
-        )
-        const response = await copilot.poll(deviceInfo.device)
+        await new Promise((resolve) => setTimeout(resolve, interval * 1000))
+        const response = await copilot.poll(deviceCode)
         if (response.status === "pending") continue
         if (response.status === "success") {
           await Auth.set("github-copilot", {


### PR DESCRIPTION
- Leverage existing `open` library to open automatically the browser to improve the Github auth UX (I was expecting the browser to open automatically)
- Small refactor:
  - the returned object from `authorize` is now closer to the API response
  - destructure the object instead of `deviceInfo`