### PR TITLE
perf: move ANSI regex compilations to package level

### DIFF
--- a/packages/tui/internal/components/diff/diff.go
+++ b/packages/tui/internal/components/diff/diff.go
@@ -38,6 +38,10 @@ const (
 	LineRemoved                 // Line removed from the old file
 )
 
+var (
+	ansiRegex = regexp.MustCompile(`\x1b(?:[@-Z\\-_]|\[[0-9?]*(?:;[0-9?]*)*[@-~])`)
+)
+
 // Segment represents a portion of a line for intra-line highlighting
 type Segment struct {
 	Start int
@@ -548,7 +552,6 @@ func createStyles(t theme.Theme) (removedLineStyle, addedLineStyle, contextLineS
 // applyHighlighting applies intra-line highlighting to a piece of text
 func applyHighlighting(content string, segments []Segment, segmentType LineType, highlightBg compat.AdaptiveColor) string {
 	// Find all ANSI sequences in the content
-	ansiRegex := regexp.MustCompile(`\x1b(?:[@-Z\\-_]|\[[0-9?]*(?:;[0-9?]*)*[@-~])`)
 	ansiMatches := ansiRegex.FindAllStringIndex(content, -1)
 
 	// Build a mapping of visible character positions to their actual indices

--- a/packages/tui/internal/layout/overlay.go
+++ b/packages/tui/internal/layout/overlay.go
@@ -15,6 +15,11 @@ import (
 	"github.com/sst/opencode/internal/util"
 )
 
+var (
+	// ANSI escape sequence regex
+	ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+)
+
 // Split a string into lines, additionally returning the size of the widest line.
 func getLines(s string) (lines []string, widest int) {
 	lines = strings.Split(s, "\n")
@@ -272,9 +277,6 @@ func combineStyles(bgStyle ansiStyle, fgColor *compat.AdaptiveColor) string {
 
 // getStyleAtPosition extracts the active ANSI style at a given visual position
 func getStyleAtPosition(s string, targetPos int) ansiStyle {
-	// ANSI escape sequence regex
-	ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*m`)
-
 	visualPos := 0
 	currentStyle := ansiStyle{}
 


### PR DESCRIPTION
Prevents the regexps from being recompiled on every function call, which improves performance especially when these functions are called frequently during diff rendering and overlay operations.