### PR TITLE
docs: Clarify MCP config instructions

### DIFF
--- a/packages/web/src/content/docs/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/docs/mcp-servers.mdx
@@ -18,19 +18,24 @@ You can define MCP servers in your opencode config under `mcp`.
 
 ### Local
 
-Add a local MCP servers under `mcp.localmcp`.
+Add local MCP servers under `mcp` with `"type": "local"`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "localmcp": {
+    "my-local-mcp-server": {
       "type": "local",
       "command": ["bun", "x", "my-mcp-command"],
       "enabled": true,
       "environment": {
         "MY_ENV_VAR": "my_env_var_value"
       }
+    }, {
+    "my-different-local-mcp-server": {
+      "type": "local",
+      "command": ["bun", "x", "my-other-mcp-command"],
+      "enabled": true
     }
   }
 }
@@ -40,13 +45,13 @@ You can also disable a server by setting `enabled` to `false`. This is useful if
 
 ### Remote
 
-Add a remote MCP servers under `mcp.remotemcp`.
+Add remote MCP servers under `mcp` with `"type": "remote"`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "remotemcp": {
+    "my-remote-mcp": {
       "type": "remote",
       "url": "https://my-mcp-server.com",
       "enabled": true


### PR DESCRIPTION
The existing MCP instructions were unclear / wrong. This clarifies that the object keys in the "mcp" object are just arbitrary names given to the servers.