### PR TITLE
Fix: Filter empty messages to prevent conversation breaks

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -273,6 +273,32 @@ export namespace Session {
     })
   }
 
+  function hasValidContent(msg: UIMessage): boolean {
+    return (
+      (msg.parts?.length ?? 0) > 0 &&
+      msg.parts.some((part) => {
+        switch (part.type) {
+          case "text":
+            return part.text && part.text.trim().length > 0
+          case "file":
+            return part.data && part.data.length > 0
+          case "tool-invocation":
+            return true
+          case "reasoning":
+            return true
+          case "source":
+            return true
+          case "step-start":
+            // Start Step Part - indicates start of a step (UI metadata only)
+            // See: https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol#start-step-part
+            return false
+          default:
+            return false // all known types handled above
+        }
+      })
+    )
+  }
+
   export async function chat(input: {
     sessionID: string
     providerID: string
@@ -367,6 +393,9 @@ export namespace Session {
     const system = input.system ?? SystemPrompt.provider(input.providerID)
     system.push(...(await SystemPrompt.environment()))
     system.push(...(await SystemPrompt.custom()))
+
+    const filteredMessages = msgs.map(toUIMessage).filter(hasValidContent)
+    const coreMessages = convertToCoreMessages(filteredMessages)
 
     const next: Message.Info = {
       id: Identifier.ascending("message"),
@@ -549,9 +578,7 @@ export namespace Session {
             content: x,
           }),
         ),
-        ...convertToCoreMessages(
-          msgs.map(toUIMessage).filter((x) => x.parts.length > 0),
-        ),
+        ...coreMessages,
       ],
       temperature: model.info.temperature ? 0 : undefined,
       tools: model.info.tool_call === false ? undefined : tools,


### PR DESCRIPTION
### Problem
Noticed that a conversation broke because I had an LLM API error occur in a conversation. This happened suddenly and broke the whole conversation from then on. [Broken Convo](https://opencode.ai/s/152Zoncg) (share link doesn't show all context)

<img width="854" alt="Screenshot 2025-07-01 at 8 11 31 PM" src="https://github.com/user-attachments/assets/18f20497-adeb-4e7b-bc44-1bda6997255c" />


Issue was `streamText` can produce assistant responses that contain only `step-start` parts. When these messages are converted to core messages via `convertToCoreMessages`, they result in empty content arrays (`content: []`) which trigger API errors from LLM providers.

### Root Cause
`step-start` parts are UI metadata that get filtered out during core message conversion. If an assistant message only contains `step-start` parts (no text, tool calls, etc.), the converted core message becomes invalid with empty content, causing API failures.

Added `hasValidContent` filter that prevents messages with only `step-start` parts from reaching `convertToCoreMessages`, avoiding API errors from empty content messages while preserving valid messages.