### PR TITLE
fix: properly handle utf-8 in diff highlighting

### DIFF
--- a/packages/tui/internal/components/diff/diff.go
+++ b/packages/tui/internal/components/diff/diff.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters"
@@ -604,7 +605,10 @@ func applyHighlighting(content string, segments []Segment, segmentType LineType,
 			ansiSequences[visibleIdx] = lastAnsiSeq
 		}
 		visibleIdx++
-		i++
+
+		// Properly advance by UTF-8 rune, not byte
+		_, size := utf8.DecodeRuneInString(content[i:])
+		i += size
 	}
 
 	// Apply highlighting
@@ -651,8 +655,9 @@ func applyHighlighting(content string, segments []Segment, segmentType LineType,
 			}
 		}
 
-		// Get current character
-		char := string(content[i])
+		// Get current character (properly handle UTF-8)
+		r, size := utf8.DecodeRuneInString(content[i:])
+		char := string(r)
 
 		if inSelection {
 			// Get the current styling
@@ -686,7 +691,7 @@ func applyHighlighting(content string, segments []Segment, segmentType LineType,
 		}
 
 		currentPos++
-		i++
+		i += size
 	}
 
 	return sb.String()


### PR DESCRIPTION
fixes https://github.com/sst/opencode/issues/379

seems like the problem was in `applyHighlighting` in `diff.go`
https://github.com/sst/opencode/blob/e99bdcefac44db9251ac08b515a6b1f5af42610c/packages/tui/internal/components/diff/diff.go#L607

the incrementing didn't honor multi-byte UTF-8 characters

i don't quite understand the code, but the solution seems to be working