### PR TITLE
fix(session): add fallback for undefined output token limit

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -321,7 +321,7 @@ export namespace Session {
     }
 
     const previous = msgs.at(-1) as MessageV2.Assistant
-    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX)
+    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
 
     // auto summarize if too long
     if (previous) {


### PR DESCRIPTION
## Summary
- Add fallback value for output token limit calculation to prevent undefined values
- Ensures `outputLimit` always has a valid numeric value when `Math.min()` returns undefined

## Test plan
- [x] Verify the change handles edge cases where `model.info.limit.output` is undefined
- [x] Confirm existing functionality remains intact

🤖 Generated with [opencode](https://opencode.ai)