### PR TITLE
fix: display errors when using `opencode run ...`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -125,6 +125,20 @@ export const RunCommand = cmd({
         }
       })
 
+      let errorMsg: string | undefined
+      Bus.subscribe(Session.Event.Error, async (evt) => {
+        const { sessionID, error } = evt.properties
+        if (sessionID !== session.id || !error) return
+        let err = String(error.name)
+
+        if ("data" in error && error.data && "message" in error.data) {
+          err = error.data.message
+        }
+        errorMsg = errorMsg ? errorMsg + "\n" + err : err
+
+        UI.error(err)
+      })
+
       const result = await Session.chat({
         sessionID: session.id,
         providerID,
@@ -140,6 +154,7 @@ export const RunCommand = cmd({
       if (isPiped) {
         const match = result.parts.findLast((x) => x.type === "text")
         if (match) process.stdout.write(match.text)
+        if (errorMsg) process.stdout.write(errorMsg)
       }
       UI.empty()
     })

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -99,6 +99,7 @@ export namespace Session {
     Error: Bus.event(
       "session.error",
       z.object({
+        sessionID: z.string().optional(),
         error: MessageV2.Assistant.shape.error,
       }),
     ),
@@ -727,6 +728,7 @@ export namespace Session {
           next.error = new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e })
       }
       Bus.publish(Event.Error, {
+        sessionID: next.sessionID,
         error: next.error,
       })
     }


### PR DESCRIPTION
Fixes: #752


Example:

<img width="468" alt="Screenshot 2025-07-08 at 9 25 56 AM" src="https://github.com/user-attachments/assets/afb30fac-f7e6-4acb-b9f9-993fee1322e5" />
