### PR TITLE
Fix: failed to open session

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -50,6 +50,9 @@ type App struct {
 	IsLeaderSequence bool
 }
 
+type SessionCreatedMsg = struct {
+	Session *opencode.Session
+}
 type SessionSelectedMsg = *opencode.Session
 type SessionLoadedMsg struct{}
 type ModelSelectedMsg struct {
@@ -380,7 +383,7 @@ func (a *App) InitializeProject(ctx context.Context) tea.Cmd {
 	}
 
 	a.Session = session
-	cmds = append(cmds, util.CmdHandler(SessionSelectedMsg(session)))
+	cmds = append(cmds, util.CmdHandler(SessionCreatedMsg{Session: session}))
 
 	go func() {
 		_, err := a.Client.Session.Init(ctx, a.Session.ID, opencode.SessionInitParams{
@@ -456,7 +459,7 @@ func (a *App) SendChatMessage(
 			return a, toast.NewErrorToast(err.Error())
 		}
 		a.Session = session
-		cmds = append(cmds, util.CmdHandler(SessionSelectedMsg(session)))
+		cmds = append(cmds, util.CmdHandler(SessionCreatedMsg{Session: session}))
 	}
 
 	message := opencode.UserMessage{

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -498,6 +498,9 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.app.Session = msg
 		a.app.Messages = messages
 		return a, util.CmdHandler(app.SessionLoadedMsg{})
+	case app.SessionCreatedMsg:
+		a.app.Session = msg.Session
+		return a, util.CmdHandler(app.SessionLoadedMsg{})
 	case app.ModelSelectedMsg:
 		a.app.Provider = &msg.Provider
 		a.app.Model = &msg.Model


### PR DESCRIPTION
Fixes: #732

Explanation of the issue:

In `packages/tui/internal/app/app.go` we have SendChatMessage. In the event of a session being new it will create one, then it added a `append(cmds, util.CmdHandler(SessionSelectedMsg))`. 

Due to the ordering of the tea.Batch the SessionSelectedMsg event is emitted and in some cases handled, before any messages are saved in the backend. Thus the `messages, err := a.app.ListMessages(context.Background(), msg.ID)` would return an error since no messages have been sent.

It seems like this issue also could have applied to /init. So the easy fix here was just making a separate event/msg for when we create a session and that allows us to not list messages for a session that doesn't have any yet!
