### PR TITLE
fix: Copilot Premium Requests

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -105,10 +105,6 @@ export namespace Provider {
                 typeof init.body === "string"
                   ? JSON.parse(init.body)
                   : init.body
-              let m
-              for (m of body.messages) {
-                Log.Default.warn("role", { role: m.role })
-              }
               if (body?.messages) {
                 isAgentCall = body.messages.some(
                   (msg: any) =>
@@ -116,7 +112,6 @@ export namespace Provider {
                 )
               }
             } catch {}
-            Log.Default.warn("isAgentCall", { isAgentCall })
             const headers = {
               ...init.headers,
               ...copilot.HEADERS,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -99,11 +99,30 @@ export namespace Provider {
               })
               info.access = tokens.access
             }
+            let isAgentCall = false
+            try {
+              const body =
+                typeof init.body === "string"
+                  ? JSON.parse(init.body)
+                  : init.body
+              let m
+              for (m of body.messages) {
+                Log.Default.warn("role", { role: m.role })
+              }
+              if (body?.messages) {
+                isAgentCall = body.messages.some(
+                  (msg: any) =>
+                    msg.role && ["tool", "assistant"].includes(msg.role),
+                )
+              }
+            } catch {}
+            Log.Default.warn("isAgentCall", { isAgentCall })
             const headers = {
               ...init.headers,
               ...copilot.HEADERS,
               Authorization: `Bearer ${info.access}`,
               "Openai-Intent": "conversation-edits",
+              "X-Initiator": isAgentCall ? "agent" : "user",
             }
             delete headers["x-api-key"]
             return fetch(input, {


### PR DESCRIPTION
All calls including those initiated by a tool or the assistant are currently being counted against the copilot premium request limit.

This header should prevent calls initiated by either the "tool" or "assistant" from counting against those request limits.

For example codecompanion.nvim recently implemented a similar [fix](https://github.com/olimorris/codecompanion.nvim/commit/ed96fe33c17b41957f2334b1cae29c24d35f8ef2)

fix #430