### PR TITLE
scripts/hooks: Change shebang to universal /bin/sh

### DIFF
--- a/scripts/hooks
+++ b/scripts/hooks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ ! -d ".git" ]; then
     exit 0


### PR DESCRIPTION
Not every Linux/Unix flavor has a /bin/bash (eg, NixOS). 