### PR TITLE
feat: Add retry mechanism for Anthropic overloaded errors

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -123,11 +123,41 @@ export namespace Config {
       ref: "KeybindsConfig",
     })
 
+  export const RetryConfig = z
+    .object({
+      maxRetries: z
+        .number()
+        .min(0)
+        .max(50)
+        .optional()
+        .default(20)
+        .describe("Maximum number of retry attempts for overloaded errors"),
+      initialDelay: z
+        .number()
+        .min(100)
+        .max(10000)
+        .optional()
+        .default(1000)
+        .describe("Initial delay in milliseconds before first retry"),
+      maxDelay: z
+        .number()
+        .min(1000)
+        .max(60000)
+        .optional()
+        .default(30000)
+        .describe("Maximum delay in milliseconds between retries"),
+    })
+    .strict()
+    .openapi({
+      ref: "RetryConfig",
+    })
+
   export const Info = z
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
+      retry: RetryConfig.optional().describe("Retry configuration for handling overloaded errors"),
       share: z
         .enum(["auto", "disabled"])
         .optional()

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -644,41 +644,67 @@ export namespace Session {
       tools[key] = item
     }
 
-    const stream = streamText({
-      onError() {},
-      maxRetries: 10,
-      maxOutputTokens: outputLimit,
-      abortSignal: abort.signal,
-      stopWhen: stepCountIs(1000),
-      providerOptions: model.info.options,
-      messages: [
-        ...system.map(
-          (x): ModelMessage => ({
-            role: "system",
-            content: x,
+    const config = await Config.state.get()
+    const retryConfig = config.retry || {}
+    const maxRetries = retryConfig.maxRetries ?? 20
+    const initialDelay = retryConfig.initialDelay ?? 1000
+    const maxDelay = retryConfig.maxDelay ?? 30000
+
+    let retryCount = 0
+
+    while (retryCount < maxRetries) {
+      try {
+        const stream = streamText({
+          onError() {},
+          maxRetries: 10,
+          maxOutputTokens: outputLimit,
+          abortSignal: abort.signal,
+          stopWhen: stepCountIs(1000),
+          providerOptions: model.info.options,
+          messages: [
+            ...system.map(
+              (x): ModelMessage => ({
+                role: "system",
+                content: x,
+              }),
+            ),
+            ...MessageV2.toModelMessage(msgs),
+          ],
+          temperature: model.info.temperature ? 0 : undefined,
+          tools: model.info.tool_call === false ? undefined : tools,
+          model: wrapLanguageModel({
+            model: model.language,
+            middleware: [
+              {
+                async transformParams(args) {
+                  if (args.type === "stream") {
+                    // @ts-expect-error
+                    args.params.prompt = ProviderTransform.message(args.params.prompt, input.providerID, input.modelID)
+                  }
+                  return args.params
+                },
+              },
+            ],
           }),
-        ),
-        ...MessageV2.toModelMessage(msgs),
-      ],
-      temperature: model.info.temperature ? 0 : undefined,
-      tools: model.info.tool_call === false ? undefined : tools,
-      model: wrapLanguageModel({
-        model: model.language,
-        middleware: [
-          {
-            async transformParams(args) {
-              if (args.type === "stream") {
-                // @ts-expect-error
-                args.params.prompt = ProviderTransform.message(args.params.prompt, input.providerID, input.modelID)
-              }
-              return args.params
-            },
-          },
-        ],
-      }),
-    })
-    const result = await processor.process(stream)
-    return result
+        })
+        const result = await processor.process(stream)
+        return result
+      } catch (error) {
+        if (error instanceof Error && error.message.includes("overloaded_error") && retryCount < maxRetries - 1) {
+          retryCount++
+          let delay = initialDelay * Math.pow(2, retryCount - 1)
+          if (delay > maxDelay) {
+            delay = maxDelay
+          }
+          const jitter = Math.random() * delay * 0.25
+          delay = Math.round(delay - jitter)
+          log.info("Retrying due to overloaded error", { attempt: retryCount, delay, maxRetries })
+          await new Promise((resolve) => setTimeout(resolve, delay))
+        } else {
+          throw error
+        }
+      }
+    }
   }
 
   function createProcessor(assistantMsg: MessageV2.Assistant, model: ModelsDev.Model) {
@@ -891,6 +917,15 @@ export namespace Session {
               break
             case LoadAPIKeyError.isInstance(e):
               assistantMsg.error = new MessageV2.AuthError(
+                {
+                  providerID: model.id,
+                  message: e.message,
+                },
+                { cause: e },
+              ).toObject()
+              break
+            case e instanceof Error && e.message.includes("overloaded_error"):
+              assistantMsg.error = new MessageV2.OverloadedError(
                 {
                   providerID: model.id,
                   message: e.message,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -15,6 +15,13 @@ export namespace MessageV2 {
       message: z.string(),
     }),
   )
+  export const OverloadedError = NamedError.create(
+    "ServiceOverloadedError",
+    z.object({
+      providerID: z.string(),
+      message: z.string(),
+    }),
+  )
 
   export const ToolStatePending = z
     .object({
@@ -186,6 +193,7 @@ export namespace MessageV2 {
         NamedError.Unknown.Schema,
         OutputLengthError.Schema,
         AbortedError.Schema,
+        OverloadedError.Schema,
       ])
       .optional(),
     system: z.string().array(),


### PR DESCRIPTION
Implement automatic retry with exponential backoff when Anthropic returns `{"type": "overloaded_error"}` responses, by checking the error message on `overloaded_error` inclusion.

**Changes**

- Add `ServiceOverloadedError` type to properly categorize these errors
- Implement configurable retry logic with exponential backoff and jitter
- Add retry configuration schema with sensible defaults (20 retries, 30s max delay)

**Configuration**

We can now configure retry behavior in opencode.json:
```json
{
  "retry": {
    "maxRetries": 20,
    "initialDelay": 1000,
    "maxDelay": 30000
  }
}
```

Closes #833