### PR TITLE
feat: provider selection

### DIFF
--- a/packages/opencode/src/cli/cmd/provider.ts
+++ b/packages/opencode/src/cli/cmd/provider.ts
@@ -1,0 +1,144 @@
+import { App } from "../../app/app"
+import { Provider } from "../../provider/provider"
+import { Config } from "../../config/config"
+import { UI } from "../ui"
+import { cmd } from "./cmd"
+import type { Argv } from "yargs"
+
+export const ProviderCommand = cmd({
+  command: "provider",
+  describe: "manage providers",
+  builder: (yargs: Argv) => {
+    return yargs
+      .command(
+        "list",
+        "list all available providers",
+        {},
+        async () => {
+          await App.provide({ cwd: process.cwd() }, async () => {
+            const providers = await Provider.list()
+            const config = await Config.get()
+            const currentModel = config.model ? Provider.parseModel(config.model) : null
+
+            UI.println(UI.Style.TEXT_NORMAL_BOLD + "Available Providers:")
+            UI.empty()
+
+            for (const [providerID, provider] of Object.entries(providers)) {
+              const modelCount = Object.keys(provider.info.models).length
+              const isCurrent = currentModel?.providerID === providerID
+              
+              const prefix = isCurrent ? "* " : "  "
+              const style = isCurrent ? UI.Style.TEXT_SUCCESS_BOLD : UI.Style.TEXT_NORMAL
+              
+              UI.println(
+                style + prefix + providerID,
+                UI.Style.TEXT_DIM + ` (${modelCount} models, ${provider.source})`
+              )
+            }
+          })
+        }
+      )
+      .command(
+        "current",
+        "show the current provider and model",
+        {},
+        async () => {
+          await App.provide({ cwd: process.cwd() }, async () => {
+            const config = await Config.get()
+            
+            if (!config.model) {
+              const defaultModel = await Provider.defaultModel()
+              UI.println(
+                UI.Style.TEXT_NORMAL_BOLD + "Current: ",
+                UI.Style.TEXT_NORMAL + `${defaultModel.providerID}/${defaultModel.modelID}`,
+                UI.Style.TEXT_DIM + " (default)"
+              )
+            } else {
+              const { providerID, modelID } = Provider.parseModel(config.model)
+              UI.println(
+                UI.Style.TEXT_NORMAL_BOLD + "Current: ",
+                UI.Style.TEXT_NORMAL + `${providerID}/${modelID}`,
+                UI.Style.TEXT_DIM + " (configured)"
+              )
+            }
+          })
+        }
+      )
+      .command(
+        "set <provider>",
+        "set the default provider",
+        (yargs) => {
+          return yargs
+            .positional("provider", {
+              type: "string",
+              describe: "provider ID to set as default",
+              demandOption: true,
+            })
+            .option("model", {
+              alias: "m",
+              type: "string",
+              describe: "specific model to use with this provider",
+            })
+        },
+        async (args) => {
+          await App.provide({ cwd: process.cwd() }, async () => {
+            const providers = await Provider.list()
+            const provider = providers[args.provider]
+            
+            if (!provider) {
+              UI.error(`Provider "${args.provider}" not found`)
+              UI.empty()
+              UI.println("Available providers:")
+              for (const providerID of Object.keys(providers)) {
+                UI.println("  " + providerID)
+              }
+              return
+            }
+
+            // Find the model to use
+            let modelID: string
+            if (args.model) {
+              // Check if the specified model exists
+              if (!provider.info.models[args.model]) {
+                UI.error(`Model "${args.model}" not found for provider "${args.provider}"`)
+                UI.empty()
+                UI.println("Available models:")
+                for (const model of Object.keys(provider.info.models)) {
+                  UI.println("  " + model)
+                }
+                return
+              }
+              modelID = args.model
+            } else {
+              // Use the default model for this provider
+              const models = Provider.sort(Object.values(provider.info.models))
+              if (models.length === 0) {
+                UI.error(`No models available for provider "${args.provider}"`)
+                return
+              }
+              modelID = models[0].id
+            }
+
+            // Update the global config
+            const configPath = await Config.global().then(() => 
+              App.info().path.config + "/config.json"
+            )
+            
+            const currentConfig = await Config.global()
+            currentConfig.model = `${args.provider}/${modelID}`
+            
+            await Bun.write(configPath, JSON.stringify(currentConfig, null, 2))
+            
+            UI.println(
+              UI.Style.TEXT_SUCCESS_BOLD + "Success: ",
+              UI.Style.TEXT_NORMAL + `Default provider set to: ${args.provider}/${modelID}`
+            )
+          })
+        }
+      )
+      .demandCommand(1, "You must specify a subcommand")
+  },
+  handler: () => {
+    // This is handled by subcommands
+  },
+})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -77,6 +77,7 @@ export namespace Config {
         .describe("Toggle compact mode for session"),
       tool_details: z.string().optional().describe("Show tool details"),
       model_list: z.string().optional().describe("List available models"),
+      provider_list: z.string().optional().describe("Switch provider"),
       theme_list: z.string().optional().describe("List available themes"),
       project_init: z
         .string()

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -8,6 +8,7 @@ import { Log } from "./util/log"
 import { AuthCommand } from "./cli/cmd/auth"
 import { UpgradeCommand } from "./cli/cmd/upgrade"
 import { ModelsCommand } from "./cli/cmd/models"
+import { ProviderCommand } from "./cli/cmd/provider"
 import { UI } from "./cli/ui"
 import { Installation } from "./installation"
 import { NamedError } from "./util/error"
@@ -54,6 +55,7 @@ const cli = yargs(hideBin(process.argv))
   .command(UpgradeCommand)
   .command(ServeCommand)
   .command(ModelsCommand)
+  .command(ProviderCommand)
   .fail((msg) => {
     if (
       msg.startsWith("Unknown argument") ||

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -16,6 +16,9 @@ import { ModelsDev } from "../provider/models"
 import { Ripgrep } from "../external/ripgrep"
 import { Installation } from "../installation"
 import { Config } from "../config/config"
+import { Auth } from "../auth"
+import { AuthAnthropic } from "../auth/anthropic"
+import { AuthCopilot } from "../auth/copilot"
 
 const ERRORS = {
   400: {
@@ -507,6 +510,235 @@ export namespace Server {
               (item) => Provider.sort(Object.values(item.models))[0].id,
             ),
           })
+        },
+      )
+      .post(
+        "/auth/providers",
+        describeRoute({
+          description: "List providers available for authentication",
+          responses: {
+            200: {
+              description: "List of providers",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.array(
+                      z.object({
+                        id: z.string(),
+                        name: z.string(),
+                        authType: z.enum(["oauth", "api", "env"]),
+                        authenticated: z.boolean(),
+                      }),
+                    ),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          const providers = await ModelsDev.get()
+          const authData = await Auth.all()
+          const priority: Record<string, number> = {
+            anthropic: 0,
+            "github-copilot": 1,
+            openai: 2,
+            google: 3,
+          }
+          
+          const authProviders = Object.entries(providers)
+            .filter(([id]) => id !== "amazon-bedrock") // Special case handled differently
+            .map(([id, provider]) => {
+              let authType: "oauth" | "api" | "env" = "api"
+              if (id === "anthropic" || id === "github-copilot") {
+                authType = "oauth"
+              } else if (id === "amazon-bedrock") {
+                authType = "env"
+              }
+              return {
+                id,
+                name: provider.name || id,
+                authType,
+                authenticated: !!authData[id],
+                priority: priority[id] ?? 99,
+              }
+            })
+            .sort((a, b) => a.priority - b.priority || a.name.localeCompare(b.name))
+            .map(({ priority, ...rest }) => rest)
+          
+          return c.json(authProviders)
+        },
+      )
+      .post(
+        "/auth/start",
+        describeRoute({
+          description: "Start OAuth authentication flow",
+          responses: {
+            200: {
+              description: "OAuth authorization URL",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      url: z.string(),
+                      verifier: z.string().optional(),
+                    }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        zValidator(
+          "json",
+          z.object({
+            providerId: z.string(),
+          }),
+        ),
+        async (c) => {
+          const { providerId } = c.req.valid("json")
+          
+          if (providerId === "anthropic") {
+            const result = await AuthAnthropic.authorize()
+            return c.json(result)
+          }
+          
+          if (providerId === "github-copilot") {
+            const copilot = await AuthCopilot()
+            if (!copilot) {
+              throw new Error("GitHub Copilot auth not available")
+            }
+            const deviceInfo = await copilot.authorize()
+            return c.json({
+              url: deviceInfo.verification,
+              verifier: deviceInfo.user,
+              deviceCode: deviceInfo.device,
+              interval: deviceInfo.interval,
+            })
+          }
+          
+          throw new Error(`OAuth not supported for provider: ${providerId}`)
+        },
+      )
+      .post(
+        "/auth/exchange",
+        describeRoute({
+          description: "Exchange OAuth code for tokens",
+          responses: {
+            200: {
+              description: "Authentication successful",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      success: z.boolean(),
+                    }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        zValidator(
+          "json",
+          z.object({
+            providerId: z.string(),
+            code: z.string(),
+            verifier: z.string().optional(),
+          }),
+        ),
+        async (c) => {
+          const { providerId, code, verifier } = c.req.valid("json")
+          
+          if (providerId === "anthropic") {
+            if (!verifier) {
+              throw new Error("Verifier required for Anthropic OAuth")
+            }
+            await AuthAnthropic.exchange(code, verifier)
+            return c.json({ success: true })
+          }
+          
+          throw new Error(`OAuth exchange not supported for provider: ${providerId}`)
+        },
+      )
+      .post(
+        "/auth/poll",
+        describeRoute({
+          description: "Poll GitHub Copilot device flow",
+          responses: {
+            200: {
+              description: "Poll status",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      status: z.enum(["pending", "success", "failed"]),
+                    }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        zValidator(
+          "json",
+          z.object({
+            deviceCode: z.string(),
+          }),
+        ),
+        async (c) => {
+          const { deviceCode } = c.req.valid("json")
+          const copilot = await AuthCopilot()
+          if (!copilot) {
+            throw new Error("GitHub Copilot auth not available")
+          }
+          
+          const response = await copilot.poll(deviceCode)
+          if (response.status === "success") {
+            await Auth.set("github-copilot", {
+              type: "oauth",
+              refresh: response.refresh,
+              access: response.access,
+              expires: response.expires,
+            })
+          }
+          
+          return c.json({ status: response.status })
+        },
+      )
+      .post(
+        "/auth/apikey",
+        describeRoute({
+          description: "Set API key for a provider",
+          responses: {
+            200: {
+              description: "API key set successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      success: z.boolean(),
+                    }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        zValidator(
+          "json",
+          z.object({
+            providerId: z.string(),
+            apiKey: z.string(),
+          }),
+        ),
+        async (c) => {
+          const { providerId, apiKey } = c.req.valid("json")
+          await Auth.set(providerId, {
+            type: "api",
+            key: apiKey,
+          })
+          return c.json({ success: true })
         },
       )
       .post(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -742,6 +742,37 @@ export namespace Server {
         },
       )
       .post(
+        "/auth/remove",
+        describeRoute({
+          description: "Remove authentication for a provider",
+          responses: {
+            200: {
+              description: "Authentication removed successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.object({
+                      success: z.boolean(),
+                    }),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        zValidator(
+          "json",
+          z.object({
+            providerId: z.string(),
+          }),
+        ),
+        async (c) => {
+          const { providerId } = c.req.valid("json")
+          await Auth.remove(providerId)
+          return c.json({ success: true })
+        },
+      )
+      .post(
         "/file_search",
         describeRoute({
           description: "Search for files",

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -177,9 +177,23 @@ func (a *App) InitializeProvider() tea.Cmd {
 			if provider.Id == a.State.Provider {
 				currentProvider = &provider
 
-				for _, model := range provider.Models {
-					if model.Id == a.State.Model {
-						currentModel = &model
+				// First check if we have a saved model for this provider
+				if savedModelId, exists := a.State.ProviderModels[provider.Id]; exists {
+					for _, model := range provider.Models {
+						if model.Id == savedModelId {
+							currentModel = &model
+							break
+						}
+					}
+				}
+				
+				// If no saved model found, use the current global model
+				if currentModel == nil {
+					for _, model := range provider.Models {
+						if model.Id == a.State.Model {
+							currentModel = &model
+							break
+						}
 					}
 				}
 			}
@@ -445,6 +459,31 @@ func (a *App) ListProviders(ctx context.Context) ([]client.ProviderInfo, error) 
 
 	providers := *resp.JSON200
 	return providers.Providers, nil
+}
+
+func (a *App) ListAuthProviders(ctx context.Context) ([]struct {
+	AuthType      client.PostAuthProviders200AuthType `json:"authType"`
+	Authenticated bool                                `json:"authenticated"`
+	Id            string                              `json:"id"`
+	Name          string                              `json:"name"`
+}, error) {
+	resp, err := a.Client.PostAuthProvidersWithResponse(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() != 200 {
+		return nil, fmt.Errorf("failed to list auth providers: %d", resp.StatusCode())
+	}
+	if resp.JSON200 == nil {
+		return []struct {
+			AuthType      client.PostAuthProviders200AuthType `json:"authType"`
+			Authenticated bool                                `json:"authenticated"`
+			Id            string                              `json:"id"`
+			Name          string                              `json:"name"`
+		}{}, nil
+	}
+
+	return *resp.JSON200, nil
 }
 
 // func (a *App) loadCustomKeybinds() {

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -79,6 +79,7 @@ const (
 	SessionCompactCommand       CommandName = "session_compact"
 	ToolDetailsCommand          CommandName = "tool_details"
 	ModelListCommand            CommandName = "model_list"
+	ProviderListCommand         CommandName = "provider_list"
 	ThemeListCommand            CommandName = "theme_list"
 	ProjectInitCommand          CommandName = "project_init"
 	InputClearCommand           CommandName = "input_clear"
@@ -177,6 +178,12 @@ func LoadFromConfig(config *client.ConfigInfo) CommandRegistry {
 			Description: "list models",
 			Keybindings: parseBindings("<leader>m"),
 			Trigger:     "models",
+		},
+		{
+			Name:        ProviderListCommand,
+			Description: "switch provider",
+			Keybindings: parseBindings("<leader>p"),
+			Trigger:     "providers",
 		},
 		{
 			Name:        ThemeListCommand,

--- a/packages/tui/internal/components/dialog/auth_api_key.go
+++ b/packages/tui/internal/components/dialog/auth_api_key.go
@@ -1,0 +1,174 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	"github.com/charmbracelet/bubbles/v2/textinput"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/components/toast"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/styles"
+	"github.com/sst/opencode/internal/theme"
+	"github.com/sst/opencode/internal/util"
+	"github.com/sst/opencode/pkg/client"
+)
+
+// AuthAPIKeyDialog shows API key input for a provider
+type AuthAPIKeyDialog interface {
+	layout.Modal
+}
+
+type authAPIKeyDialog struct {
+	app        *app.App
+	provider   AuthProviderInfo
+	modal      *modal.Modal
+	textInput  textinput.Model
+	submitting bool
+}
+
+type authAPIKeyKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+var authAPIKeyKeys = authAPIKeyKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "submit"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+// AuthSuccessMsg is sent when authentication succeeds
+type AuthSuccessMsg struct {
+	ProviderID string
+}
+
+func (d *authAPIKeyDialog) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (d *authAPIKeyDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if d.submitting {
+			return d, nil // Ignore input while submitting
+		}
+		
+		switch {
+		case key.Matches(msg, authAPIKeyKeys.Enter):
+			apiKey := d.textInput.Value()
+			if apiKey == "" {
+				return d, toast.NewErrorToast("API key cannot be empty")
+			}
+			
+			d.submitting = true
+			return d, d.submitAPIKey(apiKey)
+			
+		case key.Matches(msg, authAPIKeyKeys.Escape):
+			return d, util.CmdHandler(modal.CloseModalMsg{})
+		}
+		
+	case AuthSuccessMsg:
+		// Close modal and forward the success message to the main handler
+		return d, tea.Sequence(
+			util.CmdHandler(modal.CloseModalMsg{}),
+			util.CmdHandler(msg), // Forward the AuthSuccessMsg
+		)
+		
+	case error:
+		d.submitting = false
+		return d, toast.NewErrorToast(fmt.Sprintf("Authentication failed: %s", msg.Error()))
+	}
+
+	// Only update text input if not submitting
+	if !d.submitting {
+		d.textInput, cmd = d.textInput.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return d, tea.Batch(cmds...)
+}
+
+func (d *authAPIKeyDialog) submitAPIKey(apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := d.app.Client.PostAuthApikeyWithResponse(
+			context.Background(),
+			client.PostAuthApikeyJSONRequestBody{
+				ProviderId: d.provider.Id,
+				ApiKey:     apiKey,
+			},
+		)
+		
+		if err != nil {
+			return err
+		}
+		
+		if resp.StatusCode() != 200 {
+			return fmt.Errorf("failed with status %d", resp.StatusCode())
+		}
+		
+		return AuthSuccessMsg{ProviderID: d.provider.Id}
+	}
+}
+
+func (d *authAPIKeyDialog) View() string {
+	t := theme.CurrentTheme()
+	
+	content := []string{
+		styles.NewStyle().
+			Foreground(t.TextMuted()).
+			MarginBottom(1).
+			Render(fmt.Sprintf("Enter API key for %s", d.provider.Name)),
+		"",
+		d.textInput.View(),
+	}
+	
+	if d.submitting {
+		content = append(content, "", styles.NewStyle().
+			Foreground(t.TextMuted()).
+			Italic(true).
+			Render("Authenticating..."))
+	}
+	
+	return lipgloss.JoinVertical(lipgloss.Left, content...)
+}
+
+func (d *authAPIKeyDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *authAPIKeyDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewAuthAPIKeyDialog(app *app.App, provider AuthProviderInfo) AuthAPIKeyDialog {
+	ti := textinput.New()
+	ti.Placeholder = "sk-..."
+	ti.Focus()
+	ti.CharLimit = 200
+	ti.SetWidth(40)
+	ti.Prompt = ""
+	ti.EchoMode = textinput.EchoPassword
+	
+	return &authAPIKeyDialog{
+		app:       app,
+		provider:  provider,
+		textInput: ti,
+		modal: modal.New(
+			modal.WithTitle("Enter API Key"),
+			modal.WithMaxWidth(44),
+		),
+	}
+}

--- a/packages/tui/internal/components/dialog/auth_method_select.go
+++ b/packages/tui/internal/components/dialog/auth_method_select.go
@@ -1,0 +1,119 @@
+package dialog
+
+import (
+	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/list"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/util"
+)
+
+// AuthMethodSelectDialog shows login method selection for Anthropic
+type AuthMethodSelectDialog interface {
+	layout.Modal
+}
+
+type authMethodSelectDialog struct {
+	app          *app.App
+	provider     AuthProviderInfo
+	modal        *modal.Modal
+	methodList   list.List[list.StringItem]
+}
+
+// StartOAuthFlowMsg is sent when OAuth is selected for Anthropic
+type StartOAuthFlowMsg struct {
+	Provider AuthProviderInfo
+}
+
+// StartAPIKeyFlowMsg is sent when API key is selected for Anthropic
+type StartAPIKeyFlowMsg struct {
+	Provider AuthProviderInfo
+}
+
+type authMethodKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+var authMethodKeys = authMethodKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "select method"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+func (d *authMethodSelectDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *authMethodSelectDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, authMethodKeys.Enter):
+			_, idx := d.methodList.GetSelectedItem()
+			if idx == -1 {
+				return d, nil
+			}
+			
+			// 0 = Claude Pro/Max (OAuth), 1 = API Key
+			if idx == 0 {
+				return d, tea.Sequence(
+					util.CmdHandler(modal.CloseModalMsg{}),
+					util.CmdHandler(StartOAuthFlowMsg{Provider: d.provider}),
+				)
+			} else {
+				return d, tea.Sequence(
+					util.CmdHandler(modal.CloseModalMsg{}),
+					util.CmdHandler(StartAPIKeyFlowMsg{Provider: d.provider}),
+				)
+			}
+			
+		case key.Matches(msg, authMethodKeys.Escape):
+			return d, util.CmdHandler(modal.CloseModalMsg{})
+		}
+	}
+
+	// Update the list component
+	updatedList, cmd := d.methodList.Update(msg)
+	d.methodList = updatedList.(list.List[list.StringItem])
+	return d, cmd
+}
+
+func (d *authMethodSelectDialog) View() string {
+	return d.methodList.View()
+}
+
+func (d *authMethodSelectDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *authMethodSelectDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewAuthMethodSelectDialog(app *app.App, provider AuthProviderInfo) AuthMethodSelectDialog {
+	methods := []string{
+		"Claude Pro/Max",
+		"API Key",
+	}
+	
+	methodList := list.NewStringList(methods, 2, "", true)
+	methodList.SetMaxWidth(30)
+	
+	return &authMethodSelectDialog{
+		app:        app,
+		provider:   provider,
+		methodList: methodList,
+		modal: modal.New(
+			modal.WithTitle("Login Method"),
+			modal.WithMaxWidth(34),
+		),
+	}
+}

--- a/packages/tui/internal/components/dialog/auth_oauth.go
+++ b/packages/tui/internal/components/dialog/auth_oauth.go
@@ -1,0 +1,451 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	"github.com/charmbracelet/bubbles/v2/spinner"
+	"github.com/charmbracelet/bubbles/v2/textinput"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/components/toast"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/styles"
+	"github.com/sst/opencode/internal/theme"
+	"github.com/sst/opencode/internal/util"
+	"github.com/sst/opencode/pkg/client"
+)
+
+// AuthOAuthDialog handles OAuth authentication flow
+type AuthOAuthDialog interface {
+	layout.Modal
+}
+
+type authOAuthDialog struct {
+	app             *app.App
+	provider        AuthProviderInfo
+	modal           *modal.Modal
+	state           oauthState
+	authURL         string
+	deviceCode      string
+	userCode        string
+	pollInterval    int
+	spinner         spinner.Model
+	codeInput       textinput.Model
+	showAnthropicInput bool
+}
+
+type oauthState int
+
+const (
+	oauthStateInit oauthState = iota
+	oauthStateWaitingForAuth
+	oauthStateAnthropicCode
+	oauthStatePolling
+	oauthStateSuccess
+	oauthStateError
+)
+
+type authOAuthKeyMap struct {
+	Enter  key.Binding
+	Copy   key.Binding
+	Escape key.Binding
+}
+
+var authOAuthKeys = authOAuthKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "submit"),
+	),
+	Copy: key.NewBinding(
+		key.WithKeys("c"),
+		key.WithHelp("c", "copy URL"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+type pollTickMsg time.Time
+
+type oauthStartResponse struct {
+	url, verifier, deviceCode string
+	interval                  int
+}
+
+func (d *authOAuthDialog) Init() tea.Cmd {
+	return tea.Batch(
+		d.startOAuth(), 
+		d.spinner.Tick,
+		// Add a timeout for the initial auth request
+		tea.Tick(10*time.Second, func(t time.Time) tea.Msg {
+			if d.state == oauthStateInit {
+				return fmt.Errorf("authentication request timed out")
+			}
+			return nil
+		}),
+	)
+}
+
+func (d *authOAuthDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch d.state {
+		case oauthStateWaitingForAuth:
+			switch {
+			case key.Matches(msg, authOAuthKeys.Copy):
+				return d, tea.SetClipboard(d.authURL)
+			case key.Matches(msg, authOAuthKeys.Escape):
+				return d, util.CmdHandler(modal.CloseModalMsg{})
+			}
+			
+		case oauthStateAnthropicCode:
+			switch {
+			case key.Matches(msg, authOAuthKeys.Enter):
+				code := d.codeInput.Value()
+				if code != "" {
+					d.state = oauthStatePolling
+					return d, d.exchangeAnthropicCode(code)
+				}
+			case key.Matches(msg, authOAuthKeys.Escape):
+				return d, util.CmdHandler(modal.CloseModalMsg{})
+			}
+			
+		case oauthStatePolling, oauthStateSuccess:
+			if key.Matches(msg, authOAuthKeys.Escape) {
+				return d, util.CmdHandler(modal.CloseModalMsg{})
+			}
+		}
+		
+	case pollTickMsg:
+		if d.state == oauthStatePolling && d.provider.Id == "github-copilot" {
+			return d, d.pollDeviceAuth()
+		}
+		
+	case spinner.TickMsg:
+		d.spinner, cmd = d.spinner.Update(msg)
+		cmds = append(cmds, cmd)
+		
+	case AuthSuccessMsg:
+		d.state = oauthStateSuccess
+		// Close immediately and forward the success message
+		return d, tea.Sequence(
+			util.CmdHandler(modal.CloseModalMsg{}),
+			util.CmdHandler(msg), // Forward the AuthSuccessMsg
+		)
+		
+	case error:
+		d.state = oauthStateError
+		return d, toast.NewErrorToast(fmt.Sprintf("Authentication failed: %s", msg.Error()))
+		
+	case oauthStartResponse:
+		// OAuth start response
+		d.authURL = msg.url
+		d.userCode = msg.verifier
+		d.deviceCode = msg.deviceCode
+		d.pollInterval = msg.interval
+		
+		if d.provider.Id == "anthropic" {
+			// Anthropic needs code input after visiting URL
+			d.state = oauthStateAnthropicCode
+			d.showAnthropicInput = true
+			d.codeInput.Focus()
+			cmds = append(cmds, textinput.Blink)
+		} else if d.provider.Id == "github-copilot" {
+			// GitHub Copilot uses device flow
+			d.state = oauthStateWaitingForAuth
+			if d.userCode != "" { // userCode contains the user verification code
+				d.state = oauthStatePolling
+				interval := d.pollInterval
+				if interval == 0 {
+					interval = 5 // default
+				}
+				cmds = append(cmds, tea.Tick(time.Duration(interval)*time.Second, func(t time.Time) tea.Msg {
+					return pollTickMsg(t)
+				}))
+			}
+		} else {
+			// For other OAuth providers, just show the URL
+			d.state = oauthStateWaitingForAuth
+		}
+		
+		// Try to copy URL to clipboard
+		cmds = append(cmds, tea.SetClipboard(d.authURL))
+	}
+
+	if d.showAnthropicInput {
+		d.codeInput, cmd = d.codeInput.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return d, tea.Batch(cmds...)
+}
+
+func (d *authOAuthDialog) startOAuth() tea.Cmd {
+	return func() tea.Msg {
+		resp, err := d.app.Client.PostAuthStartWithResponse(
+			context.Background(),
+			client.PostAuthStartJSONRequestBody{
+				ProviderId: d.provider.Id,
+			},
+		)
+		
+		if err != nil {
+			return err
+		}
+		
+		if resp.StatusCode() != 200 {
+			return fmt.Errorf("failed with status %d", resp.StatusCode())
+		}
+		
+		if resp.JSON200 == nil {
+			return fmt.Errorf("empty response from auth start")
+		}
+		
+		result := oauthStartResponse{
+			url: resp.JSON200.Url,
+		}
+		
+		// Check if URL is empty
+		if result.url == "" {
+			return fmt.Errorf("no authentication URL provided")
+		}
+		
+		// Extract verifier if present
+		if resp.JSON200.Verifier != nil {
+			result.verifier = *resp.JSON200.Verifier
+		}
+		
+		// For GitHub Copilot, the verifier field contains the user code to display
+		// We'll need to extract deviceCode from the raw response if needed
+		if d.provider.Id == "github-copilot" {
+			// The verifier contains the user code to display to the user
+			// For polling, we can try using the verifier as the device code
+			result.deviceCode = result.verifier
+			result.interval = 5 // default polling interval
+		}
+		
+		return result
+	}
+}
+
+func (d *authOAuthDialog) exchangeAnthropicCode(code string) tea.Cmd {
+	return func() tea.Msg {
+		resp, err := d.app.Client.PostAuthExchangeWithResponse(
+			context.Background(),
+			client.PostAuthExchangeJSONRequestBody{
+				ProviderId: d.provider.Id,
+				Code:       code,
+				Verifier:   &d.userCode,
+			},
+		)
+		
+		if err != nil {
+			return err
+		}
+		
+		if resp.StatusCode() != 200 {
+			return fmt.Errorf("invalid authorization code")
+		}
+		
+		return AuthSuccessMsg{ProviderID: d.provider.Id}
+	}
+}
+
+func (d *authOAuthDialog) pollDeviceAuth() tea.Cmd {
+	return func() tea.Msg {
+		// For GitHub Copilot, we need to use the verifier as the device code
+		// since the actual deviceCode isn't exposed in the generated client
+		deviceCode := d.deviceCode
+		if deviceCode == "" && d.provider.Id == "github-copilot" {
+			deviceCode = d.userCode // Use verifier as device code
+		}
+		
+		resp, err := d.app.Client.PostAuthPollWithResponse(
+			context.Background(),
+			client.PostAuthPollJSONRequestBody{
+				DeviceCode: deviceCode,
+			},
+		)
+		
+		if err != nil {
+			return err
+		}
+		
+		if resp.StatusCode() != 200 {
+			return fmt.Errorf("polling failed")
+		}
+		
+		switch resp.JSON200.Status {
+		case "success":
+			return AuthSuccessMsg{ProviderID: d.provider.Id}
+		case "failed":
+			return fmt.Errorf("authorization failed")
+		case "pending":
+			// Continue polling
+			return tea.Tick(time.Duration(d.pollInterval)*time.Second, func(t time.Time) tea.Msg {
+				return pollTickMsg(t)
+			})
+		}
+		
+		return nil
+	}
+}
+
+func (d *authOAuthDialog) View() string {
+	t := theme.CurrentTheme()
+	var content []string
+	
+	switch d.state {
+	case oauthStateInit:
+		content = append(content,
+			d.spinner.View()+" Starting authentication...",
+		)
+		
+	case oauthStateWaitingForAuth, oauthStatePolling:
+		if d.authURL != "" {
+			if d.provider.Id == "github-copilot" && d.userCode != "" {
+				content = append(content,
+					styles.NewStyle().
+						Foreground(t.Text()).
+						MarginBottom(1).
+						Render("Please visit:"),
+					styles.NewStyle().
+						Foreground(t.Primary()).
+						Bold(true).
+						Render(d.authURL),
+					"",
+					styles.NewStyle().
+						Foreground(t.Text()).
+						Render("Enter code:"),
+					styles.NewStyle().
+						Foreground(t.Primary()).
+						Bold(true).
+						Render(d.userCode),
+				)
+				
+				if d.state == oauthStatePolling {
+					content = append(content, "",
+						d.spinner.View()+" Waiting for authorization...",
+					)
+				}
+			} else {
+				content = append(content,
+					styles.NewStyle().
+						Foreground(t.Text()).
+						MarginBottom(1).
+						Render("Please visit this URL to authenticate:"),
+					styles.NewStyle().
+						Foreground(t.Primary()).
+						Bold(true).
+						Render(d.authURL),
+				)
+			}
+		} else {
+			content = append(content,
+				styles.NewStyle().
+					Foreground(t.Error()).
+					Render("Error: No authentication URL received"),
+			)
+		}
+		
+		content = append(content, "",
+			styles.NewStyle().
+				Foreground(t.TextMuted()).
+				Italic(true).
+				Render("Press 'c' to copy URL | ESC to cancel"),
+		)
+		
+	case oauthStateAnthropicCode:
+		content = append(content,
+			styles.NewStyle().
+				Foreground(t.Text()).
+				MarginBottom(1).
+				Render("Visit this URL in your browser:"),
+			"",
+			// Display URL in a code block style for better visibility
+			styles.NewStyle().
+				Foreground(t.Primary()).
+				Background(t.BackgroundPanel()).
+				Padding(1).
+				Width(76).
+				Render(d.authURL),
+			"",
+			styles.NewStyle().
+				Foreground(t.TextMuted()).
+				Italic(true).
+				Render("(URL copied to clipboard)"),
+			"",
+			styles.NewStyle().
+				Foreground(t.Text()).
+				Render("Then paste the authorization code:"),
+			"",
+			d.codeInput.View(),
+			"",
+			styles.NewStyle().
+				Foreground(t.TextMuted()).
+				Italic(true).
+				Render("Press Enter to submit | Ctrl+V to paste"),
+		)
+		
+	case oauthStateSuccess:
+		content = append(content,
+			styles.NewStyle().
+				Foreground(t.Success()).
+				Bold(true).
+				Render("✓ Authentication successful!"),
+		)
+		
+	case oauthStateError:
+		content = append(content,
+			styles.NewStyle().
+				Foreground(t.Error()).
+				Render("Authentication failed"),
+		)
+	}
+	
+	return lipgloss.JoinVertical(lipgloss.Left, content...)
+}
+
+func (d *authOAuthDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *authOAuthDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewAuthOAuthDialog(app *app.App, provider AuthProviderInfo) AuthOAuthDialog {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(theme.CurrentTheme().Primary())
+	
+	ti := textinput.New()
+	ti.Placeholder = "Paste code here"
+	ti.Focus()
+	ti.CharLimit = 200
+	ti.SetWidth(70)
+	ti.Prompt = "> "
+	
+	title := fmt.Sprintf("Authenticate %s", provider.Name)
+	
+	return &authOAuthDialog{
+		app:       app,
+		provider:  provider,
+		spinner:   s,
+		codeInput: ti,
+		state:     oauthStateInit,
+		modal: modal.New(
+			modal.WithTitle(title),
+			modal.WithMaxWidth(80),
+		),
+	}
+}

--- a/packages/tui/internal/components/dialog/auth_provider_select.go
+++ b/packages/tui/internal/components/dialog/auth_provider_select.go
@@ -1,0 +1,133 @@
+package dialog
+
+import (
+	"context"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/list"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/util"
+	"github.com/sst/opencode/pkg/client"
+)
+
+// AuthProviderSelectDialog shows unauthenticated providers for selection
+type AuthProviderSelectDialog interface {
+	layout.Modal
+}
+
+type authProviderSelectDialog struct {
+	app               *app.App
+	authProviders     []AuthProviderInfo
+	modal             *modal.Modal
+	providerList      list.List[list.StringItem]
+}
+
+// AuthProviderInfo holds provider information for authentication
+type AuthProviderInfo struct {
+	Id       string
+	Name     string
+	AuthType client.PostAuthProviders200AuthType
+}
+
+// StartAuthFlowMsg is sent when a provider is selected for authentication
+type StartAuthFlowMsg struct {
+	Provider AuthProviderInfo
+}
+
+type authProviderSelectKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+var authProviderSelectKeys = authProviderSelectKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "select provider"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+func (d *authProviderSelectDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *authProviderSelectDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, authProviderSelectKeys.Enter):
+			_, idx := d.providerList.GetSelectedItem()
+			if idx == -1 || idx >= len(d.authProviders) {
+				return d, nil
+			}
+			
+			selectedProvider := d.authProviders[idx]
+			return d, tea.Sequence(
+				util.CmdHandler(modal.CloseModalMsg{}),
+				util.CmdHandler(StartAuthFlowMsg{Provider: selectedProvider}),
+			)
+			
+		case key.Matches(msg, authProviderSelectKeys.Escape):
+			return d, util.CmdHandler(modal.CloseModalMsg{})
+		}
+	}
+
+	// Update the list component
+	updatedList, cmd := d.providerList.Update(msg)
+	d.providerList = updatedList.(list.List[list.StringItem])
+	return d, cmd
+}
+
+func (d *authProviderSelectDialog) View() string {
+	return d.providerList.View()
+}
+
+func (d *authProviderSelectDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *authProviderSelectDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewAuthProviderSelectDialog(app *app.App) AuthProviderSelectDialog {
+	// Fetch auth providers and filter unauthenticated ones
+	authProviderList, _ := app.ListAuthProviders(context.Background())
+	
+	var unauthProviders []AuthProviderInfo
+	var providerNames []string
+	
+	for _, provider := range authProviderList {
+		if !provider.Authenticated {
+			unauthProviders = append(unauthProviders, AuthProviderInfo{
+				Id:       provider.Id,
+				Name:     provider.Name,
+				AuthType: provider.AuthType,
+			})
+			providerNames = append(providerNames, provider.Name)
+		}
+	}
+	
+	if len(providerNames) == 0 {
+		providerNames = append(providerNames, "All providers are authenticated")
+	}
+	
+	providerList := list.NewStringList(providerNames, 8, "No providers to add", true)
+	providerList.SetMaxWidth(40)
+	
+	return &authProviderSelectDialog{
+		app:           app,
+		authProviders: unauthProviders,
+		providerList:  providerList,
+		modal: modal.New(
+			modal.WithTitle("Add Provider"),
+			modal.WithMaxWidth(44),
+		),
+	}
+}

--- a/packages/tui/internal/components/dialog/confirm_remove_provider.go
+++ b/packages/tui/internal/components/dialog/confirm_remove_provider.go
@@ -1,0 +1,146 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/components/toast"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/styles"
+	"github.com/sst/opencode/internal/theme"
+	"github.com/sst/opencode/internal/util"
+	"github.com/sst/opencode/pkg/client"
+)
+
+// ConfirmRemoveProviderDialog interface for the confirmation dialog
+type ConfirmRemoveProviderDialog interface {
+	layout.Modal
+}
+
+type confirmRemoveProviderDialog struct {
+	app      *app.App
+	provider AuthProviderInfo
+	modal    *modal.Modal
+}
+
+type confirmRemoveKeyMap struct {
+	Yes    key.Binding
+	No     key.Binding
+	Escape key.Binding
+}
+
+var confirmRemoveKeys = confirmRemoveKeyMap{
+	Yes: key.NewBinding(
+		key.WithKeys("y"),
+		key.WithHelp("y", "confirm"),
+	),
+	No: key.NewBinding(
+		key.WithKeys("n"),
+		key.WithHelp("n", "cancel"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+func (d *confirmRemoveProviderDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *confirmRemoveProviderDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, confirmRemoveKeys.Yes):
+			// Remove the provider
+			return d, d.removeProvider()
+			
+		case key.Matches(msg, confirmRemoveKeys.No), key.Matches(msg, confirmRemoveKeys.Escape):
+			return d, util.CmdHandler(modal.CloseModalMsg{})
+		}
+	}
+	return d, nil
+}
+
+func (d *confirmRemoveProviderDialog) removeProvider() tea.Cmd {
+	return func() tea.Msg {
+		// Call the auth remove endpoint
+		resp, err := d.app.Client.PostAuthRemoveWithResponse(
+			context.Background(),
+			client.PostAuthRemoveJSONRequestBody{
+				ProviderId: d.provider.Id,
+			},
+		)
+		
+		if err != nil {
+			return toast.NewErrorToast(fmt.Sprintf("Failed to remove provider: %s", err.Error()))
+		}
+		
+		if resp.StatusCode() != 200 {
+			return toast.NewErrorToast(fmt.Sprintf("Failed to remove provider: status %d", resp.StatusCode()))
+		}
+		
+		return ProviderRemovedMsg{ProviderID: d.provider.Id}
+	}
+}
+
+func (d *confirmRemoveProviderDialog) View() string {
+	t := theme.CurrentTheme()
+	
+	content := []string{
+		styles.NewStyle().
+			Foreground(t.Warning()).
+			Bold(true).
+			Render("⚠ Warning"),
+		"",
+		fmt.Sprintf("Are you sure you want to remove %s?", d.provider.Name),
+		"",
+		styles.NewStyle().
+			Foreground(t.TextMuted()).
+			Render("This will delete your authentication credentials."),
+		styles.NewStyle().
+			Foreground(t.TextMuted()).
+			Render("You'll need to re-authenticate to use this provider again."),
+		"",
+		"",
+		lipgloss.JoinHorizontal(
+			lipgloss.Left,
+			styles.NewStyle().
+				Foreground(t.Success()).
+				Bold(true).
+				Render("[y] Yes"),
+			"    ",
+			styles.NewStyle().
+				Foreground(t.Error()).
+				Bold(true).
+				Render("[n] No"),
+		),
+	}
+	
+	return lipgloss.JoinVertical(lipgloss.Left, content...)
+}
+
+func (d *confirmRemoveProviderDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *confirmRemoveProviderDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewConfirmRemoveProviderDialog(app *app.App, provider AuthProviderInfo) ConfirmRemoveProviderDialog {
+	return &confirmRemoveProviderDialog{
+		app:      app,
+		provider: provider,
+		modal: modal.New(
+			modal.WithTitle("Confirm Remove Provider"),
+			modal.WithMaxWidth(50),
+		),
+	}
+}

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -149,20 +149,25 @@ func (m *modelDialog) View() string {
 }
 
 func (m *modelDialog) getScrollIndicators(maxWidth int) string {
-	var indicator string
-	if m.hScrollPossible {
-		indicator = "← → (switch provider) "
-	}
-	if indicator == "" {
-		return ""
-	}
-
 	t := theme.CurrentTheme()
-	return styles.NewStyle().
-		Foreground(t.TextMuted()).
-		Width(maxWidth).
-		Align(lipgloss.Right).
-		Render(indicator)
+	
+	// Show current provider position
+	providerInfo := ""
+	if m.hScrollPossible {
+		providerInfo = fmt.Sprintf("Provider %d/%d", m.hScrollOffset+1, len(m.availableProviders))
+		indicator := "← → (switch provider)"
+		
+		// Combine provider info and navigation help
+		fullText := fmt.Sprintf("%s  %s", providerInfo, indicator)
+		
+		return styles.NewStyle().
+			Foreground(t.TextMuted()).
+			Width(maxWidth).
+			Align(lipgloss.Right).
+			Render(fullText)
+	}
+	
+	return ""
 }
 
 func (m *modelDialog) setupModelsForProvider(providerId string) {

--- a/packages/tui/internal/components/dialog/providers.go
+++ b/packages/tui/internal/components/dialog/providers.go
@@ -1,0 +1,227 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/list"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/components/toast"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/theme"
+	"github.com/sst/opencode/internal/util"
+	"github.com/sst/opencode/pkg/client"
+)
+
+const (
+	numVisibleProviders = 8
+	maxProviderDialogWidth = 50
+)
+
+// AddProviderRequestMsg is sent when user wants to add a new provider
+type AddProviderRequestMsg struct{}
+
+// ShowProviderDialogMsg is sent to show the provider dialog
+type ShowProviderDialogMsg struct{}
+
+// ProviderDialog interface for the provider selection dialog
+type ProviderDialog interface {
+	layout.Modal
+}
+
+type providerDialog struct {
+	app               *app.App
+	availableProviders []client.ProviderInfo
+	authProviders     map[string]bool // provider ID -> authenticated status
+	width             int
+	height            int
+	modal             *modal.Modal
+	providerList      list.List[list.StringItem]
+}
+
+type providerKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+var providerKeys = providerKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "select provider"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "close"),
+	),
+}
+
+func (p *providerDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (p *providerDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, providerKeys.Enter):
+			_, idx := p.providerList.GetSelectedItem()
+			if idx == -1 {
+				return p, nil
+			}
+			
+			// Check if "Add new provider" was selected
+			if idx == len(p.availableProviders) {
+				return p, tea.Sequence(
+					util.CmdHandler(modal.CloseModalMsg{}),
+					util.CmdHandler(AddProviderRequestMsg{}),
+				)
+			}
+			
+			// Find the selected provider (index-based since we have formatted strings)
+			selectedProvider := p.availableProviders[idx]
+			
+			// Check if the provider is authenticated
+			isAuthenticated, exists := p.authProviders[selectedProvider.Id]
+			if !exists || !isAuthenticated {
+				// Provider not authenticated, show option to add auth
+				return p, tea.Sequence(
+					util.CmdHandler(modal.CloseModalMsg{}),
+					util.CmdHandler(AddProviderRequestMsg{}),
+					toast.NewWarningToast(fmt.Sprintf("%s requires authentication", selectedProvider.Name)),
+				)
+			}
+			
+			// Get the default model for this provider
+			models := slices.SortedFunc(maps.Values(selectedProvider.Models), func(a, b client.ModelInfo) int {
+				return strings.Compare(a.Name, b.Name)
+			})
+			
+			if len(models) == 0 {
+				return p, util.CmdHandler(modal.CloseModalMsg{})
+			}
+			
+			// Check if we have a saved model for this provider
+			var selectedModel client.ModelInfo
+			if savedModelId, exists := p.app.State.ProviderModels[selectedProvider.Id]; exists {
+				// Look for the saved model
+				for _, model := range models {
+					if model.Id == savedModelId {
+						selectedModel = model
+						break
+					}
+				}
+			}
+			
+			// If no saved model found, use the first model as default
+			if selectedModel.Id == "" {
+				selectedModel = models[0]
+			}
+			
+			return p, tea.Sequence(
+				util.CmdHandler(modal.CloseModalMsg{}),
+				util.CmdHandler(
+					app.ModelSelectedMsg{
+						Provider: selectedProvider,
+						Model:    selectedModel,
+					}),
+			)
+		case key.Matches(msg, providerKeys.Escape):
+			return p, util.CmdHandler(modal.CloseModalMsg{})
+		}
+	case tea.WindowSizeMsg:
+		p.width = msg.Width
+		p.height = msg.Height
+	}
+
+	// Update the list component
+	updatedList, cmd := p.providerList.Update(msg)
+	p.providerList = updatedList.(list.List[list.StringItem])
+	return p, cmd
+}
+
+func (p *providerDialog) View() string {
+	return p.providerList.View()
+}
+
+func (p *providerDialog) Render(background string) string {
+	return p.modal.Render(p.View(), background)
+}
+
+func (p *providerDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewProviderDialog(app *app.App) ProviderDialog {
+	availableProviders, err := app.ListProviders(context.Background())
+	if err != nil {
+		slog.Error("Failed to list providers", "error", err)
+	}
+	slog.Debug("Provider dialog: fetched providers", "count", len(availableProviders))
+	
+	// Fetch auth provider data to get authentication status
+	authProviders := make(map[string]bool)
+	authProviderList, err := app.ListAuthProviders(context.Background())
+	if err != nil {
+		slog.Error("Failed to list auth providers", "error", err)
+	}
+	for _, authProvider := range authProviderList {
+		authProviders[authProvider.Id] = authProvider.Authenticated
+	}
+	
+	// Sort providers by name
+	slices.SortFunc(availableProviders, func(a, b client.ProviderInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	
+	// Create provider names list with model count and auth status
+	providerNames := make([]string, len(availableProviders)+1)  // +1 for "Add new provider"
+	t := theme.CurrentTheme()
+	for i, provider := range availableProviders {
+		modelCount := len(provider.Models)
+		authStatus := " "
+		if authenticated, exists := authProviders[provider.Id]; exists && authenticated {
+			// Green dot for authenticated providers
+			authStatus = lipgloss.NewStyle().Foreground(t.Success()).Render("● ") 
+		} else {
+			// Hollow dot for unauthenticated providers
+			authStatus = lipgloss.NewStyle().Foreground(t.TextMuted()).Render("○ ")
+		}
+		providerNames[i] = fmt.Sprintf("%s%s (%d models)", authStatus, provider.Name, modelCount)
+	}
+	// Add the "Add new provider" option at the end
+	providerNames[len(availableProviders)] = "→ Add new provider..."
+	
+	providerList := list.NewStringList(providerNames, numVisibleProviders, "No providers available", true)
+	providerList.SetMaxWidth(maxProviderDialogWidth)
+	
+	// Set the current provider as selected
+	if app.Provider != nil {
+		for i, provider := range availableProviders {
+			if provider.Id == app.Provider.Id {
+				providerList.SetSelectedIndex(i)
+				break
+			}
+		}
+	}
+	
+	dialog := &providerDialog{
+		app:                app,
+		availableProviders: availableProviders,
+		authProviders:      authProviders,
+		providerList:      providerList,
+		modal: modal.New(
+			modal.WithTitle("Select Provider"),
+			modal.WithMaxWidth(maxProviderDialogWidth+4),
+		),
+	}
+	
+	return dialog
+}

--- a/packages/tui/internal/components/dialog/providers.go
+++ b/packages/tui/internal/components/dialog/providers.go
@@ -29,6 +29,9 @@ const (
 // AddProviderRequestMsg is sent when user wants to add a new provider
 type AddProviderRequestMsg struct{}
 
+// RemoveProviderRequestMsg is sent when user wants to remove a provider
+type RemoveProviderRequestMsg struct{}
+
 // ShowProviderDialogMsg is sent to show the provider dialog
 type ShowProviderDialogMsg struct{}
 
@@ -82,6 +85,14 @@ func (p *providerDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return p, tea.Sequence(
 					util.CmdHandler(modal.CloseModalMsg{}),
 					util.CmdHandler(AddProviderRequestMsg{}),
+				)
+			}
+			
+			// Check if "Remove provider" was selected
+			if idx == len(p.availableProviders)+1 {
+				return p, tea.Sequence(
+					util.CmdHandler(modal.CloseModalMsg{}),
+					util.CmdHandler(RemoveProviderRequestMsg{}),
 				)
 			}
 			
@@ -182,7 +193,7 @@ func NewProviderDialog(app *app.App) ProviderDialog {
 	})
 	
 	// Create provider names list with model count and auth status
-	providerNames := make([]string, len(availableProviders)+1)  // +1 for "Add new provider"
+	providerNames := make([]string, len(availableProviders)+2)  // +2 for "Add new provider" and "Remove provider"
 	t := theme.CurrentTheme()
 	for i, provider := range availableProviders {
 		modelCount := len(provider.Models)
@@ -198,6 +209,8 @@ func NewProviderDialog(app *app.App) ProviderDialog {
 	}
 	// Add the "Add new provider" option at the end
 	providerNames[len(availableProviders)] = "→ Add new provider..."
+	// Add the "Remove provider" option after that
+	providerNames[len(availableProviders)+1] = "→ Remove provider..."
 	
 	providerList := list.NewStringList(providerNames, numVisibleProviders, "No providers available", true)
 	providerList.SetMaxWidth(maxProviderDialogWidth)

--- a/packages/tui/internal/components/dialog/remove_provider.go
+++ b/packages/tui/internal/components/dialog/remove_provider.go
@@ -1,0 +1,161 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/list"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/theme"
+	"github.com/sst/opencode/internal/util"
+)
+
+// RemoveProviderDialog interface for the remove provider dialog
+type RemoveProviderDialog interface {
+	layout.Modal
+}
+
+type removeProviderDialog struct {
+	app                  *app.App
+	authenticatedProviders []AuthProviderInfo
+	providerList         list.List[list.StringItem]
+	modal                *modal.Modal
+}
+
+type removeProviderKeyMap struct {
+	Enter  key.Binding
+	Escape key.Binding
+}
+
+var removeProviderKeys = removeProviderKeyMap{
+	Enter: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "remove provider"),
+	),
+	Escape: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "cancel"),
+	),
+}
+
+// ProviderRemovedMsg is sent when a provider is successfully removed
+type ProviderRemovedMsg struct {
+	ProviderID string
+}
+
+func (d *removeProviderDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *removeProviderDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, removeProviderKeys.Enter):
+			_, idx := d.providerList.GetSelectedItem()
+			if idx == -1 || idx >= len(d.authenticatedProviders) {
+				return d, nil
+			}
+			
+			// Get the selected provider
+			selectedProvider := d.authenticatedProviders[idx]
+			
+			// Show confirmation dialog
+			return d, tea.Sequence(
+				util.CmdHandler(modal.CloseModalMsg{}),
+				util.CmdHandler(ShowConfirmRemoveMsg{
+					Provider: selectedProvider,
+				}),
+			)
+			
+		case key.Matches(msg, removeProviderKeys.Escape):
+			return d, util.CmdHandler(modal.CloseModalMsg{})
+		}
+	}
+
+	// Update the list component
+	updatedList, cmd := d.providerList.Update(msg)
+	d.providerList = updatedList.(list.List[list.StringItem])
+	return d, cmd
+}
+
+func (d *removeProviderDialog) View() string {
+	if len(d.authenticatedProviders) == 0 {
+		t := theme.CurrentTheme()
+		return lipgloss.NewStyle().
+			Foreground(t.TextMuted()).
+			Italic(true).
+			Render("No authenticated providers to remove")
+	}
+	return d.providerList.View()
+}
+
+func (d *removeProviderDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *removeProviderDialog) Close() tea.Cmd {
+	return nil
+}
+
+func NewRemoveProviderDialog(app *app.App) RemoveProviderDialog {
+	// Get authenticated providers
+	authProviderList, err := app.ListAuthProviders(context.Background())
+	if err != nil {
+		slog.Error("Failed to list auth providers", "error", err)
+	}
+	
+	// Filter only authenticated providers
+	var authenticatedProviders []AuthProviderInfo
+	for _, provider := range authProviderList {
+		if provider.Authenticated {
+			authenticatedProviders = append(authenticatedProviders, AuthProviderInfo{
+				Id:       provider.Id,
+				Name:     provider.Name,
+				AuthType: provider.AuthType,
+			})
+		}
+	}
+	
+	// Sort by name
+	slices.SortFunc(authenticatedProviders, func(a, b AuthProviderInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	
+	// Create provider names list
+	providerNames := make([]string, len(authenticatedProviders))
+	t := theme.CurrentTheme()
+	for i, provider := range authenticatedProviders {
+		// Show with a red X icon to indicate removal
+		providerNames[i] = fmt.Sprintf("%s %s", 
+			lipgloss.NewStyle().Foreground(t.Error()).Render("✕"),
+			provider.Name,
+		)
+	}
+	
+	providerList := list.NewStringList(providerNames, 8, "No providers to remove", true)
+	providerList.SetMaxWidth(40)
+	
+	return &removeProviderDialog{
+		app:                    app,
+		authenticatedProviders: authenticatedProviders,
+		providerList:          providerList,
+		modal: modal.New(
+			modal.WithTitle("Remove Provider"),
+			modal.WithMaxWidth(44),
+		),
+	}
+}
+
+// ShowConfirmRemoveMsg shows confirmation dialog for removing provider
+type ShowConfirmRemoveMsg struct {
+	Provider AuthProviderInfo
+}

--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -87,6 +87,16 @@ func (m statusComponent) View() string {
 
 	logo := m.logo()
 
+	// Add provider/model info
+	providerModel := ""
+	if m.app.Provider != nil && m.app.Model != nil {
+		providerModel = styles.NewStyle().
+			Foreground(t.Primary()).
+			Background(t.BackgroundElement()).
+			Padding(0, 1).
+			Render(fmt.Sprintf("%s/%s", m.app.Provider.Id, m.app.Model.Id))
+	}
+
 	cwd := styles.NewStyle().
 		Foreground(t.TextMuted()).
 		Background(t.BackgroundPanel()).
@@ -124,11 +134,11 @@ func (m statusComponent) View() string {
 
 	space := max(
 		0,
-		m.width-lipgloss.Width(logo)-lipgloss.Width(cwd)-lipgloss.Width(sessionInfo),
+		m.width-lipgloss.Width(logo)-lipgloss.Width(providerModel)-lipgloss.Width(cwd)-lipgloss.Width(sessionInfo),
 	)
 	spacer := styles.NewStyle().Background(t.BackgroundPanel()).Width(space).Render("")
 
-	status := logo + cwd + spacer + sessionInfo
+	status := logo + providerModel + cwd + spacer + sessionInfo
 
 	blank := styles.NewStyle().Background(t.Background()).Width(m.width).Render("")
 	return blank + "\n" + status

--- a/packages/tui/internal/config/config.go
+++ b/packages/tui/internal/config/config.go
@@ -11,14 +11,16 @@ import (
 )
 
 type State struct {
-	Theme    string `toml:"theme"`
-	Provider string `toml:"provider"`
-	Model    string `toml:"model"`
+	Theme         string            `toml:"theme"`
+	Provider      string            `toml:"provider"`
+	Model         string            `toml:"model"`
+	ProviderModels map[string]string `toml:"provider_models"` // Maps provider ID to last selected model
 }
 
 func NewState() *State {
 	return &State{
-		Theme: "opencode",
+		Theme:          "opencode",
+		ProviderModels: make(map[string]string),
 	}
 }
 
@@ -60,6 +62,10 @@ func LoadState(filePath string) (*State, error) {
 			return nil, fmt.Errorf("state file not found at %s: %w", filePath, statErr)
 		}
 		return nil, fmt.Errorf("failed to decode TOML from file %s: %w", filePath, err)
+	}
+	// Initialize ProviderModels map if it's nil
+	if state.ProviderModels == nil {
+		state.ProviderModels = make(map[string]string)
 	}
 	return &state, nil
 }

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -379,6 +379,23 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Show the provider selection dialog for unauthenticated providers
 		authSelectDialog := dialog.NewAuthProviderSelectDialog(a.app)
 		a.modal = authSelectDialog
+	case dialog.RemoveProviderRequestMsg:
+		// Show the remove provider dialog
+		removeDialog := dialog.NewRemoveProviderDialog(a.app)
+		a.modal = removeDialog
+	case dialog.ShowConfirmRemoveMsg:
+		// Show confirmation dialog for removing provider
+		confirmDialog := dialog.NewConfirmRemoveProviderDialog(a.app, msg.Provider)
+		a.modal = confirmDialog
+	case dialog.ProviderRemovedMsg:
+		// Provider was successfully removed
+		return a, tea.Sequence(
+			toast.NewSuccessToast(fmt.Sprintf("Provider removed successfully")),
+			// Show the provider dialog again with updated list
+			func() tea.Msg {
+				return dialog.ShowProviderDialogMsg{}
+			},
+		)
 	case dialog.StartAuthFlowMsg:
 		// Start the appropriate auth flow based on provider type
 		if msg.Provider.Id == "anthropic" {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -344,11 +345,80 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.app.Session = msg
 		a.app.Messages = messages
 	case app.ModelSelectedMsg:
+		// Store previous provider for comparison
+		previousProvider := ""
+		if a.app.Provider != nil {
+			previousProvider = a.app.Provider.Id
+		}
+		
 		a.app.Provider = &msg.Provider
 		a.app.Model = &msg.Model
 		a.app.State.Provider = msg.Provider.Id
 		a.app.State.Model = msg.Model.Id
+		
+		// Save the selected model for this provider
+		if a.app.State.ProviderModels == nil {
+			a.app.State.ProviderModels = make(map[string]string)
+		}
+		a.app.State.ProviderModels[msg.Provider.Id] = msg.Model.Id
+		
 		a.app.SaveState()
+		
+		// Show toast notification about provider/model change
+		if previousProvider != msg.Provider.Id && previousProvider != "" {
+			return a, toast.NewSuccessToast(
+				fmt.Sprintf("Switched to %s/%s", msg.Provider.Id, msg.Model.Id),
+				toast.WithTitle("Provider changed"),
+			)
+		} else {
+			return a, toast.NewInfoToast(
+				fmt.Sprintf("Selected %s/%s", msg.Provider.Id, msg.Model.Id),
+			)
+		}
+	case dialog.AddProviderRequestMsg:
+		// Show the provider selection dialog for unauthenticated providers
+		authSelectDialog := dialog.NewAuthProviderSelectDialog(a.app)
+		a.modal = authSelectDialog
+	case dialog.StartAuthFlowMsg:
+		// Start the appropriate auth flow based on provider type
+		if msg.Provider.Id == "anthropic" {
+			// Anthropic needs method selection first
+			methodDialog := dialog.NewAuthMethodSelectDialog(a.app, msg.Provider)
+			a.modal = methodDialog
+		} else {
+			switch msg.Provider.AuthType {
+			case "api":
+				apiKeyDialog := dialog.NewAuthAPIKeyDialog(a.app, msg.Provider)
+				a.modal = apiKeyDialog
+				return a, apiKeyDialog.Init()
+			case "oauth":
+				oauthDialog := dialog.NewAuthOAuthDialog(a.app, msg.Provider)
+				a.modal = oauthDialog
+				return a, oauthDialog.Init()
+			}
+		}
+	case dialog.StartOAuthFlowMsg:
+		// Start OAuth flow (from Anthropic method selection)
+		oauthDialog := dialog.NewAuthOAuthDialog(a.app, msg.Provider)
+		a.modal = oauthDialog
+		return a, oauthDialog.Init()
+	case dialog.StartAPIKeyFlowMsg:
+		// Start API key flow (from Anthropic method selection)
+		apiKeyDialog := dialog.NewAuthAPIKeyDialog(a.app, msg.Provider)
+		a.modal = apiKeyDialog
+		return a, apiKeyDialog.Init()
+	case dialog.AuthSuccessMsg:
+		// Refresh provider list after successful auth
+		// Note: Due to provider caching on the server side, the new provider
+		// may not appear until the app is restarted
+		return a, tea.Sequence(
+			a.app.InitializeProvider(),
+			toast.NewSuccessToast("Provider added! Restart the app to see it in the list"),
+		)
+	case dialog.ShowProviderDialogMsg:
+		// Show the provider dialog (used after adding a new provider)
+		providerDialog := dialog.NewProviderDialog(a.app)
+		a.modal = providerDialog
 	case dialog.ThemeSelectedMsg:
 		a.app.State.Theme = msg.ThemeName
 		a.app.SaveState()
@@ -549,6 +619,10 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 	case commands.ModelListCommand:
 		modelDialog := dialog.NewModelDialog(a.app)
 		a.modal = modelDialog
+	case commands.ProviderListCommand:
+		// Open provider dialog for switching providers
+		providerDialog := dialog.NewProviderDialog(a.app)
+		a.modal = providerDialog
 	case commands.ThemeListCommand:
 		themeDialog := dialog.NewThemeDialog()
 		a.modal = themeDialog
@@ -672,3 +746,4 @@ func NewModel(app *app.App) tea.Model {
 
 	return model
 }
+

--- a/packages/tui/pkg/client/gen/openapi.json
+++ b/packages/tui/pkg/client/gen/openapi.json
@@ -773,6 +773,50 @@
         }
       }
     },
+    "/auth/remove": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Authentication removed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAuthRemove",
+        "parameters": [],
+        "description": "Remove authentication for a provider",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/file_search": {
       "post": {
         "responses": {

--- a/packages/tui/pkg/client/gen/openapi.json
+++ b/packages/tui/pkg/client/gen/openapi.json
@@ -531,6 +531,248 @@
         "description": "List all providers"
       }
     },
+    "/auth/providers": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "List of providers",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "authType": {
+                        "type": "string",
+                        "enum": [
+                          "oauth",
+                          "api",
+                          "env"
+                        ]
+                      },
+                      "authenticated": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "authType",
+                      "authenticated"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAuthProviders",
+        "parameters": [],
+        "description": "List providers available for authentication"
+      }
+    },
+    "/auth/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OAuth authorization URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string"
+                    },
+                    "verifier": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAuthStart",
+        "parameters": [],
+        "description": "Start OAuth authentication flow",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/exchange": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Authentication successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAuthExchange",
+        "parameters": [],
+        "description": "Exchange OAuth code for tokens",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "verifier": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "code"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/poll": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Poll status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "success",
+                        "failed"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAuthPoll",
+        "parameters": [],
+        "description": "Poll GitHub Copilot device flow",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deviceCode": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "deviceCode"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/apikey": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "API key set successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAuthApikey",
+        "parameters": [],
+        "description": "Set API key for a provider",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string"
+                  },
+                  "apiKey": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "apiKey"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/file_search": {
       "post": {
         "responses": {
@@ -595,16 +837,19 @@
       "Event": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/Event.storage.write"
-          },
-          {
-            "$ref": "#/components/schemas/Event.installation.updated"
-          },
-          {
             "$ref": "#/components/schemas/Event.lsp.client.diagnostics"
           },
           {
             "$ref": "#/components/schemas/Event.permission.updated"
+          },
+          {
+            "$ref": "#/components/schemas/Event.file.edited"
+          },
+          {
+            "$ref": "#/components/schemas/Event.storage.write"
+          },
+          {
+            "$ref": "#/components/schemas/Event.installation.updated"
           },
           {
             "$ref": "#/components/schemas/Event.message.updated"
@@ -619,72 +864,28 @@
             "$ref": "#/components/schemas/Event.session.deleted"
           },
           {
+            "$ref": "#/components/schemas/Event.session.idle"
+          },
+          {
             "$ref": "#/components/schemas/Event.session.error"
           }
         ],
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "storage.write": "#/components/schemas/Event.storage.write",
-            "installation.updated": "#/components/schemas/Event.installation.updated",
             "lsp.client.diagnostics": "#/components/schemas/Event.lsp.client.diagnostics",
             "permission.updated": "#/components/schemas/Event.permission.updated",
+            "file.edited": "#/components/schemas/Event.file.edited",
+            "storage.write": "#/components/schemas/Event.storage.write",
+            "installation.updated": "#/components/schemas/Event.installation.updated",
             "message.updated": "#/components/schemas/Event.message.updated",
             "message.part.updated": "#/components/schemas/Event.message.part.updated",
             "session.updated": "#/components/schemas/Event.session.updated",
             "session.deleted": "#/components/schemas/Event.session.deleted",
+            "session.idle": "#/components/schemas/Event.session.idle",
             "session.error": "#/components/schemas/Event.session.error"
           }
         }
-      },
-      "Event.storage.write": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "storage.write"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "key": {
-                "type": "string"
-              },
-              "content": {}
-            },
-            "required": [
-              "key"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
-      },
-      "Event.installation.updated": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "installation.updated"
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "version": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "version"
-            ]
-          }
-        },
-        "required": [
-          "type",
-          "properties"
-        ]
       },
       "Event.lsp.client.diagnostics": {
         "type": "object",
@@ -764,6 +965,79 @@
           "title",
           "metadata",
           "time"
+        ]
+      },
+      "Event.file.edited": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file.edited"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "file": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "file"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.storage.write": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "storage.write"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "content": {}
+            },
+            "required": [
+              "key"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "Event.installation.updated": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "installation.updated"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "version"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
         ]
       },
       "Event.message.updated": {
@@ -1423,6 +1697,30 @@
           "properties"
         ]
       },
