### PR TITLE
support multiple prompt {file:...} directives

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -234,14 +234,14 @@ export namespace Config {
       return process.env[varName] || ""
     })
 
-    const fileMatches = text.match(/"?\{file:([^}]+)\}"?/g)
+    const fileMatches = text.match(/\{file:([^}]+)\}/g)
     if (fileMatches) {
       const configDir = path.dirname(configPath)
       for (const match of fileMatches) {
         const filePath = match.replace(/^"?\{file:/, "").replace(/\}"?$/, "")
         const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
         const fileContent = await Bun.file(resolvedPath).text()
-        text = text.replace(match, JSON.stringify(fileContent))
+        text = text.replace(match, JSON.stringify(fileContent).slice(1, -1))
       }
     }
 


### PR DESCRIPTION
this is a small tweak in the config loader to support handling multiple file references in the config, so we can have something like this:
```json
{
    "mode": {
        "foobar": {
            "prompt": "{file:./prompts/foo.txt}{file:./prompts/bar.txt}"
        }
    }
```
for example