### PR TITLE
feat: support AWS_BEARER_TOKEN_BEDROCK for amazon bedrock provider autoloading

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -120,7 +120,7 @@ export const AuthLoginCommand = cmd({
 
     if (provider === "amazon-bedrock") {
       prompts.log.info(
-        "Amazon bedrock can be configured with standard AWS environment variables like AWS_PROFILE or AWS_ACCESS_KEY_ID",
+        "Amazon bedrock can be configured with standard AWS environment variables like AWS_BEARER_TOKEN_BEDROCK, AWS_PROFILE or AWS_ACCESS_KEY_ID",
       )
       prompts.outro("Done")
       return

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -139,7 +139,8 @@ export namespace Provider {
       }
     },
     "amazon-bedrock": async () => {
-      if (!process.env["AWS_PROFILE"] && !process.env["AWS_ACCESS_KEY_ID"]) return { autoload: false }
+      if (!process.env["AWS_PROFILE"] && !process.env["AWS_ACCESS_KEY_ID"] && !process.env["AWS_BEARER_TOKEN_BEDROCK"])
+        return { autoload: false }
 
       const region = process.env["AWS_REGION"] ?? "us-east-1"
 


### PR DESCRIPTION
Adds support for auto-loading the Amazon Bedrock provider when `AWS_BEARER_TOKEN_BEDROCK` is available in the environment. This is a recent addition by AWS to allow for quicker access to Bedrock using API keys, this is since recently supported in the SDKs too.

Resources:
https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html

Related:
https://github.com/aws/aws-sdk-js-v3/issues/7204