### PR TITLE
chore(docs): Improve Data Storage Clarity and Accessibility

### DIFF
--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -51,9 +51,9 @@ opencode comes with two built-in modes: _build_, the default with all tools enab
 {
   "$schema": "https://opencode.ai/config.json",
   "mode": {
-    "build": { },
-    "plan": { },
-    "my-custom-mode": { }
+    "build": {},
+    "plan": {},
+    "my-custom-mode": {}
   }
 }
 ```
@@ -120,6 +120,55 @@ With the following options:
 
 The **default** log level is `INFO`. If you are running opencode locally in
 development mode it's set to `DEBUG`.
+
+---
+
+### Data Storage
+
+opencode stores various types of data in different locations on your system:
+
+#### Configuration & Authentication
+
+- **Global config**: `~/.config/opencode/opencode.json`
+- **Authentication**: `~/.local/share/opencode/auth.json` (API keys from `opencode auth login`)
+
+#### Session Data & Project Files
+
+- **Session data**: `~/.local/share/opencode/project/{project-name}/storage/session/`
+- **Message history**: `~/.local/share/opencode/project/{project-name}/storage/session/message/{session-id}/`
+- **Project state**: `~/.local/share/opencode/project/{project-name}/app.json`
+
+#### Logs & Cache
+
+- **Logs**:
+  - **macOS/Linux**: `~/.local/share/opencode/log/`
+  - **Windows**: `%APPDATA%\opencode\log\`
+- **Cache**: `~/.cache/opencode/`
+
+#### Project Name Generation
+
+Project names are generated from your Git repository path by:
+
+1. Taking the full repository root path
+2. Replacing path separators with hyphens
+3. Replacing non-alphanumeric characters with hyphens
+
+**Example**: `/Users/john/projects/my-app` becomes `Users-john-projects-my-app`
+
+#### Finding Your Data
+
+To locate your opencode data:
+
+```bash
+# View all projects
+ls ~/.local/share/opencode/project/
+
+# View sessions for a specific project
+ls ~/.local/share/opencode/project/{project-name}/storage/session/
+
+# View authentication info
+cat ~/.local/share/opencode/auth.json
+```
 
 ---
 


### PR DESCRIPTION
## Summary
• Added a proper "Data Storage" section to the config docs because apparently nobody knew where opencode puts their files
• Explains where sessions, configs, logs, and cache live on your machine
• Shows how project names get generated from git paths (spoiler: lots of hyphens)
• Gives you actual commands to find your data instead of making you guess
