### PR TITLE
fix: Prevent division by zero in context percentage calculation

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -451,7 +451,10 @@ func formatTokensAndCost(
 		formattedTokens = strings.Replace(formattedTokens, ".0M", "M", 1)
 	}
 
-	percentage := (float64(tokens) / float64(contextWindow)) * 100
+	percentage := 0.0
+	if contextWindow > 0 {
+		percentage = (float64(tokens) / float64(contextWindow)) * 100
+	}
 
 	if isSubscriptionModel {
 		return fmt.Sprintf(


### PR DESCRIPTION
## Summary
This PR fixes a bug where the context percentage would display a garbage value when using a custom provider with a context window of 0.

<img width="818" height="64" alt="image" src="https://github.com/user-attachments/assets/529571c8-5069-48b8-91cd-a6d299fd53b0" />

This was caused by a division-by-zero error. The code has been updated to check for a zero context window before performing the division.

## Test plan
Manually tested with a custom provider with a context window of 0. The percentage now correctly displays 0%.