### PR TITLE
feat(tui): shift+tab to cycle modes backward

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -81,7 +81,8 @@ export namespace Config {
     .object({
       leader: z.string().optional().default("ctrl+x").describe("Leader key for keybind combinations"),
       app_help: z.string().optional().default("<leader>h").describe("Show help dialog"),
-      switch_mode: z.string().optional().default("tab").describe("Switch mode"),
+      next_mode: z.string().optional().default("tab").describe("Next mode"),
+      previous_mode: z.string().optional().default("shift+tab").describe("Previous mode"),
       editor_open: z.string().optional().default("<leader>e").describe("Open external editor"),
       session_export: z.string().optional().default("<leader>x").describe("Export session to editor"),
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -81,8 +81,8 @@ export namespace Config {
     .object({
       leader: z.string().optional().default("ctrl+x").describe("Leader key for keybind combinations"),
       app_help: z.string().optional().default("<leader>h").describe("Show help dialog"),
-      next_mode: z.string().optional().default("tab").describe("Next mode"),
-      previous_mode: z.string().optional().default("shift+tab").describe("Previous mode"),
+      switch_mode: z.string().optional().default("tab").describe("Next mode"),
+      switch_mode_reverse: z.string().optional().default("shift+tab").describe("Previous Mode"),
       editor_open: z.string().optional().default("<leader>e").describe("Open external editor"),
       session_export: z.string().optional().default("<leader>x").describe("Export session to editor"),
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -205,10 +205,17 @@ func (a *App) SetClipboard(text string) tea.Cmd {
 	return tea.Sequence(cmds...)
 }
 
-func (a *App) SwitchMode() (*App, tea.Cmd) {
-	a.ModeIndex++
-	if a.ModeIndex >= len(a.Modes) {
-		a.ModeIndex = 0
+func (a *App) cycleMode(forward bool) (*App, tea.Cmd) {
+	if forward {
+		a.ModeIndex++
+		if a.ModeIndex >= len(a.Modes) {
+			a.ModeIndex = 0
+		}
+	} else {
+		a.ModeIndex--
+		if a.ModeIndex < 0 {
+			a.ModeIndex = len(a.Modes) - 1
+		}
 	}
 	a.Mode = &a.Modes[a.ModeIndex]
 
@@ -242,6 +249,14 @@ func (a *App) SwitchMode() (*App, tea.Cmd) {
 		a.SaveState()
 		return nil
 	}
+}
+
+func (a *App) NextMode() (*App, tea.Cmd) {
+	return a.cycleMode(true)
+}
+
+func (a *App) PreviousMode() (*App, tea.Cmd) {
+	return a.cycleMode(false)
 }
 
 func (a *App) InitializeProvider() tea.Cmd {

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -251,11 +251,11 @@ func (a *App) cycleMode(forward bool) (*App, tea.Cmd) {
 	}
 }
 
-func (a *App) NextMode() (*App, tea.Cmd) {
+func (a *App) SwitchMode() (*App, tea.Cmd) {
 	return a.cycleMode(true)
 }
 
-func (a *App) PreviousMode() (*App, tea.Cmd) {
+func (a *App) SwitchModeReverse() (*App, tea.Cmd) {
 	return a.cycleMode(false)
 }
 

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -86,7 +86,8 @@ func (r CommandRegistry) Matches(msg tea.KeyPressMsg, leader bool) []Command {
 
 const (
 	AppHelpCommand              CommandName = "app_help"
-	SwitchModeCommand           CommandName = "switch_mode"
+	NextModeCommand             CommandName = "next_mode"
+	PreviousModeCommand         CommandName = "previous_mode"
 	EditorOpenCommand           CommandName = "editor_open"
 	SessionNewCommand           CommandName = "session_new"
 	SessionListCommand          CommandName = "session_list"
@@ -155,9 +156,14 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 			Trigger:     []string{"help"},
 		},
 		{
-			Name:        SwitchModeCommand,
-			Description: "switch mode",
+			Name:        NextModeCommand,
+			Description: "next mode",
 			Keybindings: parseBindings("tab"),
+		},
+		{
+			Name:        PreviousModeCommand,
+			Description: "previous mode",
+			Keybindings: parseBindings("shift+tab"),
 		},
 		{
 			Name:        EditorOpenCommand,

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -86,8 +86,8 @@ func (r CommandRegistry) Matches(msg tea.KeyPressMsg, leader bool) []Command {
 
 const (
 	AppHelpCommand              CommandName = "app_help"
-	NextModeCommand             CommandName = "next_mode"
-	PreviousModeCommand         CommandName = "previous_mode"
+	SwitchModeCommand           CommandName = "switch_mode"
+	SwitchModeReverseCommand    CommandName = "switch_mode_reverse"
 	EditorOpenCommand           CommandName = "editor_open"
 	SessionNewCommand           CommandName = "session_new"
 	SessionListCommand          CommandName = "session_list"
@@ -156,12 +156,12 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 			Trigger:     []string{"help"},
 		},
 		{
-			Name:        NextModeCommand,
+			Name:        SwitchModeCommand,
 			Description: "next mode",
 			Keybindings: parseBindings("tab"),
 		},
 		{
-			Name:        PreviousModeCommand,
+			Name:        SwitchModeReverseCommand,
 			Description: "previous mode",
 			Keybindings: parseBindings("shift+tab"),
 		},

--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -94,7 +94,7 @@ func (m statusComponent) View() string {
 		modeForeground = t.BackgroundPanel()
 	}
 
-	command := m.app.Commands[commands.SwitchModeCommand]
+	command := m.app.Commands[commands.NextModeCommand]
 	kb := command.Keybindings[0]
 	key := kb.Key
 	if kb.RequiresLeader {

--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -94,7 +94,7 @@ func (m statusComponent) View() string {
 		modeForeground = t.BackgroundPanel()
 	}
 
-	command := m.app.Commands[commands.NextModeCommand]
+	command := m.app.Commands[commands.SwitchModeCommand]
 	kb := command.Keybindings[0]
 	key := kb.Key
 	if kb.RequiresLeader {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -806,8 +806,12 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 	case commands.AppHelpCommand:
 		helpDialog := dialog.NewHelpDialog(a.app)
 		a.modal = helpDialog
-	case commands.SwitchModeCommand:
-		updated, cmd := a.app.SwitchMode()
+	case commands.NextModeCommand:
+		updated, cmd := a.app.NextMode()
+		a.app = updated
+		cmds = append(cmds, cmd)
+	case commands.PreviousModeCommand:
+		updated, cmd := a.app.PreviousMode()
 		a.app = updated
 		cmds = append(cmds, cmd)
 	case commands.EditorOpenCommand:

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -806,12 +806,12 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 	case commands.AppHelpCommand:
 		helpDialog := dialog.NewHelpDialog(a.app)
 		a.modal = helpDialog
-	case commands.NextModeCommand:
-		updated, cmd := a.app.NextMode()
+	case commands.SwitchModeCommand:
+		updated, cmd := a.app.SwitchMode()
 		a.app = updated
 		cmds = append(cmds, cmd)
-	case commands.PreviousModeCommand:
-		updated, cmd := a.app.PreviousMode()
+	case commands.SwitchModeReverseCommand:
+		updated, cmd := a.app.SwitchModeReverse()
 		a.app = updated
 		cmds = append(cmds, cmd)
 	case commands.EditorOpenCommand:

--- a/packages/tui/sdk/config.go
+++ b/packages/tui/sdk/config.go
@@ -558,8 +558,10 @@ type Keybinds struct {
 	SessionShare string `json:"session_share,required"`
 	// Unshare current session
 	SessionUnshare string `json:"session_unshare,required"`
-	// Switch mode
-	SwitchMode string `json:"switch_mode,required"`
+	// Next mode
+	NextMode string `json:"next_mode,required"`
+	// Previous mode
+	PreviousMode string `json:"previous_mode,required"`
 	// List available themes
 	ThemeList string `json:"theme_list,required"`
 	// Toggle tool details
@@ -600,7 +602,8 @@ type keybindsJSON struct {
 	SessionNew           apijson.Field
 	SessionShare         apijson.Field
 	SessionUnshare       apijson.Field
-	SwitchMode           apijson.Field
+	NextMode             apijson.Field
+	PreviousMode         apijson.Field
 	ThemeList            apijson.Field
 	ToolDetails          apijson.Field
 	raw                  string

--- a/packages/tui/sdk/config.go
+++ b/packages/tui/sdk/config.go
@@ -558,10 +558,10 @@ type Keybinds struct {
 	SessionShare string `json:"session_share,required"`
 	// Unshare current session
 	SessionUnshare string `json:"session_unshare,required"`
-	// Next mode
-	NextMode string `json:"next_mode,required"`
-	// Previous mode
-	PreviousMode string `json:"previous_mode,required"`
+	// Switch mode
+	SwitchMode string `json:"switch_mode,required"`
+	// Switch mode reverse
+	SwitchModeReverse string `json:"switch_mode_reverse,required"`
 	// List available themes
 	ThemeList string `json:"theme_list,required"`
 	// Toggle tool details
@@ -602,8 +602,8 @@ type keybindsJSON struct {
 	SessionNew           apijson.Field
 	SessionShare         apijson.Field
 	SessionUnshare       apijson.Field
-	NextMode             apijson.Field
-	PreviousMode         apijson.Field
+	SwitchMode           apijson.Field
+	SwitchModeReverse    apijson.Field
 	ThemeList            apijson.Field
 	ToolDetails          apijson.Field
 	raw                  string


### PR DESCRIPTION
I've renamed `switch_mode` to `next_mode` and added `previous_mode` with a shift+tab keybind.

Feels intuitive and saves some time when you have more than two modes.