### PR TITLE
fix: Small typo in CLI `--model` flag description

### DIFF
--- a/packages/web/src/content/docs/docs/cli.mdx
+++ b/packages/web/src/content/docs/docs/cli.mdx
@@ -41,7 +41,7 @@ opencode run Explain the use of context in Go
 | `--continue`          | `-c`  | Continue the last session |
 | `--session`          | `-s`  | Session ID to continue |
 | `--share`          |   | Share the session |
-| `--model`          | `-m`  | Mode to use in the form of provider/model |
+| `--model`          | `-m`  | Model to use in the form of provider/model |
 
 ---
 


### PR DESCRIPTION
Mode → Model in CLI --model flag description