### PR TITLE
docs(share): add explicit manual share mode

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -139,9 +139,11 @@ export namespace Config {
       theme: z.string().optional().describe("Theme name to use for the interface"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       share: z
-        .enum(["auto", "disabled"])
+        .enum(["manual", "auto", "disabled"])
         .optional()
-        .describe("Control sharing behavior: 'auto' enables automatic sharing, 'disabled' disables all sharing"),
+        .describe(
+          "Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing",
+        ),
       autoshare: z
         .boolean()
         .optional()

--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -135,28 +135,28 @@ With the following options:
 | `WARN`  | Warnings and errors only                 |
 | `ERROR` | Errors only                              |
 
-The **default** log level is `INFO`. If you are running opencode locally in
+The **default** log level is `INFO`. If you are running opencode locally in development mode it's set to `DEBUG`.
 
 ---
 
 ### Sharing
 
-You configure the [share](/docs/share) feature through the `share` option.
+You can configure the [share](/docs/share) feature through the `share` option.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "share": "auto"
+  "share": "manual"
 }
 ```
 
 This takes:
 
+- `"manual"` - Allow manual sharing via commands (default)
 - `"auto"` - Automatically share new conversations
 - `"disabled"` - Disable sharing entirely
 
-By default, you'll need to manually share new conversations.
-development mode it's set to `DEBUG`.
+By default, sharing is set to manual mode where you need to explicitly share conversations using the `/share` command.
 
 ---
 
@@ -256,7 +256,7 @@ Use `{env:VARIABLE_NAME}` to substitute environment variables:
     "anthropic": {
       "options": {
         "apiKey": "{env:ANTHROPIC_API_KEY}"
-        }
+      }
     }
   }
 }

--- a/packages/web/src/content/docs/docs/share.mdx
+++ b/packages/web/src/content/docs/docs/share.mdx
@@ -23,13 +23,13 @@ When you share a conversation, opencode:
 
 ## Sharing
 
-You can manually share a conversation or enable automatic sharing for all new conversations.
+opencode supports three sharing modes that control how conversations are shared:
 
 ---
 
-### Manual
+### Manual (default)
 
-Use the `/share` command in any conversation to create a shareable link:
+By default, opencode uses manual sharing mode. Sessions are not shared automatically, but you can manually share them using the `/share` command:
 
 ```
 /share
@@ -37,11 +37,20 @@ Use the `/share` command in any conversation to create a shareable link:
 
 This will generate a unique URL that'll be copied to your clipboard.
 
+To explicitly set manual mode in your [config file](/docs/config):
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "manual"
+}
+```
+
 ---
 
 ### Auto-share
 
-You can enable automatic sharing for all new conversations through the `autoshare` option in your [config file](/docs/config).
+You can enable automatic sharing for all new conversations by setting the `share` option to `"auto"` in your [config file](/docs/config):
 
 ```json title="opencode.json"
 {
@@ -50,7 +59,22 @@ You can enable automatic sharing for all new conversations through the `autoshar
 }
 ```
 
-By default, automatic sharing is disabled.
+With auto-share enabled, every new conversation will automatically be shared and a link will be generated.
+
+---
+
+### Disabled
+
+You can disable sharing entirely by setting the `share` option to `"disabled"` in your [config file](/docs/config):
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled"
+}
+```
+
+To enforce this across your team for a given project, add it to the `opencode.json` in your project and check into Git.
 
 ---
 
@@ -63,21 +87,6 @@ To stop sharing a conversation and remove it from public access:
 ```
 
 This will remove the share link and delete the data related to the conversation.
-
----
-
-## Disable
-
-If you'd like to disable sharing entirely, you can do so by setting the `share` option to `"disabled"` in your [config file](/docs/config).
-
-```json title="opencode.json"
-{
-  "$schema": "https://opencode.ai/config.json",
-  "share": "disabled"
-}
-```
-
-To enforce this across your team for a given project, add it to the `opencode.json` in your project and check into Git.
 
 ---
 


### PR DESCRIPTION
I was super confused with the new share config. For a bit I thought there was just "auto" and "disabled" now (by looking at the config json autocomplete).

This PR adds the default "manual" mode to the config JSON and docs to make the share options more clear.

If I am the only one who is confused feel free to just close this PR 😊