### PR TITLE
Add Option to Disable MCP Servers

### DIFF
--- a/packages/opencode/config.schema.json
+++ b/packages/opencode/config.schema.json
@@ -264,6 +264,10 @@
                   "type": "string"
                 },
                 "description": "Environment variables to set when running the MCP server"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable or disable the MCP server on startup"
               }
             },
             "required": ["type", "command"],
@@ -280,6 +284,10 @@
               "url": {
                 "type": "string",
                 "description": "URL of the remote MCP server"
+              },
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable or disable the MCP server on startup"
               }
             },
             "required": ["type", "url"],

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -37,6 +37,10 @@ export namespace Config {
         .record(z.string(), z.string())
         .optional()
         .describe("Environment variables to set when running the MCP server"),
+      enabled: z
+        .boolean()
+        .optional()
+        .describe("Enable or disable the MCP server on startup"),
     })
     .strict()
     .openapi({
@@ -47,6 +51,10 @@ export namespace Config {
     .object({
       type: z.literal("remote").describe("Type of MCP server connection"),
       url: z.string().describe("URL of the remote MCP server"),
+      enabled: z
+        .boolean()
+        .optional()
+        .describe("Enable or disable the MCP server on startup"),
     })
     .strict()
     .openapi({

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -26,6 +26,10 @@ export namespace MCP {
         [name: string]: Awaited<ReturnType<typeof experimental_createMCPClient>>
       } = {}
       for (const [key, mcp] of Object.entries(cfg.mcp ?? {})) {
+        if (mcp.enabled === false) {
+          log.info("mcp server disabled", { key })
+          continue
+        }
         log.info("found", { key, type: mcp.type })
         if (mcp.type === "remote") {
           const client = await experimental_createMCPClient({


### PR DESCRIPTION
Adds the (simple) option to enable/disable MCP servers via the config:

-  Adds a new optional "enabled" key to the config.
-  A missing key means enabled for backwards compatibility.
- "Disabled" prevents the server from being started.

Closes #512