### PR TITLE
Restore Messages after send chat error

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -74,6 +74,12 @@ type OptimisticMessageAddedMsg struct {
 type FileRenderedMsg struct {
 	FilePath string
 }
+type SendFailedMsg struct {
+	Text        string
+	Attachments []opencode.FilePartParam
+	Error       string
+	MessageID   string
+}
 
 func New(
 	ctx context.Context,
@@ -535,7 +541,7 @@ func (a *App) SendChatMessage(
 			}
 		}
 
-		_, err := a.Client.Session.Chat(ctx, a.Session.ID, opencode.SessionChatParams{
+		_, err := a.Client.Session.Chat(ctx, "invalid id", opencode.SessionChatParams{
 			Parts:      opencode.F(partsParam),
 			MessageID:  opencode.F(message.ID),
 			ProviderID: opencode.F(a.Provider.ID),
@@ -545,7 +551,12 @@ func (a *App) SendChatMessage(
 		if err != nil {
 			errormsg := fmt.Sprintf("failed to send message: %v", err)
 			slog.Error(errormsg)
-			return toast.NewErrorToast(errormsg)()
+			return SendFailedMsg{
+				Text:        text,
+				Attachments: attachments,
+				Error:       errormsg,
+				MessageID:   message.ID,
+			}
 		}
 		return nil
 	})

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -541,7 +541,7 @@ func (a *App) SendChatMessage(
 			}
 		}
 
-		_, err := a.Client.Session.Chat(ctx, "invalid id", opencode.SessionChatParams{
+		_, err := a.Client.Session.Chat(ctx, a.Session.ID, opencode.SessionChatParams{
 			Parts:      opencode.F(partsParam),
 			MessageID:  opencode.F(message.ID),
 			ProviderID: opencode.F(a.Provider.ID),

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -41,6 +41,7 @@ type EditorComponent interface {
 	Newline() (tea.Model, tea.Cmd)
 	SetValue(value string)
 	SetValueWithAttachments(value string)
+	RestoreMessage(text string, attachments []opencode.FilePartParam)
 	SetInterruptKeyInDebounce(inDebounce bool)
 	SetExitKeyInDebounce(inDebounce bool)
 }
@@ -404,6 +405,29 @@ func (m *editorComponent) SetValueWithAttachments(value string) {
 
 func (m *editorComponent) SetExitKeyInDebounce(inDebounce bool) {
 	m.exitKeyInDebounce = inDebounce
+}
+
+func (m *editorComponent) RestoreMessage(text string, attachments []opencode.FilePartParam) {
+	m.textarea.Reset()
+
+	for _, attachment := range attachments {
+		fileDisplay := "@" + attachment.Filename.Value
+		textareaAttachment := &textarea.Attachment{
+			ID:        uuid.NewString(),
+			Display:   fileDisplay,
+			URL:       attachment.URL.Value,
+			Filename:  attachment.Filename.Value,
+			MediaType: attachment.Mime.Value,
+		}
+		m.textarea.InsertAttachment(textareaAttachment)
+		m.textarea.InsertString(" ")
+
+		// text already includes file name
+		text = strings.ReplaceAll(text, fileDisplay+" ", "")
+		text = strings.ReplaceAll(text, fileDisplay, "")
+	}
+
+	m.textarea.InsertString(text)
 }
 
 func (m *editorComponent) getInterruptKeyText() string {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -338,6 +338,12 @@ func (a appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		updated, cmd := a.editor.Focus()
 		a.editor = updated.(chat.EditorComponent)
 		cmds = append(cmds, cmd)
+	case app.SendFailedMsg:
+		a.editor.RestoreMessage(msg.Text, msg.Attachments)
+		updated, cmd := a.editor.Focus()
+		a.editor = updated.(chat.EditorComponent)
+		cmds = append(cmds, cmd)
+		cmds = append(cmds, toast.NewErrorToast(msg.Error))
 	case dialog.CompletionDialogCloseMsg:
 		a.showCompletionDialog = false
 	case opencode.EventListResponseEventInstallationUpdated:


### PR DESCRIPTION
Quality of life feature meant for restoring message text and attachments when there is an error sending a chat. Motivation came from losing messages after submitting because of Claude overloaded errors. 

https://github.com/user-attachments/assets/7f914ee3-013d-40c9-bf91-442ccc3400f0

