### PR TITLE
fix: title generation for certain providers

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -540,7 +540,7 @@ export namespace Session {
     if (msgs.length === 0 && !session.parentID) {
       const small = (await Provider.getSmallModel(input.providerID)) ?? model
       generateText({
-        maxOutputTokens: input.providerID === "google" ? 1024 : 20,
+        maxOutputTokens: small.info.reasoning ? 1024 : 20,
         providerOptions: {
           [input.providerID]: small.info.options,
         },


### PR DESCRIPTION
Fixes: #1158

Failed to generate titles because openai and others can use reasoning models, when using a reasoning model unless you can turn off the thinking which for openai I don't think you can, the model runs out of tokens before generating title.

This fixes it and retains functionality for google provider because gemini-2.5-flash is a thinking model