### PR TITLE
feat(tui): subsitute cwd home path on status bar

### DIFF
--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea/v2"
@@ -89,11 +90,16 @@ func (m statusComponent) View() string {
 	t := theme.CurrentTheme()
 	logo := m.logo()
 
+	homePath, err := os.UserHomeDir()
+	cwdPath := m.app.Info.Path.Cwd
+	if err == nil && homePath != "" && strings.HasPrefix(cwdPath, homePath) {
+		cwdPath = "~" + cwdPath[len(homePath):]
+	}
 	cwd := styles.NewStyle().
 		Foreground(t.TextMuted()).
 		Background(t.BackgroundPanel()).
 		Padding(0, 1).
-		Render(m.app.Info.Path.Cwd)
+		Render(cwdPath)
 
 	sessionInfo := ""
 	if m.app.Session.ID != "" {

--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -21,6 +21,7 @@ type StatusComponent interface {
 type statusComponent struct {
 	app   *app.App
 	width int
+	cwd   string
 }
 
 func (m statusComponent) Init() tea.Cmd {
@@ -90,16 +91,11 @@ func (m statusComponent) View() string {
 	t := theme.CurrentTheme()
 	logo := m.logo()
 
-	homePath, err := os.UserHomeDir()
-	cwdPath := m.app.Info.Path.Cwd
-	if err == nil && homePath != "" && strings.HasPrefix(cwdPath, homePath) {
-		cwdPath = "~" + cwdPath[len(homePath):]
-	}
 	cwd := styles.NewStyle().
 		Foreground(t.TextMuted()).
 		Background(t.BackgroundPanel()).
 		Padding(0, 1).
-		Render(cwdPath)
+		Render(m.cwd)
 
 	sessionInfo := ""
 	if m.app.Session.ID != "" {
@@ -150,6 +146,13 @@ func NewStatusCmp(app *app.App) StatusComponent {
 	statusComponent := &statusComponent{
 		app: app,
 	}
+
+	homePath, err := os.UserHomeDir()
+	cwdPath := app.Info.Path.Cwd
+	if err == nil && homePath != "" && strings.HasPrefix(cwdPath, homePath) {
+		cwdPath = "~" + cwdPath[len(homePath):]
+	}
+	statusComponent.cwd = cwdPath
 
 	return statusComponent
 }


### PR DESCRIPTION
Replaces the user's home path with `~` in the status bar.

<img width="403" alt="SCR-20250709-nlux" src="https://github.com/user-attachments/assets/a55997d6-7e1e-4975-8865-acd3f47dd892" />
