### PR TITLE
fix mouse scroll events being interpreted as keyboard input

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -107,6 +107,25 @@ var BUGGED_SCROLL_KEYS = map[string]bool{
 	";": true,
 }
 
+func isScrollRelatedInput(keyString string) bool {
+	if len(keyString) == 0 {
+		return false
+	}
+	
+	for _, char := range keyString {
+		charStr := string(char)
+		if !BUGGED_SCROLL_KEYS[charStr] {
+			return false
+		}
+	}
+	
+	if len(keyString) > 3 && (keyString[len(keyString)-1] == 'M' || keyString[len(keyString)-1] == 'm') {
+		return true
+	}
+	
+	return len(keyString) > 1
+}
+
 func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	var cmds []tea.Cmd
@@ -114,7 +133,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		keyString := msg.String()
-		if time.Since(a.lastScroll) < time.Millisecond*100 && BUGGED_SCROLL_KEYS[keyString] {
+		if time.Since(a.lastScroll) < time.Millisecond*100 && (BUGGED_SCROLL_KEYS[keyString] || isScrollRelatedInput(keyString)) {
 			return a, nil
 		}
 


### PR DESCRIPTION
Fixes an issue where trackpad scrolling with "momentum" like on a macbook would capture all overflow events (scrolling to the bottom before that momentum would have stopped scrolling) and interpret it as keyboard input like "5;40;37M;37M5;40". Leveraged the existing `BUGGED_SCROLL_KEYS`, to add a safer guard to prevent it. 