### PR TITLE
feat(tui): collapse session header into single line when sharing is disabled

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -446,17 +446,16 @@ func (m *messagesComponent) renderHeader() string {
 		Foreground(t.TextMuted()).
 		Background(t.Background()).
 		Render(formatTokensAndCost(tokens, contextWindow, cost, isSubscriptionModel))
+
+	shareEnabled := m.app.Config.Share != opencode.ConfigShareDisabled
 	headerText := util.ToMarkdown("# "+m.app.Session.Title, headerWidth-len(sessionInfo), t.Background())
 
 	var items []layout.FlexItem
-	if m.app.Config.Share != opencode.ConfigShareDisabled {
-		share := ""
+	if shareEnabled {
+		share := base("/share") + muted(" to create a shareable link")
 		if m.app.Session.Share.URL != "" {
 			share = muted(m.app.Session.Share.URL + "  /unshare")
-		} else {
-			share = base("/share") + muted(" to create a shareable link")
 		}
-
 		items = []layout.FlexItem{{View: share}, {View: sessionInfo}}
 	} else {
 		items = []layout.FlexItem{{View: headerText}, {View: sessionInfo}}
@@ -475,7 +474,7 @@ func (m *messagesComponent) renderHeader() string {
 	)
 
 	var headerLines []string
-	if m.app.Config.Share != opencode.ConfigShareDisabled {
+	if shareEnabled {
 		headerLines = []string{headerText, headerRow}
 	} else {
 		headerLines = []string{headerRow}

--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -414,18 +414,6 @@ func (m *messagesComponent) renderHeader() string {
 	t := theme.CurrentTheme()
 	base := styles.NewStyle().Foreground(t.Text()).Background(t.Background()).Render
 	muted := styles.NewStyle().Foreground(t.TextMuted()).Background(t.Background()).Render
-	headerLines := []string{}
-	headerLines = append(
-		headerLines,
-		util.ToMarkdown("# "+m.app.Session.Title, headerWidth-6, t.Background()),
-	)
-
-	share := ""
-	if m.app.Session.Share.URL != "" {
-		share = muted(m.app.Session.Share.URL + "  /unshare")
-	} else {
-		share = base("/share") + muted(" to create a shareable link")
-	}
 
 	sessionInfo := ""
 	tokens := float64(0)
@@ -458,31 +446,40 @@ func (m *messagesComponent) renderHeader() string {
 		Foreground(t.TextMuted()).
 		Background(t.Background()).
 		Render(formatTokensAndCost(tokens, contextWindow, cost, isSubscriptionModel))
-
-	background := t.Background()
+	headerText := util.ToMarkdown("# "+m.app.Session.Title, headerWidth-len(sessionInfo), t.Background())
 
 	var items []layout.FlexItem
-	justify := layout.JustifyEnd
-
 	if m.app.Config.Share != opencode.ConfigShareDisabled {
-		items = append(items, layout.FlexItem{View: share})
-		justify = layout.JustifySpaceBetween
+		share := ""
+		if m.app.Session.Share.URL != "" {
+			share = muted(m.app.Session.Share.URL + "  /unshare")
+		} else {
+			share = base("/share") + muted(" to create a shareable link")
+		}
+
+		items = []layout.FlexItem{{View: share}, {View: sessionInfo}}
+	} else {
+		items = []layout.FlexItem{{View: headerText}, {View: sessionInfo}}
 	}
 
-	items = append(items, layout.FlexItem{View: sessionInfo})
-
+	background := t.Background()
 	headerRow := layout.Render(
 		layout.FlexOptions{
 			Background: &background,
 			Direction:  layout.Row,
-			Justify:    justify,
+			Justify:    layout.JustifySpaceBetween,
 			Align:      layout.AlignStretch,
 			Width:      headerWidth - 6,
 		},
 		items...,
 	)
 
-	headerLines = append(headerLines, headerRow)
+	var headerLines []string
+	if m.app.Config.Share != opencode.ConfigShareDisabled {
+		headerLines = []string{headerText, headerRow}
+	} else {
+		headerLines = []string{headerRow}
+	}
 
 	header := strings.Join(headerLines, "\n")
 	header = styles.NewStyle().


### PR DESCRIPTION
Currently the session header always occupies at least two rows. This is required when the sharing function is enabled, but may be unnecessary when it is disabled. This collapses the header into a single row if sharing disabled, giving us one row back.

#### Before

<img width="768" height="131" alt="image" src="https://github.com/user-attachments/assets/f7d3f577-81d8-498e-95be-13817a69f813" />

#### After

<img width="780" height="118" alt="image" src="https://github.com/user-attachments/assets/a0d8b29e-c270-44ae-8864-dc5e7a95a61c" />

---

Session header when sharing enabled for comparison:

<img width="771" height="125" alt="image" src="https://github.com/user-attachments/assets/b2bfc822-b0be-4b28-b060-902d76bf3ffc" />