### PR TITLE
feat: Allow for custom chat width in percentage

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -140,6 +140,7 @@ export namespace Config {
         .describe("Custom provider configurations and model overrides"),
       mcp: z.record(z.string(), Mcp).optional().describe("MCP (Model Context Protocol) server configurations"),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
+      chat_width: z.number().optional().describe("Width of chat interface as percentage (0.0 to 1.0)"),
       experimental: z
         .object({
           hook: z

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -140,7 +140,7 @@ export namespace Config {
         .describe("Custom provider configurations and model overrides"),
       mcp: z.record(z.string(), Mcp).optional().describe("MCP (Model Context Protocol) server configurations"),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
-      chat_width: z.number().optional().describe("Width of chat interface as percentage (0.0 to 1.0)"),
+      chat_width: z.number().min(0.1).max(1.0).optional().describe("Width of chat interface as percentage (0.1 to 1.0)"),
       experimental: z
         .object({
           hook: z

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -104,7 +104,7 @@ func New(
 	}
 
 	if configInfo.ChatWidth > 0.0 {
-		appState.ChatWidth = configInfo.ChatWidth
+		appState.ChatWidth = max(0.1, min(1.0, configInfo.ChatWidth))
 	}
 
 	var modeIndex int

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -103,6 +103,10 @@ func New(
 		appState.Theme = configInfo.Theme
 	}
 
+	if configInfo.ChatWidth > 0.0 {
+		appState.ChatWidth = configInfo.ChatWidth
+	}
+
 	var modeIndex int
 	var mode *opencode.Mode
 	modeName := "build"

--- a/packages/tui/internal/config/config.go
+++ b/packages/tui/internal/config/config.go
@@ -30,6 +30,7 @@ type State struct {
 	RecentlyUsedModels []ModelUsage         `toml:"recently_used_models"`
 	MessagesRight      bool                 `toml:"messages_right"`
 	SplitDiff          bool                 `toml:"split_diff"`
+	ChatWidth          float64              `toml:"chat_width"`
 }
 
 func NewState() *State {
@@ -38,6 +39,7 @@ func NewState() *State {
 		Mode:               "build",
 		ModeModel:          make(map[string]ModeModel),
 		RecentlyUsedModels: make([]ModelUsage, 0),
+		ChatWidth:          0.0,
 	}
 }
 

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -434,12 +434,18 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		msg.Height -= 2 // Make space for the status bar
 		a.width, a.height = msg.Width, msg.Height
-		container := min(a.width, 84)
-		if a.fileViewer.HasFile() {
-			if a.width < fileViewerFullWidthCutoff {
-				container = a.width
-			} else {
-				container = min(min(a.width, max(a.width/2, 50)), 84)
+
+		var container int
+		if a.app.State.ChatWidth > 0.0 {
+			container = int(float64(a.width) * a.app.State.ChatWidth)
+		} else {
+			container = min(a.width, 84)
+			if a.fileViewer.HasFile() {
+				if a.width < fileViewerFullWidthCutoff {
+					container = a.width
+				} else {
+					container = min(min(a.width, max(a.width/2, 50)), 84)
+				}
 			}
 		}
 		layout.Current = &layout.LayoutInfo{

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -437,7 +437,8 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		var container int
 		if a.app.State.ChatWidth > 0.0 {
-			container = int(float64(a.width) * a.app.State.ChatWidth)
+			chatWidth := max(0.1, min(1.0, a.app.State.ChatWidth))
+			container = int(float64(a.width) * chatWidth)
 		} else {
 			container = min(a.width, 84)
 			if a.fileViewer.HasFile() {

--- a/packages/tui/sdk/config.go
+++ b/packages/tui/sdk/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	Autoshare bool `json:"autoshare"`
 	// Automatically update to the latest version
 	Autoupdate bool `json:"autoupdate"`
-	// Width of chat interface as percentage (0.0 to 1.0)
+	// Width of chat interface as percentage (0.1 to 1.0)
 	ChatWidth float64 `json:"chat_width"`
 	// Disable providers that are loaded automatically
 	DisabledProviders []string           `json:"disabled_providers"`

--- a/packages/tui/sdk/config.go
+++ b/packages/tui/sdk/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	Autoshare bool `json:"autoshare"`
 	// Automatically update to the latest version
 	Autoupdate bool `json:"autoupdate"`
+	// Width of chat interface as percentage (0.0 to 1.0)
+	ChatWidth float64 `json:"chat_width"`
 	// Disable providers that are loaded automatically
 	DisabledProviders []string           `json:"disabled_providers"`
 	Experimental      ConfigExperimental `json:"experimental"`
@@ -81,6 +83,7 @@ type configJSON struct {
 	Schema            apijson.Field
 	Autoshare         apijson.Field
 	Autoupdate        apijson.Field
+	ChatWidth         apijson.Field
 	DisabledProviders apijson.Field
 	Experimental      apijson.Field
 	Instructions      apijson.Field


### PR DESCRIPTION
<img width="1680" height="1050" alt="Screenshot 2025-07-13 at 18 05 07" src="https://github.com/user-attachments/assets/c575f80b-b30d-4023-b50e-7073ff148b49" />

```
chat_width: 0.1 - 1.0
```
allows for users to specify a desired width for the chat