### PR TITLE
ci: fix setup-go cache dependency path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           go-version: ">=1.24.0"
           cache: true
-          cache-dependency-path: go.sum
+          cache-dependency-path: "**/*.sum"
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
Fixing the path used by the cache.
[Official docs](https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs)

<img width="580" alt="image" src="https://github.com/user-attachments/assets/63e5fcaa-090c-4706-9676-2c6e81f75aeb" />
