### PR TITLE
fix: move print_message function before first usage in install script

### DIFF
--- a/install
+++ b/install
@@ -54,6 +54,20 @@ fi
 
 mkdir -p "$INSTALL_DIR"
 
+print_message() {
+    local level=$1
+    local message=$2
+    local color=""
+
+    case $level in
+        info) color="${GREEN}" ;;
+        warning) color="${YELLOW}" ;;
+        error) color="${RED}" ;;
+    esac
+
+    echo -e "${color}${message}${NC}"
+}
+
 print_message info "Installing to: ${YELLOW}$INSTALL_DIR${GREEN}"
 
 if [ -z "$requested_version" ]; then
@@ -68,20 +82,6 @@ else
     url="https://github.com/sst/opencode/releases/download/v${requested_version}/$filename"
     specific_version=$requested_version
 fi
-
-print_message() {
-    local level=$1
-    local message=$2
-    local color=""
-
-    case $level in
-        info) color="${GREEN}" ;;
-        warning) color="${YELLOW}" ;;
-        error) color="${RED}" ;;
-    esac
-
-    echo -e "${color}${message}${NC}"
-}
 
 check_version() {
     if command -v opencode >/dev/null 2>&1; then


### PR DESCRIPTION
The `print_message` function was being called before its definition, causing a `command not found` error.
Moved the function definition to appear before its first invocation.