### PR TITLE
feat(tui): treat pasted text file paths as file references

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -96,7 +96,16 @@ func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case ".pdf":
 			mediaType = "application/pdf"
 		default:
-			mediaType = "text/plain"
+			attachment := &textarea.Attachment{
+				ID:        uuid.NewString(),
+				Display:   "@" + filePath,
+				URL:       fmt.Sprintf("file://./%s", filePath),
+				Filename:  filePath,
+				MediaType: "text/plain",
+			}
+			m.textarea.InsertAttachment(attachment)
+			m.textarea.InsertString(" ")
+			return m, nil
 		}
 
 		fileBytes, err := os.ReadFile(filePath)


### PR DESCRIPTION
This PR updates the new paste file handling in a way that for text files it doesn't try to add them as a base64 attachments but treats them as a file reference (like when you added the file via the @ fuzzy search).

This restores my workflow of copying file paths in Neovim (e.g. packages/tui/internal/components/chat/editor.go) and pasting them in my prompt. (Mostly, I don't use the @ file search as I have the relevant files already open for browsing in Neovim.) This workflow broke with the new paste handling.

This change shouldn't break anything, as the current handling for text files just produces an error: "AI_UnsupportedFunctionalityError: 'file part media type text/plain' functionality not supported."