### PR TITLE
fix: check for wl-copy not wl-clipboard

### DIFF
--- a/packages/tui/internal/clipboard/clipboard_linux.go
+++ b/packages/tui/internal/clipboard/clipboard_linux.go
@@ -44,7 +44,7 @@ var (
 			writeImg: []string{"xsel", "--clipboard", "--input"},
 		},
 		{
-			name:     "wl-clipboard",
+			name:     "wl-copy",
 			readCmd:  []string{"wl-paste", "-n"},
 			writeCmd: []string{"wl-copy"},
 			readImg:  []string{"wl-paste", "-t", "image/png", "-n"},


### PR DESCRIPTION
wl-clipboard is the package but there is no wl-cliboard executable so we need to check for wl-copy instead