### PR TITLE
fix(tui): remove mode left-border in statusbar

### DIFF
--- a/packages/tui/internal/components/status/status.go
+++ b/packages/tui/internal/components/status/status.go
@@ -107,10 +107,6 @@ func (m statusComponent) View() string {
 	mode := modeNameStyle(strings.ToUpper(m.app.Mode.Name)) + modeDescStyle(" MODE")
 	mode = modeStyle.
 		Padding(0, 1).
-		BorderLeft(true).
-		BorderStyle(lipgloss.ThickBorder()).
-		BorderForeground(modeBackground).
-		BorderBackground(t.BackgroundPanel()).
 		Render(mode)
 
 	mode = styles.NewStyle().


### PR DESCRIPTION
The border on the "Mode" in Status Bar seems "off" to me


## Before

https://github.com/user-attachments/assets/f60632c8-35e4-4eaf-98fe-aba8e7a8ad52


## After

https://github.com/user-attachments/assets/dae1eed8-aad7-4b20-a326-3ad349cd400b



Other improvements that I would suggest:
- Fixing the themes for this Status Bar, as you can see in the video, it's barely readable in some theme. OR make it completely customisable in the themes.
- Fixed size for the mode, even if aligned to the right, the jump in width is not UX friendly. I would fix the size to the max possible size, for now there is only 2 modes but I guess there will never be a "VERY VERY LONG MODE".
