### PR TITLE
Improve system theme

### DIFF
--- a/packages/tui/internal/theme/system.go
+++ b/packages/tui/internal/theme/system.go
@@ -1,13 +1,20 @@
 package theme
 
 import (
-	"fmt"
 	"image/color"
-	"math"
 
 	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/charmbracelet/lipgloss/v2/compat"
+	"github.com/charmbracelet/x/ansi"
 )
+
+func monoColor(c ansi.BasicColor) compat.AdaptiveColor {
+	return compat.AdaptiveColor{Dark: c, Light: c}
+}
+
+func monoNoColor() compat.AdaptiveColor {
+	return compat.AdaptiveColor{Dark: lipgloss.NoColor{}, Light: lipgloss.NoColor{}}
+}
 
 // SystemTheme is a dynamic theme that derives its gray scale colors
 // from the terminal's background color at runtime
@@ -33,271 +40,71 @@ func (t *SystemTheme) Name() string {
 
 // initializeColors sets up all theme colors
 func (t *SystemTheme) initializeColors() {
-	// Generate gray scale based on terminal background
-	grays := t.generateGrayScale()
-
 	// Set ANSI colors for primary colors
-	t.PrimaryColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Cyan,
-		Light: lipgloss.Cyan,
-	}
-	t.SecondaryColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Magenta,
-		Light: lipgloss.Magenta,
-	}
-	t.AccentColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Cyan,
-		Light: lipgloss.Cyan,
-	}
+	t.PrimaryColor = monoColor(lipgloss.Cyan)
+	t.SecondaryColor = monoColor(lipgloss.Magenta)
+	t.AccentColor = monoColor(lipgloss.Cyan)
 
 	// Status colors using ANSI
-	t.ErrorColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Red,
-		Light: lipgloss.Red,
-	}
-	t.WarningColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Yellow,
-		Light: lipgloss.Yellow,
-	}
-	t.SuccessColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Green,
-		Light: lipgloss.Green,
-	}
-	t.InfoColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Cyan,
-		Light: lipgloss.Cyan,
-	}
+	t.ErrorColor = monoColor(lipgloss.Red)
+	t.WarningColor = monoColor(lipgloss.Yellow)
+	t.SuccessColor = monoColor(lipgloss.Green)
+	t.InfoColor = monoColor(lipgloss.Cyan)
 
 	// Text colors
-	t.TextColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
-	// Derive muted text color from terminal foreground
-	t.TextMutedColor = t.generateMutedTextColor()
+	t.TextColor = monoNoColor()
+	t.TextMutedColor = monoColor(lipgloss.BrightWhite)
 
 	// Background colors
-	t.BackgroundColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
-	t.BackgroundPanelColor = grays[2]
-	t.BackgroundElementColor = grays[3]
+	t.BackgroundColor = monoNoColor()
+	t.BackgroundPanelColor = monoColor(lipgloss.Black)
+	t.BackgroundElementColor = monoColor(lipgloss.BrightBlack)
 
 	// Border colors
-	t.BorderSubtleColor = grays[6]
-	t.BorderColor = grays[7]
-	t.BorderActiveColor = grays[8]
+	t.BorderSubtleColor = monoColor(lipgloss.Black)
+	t.BorderColor = monoColor(lipgloss.BrightBlack)
+	t.BorderActiveColor = monoColor(lipgloss.Blue)
 
 	// Diff colors using ANSI colors
-	t.DiffAddedColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("2"), // green
-		Light: lipgloss.Color("2"),
-	}
-	t.DiffRemovedColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("1"), // red
-		Light: lipgloss.Color("1"),
-	}
-	t.DiffContextColor = grays[7] // Use gray for context
-	t.DiffHunkHeaderColor = grays[7]
-	t.DiffHighlightAddedColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("2"), // green
-		Light: lipgloss.Color("2"),
-	}
-	t.DiffHighlightRemovedColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("1"), // red
-		Light: lipgloss.Color("1"),
-	}
+	t.DiffAddedColor = monoColor(lipgloss.Green)
+	t.DiffRemovedColor = monoColor(lipgloss.Red)
+	t.DiffContextColor = monoNoColor()
+	t.DiffHunkHeaderColor = monoNoColor()
+	t.DiffHighlightAddedColor = monoColor(lipgloss.Green)
+	t.DiffHighlightRemovedColor = monoColor(lipgloss.Red)
+
 	// Use subtle gray backgrounds for diff
