### PR TITLE
fix: message error centering

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -380,6 +380,12 @@ func (m *messagesComponent) renderView() {
 				width,
 				WithBorderColor(t.Error()),
 			)
+			error = lipgloss.PlaceHorizontal(
+				m.width,
+				lipgloss.Center,
+				error,
+				styles.WhitespaceStyle(t.Background()),
+			)
 			blocks = append(blocks, error)
 			m.lineCount += lipgloss.Height(error) + 1
 		}


### PR DESCRIPTION
Fixes: #1082

### Before:
<img width="1503" height="652" alt="Screenshot 2025-07-16 at 11 26 12 PM" src="https://github.com/user-attachments/assets/0fbe8a7f-e47c-4dcd-8a3a-1f858d1f06d1" />


### After:
<img width="1511" height="643" alt="Screenshot 2025-07-16 at 11 26 06 PM" src="https://github.com/user-attachments/assets/bdcec1c0-f7aa-4473-a51f-35bcba5e4924" />
