### PR TITLE
fix(tui): optimistic rendering

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -68,11 +68,9 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.selectedPart = -1
 		return m, nil
 	case app.OptimisticMessageAddedMsg:
-		m.renderView(m.width)
-		if m.tail {
-			m.viewport.GotoBottom()
-		}
-		return m, nil
+		m.tail = true
+		m.rendering = true
+		return m, m.Reload()
 	case dialog.ThemeSelectedMsg:
 		m.cache.Clear()
 		m.rendering = true


### PR DESCRIPTION
The optimistic update mechanism had delays when displaying user input messages. Sometimes there would be a long delay before the user's message appeared after hitting enter.

- The `OptimisticMessageAddedMsg` handler called `m.renderView(m.width)` synchronously, which could block the UI.
- Changed the handler to use asynchronous rendering like other parts of the codebase:

This ensures the first thing that happens when a user hits enter is that their message gets rendered immediately, providing instant feedback.

Closes #686 