### PR TITLE
fix(#467): more granular bedrock modelID based on aws region

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -140,10 +140,52 @@ export namespace Provider {
           credentialProvider: fromNodeProviderChain(),
         },
         async getModel(sdk: any, modelID: string) {
-          if (modelID.includes("claude")) {
-            const prefix = region.split("-")[0]
-            modelID = `${prefix}.${modelID}`
+          let regionPrefix = region.split("-")[0]
+
+          switch (regionPrefix) {
+            case "us": {
+              const modelRequiresPrefix = ["claude", "deepseek"].some((m) =>
+                modelID.includes(m),
+              )
+              if (modelRequiresPrefix) {
+                modelID = `${regionPrefix}.${modelID}`
+              }
+              break
+            }
+            case "eu": {
+              const regionRequiresPrefix = [
+                "eu-west-1",
+                "eu-west-3",
+                "eu-north-1",
+                "eu-central-1",
+              ].some((r) => region.includes(r))
+              const modelRequiresPrefix = [
+                "claude",
+                "nova-lite",
+                "nova-micro",
+                "llama3",
+                "pixtral",
+              ].some((m) => modelID.includes(m))
+              if (regionRequiresPrefix && modelRequiresPrefix) {
+                modelID = `${regionPrefix}.${modelID}`
+              }
+              break
+            }
+            case "ap": {
+              const modelRequiresPrefix = [
+                "claude",
+                "nova-lite",
+                "nova-micro",
+                "nova-pro",
+              ].some((m) => modelID.includes(m))
+              if (modelRequiresPrefix) {
+                regionPrefix = "apac"
+                modelID = `${regionPrefix}.${modelID}`
+              }
+              break
+            }
           }
+
           return sdk.languageModel(modelID)
         },
       }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -158,6 +158,8 @@ export namespace Provider {
                 "eu-west-3",
                 "eu-north-1",
                 "eu-central-1",
+                "eu-south-1",
+                "eu-south-2",
               ].some((r) => region.includes(r))
               const modelRequiresPrefix = [
                 "claude",


### PR DESCRIPTION
https://github.com/sst/opencode/issues/467

## Problem

Unfortunately bedrock is not consistent in enforcing regional model IDs

While all `us` regions require prefixes like `us.anthropic***` in `eu` it's only required for some of the regions, and e.g. in `eu-west-2` a prefix-less model ID is required

This PR aims to handle these cases and make sure OpenCode supports them better

## How was this tested?

Ran opencode with `AWS_REGION=eu-west-2` with Claude 3 and made sure it works

<img width="1030" alt="Screenshot 2025-06-27 at 22 50 31" src="https://github.com/user-attachments/assets/8dc0781b-c383-4115-b6c2-636a62879006" />
