### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 80


### PR DESCRIPTION
Add an `.editorconfig` file so that all contributors' code editors will automatically conform to the existing whitespace style, even before `prettier` is run.

See https://editorconfig.org/ for more details.