### PR TITLE
fix: grep omitting text after a colon

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -55,12 +55,11 @@ export const GrepTool = Tool.define({
     for (const line of lines) {
       if (!line) continue
 
-      const parts = line.split(":", 3)
-      if (parts.length < 3) continue
+      const [filePath, lineNumStr, ...lineTextParts] = line.split(":")
+      if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
 
-      const filePath = parts[0]
-      const lineNum = parseInt(parts[1], 10)
-      const lineText = parts[2]
+      const lineNum = parseInt(lineNumStr, 10)
+      const lineText = lineTextParts.join(":")
 
       const file = Bun.file(filePath)
       const stats = await file.stat().catch(() => null)


### PR DESCRIPTION
Text after a colon `:` is omitted from the grep tool's output. You can see it happening in the first tool call here:

https://opencode.ai/s/OH8XImqo

<img width="641" height="443" alt="Screenshot 2025-07-16 at 8 51 21 AM" src="https://github.com/user-attachments/assets/541e9afa-be02-4b76-8da7-dd5acfa8e729" />
