### PR TITLE
feat(storage): ensure storage directory exists and handle paths correctly

### DIFF
--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -39,7 +39,8 @@ export namespace Storage {
 
   const state = App.state("storage", async () => {
     const app = App.info()
-    const dir = path.join(app.path.data, "storage")
+    const dir = path.normalize(path.join(app.path.data, "storage"))
+    await fs.mkdir(dir, { recursive: true })
     const migration = await Bun.file(path.join(dir, "migration"))
       .json()
       .then((x) => parseInt(x))


### PR DESCRIPTION
This pull request ensures that the 'storage' directory is created if it doesn't exist before any write operations are made. This prevents potential race conditions and errors on the first run. It also uses path.normalize to ensure robust cross-platform path handling. 

I can't figure out how to retrieve the HTTP Error between the TUI and the server, but this should solve the error raised when that storage directory does not exist.

