### PR TITLE
improve error handling and logging for GitHub API failures in upgrade and install script

### DIFF
--- a/install
+++ b/install
@@ -48,7 +48,7 @@ if [ -z "$requested_version" ]; then
     url="https://github.com/sst/opencode/releases/latest/download/$filename"
     specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | awk -F'"' '/"tag_name": "/ {gsub(/^v/, "", $4); print $4}')
 
-    if [[ $? -ne 0 ]]; then
+    if [[ $? -ne 0 || -z "$specific_version" ]]; then
         echo "${RED}Failed to fetch version information${NC}"
         exit 1
     fi

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -140,6 +140,12 @@ export namespace Installation {
   export async function latest() {
     return fetch("https://api.github.com/repos/sst/opencode/releases/latest")
       .then((res) => res.json())
-      .then((data) => data.tag_name.slice(1) as string)
+      .then((data) => {
+        if (typeof data.tag_name !== "string") {
+          log.error("GitHub API error", data)
+          throw new Error("failed to fetch latest version")
+        }
+        return data.tag_name.slice(1) as string
+      })
   }
 }


### PR DESCRIPTION
I encountered an error when running `opencode upgrade`. The log looked like this:

```
ERROR 2025-07-14T05:44:30 +115ms service=default name=TypeError message=undefined is not an object (evaluating 'q.tag_name.slice') fatal
```

It turned out that I was getting 429 from the GitHub API, probably because I was using a VPN.

With this change the log should provide the user with more useful information for troubleshooting and future debugging:

```
ERROR 2025-07-14T11:04:01 +2272ms service=installation message=API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) documentation_url=https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting GitHub API error
ERROR 2025-07-14T11:04:01 +1ms service=default name=Error message=failed to fetch latest version fatal
```

The install script had a similar issue. This is what I got when I tried to reinstall opencode. `$specific_version` is empty when the API has an error:

```
> curl -fsSL https://opencode.ai/install | bash
Version  already installed
```