### PR TITLE
docs: use correct `baseUrl` for astro `editLink`

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -42,7 +42,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: `${github}/edit/master/www/`,
+        baseUrl: `${github}/edit/dev/packages/web/`,
       },
       markdown: {
         headingLinks: false,


### PR DESCRIPTION
The development branch is `dev`, and the subpath is `packages/web/` not `www/`.