### PR TITLE
fix: typescript error

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -205,7 +205,7 @@ export namespace Provider {
         },
       }
     },
-    openrouter: async (provider) => {
+    openrouter: async () => {
       return {
         autoload: false,
         options: {


### PR DESCRIPTION
This fixes a  typescript error (var declared but never read) because when working on opencode with opencode most models run typcheck and then want to fix this unrelated type error.