### PR TITLE
feat: configurable instructions

### DIFF
--- a/packages/opencode/config.schema.json
+++ b/packages/opencode/config.schema.json
@@ -297,6 +297,13 @@
       },
       "description": "MCP (Model Context Protocol) server configurations"
     },
+    "instructions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Additional instruction files or patterns to include"
+    },
     "experimental": {
       "type": "object",
       "properties": {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -176,6 +176,10 @@ export namespace Config {
         .record(z.string(), Mcp)
         .optional()
         .describe("MCP (Model Context Protocol) server configurations"),
+      instructions: z
+        .array(z.string())
+        .optional()
+        .describe("Additional instruction files or patterns to include"),
       experimental: z
         .object({
           hook: z

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -15,4 +15,28 @@ export namespace Filesystem {
     }
     return result
   }
+
+  export async function globUp(pattern: string, start: string, stop?: string) {
+    let current = start
+    const result = []
+    while (true) {
+      try {
+        const glob = new Bun.Glob(pattern)
+        for await (const match of glob.scan({
+          cwd: current,
+          onlyFiles: true,
+          dot: true,
+        })) {
+          result.push(join(current, match))
+        }
+      } catch {
+        // Skip invalid glob patterns
+      }
+      if (stop === current) break
+      const parent = dirname(current)
+      if (parent === current) break
+      current = parent
+    }
+    return result
+  }
 }


### PR DESCRIPTION
Fixes: #583

Changes:
- optional `instructions` config key (array of files to read for instructions)
- behaviors:
   * instructions **won't override** the defaults only extend (AGENTS.md, CLAUDE.md, CONTEXT.md) 
   * instructions can be globs (notably for .cursor/rules/*.mdc support) 

This was just an initial pass happy to make any changes.