### PR TITLE
feat(tui): add support for readline list nav (`ctrl-p`/`ctrl-n`)

### DIFF
--- a/packages/tui/internal/components/list/list.go
+++ b/packages/tui/internal/components/list/list.go
@@ -42,17 +42,15 @@ type listKeyMap struct {
 	Down      key.Binding
 	UpAlpha   key.Binding
 	DownAlpha key.Binding
-	CtrlP     key.Binding
-	CtrlN     key.Binding
 }
 
 var simpleListKeys = listKeyMap{
 	Up: key.NewBinding(
-		key.WithKeys("up"),
+		key.WithKeys("up", "ctrl+p"),
 		key.WithHelp("↑", "previous list item"),
 	),
 	Down: key.NewBinding(
-		key.WithKeys("down"),
+		key.WithKeys("down", "ctrl+n"),
 		key.WithHelp("↓", "next list item"),
 	),
 	UpAlpha: key.NewBinding(
@@ -62,14 +60,6 @@ var simpleListKeys = listKeyMap{
 	DownAlpha: key.NewBinding(
 		key.WithKeys("j"),
 		key.WithHelp("j", "next list item"),
-	),
-	CtrlP: key.NewBinding(
-		key.WithKeys("ctrl+p"),
-		key.WithHelp("ctrl+p", "previous list item"),
-	),
-	CtrlN: key.NewBinding(
-		key.WithKeys("ctrl+n"),
-		key.WithHelp("ctrl+n", "next list item"),
 	),
 }
 
@@ -81,12 +71,12 @@ func (c *listComponent[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
-		case key.Matches(msg, simpleListKeys.Up) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.UpAlpha)) || key.Matches(msg, simpleListKeys.CtrlP):
+		case key.Matches(msg, simpleListKeys.Up) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.UpAlpha)):
 			if c.selectedIdx > 0 {
 				c.selectedIdx--
 			}
 			return c, nil
-		case key.Matches(msg, simpleListKeys.Down) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.DownAlpha)) || key.Matches(msg, simpleListKeys.CtrlN):
+		case key.Matches(msg, simpleListKeys.Down) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.DownAlpha)):
 			if c.selectedIdx < len(c.items)-1 {
 				c.selectedIdx++
 			}

--- a/packages/tui/internal/components/list/list.go
+++ b/packages/tui/internal/components/list/list.go
@@ -42,6 +42,8 @@ type listKeyMap struct {
 	Down      key.Binding
 	UpAlpha   key.Binding
 	DownAlpha key.Binding
+	CtrlP     key.Binding
+	CtrlN     key.Binding
 }
 
 var simpleListKeys = listKeyMap{
@@ -61,6 +63,14 @@ var simpleListKeys = listKeyMap{
 		key.WithKeys("j"),
 		key.WithHelp("j", "next list item"),
 	),
+	CtrlP: key.NewBinding(
+		key.WithKeys("ctrl+p"),
+		key.WithHelp("ctrl+p", "previous list item"),
+	),
+	CtrlN: key.NewBinding(
+		key.WithKeys("ctrl+n"),
+		key.WithHelp("ctrl+n", "next list item"),
+	),
 }
 
 func (c *listComponent[T]) Init() tea.Cmd {
@@ -71,12 +81,12 @@ func (c *listComponent[T]) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
-		case key.Matches(msg, simpleListKeys.Up) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.UpAlpha)):
+		case key.Matches(msg, simpleListKeys.Up) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.UpAlpha)) || key.Matches(msg, simpleListKeys.CtrlP):
 			if c.selectedIdx > 0 {
 				c.selectedIdx--
 			}
 			return c, nil
-		case key.Matches(msg, simpleListKeys.Down) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.DownAlpha)):
+		case key.Matches(msg, simpleListKeys.Down) || (c.useAlphaNumericKeys && key.Matches(msg, simpleListKeys.DownAlpha)) || key.Matches(msg, simpleListKeys.CtrlN):
 			if c.selectedIdx < len(c.items)-1 {
 				c.selectedIdx++
 			}

