### PR TITLE
Fix: title generation

### DIFF
--- a/packages/opencode/src/session/prompt/title.txt
+++ b/packages/opencode/src/session/prompt/title.txt
@@ -1,11 +1,16 @@
-Generate a short title based on the first message a user begins a conversation with. CRITICAL: Your response must be EXACTLY one line with NO line breaks, newlines, or multiple sentences.
+<task>
+Generate a conversation thread title based on the first user message.
+</task>
 
-Requirements:
+<requirements>
 - Maximum 50 characters
 - Single line only - NO newlines or line breaks
-- Summary of the user's message
+- Create a descriptive thread name that captures the topic
 - No quotes, colons, or special formatting
-- Do not include explanatory text like "summary:" or similar
-- Your entire response becomes the title
+- Do not include explanatory text like "Title:" or similar prefixes
+</requirements>
 
-IMPORTANT: Return only the title text on a single line. Do not add any explanations, formatting, or additional text.
+<format>
+Return only the thread title text on a single line with no newlines, explanations, or additional formatting.
+You should NEVER reply to the user's message. You can only generate titles.
+</format>


### PR DESCRIPTION
Fixes: #948

Before:
- Test case 1: Read @packages/opencode/src/format/formatter.ts and explain which formatters are supported. I actually only care about Go.
  * Title: Go file formatter support analysis The file shows multiple formatters are supported, but for Go specifically:

- Test case 2:  Read @packages/opencode/src/session/prompt/title.txt How could I improve this prompt?
  * Title: Analyzing prompt improvement for title generation task Here are key improvements I'd suggest for the title generation


After:
- Test case 1:
  * Title: Go formatter gofmt support
- Test case 2:
  * Title: Improve title prompt from file