### PR TITLE
Fix Documentation on Modes - Update modes.mdx

### DIFF
--- a/packages/web/src/content/docs/docs/modes.mdx
+++ b/packages/web/src/content/docs/docs/modes.mdx
@@ -105,7 +105,7 @@ Specify a custom system prompt file for this mode with the `prompt` config. The 
 {
   "mode": {
     "review": {
-      "prompt": "{file:./prompts/code-review.txt}"
+      "prompt": "./prompts/code-review.txt"
     }
   }
 }
@@ -170,7 +170,7 @@ You can create your own custom modes by adding them to the `mode` configuration.
   "$schema": "https://opencode.ai/config.json",
   "mode": {
     "docs": {
-      "prompt": "{file:./prompts/documentation.txt}",
+      "prompt": "./prompts/documentation.txt",
       "tools": {
         "write": true,
         "edit": true,


### PR DESCRIPTION
Fix configuration with mode.{name}.prompt

based on past documentation the following doesn't work


```
  "mode": {
    "build": {
      "model": "anthropic/claude-sonnet-4-20250514",
      "prompt": "{file:./agents/atlas/atlas_fastrtc_developer.md}",
      "name": "Atlas",
      "tools": {
        "write": true,
        "edit": true,
        "bash": true
      }
    },
```

After looking into `opencode/packages/opencode/src/session/mode.ts:56`
https://github.com/sst/opencode/blob/c7f30e1065c666f8eb687db75bdc06ce4b8c4882/packages/opencode/src/session/mode.ts#L56 The correct way is the following:
```
  "mode": {
    "build": {
      "model": "anthropic/claude-sonnet-4-20250514",
      "prompt": "./agents/atlas/atlas_fastrtc_developer.md",
      "name": "Atlas",
      "tools": {
        "write": true,
        "edit": true,
        "bash": true
      }
    },
```