### PR TITLE
fix(tui): ensure viewport scrolls to bottom on new messages

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -393,6 +393,9 @@ func (m *messagesComponent) renderView() {
 
 	m.viewport.SetHeight(m.height - lipgloss.Height(m.header))
 	m.viewport.SetContent("\n" + strings.Join(blocks, "\n\n"))
+	if m.tail {
+		m.viewport.GotoBottom()
+	}
 }
 
 func (m *messagesComponent) renderHeader() string {


### PR DESCRIPTION
## Summary

Fixes a scrolling issue in the TUI client where pressing Enter or continuing a conversation wouldn't always scroll to the bottom to show new messages.

## Changes

- Added explicit GotoBottom() call in renderView() when tail is enabled
- Ensures consistent scrolling behavior after content updates
- Maintains user control when manually scrolled up

## Problem

Users occasionally had to manually scroll to see new messages after pressing Enter or continuing a conversation due to timing issues in viewport scrolling.

## Solution

The fix ensures that whenever new content is rendered and the user was previously at the bottom (indicated by tail=true), the viewport will immediately scroll to show the latest messages.

## Testing

- [x] Pressing Enter after typing a message scrolls to bottom
- [x] New incoming messages auto-scroll when at bottom
- [x] Manual scroll up preserves reading position
- [x] Scroll behavior works consistently across different conversation states