### PR TITLE
tweak: cleanup cancelled markdown

### DIFF
--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -401,7 +401,7 @@ func renderToolDetails(
 						body += fmt.Sprintf("- [x] %s\n", content)
 					case "cancelled":
 						// strike through cancelled todo
-						body += fmt.Sprintf("- [~] ~~%s~~\n", content)
+						body += fmt.Sprintf("- [ ] ~~%s~~\n", content)
 					case "in_progress":
 						// highlight in progress todo
 						body += fmt.Sprintf("- [ ] `%s`\n", content)


### PR DESCRIPTION
Fixes: #1221


Matches pattern used to track in progress tasks (Task block only supports checked or unchecked states)

See:
<img width="1504" height="144" alt="Screenshot 2025-07-22 at 11 56 16 AM" src="https://github.com/user-attachments/assets/2764722d-9d60-49e6-b42f-9dfc39a6ed4e" />
