### PR TITLE
Standardize parameter description references in Edit and MultiEdit tools

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -20,8 +20,8 @@ export const EditTool = Tool.define({
   parameters: z.object({
     filePath: z.string().describe("The absolute path to the file to modify"),
     oldString: z.string().describe("The text to replace"),
-    newString: z.string().describe("The text to replace it with (must be different from old_string)"),
-    replaceAll: z.boolean().optional().describe("Replace all occurrences of old_string (default false)"),
+    newString: z.string().describe("The text to replace it with (must be different from oldString)"),
+    replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
   }),
   async execute(params, ctx) {
     if (!params.filePath) {

--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -2,8 +2,8 @@ Performs exact string replacements in files.
 
 Usage:
 - You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
-- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the old_string or new_string.
+- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
-- The edit will FAIL if `old_string` is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use `replace_all` to change every instance of `old_string`. 
-- Use `replace_all` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
+- The edit will FAIL if `oldString` is not unique in the file. Either provide a larger string with more surrounding context to make it unique or use `replaceAll` to change every instance of `oldString`. 
+- Use `replaceAll` for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.

--- a/packages/opencode/src/tool/multiedit.txt
+++ b/packages/opencode/src/tool/multiedit.txt
@@ -8,9 +8,9 @@ Before using this tool:
 To make multiple file edits, provide the following:
 1. file_path: The absolute path to the file to modify (must be absolute, not relative)
 2. edits: An array of edit operations to perform, where each edit contains:
-   - old_string: The text to replace (must match the file contents exactly, including all whitespace and indentation)
-   - new_string: The edited text to replace the old_string
-   - replace_all: Replace all occurrences of old_string. This parameter is optional and defaults to false.
+   - oldString: The text to replace (must match the file contents exactly, including all whitespace and indentation)
+   - newString: The edited text to replace the oldString
+   - replaceAll: Replace all occurrences of oldString. This parameter is optional and defaults to false.
 
 IMPORTANT:
 - All edits are applied in sequence, in the order they are provided
@@ -24,8 +24,8 @@ CRITICAL REQUIREMENTS:
 3. Plan your edits carefully to avoid conflicts between sequential operations
 
 WARNING:
-- The tool will fail if edits.old_string doesn't match the file contents exactly (including whitespace)
-- The tool will fail if edits.old_string and edits.new_string are the same
+- The tool will fail if edits.oldString doesn't match the file contents exactly (including whitespace)
+- The tool will fail if edits.oldString and edits.newString are the same
 - Since edits are applied in sequence, ensure that earlier edits don't affect the text that later edits are trying to find
 
 When making edits:
@@ -33,9 +33,9 @@ When making edits:
 - Do not leave the code in a broken state
 - Always use absolute file paths (starting with /)
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
-- Use replace_all for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
+- Use replaceAll for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
 
 If you want to create a new file, use:
 - A new file path, including dir name if needed
-- First edit: empty old_string and the new file's contents as new_string
+- First edit: empty oldString and the new file's contents as newString
 - Subsequent edits: normal edit operations on the created content


### PR DESCRIPTION
Attempt to reduce confusion for GPT-4.1. at times it will use `old_string` vs `oldString` as parameter names.

Fixes #985