### PR TITLE
fix: OpenRouter tool_calls validation error with kimi-k2 model

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -202,6 +202,60 @@ export namespace Provider {
             "HTTP-Referer": "https://opencode.ai/",
             "X-Title": "opencode",
           },
+          async fetch(input: any, init: any) {
+            const response = await fetch(input, init)
+            
+            // For streaming responses, we need to transform the stream
+            if (response.body && (response.headers.get('content-type')?.includes('text/plain') || response.headers.get('content-type')?.includes('text/event-stream'))) {
+              const reader = response.body.getReader()
+              const stream = new ReadableStream({
+                start(controller) {
+                  function pump(): Promise<void> {
+                    return reader.read().then(({ done, value }) => {
+                      if (done) {
+                        controller.close()
+                        return
+                      }
+                      
+                      // Parse and fix tool_calls type
+                      const text = new TextDecoder().decode(value)
+                      const lines = text.split('\n')
+                      const fixedLines = lines.map(line => {
+                        if (line.startsWith('data: ') && line !== 'data: [DONE]') {
+                          try {
+                            const data = JSON.parse(line.slice(6))
+                            if (data.choices?.[0]?.delta?.tool_calls) {
+                              for (const toolCall of data.choices[0].delta.tool_calls) {
+                                if (toolCall.type === "") {
+                                  toolCall.type = "function"
+                                }
+                              }
+                            }
+                            return 'data: ' + JSON.stringify(data)
+                          } catch (e) {
+                            return line
+                          }
+                        }
+                        return line
+                      })
+                      
+                      controller.enqueue(new TextEncoder().encode(fixedLines.join('\n')))
+                      return pump()
+                    })
+                  }
+                  return pump()
+                },
+              })
+              
+              return new Response(stream, {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+              })
+            }
+            
+            return response
+          },
         },
       }
     },


### PR DESCRIPTION
## Summary
Fixes AI_TypeValidationError when using OpenRouter's moonshotai/kimi-k2 model by transforming invalid tool_call responses.

## Problem
The moonshotai/kimi-k2 model through OpenRouter returns tool calls with `type: ""` (empty string) instead of `type: "function"`, causing the AI SDK to throw a validation error:

```
AI_TypeValidationError: Type validation failed
Error message: Invalid input: expected "function"
```

## Solution
Added a custom fetch override in the OpenRouter provider configuration that:
- Intercepts streaming responses from OpenRouter
- Parses each data chunk in the Server-Sent Events stream
- Transforms any tool calls with empty `type` to `type: "function"`
- Reconstructs the stream with corrected data

## Test plan
- [x] Reproduced the original error with `opencode run -m openrouter/moonshotai/kimi-k2 "explore this project"`
- [x] Verified the fix resolves the validation error
- [x] Confirmed the model now works correctly with tool calls
- [x] Tested that other OpenRouter models continue to work

Fixes #914

🤖 Generated with [Claude Code](https://claude.ai/code)