### PR TITLE
fix(tui): remove extra newline after exiting /editor

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -408,7 +408,7 @@ func (m *editorComponent) SetInterruptKeyInDebounce(inDebounce bool) {
 }
 
 func (m *editorComponent) SetValue(value string) {
-	m.textarea.SetValue(value)
+	m.textarea.SetValue(strings.TrimSuffix(value, "\n"))
 }
 
 func (m *editorComponent) SetExitKeyInDebounce(inDebounce bool) {


### PR DESCRIPTION
Basically, whenever you exit the editor after making a change it would add an extra newline because of some weird read file interaction.
Fixed that by truncating one `"\n"` in the `SetValue` function.
 

(also deleted an extra binary that accidentally got included in my last commit)