### PR TITLE
chore: remove duplicate EditTool in TOOLS array

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -407,7 +407,6 @@ export namespace Provider {
     LspHoverTool,
     PatchTool,
     ReadTool,
-    EditTool,
     // MultiEditTool,
     WriteTool,
     TodoWriteTool,


### PR DESCRIPTION
This looks like a bug to me, but just close this if I'm wrong.