### PR TITLE
fix: handle null case if tool args are empty for todos

### DIFF
--- a/packages/web/src/components/Share.tsx
+++ b/packages/web/src/components/Share.tsx
@@ -1616,7 +1616,7 @@ export default function Share(props: {
                         >
                           {(_part) => {
                             const todos = createMemo(() =>
-                              sortTodosByStatus(toolData()?.args.todos),
+                              sortTodosByStatus(toolData()?.args?.todos ?? []),
                             )
                             const starting = () =>
                               todos().every((t) => t.status === "pending")


### PR DESCRIPTION
Probably not the best solution ever but it alleviates the hydration issue so I can actually view the share link. 

fixes: #587

See:
<img width="1498" alt="Screenshot 2025-07-01 at 5 10 45 PM" src="https://github.com/user-attachments/assets/c381940c-ba95-4903-9d25-6139df1af875" />

As you can see when running locally it now works id: `.../s/vTXv6fTC`
