### PR TITLE
fix: generate title should use same options as model it uses to gen

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -508,7 +508,7 @@ export namespace Session {
       const small = (await Provider.getSmallModel(input.providerID)) ?? model
       generateText({
         maxOutputTokens: input.providerID === "google" ? 1024 : 20,
-        providerOptions: model.info.options,
+        providerOptions: small.info.options,
         messages: [
           ...SystemPrompt.title(input.providerID).map(
             (x): ModelMessage => ({


### PR DESCRIPTION
For title generation we use `const small = (await Provider.getSmallModel(input.providerID)) ?? model` however we are setting `providerOptions: model.info.options,` this looks like a small bug that wasn't caught when small was added. Super basic fix here of just ensuring we use the options for the model we are actually using to gen