### PR TITLE
fix: \{return} should be replaced with new line on all lines

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -297,7 +297,8 @@ func (m *editorComponent) Submit() (tea.Model, tea.Cmd) {
 
 	if len(value) > 0 && value[len(value)-1] == '\\' {
 		// If the last character is a backslash, remove it and add a newline
-		m.textarea.ReplaceRange(len(value)-1, len(value), "")
+		backslashCol := m.textarea.CurrentRowLength() - 1
+		m.textarea.ReplaceRange(backslashCol, backslashCol+1, "")
 		m.textarea.InsertString("\n")
 		return m, nil
 	}


### PR DESCRIPTION
This fixes #1104.

ReplaceRange should use the position within the current row rather than the position within the full text