### PR TITLE
docs: update filename for global config

### DIFF
--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -21,7 +21,7 @@ This can be used to configure opencode globally or for a specific project.
 
 ### Global
 
-Place your global opencode config in `~/.config/opencode/opencode.json`. You'll want to use the global config for things like themes, providers, or keybinds.
+Place your global opencode config in `~/.config/opencode/config.json`. You'll want to use the global config for things like themes, providers, or keybinds.
 
 ---
 


### PR DESCRIPTION
# Summary

* The filename used for global config is incorrect in the docs, the path should be `~/.config/opencode/config.json` as noted here: https://github.com/sst/opencode/issues/698