### PR TITLE
fix: tab key inserts character when toast notification is visible

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -208,15 +208,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, tea.Batch(cmds...)
 		}
 
-		// 4. Maximize editor responsiveness for printable characters
-		if msg.Text != "" {
-			updated, cmd := a.editor.Update(msg)
-			a.editor = updated.(chat.EditorComponent)
-			cmds = append(cmds, cmd)
-			return a, tea.Batch(cmds...)
-		}
-
-		// 5. Check for leader key activation
+		// 4. Check for leader key activation
 		if a.leaderBinding != nil &&
 			!a.app.IsLeaderSequence &&
 			key.Matches(msg, *a.leaderBinding) {
@@ -224,13 +216,33 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// 6 Handle input clear command
+		// 5. Check for commands that don't require leader (including tab for mode switching)
+		matches := a.app.Commands.Matches(msg, a.app.IsLeaderSequence)
+		if len(matches) > 0 {
+			// Skip interrupt key if we're in debounce mode and app is busy
+			interruptCommand := a.app.Commands[commands.SessionInterruptCommand]
+			if interruptCommand.Matches(msg, a.app.IsLeaderSequence) && a.app.IsBusy() && a.interruptKeyState != InterruptKeyIdle {
+				// Let it fall through to interrupt debounce handling below
+			} else {
+				return a, util.CmdHandler(commands.ExecuteCommandsMsg(matches))
+			}
+		}
+
+		// 6. Maximize editor responsiveness for printable characters
+		if msg.Text != "" {
+			updated, cmd := a.editor.Update(msg)
+			a.editor = updated.(chat.EditorComponent)
+			cmds = append(cmds, cmd)
+			return a, tea.Batch(cmds...)
+		}
+
+		// 7. Handle input clear command
 		inputClearCommand := a.app.Commands[commands.InputClearCommand]
 		if inputClearCommand.Matches(msg, a.app.IsLeaderSequence) && a.editor.Length() > 0 {
 			return a, util.CmdHandler(commands.ExecuteCommandMsg(inputClearCommand))
 		}
 
-		// 7. Handle interrupt key debounce for session interrupt
+		// 8. Handle interrupt key debounce for session interrupt
 		interruptCommand := a.app.Commands[commands.SessionInterruptCommand]
 		if interruptCommand.Matches(msg, a.app.IsLeaderSequence) && a.app.IsBusy() {
 			switch a.interruptKeyState {
@@ -249,7 +261,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// 8. Handle exit key debounce for app exit when using non-leader command
+		// 9. Handle exit key debounce for app exit when using non-leader command
 		exitCommand := a.app.Commands[commands.AppExitCommand]
 		if exitCommand.Matches(msg, a.app.IsLeaderSequence) {
 			switch a.exitKeyState {
@@ -268,17 +280,7 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// 9. Check again for commands that don't require leader (excluding interrupt when busy and exit when in debounce)
-		matches := a.app.Commands.Matches(msg, a.app.IsLeaderSequence)
-		if len(matches) > 0 {
-			// Skip interrupt key if we're in debounce mode and app is busy
-			if interruptCommand.Matches(msg, a.app.IsLeaderSequence) && a.app.IsBusy() && a.interruptKeyState != InterruptKeyIdle {
-				return a, nil
-			}
-			return a, util.CmdHandler(commands.ExecuteCommandsMsg(matches))
-		}
-
-		// 10. Fallback to editor. This is for other characters like backspace, tab, etc.
+		// 10. Fallback to editor. This is for other characters like backspace, etc.
 		updatedEditor, cmd := a.editor.Update(msg)
 		a.editor = updatedEditor.(chat.EditorComponent)
 		return a, cmd


### PR DESCRIPTION
# Fix: Tab key inserts character instead of switching modes when toast notification is visible

## Problem

When a toast notification (e.g., update notification) is displayed in the TUI, pressing the Tab key inserts a tab character into the editor instead of switching between plan/execute modes as expected.

### Root Cause

The issue occurs due to the input processing order in `tui.go`:

1. When a key with text content (including tab) is pressed, it was being processed by the editor component first (for "maximum responsiveness")
2. Command processing happened later in the update cycle
3. Since tab has text content (`\t`), it was caught by the editor before the command system could handle it as `SwitchModeCommand`

### Reproduction Steps

1. Start opencode TUI
2. Wait for or trigger a toast notification (e.g., update notification, error toast)
3. While the toast is visible, press Tab
4. **Bug**: A tab character appears in the editor instead of switching modes

## Solution

Reordered the input processing logic to check for commands before processing printable characters:

```go
// Before: Step 4 was printable character processing
// After: Step 5 is now command checking (including tab for mode switching)
matches := a.app.Commands.Matches(msg, a.app.IsLeaderSequence)
if len(matches) > 0 {
    // Handle commands first
    return a, util.CmdHandler(commands.ExecuteCommandsMsg(matches))
}

// Step 6 is now printable character processing (was step 4)
if msg.Text != "" {
    updated, cmd := a.editor.Update(msg)
    a.editor = updated.(chat.EditorComponent)
    cmds = append(cmds, cmd)
    return a, tea.Batch(cmds...)
}
```

## Changes Made

- Moved command matching logic before printable character processing
- Updated the fallback comment to reflect that tab is no longer handled there