### PR TITLE
tweak: keep completion options open when trigger is still present

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -202,7 +202,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 
 			// Set command provider for command completion
-			a.completions = dialog.NewCompletionDialogComponent(a.commandProvider)
+			a.completions = dialog.NewCompletionDialogComponent(a.commandProvider, "/")
 			updated, cmd = a.completions.Update(msg)
 			a.completions = updated.(dialog.CompletionDialog)
 			cmds = append(cmds, cmd)
@@ -221,7 +221,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 
 			// Set file provider for file completion
-			a.completions = dialog.NewCompletionDialogComponent(a.fileProvider)
+			a.completions = dialog.NewCompletionDialogComponent(a.fileProvider, "@")
 			updated, cmd = a.completions.Update(msg)
 			a.completions = updated.(dialog.CompletionDialog)
 			cmds = append(cmds, cmd)
@@ -1034,7 +1034,7 @@ func NewModel(app *app.App) tea.Model {
 
 	messages := chat.NewMessagesComponent(app)
 	editor := chat.NewEditorComponent(app)
-	completions := dialog.NewCompletionDialogComponent(commandProvider)
+	completions := dialog.NewCompletionDialogComponent(commandProvider, "/")
 
 	var leaderBinding *key.Binding
 	if app.Config.Keybinds.Leader != "" {


### PR DESCRIPTION
Fixes: #788

As you can see in the video now when you type `/h` and delete the "h" the command menu will stay open. The same for `@`.


https://github.com/user-attachments/assets/90d6270c-0f10-46bf-ab3d-8e278089a271

