### PR TITLE
An option to disable git snapshots

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -142,6 +142,13 @@ export namespace Config {
         .describe(
           "Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing",
         ),
+      snapshot: z
+        .enum(["enabled", "disabled"])
+        .optional()
+        .default("enabled")
+        .describe(
+          "Control snapshot behavior: 'enabled' creates git snapshots for reverting changes, 'disabled' skips snapshot creation (improves performance on large codebases)",
+        ),
       autoshare: z
         .boolean()
         .optional()

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -4,12 +4,21 @@ import path from "path"
 import fs from "fs/promises"
 import { Ripgrep } from "../file/ripgrep"
 import { Log } from "../util/log"
+import { Config } from "../config/config"
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
 
   export async function create(sessionID: string) {
     log.info("creating snapshot")
+    
+    // Check if snapshots are disabled in config
+    const config = await Config.get()
+    if (config.snapshot === "disabled") {
+      log.info("skipping snapshot - disabled in config")
+      return
+    }
+    
     const app = App.info()
 
     // not a git repo, check if too big to snapshot


### PR DESCRIPTION
Otherwise it takes an enormous amount of time on a large repo:
```
  INFO  2025-07-19T07:42:05 +0ms service=app name=tool.filetimes registering service
  INFO  2025-07-19T08:08:17 +1572073ms service=server duration=1589896 response
  INFO  2025-07-19T08:16:14 +476882ms service=snapshot added files
  INFO  2025-07-19T08:17:07 +53474ms service=session session=ses_7e3846879ffe1nGX38z2KH6uZ2 type=start-step part
```