### PR TITLE
fix: set optional provider attributes from nullable to nullable optional

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -521,7 +521,7 @@ export namespace Provider {
       for (const [key, value] of Object.entries(shape)) {
         const zodValue = value as z.ZodTypeAny
         if (zodValue instanceof z.ZodOptional) {
-          newShape[key] = zodValue.unwrap().nullable()
+          newShape[key] = zodValue.unwrap().nullable().optional()
         } else {
           newShape[key] = optionalToNullable(zodValue)
         }


### PR DESCRIPTION
We experienced an error using the Azure provideer when directly requesting a command call, e.g.:

**Prompt**
```
run ls
```
This appeared to be due to optional tools fields being set to nullable and loosing their optional attribute.... Would need to go back to recreate this to be more detailed here--let me know if that helps.

Solution is define the value as optional after being set to nullable.