### PR TITLE
fix table heading rendering

### DIFF
--- a/packages/tui/internal/styles/markdown.go
+++ b/packages/tui/internal/styles/markdown.go
@@ -282,12 +282,6 @@ func generateMarkdownStyleConfig(backgroundColor compat.AdaptiveColor) ansi.Styl
 			},
 		},
 		Table: ansi.StyleTable{
-			StyleBlock: ansi.StyleBlock{
-				StylePrimitive: ansi.StylePrimitive{
-					BlockPrefix: "\n",
-					BlockSuffix: "\n",
-				},
-			},
 			CenterSeparator: stringPtr("┼"),
 			ColumnSeparator: stringPtr("│"),
 			RowSeparator:    stringPtr("─"),

--- a/packages/tui/internal/styles/markdown.go
+++ b/packages/tui/internal/styles/markdown.go
@@ -282,6 +282,11 @@ func generateMarkdownStyleConfig(backgroundColor compat.AdaptiveColor) ansi.Styl
 			},
 		},
 		Table: ansi.StyleTable{
+			StyleBlock: ansi.StyleBlock{
+				StylePrimitive: ansi.StylePrimitive{
+					BlockSuffix: "\n",
+				},
+			},
 			CenterSeparator: stringPtr("┼"),
 			ColumnSeparator: stringPtr("│"),
 			RowSeparator:    stringPtr("─"),


### PR DESCRIPTION
fix #688 

These `\n` have existed since the first commit. I'm not sure what's the purpose of it, but they are breaking the table rendering. The entire table looks quite weird and the headings are missing.

The background color of the table also doesn't look right, but it seems to be an issue of glamour. They've already fixed it but just haven't released it yet.

### Before
<img width="1142" height="296" alt="before" src="https://github.com/user-attachments/assets/7435bfeb-b8ea-40da-af9a-765bda3dfc0c" />

### After
<img width="1143" height="174" alt="after" src="https://github.com/user-attachments/assets/8ee65eae-a1d5-41c2-991c-f52ee5155b5f" />

a small issue is that the color of `ColumnSeparator` is different from `CenterSeparator` and `RowSeparator` (these two seem to be `TextMuted`). not sure where they inherit the colors from. at least the table looks more normal now

---

Update:

just found that if we keep the `BlockSuffix` the border colors will look consistent. I've updated the code. it adds some extra spaces but I assume it looks better? 

<img width="1146" height="227" alt="BlockSuffix" src="https://github.com/user-attachments/assets/85060585-c729-4dfe-b912-84806baab3af" />
