### PR TITLE
Allow multiline prompts for github agent

### DIFF
--- a/sdks/github/src/index.ts
+++ b/sdks/github/src/index.ts
@@ -43,8 +43,8 @@ let state:
 
 async function run() {
   try {
-    const match = body.match(/^hey\s*opencode,?\s*(.*)$/)
-    if (!match?.[1]) throw new Error("Command must start with `hey opencode`")
+    const match = body.match(/^hey\s*opencode,/)
+    if (!match?.[1]) throw new Error("Command must start with `hey opencode,`")
     const userPrompt = match[1]
 
     const oidcToken = await generateGitHubToken()


### PR DESCRIPTION
I noticed it always fails on multiline prompts. This fixes that and just allows the prompt to be ANYTHING as long as it starts with 'hey opencode,'

