### PR TITLE
Fix `undefined is not an object (evaluating 'G.title')`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -134,7 +134,7 @@ export const RunCommand = cmd({
               part.toolInvocation.toolName,
               UI.Style.TEXT_INFO_BOLD,
             ]
-            printEvent(color, tool, metadata.title)
+            printEvent(color, tool, metadata?.title || 'Unknown')
           }
 
           if (part.type === "text") {


### PR DESCRIPTION
When doing `opencode run 'Prompt'` I see:

```
TypeError: undefined is not an object (evaluating 'G.title')
```

I asked opencode to fix the error and it honed in on `metadata.title` here and added optional chaining. I don't see the error when testing with a local build.