### PR TITLE
Fix Elixir LSP startup

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -66,6 +66,7 @@ export namespace LSPClient {
     log.info("sending initialize", { id: serverID })
     await withTimeout(
       connection.sendRequest("initialize", {
+        rootUri: "file://" + app.path.cwd,
         processId: server.process.pid,
         workspaceFolders: [
           {


### PR DESCRIPTION
The Elixir LSP won't start without the rootUri set, resulting in initialize errors.