### PR TITLE
fix: ENAMETOOLONG: name too long when adding custom mode

### DIFF
--- a/packages/opencode/src/session/mode.ts
+++ b/packages/opencode/src/session/mode.ts
@@ -53,7 +53,7 @@ export namespace Mode {
           providerID,
         }
       }
-      if (value.prompt) item.prompt = await Bun.file(value.prompt).text()
+      if (value.prompt) item.prompt = value.prompt
       if (value.tools) item.tools = value.tools
     }
 


### PR DESCRIPTION
fix https://github.com/sst/opencode/issues/861
No need to treat "prompt" as file path here since {file: } will be processed in config.ts