### PR TITLE
Fix: Add escape sequence for @ symbols to prevent send blocking

### DIFF
--- a/packages/tui/internal/components/dialog/complete.go
+++ b/packages/tui/internal/components/dialog/complete.go
@@ -56,7 +56,7 @@ var completionDialogKeys = completionDialogKeyMap{
 		key.WithKeys("tab", "enter", "right"),
 	),
 	Cancel: key.NewBinding(
-		key.WithKeys(" ", "esc", "backspace", "ctrl+h", "ctrl+c"),
+		key.WithKeys("space", " ", "esc", "backspace", "ctrl+h", "ctrl+c"),
 	),
 }
 


### PR DESCRIPTION
Users cannot send messages containing @ symbols when no matching file exists, effectively blocking input (e.g., `explain @media queries in CSS` or `find all @Component decorators` cannot be sent).

## Solution
- `\@` now renders as literal @
- Fixes send blocking when @ symbols don't match files
- Existing file linking with @ unchanged

## Usage
- `@filename` - links to file (existing)
- `\@username` - literal @ symbol, allows sending

**NOTE**: Escaped @ symbols are rendered without prepended

## Example
<img width="1132" height="676" alt="Screenshot 2025-07-15 at 2 07 57 PM" src="https://github.com/user-attachments/assets/53832163-f8dd-4a50-8c21-25a142398771" />