-	t.DiffAddedBgColor = grays[2]
-	t.DiffRemovedBgColor = grays[2]
-	t.DiffContextBgColor = grays[1]
-	t.DiffLineNumberColor = grays[6]
-	t.DiffAddedLineNumberBgColor = grays[3]
-	t.DiffRemovedLineNumberBgColor = grays[3]
+	t.DiffAddedBgColor = monoNoColor()
+	t.DiffRemovedBgColor = monoNoColor()
+	t.DiffContextBgColor = monoNoColor()
+	t.DiffLineNumberColor = monoColor(lipgloss.BrightWhite)
+	t.DiffAddedLineNumberBgColor = monoNoColor()
+	t.DiffRemovedLineNumberBgColor = monoNoColor()
 
 	// Markdown colors using ANSI
-	t.MarkdownTextColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
-	t.MarkdownHeadingColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
-	t.MarkdownLinkColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("4"), // blue
-		Light: lipgloss.Color("4"),
-	}
-	t.MarkdownLinkTextColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("6"), // cyan
-		Light: lipgloss.Color("6"),
-	}
-	t.MarkdownCodeColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("2"), // green
-		Light: lipgloss.Color("2"),
-	}
-	t.MarkdownBlockQuoteColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("3"), // yellow
-		Light: lipgloss.Color("3"),
-	}
-	t.MarkdownEmphColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("3"), // yellow
-		Light: lipgloss.Color("3"),
-	}
-	t.MarkdownStrongColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
+	t.MarkdownTextColor = monoNoColor()
+	t.MarkdownHeadingColor = monoNoColor()
+	t.MarkdownLinkColor = monoColor(lipgloss.Blue)
+	t.MarkdownLinkTextColor = monoColor(lipgloss.Cyan)
+	t.MarkdownCodeColor = monoColor(lipgloss.Green)
+	t.MarkdownBlockQuoteColor = monoColor(lipgloss.Yellow)
+	t.MarkdownEmphColor = monoColor(lipgloss.Yellow)
+	t.MarkdownStrongColor = monoNoColor()
 	t.MarkdownHorizontalRuleColor = t.BorderColor
-	t.MarkdownListItemColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("4"), // blue
-		Light: lipgloss.Color("4"),
-	}
-	t.MarkdownListEnumerationColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("6"), // cyan
-		Light: lipgloss.Color("6"),
-	}
-	t.MarkdownImageColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("4"), // blue
-		Light: lipgloss.Color("4"),
-	}
-	t.MarkdownImageTextColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("6"), // cyan
-		Light: lipgloss.Color("6"),
-	}
-	t.MarkdownCodeBlockColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
+	t.MarkdownListItemColor = monoColor(lipgloss.Blue)
+	t.MarkdownListEnumerationColor = monoColor(lipgloss.Cyan)
+	t.MarkdownImageColor = monoColor(lipgloss.Blue)
+	t.MarkdownImageTextColor = monoColor(lipgloss.Cyan)
+	t.MarkdownCodeBlockColor = monoNoColor()
 
 	// Syntax colors
 	t.SyntaxCommentColor = t.TextMutedColor // Use same as muted text
