### PR TITLE
fix: Use model cost defined in config, if set.

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -272,12 +272,10 @@ export namespace Provider {
           temperature: model.temperature ?? existing?.temperature ?? false,
           tool_call: model.tool_call ?? existing?.tool_call ?? true,
           cost: {
-            ...existing?.cost,
-            ...model.cost,
-            input: 0,
-            output: 0,
-            cache_read: 0,
-            cache_write: 0,
+            input: model.cost?.input ?? existing?.cost?.input ?? 0,
+            output: model.cost?.output ?? existing?.cost?.output ?? 0,
+            cache_read: model.cost?.cache_read ?? existing?.cost?.cache_read ?? 0,
+            cache_write: model.cost?.cache_write ?? existing?.cost?.cache_write ?? 0,
           },
           options: {
             ...existing?.options,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -271,11 +271,11 @@ export namespace Provider {
           reasoning: model.reasoning ?? existing?.reasoning ?? false,
           temperature: model.temperature ?? existing?.temperature ?? false,
           tool_call: model.tool_call ?? existing?.tool_call ?? true,
-          cost: {
-            input: model.cost?.input ?? existing?.cost?.input ?? 0,
-            output: model.cost?.output ?? existing?.cost?.output ?? 0,
-            cache_read: model.cost?.cache_read ?? existing?.cost?.cache_read ?? 0,
-            cache_write: model.cost?.cache_write ?? existing?.cost?.cache_write ?? 0,
+          cost: model.cost ?? existing?.cost ?? {
+            input: 0,
+            output: 0,
+            cache_read: 0,
+            cache_write: 0,
           },
           options: {
             ...existing?.options,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -271,11 +271,13 @@ export namespace Provider {
           reasoning: model.reasoning ?? existing?.reasoning ?? false,
           temperature: model.temperature ?? existing?.temperature ?? false,
           tool_call: model.tool_call ?? existing?.tool_call ?? true,
-          cost: model.cost ?? existing?.cost ?? {
+          cost: {
             input: 0,
             output: 0,
             cache_read: 0,
             cache_write: 0,
+            ...existing?.cost,
+            ...model?.cost
           },
           options: {
             ...existing?.options,


### PR DESCRIPTION
Currently, cost that are defined in config file such as:
```json
  "provider": {
    "openrouter": {
      "models": {
        "qwen/qwen3-235b-a22b": {
          "cost": {
            "input": 0.60,
            "output": 1.20
          },
...
```
Are ignored and overwritten to 0.
We should give priority to config values, then existing values and finally in last option to 0s.