### PR TITLE
Add Favorites to Models Dialog

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -157,6 +157,12 @@ export namespace Config {
         .array(z.string())
         .optional()
         .describe("Disable providers that are loaded automatically"),
+      favoriteModels: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "An array of favorite models to be displayed first in the list",
+        ),
       model: z
         .string()
         .describe(

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -161,7 +161,7 @@ export namespace Config {
         .array(z.string())
         .optional()
         .describe(
-          "An array of favorite models to be displayed first in the list",
+          "An array of favorite models to be displayed first in the the models list",
         ),
       model: z
         .string()

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -146,6 +146,7 @@ func (m *modelDialog) models() []opencode.Model {
 
 func (m *modelDialog) switchProvider(offset int) {
 	newOffset := m.hScrollOffset + offset
+
 	if newOffset < 0 {
 		newOffset = len(m.availableProviders) - 1
 	}
@@ -183,7 +184,6 @@ func (m *modelDialog) getScrollIndicators(maxWidth int) string {
 }
 
 func (m *modelDialog) setupModelsForProvider(providerId string) {
-	m.hScrollPossible = len(m.availableProviders) > 1
 	models := m.models()
 	modelNames := make([]string, len(models))
 	for i, model := range models {

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -32,11 +32,13 @@ type ModelDialog interface {
 
 type modelDialog struct {
 	app                *app.App
+	favoriteModels     []opencode.Model
 	availableProviders []opencode.Provider
 	provider           opencode.Provider
 	width              int
 	height             int
 	hScrollOffset      int
+	isFavorites        bool
 	hScrollPossible    bool
 	modal              *modal.Modal
 	modelList          list.List[list.StringItem]
@@ -97,6 +99,16 @@ func (m *modelDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 			}
+			if m.isFavorites {
+				for _, p := range m.availableProviders {
+					for _, model := range p.Models {
+						if model.ID == selectedModel.ID {
+							m.provider = p
+							break
+						}
+					}
+				}
+			}
 			return m, tea.Sequence(
 				util.CmdHandler(modal.CloseModalMsg{}),
 				util.CmdHandler(
@@ -120,6 +132,9 @@ func (m *modelDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *modelDialog) models() []opencode.Model {
+	if m.isFavorites {
+		return m.favoriteModels
+	}
 	models := slices.SortedFunc(maps.Values(m.provider.Models), func(a, b opencode.Model) int {
 		return strings.Compare(a.Name, b.Name)
 	})
@@ -127,6 +142,11 @@ func (m *modelDialog) models() []opencode.Model {
 }
 
 func (m *modelDialog) switchProvider(offset int) {
+	if m.isFavorites {
+		m.isFavorites = false
+		m.hScrollOffset = -1
+	}
+
 	newOffset := m.hScrollOffset + offset
 
 	if newOffset < 0 {
@@ -150,7 +170,9 @@ func (m *modelDialog) View() string {
 
 func (m *modelDialog) getScrollIndicators(maxWidth int) string {
 	var indicator string
-	if m.hScrollPossible {
+	if m.isFavorites {
+		indicator = "← → (switch to providers) "
+	} else if m.hScrollPossible {
 		indicator = "← → (switch provider) "
 	}
 	if indicator == "" {
@@ -166,6 +188,9 @@ func (m *modelDialog) getScrollIndicators(maxWidth int) string {
 }
 
 func (m *modelDialog) setupModelsForProvider(providerId string) {
+	if m.isFavorites {
+		m.hScrollPossible = len(m.availableProviders) > 0
+	}
 	models := m.models()
 	modelNames := make([]string, len(models))
 	for i, model := range models {
@@ -214,10 +239,52 @@ func NewModelDialog(app *app.App) ModelDialog {
 		hScrollOffset:      hScrollOffset,
 		hScrollPossible:    len(availableProviders) > 1,
 		provider:           currentProvider,
-		modal: modal.New(
-			modal.WithTitle(fmt.Sprintf("Select %s Model", currentProvider.Name)),
-			modal.WithMaxWidth(maxDialogWidth+4),
-		),
+	}
+	dialog.modal = modal.New(
+		modal.WithTitle(fmt.Sprintf("Select %s Model", currentProvider.Name)),
+		modal.WithMaxWidth(maxDialogWidth+4),
+	)
+
+	if len(app.Config.FavoriteModels) > 0 {
+		for _, p := range availableProviders {
+			for _, m := range p.Models {
+				for _, fav := range app.Config.FavoriteModels {
+					if fav == m.ID {
+						dialog.favoriteModels = append(dialog.favoriteModels, m)
+					}
+				}
+			}
+		}
+	}
+
+	if len(dialog.favoriteModels) > 0 {
+		dialog.isFavorites = true
+		dialog.provider = opencode.Provider{
+			ID:   "favorites",
+			Name: "Favorites",
+		}
+		dialog.modal.SetTitle("Select a Favorite Model")
+	}
+
+	if len(app.Config.FavoriteModels) > 0 {
+		for _, p := range availableProviders {
+			for _, m := range p.Models {
+				for _, fav := range app.Config.FavoriteModels {
+					if fav == m.ID {
+						dialog.favoriteModels = append(dialog.favoriteModels, m)
+					}
+				}
+			}
+		}
+	}
+
+	if len(dialog.favoriteModels) > 0 {
+		dialog.isFavorites = true
+		dialog.provider = opencode.Provider{
+			ID:   "favorites",
+			Name: "Favorites",
+		}
+		dialog.modal.SetTitle("Select a Favorite Model")
 	}
 
 	dialog.setupModelsForProvider(currentProvider.ID)

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -269,11 +269,11 @@ func NewModelDialog(app *app.App) ModelDialog {
 		hScrollOffset:      hScrollOffset,
 		hScrollPossible:    len(providers) > 1,
 		provider:           currentProvider,
+		modal: modal.New(
+			modal.WithTitle(fmt.Sprintf("Select %s Model", currentProvider.Name)),
+			modal.WithMaxWidth(maxDialogWidth+4),
+		),
 	}
-	dialog.modal = modal.New(
-		modal.WithTitle(fmt.Sprintf("Select %s Model", currentProvider.Name)),
-		modal.WithMaxWidth(maxDialogWidth+4),
-	)
 
 	dialog.setupModelsForProvider(currentProvider.ID)
 	return dialog

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -213,32 +213,33 @@ func (s *modelDialog) Close() tea.Cmd {
 
 func NewModelDialog(app *app.App) ModelDialog {
 	// MOCK: Using a hardcoded list of favorite models for testing
-	mockFavoriteModels := []string{"openai/o3", "google/gemini-2.5-pro"} // e.g. "openai/gpt-4-turbo"
+	favoriteModels := []string{"openai/o3", "google/gemini-2.5-pro"}
+	// favoriteModels := app.Config.FavoriteModels
 	allProviders, _ := app.ListProviders(context.Background())
 
 	var providers []opencode.Provider
-	if len(mockFavoriteModels) > 0 {
-		var favoriteModels []opencode.Model
+	if len(favoriteModels) > 0 {
+		var models []opencode.Model
 		for _, p := range allProviders {
 			for _, m := range p.Models {
-				for _, fav := range mockFavoriteModels {
+				for _, fav := range favoriteModels {
 					if fav == fmt.Sprintf("%s/%s", p.ID, m.ID) {
 						newModel := m
 						newModel.ID = fmt.Sprintf("%s/%s", p.ID, m.ID)
 						newModel.Name = fmt.Sprintf("%s (%s)", m.Name, p.Name)
-						favoriteModels = append(favoriteModels, newModel)
+						models = append(models, newModel)
 					}
 				}
 			}
 		}
 
-		if len(favoriteModels) > 0 {
+		if len(models) > 0 {
 			favoritesProvider := opencode.Provider{
 				ID:     "favorites",
 				Name:   "Favorites",
 				Models: make(map[string]opencode.Model),
 			}
-			for _, m := range favoriteModels {
+			for _, m := range models {
 				favoritesProvider.Models[m.ID] = m
 			}
 			providers = append(providers, favoritesProvider)

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -32,13 +32,11 @@ type ModelDialog interface {
 
 type modelDialog struct {
 	app                *app.App
-	favoriteModels     []opencode.Model
 	availableProviders []opencode.Provider
 	provider           opencode.Provider
 	width              int
 	height             int
 	hScrollOffset      int
-	isFavorites        bool
 	hScrollPossible    bool
 	modal              *modal.Modal
 	modelList          list.List[list.StringItem]
@@ -99,22 +97,30 @@ func (m *modelDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 			}
-			if m.isFavorites {
+
+			providerToUse := m.provider
+			modelToSend := selectedModel
+
+			if m.provider.ID == "favorites" {
+				parts := strings.SplitN(selectedModel.ID, "/", 2)
+				providerID := parts[0]
+				modelID := parts[1]
+
 				for _, p := range m.availableProviders {
-					for _, model := range p.Models {
-						if model.ID == selectedModel.ID {
-							m.provider = p
-							break
-						}
+					if p.ID == providerID {
+						providerToUse = p
+						break
 					}
 				}
+				modelToSend = providerToUse.Models[modelID]
 			}
+
 			return m, tea.Sequence(
 				util.CmdHandler(modal.CloseModalMsg{}),
 				util.CmdHandler(
 					app.ModelSelectedMsg{
-						Provider: m.provider,
-						Model:    selectedModel,
+						Provider: providerToUse,
+						Model:    modelToSend,
 					}),
 			)
 		case key.Matches(msg, modelKeys.Escape):
@@ -132,9 +138,6 @@ func (m *modelDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *modelDialog) models() []opencode.Model {
-	if m.isFavorites {
-		return m.favoriteModels
-	}
 	models := slices.SortedFunc(maps.Values(m.provider.Models), func(a, b opencode.Model) int {
 		return strings.Compare(a.Name, b.Name)
 	})
@@ -142,13 +145,7 @@ func (m *modelDialog) models() []opencode.Model {
 }
 
 func (m *modelDialog) switchProvider(offset int) {
-	if m.isFavorites {
-		m.isFavorites = false
-		m.hScrollOffset = -1
-	}
-
 	newOffset := m.hScrollOffset + offset
-
 	if newOffset < 0 {
 		newOffset = len(m.availableProviders) - 1
 	}
@@ -170,9 +167,7 @@ func (m *modelDialog) View() string {
 
 func (m *modelDialog) getScrollIndicators(maxWidth int) string {
 	var indicator string
-	if m.isFavorites {
-		indicator = "← → (switch to providers) "
-	} else if m.hScrollPossible {
+	if m.hScrollPossible {
 		indicator = "← → (switch provider) "
 	}
 	if indicator == "" {
@@ -188,9 +183,7 @@ func (m *modelDialog) getScrollIndicators(maxWidth int) string {
 }
 
 func (m *modelDialog) setupModelsForProvider(providerId string) {
-	if m.isFavorites {
-		m.hScrollPossible = len(m.availableProviders) > 0
-	}
+	m.hScrollPossible = len(m.availableProviders) > 1
 	models := m.models()
 	modelNames := make([]string, len(models))
 	for i, model := range models {
@@ -219,12 +212,44 @@ func (s *modelDialog) Close() tea.Cmd {
 }
 
 func NewModelDialog(app *app.App) ModelDialog {
-	availableProviders, _ := app.ListProviders(context.Background())
+	// MOCK: Using a hardcoded list of favorite models for testing
+	mockFavoriteModels := []string{"openai/o3", "google/gemini-2.5-pro"} // e.g. "openai/gpt-4-turbo"
+	allProviders, _ := app.ListProviders(context.Background())
 
-	currentProvider := availableProviders[0]
+	var providers []opencode.Provider
+	if len(mockFavoriteModels) > 0 {
+		var favoriteModels []opencode.Model
+		for _, p := range allProviders {
+			for _, m := range p.Models {
+				for _, fav := range mockFavoriteModels {
+					if fav == fmt.Sprintf("%s/%s", p.ID, m.ID) {
+						newModel := m
+						newModel.ID = fmt.Sprintf("%s/%s", p.ID, m.ID)
+						newModel.Name = fmt.Sprintf("%s (%s)", m.Name, p.Name)
+						favoriteModels = append(favoriteModels, newModel)
+					}
+				}
+			}
+		}
+
+		if len(favoriteModels) > 0 {
+			favoritesProvider := opencode.Provider{
+				ID:     "favorites",
+				Name:   "Favorites",
+				Models: make(map[string]opencode.Model),
+			}
+			for _, m := range favoriteModels {
+				favoritesProvider.Models[m.ID] = m
+			}
+			providers = append(providers, favoritesProvider)
+		}
+	}
+	providers = append(providers, allProviders...)
+
+	currentProvider := providers[0]
 	hScrollOffset := 0
 	if app.Provider != nil {
-		for i, provider := range availableProviders {
+		for i, provider := range providers {
 			if provider.ID == app.Provider.ID {
 				currentProvider = provider
 				hScrollOffset = i
@@ -233,59 +258,22 @@ func NewModelDialog(app *app.App) ModelDialog {
 		}
 	}
 
+	if len(providers) > 0 && providers[0].ID == "favorites" {
+		currentProvider = providers[0]
+		hScrollOffset = 0
+	}
+
 	dialog := &modelDialog{
 		app:                app,
-		availableProviders: availableProviders,
+		availableProviders: providers,
 		hScrollOffset:      hScrollOffset,
-		hScrollPossible:    len(availableProviders) > 1,
+		hScrollPossible:    len(providers) > 1,
 		provider:           currentProvider,
 	}
 	dialog.modal = modal.New(
 		modal.WithTitle(fmt.Sprintf("Select %s Model", currentProvider.Name)),
 		modal.WithMaxWidth(maxDialogWidth+4),
 	)
-
-	if len(app.Config.FavoriteModels) > 0 {
-		for _, p := range availableProviders {
-			for _, m := range p.Models {
-				for _, fav := range app.Config.FavoriteModels {
-					if fav == m.ID {
-						dialog.favoriteModels = append(dialog.favoriteModels, m)
-					}
-				}
-			}
-		}
-	}
-
-	if len(dialog.favoriteModels) > 0 {
-		dialog.isFavorites = true
-		dialog.provider = opencode.Provider{
-			ID:   "favorites",
-			Name: "Favorites",
-		}
-		dialog.modal.SetTitle("Select a Favorite Model")
-	}
-
-	if len(app.Config.FavoriteModels) > 0 {
-		for _, p := range availableProviders {
-			for _, m := range p.Models {
-				for _, fav := range app.Config.FavoriteModels {
-					if fav == m.ID {
-						dialog.favoriteModels = append(dialog.favoriteModels, m)
-					}
-				}
-			}
-		}
-	}
-
-	if len(dialog.favoriteModels) > 0 {
-		dialog.isFavorites = true
-		dialog.provider = opencode.Provider{
-			ID:   "favorites",
-			Name: "Favorites",
-		}
-		dialog.modal.SetTitle("Select a Favorite Model")
-	}
 
 	dialog.setupModelsForProvider(currentProvider.ID)
 	return dialog


### PR DESCRIPTION
This implements an easy way to define favorite models and switch between them quickly:

-  Adds a new optional "favoriteModels" key to the config (an array with "provider/model" strings).
-  If the user has models in the favorites list, add them to the list of providers as a additional "provoder" (in first place) to display them in the /models dialog as the first page.

![Bildschirmfoto 2025-06-29 um 20 54 56](https://github.com/user-attachments/assets/50abdb12-cecf-4f12-90ac-1eb43db02d74)

Closes #541
