### PR TITLE
feat(formatter): Add detekt as Kotlin formatter

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -114,6 +114,15 @@ export const clang: Info = {
   },
 }
 
+export const detekt: Info = {
+  name: "detekt",
+  command: ["detekt", "-ac", "-i", "$FILE"],
+  extensions: [".kt", ".kts"],
+  async enabled() {
+    return Bun.which("detekt") !== null
+  },
+}
+
 export const ktlint: Info = {
   name: "ktlint",
   command: ["ktlint", "-F", "$FILE"],


### PR DESCRIPTION
detekt [1] can be used as a wrapper for ktlint [2]. When using detekt as a formatter, the ktlint CLI is not required and might not be installed. To offer formatting in this case, define `detekt --auto-format` as formatter for Kotlin source files.

[1]: https://detekt.dev
[2]: https://detekt.dev/docs/rules/formatting