### PR TITLE
fix: proper message for rate limit hit on anthropic provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -59,10 +59,36 @@ export namespace Provider {
               "anthropic-beta": "oauth-2025-04-20",
             }
             delete headers["x-api-key"]
-            return fetch(input, {
+            const response = await fetch(input, {
               ...init,
               headers,
             })
+
+            if (response.status === 429) {
+              const resetTimestampStr = response.headers.get("anthropic-ratelimit-unified-reset")
+              let userMessage = `Anthropic API rate limit exceeded. `
+              let resetTimestamp = parseInt(resetTimestampStr || "", 10)
+
+              if (!isNaN(resetTimestamp)) {
+                const resetDate = new Date(resetTimestamp * 1000)
+                const currentDate = new Date()
+
+                let resetStr: string;
+                if (currentDate.toLocaleDateString() == resetDate.toLocaleDateString()) {
+                  resetStr = resetDate.toLocaleTimeString()
+                } else {
+                  resetStr = resetDate.toLocaleString()
+                }
+
+                userMessage += `Please try again after ${resetStr}.`
+              } else {
+                userMessage += "Please try again later."
+              }
+
+              throw new Error(userMessage)
+            }
+
+            return response
           },
         },
       }


### PR DESCRIPTION
Added better message for rate limit hit on anthropic models.

Before:

<img width="652" alt="image" src="https://github.com/user-attachments/assets/1bf87be9-f10e-42fe-a3ac-756e4626b599" />

After:

<img width="657" alt="image" src="https://github.com/user-attachments/assets/78474f2c-7675-4140-bec4-8ad7364e06c4" />

