### PR TITLE
MCP tool schema transformation for OpenAI/Azure providers

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -143,15 +143,47 @@ export namespace MCP {
     return state().then((state) => state.clients)
   }
 
-  export async function tools() {
+  export async function tools(providerID?: string) {
     const result: Record<string, Tool> = {}
-    for (const [clientName, client] of Object.entries(await clients())) {
-      for (const [toolName, tool] of Object.entries(await client.tools())) {
-        const sanitizedClientName = clientName.replace(/\s+/g, "_")
-        const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = tool
+    const clientEntries = Object.entries(await clients())
+    
+    for (const [clientName, client] of clientEntries) {
+      try {
+        const clientTools = await client.tools()
+        
+        for (const [toolName, tool] of Object.entries(clientTools)) {
+          const sanitizedClientName = clientName.replace(/\s+/g, "_")
+          const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
+          const toolKey = sanitizedClientName + "_" + sanitizedToolName
+          
+          if (providerID) {
+            const transformedTool = await transformToolForProvider(tool, providerID)
+            result[toolKey] = transformedTool
+          } else {
+            result[toolKey] = tool
+          }
+        }
+      } catch (error: any) {
+        log.error('Failed to get tools from MCP client', { clientName, error: error.message })
       }
     }
+    
     return result
+  }
+
+  async function transformToolForProvider(tool: any, providerID: string): Promise<any> {
+    if (!['openai', 'azure'].includes(providerID)) return tool
+    
+    try {
+      const { Provider } = await import("../provider/provider")
+      return Provider.transformMCPToolForProvider(tool, providerID)
+    } catch (error: any) {
+      log.warn('Could not transform MCP tool schema, using as-is', { 
+        toolId: tool.id || 'unknown',
+        providerID,
+        error: error.message
+      })
+      return tool
+    }
   }
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -146,16 +146,16 @@ export namespace MCP {
   export async function tools(providerID?: string) {
     const result: Record<string, Tool> = {}
     const clientEntries = Object.entries(await clients())
-    
+
     for (const [clientName, client] of clientEntries) {
       try {
         const clientTools = await client.tools()
-        
+
         for (const [toolName, tool] of Object.entries(clientTools)) {
           const sanitizedClientName = clientName.replace(/\s+/g, "_")
           const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
           const toolKey = sanitizedClientName + "_" + sanitizedToolName
-          
+
           if (providerID) {
             const transformedTool = await transformToolForProvider(tool, providerID)
             result[toolKey] = transformedTool
@@ -164,24 +164,24 @@ export namespace MCP {
           }
         }
       } catch (error: any) {
-        log.error('Failed to get tools from MCP client', { clientName, error: error.message })
+        log.error("Failed to get tools from MCP client", { clientName, error: error.message })
       }
     }
-    
+
     return result
   }
 
   async function transformToolForProvider(tool: any, providerID: string): Promise<any> {
-    if (!['openai', 'azure'].includes(providerID)) return tool
-    
+    if (!["openai", "azure"].includes(providerID)) return tool
+
     try {
       const { Provider } = await import("../provider/provider")
       return Provider.transformMCPToolForProvider(tool, providerID)
     } catch (error: any) {
-      log.warn('Could not transform MCP tool schema, using as-is', { 
-        toolId: tool.id || 'unknown',
+      log.warn("Could not transform MCP tool schema, using as-is", {
+        toolId: tool.id || "unknown",
         providerID,
-        error: error.message
+        error: error.message,
       })
       return tool
     }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -486,43 +486,43 @@ export namespace Provider {
     }
   }
 
-function transformJsonSchema(schema: any): any {
+  function transformJsonSchema(schema: any): any {
     // Only handle simple object schemas
-    if (!schema || schema.type !== 'object' || !schema.properties) {
+    if (!schema || schema.type !== "object" || !schema.properties) {
       return schema // Return as-is for anything we don't understand
     }
-    
+
     // If it has oneOf, anyOf, allOf, or other complex stuff - bail out
     if (schema.oneOf || schema.anyOf || schema.allOf) {
-      log.warn('Complex JSON schema detected, skipping transformation', { schema })
+      log.warn("Complex JSON schema detected, skipping transformation", { schema })
       return schema
     }
-    
+
     // Simple transformation: all properties become required + nullable
     const required = Object.keys(schema.properties)
     const properties: Record<string, any> = {}
-    
+
     for (const [key, prop] of Object.entries(schema.properties)) {
       if (!schema.required?.includes(key)) {
         // Make it nullable
-        properties[key] = { 
-          anyOf: [prop, { type: 'null' }] 
+        properties[key] = {
+          anyOf: [prop, { type: "null" }],
         }
       } else {
         properties[key] = prop
       }
     }
-    
+
     return {
       ...schema,
       required,
-      properties
+      properties,
     }
   }
 
   export function transformMCPToolForProvider(tool: any, providerID: string): any {
-    if (!['openai', 'azure'].includes(providerID)) return tool
-    
+    if (!["openai", "azure"].includes(providerID)) return tool
+
     try {
       // AI SDK converts MCP tools to: { parameters: { jsonSchema: <original_inputSchema> } }
       if (tool.parameters?.jsonSchema) {
@@ -531,16 +531,16 @@ function transformJsonSchema(schema: any): any {
           ...tool,
           parameters: {
             ...tool.parameters,
-            jsonSchema: transformedSchema
-          }
+            jsonSchema: transformedSchema,
+          },
         }
       }
-      
+
       return tool
     } catch (error: any) {
-      log.warn('Could not transform MCP tool schema, using as-is', { 
-        toolId: tool.id || 'unknown',
-        error: error.message 
+      log.warn("Could not transform MCP tool schema, using as-is", {
+        toolId: tool.id || "unknown",
+        error: error.message,
       })
       return tool
     }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -486,6 +486,65 @@ export namespace Provider {
     }
   }
 
+function transformJsonSchema(schema: any): any {
+    // Only handle simple object schemas
+    if (!schema || schema.type !== 'object' || !schema.properties) {
+      return schema // Return as-is for anything we don't understand
+    }
+    
+    // If it has oneOf, anyOf, allOf, or other complex stuff - bail out
+    if (schema.oneOf || schema.anyOf || schema.allOf) {
+      log.warn('Complex JSON schema detected, skipping transformation', { schema })
+      return schema
+    }
+    
+    // Simple transformation: all properties become required + nullable
+    const required = Object.keys(schema.properties)
+    const properties: Record<string, any> = {}
+    
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      if (!schema.required?.includes(key)) {
+        // Make it nullable
+        properties[key] = { 
+          anyOf: [prop, { type: 'null' }] 
+        }
+      } else {
+        properties[key] = prop
+      }
+    }
+    
+    return {
+      ...schema,
+      required,
+      properties
+    }
+  }
+
+  export function transformMCPToolForProvider(tool: any, providerID: string): any {
+    if (!['openai', 'azure'].includes(providerID)) return tool
+    
+    try {
+      // AI SDK converts MCP tools to: { parameters: { jsonSchema: <original_inputSchema> } }
+      if (tool.parameters?.jsonSchema) {
+        const transformedSchema = transformJsonSchema(tool.parameters.jsonSchema)
+        return {
+          ...tool,
+          parameters: {
+            ...tool.parameters,
+            jsonSchema: transformedSchema
+          }
+        }
+      }
+      
+      return tool
+    } catch (error: any) {
+      log.warn('Could not transform MCP tool schema, using as-is', { 
+        toolId: tool.id || 'unknown',
+        error: error.message 
+      })
+      return tool
+    }
+  }
   export const ModelNotFoundError = NamedError.create(
     "ProviderModelNotFoundError",
     z.object({

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -918,7 +918,7 @@ export namespace Session {
       })
     }
 
-    for (const [key, item] of Object.entries(await MCP.tools())) {
+for (const [key, item] of Object.entries(await MCP.tools(model.providerID))) {
       if (Wildcard.all(key, enabledTools) === false) continue
       const execute = item.execute
       if (!execute) continue

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -918,7 +918,7 @@ export namespace Session {
       })
     }
 
-for (const [key, item] of Object.entries(await MCP.tools(model.providerID))) {
+    for (const [key, item] of Object.entries(await MCP.tools(model.providerID))) {
       if (Wildcard.all(key, enabledTools) === false) continue
       const execute = item.execute
       if (!execute) continue


### PR DESCRIPTION
Fixes MCP tools failing with OpenAI/Azure providers due to schema compatibility
issues.

**Resolves:**
- #250
- #441

**Changes:**
- Transform MCP tool schemas to make optional parameters nullable + required for
OpenAI/Azure
- Move transformation logic to MCP module for cleaner architecture
- Graceful fallback for complex schemas

**Tested with:** context7-mcp, works with OpenAI models
