### PR TITLE
Fix clipboard on Wayland systems

### DIFF
--- a/packages/web/src/content/docs/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/docs/troubleshooting.mdx
@@ -115,4 +115,4 @@ Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 export DISPLAY=:99.0
 ```
 
-opencode will automatically detect and use the first available clipboard tool in order of preference: `xclip`, `xsel`, then `wl-clipboard`.
+opencode will detect if you're using Wayland and prefer `wl-clipboard`, otherwise it will try to find clipboard tools in order of: `xclip` and `xsel`.


### PR DESCRIPTION
On Linux systems running a Wayland session, clipboard functionality could fail if both `wl-clipboard` and an X11-based tool like `xsel` were installed. The existing implementation did not prioritize the Wayland-native tool.

This change addresses the issue by:

- Detecting a Wayland environment via the `WAYLAND_DISPLAY` variable.
- Adjusting the tool preference order to prioritize `wl-copy`.
- Correcting the tool name from `wl-clipboard` to `wl-copy` to ensure it is found in the system's PATH.