### PR TITLE
fix: avoid worker exception, graceful 404

### DIFF
--- a/packages/function/src/api.ts
+++ b/packages/function/src/api.ts
@@ -107,7 +107,7 @@ export class SyncServer extends DurableObject<Env> {
 }
 
 export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url)
     const splits = url.pathname.split("/")
     const method = splits[1]
@@ -258,5 +258,7 @@ export default {
         headers: { "Content-Type": "application/json" },
       })
     }
+
+    return new Response("Not Found", { status: 404 })
   },
 }


### PR DESCRIPTION
- Added return type annotation to enforce proper returns
- Not returning a response causes worker to throw an exception