### PR TITLE
Add `copilot-instructions.md` to the system prompt custom files search

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -95,6 +95,7 @@ export namespace SystemPrompt {
   const CUSTOM_FILES = [
     "AGENTS.md",
     "CLAUDE.md",
+    path.join(".github", "copilot-instructions.md"),
     "CONTEXT.md", // deprecated
   ]
   export async function custom() {


### PR DESCRIPTION
This adds [.github/copilot-instructions.md](https://code.visualstudio.com/docs/copilot/copilot-customization#_types-of-custom-instructions) to the list of custom files that the system prompt will search for. This file is used to provide instructions to Copilot in VS Code and may be nice to apply when using OpenCode.