### PR TITLE
fix(formatting): check for enabled formatters

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -31,7 +31,7 @@ export namespace Format {
     const result = []
     for (const item of Object.values(Formatter)) {
       if (!item.extensions.includes(ext)) continue
-      if (!isEnabled(item)) continue
+      if (!(await isEnabled(item))) continue
       result.push(item)
     }
     return result


### PR DESCRIPTION
I think there was a await missing so all formatter where evaluated as enabled as `isEnabled` returns a promise.