### PR TITLE
fix: typescript error (any) from models

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -57,7 +57,7 @@ export namespace ModelsDev {
     }
     refresh()
     const json = await data()
-    return JSON.parse(json)
+    return JSON.parse(json) as Record<string, Provider>
   }
 
   async function refresh() {


### PR DESCRIPTION
This TS error wasn't letting me push due to the commit hooks. Needed to type cast `as` a record string provider object.