### PR TITLE
fix: don't sign snapshot commits

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -38,10 +38,11 @@ export namespace Snapshot {
     await $`git --git-dir ${git} add .`.quiet().cwd(app.path.cwd).nothrow()
     log.info("added files")
 
-    const result = await $`git --git-dir ${git} commit -m "snapshot" --author="opencode <mail@opencode.ai>"`
-      .quiet()
-      .cwd(app.path.cwd)
-      .nothrow()
+    const result =
+      await $`git --git-dir ${git} commit -m "snapshot" --no-gpg-sign --author="opencode <mail@opencode.ai>"`
+        .quiet()
+        .cwd(app.path.cwd)
+        .nothrow()
 
     const match = result.stdout.toString().match(/\[.+ ([a-f0-9]+)\]/)
     if (!match) return


### PR DESCRIPTION
if git is globally configured to always sign commits with GPG, the snapshot creation can fail due to the GPG password promt being injected in the TUI. In principle, automatically created commits shouldn't be signed at all with the users key.