### PR TITLE
feat(tui): /editor - change the auto-send behavior to put content in input box instead

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -50,6 +50,9 @@ type SendMsg struct {
 	Text        string
 	Attachments []opencode.FilePartParam
 }
+type SetEditorContentMsg struct {
+	Text string
+}
 type OptimisticMessageAddedMsg struct {
 	Message opencode.MessageUnion
 }

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -38,6 +38,7 @@ type EditorComponent interface {
 	Clear() (tea.Model, tea.Cmd)
 	Paste() (tea.Model, tea.Cmd)
 	Newline() (tea.Model, tea.Cmd)
+	SetValue(value string)
 	SetInterruptKeyInDebounce(inDebounce bool)
 	SetExitKeyInDebounce(inDebounce bool)
 }
@@ -382,6 +383,10 @@ func (m *editorComponent) Newline() (tea.Model, tea.Cmd) {
 
 func (m *editorComponent) SetInterruptKeyInDebounce(inDebounce bool) {
 	m.interruptKeyInDebounce = inDebounce
+}
+
+func (m *editorComponent) SetValue(value string) {
+	m.textarea.SetValue(value)
 }
 
 func (m *editorComponent) SetExitKeyInDebounce(inDebounce bool) {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -389,6 +389,12 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.showCompletionDialog = false
 		a.app, cmd = a.app.SendChatMessage(context.Background(), msg.Text, msg.Attachments)
 		cmds = append(cmds, cmd)
+	case app.SetEditorContentMsg:
+		// Set the editor content without sending
+		a.editor.SetValue(msg.Text)
+		updated, cmd := a.editor.Focus()
+		a.editor = updated.(chat.EditorComponent)
+		cmds = append(cmds, cmd)
 	case dialog.CompletionDialogCloseMsg:
 		a.showCompletionDialog = false
 		a.fileCompletionActive = false
@@ -857,7 +863,7 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 				return nil
 			}
 			os.Remove(tmpfile.Name())
-			return app.SendMsg{
+			return app.SetEditorContentMsg{
 				Text: string(content),
 			}
 		})


### PR DESCRIPTION
Makes much more sense to me, since I would often like to look at the previous messages before finally sending my request.

Let me know if it should be configurable, or implemented differently. 