### PR TITLE
refactor: centralize todo status and priority enums

### DIFF
--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -2,18 +2,8 @@ import { z } from "zod"
 import { Tool } from "./tool"
 import DESCRIPTION_WRITE from "./todowrite.txt"
 import { App } from "../app/app"
+import { TodoInfo } from "../util/schema"
 
-const TodoInfo = z.object({
-  content: z.string().min(1).describe("Brief description of the task"),
-  status: z
-    .enum(["pending", "in_progress", "completed"])
-    .describe("Current status of the task"),
-  priority: z
-    .enum(["high", "medium", "low"])
-    .describe("Priority level of the task"),
-  id: z.string().describe("Unique identifier for the todo item"),
-})
-type TodoInfo = z.infer<typeof TodoInfo>
 
 const state = App.state("todo-tool", () => {
   const todos: {

--- a/packages/opencode/src/util/schema.ts
+++ b/packages/opencode/src/util/schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+// Enum status
+export const StatusEnum = z.enum(["pending", "in_progress", "completed"])
+// Enum priority
+export const PriorityEnum = z.enum(["high", "medium", "low"])
+
+// Schema for todo info
+export const TodoInfo = z.object({
+  content: z.string().min(1).describe("Brief description of the task"),
+  status: StatusEnum.describe("Current status of the task"),
+  priority: PriorityEnum.describe("Priority level of the task"),
+  id: z.string().describe("Unique identifier for the todo item"),
+})
+export type StatusEnum = z.infer<typeof StatusEnum>
+export type PriorityEnum = z.infer<typeof PriorityEnum>
+export type TodoInfo = z.infer<typeof TodoInfo>


### PR DESCRIPTION
### refactor: centralize todo status and priority enums

 #### Description
This PR centralizes the Zod enums for todo status and priority into a single shared file (src/util/schemas.ts).
The goal is to avoid duplication, improve maintainability, and ensure consistency across the codebase.

 #### Changes
 - Created src/util/schemas.ts to export:
 - StatusEnum (pending, in_progress, completed)
 - PriorityEnum (high, medium, low)
 - (Optionally) a shared TodoInfo schema and types
 - Updated src/tool/todo.ts to import and use these enums instead of local definitions.
 - Updated TypeScript types to use z.infer<typeof StatusEnum> and z.infer<typeof PriorityEnum>.

 #### Motivation
 - Single source of truth for todo status and priority values.
 - Easier future changes: adding or renaming a status/priority only requires editing one file.
 - Consistency: all modules use the exact same validation and types.

 #### Checklist
 - [x] All usages of todo status and priority enums in src/tool/todo.ts now use the shared enums.
 - [x] Types are inferred from Zod schemas.
 - [x] All tests pass (bun test).
 - [x] Code style and conventions follow the project’s AGENTS.md guidelines.

 #### Notes
 - This PR is limited to the todo tool. If similar enums are found elsewhere, a follow-up PR can further centralize them.
 - Please let me know if you prefer the shared TodoInfo schema to be used in other modules as well.

 ---
> Thank you for reviewing!