### PR TITLE
feat(config): add option to disable AI attribution in commits and PRs

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -179,6 +179,7 @@ export namespace Config {
         .describe("Custom provider configurations and model overrides"),
       mcp: z.record(z.string(), Mcp).optional().describe("MCP (Model Context Protocol) server configurations"),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
+      disable_ai_attribution: z.boolean().optional().describe("Disable AI attribution in commits and pull requests"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       experimental: z
         .object({

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -59,7 +59,7 @@ When the user asks you to create a new git commit, follow these steps carefully:
 
 3. You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. ALWAYS run the following commands in parallel:
    - Add relevant untracked files to the staging area.
-   - Create the commit with a message ending with:
+   - Create the commit with a message. If the user's config has `disable_ai_attribution` set to true, use only the commit message without any attribution. Otherwise, end the commit message with:
    🤖 Generated with [opencode](https://opencode.ai)
 
    Co-Authored-By: opencode <noreply@opencode.ai>
@@ -78,12 +78,19 @@ Important notes:
 - Return an empty response - the user will see the git output directly
 - In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
 <example>
+# With attribution (default):
 git commit -m "$(cat <<'EOF'
    Commit message here.
 
    🤖 Generated with [opencode](https://opencode.ai)
 
    Co-Authored-By: opencode <noreply@opencode.ai>
+   EOF
+   )"
+
+# Without attribution (when disable_ai_attribution is true):
+git commit -m "$(cat <<'EOF'
+   Commit message here.
    EOF
    )"
 </example>
@@ -119,8 +126,9 @@ IMPORTANT: When the user asks you to create a pull request, follow these steps c
 3. You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. ALWAYS run the following commands in parallel:
    - Create new branch if needed
    - Push to remote with -u flag if needed
-   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting.
+   - Create PR using gh pr create with the format below. Use a HEREDOC to pass the body to ensure correct formatting. If the user's config has `disable_ai_attribution` set to true, omit the attribution line.
 <example>
+# With attribution (default):
 gh pr create --title "the pr title" --body "$(cat <<'EOF'
 ## Summary
 <1-3 bullet points>
@@ -129,6 +137,16 @@ gh pr create --title "the pr title" --body "$(cat <<'EOF'
 [Checklist of TODOs for testing the pull request...]
 
 🤖 Generated with [opencode](https://opencode.ai)
+EOF
+)"
+
+# Without attribution (when disable_ai_attribution is true):
+gh pr create --title "the pr title" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points>
+
+## Test plan
+[Checklist of TODOs for testing the pull request...]
 EOF
 )"
 </example>


### PR DESCRIPTION
Adds `disable_ai_attribution` config option that allows users to remove the "🤖 Generated with opencode" and "Co-Authored-By: opencode" lines from git commits and pull request descriptions when set to true.

Addresses #1135