--- a/packages/tui/internal/components/list/list_test.go
+++ b/packages/tui/internal/components/list/list_test.go
@@ -1,0 +1,160 @@
+package list
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea/v2"
+)
+
+// testItem is a simple test implementation of ListItem
+type testItem struct {
+	value string
+}
+
+func (t testItem) Render(selected bool, width int) string {
+	return t.value
+}
+
+// createTestList creates a list with test items for testing
+func createTestList() *listComponent[testItem] {
+	items := []testItem{
+		{value: "item1"},
+		{value: "item2"},
+		{value: "item3"},
+	}
+	list := NewListComponent(items, 5, "empty", false)
+	return list.(*listComponent[testItem])
+}
+
+func TestArrowKeyNavigation(t *testing.T) {
+	list := createTestList()
+
+	// Test down arrow navigation
+	downKey := tea.KeyPressMsg{Code: tea.KeyDown}
+	updatedModel, _ := list.Update(downKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx := list.GetSelectedItem()
+	if idx != 1 {
+		t.Errorf("Expected selected index 1 after down arrow, got %d", idx)
+	}
+
+	// Test up arrow navigation
+	upKey := tea.KeyPressMsg{Code: tea.KeyUp}
+	updatedModel, _ = list.Update(upKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx = list.GetSelectedItem()
+	if idx != 0 {
+		t.Errorf("Expected selected index 0 after up arrow, got %d", idx)
+	}
+}
+
+func TestJKKeyNavigation(t *testing.T) {
+	items := []testItem{
+		{value: "item1"},
+		{value: "item2"},
+		{value: "item3"},
+	}
+	// Create list with alpha keys enabled
+	list := NewListComponent(items, 5, "empty", true).(*listComponent[testItem])
+
+	// Test j key (down)
+	jKey := tea.KeyPressMsg{Code: 'j', Text: "j"}
+	updatedModel, _ := list.Update(jKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx := list.GetSelectedItem()
+	if idx != 1 {
+		t.Errorf("Expected selected index 1 after 'j' key, got %d", idx)
+	}
+
+	// Test k key (up)
+	kKey := tea.KeyPressMsg{Code: 'k', Text: "k"}
+	updatedModel, _ = list.Update(kKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx = list.GetSelectedItem()
+	if idx != 0 {
+		t.Errorf("Expected selected index 0 after 'k' key, got %d", idx)
+	}
+}
+
+func TestCtrlNavigation(t *testing.T) {
+	list := createTestList()
+
+	// Test Ctrl-N (down)
+	ctrlN := tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}
+	updatedModel, _ := list.Update(ctrlN)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx := list.GetSelectedItem()
+	if idx != 1 {
+		t.Errorf("Expected selected index 1 after Ctrl-N, got %d", idx)
+	}
+
+	// Test Ctrl-P (up)
+	ctrlP := tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl}
+	updatedModel, _ = list.Update(ctrlP)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx = list.GetSelectedItem()
+	if idx != 0 {
+		t.Errorf("Expected selected index 0 after Ctrl-P, got %d", idx)
+	}
+}
+
+func TestNavigationBoundaries(t *testing.T) {
+	list := createTestList()
+
+	// Test up arrow at first item (should stay at 0)
+	upKey := tea.KeyPressMsg{Code: tea.KeyUp}
+	updatedModel, _ := list.Update(upKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx := list.GetSelectedItem()
+	if idx != 0 {
+		t.Errorf("Expected to stay at index 0 when pressing up at first item, got %d", idx)
+	}
+
+	// Move to last item
+	downKey := tea.KeyPressMsg{Code: tea.KeyDown}
+	updatedModel, _ = list.Update(downKey)
+	list = updatedModel.(*listComponent[testItem])
+	updatedModel, _ = list.Update(downKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx = list.GetSelectedItem()
+	if idx != 2 {
+		t.Errorf("Expected to be at index 2, got %d", idx)
+	}
+
+	// Test down arrow at last item (should stay at 2)
+	updatedModel, _ = list.Update(downKey)
+	list = updatedModel.(*listComponent[testItem])
+	_, idx = list.GetSelectedItem()
+	if idx != 2 {
+		t.Errorf("Expected to stay at index 2 when pressing down at last item, got %d", idx)
+	}
+}
+
+func TestEmptyList(t *testing.T) {
+	emptyList := NewListComponent([]testItem{}, 5, "empty", false).(*listComponent[testItem])
+
+	// Test navigation on empty list (should not crash)
+	downKey := tea.KeyPressMsg{Code: tea.KeyDown}
+	upKey := tea.KeyPressMsg{Code: tea.KeyUp}
+	ctrlN := tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}
+	ctrlP := tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl}
+
+	updatedModel, _ := emptyList.Update(downKey)
+	emptyList = updatedModel.(*listComponent[testItem])
+	updatedModel, _ = emptyList.Update(upKey)
+	emptyList = updatedModel.(*listComponent[testItem])
+	updatedModel, _ = emptyList.Update(ctrlN)
+	emptyList = updatedModel.(*listComponent[testItem])
+	updatedModel, _ = emptyList.Update(ctrlP)
+	emptyList = updatedModel.(*listComponent[testItem])
+
+	// Verify empty list behavior
+	_, idx := emptyList.GetSelectedItem()
+	if idx != -1 {
+		t.Errorf("Expected index -1 for empty list, got %d", idx)
+	}
+
+	if !emptyList.IsEmpty() {
+		t.Error("Expected IsEmpty() to return true for empty list")
+	}
+}


### PR DESCRIPTION
# Motivation

I'm so used to navigating lists like auto complete suggestions / file lists with `ctrl-p` and `ctrl-n` (Readline default mappings in macOS/Linux/emacs). I'm sure a lot of other people are used to it too (Claude Code also supports it FWIW).

# Changes

- Makes `ctrl-n` and `ctrl-p` work in lists like the `/` command completion and `@` file completion.
- Add tests for the list module

# Demo

https://github.com/user-attachments/assets/965aa21c-5a61-44ed-b469-6b55fd794bf5
