### PR TITLE
Changed handling of OpenRouter requests to add some custom headers so that it can see the app

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -192,13 +192,9 @@ export namespace Provider {
       }
     },
     openrouter: async (provider) => {
-      const apiKey = provider.env.map((item) => process.env[item]).at(0)
-      if (!apiKey) return { autoload: false }
-
       return {
         autoload: true,
         options: {
-          apiKey,
           async fetch(input: any, init: any) {
             const headers = {
               ...init.headers,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -191,6 +191,25 @@ export namespace Provider {
         },
       }
     },
+    openrouter: async (provider) => {
+      const apiKey = provider.env.map((item) => process.env[item]).at(0)
+      if (!apiKey) return { autoload: false }
+
+      return {
+        autoload: true,
+        options: {
+          apiKey,
+          async fetch(input: any, init: any) {
+            const headers = {
+              ...init.headers,
+              "HTTP-Referer": "https://opencode.ai/",
+              "X-Title": "opencode",
+            }
+            return fetch(input, { ...init, headers })
+          },
+        },
+      }
+    },
   }
 
   const state = App.state("provider", async () => {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -193,15 +193,11 @@ export namespace Provider {
     },
     openrouter: async (provider) => {
       return {
-        autoload: true,
+        autoload: false,
         options: {
-          async fetch(input: any, init: any) {
-            const headers = {
-              ...init.headers,
-              "HTTP-Referer": "https://opencode.ai/",
-              "X-Title": "opencode",
-            }
-            return fetch(input, { ...init, headers })
+          headers: {
+            "HTTP-Referer": "https://opencode.ai/",
+            "X-Title": "opencode",
           },
         },
       }


### PR DESCRIPTION
Should now correctly show up in the OpenRouter Activity with the opencode url and name rather than unknown. This means that opencode will show up in the charts for models and it will be generally easier to tack usage of a key.