### PR TITLE
fix(hooks): prevent session_complete hook from firing on subagent sessions

### DIFF
--- a/packages/opencode/src/config/hooks.ts
+++ b/packages/opencode/src/config/hooks.ts
@@ -31,9 +31,13 @@ export namespace ConfigHooks {
       }
     })
 
-    Bus.subscribe(Session.Event.Idle, async () => {
+    Bus.subscribe(Session.Event.Idle, async (payload) => {
       const cfg = await Config.get()
       if (cfg.experimental?.hook?.session_completed) {
+        const session = await Session.get(payload.properties.sessionID)
+        // Only fire hook for top-level sessions (not subagent sessions)
+        if (session.parentID) return
+
         for (const item of cfg.experimental.hook.session_completed) {
           log.info("session_completed", {
             command: item.command,


### PR DESCRIPTION
Only fire the session_complete hook for top-level sessions. I think that is the more expected behavior. For example, when using it for notifications when the agent is done.