### PR TITLE
fix(tui): close completion dialog on ctrl+h

### DIFF
--- a/packages/tui/internal/components/dialog/complete.go
+++ b/packages/tui/internal/components/dialog/complete.go
@@ -139,7 +139,7 @@ var completionDialogKeys = completionDialogKeyMap{
 		key.WithKeys("tab", "enter", "right"),
 	),
 	Cancel: key.NewBinding(
-		key.WithKeys(" ", "esc", "backspace", "ctrl+c"),
+		key.WithKeys(" ", "esc", "backspace", "ctrl+h", "ctrl+c"),
 	),
 }
 
@@ -230,7 +230,7 @@ func (c *completionDialogComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				width := lipgloss.Width(value)
 				triggerWidth := lipgloss.Width(c.trigger)
 				// Only close on backspace when there are no characters left, unless we're back to just the trigger
-				if msg.String() != "backspace" || (width <= triggerWidth && value != c.trigger) {
+				if (msg.String() != "backspace" && msg.String() != "ctrl+h") || (width <= triggerWidth && value != c.trigger) {
 					return c, c.close()
 				}
 			}


### PR DESCRIPTION
This PR adds a small patch to close the completion dialog on ctrl+h. Previously the dialog stayed open when deleting the last character with ctrl+h.