### PR TITLE
feat: Add support for ktlint - Kotlin and clang-format - Java file formatting

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -161,5 +161,43 @@ export namespace Format {
         }
       },
     },
+    {
+      name: "ktlint",
+      command: ["ktlint", "-F", "$FILE"],
+      extensions: [".kt",".kts"],
+      async enabled() {
+        try {
+          const proc = Bun.spawn({
+            cmd: ["ktlint", "-h"],
+            cwd: App.info().path.cwd,
+            stdout: "ignore",
+            stderr: "ignore",
+          })
+          const exit = await proc.exited
+          return exit === 0
+        } catch {
+          return false
+        }
+      },
+    },
+    {
+      name: "clang-format",
+      command: ["clang-format", "-i", "$FILE"],
+      extensions: [".java"],
+      async enabled() {
+        try {
+          const proc = Bun.spawn({
+            cmd: ["clang-format", "--version"],
+            cwd: App.info().path.cwd,
+            stdout: "ignore",
+            stderr: "ignore",
+          });
+          const exit = await proc.exited;
+          return exit === 0;
+        } catch {
+          return false;
+        }
+      },
+    },
   ]
 }


### PR DESCRIPTION
This code makes use of Ktlint linter for Kotlin and clang-format formatter for Java 

Fixes #493 


Once the PR #478 is accpeted changes would be made to format java source codes 
Kotlin formatter remains the same 