### PR TITLE
fix: deduplicate command entries in search completion

### DIFF
--- a/packages/tui/go.mod
+++ b/packages/tui/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3
 	github.com/charmbracelet/x/ansi v0.9.3
-	github.com/charmbracelet/x/input v0.3.7
 	github.com/google/uuid v1.6.0
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6
@@ -34,6 +33,7 @@ require (
 	github.com/atombender/go-jsonschema v0.20.0 // indirect
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
+	github.com/charmbracelet/x/input v0.3.7 // indirect
 	github.com/charmbracelet/x/windows v0.2.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/packages/tui/internal/completions/commands.go
+++ b/packages/tui/internal/completions/commands.go
@@ -77,6 +77,7 @@ func (c *CommandCompletionProvider) GetChildEntries(
 	// Use fuzzy matching for commands
 	var commandNames []string
 	commandMap := make(map[string]dialog.CompletionItemI)
+	seenCommands := make(map[string]bool)
 
 	for _, cmd := range sorted {
 		if !cmd.HasTrigger() {
@@ -96,11 +97,16 @@ func (c *CommandCompletionProvider) GetChildEntries(
 	// Sort by score (best matches first)
 	sort.Sort(matches)
 
-	// Convert matches to completion items
+	// Convert matches to completion items, deduplicating by command name
 	items := []dialog.CompletionItemI{}
 	for _, match := range matches {
 		if item, ok := commandMap[match.Target]; ok {
-			items = append(items, item)
+			// Use the completion item value (command name) for deduplication
+			cmdName := item.GetValue()
+			if !seenCommands[cmdName] {
+				items = append(items, item)
+				seenCommands[cmdName] = true
+			}
 		}
 	}
 	return items, nil


### PR DESCRIPTION
Fixes #875 

## Summary
- Fix duplicate command entries appearing in search completion
- Commands with multiple triggers (like `/sessions` with "sessions", "resume", "continue") were showing up multiple times in search results

| Before | After |
|---|---|
| <img width="669" height="170" alt="image" src="https://github.com/user-attachments/assets/2cde1337-0dab-465a-83a2-ba9a7af40e6c" /> | <img width="718" height="189" alt="image" src="https://github.com/user-attachments/assets/38a133c8-6c3e-49a6-844c-19dd9bf1e18e" /> |

## Test plan
- [x] Search for "sessions" command and verify only one entry appears
- [x] Verify all command triggers still work correctly
- [x] Test fuzzy search functionality remains intact

🤖 Generated with [opencode](https://opencode.ai)