+      "Event.session.idle": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "session.idle"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "sessionID": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionID"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
       "Event.session.error": {
         "type": "object",
         "properties": {
@@ -1465,9 +1763,6 @@
       "App.Info": {
         "type": "object",
         "properties": {
-          "project": {
-            "type": "string"
-          },
           "user": {
             "type": "string"
           },
@@ -1514,7 +1809,6 @@
           }
         },
         "required": [
-          "project",
           "user",
           "hostname",
           "git",
@@ -1781,6 +2075,10 @@
           "model_list": {
             "type": "string",
             "description": "List available models"
+          },
+          "provider_list": {
+            "type": "string",
+            "description": "Switch provider"
           },
           "theme_list": {
             "type": "string",

--- a/packages/tui/pkg/client/generated-client.go
+++ b/packages/tui/pkg/client/generated-client.go
@@ -34,8 +34,7 @@ type AppInfo struct {
 		Root   string `json:"root"`
 		State  string `json:"state"`
 	} `json:"path"`
-	Project string `json:"project"`
-	Time    struct {
+	Time struct {
 		Initialized *float32 `json:"initialized,omitempty"`
 	} `json:"time"`
 	User string `json:"user"`
@@ -174,6 +173,9 @@ type ConfigKeybinds struct {
 	// ProjectInit Initialize project configuration
 	ProjectInit *string `json:"project_init,omitempty"`
 
+	// ProviderList Switch provider
+	ProviderList *string `json:"provider_list,omitempty"`
+
 	// SessionCompact Toggle compact mode for session
 	SessionCompact *string `json:"session_compact,omitempty"`
 
@@ -225,6 +227,14 @@ type Error struct {
 // Event defines model for Event.
 type Event struct {
 	union json.RawMessage
+}
+
+// EventFileEdited defines model for Event.file.edited.
+type EventFileEdited struct {
+	Properties struct {
+		File string `json:"file"`
+	} `json:"properties"`
+	Type string `json:"type"`
 }
 
 // EventInstallationUpdated defines model for Event.installation.updated.
@@ -287,6 +297,14 @@ type EventSessionError struct {
 // EventSessionError_Properties_Error defines model for EventSessionError.Properties.Error.
 type EventSessionError_Properties_Error struct {
 	union json.RawMessage
+}
+
+// EventSessionIdle defines model for Event.session.idle.
+type EventSessionIdle struct {
+	Properties struct {
+		SessionID string `json:"sessionID"`
+	} `json:"properties"`
+	Type string `json:"type"`
 }
 
 // EventSessionUpdated defines model for Event.session.updated.
@@ -528,6 +546,29 @@ type SessionInfo struct {
 	Version string `json:"version"`
 }
 
+// PostAuthApikeyJSONBody defines parameters for PostAuthApikey.
+type PostAuthApikeyJSONBody struct {
+	ApiKey     string `json:"apiKey"`
+	ProviderId string `json:"providerId"`
+}
+
+// PostAuthExchangeJSONBody defines parameters for PostAuthExchange.
+type PostAuthExchangeJSONBody struct {
+	Code       string  `json:"code"`
+	ProviderId string  `json:"providerId"`
+	Verifier   *string `json:"verifier,omitempty"`
+}
+
+// PostAuthPollJSONBody defines parameters for PostAuthPoll.
+type PostAuthPollJSONBody struct {
+	DeviceCode string `json:"deviceCode"`
+}
+
+// PostAuthStartJSONBody defines parameters for PostAuthStart.
+type PostAuthStartJSONBody struct {
+	ProviderId string `json:"providerId"`
+}
+
 // PostFileSearchJSONBody defines parameters for PostFileSearch.
 type PostFileSearchJSONBody struct {
 	Query string `json:"query"`
@@ -579,6 +620,18 @@ type PostSessionSummarizeJSONBody struct {
 type PostSessionUnshareJSONBody struct {
 	SessionID string `json:"sessionID"`
 }
+
+// PostAuthApikeyJSONRequestBody defines body for PostAuthApikey for application/json ContentType.
+type PostAuthApikeyJSONRequestBody PostAuthApikeyJSONBody
+
+// PostAuthExchangeJSONRequestBody defines body for PostAuthExchange for application/json ContentType.
+type PostAuthExchangeJSONRequestBody PostAuthExchangeJSONBody
+
+// PostAuthPollJSONRequestBody defines body for PostAuthPoll for application/json ContentType.
+type PostAuthPollJSONRequestBody PostAuthPollJSONBody
+
+// PostAuthStartJSONRequestBody defines body for PostAuthStart for application/json ContentType.
+type PostAuthStartJSONRequestBody PostAuthStartJSONBody
 
 // PostFileSearchJSONRequestBody defines body for PostFileSearch for application/json ContentType.
 type PostFileSearchJSONRequestBody PostFileSearchJSONBody
@@ -775,62 +828,6 @@ func (t *ConfigInfo_Mcp_AdditionalProperties) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-// AsEventStorageWrite returns the union data inside the Event as a EventStorageWrite
-func (t Event) AsEventStorageWrite() (EventStorageWrite, error) {
-	var body EventStorageWrite
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromEventStorageWrite overwrites any union data inside the Event as the provided EventStorageWrite
-func (t *Event) FromEventStorageWrite(v EventStorageWrite) error {
-	v.Type = "storage.write"
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeEventStorageWrite performs a merge with any union data inside the Event, using the provided EventStorageWrite
-func (t *Event) MergeEventStorageWrite(v EventStorageWrite) error {
-	v.Type = "storage.write"
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsEventInstallationUpdated returns the union data inside the Event as a EventInstallationUpdated
-func (t Event) AsEventInstallationUpdated() (EventInstallationUpdated, error) {
-	var body EventInstallationUpdated
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromEventInstallationUpdated overwrites any union data inside the Event as the provided EventInstallationUpdated
-func (t *Event) FromEventInstallationUpdated(v EventInstallationUpdated) error {
-	v.Type = "installation.updated"
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeEventInstallationUpdated performs a merge with any union data inside the Event, using the provided EventInstallationUpdated
-func (t *Event) MergeEventInstallationUpdated(v EventInstallationUpdated) error {
-	v.Type = "installation.updated"
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
 // AsEventLspClientDiagnostics returns the union data inside the Event as a EventLspClientDiagnostics
 func (t Event) AsEventLspClientDiagnostics() (EventLspClientDiagnostics, error) {
 	var body EventLspClientDiagnostics
@@ -877,6 +874,90 @@ func (t *Event) FromEventPermissionUpdated(v EventPermissionUpdated) error {
 // MergeEventPermissionUpdated performs a merge with any union data inside the Event, using the provided EventPermissionUpdated
 func (t *Event) MergeEventPermissionUpdated(v EventPermissionUpdated) error {
 	v.Type = "permission.updated"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsEventFileEdited returns the union data inside the Event as a EventFileEdited
+func (t Event) AsEventFileEdited() (EventFileEdited, error) {
+	var body EventFileEdited
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromEventFileEdited overwrites any union data inside the Event as the provided EventFileEdited
+func (t *Event) FromEventFileEdited(v EventFileEdited) error {
+	v.Type = "file.edited"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeEventFileEdited performs a merge with any union data inside the Event, using the provided EventFileEdited
+func (t *Event) MergeEventFileEdited(v EventFileEdited) error {
+	v.Type = "file.edited"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsEventStorageWrite returns the union data inside the Event as a EventStorageWrite
+func (t Event) AsEventStorageWrite() (EventStorageWrite, error) {
+	var body EventStorageWrite
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromEventStorageWrite overwrites any union data inside the Event as the provided EventStorageWrite
+func (t *Event) FromEventStorageWrite(v EventStorageWrite) error {
+	v.Type = "storage.write"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeEventStorageWrite performs a merge with any union data inside the Event, using the provided EventStorageWrite
+func (t *Event) MergeEventStorageWrite(v EventStorageWrite) error {
+	v.Type = "storage.write"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsEventInstallationUpdated returns the union data inside the Event as a EventInstallationUpdated
+func (t Event) AsEventInstallationUpdated() (EventInstallationUpdated, error) {
+	var body EventInstallationUpdated
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromEventInstallationUpdated overwrites any union data inside the Event as the provided EventInstallationUpdated
+func (t *Event) FromEventInstallationUpdated(v EventInstallationUpdated) error {
+	v.Type = "installation.updated"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeEventInstallationUpdated performs a merge with any union data inside the Event, using the provided EventInstallationUpdated
+func (t *Event) MergeEventInstallationUpdated(v EventInstallationUpdated) error {
+	v.Type = "installation.updated"
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err
@@ -999,6 +1080,34 @@ func (t *Event) MergeEventSessionDeleted(v EventSessionDeleted) error {
 	return err
 }
 
+// AsEventSessionIdle returns the union data inside the Event as a EventSessionIdle
+func (t Event) AsEventSessionIdle() (EventSessionIdle, error) {
+	var body EventSessionIdle
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromEventSessionIdle overwrites any union data inside the Event as the provided EventSessionIdle
+func (t *Event) FromEventSessionIdle(v EventSessionIdle) error {
+	v.Type = "session.idle"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeEventSessionIdle performs a merge with any union data inside the Event, using the provided EventSessionIdle
+func (t *Event) MergeEventSessionIdle(v EventSessionIdle) error {
+	v.Type = "session.idle"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 // AsEventSessionError returns the union data inside the Event as a EventSessionError
 func (t Event) AsEventSessionError() (EventSessionError, error) {
 	var body EventSessionError
@@ -1041,6 +1150,8 @@ func (t Event) ValueByDiscriminator() (interface{}, error) {
 		return nil, err
 	}
 	switch discriminator {
+	case "file.edited":
+		return t.AsEventFileEdited()
 	case "installation.updated":
 		return t.AsEventInstallationUpdated()
 	case "lsp.client.diagnostics":
@@ -1055,6 +1166,8 @@ func (t Event) ValueByDiscriminator() (interface{}, error) {
 		return t.AsEventSessionDeleted()
 	case "session.error":
 		return t.AsEventSessionError()
+	case "session.idle":
+		return t.AsEventSessionIdle()
 	case "session.updated":
 		return t.AsEventSessionUpdated()
 	case "storage.write":
@@ -1719,6 +1832,29 @@ type ClientInterface interface {
 	// PostAppInitialize request
 	PostAppInitialize(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostAuthApikeyWithBody request with any body
+	PostAuthApikeyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostAuthApikey(ctx context.Context, body PostAuthApikeyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostAuthExchangeWithBody request with any body
+	PostAuthExchangeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostAuthExchange(ctx context.Context, body PostAuthExchangeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostAuthPollWithBody request with any body
+	PostAuthPollWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostAuthPoll(ctx context.Context, body PostAuthPollJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostAuthProviders request
+	PostAuthProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostAuthStartWithBody request with any body
+	PostAuthStartWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostAuthStart(ctx context.Context, body PostAuthStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostConfigGet request
 	PostConfigGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -1800,6 +1936,114 @@ func (c *Client) PostAppInfo(ctx context.Context, reqEditors ...RequestEditorFn)
 
 func (c *Client) PostAppInitialize(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostAppInitializeRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthApikeyWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthApikeyRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthApikey(ctx context.Context, body PostAuthApikeyJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthApikeyRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthExchangeWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthExchangeRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthExchange(ctx context.Context, body PostAuthExchangeJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthExchangeRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthPollWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthPollRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthPoll(ctx context.Context, body PostAuthPollJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthPollRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthProvidersRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthStartWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthStartRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthStart(ctx context.Context, body PostAuthStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthStartRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2160,6 +2404,193 @@ func NewPostAppInitializeRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewPostAuthApikeyRequest calls the generic PostAuthApikey builder with application/json body
+func NewPostAuthApikeyRequest(server string, body PostAuthApikeyJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostAuthApikeyRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostAuthApikeyRequestWithBody generates requests for PostAuthApikey with any type of body
+func NewPostAuthApikeyRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/auth/apikey")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPostAuthExchangeRequest calls the generic PostAuthExchange builder with application/json body
+func NewPostAuthExchangeRequest(server string, body PostAuthExchangeJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostAuthExchangeRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostAuthExchangeRequestWithBody generates requests for PostAuthExchange with any type of body
+func NewPostAuthExchangeRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/auth/exchange")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPostAuthPollRequest calls the generic PostAuthPoll builder with application/json body
+func NewPostAuthPollRequest(server string, body PostAuthPollJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostAuthPollRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostAuthPollRequestWithBody generates requests for PostAuthPoll with any type of body
+func NewPostAuthPollRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/auth/poll")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPostAuthProvidersRequest generates requests for PostAuthProviders
+func NewPostAuthProvidersRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/auth/providers")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostAuthStartRequest calls the generic PostAuthStart builder with application/json body
+func NewPostAuthStartRequest(server string, body PostAuthStartJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostAuthStartRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostAuthStartRequestWithBody generates requests for PostAuthStart with any type of body
+func NewPostAuthStartRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/auth/start")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -2762,6 +3193,29 @@ type ClientWithResponsesInterface interface {
 	// PostAppInitializeWithResponse request
 	PostAppInitializeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostAppInitializeResponse, error)
 
+	// PostAuthApikeyWithBodyWithResponse request with any body
+	PostAuthApikeyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthApikeyResponse, error)
+
+	PostAuthApikeyWithResponse(ctx context.Context, body PostAuthApikeyJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthApikeyResponse, error)
+
+	// PostAuthExchangeWithBodyWithResponse request with any body
+	PostAuthExchangeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthExchangeResponse, error)
+
+	PostAuthExchangeWithResponse(ctx context.Context, body PostAuthExchangeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthExchangeResponse, error)
+
+	// PostAuthPollWithBodyWithResponse request with any body
+	PostAuthPollWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthPollResponse, error)
+
+	PostAuthPollWithResponse(ctx context.Context, body PostAuthPollJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthPollResponse, error)
+
+	// PostAuthProvidersWithResponse request
+	PostAuthProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostAuthProvidersResponse, error)
+
+	// PostAuthStartWithBodyWithResponse request with any body
+	PostAuthStartWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthStartResponse, error)
+
+	PostAuthStartWithResponse(ctx context.Context, body PostAuthStartJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthStartResponse, error)
+
 	// PostConfigGetWithResponse request
 	PostConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostConfigGetResponse, error)
 
@@ -2867,6 +3321,132 @@ func (r PostAppInitializeResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostAppInitializeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAuthApikeyResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Success bool `json:"success"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostAuthApikeyResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAuthApikeyResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAuthExchangeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Success bool `json:"success"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostAuthExchangeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAuthExchangeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAuthPollResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Status PostAuthPoll200Status `json:"status"`
+	}
+}
+type PostAuthPoll200Status string
+
+// Status returns HTTPResponse.Status
+func (r PostAuthPollResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAuthPollResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAuthProvidersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]struct {
+		AuthType      PostAuthProviders200AuthType `json:"authType"`
+		Authenticated bool                         `json:"authenticated"`
+		Id            string                       `json:"id"`
+		Name          string                       `json:"name"`
+	}
+}
+type PostAuthProviders200AuthType string
+
+// Status returns HTTPResponse.Status
+func (r PostAuthProvidersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAuthProvidersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAuthStartResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Url      string  `json:"url"`
+		Verifier *string `json:"verifier,omitempty"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostAuthStartResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAuthStartResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3252,6 +3832,83 @@ func (c *ClientWithResponses) PostAppInitializeWithResponse(ctx context.Context,
 	return ParsePostAppInitializeResponse(rsp)
 }
 
+// PostAuthApikeyWithBodyWithResponse request with arbitrary body returning *PostAuthApikeyResponse
+func (c *ClientWithResponses) PostAuthApikeyWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthApikeyResponse, error) {
+	rsp, err := c.PostAuthApikeyWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthApikeyResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostAuthApikeyWithResponse(ctx context.Context, body PostAuthApikeyJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthApikeyResponse, error) {
+	rsp, err := c.PostAuthApikey(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthApikeyResponse(rsp)
+}
+
+// PostAuthExchangeWithBodyWithResponse request with arbitrary body returning *PostAuthExchangeResponse
+func (c *ClientWithResponses) PostAuthExchangeWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthExchangeResponse, error) {
+	rsp, err := c.PostAuthExchangeWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthExchangeResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostAuthExchangeWithResponse(ctx context.Context, body PostAuthExchangeJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthExchangeResponse, error) {
+	rsp, err := c.PostAuthExchange(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthExchangeResponse(rsp)
+}
+
+// PostAuthPollWithBodyWithResponse request with arbitrary body returning *PostAuthPollResponse
+func (c *ClientWithResponses) PostAuthPollWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthPollResponse, error) {
+	rsp, err := c.PostAuthPollWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthPollResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostAuthPollWithResponse(ctx context.Context, body PostAuthPollJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthPollResponse, error) {
+	rsp, err := c.PostAuthPoll(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthPollResponse(rsp)
+}
+
+// PostAuthProvidersWithResponse request returning *PostAuthProvidersResponse
+func (c *ClientWithResponses) PostAuthProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostAuthProvidersResponse, error) {
+	rsp, err := c.PostAuthProviders(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthProvidersResponse(rsp)
+}
+
+// PostAuthStartWithBodyWithResponse request with arbitrary body returning *PostAuthStartResponse
+func (c *ClientWithResponses) PostAuthStartWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthStartResponse, error) {
+	rsp, err := c.PostAuthStartWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthStartResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostAuthStartWithResponse(ctx context.Context, body PostAuthStartJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthStartResponse, error) {
+	rsp, err := c.PostAuthStart(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthStartResponse(rsp)
+}
+
 // PostConfigGetWithResponse request returning *PostConfigGetResponse
 func (c *ClientWithResponses) PostConfigGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostConfigGetResponse, error) {
 	rsp, err := c.PostConfigGet(ctx, reqEditors...)
@@ -3510,6 +4167,150 @@ func ParsePostAppInitializeResponse(rsp *http.Response) (*PostAppInitializeRespo
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest bool
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAuthApikeyResponse parses an HTTP response from a PostAuthApikeyWithResponse call
+func ParsePostAuthApikeyResponse(rsp *http.Response) (*PostAuthApikeyResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAuthApikeyResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Success bool `json:"success"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAuthExchangeResponse parses an HTTP response from a PostAuthExchangeWithResponse call
+func ParsePostAuthExchangeResponse(rsp *http.Response) (*PostAuthExchangeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAuthExchangeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Success bool `json:"success"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAuthPollResponse parses an HTTP response from a PostAuthPollWithResponse call
+func ParsePostAuthPollResponse(rsp *http.Response) (*PostAuthPollResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAuthPollResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Status PostAuthPoll200Status `json:"status"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAuthProvidersResponse parses an HTTP response from a PostAuthProvidersWithResponse call
+func ParsePostAuthProvidersResponse(rsp *http.Response) (*PostAuthProvidersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAuthProvidersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []struct {
+			AuthType      PostAuthProviders200AuthType `json:"authType"`
+			Authenticated bool                         `json:"authenticated"`
+			Id            string                       `json:"id"`
+			Name          string                       `json:"name"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAuthStartResponse parses an HTTP response from a PostAuthStartWithResponse call
+func ParsePostAuthStartResponse(rsp *http.Response) (*PostAuthStartResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAuthStartResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Url      string  `json:"url"`
+			Verifier *string `json:"verifier,omitempty"`
+		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/packages/tui/pkg/client/generated-client.go
+++ b/packages/tui/pkg/client/generated-client.go
@@ -564,6 +564,11 @@ type PostAuthPollJSONBody struct {
 	DeviceCode string `json:"deviceCode"`
 }
 
+// PostAuthRemoveJSONBody defines parameters for PostAuthRemove.
+type PostAuthRemoveJSONBody struct {
+	ProviderId string `json:"providerId"`
+}
+
 // PostAuthStartJSONBody defines parameters for PostAuthStart.
 type PostAuthStartJSONBody struct {
 	ProviderId string `json:"providerId"`
@@ -629,6 +634,9 @@ type PostAuthExchangeJSONRequestBody PostAuthExchangeJSONBody
 
 // PostAuthPollJSONRequestBody defines body for PostAuthPoll for application/json ContentType.
 type PostAuthPollJSONRequestBody PostAuthPollJSONBody
+
+// PostAuthRemoveJSONRequestBody defines body for PostAuthRemove for application/json ContentType.
+type PostAuthRemoveJSONRequestBody PostAuthRemoveJSONBody
 
 // PostAuthStartJSONRequestBody defines body for PostAuthStart for application/json ContentType.
 type PostAuthStartJSONRequestBody PostAuthStartJSONBody
@@ -1850,6 +1858,11 @@ type ClientInterface interface {
 	// PostAuthProviders request
 	PostAuthProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostAuthRemoveWithBody request with any body
+	PostAuthRemoveWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostAuthRemove(ctx context.Context, body PostAuthRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PostAuthStartWithBody request with any body
 	PostAuthStartWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2020,6 +2033,30 @@ func (c *Client) PostAuthPoll(ctx context.Context, body PostAuthPollJSONRequestB
 
 func (c *Client) PostAuthProviders(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostAuthProvidersRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthRemoveWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthRemoveRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAuthRemove(ctx context.Context, body PostAuthRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAuthRemoveRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -2551,6 +2588,46 @@ func NewPostAuthProvidersRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewPostAuthRemoveRequest calls the generic PostAuthRemove builder with application/json body
+func NewPostAuthRemoveRequest(server string, body PostAuthRemoveJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostAuthRemoveRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostAuthRemoveRequestWithBody generates requests for PostAuthRemove with any type of body
+func NewPostAuthRemoveRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/auth/remove")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -3211,6 +3288,11 @@ type ClientWithResponsesInterface interface {
 	// PostAuthProvidersWithResponse request
 	PostAuthProvidersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostAuthProvidersResponse, error)
 
+	// PostAuthRemoveWithBodyWithResponse request with any body
+	PostAuthRemoveWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthRemoveResponse, error)
+
+	PostAuthRemoveWithResponse(ctx context.Context, body PostAuthRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthRemoveResponse, error)
+
 	// PostAuthStartWithBodyWithResponse request with any body
 	PostAuthStartWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthStartResponse, error)
 
@@ -3422,6 +3504,30 @@ func (r PostAuthProvidersResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r PostAuthProvidersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAuthRemoveResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *struct {
+		Success bool `json:"success"`
+	}
+}
+
+// Status returns HTTPResponse.Status
+func (r PostAuthRemoveResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAuthRemoveResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3892,6 +3998,23 @@ func (c *ClientWithResponses) PostAuthProvidersWithResponse(ctx context.Context,
 	return ParsePostAuthProvidersResponse(rsp)
 }
 
+// PostAuthRemoveWithBodyWithResponse request with arbitrary body returning *PostAuthRemoveResponse
+func (c *ClientWithResponses) PostAuthRemoveWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthRemoveResponse, error) {
+	rsp, err := c.PostAuthRemoveWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthRemoveResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostAuthRemoveWithResponse(ctx context.Context, body PostAuthRemoveJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAuthRemoveResponse, error) {
+	rsp, err := c.PostAuthRemove(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAuthRemoveResponse(rsp)
+}
+
 // PostAuthStartWithBodyWithResponse request with arbitrary body returning *PostAuthStartResponse
 func (c *ClientWithResponses) PostAuthStartWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAuthStartResponse, error) {
 	rsp, err := c.PostAuthStartWithBody(ctx, contentType, body, reqEditors...)
@@ -4281,6 +4404,34 @@ func ParsePostAuthProvidersResponse(rsp *http.Response) (*PostAuthProvidersRespo
 			Authenticated bool                         `json:"authenticated"`
 			Id            string                       `json:"id"`
 			Name          string                       `json:"name"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAuthRemoveResponse parses an HTTP response from a PostAuthRemoveWithResponse call
+func ParsePostAuthRemoveResponse(rsp *http.Response) (*PostAuthRemoveResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAuthRemoveResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest struct {
+			Success bool `json:"success"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err


### PR DESCRIPTION
It didn’t have the ability to switch between providers in the middle of chat, and it would not let you set up more than one provider after you set up your initial one. So, now the workflow is you started up it asks you to set up your provider, then in the TUI, you have a providers modal that will allow you to add additional providers with the key or authentication. And from that point forward, you can switch between different providers and it will remember the model you had selected.

I wanted to use anthropic and o3 for different parts of the chat.  I'm doing a PR on this, because I'm pretty sure this is a main feature you'd want in the app. 

I'm going to add a favorites section, or hot swap section it quickly let me swap from one provider to another.  Might do another PR for that one later.