### PR TITLE
fix: pasting issue

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -60,6 +60,10 @@ func (s selection) selecting() bool {
 	return s.startX >= 0 && s.startY >= 0
 }
 
+func (s selection) hasCompleteSelection() bool {
+	return s.startX >= 0 && s.startY >= 0 && s.endX >= 0 && s.endY >= 0
+}
+
 func (s selection) coords(offset int) selection {
 	// selecting backwards
 	if s.startY > s.endY && s.endY >= 0 {
@@ -127,7 +131,7 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.MouseReleaseMsg:
-		if m.selection.selecting() {
+		if m.selection.hasCompleteSelection() {
 			m.selection = selection{
 				startX: -1,
 				startY: -1,


### PR DESCRIPTION
I think this should fix: #1181
Also this **does not** break text selection 

> hasCompleteSelection() requires a complete recent selection workflow (all four coordinates set by the app's own mouse handlers)


The pasting bug is linked to moving of the mouse


Video proof:

https://github.com/user-attachments/assets/ea9f623f-f9a1-4b2f-ad4a-ead810c0dd11

