### PR TITLE
Adds real example in docs of how to configure custom provider

### DIFF
--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -46,6 +46,42 @@ You can configure the providers and models you want to use in your opencode conf
 
 [Learn more here](/docs/models).
 
+#### Custom Providers
+
+You can also define custom providers in your configuration. This is useful for connecting to services that are not natively supported but are OpenAI API-compatible, such as local models served through LM Studio or Ollama.
+
+Here's an example of how to configure a local on-device model from LM Studio:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "lmstudio/google/gemma-3n-e4b",
+  "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "google/gemma-3n-e4b": {
+          "name": "Gemma 3n-e4b (local)"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example:
+
+- `lmstudio` is the custom provider ID.
+- `npm` specifies the package to use for this provider. `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
+- `name` is the display name for the provider in the UI.
+- `options.baseURL` is the endpoint for the local server.
+- `models` is a map of model IDs to their configurations. The model name will be displayed in the model selection list.
+- The `model` key at the root is set to the full ID of the model you want to use, which is `provider_id/model_id`.
+
 ---
 
 ### Themes


### PR DESCRIPTION
In the terminal and in general docs it references looking at the config docs to see how to configure custom providers on opencode, but the actual config docs don't have an in-depth example of how to configure a custom provider.

Since I'm hoping open models will soon be good enough to run AI agents totally locally, I thought it would be worthwhile to show how to set this up. In this case, I added docs from a working example of running LM Studio locally.