### PR TITLE
fix: use correct opencode bin path when running in development mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -100,7 +100,7 @@ export const TuiCommand = cmd({
         UI.empty()
         UI.println(UI.logo("   "))
         const result = await Bun.spawn({
-          cmd: [process.execPath, "auth", "login"],
+          cmd: [...getOpencodeCommand(), "auth", "login"],
           cwd: process.cwd(),
           stdout: "inherit",
           stderr: "inherit",
@@ -112,3 +112,25 @@ export const TuiCommand = cmd({
     }
   },
 })
+
+/**
+ * Get the correct command to run opencode CLI
+ * In development: ["bun", "run", "packages/opencode/src/index.ts"]
+ * In production: ["/path/to/opencode"]
+ */
+function getOpencodeCommand(): string[] {
+  // Check if OPENCODE_BIN_PATH is set (used by shell wrapper scripts)
+  if (process.env["OPENCODE_BIN_PATH"]) {
+    return [process.env["OPENCODE_BIN_PATH"]]
+  }
+
+  const execPath = process.execPath.toLowerCase()
+
+  if (Installation.isDev()) {
+    // In development, use bun to run the TypeScript entry point
+    return [execPath, "run", process.argv[1]]
+  }
+
+  // In production, use the current executable path
+  return [process.execPath]
+}


### PR DESCRIPTION
fixes local dev being broken since https://github.com/sst/opencode/commit/c0773dc7c53cf15e9c8d63b4e49aa7527c9a1328

## Before:

![image](https://github.com/user-attachments/assets/06c33b08-6e87-41dc-98de-206825858f23)

## After:

![CleanShot_2025-06-27T16-04-29_Cursor@2x](https://github.com/user-attachments/assets/3b7cc80a-aaeb-4949-8367-4d0fcd16093f)
