### PR TITLE
PR: Platform-Specific Leader Keys for macOS

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -71,6 +72,9 @@ func New(
 	configInfo := configResponse.JSON200
 	if configInfo.Keybinds == nil {
 		leader := "ctrl+x"
+		if runtime.GOOS == "darwin" {
+			leader = "cmd+x"
+		}
 		keybinds := client.ConfigKeybinds{
 			Leader: &leader,
 		}


### PR DESCRIPTION
## Platform-Specific Leader Keys for macOS

Implements platform-aware default leader keys. macOS users now get `cmd+x` as the default leader key instead of `ctrl+x`, aligning better with macOS conventions and reducing terminal conflicts.

## Changes Made
- Added platform detection in `packages/tui/internal/app/app.go` using `runtime.GOOS`
- Set default leader keys: `cmd+x` for macOS, `ctrl+x` for other platforms
- Updated `Draft.md` documentation

## Details
```go
// Platform-specific leader key defaults
if configInfo.Keybinds == nil {
    leader := "ctrl+x"
    if runtime.GOOS == "darwin" {
        leader = "cmd+x"
    }
    keybinds := client.ConfigKeybinds{Leader: &leader}
    configInfo.Keybinds = &keybinds
}
```


