### PR TITLE
fix: re-enable history shortcuts

### DIFF
--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -210,16 +210,16 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 			Description: "insert newline",
 			Keybindings: parseBindings("shift+enter", "ctrl+j"),
 		},
-		// {
-		// 	Name:        HistoryPreviousCommand,
-		// 	Description: "previous prompt",
-		// 	Keybindings: parseBindings("up"),
-		// },
-		// {
-		// 	Name:        HistoryNextCommand,
-		// 	Description: "next prompt",
-		// 	Keybindings: parseBindings("down"),
-		// },
+		{
+			Name:        HistoryPreviousCommand,
+			Description: "previous prompt",
+			Keybindings: parseBindings("up"),
+		},
+		{
+			Name:        HistoryNextCommand,
+			Description: "next prompt",
+			Keybindings: parseBindings("down"),
+		},
 		{
 			Name:        MessagesPageUpCommand,
 			Description: "page up",


### PR DESCRIPTION
Arrow keys up/down were not working for navigating through history. They were commented out in 568c04753ec820e6c0c7c6b15bf835b889bb8af7, looks like an accident, but I could be wrong.
