### PR TITLE
fix: encode & decode file paths

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -350,7 +350,9 @@ export namespace Session {
           switch (url.protocol) {
             case "file:":
               // have to normalize, symbol search returns absolute paths
-              const relativePath = url.pathname.replace(app.path.cwd, ".")
+              // Decode the pathname since URL constructor doesn't automatically decode it
+              const pathname = decodeURIComponent(url.pathname)
+              const relativePath = pathname.replace(app.path.cwd, ".")
               const filePath = path.join(app.path.cwd, relativePath)
 
               if (part.mime === "text/plain") {
@@ -414,7 +416,7 @@ export namespace Session {
               return [
                 {
                   type: "text",
-                  text: `Called the Read tool with the following input: {\"filePath\":\"${url.pathname}\"}`,
+                  text: `Called the Read tool with the following input: {\"filePath\":\"${pathname}\"}`,
                   synthetic: true,
                 },
                 {

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -180,7 +181,7 @@ func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			attachment := &textarea.Attachment{
 				ID:        uuid.NewString(),
 				Display:   "@" + filePath,
-				URL:       fmt.Sprintf("file://./%s", filePath),
+				URL:       fmt.Sprintf("file://./%s", url.PathEscape(filePath)),
 				Filename:  filePath,
 				MediaType: mediaType,
 			}


### PR DESCRIPTION
Should fix: #787


See video for how it fixes things that opencode currently fails on:

Current behavior:

https://github.com/user-attachments/assets/f0b7898a-257b-4794-b679-c9fe2af753f2

New behavior:

https://github.com/user-attachments/assets/a165b019-9cd3-4d96-805f-158cffc1e5ab

