### PR TITLE
fix(tui): display only first line of session titles in dialog

### DIFF
--- a/packages/tui/internal/components/dialog/session.go
+++ b/packages/tui/internal/components/dialog/session.go
@@ -42,7 +42,7 @@ func (s sessionItem) Render(
 	if s.isDeleteConfirming {
 		text = "Press again to confirm delete"
 	} else {
-		text = s.title
+		text = strings.Split(s.title, "\n")[0]
 	}
 
 	truncatedStr := truncate.StringWithTail(text, uint(width-1), "...")


### PR DESCRIPTION
Sometimes titles are generated with newline characters. Looks kinda clunky in session dialog.

<img width="1275" height="729" alt="Screenshot 2025-07-16 at 8 52 06 PM" src="https://github.com/user-attachments/assets/6f0eeb57-6861-4aa8-ae42-8d20bb24f7b9" />
