### PR TITLE
test: Defines symbols for successful test build

### DIFF
--- a/packages/tui/internal/components/list/list.go
+++ b/packages/tui/internal/components/list/list.go
@@ -27,6 +27,7 @@ type SelectableFunc[T any] func(item T) bool
 type Options[T any] struct {
 	items               []T
 	maxVisibleHeight    int
+	maxVisibleItems     int
 	fallbackMsg         string
 	useAlphaNumericKeys bool
 	renderItem          RenderFunc[T]
@@ -37,10 +38,28 @@ type Options[T any] struct {
 // Option is a function that configures the list component
 type Option[T any] func(*Options[T])
 
+// ListOption is a function that configures a listComponent.
+type ListOption[T any] func(*listComponent[T])
+
 // WithItems sets the initial items for the list
 func WithItems[T any](items []T) Option[T] {
 	return func(o *Options[T]) {
 		o.items = items
+	}
+}
+
+// WithHeightFunc sets the maxVisibleHeight based on a user defined function
+func WithHeightFunc[T any](fn func(item T, isFirstInViewport bool) int) Option[T] {
+	return func(o *Options[T]) {
+		var i T
+		o.maxVisibleHeight = fn(i, true)
+	}
+}
+
+// WithMaxVisibleItems sets the maximum number of visible items in the list.
+func WithMaxVisibleItems[T any](n int) Option[T] {
+	return func(o *Options[T]) {
+		o.maxVisibleItems = n
 	}
 }
 

--- a/packages/tui/internal/components/list/list.go
+++ b/packages/tui/internal/components/list/list.go
@@ -38,9 +38,6 @@ type Options[T any] struct {
 // Option is a function that configures the list component
 type Option[T any] func(*Options[T])
 
-// ListOption is a function that configures a listComponent.
-type ListOption[T any] func(*listComponent[T])
-
 // WithItems sets the initial items for the list
 func WithItems[T any](items []T) Option[T] {
 	return func(o *Options[T]) {


### PR DESCRIPTION
There were two symbols used in `list_test.go` that were not defined. This pull request defines them. 

While this does make the tests compile and pass, I am not sure if the correct behaviour is actually being verified. I have not contributed to this project before (only been a user for a week or two) so I don't have a good handle on the codebase as a whole yet. It doesn't seem like these tests are being run in CI? Is that intentional?

I would appreciate some feedback and guidance on whether this is a valuable change or alternative approaches.

Thanks


