### PR TITLE
fix: guard against large output limit causing infinite summarize loop

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -287,7 +287,10 @@ export namespace Session {
       if (
         model.info.limit.context &&
         tokens >
-          (model.info.limit.context - (model.info.limit.output ?? 0)) * 0.9
+          Math.max(
+            (model.info.limit.context - (model.info.limit.output ?? 0)) * 0.9,
+            0,
+          )
       ) {
         await summarize({
           sessionID: input.sessionID,


### PR DESCRIPTION
Attempt fixing https://github.com/sst/opencode/issues/262

Problem:
The auto summarize logic goes into infinite loop summarizing the previous conversation if model output limit ends up being larger than the context limit. 

Easy way to reproduce this is using a local model with such configuration. However, this could happen for other providers as well if the reported limits are faulty.
```json
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "lmstudio": {
      "npm": "@ai-sdk/openai-compatible",
      "options": {
        "baseURL": "http://localhost:8080/v1"
      },
      "models": {
        "qwen/qwen3-30b-a3b": {
          "limit": { "context": 131072, "output": 1000000 }
        },
        "mistralai/devstral-small-2505": {
          "limit": { "context": 131072, "output": 1000000 }
        }
      }
    }
  }
}
```

Solution:
Use 0 as minimum value for the limit calculation to avoid any possibility of that calculation resulting in negative number.