### PR TITLE
fix(tui): no space between agent and user message

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -109,7 +109,7 @@ func (m *messagesComponent) renderView() {
 	width := layout.Current.Container.Width
 
 	sb := strings.Builder{}
-	util.WriteStringsPar(&sb, m.app.Messages, func(message opencode.Message) string {
+	util.MapReducePar(m.app.Messages, &sb, func(message opencode.Message) func(*strings.Builder) *strings.Builder {
 		var content string
 		var cached bool
 		blocks := make([]string, 0)
@@ -248,7 +248,14 @@ func (m *messagesComponent) renderView() {
 			blocks = append(blocks, error)
 		}
 
-		return strings.Join(blocks, "\n\n")
+		str := strings.Join(blocks, "\n\n")
+		return func(sbdr *strings.Builder) *strings.Builder {
+			if sbdr.Len() > 0 && str != "" {
+				sbdr.WriteString("\n\n")
+			}
+			sbdr.WriteString(str)
+			return sbdr
+		}
 	})
 
 	content := sb.String()


### PR DESCRIPTION
This PR adds back the space between user and agent messages. If it was taken out on purpose or if it should be fixed in another way, you can just close this PR.

Closes #599 

![Bildschirmfoto 2025-07-02 um 08 47 18](https://github.com/user-attachments/assets/cf05f64b-4319-4e6b-80cc-bbfc9c74c888)
