### PR TITLE
feat: Add config flag to filter provider models

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -204,6 +204,7 @@ export namespace Config {
         .describe("@deprecated Use 'share' field instead. Share newly created sessions automatically"),
       autoupdate: z.boolean().optional().describe("Automatically update to the latest version"),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
+      onlyConfigModels: z.boolean().optional().describe("Only show models that are explicitly defined in the config (global setting)"),
       model: z.string().describe("Model to use in the format of provider/model, eg anthropic/claude-2").optional(),
       small_model: z
         .string()
@@ -242,6 +243,10 @@ export namespace Config {
                 })
                 .catchall(z.any())
                 .optional(),
+            onlyConfigModels: z
+              .boolean()
+              .optional()
+              .describe("Only show models that are explicitly defined in the config for this provider"),
             })
             .strict(),
         )

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -241,13 +241,18 @@ export namespace Provider {
 
     for (const [providerID, provider] of configProviders) {
       const existing = database[providerID]
+      
+      // Check if onlyConfigModels is enabled (per-provider setting takes precedence over global)
+      const onlyConfigModels = provider.onlyConfigModels ?? config.onlyConfigModels ?? false
+      
       const parsed: ModelsDev.Provider = {
         id: providerID,
         npm: provider.npm ?? existing?.npm,
         name: provider.name ?? existing?.name ?? providerID,
         env: provider.env ?? existing?.env ?? [],
         api: provider.api ?? existing?.api,
-        models: existing?.models ?? {},
+        // If onlyConfigModels is true, start with empty models, otherwise use database models
+        models: onlyConfigModels ? {} : (existing?.models ?? {}),
       }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {


### PR DESCRIPTION
# Problem
When using Azure OpenAI as a model provider, all potentially available models from this service are shown, but that likely doesn't correspond to the deployed models in a workspace of this service--we have 4 deployed models. You of course get an error if you try to call a model that is not deployed.

# Solution
The fix in this PR adds a flag that allows filtering to only the models defined in the config file. 

**Example**
Here, no models will be shown for Copilot despite a Github token being found, and only 3 models of 4 deployed are shown, with the rest found and added to the database being hidden.
```json
{
  "$schema": "https://opencode.ai/config.json",
  "onlyConfigModels": true,
  "provider": {
    "github-copilot": {
      "models": {}
    },
    "azure": {
      "models": {
        "GPT-4.1": {
          "name": "GPT4.1"
        },
        "GPT-4.1-mini": {
          "name": "GPT4.1-mini"
        },
        "GPT-4.1-nano": {
          "name": "GPT4.1-nano"
        }
      }
    }
  }
}

```

Alternatively, this could just be default behavior omitting the need for such a flag. 

It would also be nice to query the available models to prevent the need to define models in the config., but the included solution is easy enough and allows some additional flexibility about which models to show.