### PR TITLE
Add support for job-control suspend (ctrl+z/SIGSTP).

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -114,6 +114,11 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		keyString := msg.String()
 
+		// Handle Ctrl+Z for suspend
+		if keyString == "ctrl+z" {
+			return a, tea.Suspend
+		}
+
 		// 1. Handle active modal
 		if a.modal != nil {
 			switch keyString {


### PR DESCRIPTION
Fixes #584.

This allows you to drop out of opencode, run some things in your shell, and resume opencode.

Pressing ctrl+z suspends the opencode job in your shell, you can run `fg` to resume it.
This was surprisingly easy to add. It seems like bubbletea handles switching to/from raw mode on suspend/resume.
I've tested suspending/resuming opencode and my terminal remains clean.

See: https://github.com/charmbracelet/bubbletea/pull/1054/files#diff-d97478697adeda9d52cdf576d22266813b2fd5c030ec40dc2576c255347cfa2eR13-R24
