### PR TITLE
feat(server): improve server startup error handling

### DIFF
--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -1,6 +1,7 @@
 import { Config } from "../config/config"
 import { MCP } from "../mcp"
 import { UI } from "./ui"
+import { Server } from "../server/server"
 
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
@@ -13,4 +14,8 @@ export function FormatError(input: unknown) {
     ].join("\n")
 
   if (UI.CancelledError.isInstance(input)) return ""
+
+  if (Server.ServerStartError.isInstance(input)) {
+    return input.data.message
+  }
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -766,12 +766,32 @@ export namespace Server {
   }
 
   export function listen(opts: { port: number; hostname: string }) {
-    const server = Bun.serve({
-      port: opts.port,
-      hostname: opts.hostname,
-      idleTimeout: 0,
-      fetch: app().fetch,
-    })
-    return server
+    try {
+      const server = Bun.serve({
+        port: opts.port,
+        hostname: opts.hostname,
+        idleTimeout: 0,
+        fetch: app().fetch,
+      })
+      return server
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new ServerStartError({
+          port: opts.port,
+          hostname: opts.hostname,
+          message: error.message,
+        })
+      }
+      throw error
+    }
   }
+
+  export const ServerStartError = NamedError.create(
+    "ServerStartError",
+    z.object({
+      port: z.number(),
+      hostname: z.string(),
+      message: z.string(),
+    }),
+  )
 }


### PR DESCRIPTION
Previously, when users ran the `opencode serve` command and the default port 4096 was already in use, they would see an unexpected error message:

```bash
Error: Unexpected error, check log file at ~/.local/share/opencode/log/dev.log for more details
error: script "dev" exited with code 1
```

The implementation wraps Bun.serve() calls in try-catch blocks and maps them into `ServerStartError` errors using the established NamedError pattern. The original Bun error message (like "Failed to start server. Is port 4096 in use?") is preserved and displayed directly to users via the FormatError system.