-	t.SyntaxKeywordColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("5"), // magenta
-		Light: lipgloss.Color("5"),
-	}
-	t.SyntaxFunctionColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("4"), // blue
-		Light: lipgloss.Color("4"),
-	}
-	t.SyntaxVariableColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
-	t.SyntaxStringColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("2"), // green
-		Light: lipgloss.Color("2"),
-	}
-	t.SyntaxNumberColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("3"), // yellow
-		Light: lipgloss.Color("3"),
-	}
-	t.SyntaxTypeColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("6"), // cyan
-		Light: lipgloss.Color("6"),
-	}
-	t.SyntaxOperatorColor = compat.AdaptiveColor{
-		Dark:  lipgloss.Color("6"), // cyan
-		Light: lipgloss.Color("6"),
-	}
-	t.SyntaxPunctuationColor = compat.AdaptiveColor{
-		Dark:  lipgloss.NoColor{},
-		Light: lipgloss.NoColor{},
-	}
-}
-
-// generateGrayScale creates a gray scale based on the terminal background
-func (t *SystemTheme) generateGrayScale() map[int]compat.AdaptiveColor {
-	grays := make(map[int]compat.AdaptiveColor)
-
-	r, g, b, _ := t.terminalBg.RGBA()
-	bgR := float64(r >> 8)
-	bgG := float64(g >> 8)
-	bgB := float64(b >> 8)
-
-	luminance := 0.299*bgR + 0.587*bgG + 0.114*bgB
-
-	for i := 1; i <= 12; i++ {
-		var stepColor string
-		factor := float64(i) / 12.0
-
-		if t.terminalBgIsDark {
-			if luminance < 10 {
-				grayValue := int(factor * 0.4 * 255)
-				stepColor = fmt.Sprintf("#%02x%02x%02x", grayValue, grayValue, grayValue)
-			} else {
-				newLum := luminance + (255-luminance)*factor*0.4
-
-				ratio := newLum / luminance
-				newR := math.Min(bgR*ratio, 255)
-				newG := math.Min(bgG*ratio, 255)
-				newB := math.Min(bgB*ratio, 255)
-
-				stepColor = fmt.Sprintf("#%02x%02x%02x", int(newR), int(newG), int(newB))
-			}
-		} else {
-			if luminance > 245 {
-				grayValue := int(255 - factor*0.4*255)
-				stepColor = fmt.Sprintf("#%02x%02x%02x", grayValue, grayValue, grayValue)
-			} else {
-				newLum := luminance * (1 - factor*0.4)
-
-				ratio := newLum / luminance
-				newR := math.Max(bgR*ratio, 0)
-				newG := math.Max(bgG*ratio, 0)
-				newB := math.Max(bgB*ratio, 0)
-
-				stepColor = fmt.Sprintf("#%02x%02x%02x", int(newR), int(newG), int(newB))
-			}
-		}
-
-		grays[i] = compat.AdaptiveColor{
-			Dark:  lipgloss.Color(stepColor),
-			Light: lipgloss.Color(stepColor),
-		}
-	}
-
-	return grays
-}
-
-// generateMutedTextColor creates a muted gray color based on the terminal background
-func (t *SystemTheme) generateMutedTextColor() compat.AdaptiveColor {
-	bgR, bgG, bgB, _ := t.terminalBg.RGBA()
-
-	bgRf := float64(bgR >> 8)
-	bgGf := float64(bgG >> 8)
-	bgBf := float64(bgB >> 8)
-
-	bgLum := 0.299*bgRf + 0.587*bgGf + 0.114*bgBf
-
-	var grayValue int
-	if t.terminalBgIsDark {
-		if bgLum < 10 {
-			// Very dark/black background
-			// grays[3] would be around #2e (46), so we need much lighter
-			grayValue = 180 // #b4b4b4
-		} else {
-			// Scale up for lighter dark backgrounds
-			// Ensure we're always significantly brighter than BackgroundElement
-			grayValue = min(int(160+(bgLum*0.3)), 200)
-		}
-	} else {
-		if bgLum > 245 {
-			// Very light/white background
-			// grays[3] would be around #f5 (245), so we need much darker
-			grayValue = 75 // #4b4b4b
-		} else {
-			// Scale down for darker light backgrounds
-			// Ensure we're always significantly darker than BackgroundElement
-			grayValue = max(int(100-((255-bgLum)*0.2)), 60)
-		}
-	}
-
-	mutedColor := fmt.Sprintf("#%02x%02x%02x", grayValue, grayValue, grayValue)
-
-	return compat.AdaptiveColor{
-		Dark:  lipgloss.Color(mutedColor),
-		Light: lipgloss.Color(mutedColor),
-	}
+	t.SyntaxKeywordColor = monoColor(lipgloss.Magenta)
+	t.SyntaxFunctionColor = monoColor(lipgloss.Blue)
+	t.SyntaxVariableColor = monoNoColor()
+	t.SyntaxStringColor = monoColor(lipgloss.Green)
+	t.SyntaxNumberColor = monoColor(lipgloss.Yellow)
+	t.SyntaxTypeColor = monoColor(lipgloss.Cyan)
+	t.SyntaxOperatorColor = monoColor(lipgloss.Cyan)
+	t.SyntaxPunctuationColor = monoNoColor()
 }


### PR DESCRIPTION
I use opencode within tmux and neovim and have been getting this rendering issue.

![SCR-20250709-tvxe](https://github.com/user-attachments/assets/865e05b9-2c6a-4a19-922d-17901e7af6d0)

The underlying issue here is the gray colors in the system theme are converting to RGB values that seem to be incompatible with `xterm-256color:RGB`. I tried adjusting wh;ich terminal profile to use for color rendering and even if I could get it to work with opencode, I'd end up messing up the Neovim colors.

I think the best solution is to stick to a true "system" theme and stick with the 4-bit color constraint. So all of the grays have been changed to ansi Black and Bright Black

![SCR-20250709-ugnf](https://github.com/user-attachments/assets/4853c80d-b633-4275-8a3c-587eddbcfe94)

I also simplified the code duplication by creating reusable functions and using the named helper colors instead of color codes with comments.

> [!NOTE]
> I'd like to test all the UI elements to make sure there aren't any visual regressions here, please let me know if there is a simple process for rendering all element types 🙏

> [!NOTE]
> There is something weird going on with the status. I think it has something to do with nested styles but I ultimately didn't find the root cause. I think the ansi values end up getting converted to RGB along the way somewhere and the colors come out different.