### PR TITLE
fix: Skip opencode upgrade if same version

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -35,6 +35,15 @@ export const UpgradeCommand = {
     }
     prompts.log.info("Using method: " + method)
     const target = args.target ?? (await Installation.latest())
+
+    if (Installation.VERSION === target) {
+      prompts.log.warn(
+        `opencode upgrade skipped: ${target} is already installed`,
+      )
+      prompts.outro("Done")
+      return
+    }
+
     prompts.log.info(`From ${Installation.VERSION} → ${target}`)
     const spinner = prompts.spinner()
     spinner.start("Upgrading...")


### PR DESCRIPTION
Currently, upgrading OpenCode would redownload the latest executable file even if the version number is the same as the one installed. This PR makes the code return early, it should work with latest version and targetted versions.

![image](https://github.com/user-attachments/assets/b6e02ca7-f481-4ce9-8b78-4ea16798f58c)