### PR TITLE
fix: Add Gemini tool schema sanitization to MCP tools as well

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -10,68 +10,66 @@ import { AuthCopilot } from "../auth/copilot"
 import { ModelsDev } from "./models"
 import { NamedError } from "../util/error"
 import { Auth } from "../auth"
-
-import { sanitizeGeminiJsonSchema } from "./utils";
-import { zodToJsonSchema } from "zod-to-json-schema";
-
+import { sanitizeGeminiJsonSchema } from "./utils"
+import { zodToJsonSchema } from "zod-to-json-schema"
 
 export namespace Provider {
-  export type FlexibleSchema<T> = z.ZodType<T> | Record<string, any>;
-  const log = Log.create({ service: "provider" });
+  export type FlexibleSchema<T> = z.ZodType<T> | Record<string, any>
+  const log = Log.create({ service: "provider" })
 
   type CustomLoader = (
     provider: ModelsDev.Provider,
     api?: string,
   ) => Promise<{
-    autoload: boolean;
-    getModel?: (sdk: any, modelID: string) => Promise<any>;
-    options?: Record<string, any>;
-  }>;
+    autoload: boolean
+    getModel?: (sdk: any, modelID: string) => Promise<any>
+    options?: Record<string, any>
+  }>
 
-  type Source = "env" | "config" | "custom" | "api";
+  type Source = "env" | "config" | "custom" | "api"
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
     async anthropic(provider) {
-      const access = await AuthAnthropic.access();
-      if (!access) return { autoload: false };
+      const access = await AuthAnthropic.access()
+      if (!access) return { autoload: false }
       for (const model of Object.values(provider.models)) {
         model.cost = {
           input: 0,
           output: 0,
-        };
+        }
       }
       return {
         autoload: true,
         options: {
           apiKey: "",
           async fetch(input: any, init: any) {
-            const access = await AuthAnthropic.access();
+            const access = await AuthAnthropic.access()
             const headers = {
               ...init.headers,
               authorization: `Bearer ${access}`,
               "anthropic-beta": "oauth-2025-04-20",
-            };
-            delete headers["x-api-key"];
+            }
+            delete headers["x-api-key"]
             return fetch(input, {
               ...init,
               headers,
-            });
+            })
           },
         },
-      };
+      }
     },
     "github-copilot": async (provider) => {
-      const copilot = await AuthCopilot();
-      if (!copilot) return { autoload: false };
-      let info = await Auth.get("github-copilot");
-      if (!info || info.type !== "oauth") return { autoload: false };
+      const copilot = await AuthCopilot()
+      if (!copilot) return { autoload: false }
+      let info = await Auth.get("github-copilot")
+      if (!info || info.type !== "oauth") return { autoload: false }
 
       if (provider && provider.models) {
         for (const model of Object.values(provider.models)) {
           model.cost = {
             input: 0,
             output: 0,
-          };
+          }
         }
       }
 
@@ -80,34 +78,29 @@ export namespace Provider {
         options: {
           apiKey: "",
           async fetch(input: any, init: any) {
-            const info = await Auth.get("github-copilot");
-            if (!info || info.type !== "oauth") return;
+            const info = await Auth.get("github-copilot")
+            if (!info || info.type !== "oauth") return
             if (!info.access || info.expires < Date.now()) {
-              const tokens = await copilot.access(info.refresh);
+              const tokens = await copilot.access(info.refresh)
               if (!tokens) {
-                throw new Error("GitHub Copilot authentication expired");
+                throw new Error("GitHub Copilot authentication expired")
               }
               await Auth.set("github-copilot", {
                 type: "oauth",
                 ...tokens,
-              });
-              info.access = tokens.access;
+              })
+              info.access = tokens.access
             }
-            let isAgentCall = false;
-            let isVisionRequest = false;
+            let isAgentCall = false
+            let isVisionRequest = false
             try {
-              const body = typeof init.body === "string"
-                ? JSON.parse(init.body)
-                : init.body;
+              const body = typeof init.body === "string" ? JSON.parse(init.body) : init.body
               if (body?.messages) {
-                isAgentCall = body.messages.some((msg: any) =>
-                  msg.role && ["tool", "assistant"].includes(msg.role)
-                );
+                isAgentCall = body.messages.some((msg: any) => msg.role && ["tool", "assistant"].includes(msg.role))
                 isVisionRequest = body.messages.some(
                   (msg: any) =>
-                    Array.isArray(msg.content) &&
-                    msg.content.some((part: any) => part.type === "image_url"),
-                );
+                    Array.isArray(msg.content) && msg.content.some((part: any) => part.type === "image_url"),
+                )
               }
             } catch {}
             const headers: Record<string, string> = {
@@ -116,27 +109,27 @@ export namespace Provider {
               Authorization: `Bearer ${info.access}`,
               "Openai-Intent": "conversation-edits",
               "X-Initiator": isAgentCall ? "agent" : "user",
-            };
-            if (isVisionRequest) {
-              headers["Copilot-Vision-Request"] = "true";
             }
-            delete headers["x-api-key"];
+            if (isVisionRequest) {
+              headers["Copilot-Vision-Request"] = "true"
+            }
+            delete headers["x-api-key"]
             return fetch(input, {
               ...init,
               headers,
-            });
+            })
           },
         },
-      };
+      }
     },
     openai: async () => {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string) {
-          return sdk.responses(modelID);
+          return sdk.responses(modelID)
         },
         options: {},
-      };
+      }
     },
     azure: async () => {
       return {
@@ -153,14 +146,12 @@ export namespace Provider {
         !process.env["AWS_ACCESS_KEY_ID"] &&
         !process.env["AWS_BEARER_TOKEN_BEDROCK"]
       ) {
-        return { autoload: false };
+        return { autoload: false }
       }
 
-      const region = process.env["AWS_REGION"] ?? "us-east-1";
+      const region = process.env["AWS_REGION"] ?? "us-east-1"
 
-      const { fromNodeProviderChain } = await import(
-        await BunProc.install("@aws-sdk/credential-providers")
-      );
+      const { fromNodeProviderChain } = await import(await BunProc.install("@aws-sdk/credential-providers"))
       return {
         autoload: true,
         options: {
@@ -168,17 +159,15 @@ export namespace Provider {
           credentialProvider: fromNodeProviderChain(),
         },
         async getModel(sdk: any, modelID: string) {
-          let regionPrefix = region.split("-")[0];
+          let regionPrefix = region.split("-")[0]
 
           switch (regionPrefix) {
             case "us": {
-              const modelRequiresPrefix = ["claude", "deepseek"].some((m) =>
-                modelID.includes(m)
-              );
+              const modelRequiresPrefix = ["claude", "deepseek"].some((m) => modelID.includes(m))
               if (modelRequiresPrefix) {
-                modelID = `${regionPrefix}.${modelID}`;
+                modelID = `${regionPrefix}.${modelID}`
               }
-              break;
+              break
             }
             case "eu": {
               const regionRequiresPrefix = [
@@ -188,37 +177,30 @@ export namespace Provider {
                 "eu-central-1",
                 "eu-south-1",
                 "eu-south-2",
-              ].some((r) => region.includes(r));
-              const modelRequiresPrefix = [
-                "claude",
-                "nova-lite",
-                "nova-micro",
-                "llama3",
-                "pixtral",
-              ].some((m) => modelID.includes(m));
+              ].some((r) => region.includes(r))
+              const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "llama3", "pixtral"].some((m) =>
+                modelID.includes(m),
+              )
               if (regionRequiresPrefix && modelRequiresPrefix) {
-                modelID = `${regionPrefix}.${modelID}`;
+                modelID = `${regionPrefix}.${modelID}`
               }
-              break;
+              break
             }
             case "ap": {
-              const modelRequiresPrefix = [
-                "claude",
-                "nova-lite",
-                "nova-micro",
-                "nova-pro",
-              ].some((m) => modelID.includes(m));
+              const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
+                modelID.includes(m),
+              )
               if (modelRequiresPrefix) {
-                regionPrefix = "apac";
-                modelID = `${regionPrefix}.${modelID}`;
+                regionPrefix = "apac"
+                modelID = `${regionPrefix}.${modelID}`
               }
-              break;
+              break
             }
           }
 
-          return sdk.languageModel(modelID);
+          return sdk.languageModel(modelID)
         },
-      };
+      }
     },
     openrouter: async () => {
       return {
@@ -229,7 +211,7 @@ export namespace Provider {
             "X-Title": "opencode",
           },
         },
-      };
+      }
     },
     vercel: async () => {
       return {
@@ -245,24 +227,21 @@ export namespace Provider {
   }
 
   const state = App.state("provider", async () => {
-    const config = await Config.get();
-    const database = await ModelsDev.get();
+    const config = await Config.get()
+    const database = await ModelsDev.get()
 
     const providers: {
       [providerID: string]: {
-        source: Source;
-        info: ModelsDev.Provider;
-        getModel?: (sdk: any, modelID: string) => Promise<any>;
-        options: Record<string, any>;
-      };
-    } = {};
-    const models = new Map<
-      string,
-      { info: ModelsDev.Model; language: LanguageModel }
-    >();
-    const sdk = new Map<string, SDK>();
+        source: Source
+        info: ModelsDev.Provider
+        getModel?: (sdk: any, modelID: string) => Promise<any>
+        options: Record<string, any>
+      }
+    } = {}
+    const models = new Map<string, { info: ModelsDev.Model; language: LanguageModel }>()
+    const sdk = new Map<string, SDK>()
 
-    log.info("init");
+    log.info("init")
 
     function mergeProvider(
       id: string,
@@ -270,28 +249,28 @@ export namespace Provider {
       source: Source,
       getModel?: (sdk: any, modelID: string) => Promise<any>,
     ) {
-      const provider = providers[id];
+      const provider = providers[id]
       if (!provider) {
-        const info = database[id];
-        if (!info) return;
-        if (info.api && !options["baseURL"]) options["baseURL"] = info.api;
+        const info = database[id]
+        if (!info) return
+        if (info.api && !options["baseURL"]) options["baseURL"] = info.api
         providers[id] = {
           source,
           info,
           options,
           getModel,
-        };
-        return;
+        }
+        return
       }
-      provider.options = mergeDeep(provider.options, options);
-      provider.source = source;
-      provider.getModel = getModel ?? provider.getModel;
+      provider.options = mergeDeep(provider.options, options)
+      provider.source = source
+      provider.getModel = getModel ?? provider.getModel
     }
 
-    const configProviders = Object.entries(config.provider ?? {});
+    const configProviders = Object.entries(config.provider ?? {})
 
     for (const [providerID, provider] of configProviders) {
-      const existing = database[providerID];
+      const existing = database[providerID]
       const parsed: ModelsDev.Provider = {
         id: providerID,
         npm: provider.npm ?? existing?.npm,
@@ -299,10 +278,10 @@ export namespace Provider {
         env: provider.env ?? existing?.env ?? [],
         api: provider.api ?? existing?.api,
         models: existing?.models ?? {},
-      };
+      }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
-        const existing = parsed.models[modelID];
+        const existing = parsed.models[modelID]
         const parsedModel: ModelsDev.Model = {
           id: modelID,
           name: model.name ?? existing?.name ?? modelID,
@@ -337,91 +316,84 @@ export namespace Provider {
         }
         parsed.models[modelID] = parsedModel
       }
-      database[providerID] = parsed;
+      database[providerID] = parsed
     }
 
-    const disabled = await Config.get().then((cfg) =>
-      new Set(cfg.disabled_providers ?? [])
-    );
+    const disabled = await Config.get().then((cfg) => new Set(cfg.disabled_providers ?? []))
     // load env
     for (const [providerID, provider] of Object.entries(database)) {
-      if (disabled.has(providerID)) continue;
-      const apiKey = provider.env.map((item) => process.env[item]).at(0);
-      if (!apiKey) continue;
+      if (disabled.has(providerID)) continue
+      const apiKey = provider.env.map((item) => process.env[item]).at(0)
+      if (!apiKey) continue
       mergeProvider(
         providerID,
         // only include apiKey if there's only one potential option
         provider.env.length === 1 ? { apiKey } : {},
         "env",
-      );
+      )
     }
 
     // load apikeys
     for (const [providerID, provider] of Object.entries(await Auth.all())) {
-      if (disabled.has(providerID)) continue;
+      if (disabled.has(providerID)) continue
       if (provider.type === "api") {
-        mergeProvider(providerID, { apiKey: provider.key }, "api");
+        mergeProvider(providerID, { apiKey: provider.key }, "api")
       }
     }
 
     // load custom
     for (const [providerID, fn] of Object.entries(CUSTOM_LOADERS)) {
-      if (disabled.has(providerID)) continue;
-      const result = await fn(database[providerID]);
+      if (disabled.has(providerID)) continue
+      const result = await fn(database[providerID])
       if (result && (result.autoload || providers[providerID])) {
-        mergeProvider(
-          providerID,
-          result.options ?? {},
-          "custom",
-          result.getModel,
-        );
+        mergeProvider(providerID, result.options ?? {}, "custom", result.getModel)
       }
     }
 
     // load config
     for (const [providerID, provider] of configProviders) {
-      mergeProvider(providerID, provider.options ?? {}, "config");
+      mergeProvider(providerID, provider.options ?? {}, "config")
     }
 
     for (const [providerID, provider] of Object.entries(providers)) {
       if (Object.keys(provider.info.models).length === 0) {
-        delete providers[providerID];
-        continue;
+        delete providers[providerID]
+        continue
       }
-      log.info("found", { providerID });
+      log.info("found", { providerID })
     }
 
     return {
       models,
       providers,
       sdk,
-    };
-  });
+    }
+  })
 
   export async function list() {
-    return state().then((state) => state.providers);
+    return state().then((state) => state.providers)
   }
 
   async function getSDK(provider: ModelsDev.Provider) {
     return (async () => {
       using _ = log.time("getSDK", {
         providerID: provider.id,
-      });
-      const s = await state();
-      const existing = s.sdk.get(provider.id);
-      if (existing) return existing;
-      const pkg = provider.npm ?? provider.id;
-      const mod = await import(await BunProc.install(pkg, "beta"));
-      const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!];
+      })
+      const s = await state()
+      const existing = s.sdk.get(provider.id)
+      if (existing) return existing
+      const pkg = provider.npm ?? provider.id
+      const mod = await import(await BunProc.install(pkg, "beta"))
+      const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
       const loaded = fn({
         name: provider.id,
         ...s.providers[provider.id]?.options,
-      });
-      s.sdk.set(provider.id, loaded);
-      return loaded as SDK;
+      })
+      s.sdk.set(provider.id, loaded)
+      return loaded as SDK
     })().catch((e) => {
-      throw new InitError({ providerID: provider.id }, { cause: e });
-    });
+      throw new InitError({ providerID: provider.id }, { cause: e })
+    })
   }
 
   export async function getProvider(providerID: string) {
@@ -429,34 +401,32 @@ export namespace Provider {
   }
 
   export async function getModel(providerID: string, modelID: string) {
-    const key = `${providerID}/${modelID}`;
-    const s = await state();
-    if (s.models.has(key)) return s.models.get(key)!;
+    const key = `${providerID}/${modelID}`
+    const s = await state()
+    if (s.models.has(key)) return s.models.get(key)!
 
     log.info("getModel", {
       providerID,
       modelID,
-    });
+    })
 
-    const provider = s.providers[providerID];
-    if (!provider) throw new ModelNotFoundError({ providerID, modelID });
-    const info = provider.info.models[modelID];
-    if (!info) throw new ModelNotFoundError({ providerID, modelID });
-    const sdk = await getSDK(provider.info);
+    const provider = s.providers[providerID]
+    if (!provider) throw new ModelNotFoundError({ providerID, modelID })
+    const info = provider.info.models[modelID]
+    if (!info) throw new ModelNotFoundError({ providerID, modelID })
+    const sdk = await getSDK(provider.info)
 
     try {
-      const language = provider.getModel
-        ? await provider.getModel(sdk, modelID)
-        : sdk.languageModel(modelID);
-      log.info("found", { providerID, modelID });
+      const language = provider.getModel ? await provider.getModel(sdk, modelID) : sdk.languageModel(modelID)
+      log.info("found", { providerID, modelID })
       s.models.set(key, {
         info,
         language,
-      });
+      })
       return {
         info,
         language,
-      };
+      }
     } catch (e) {
       if (e instanceof NoSuchModelError) {
         throw new ModelNotFoundError(
@@ -465,68 +435,61 @@ export namespace Provider {
             providerID,
           },
           { cause: e },
-        );
+        )
       }
-      throw e;
+      throw e
     }
   }
 
   export async function getSmallModel(providerID: string) {
-    const cfg = await Config.get();
+    const cfg = await Config.get()
 
     if (cfg.small_model) {
-      const parsed = parseModel(cfg.small_model);
-      return getModel(parsed.providerID, parsed.modelID);
+      const parsed = parseModel(cfg.small_model)
+      return getModel(parsed.providerID, parsed.modelID)
     }
 
-    const provider = await state().then((state) => state.providers[providerID]);
-    if (!provider) return;
-    const priority = ["3-5-haiku", "3.5-haiku", "gemini-2.5-flash"];
+    const provider = await state().then((state) => state.providers[providerID])
+    if (!provider) return
+    const priority = ["3-5-haiku", "3.5-haiku", "gemini-2.5-flash"]
     for (const item of priority) {
       for (const model of Object.keys(provider.info.models)) {
-        if (model.includes(item)) return getModel(providerID, model);
+        if (model.includes(item)) return getModel(providerID, model)
       }
     }
   }
 
-  const priority = ["gemini-2.5-pro-preview", "codex-mini", "claude-sonnet-4"];
+  const priority = ["gemini-2.5-pro-preview", "codex-mini", "claude-sonnet-4"]
   export function sort(models: ModelsDev.Model[]) {
     return sortBy(
       models,
-      [
-        (model) => priority.findIndex((filter) => model.id.includes(filter)),
-        "desc",
-      ],
+      [(model) => priority.findIndex((filter) => model.id.includes(filter)), "desc"],
       [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
       [(model) => model.id, "desc"],
-    );
+    )
   }
 
   export async function defaultModel() {
-    const cfg = await Config.get();
-    if (cfg.model) return parseModel(cfg.model);
+    const cfg = await Config.get()
+    if (cfg.model) return parseModel(cfg.model)
     const provider = await list()
       .then((val) => Object.values(val))
-      .then((x) =>
-        x.find((p) =>
-          !cfg.provider || Object.keys(cfg.provider).includes(p.info.id)
-        )
-      );
-    if (!provider) throw new Error("no providers found");
-    const [model] = sort(Object.values(provider.info.models));
-    if (!model) throw new Error("no models found");
+      .then((x) => x.find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.info.id)))
+    if (!provider) throw new Error("no providers found")
+    const [model] = sort(Object.values(provider.info.models))
+    if (!model) throw new Error("no models found")
     return {
       providerID: provider.info.id,
       modelID: model.id,
-    };
+    }
   }
 
   export function parseModel(model: string) {
-    const [providerID, ...rest] = model.split("/");
+    const [providerID, ...rest] = model.split("/")
     return {
       providerID: providerID,
       modelID: rest.join("/"),
-    };
+    }
   }
 
   export const ModelNotFoundError = NamedError.create(
@@ -535,12 +498,38 @@ export namespace Provider {
       providerID: z.string(),
       modelID: z.string(),
     }),
-  );
+  )
 
   export const InitError = NamedError.create(
     "ProviderInitError",
     z.object({
       providerID: z.string(),
     }),
-  );
+  )
+
+  export function transformToolSchema(schema: FlexibleSchema<any>, providerID: string): Record<string, any> | null {
+    try {
+      let jsonSchema: Record<string, any>
+
+      // If it's already a JSON schema object, use it directly
+      if (typeof schema === "object" && !("_def" in schema)) {
+        jsonSchema = schema as Record<string, any>
+      } else {
+        // Convert Zod schema to JSON schema
+        jsonSchema = zodToJsonSchema(schema as z.ZodType<any>, {
+          target: "jsonSchema7",
+        })
+      }
+
+      // Apply provider-specific transformations
+      if (providerID === "google") {
+        return sanitizeGeminiJsonSchema(jsonSchema)
+      }
+
+      return jsonSchema
+    } catch (error) {
+      log.warn("Failed to transform tool schema", { error, providerID })
+      return null
+    }
+  }
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -11,62 +11,67 @@ import { ModelsDev } from "./models"
 import { NamedError } from "../util/error"
 import { Auth } from "../auth"
 
+import { sanitizeGeminiJsonSchema } from "./utils";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+
 export namespace Provider {
-  const log = Log.create({ service: "provider" })
+  export type FlexibleSchema<T> = z.ZodType<T> | Record<string, any>;
+  const log = Log.create({ service: "provider" });
 
   type CustomLoader = (
     provider: ModelsDev.Provider,
     api?: string,
   ) => Promise<{
-    autoload: boolean
-    getModel?: (sdk: any, modelID: string) => Promise<any>
-    options?: Record<string, any>
-  }>
+    autoload: boolean;
+    getModel?: (sdk: any, modelID: string) => Promise<any>;
+    options?: Record<string, any>;
+  }>;
 
-  type Source = "env" | "config" | "custom" | "api"
+  type Source = "env" | "config" | "custom" | "api";
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
     async anthropic(provider) {
-      const access = await AuthAnthropic.access()
-      if (!access) return { autoload: false }
+      const access = await AuthAnthropic.access();
+      if (!access) return { autoload: false };
       for (const model of Object.values(provider.models)) {
         model.cost = {
           input: 0,
           output: 0,
-        }
+        };
       }
       return {
         autoload: true,
         options: {
           apiKey: "",
           async fetch(input: any, init: any) {
-            const access = await AuthAnthropic.access()
+            const access = await AuthAnthropic.access();
             const headers = {
               ...init.headers,
               authorization: `Bearer ${access}`,
               "anthropic-beta": "oauth-2025-04-20",
-            }
-            delete headers["x-api-key"]
+            };
+            delete headers["x-api-key"];
             return fetch(input, {
               ...init,
               headers,
-            })
+            });
           },
         },
-      }
+      };
     },
     "github-copilot": async (provider) => {
-      const copilot = await AuthCopilot()
-      if (!copilot) return { autoload: false }
-      let info = await Auth.get("github-copilot")
-      if (!info || info.type !== "oauth") return { autoload: false }
+      const copilot = await AuthCopilot();
+      if (!copilot) return { autoload: false };
+      let info = await Auth.get("github-copilot");
+      if (!info || info.type !== "oauth") return { autoload: false };
 
       if (provider && provider.models) {
         for (const model of Object.values(provider.models)) {
           model.cost = {
             input: 0,
             output: 0,
-          }
+          };
         }
       }
 
@@ -75,27 +80,34 @@ export namespace Provider {
         options: {
           apiKey: "",
           async fetch(input: any, init: any) {
-            const info = await Auth.get("github-copilot")
-            if (!info || info.type !== "oauth") return
+            const info = await Auth.get("github-copilot");
+            if (!info || info.type !== "oauth") return;
             if (!info.access || info.expires < Date.now()) {
-              const tokens = await copilot.access(info.refresh)
-              if (!tokens) throw new Error("GitHub Copilot authentication expired")
+              const tokens = await copilot.access(info.refresh);
+              if (!tokens) {
+                throw new Error("GitHub Copilot authentication expired");
+              }
               await Auth.set("github-copilot", {
                 type: "oauth",
                 ...tokens,
-              })
-              info.access = tokens.access
+              });
+              info.access = tokens.access;
             }
-            let isAgentCall = false
-            let isVisionRequest = false
+            let isAgentCall = false;
+            let isVisionRequest = false;
             try {
-              const body = typeof init.body === "string" ? JSON.parse(init.body) : init.body
+              const body = typeof init.body === "string"
+                ? JSON.parse(init.body)
+                : init.body;
               if (body?.messages) {
-                isAgentCall = body.messages.some((msg: any) => msg.role && ["tool", "assistant"].includes(msg.role))
+                isAgentCall = body.messages.some((msg: any) =>
+                  msg.role && ["tool", "assistant"].includes(msg.role)
+                );
                 isVisionRequest = body.messages.some(
                   (msg: any) =>
-                    Array.isArray(msg.content) && msg.content.some((part: any) => part.type === "image_url"),
-                )
+                    Array.isArray(msg.content) &&
+                    msg.content.some((part: any) => part.type === "image_url"),
+                );
               }
             } catch {}
             const headers: Record<string, string> = {
@@ -104,27 +116,27 @@ export namespace Provider {
               Authorization: `Bearer ${info.access}`,
               "Openai-Intent": "conversation-edits",
               "X-Initiator": isAgentCall ? "agent" : "user",
-            }
+            };
             if (isVisionRequest) {
-              headers["Copilot-Vision-Request"] = "true"
+              headers["Copilot-Vision-Request"] = "true";
             }
-            delete headers["x-api-key"]
+            delete headers["x-api-key"];
             return fetch(input, {
               ...init,
               headers,
-            })
+            });
           },
         },
-      }
+      };
     },
     openai: async () => {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string) {
-          return sdk.responses(modelID)
+          return sdk.responses(modelID);
         },
         options: {},
-      }
+      };
     },
     azure: async () => {
       return {
@@ -136,12 +148,19 @@ export namespace Provider {
       }
     },
     "amazon-bedrock": async () => {
-      if (!process.env["AWS_PROFILE"] && !process.env["AWS_ACCESS_KEY_ID"] && !process.env["AWS_BEARER_TOKEN_BEDROCK"])
-        return { autoload: false }
+      if (
+        !process.env["AWS_PROFILE"] &&
+        !process.env["AWS_ACCESS_KEY_ID"] &&
+        !process.env["AWS_BEARER_TOKEN_BEDROCK"]
+      ) {
+        return { autoload: false };
+      }
 
-      const region = process.env["AWS_REGION"] ?? "us-east-1"
+      const region = process.env["AWS_REGION"] ?? "us-east-1";
 
-      const { fromNodeProviderChain } = await import(await BunProc.install("@aws-sdk/credential-providers"))
+      const { fromNodeProviderChain } = await import(
+        await BunProc.install("@aws-sdk/credential-providers")
+      );
       return {
         autoload: true,
         options: {
@@ -149,15 +168,17 @@ export namespace Provider {
           credentialProvider: fromNodeProviderChain(),
         },
         async getModel(sdk: any, modelID: string) {
-          let regionPrefix = region.split("-")[0]
+          let regionPrefix = region.split("-")[0];
 
           switch (regionPrefix) {
             case "us": {
-              const modelRequiresPrefix = ["claude", "deepseek"].some((m) => modelID.includes(m))
+              const modelRequiresPrefix = ["claude", "deepseek"].some((m) =>
+                modelID.includes(m)
+              );
               if (modelRequiresPrefix) {
-                modelID = `${regionPrefix}.${modelID}`
+                modelID = `${regionPrefix}.${modelID}`;
               }
-              break
+              break;
             }
             case "eu": {
               const regionRequiresPrefix = [
@@ -167,30 +188,37 @@ export namespace Provider {
                 "eu-central-1",
                 "eu-south-1",
                 "eu-south-2",
-              ].some((r) => region.includes(r))
-              const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "llama3", "pixtral"].some((m) =>
-                modelID.includes(m),
-              )
+              ].some((r) => region.includes(r));
+              const modelRequiresPrefix = [
+                "claude",
+                "nova-lite",
+                "nova-micro",
+                "llama3",
+                "pixtral",
+              ].some((m) => modelID.includes(m));
               if (regionRequiresPrefix && modelRequiresPrefix) {
-                modelID = `${regionPrefix}.${modelID}`
+                modelID = `${regionPrefix}.${modelID}`;
               }
-              break
+              break;
             }
             case "ap": {
-              const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
-                modelID.includes(m),
-              )
+              const modelRequiresPrefix = [
+                "claude",
+                "nova-lite",
+                "nova-micro",
+                "nova-pro",
+              ].some((m) => modelID.includes(m));
               if (modelRequiresPrefix) {
-                regionPrefix = "apac"
-                modelID = `${regionPrefix}.${modelID}`
+                regionPrefix = "apac";
+                modelID = `${regionPrefix}.${modelID}`;
               }
-              break
+              break;
             }
           }
 
-          return sdk.languageModel(modelID)
+          return sdk.languageModel(modelID);
         },
-      }
+      };
     },
     openrouter: async () => {
       return {
@@ -201,7 +229,7 @@ export namespace Provider {
             "X-Title": "opencode",
           },
         },
-      }
+      };
     },
     vercel: async () => {
       return {
@@ -217,21 +245,24 @@ export namespace Provider {
   }
 
   const state = App.state("provider", async () => {
-    const config = await Config.get()
-    const database = await ModelsDev.get()
+    const config = await Config.get();
+    const database = await ModelsDev.get();
 
     const providers: {
       [providerID: string]: {
-        source: Source
-        info: ModelsDev.Provider
-        getModel?: (sdk: any, modelID: string) => Promise<any>
-        options: Record<string, any>
-      }
-    } = {}
-    const models = new Map<string, { info: ModelsDev.Model; language: LanguageModel }>()
-    const sdk = new Map<string, SDK>()
+        source: Source;
+        info: ModelsDev.Provider;
+        getModel?: (sdk: any, modelID: string) => Promise<any>;
+        options: Record<string, any>;
+      };
+    } = {};
+    const models = new Map<
+      string,
+      { info: ModelsDev.Model; language: LanguageModel }
+    >();
+    const sdk = new Map<string, SDK>();
 
-    log.info("init")
+    log.info("init");
 
     function mergeProvider(
       id: string,
@@ -239,28 +270,28 @@ export namespace Provider {
       source: Source,
       getModel?: (sdk: any, modelID: string) => Promise<any>,
     ) {
-      const provider = providers[id]
+      const provider = providers[id];
       if (!provider) {
-        const info = database[id]
-        if (!info) return
-        if (info.api && !options["baseURL"]) options["baseURL"] = info.api
+        const info = database[id];
+        if (!info) return;
+        if (info.api && !options["baseURL"]) options["baseURL"] = info.api;
         providers[id] = {
           source,
           info,
           options,
           getModel,
-        }
-        return
+        };
+        return;
       }
-      provider.options = mergeDeep(provider.options, options)
-      provider.source = source
-      provider.getModel = getModel ?? provider.getModel
+      provider.options = mergeDeep(provider.options, options);
+      provider.source = source;
+      provider.getModel = getModel ?? provider.getModel;
     }
 
-    const configProviders = Object.entries(config.provider ?? {})
+    const configProviders = Object.entries(config.provider ?? {});
 
     for (const [providerID, provider] of configProviders) {
-      const existing = database[providerID]
+      const existing = database[providerID];
       const parsed: ModelsDev.Provider = {
         id: providerID,
         npm: provider.npm ?? existing?.npm,
@@ -268,10 +299,10 @@ export namespace Provider {
         env: provider.env ?? existing?.env ?? [],
         api: provider.api ?? existing?.api,
         models: existing?.models ?? {},
-      }
+      };
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
-        const existing = parsed.models[modelID]
+        const existing = parsed.models[modelID];
         const parsedModel: ModelsDev.Model = {
           id: modelID,
           name: model.name ?? existing?.name ?? modelID,
@@ -306,84 +337,91 @@ export namespace Provider {
         }
         parsed.models[modelID] = parsedModel
       }
-      database[providerID] = parsed
+      database[providerID] = parsed;
     }
 
-    const disabled = await Config.get().then((cfg) => new Set(cfg.disabled_providers ?? []))
+    const disabled = await Config.get().then((cfg) =>
+      new Set(cfg.disabled_providers ?? [])
+    );
     // load env
     for (const [providerID, provider] of Object.entries(database)) {
-      if (disabled.has(providerID)) continue
-      const apiKey = provider.env.map((item) => process.env[item]).at(0)
-      if (!apiKey) continue
+      if (disabled.has(providerID)) continue;
+      const apiKey = provider.env.map((item) => process.env[item]).at(0);
+      if (!apiKey) continue;
       mergeProvider(
         providerID,
         // only include apiKey if there's only one potential option
         provider.env.length === 1 ? { apiKey } : {},
         "env",
-      )
+      );
     }
 
     // load apikeys
     for (const [providerID, provider] of Object.entries(await Auth.all())) {
-      if (disabled.has(providerID)) continue
+      if (disabled.has(providerID)) continue;
       if (provider.type === "api") {
-        mergeProvider(providerID, { apiKey: provider.key }, "api")
+        mergeProvider(providerID, { apiKey: provider.key }, "api");
       }
     }
 
     // load custom
     for (const [providerID, fn] of Object.entries(CUSTOM_LOADERS)) {
-      if (disabled.has(providerID)) continue
-      const result = await fn(database[providerID])
+      if (disabled.has(providerID)) continue;
+      const result = await fn(database[providerID]);
       if (result && (result.autoload || providers[providerID])) {
-        mergeProvider(providerID, result.options ?? {}, "custom", result.getModel)
+        mergeProvider(
+          providerID,
+          result.options ?? {},
+          "custom",
+          result.getModel,
+        );
       }
     }
 
     // load config
     for (const [providerID, provider] of configProviders) {
-      mergeProvider(providerID, provider.options ?? {}, "config")
+      mergeProvider(providerID, provider.options ?? {}, "config");
     }
 
     for (const [providerID, provider] of Object.entries(providers)) {
       if (Object.keys(provider.info.models).length === 0) {
-        delete providers[providerID]
-        continue
+        delete providers[providerID];
+        continue;
       }
-      log.info("found", { providerID })
+      log.info("found", { providerID });
     }
 
     return {
       models,
       providers,
       sdk,
-    }
-  })
+    };
+  });
 
   export async function list() {
-    return state().then((state) => state.providers)
+    return state().then((state) => state.providers);
   }
 
   async function getSDK(provider: ModelsDev.Provider) {
     return (async () => {
       using _ = log.time("getSDK", {
         providerID: provider.id,
-      })
-      const s = await state()
-      const existing = s.sdk.get(provider.id)
-      if (existing) return existing
-      const pkg = provider.npm ?? provider.id
-      const mod = await import(await BunProc.install(pkg, "beta"))
-      const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
+      });
+      const s = await state();
+      const existing = s.sdk.get(provider.id);
+      if (existing) return existing;
+      const pkg = provider.npm ?? provider.id;
+      const mod = await import(await BunProc.install(pkg, "beta"));
+      const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!];
       const loaded = fn({
         name: provider.id,
         ...s.providers[provider.id]?.options,
-      })
-      s.sdk.set(provider.id, loaded)
-      return loaded as SDK
+      });
+      s.sdk.set(provider.id, loaded);
+      return loaded as SDK;
     })().catch((e) => {
-      throw new InitError({ providerID: provider.id }, { cause: e })
-    })
+      throw new InitError({ providerID: provider.id }, { cause: e });
+    });
   }
 
   export async function getProvider(providerID: string) {
@@ -391,94 +429,104 @@ export namespace Provider {
   }
 
   export async function getModel(providerID: string, modelID: string) {
-    const key = `${providerID}/${modelID}`
-    const s = await state()
-    if (s.models.has(key)) return s.models.get(key)!
+    const key = `${providerID}/${modelID}`;
+    const s = await state();
+    if (s.models.has(key)) return s.models.get(key)!;
 
     log.info("getModel", {
       providerID,
       modelID,
-    })
+    });
 
-    const provider = s.providers[providerID]
-    if (!provider) throw new ModelNotFoundError({ providerID, modelID })
-    const info = provider.info.models[modelID]
-    if (!info) throw new ModelNotFoundError({ providerID, modelID })
-    const sdk = await getSDK(provider.info)
+    const provider = s.providers[providerID];
+    if (!provider) throw new ModelNotFoundError({ providerID, modelID });
+    const info = provider.info.models[modelID];
+    if (!info) throw new ModelNotFoundError({ providerID, modelID });
+    const sdk = await getSDK(provider.info);
 
     try {
-      const language = provider.getModel ? await provider.getModel(sdk, modelID) : sdk.languageModel(modelID)
-      log.info("found", { providerID, modelID })
+      const language = provider.getModel
+        ? await provider.getModel(sdk, modelID)
+        : sdk.languageModel(modelID);
+      log.info("found", { providerID, modelID });
       s.models.set(key, {
         info,
         language,
-      })
+      });
       return {
         info,
         language,
-      }
+      };
     } catch (e) {
-      if (e instanceof NoSuchModelError)
+      if (e instanceof NoSuchModelError) {
         throw new ModelNotFoundError(
           {
             modelID: modelID,
             providerID,
           },
           { cause: e },
-        )
-      throw e
+        );
+      }
+      throw e;
     }
   }
 
   export async function getSmallModel(providerID: string) {
-    const cfg = await Config.get()
+    const cfg = await Config.get();
 
     if (cfg.small_model) {
-      const parsed = parseModel(cfg.small_model)
-      return getModel(parsed.providerID, parsed.modelID)
+      const parsed = parseModel(cfg.small_model);
+      return getModel(parsed.providerID, parsed.modelID);
     }
 
-    const provider = await state().then((state) => state.providers[providerID])
-    if (!provider) return
-    const priority = ["3-5-haiku", "3.5-haiku", "gemini-2.5-flash"]
+    const provider = await state().then((state) => state.providers[providerID]);
+    if (!provider) return;
+    const priority = ["3-5-haiku", "3.5-haiku", "gemini-2.5-flash"];
     for (const item of priority) {
       for (const model of Object.keys(provider.info.models)) {
-        if (model.includes(item)) return getModel(providerID, model)
+        if (model.includes(item)) return getModel(providerID, model);
       }
     }
   }
 
-  const priority = ["gemini-2.5-pro-preview", "codex-mini", "claude-sonnet-4"]
+  const priority = ["gemini-2.5-pro-preview", "codex-mini", "claude-sonnet-4"];
   export function sort(models: ModelsDev.Model[]) {
     return sortBy(
       models,
-      [(model) => priority.findIndex((filter) => model.id.includes(filter)), "desc"],
+      [
+        (model) => priority.findIndex((filter) => model.id.includes(filter)),
+        "desc",
+      ],
       [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
       [(model) => model.id, "desc"],
-    )
+    );
   }
 
   export async function defaultModel() {
-    const cfg = await Config.get()
-    if (cfg.model) return parseModel(cfg.model)
+    const cfg = await Config.get();
+    if (cfg.model) return parseModel(cfg.model);
     const provider = await list()
       .then((val) => Object.values(val))
-      .then((x) => x.find((p) => !cfg.provider || Object.keys(cfg.provider).includes(p.info.id)))
-    if (!provider) throw new Error("no providers found")
-    const [model] = sort(Object.values(provider.info.models))
-    if (!model) throw new Error("no models found")
+      .then((x) =>
+        x.find((p) =>
+          !cfg.provider || Object.keys(cfg.provider).includes(p.info.id)
+        )
+      );
+    if (!provider) throw new Error("no providers found");
+    const [model] = sort(Object.values(provider.info.models));
+    if (!model) throw new Error("no models found");
     return {
       providerID: provider.info.id,
       modelID: model.id,
-    }
+    };
   }
 
   export function parseModel(model: string) {
-    const [providerID, ...rest] = model.split("/")
+    const [providerID, ...rest] = model.split("/");
     return {
       providerID: providerID,
       modelID: rest.join("/"),
-    }
+    };
   }
 
   export const ModelNotFoundError = NamedError.create(
@@ -487,12 +535,12 @@ export namespace Provider {
       providerID: z.string(),
       modelID: z.string(),
     }),
-  )
+  );
 
   export const InitError = NamedError.create(
     "ProviderInitError",
     z.object({
       providerID: z.string(),
     }),
-  )
+  );
 }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1,6 +1,6 @@
 import type { ModelMessage } from "ai"
 import { unique } from "remeda"
-import { ToolRegistry } from "../tool/registry"
+import { sanitizeGeminiJsonSchema } from "./utils"
 
 export namespace ProviderTransform {
   function normalizeToolCallIds(msgs: ModelMessage[]): ModelMessage[] {
@@ -91,10 +91,10 @@ export namespace ProviderTransform {
           key,
           {
             ...tool,
-            // Apply sanitizeGeminiParameters to the tool's input schema
-            inputSchema: tool.inputSchema ? ToolRegistry.sanitizeGeminiParameters(tool.inputSchema) : tool.inputSchema
-          }
-        ])
+            // Apply sanitizeGeminiJsonSchema to the tool's input schema
+            inputSchema: tool.inputSchema ? sanitizeGeminiJsonSchema(tool.inputSchema) : tool.inputSchema,
+          },
+        ]),
       )
     }
     return tools

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage } from "ai"
 import { unique } from "remeda"
+import { ToolRegistry } from "../tool/registry"
 
 export namespace ProviderTransform {
   function normalizeToolCallIds(msgs: ModelMessage[]): ModelMessage[] {
@@ -80,5 +81,22 @@ export namespace ProviderTransform {
   export function topP(_providerID: string, modelID: string) {
     if (modelID.toLowerCase().includes("qwen")) return 1
     return undefined
+  }
+
+  export function tools(tools: any, providerID: string, modelID: string) {
+    if (providerID === "google" || modelID.includes("gemini")) {
+      // Apply Gemini-specific tool transformations
+      return Object.fromEntries(
+        Object.entries(tools).map(([key, tool]: [string, any]) => [
+          key,
+          {
+            ...tool,
+            // Apply sanitizeGeminiParameters to the tool's input schema
+            inputSchema: tool.inputSchema ? ToolRegistry.sanitizeGeminiParameters(tool.inputSchema) : tool.inputSchema
+          }
+        ])
+      )
+    }
+    return tools
   }
 }

--- a/packages/opencode/src/provider/utils.ts
+++ b/packages/opencode/src/provider/utils.ts
@@ -1,0 +1,82 @@
+
+/**
+ * Sanitizes JSON Schema for Gemini compatibility
+ * Handles Gemini's incompatibility with certain patterns
+ */
+export function sanitizeGeminiJsonSchema(schema: any, visited = new Set()): any {
+  if (!schema || typeof schema !== "object" || visited.has(schema)) {
+    return schema;
+  }
+  visited.add(schema);
+
+  const sanitized = { ...schema };
+
+  // Handle anyOf with defaults - Gemini doesn't support default on anyOf
+  if (sanitized.anyOf && sanitized.default !== undefined) {
+    delete sanitized.default;
+  }
+
+  // Handle union types with defaults - Gemini doesn't support default on unions
+  if (Array.isArray(sanitized.type) && sanitized.default !== undefined) {
+    delete sanitized.default;
+  }
+
+  // Remove additionalProperties that Gemini doesn't handle well
+  if (sanitized.additionalProperties !== undefined) {
+    delete sanitized.additionalProperties;
+  }
+
+  // Sanitize string constraints that Gemini may not support
+  if (sanitized.type === "string") {
+    // Keep essential JSON Schema properties
+    const essentialProperties = [
+      // Core/Identity
+      "$schema", "$id", "$ref", "$anchor", "$dynamicAnchor", "$dynamicRef", "$defs",
+      // Type
+      "type",
+      // Validation (for strings)
+      "const", "enum", "minLength", "maxLength", "pattern", "format",
+      // Annotation
+      "title", "description", "default", "examples",
+      // Content
+      "contentEncoding", "contentMediaType", "contentSchema"
+    ];
+    
+    Object.keys(sanitized).forEach((key) => {
+      // Remove custom format properties but keep standard ones
+      if (key.startsWith("format") && key !== "format") {
+        delete sanitized[key];
+      }
+      // Only remove keys that are not essential properties
+      else if (!essentialProperties.includes(key)) {
+        delete sanitized[key];
+      }
+    });
+  }
+
+  // Recursively process object properties
+  if (sanitized.properties) {
+    sanitized.properties = Object.fromEntries(
+      Object.entries(sanitized.properties).map(([key, value]) => [
+        key,
+        sanitizeGeminiJsonSchema(value as any, visited),
+      ]),
+    );
+  }
+
+  // Recursively process array items
+  if (sanitized.items) {
+    sanitized.items = sanitizeGeminiJsonSchema(sanitized.items, visited);
+  }
+
+  // Recursively process anyOf/oneOf/allOf
+  ["anyOf", "oneOf", "allOf"].forEach((combiner) => {
+    if (Array.isArray(sanitized[combiner])) {
+      sanitized[combiner] = sanitized[combiner].map((item: any) =>
+        sanitizeGeminiJsonSchema(item, visited)
+      );
+    }
+  });
+
+  return sanitized;
+}

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -45,9 +45,9 @@ import { ToolRegistry } from "../tool/registry"
 import { Plugin } from "../plugin"
 
 export namespace Session {
-  const log = Log.create({ service: "session" });
+  const log = Log.create({ service: "session" })
 
-  const OUTPUT_TOKEN_MAX = 32_000;
+  const OUTPUT_TOKEN_MAX = 32_000
 
   export const Info = z
     .object({
@@ -75,8 +75,8 @@ export namespace Session {
     })
     .openapi({
       ref: "Session",
-    });
-  export type Info = z.output<typeof Info>;
+    })
+  export type Info = z.output<typeof Info>
 
   export const ShareInfo = z
     .object({
@@ -85,8 +85,8 @@ export namespace Session {
     })
     .openapi({
       ref: "SessionShare",
-    });
-  export type ShareInfo = z.output<typeof ShareInfo>;
+    })
+  export type ShareInfo = z.output<typeof ShareInfo>
 
   export const Event = {
     Updated: Bus.event(
@@ -114,156 +114,148 @@ export namespace Session {
         error: MessageV2.Assistant.shape.error,
       }),
     ),
-  };
+  }
 
   const state = App.state(
     "session",
     () => {
-      const sessions = new Map<string, Info>();
-      const messages = new Map<string, MessageV2.Info[]>();
-      const pending = new Map<string, AbortController>();
+      const sessions = new Map<string, Info>()
+      const messages = new Map<string, MessageV2.Info[]>()
+      const pending = new Map<string, AbortController>()
       const queued = new Map<
         string,
         {
-          input: ChatInput;
-          message: MessageV2.User;
-          parts: MessageV2.Part[];
-          processed: boolean;
-          callback: (
-            input: { info: MessageV2.Assistant; parts: MessageV2.Part[] },
-          ) => void;
+          input: ChatInput
+          message: MessageV2.User
+          parts: MessageV2.Part[]
+          processed: boolean
+          callback: (input: { info: MessageV2.Assistant; parts: MessageV2.Part[] }) => void
         }[]
-      >();
+      >()
 
       return {
         sessions,
         messages,
         pending,
         queued,
-      };
+      }
     },
     async (state) => {
       for (const [_, controller] of state.pending) {
-        controller.abort();
+        controller.abort()
       }
     },
-  );
+  )
 
   export async function create(parentID?: string) {
     const result: Info = {
       id: Identifier.descending("session"),
       version: Installation.VERSION,
       parentID,
-      title: (parentID ? "Child session - " : "New Session - ") +
-        new Date().toISOString(),
+      title: (parentID ? "Child session - " : "New Session - ") + new Date().toISOString(),
       time: {
         created: Date.now(),
         updated: Date.now(),
       },
-    };
-    log.info("created", result);
-    state().sessions.set(result.id, result);
-    await Storage.writeJSON("session/info/" + result.id, result);
-    const cfg = await Config.get();
-    if (
-      !result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")
-    ) {
+    }
+    log.info("created", result)
+    state().sessions.set(result.id, result)
+    await Storage.writeJSON("session/info/" + result.id, result)
+    const cfg = await Config.get()
+    if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")) {
       share(result.id)
         .then((share) => {
           update(result.id, (draft) => {
-            draft.share = share;
-          });
+            draft.share = share
+          })
         })
         .catch(() => {
           // Silently ignore sharing errors during session creation
-        });
+        })
     }
     Bus.publish(Event.Updated, {
       info: result,
-    });
-    return result;
+    })
+    return result
   }
 
   export async function get(id: string) {
-    const result = state().sessions.get(id);
+    const result = state().sessions.get(id)
     if (result) {
-      return result;
+      return result
     }
-    const read = await Storage.readJSON<Info>("session/info/" + id);
-    state().sessions.set(id, read);
-    return read as Info;
+    const read = await Storage.readJSON<Info>("session/info/" + id)
+    state().sessions.set(id, read)
+    return read as Info
   }
 
   export async function getShare(id: string) {
-    return Storage.readJSON<ShareInfo>("session/share/" + id);
+    return Storage.readJSON<ShareInfo>("session/share/" + id)
   }
 
   export async function share(id: string) {
-    const cfg = await Config.get();
+    const cfg = await Config.get()
     if (cfg.share === "disabled") {
-      throw new Error("Sharing is disabled in configuration");
+      throw new Error("Sharing is disabled in configuration")
     }
 
-    const session = await get(id);
-    if (session.share) return session.share;
-    const share = await Share.create(id);
+    const session = await get(id)
+    if (session.share) return session.share
+    const share = await Share.create(id)
     await update(id, (draft) => {
       draft.share = {
         url: share.url,
-      };
-    });
-    await Storage.writeJSON<ShareInfo>("session/share/" + id, share);
-    await Share.sync("session/info/" + id, session);
+      }
+    })
+    await Storage.writeJSON<ShareInfo>("session/share/" + id, share)
+    await Share.sync("session/info/" + id, session)
     for (const msg of await messages(id)) {
-      await Share.sync("session/message/" + id + "/" + msg.info.id, msg.info);
+      await Share.sync("session/message/" + id + "/" + msg.info.id, msg.info)
       for (const part of msg.parts) {
-        await Share.sync(
-          "session/part/" + id + "/" + msg.info.id + "/" + part.id,
-          part,
-        );
+        await Share.sync("session/part/" + id + "/" + msg.info.id + "/" + part.id, part)
       }
     }
-    return share;
+    return share
   }
 
   export async function unshare(id: string) {
-    const share = await getShare(id);
-    if (!share) return;
-    await Storage.remove("session/share/" + id);
+    const share = await getShare(id)
+    if (!share) return
+    await Storage.remove("session/share/" + id)
     await update(id, (draft) => {
-      draft.share = undefined;
-    });
-    await Share.remove(id, share.secret);
+      draft.share = undefined
+    })
+    await Share.remove(id, share.secret)
   }
 
   export async function update(id: string, editor: (session: Info) => void) {
-    const { sessions } = state();
-    const session = await get(id);
-    if (!session) return;
-    editor(session);
-    session.time.updated = Date.now();
-    sessions.set(id, session);
-    await Storage.writeJSON("session/info/" + id, session);
+    const { sessions } = state()
+    const session = await get(id)
+    if (!session) return
+    editor(session)
+    session.time.updated = Date.now()
+    sessions.set(id, session)
+    await Storage.writeJSON("session/info/" + id, session)
     Bus.publish(Event.Updated, {
       info: session,
-    });
-    return session;
+    })
+    return session
   }
 
   export async function messages(sessionID: string) {
     const result = [] as {
-      info: MessageV2.Info;
-      parts: MessageV2.Part[];
-    }[];
+      info: MessageV2.Info
+      parts: MessageV2.Part[]
+    }[]
     for (const p of await Storage.list("session/message/" + sessionID)) {
-      const read = await Storage.readJSON<MessageV2.Info>(p);
+      const read = await Storage.readJSON<MessageV2.Info>(p)
       result.push({
         info: read,
         parts: await getParts(sessionID, read.id),
       })
     }
-    result.sort((a, b) => (a.info.id > b.info.id ? 1 : -1));
-    return result;
+    result.sort((a, b) => (a.info.id > b.info.id ? 1 : -1))
+    return result
   }
 
   export async function getMessage(sessionID: string, messageID: string) {
@@ -279,26 +271,26 @@ export namespace Session {
       const read = await Storage.readJSON<MessageV2.Part>(item)
       result.push(read)
     }
-    result.sort((a, b) => (a.id > b.id ? 1 : -1));
-    return result;
+    result.sort((a, b) => (a.id > b.id ? 1 : -1))
+    return result
   }
 
   export async function* list() {
     for (const item of await Storage.list("session/info")) {
-      const sessionID = path.basename(item, ".json");
-      yield get(sessionID);
+      const sessionID = path.basename(item, ".json")
+      yield get(sessionID)
     }
   }
 
   export async function children(parentID: string) {
-    const result = [] as Session.Info[];
+    const result = [] as Session.Info[]
     for (const item of await Storage.list("session/info")) {
-      const sessionID = path.basename(item, ".json");
-      const session = await get(sessionID);
-      if (session.parentID !== parentID) continue;
-      result.push(session);
+      const sessionID = path.basename(item, ".json")
+      const session = await get(sessionID)
+      if (session.parentID !== parentID) continue
+      result.push(session)
     }
-    return result;
+    return result
   }
 
   export function abort(sessionID: string) {
@@ -314,45 +306,39 @@ export namespace Session {
 
   export async function remove(sessionID: string, emitEvent = true) {
     try {
-      abort(sessionID);
-      const session = await get(sessionID);
+      abort(sessionID)
+      const session = await get(sessionID)
       for (const child of await children(sessionID)) {
-        await remove(child.id, false);
+        await remove(child.id, false)
       }
-      await unshare(sessionID).catch(() => {});
-      await Storage.remove(`session/info/${sessionID}`).catch(() => {});
-      await Storage.removeDir(`session/message/${sessionID}/`).catch(() => {});
-      state().sessions.delete(sessionID);
-      state().messages.delete(sessionID);
+      await unshare(sessionID).catch(() => {})
+      await Storage.remove(`session/info/${sessionID}`).catch(() => {})
+      await Storage.removeDir(`session/message/${sessionID}/`).catch(() => {})
+      state().sessions.delete(sessionID)
+      state().messages.delete(sessionID)
       if (emitEvent) {
         Bus.publish(Event.Deleted, {
           info: session,
-        });
+        })
       }
     } catch (e) {
-      log.error(e);
+      log.error(e)
     }
   }
 
   async function updateMessage(msg: MessageV2.Info) {
-    await Storage.writeJSON(
-      "session/message/" + msg.sessionID + "/" + msg.id,
-      msg,
-    );
+    await Storage.writeJSON("session/message/" + msg.sessionID + "/" + msg.id, msg)
     Bus.publish(MessageV2.Event.Updated, {
       info: msg,
-    });
+    })
   }
 
   async function updatePart(part: MessageV2.Part) {
-    await Storage.writeJSON(
-      ["session", "part", part.sessionID, part.messageID, part.id].join("/"),
-      part,
-    );
+    await Storage.writeJSON(["session", "part", part.sessionID, part.messageID, part.id].join("/"), part)
     Bus.publish(MessageV2.Event.PartUpdated, {
       part,
-    });
-    return part;
+    })
+    return part
   }
 
   export const ChatInput = z.object({
@@ -387,14 +373,14 @@ export namespace Session {
           }),
       ]),
     ),
-  });
-  export type ChatInput = z.infer<typeof ChatInput>;
+  })
+  export type ChatInput = z.infer<typeof ChatInput>
 
   export async function chat(
     input: z.infer<typeof ChatInput>,
   ): Promise<{ info: MessageV2.Assistant; parts: MessageV2.Part[] }> {
-    const l = log.clone().tag("session", input.sessionID);
-    l.info("chatting");
+    const l = log.clone().tag("session", input.sessionID)
+    l.info("chatting")
 
     const inputMode = input.mode ?? "build"
 
@@ -434,13 +420,13 @@ export namespace Session {
       time: {
         created: Date.now(),
       },
-    };
+    }
 
-    const app = App.info();
+    const app = App.info()
     const userParts = await Promise.all(
       input.parts.map(async (part): Promise<MessageV2.Part[]> => {
         if (part.type === "file") {
-          const url = new URL(part.url);
+          const url = new URL(part.url)
           switch (url.protocol) {
             case "data:":
               if (part.mime === "text/plain") {
@@ -475,37 +461,37 @@ export namespace Session {
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filePath = decodeURIComponent(url.pathname)
               if (part.mime === "text/plain") {
-                let offset: number | undefined = undefined;
-                let limit: number | undefined = undefined;
+                let offset: number | undefined = undefined
+                let limit: number | undefined = undefined
                 const range = {
                   start: url.searchParams.get("start"),
                   end: url.searchParams.get("end"),
-                };
+                }
                 if (range.start != null) {
-                  const filePath = part.url.split("?")[0];
-                  let start = parseInt(range.start);
-                  let end = range.end ? parseInt(range.end) : undefined;
+                  const filePath = part.url.split("?")[0]
+                  let start = parseInt(range.start)
+                  let end = range.end ? parseInt(range.end) : undefined
                   // some LSP servers (eg, gopls) don't give full range in
                   // workspace/symbol searches, so we'll try to find the
                   // symbol in the document to get the full range
                   if (start === end) {
-                    const symbols = await LSP.documentSymbol(filePath);
+                    const symbols = await LSP.documentSymbol(filePath)
                     for (const symbol of symbols) {
-                      let range: LSP.Range | undefined;
+                      let range: LSP.Range | undefined
                       if ("range" in symbol) {
-                        range = symbol.range;
+                        range = symbol.range
                       } else if ("location" in symbol) {
-                        range = symbol.location.range;
+                        range = symbol.location.range
                       }
                       if (range?.start?.line && range?.start?.line === start) {
-                        start = range.start.line;
-                        end = range?.end?.line ?? start;
-                        break;
+                        start = range.start.line
+                        end = range?.end?.line ?? start
+                        break
                       }
                     }
-                    offset = Math.max(start - 2, 0);
+                    offset = Math.max(start - 2, 0)
                     if (end) {
-                      limit = end - offset + 2;
+                      limit = end - offset + 2
                     }
                   }
                 }
@@ -525,9 +511,7 @@ export namespace Session {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    text: `Called the Read tool with the following input: ${
-                      JSON.stringify(args)
-                    }`,
+                    text: `Called the Read tool with the following input: ${JSON.stringify(args)}`,
                   },
                   {
                     id: Identifier.ascending("part"),
@@ -543,11 +527,11 @@ export namespace Session {
                     messageID: userMsg.id,
                     sessionID: input.sessionID,
                   },
-                ];
+                ]
               }
 
-              let file = Bun.file(filePath);
-              FileTime.read(input.sessionID, filePath);
+              let file = Bun.file(filePath)
+              FileTime.read(input.sessionID, filePath)
               return [
                 {
                   id: Identifier.ascending("part"),
@@ -562,13 +546,12 @@ export namespace Session {
                   messageID: userMsg.id,
                   sessionID: input.sessionID,
                   type: "file",
-                  url: `data:${part.mime};base64,` +
-                    Buffer.from(await file.bytes()).toString("base64"),
+                  url: `data:${part.mime};base64,` + Buffer.from(await file.bytes()).toString("base64"),
                   mime: part.mime,
                   filename: part.filename!,
                   source: part.source,
                 },
-              ];
+              ]
           }
         }
         return [
@@ -578,7 +561,7 @@ export namespace Session {
             messageID: userMsg.id,
             sessionID: input.sessionID,
           },
-        ];
+        ]
       }),
     ).then((x) => x.flat())
     if (inputMode === "plan")
@@ -600,7 +583,7 @@ export namespace Session {
     )
     await updateMessage(userMsg)
     for (const part of userParts) {
-      await updatePart(part);
+      await updatePart(part)
     }
 
     // mark session as updated
@@ -609,54 +592,47 @@ export namespace Session {
 
     if (isLocked(input.sessionID)) {
       return new Promise((resolve) => {
-        const queue = state().queued.get(input.sessionID) ?? [];
+        const queue = state().queued.get(input.sessionID) ?? []
         queue.push({
           input: input,
           message: userMsg,
           parts: userParts,
           processed: false,
           callback: resolve,
-        });
-        state().queued.set(input.sessionID, queue);
-      });
+        })
+        state().queued.set(input.sessionID, queue)
+      })
     }
 
     const model = await Provider.getModel(input.providerID, input.modelID)
     let msgs = await messages(input.sessionID)
 
-    const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)
-      ?.info as MessageV2.Assistant;
-    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) ||
-      OUTPUT_TOKEN_MAX;
+    const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
+    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
 
     // auto summarize if too long
     if (previous && previous.tokens) {
-      const tokens = previous.tokens.input + previous.tokens.cache.read +
-        previous.tokens.cache.write + previous.tokens.output;
-      if (
-        model.info.limit.context &&
-        tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)
-      ) {
+      const tokens =
+        previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
+      if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
         await summarize({
           sessionID: input.sessionID,
           providerID: input.providerID,
           modelID: input.modelID,
-        });
-        return chat(input);
+        })
+        return chat(input)
       }
     }
 
-    using abort = lock(input.sessionID);
+    using abort = lock(input.sessionID)
 
-    const lastSummary = msgs.findLast((msg) =>
-      msg.info.role === "assistant" && msg.info.summary === true
-    );
+    const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
     if (lastSummary) {
-      msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id);
+      msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id)
     }
 
     if (msgs.length === 1 && !session.parentID) {
-      const small = (await Provider.getSmallModel(input.providerID)) ?? model;
+      const small = (await Provider.getSmallModel(input.providerID)) ?? model
       generateText({
         maxOutputTokens: small.info.reasoning ? 1024 : 20,
         providerOptions: {
@@ -692,8 +668,9 @@ export namespace Session {
               const title = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
               draft.title = title.trim()
             })
+          }
         })
-        .catch(() => {});
+        .catch(() => {})
     }
 
     const mode = await Mode.get(inputMode)
@@ -708,8 +685,8 @@ export namespace Session {
     system.push(...(await SystemPrompt.environment()))
     system.push(...(await SystemPrompt.custom()))
     // max 2 system prompt messages for caching purposes
-    const [first, ...rest] = system;
-    system = [first, rest.join("\n")];
+    const [first, ...rest] = system
+    system = [first, rest.join("\n")]
 
     const assistantMsg: MessageV2.Info = {
       id: Identifier.ascending("message"),
@@ -733,11 +710,11 @@ export namespace Session {
         created: Date.now(),
       },
       sessionID: input.sessionID,
-    };
-    await updateMessage(assistantMsg);
-    const tools: Record<string, AITool> = {};
+    }
+    await updateMessage(assistantMsg)
+    const tools: Record<string, AITool> = {}
 
-    const processor = createProcessor(assistantMsg, model.info);
+    const processor = createProcessor(assistantMsg, model.info)
 
     const enabledTools = pipe(
       mode.tools,
@@ -768,7 +745,7 @@ export namespace Session {
             messageID: assistantMsg.id,
             callID: options.toolCallId,
             metadata: async (val) => {
-              const match = processor.partFromToolCall(options.toolCallId);
+              const match = processor.partFromToolCall(options.toolCallId)
               if (match && match.state.status === "running") {
                 await updatePart({
                   ...match,
@@ -781,7 +758,7 @@ export namespace Session {
                       start: Date.now(),
                     },
                   },
-                });
+                })
               }
             },
           })
@@ -800,9 +777,9 @@ export namespace Session {
           return {
             type: "text",
             value: result.output,
-          };
+          }
         },
-      });
+      })
     }
 
     for (const [key, item] of Object.entries(await MCP.tools())) {
@@ -814,29 +791,26 @@ export namespace Session {
         const output = result.content
           .filter((x: any) => x.type === "text")
           .map((x: any) => x.text)
-          .join("\n\n");
+          .join("\n\n")
 
         return {
           output,
-        };
-      };
+        }
+      }
       item.toModelOutput = (result) => {
         return {
           type: "text",
           value: result.output,
-        };
-      };
-      const schema = (item as any).inputSchema ?? (item as any).parameters;
-      if (schema) {
-        const transformedSchema = Provider.transformToolSchema(
-          schema as Provider.FlexibleSchema<any>,
-          input.providerID,
-        );
-        if (transformedSchema) {
-          (item as any).inputSchema = transformedSchema;
         }
       }
-      tools[key] = item;
+      const schema = (item as any).inputSchema ?? (item as any).parameters
+      if (schema) {
+        const transformedSchema = Provider.transformToolSchema(schema as Provider.FlexibleSchema<any>, input.providerID)
+        if (transformedSchema) {
+          ;(item as any).inputSchema = transformedSchema
+        }
+      }
+      tools[key] = item
     }
 
     const params = {
@@ -861,12 +835,10 @@ export namespace Session {
         })
       },
       async prepareStep({ messages }) {
-        const queue = (state().queued.get(input.sessionID) ?? []).filter((x) =>
-          !x.processed
-        );
+        const queue = (state().queued.get(input.sessionID) ?? []).filter((x) => !x.processed)
         if (queue.length) {
           for (const item of queue) {
-            if (item.processed) continue;
+            if (item.processed) continue
             messages.push(
               ...MessageV2.toModelMessage([
                 {
@@ -874,11 +846,11 @@ export namespace Session {
                   parts: item.parts,
                 },
               ]),
-            );
-            item.processed = true;
+            )
+            item.processed = true
           }
-          assistantMsg.time.completed = Date.now();
-          await updateMessage(assistantMsg);
+          assistantMsg.time.completed = Date.now()
+          await updateMessage(assistantMsg)
           Object.assign(assistantMsg, {
             id: Identifier.ascending("message"),
             role: "assistant",
@@ -901,12 +873,12 @@ export namespace Session {
               created: Date.now(),
             },
             sessionID: input.sessionID,
-          });
-          await updateMessage(assistantMsg);
+          })
+          await updateMessage(assistantMsg)
         }
         return {
           messages,
-        };
+        }
       },
       async experimental_repairToolCall(input) {
         if (InvalidToolInputError.isInstance(input.error)) {
@@ -940,7 +912,8 @@ export namespace Session {
         ),
         ...MessageV2.toModelMessage(msgs),
       ],
-      tools: model.info.tool_call === false ? undefined : ProviderTransform.tools(tools, input.providerID, input.modelID),
+      tools:
+        model.info.tool_call === false ? undefined : ProviderTransform.tools(tools, input.providerID, input.modelID),
       model: wrapLanguageModel({
         model: model.language,
         middleware: [
@@ -948,30 +921,26 @@ export namespace Session {
             async transformParams(args) {
               if (args.type === "stream") {
                 // @ts-expect-error
-                args.params.prompt = ProviderTransform.message(
-                  args.params.prompt,
-                  input.providerID,
-                  input.modelID,
-                );
+                args.params.prompt = ProviderTransform.message(args.params.prompt, input.providerID, input.modelID)
               }
-              return args.params;
+              return args.params
             },
           },
         ],
       }),
-    });
-    const result = await processor.process(stream);
-    const queued = state().queued.get(input.sessionID) ?? [];
-    const unprocessed = queued.find((x) => !x.processed);
+    })
+    const result = await processor.process(stream)
+    const queued = state().queued.get(input.sessionID) ?? []
+    const unprocessed = queued.find((x) => !x.processed)
     if (unprocessed) {
-      unprocessed.processed = true;
-      return chat(unprocessed.input);
+      unprocessed.processed = true
+      return chat(unprocessed.input)
     }
     for (const item of queued) {
-      item.callback(result);
+      item.callback(result)
     }
-    state().queued.delete(input.sessionID);
-    return result;
+    state().queued.delete(input.sessionID)
+    return result
   }
 
   function createProcessor(assistantMsg: MessageV2.Assistant, model: ModelsDev.Model) {
@@ -983,12 +952,12 @@ export namespace Session {
       },
       async process(stream: StreamTextResult<Record<string, AITool>, never>) {
         try {
-          let currentText: MessageV2.TextPart | undefined;
+          let currentText: MessageV2.TextPart | undefined
 
           for await (const value of stream.fullStream) {
             log.info("part", {
               type: value.type,
-            });
+            })
             switch (value.type) {
               case "start":
                 break
@@ -1009,7 +978,7 @@ export namespace Session {
                 break
 
               case "tool-input-delta":
-                break;
+                break
 
               case "tool-input-end":
                 break
@@ -1030,7 +999,7 @@ export namespace Session {
                   })
                   toolcalls[value.toolCallId] = part as MessageV2.ToolPart
                 }
-                break;
+                break
               }
               case "tool-result": {
                 const match = toolcalls[value.toolCallId]
@@ -1051,7 +1020,7 @@ export namespace Session {
                   })
                   delete toolcalls[value.toolCallId]
                 }
-                break;
+                break
               }
 
               case "tool-error": {
@@ -1071,11 +1040,11 @@ export namespace Session {
                   })
                   delete toolcalls[value.toolCallId]
                 }
-                break;
+                break
               }
 
               case "error":
-                throw value.error;
+                throw value.error
 
               case "start-step":
                 await updatePart({
@@ -1088,13 +1057,9 @@ export namespace Session {
                 break
 
               case "finish-step":
-                const usage = getUsage(
-                  model,
-                  value.usage,
-                  value.providerMetadata,
-                );
-                assistantMsg.cost += usage.cost;
-                assistantMsg.tokens = usage.tokens;
+                const usage = getUsage(model, value.usage, value.providerMetadata)
+                assistantMsg.cost += usage.cost
+                assistantMsg.tokens = usage.tokens
                 await updatePart({
                   id: Identifier.ascending("part"),
                   messageID: assistantMsg.id,
@@ -1130,15 +1095,15 @@ export namespace Session {
                   time: {
                     start: Date.now(),
                   },
-                };
-                break;
+                }
+                break
 
               case "text-delta":
                 if (currentText) {
                   currentText.text += value.text
                   if (currentText.text) await updatePart(currentText)
                 }
-                break;
+                break
 
               case "text-end":
                 if (currentText) {
@@ -1149,25 +1114,25 @@ export namespace Session {
                   }
                   await updatePart(currentText)
                 }
-                currentText = undefined;
-                break;
+                currentText = undefined
+                break
 
               case "finish":
-                assistantMsg.time.completed = Date.now();
-                await updateMessage(assistantMsg);
-                break;
+                assistantMsg.time.completed = Date.now()
+                await updateMessage(assistantMsg)
+                break
 
               default:
                 log.info("unhandled", {
                   ...value,
-                });
-                continue;
+                })
+                continue
             }
           }
         } catch (e) {
           log.error("", {
             error: e,
-          });
+          })
           switch (true) {
             case e instanceof DOMException && e.name === "AbortError":
               assistantMsg.error = new MessageV2.AbortedError(
@@ -1175,11 +1140,11 @@ export namespace Session {
                 {
                   cause: e,
                 },
-              ).toObject();
-              break;
+              ).toObject()
+              break
             case MessageV2.OutputLengthError.isInstance(e):
-              assistantMsg.error = e;
-              break;
+              assistantMsg.error = e
+              break
             case LoadAPIKeyError.isInstance(e):
               assistantMsg.error = new MessageV2.AuthError(
                 {
@@ -1187,22 +1152,28 @@ export namespace Session {
                   message: e.message,
                 },
                 { cause: e },
-              ).toObject();
-              break;
+              ).toObject()
+              break
             case e instanceof Error:
-              assistantMsg.error = new NamedError.Unknown({
-                message: e.toString(),
-              }, { cause: e }).toObject();
-              break;
+              assistantMsg.error = new NamedError.Unknown(
+                {
+                  message: e.toString(),
+                },
+                { cause: e },
+              ).toObject()
+              break
             default:
-              assistantMsg.error = new NamedError.Unknown({
-                message: JSON.stringify(e),
-              }, { cause: e });
+              assistantMsg.error = new NamedError.Unknown(
+                {
+                  message: JSON.stringify(e),
+                },
+                { cause: e },
+              )
           }
           Bus.publish(Event.Error, {
             sessionID: assistantMsg.sessionID,
             error: assistantMsg.error,
-          });
+          })
         }
         const p = await getParts(assistantMsg.sessionID, assistantMsg.id)
         for (const part of p) {
@@ -1218,14 +1189,14 @@ export namespace Session {
                 },
                 input: {},
               },
-            });
+            })
           }
         }
-        assistantMsg.time.completed = Date.now();
-        await updateMessage(assistantMsg);
-        return { info: assistantMsg, parts: p };
+        assistantMsg.time.completed = Date.now()
+        await updateMessage(assistantMsg)
+        return { info: assistantMsg, parts: p }
       },
-    };
+    }
   }
 
   export const RevertInput = z.object({
@@ -1326,10 +1297,10 @@ export namespace Session {
       time: {
         created: Date.now(),
       },
-    };
-    await updateMessage(next);
+    }
+    await updateMessage(next)
 
-    const processor = createProcessor(next, model.info);
+    const processor = createProcessor(next, model.info)
     const stream = streamText({
       maxRetries: 10,
       abortSignal: abort.signal,
@@ -1347,44 +1318,39 @@ export namespace Session {
           content: [
             {
               type: "text",
-              text:
-                "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.",
+              text: "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.",
             },
           ],
         },
       ],
-    });
+    })
 
-    const result = await processor.process(stream);
-    return result;
+    const result = await processor.process(stream)
+    return result
   }
 
   function isLocked(sessionID: string) {
-    return state().pending.has(sessionID);
+    return state().pending.has(sessionID)
   }
 
   function lock(sessionID: string) {
-    log.info("locking", { sessionID });
-    if (state().pending.has(sessionID)) throw new BusyError(sessionID);
-    const controller = new AbortController();
-    state().pending.set(sessionID, controller);
+    log.info("locking", { sessionID })
+    if (state().pending.has(sessionID)) throw new BusyError(sessionID)
+    const controller = new AbortController()
+    state().pending.set(sessionID, controller)
     return {
       signal: controller.signal,
       [Symbol.dispose]() {
-        log.info("unlocking", { sessionID });
-        state().pending.delete(sessionID);
+        log.info("unlocking", { sessionID })
+        state().pending.delete(sessionID)
         Bus.publish(Event.Idle, {
           sessionID,
-        });
+        })
       },
-    };
+    }
   }
 
-  function getUsage(
-    model: ModelsDev.Model,
-    usage: LanguageModelUsage,
-    metadata?: ProviderMetadata,
-  ) {
+  function getUsage(model: ModelsDev.Model, usage: LanguageModelUsage, metadata?: ProviderMetadata) {
     const tokens = {
       input: usage.inputTokens ?? 0,
       output: usage.outputTokens ?? 0,
@@ -1396,39 +1362,31 @@ export namespace Session {
           0) as number,
         read: usage.cachedInputTokens ?? 0,
       },
-    };
+    }
     return {
       cost: new Decimal(0)
         .add(new Decimal(tokens.input).mul(model.cost.input).div(1_000_000))
         .add(new Decimal(tokens.output).mul(model.cost.output).div(1_000_000))
-        .add(
-          new Decimal(tokens.cache.read).mul(model.cost.cache_read ?? 0).div(
-            1_000_000,
-          ),
-        )
-        .add(
-          new Decimal(tokens.cache.write).mul(model.cost.cache_write ?? 0).div(
-            1_000_000,
-          ),
-        )
+        .add(new Decimal(tokens.cache.read).mul(model.cost.cache_read ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.cache.write).mul(model.cost.cache_write ?? 0).div(1_000_000))
         .toNumber(),
       tokens,
-    };
+    }
   }
 
   export class BusyError extends Error {
     constructor(public readonly sessionID: string) {
-      super(`Session ${sessionID} is busy`);
+      super(`Session ${sessionID} is busy`)
     }
   }
 
   export async function initialize(input: {
-    sessionID: string;
-    modelID: string;
-    providerID: string;
-    messageID: string;
+    sessionID: string
+    modelID: string
+    providerID: string
+    messageID: string
   }) {
-    const app = App.info();
+    const app = App.info()
     await Session.chat({
       sessionID: input.sessionID,
       messageID: input.messageID,
@@ -1441,7 +1399,7 @@ export namespace Session {
           text: PROMPT_INITIALIZE.replace("${path}", app.path.root),
         },
       ],
-    });
-    await App.initialize();
+    })
+    await App.initialize()
   }
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -3,16 +3,16 @@ import { Decimal } from "decimal.js"
 import { z, ZodSchema } from "zod"
 import {
   generateText,
+  type LanguageModelUsage,
   LoadAPIKeyError,
+  type ModelMessage,
+  type ProviderMetadata,
+  stepCountIs,
   streamText,
+  type StreamTextResult,
+  type Tool as AITool,
   tool,
   wrapLanguageModel,
-  type Tool as AITool,
-  type LanguageModelUsage,
-  type ProviderMetadata,
-  type ModelMessage,
-  stepCountIs,
-  type StreamTextResult,
   InvalidToolInputError,
 } from "ai"
 
@@ -45,9 +45,9 @@ import { ToolRegistry } from "../tool/registry"
 import { Plugin } from "../plugin"
 
 export namespace Session {
-  const log = Log.create({ service: "session" })
+  const log = Log.create({ service: "session" });
 
-  const OUTPUT_TOKEN_MAX = 32_000
+  const OUTPUT_TOKEN_MAX = 32_000;
 
   export const Info = z
     .object({
@@ -75,8 +75,8 @@ export namespace Session {
     })
     .openapi({
       ref: "Session",
-    })
-  export type Info = z.output<typeof Info>
+    });
+  export type Info = z.output<typeof Info>;
 
   export const ShareInfo = z
     .object({
@@ -85,8 +85,8 @@ export namespace Session {
     })
     .openapi({
       ref: "SessionShare",
-    })
-  export type ShareInfo = z.output<typeof ShareInfo>
+    });
+  export type ShareInfo = z.output<typeof ShareInfo>;
 
   export const Event = {
     Updated: Bus.event(
@@ -114,147 +114,156 @@ export namespace Session {
         error: MessageV2.Assistant.shape.error,
       }),
     ),
-  }
+  };
 
   const state = App.state(
     "session",
     () => {
-      const sessions = new Map<string, Info>()
-      const messages = new Map<string, MessageV2.Info[]>()
-      const pending = new Map<string, AbortController>()
+      const sessions = new Map<string, Info>();
+      const messages = new Map<string, MessageV2.Info[]>();
+      const pending = new Map<string, AbortController>();
       const queued = new Map<
         string,
         {
-          input: ChatInput
-          message: MessageV2.User
-          parts: MessageV2.Part[]
-          processed: boolean
-          callback: (input: { info: MessageV2.Assistant; parts: MessageV2.Part[] }) => void
+          input: ChatInput;
+          message: MessageV2.User;
+          parts: MessageV2.Part[];
+          processed: boolean;
+          callback: (
+            input: { info: MessageV2.Assistant; parts: MessageV2.Part[] },
+          ) => void;
         }[]
-      >()
+      >();
 
       return {
         sessions,
         messages,
         pending,
         queued,
-      }
+      };
     },
     async (state) => {
       for (const [_, controller] of state.pending) {
-        controller.abort()
+        controller.abort();
       }
     },
-  )
+  );
 
   export async function create(parentID?: string) {
     const result: Info = {
       id: Identifier.descending("session"),
       version: Installation.VERSION,
       parentID,
-      title: (parentID ? "Child session - " : "New Session - ") + new Date().toISOString(),
+      title: (parentID ? "Child session - " : "New Session - ") +
+        new Date().toISOString(),
       time: {
         created: Date.now(),
         updated: Date.now(),
       },
-    }
-    log.info("created", result)
-    state().sessions.set(result.id, result)
-    await Storage.writeJSON("session/info/" + result.id, result)
-    const cfg = await Config.get()
-    if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto"))
+    };
+    log.info("created", result);
+    state().sessions.set(result.id, result);
+    await Storage.writeJSON("session/info/" + result.id, result);
+    const cfg = await Config.get();
+    if (
+      !result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto")
+    ) {
       share(result.id)
         .then((share) => {
           update(result.id, (draft) => {
-            draft.share = share
-          })
+            draft.share = share;
+          });
         })
         .catch(() => {
           // Silently ignore sharing errors during session creation
-        })
+        });
+    }
     Bus.publish(Event.Updated, {
       info: result,
-    })
-    return result
+    });
+    return result;
   }
 
   export async function get(id: string) {
-    const result = state().sessions.get(id)
+    const result = state().sessions.get(id);
     if (result) {
-      return result
+      return result;
     }
-    const read = await Storage.readJSON<Info>("session/info/" + id)
-    state().sessions.set(id, read)
-    return read as Info
+    const read = await Storage.readJSON<Info>("session/info/" + id);
+    state().sessions.set(id, read);
+    return read as Info;
   }
 
   export async function getShare(id: string) {
-    return Storage.readJSON<ShareInfo>("session/share/" + id)
+    return Storage.readJSON<ShareInfo>("session/share/" + id);
   }
 
   export async function share(id: string) {
-    const cfg = await Config.get()
+    const cfg = await Config.get();
     if (cfg.share === "disabled") {
-      throw new Error("Sharing is disabled in configuration")
+      throw new Error("Sharing is disabled in configuration");
     }
 
-    const session = await get(id)
-    if (session.share) return session.share
-    const share = await Share.create(id)
+    const session = await get(id);
+    if (session.share) return session.share;
+    const share = await Share.create(id);
     await update(id, (draft) => {
       draft.share = {
         url: share.url,
-      }
-    })
-    await Storage.writeJSON<ShareInfo>("session/share/" + id, share)
-    await Share.sync("session/info/" + id, session)
+      };
+    });
+    await Storage.writeJSON<ShareInfo>("session/share/" + id, share);
+    await Share.sync("session/info/" + id, session);
     for (const msg of await messages(id)) {
-      await Share.sync("session/message/" + id + "/" + msg.info.id, msg.info)
+      await Share.sync("session/message/" + id + "/" + msg.info.id, msg.info);
       for (const part of msg.parts) {
-        await Share.sync("session/part/" + id + "/" + msg.info.id + "/" + part.id, part)
+        await Share.sync(
+          "session/part/" + id + "/" + msg.info.id + "/" + part.id,
+          part,
+        );
       }
     }
-    return share
+    return share;
   }
 
   export async function unshare(id: string) {
-    const share = await getShare(id)
-    if (!share) return
-    await Storage.remove("session/share/" + id)
+    const share = await getShare(id);
+    if (!share) return;
+    await Storage.remove("session/share/" + id);
     await update(id, (draft) => {
-      draft.share = undefined
-    })
-    await Share.remove(id, share.secret)
+      draft.share = undefined;
+    });
+    await Share.remove(id, share.secret);
   }
 
   export async function update(id: string, editor: (session: Info) => void) {
-    const { sessions } = state()
-    const session = await get(id)
-    if (!session) return
-    editor(session)
-    session.time.updated = Date.now()
-    sessions.set(id, session)
-    await Storage.writeJSON("session/info/" + id, session)
+    const { sessions } = state();
+    const session = await get(id);
+    if (!session) return;
+    editor(session);
+    session.time.updated = Date.now();
+    sessions.set(id, session);
+    await Storage.writeJSON("session/info/" + id, session);
     Bus.publish(Event.Updated, {
       info: session,
-    })
-    return session
+    });
+    return session;
   }
 
   export async function messages(sessionID: string) {
     const result = [] as {
-      info: MessageV2.Info
-      parts: MessageV2.Part[]
-    }[]
+      info: MessageV2.Info;
+      parts: MessageV2.Part[];
+    }[];
     for (const p of await Storage.list("session/message/" + sessionID)) {
-      const read = await Storage.readJSON<MessageV2.Info>(p)
+      const read = await Storage.readJSON<MessageV2.Info>(p);
       result.push({
         info: read,
         parts: await getParts(sessionID, read.id),
       })
     }
-    result.sort((a, b) => (a.info.id > b.info.id ? 1 : -1))
-    return result
+    result.sort((a, b) => (a.info.id > b.info.id ? 1 : -1));
+    return result;
   }
 
   export async function getMessage(sessionID: string, messageID: string) {
@@ -270,26 +279,26 @@ export namespace Session {
       const read = await Storage.readJSON<MessageV2.Part>(item)
       result.push(read)
     }
-    result.sort((a, b) => (a.id > b.id ? 1 : -1))
-    return result
+    result.sort((a, b) => (a.id > b.id ? 1 : -1));
+    return result;
   }
 
   export async function* list() {
     for (const item of await Storage.list("session/info")) {
-      const sessionID = path.basename(item, ".json")
-      yield get(sessionID)
+      const sessionID = path.basename(item, ".json");
+      yield get(sessionID);
     }
   }
 
   export async function children(parentID: string) {
-    const result = [] as Session.Info[]
+    const result = [] as Session.Info[];
     for (const item of await Storage.list("session/info")) {
-      const sessionID = path.basename(item, ".json")
-      const session = await get(sessionID)
-      if (session.parentID !== parentID) continue
-      result.push(session)
+      const sessionID = path.basename(item, ".json");
+      const session = await get(sessionID);
+      if (session.parentID !== parentID) continue;
+      result.push(session);
     }
-    return result
+    return result;
   }
 
   export function abort(sessionID: string) {
@@ -305,39 +314,45 @@ export namespace Session {
 
   export async function remove(sessionID: string, emitEvent = true) {
     try {
-      abort(sessionID)
-      const session = await get(sessionID)
+      abort(sessionID);
+      const session = await get(sessionID);
       for (const child of await children(sessionID)) {
-        await remove(child.id, false)
+        await remove(child.id, false);
       }
-      await unshare(sessionID).catch(() => {})
-      await Storage.remove(`session/info/${sessionID}`).catch(() => {})
-      await Storage.removeDir(`session/message/${sessionID}/`).catch(() => {})
-      state().sessions.delete(sessionID)
-      state().messages.delete(sessionID)
+      await unshare(sessionID).catch(() => {});
+      await Storage.remove(`session/info/${sessionID}`).catch(() => {});
+      await Storage.removeDir(`session/message/${sessionID}/`).catch(() => {});
+      state().sessions.delete(sessionID);
+      state().messages.delete(sessionID);
       if (emitEvent) {
         Bus.publish(Event.Deleted, {
           info: session,
-        })
+        });
       }
     } catch (e) {
-      log.error(e)
+      log.error(e);
     }
   }
 
   async function updateMessage(msg: MessageV2.Info) {
-    await Storage.writeJSON("session/message/" + msg.sessionID + "/" + msg.id, msg)
+    await Storage.writeJSON(
+      "session/message/" + msg.sessionID + "/" + msg.id,
+      msg,
+    );
     Bus.publish(MessageV2.Event.Updated, {
       info: msg,
-    })
+    });
   }
 
   async function updatePart(part: MessageV2.Part) {
-    await Storage.writeJSON(["session", "part", part.sessionID, part.messageID, part.id].join("/"), part)
+    await Storage.writeJSON(
+      ["session", "part", part.sessionID, part.messageID, part.id].join("/"),
+      part,
+    );
     Bus.publish(MessageV2.Event.PartUpdated, {
       part,
-    })
-    return part
+    });
+    return part;
   }
 
   export const ChatInput = z.object({
@@ -372,14 +387,14 @@ export namespace Session {
           }),
       ]),
     ),
-  })
-  export type ChatInput = z.infer<typeof ChatInput>
+  });
+  export type ChatInput = z.infer<typeof ChatInput>;
 
   export async function chat(
     input: z.infer<typeof ChatInput>,
   ): Promise<{ info: MessageV2.Assistant; parts: MessageV2.Part[] }> {
-    const l = log.clone().tag("session", input.sessionID)
-    l.info("chatting")
+    const l = log.clone().tag("session", input.sessionID);
+    l.info("chatting");
 
     const inputMode = input.mode ?? "build"
 
@@ -419,13 +434,13 @@ export namespace Session {
       time: {
         created: Date.now(),
       },
-    }
+    };
 
-    const app = App.info()
+    const app = App.info();
     const userParts = await Promise.all(
       input.parts.map(async (part): Promise<MessageV2.Part[]> => {
         if (part.type === "file") {
-          const url = new URL(part.url)
+          const url = new URL(part.url);
           switch (url.protocol) {
             case "data:":
               if (part.mime === "text/plain") {
@@ -459,39 +474,38 @@ export namespace Session {
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filePath = decodeURIComponent(url.pathname)
-
               if (part.mime === "text/plain") {
-                let offset: number | undefined = undefined
-                let limit: number | undefined = undefined
+                let offset: number | undefined = undefined;
+                let limit: number | undefined = undefined;
                 const range = {
                   start: url.searchParams.get("start"),
                   end: url.searchParams.get("end"),
-                }
+                };
                 if (range.start != null) {
-                  const filePath = part.url.split("?")[0]
-                  let start = parseInt(range.start)
-                  let end = range.end ? parseInt(range.end) : undefined
+                  const filePath = part.url.split("?")[0];
+                  let start = parseInt(range.start);
+                  let end = range.end ? parseInt(range.end) : undefined;
                   // some LSP servers (eg, gopls) don't give full range in
                   // workspace/symbol searches, so we'll try to find the
                   // symbol in the document to get the full range
                   if (start === end) {
-                    const symbols = await LSP.documentSymbol(filePath)
+                    const symbols = await LSP.documentSymbol(filePath);
                     for (const symbol of symbols) {
-                      let range: LSP.Range | undefined
+                      let range: LSP.Range | undefined;
                       if ("range" in symbol) {
-                        range = symbol.range
+                        range = symbol.range;
                       } else if ("location" in symbol) {
-                        range = symbol.location.range
+                        range = symbol.location.range;
                       }
                       if (range?.start?.line && range?.start?.line === start) {
-                        start = range.start.line
-                        end = range?.end?.line ?? start
-                        break
+                        start = range.start.line;
+                        end = range?.end?.line ?? start;
+                        break;
                       }
                     }
-                    offset = Math.max(start - 2, 0)
+                    offset = Math.max(start - 2, 0);
                     if (end) {
-                      limit = end - offset + 2
+                      limit = end - offset + 2;
                     }
                   }
                 }
@@ -511,7 +525,9 @@ export namespace Session {
                     sessionID: input.sessionID,
                     type: "text",
                     synthetic: true,
-                    text: `Called the Read tool with the following input: ${JSON.stringify(args)}`,
+                    text: `Called the Read tool with the following input: ${
+                      JSON.stringify(args)
+                    }`,
                   },
                   {
                     id: Identifier.ascending("part"),
@@ -527,11 +543,11 @@ export namespace Session {
                     messageID: userMsg.id,
                     sessionID: input.sessionID,
                   },
-                ]
+                ];
               }
 
-              let file = Bun.file(filePath)
-              FileTime.read(input.sessionID, filePath)
+              let file = Bun.file(filePath);
+              FileTime.read(input.sessionID, filePath);
               return [
                 {
                   id: Identifier.ascending("part"),
@@ -546,12 +562,13 @@ export namespace Session {
                   messageID: userMsg.id,
                   sessionID: input.sessionID,
                   type: "file",
-                  url: `data:${part.mime};base64,` + Buffer.from(await file.bytes()).toString("base64"),
+                  url: `data:${part.mime};base64,` +
+                    Buffer.from(await file.bytes()).toString("base64"),
                   mime: part.mime,
                   filename: part.filename!,
                   source: part.source,
                 },
-              ]
+              ];
           }
         }
         return [
@@ -561,7 +578,7 @@ export namespace Session {
             messageID: userMsg.id,
             sessionID: input.sessionID,
           },
-        ]
+        ];
       }),
     ).then((x) => x.flat())
     if (inputMode === "plan")
@@ -583,7 +600,7 @@ export namespace Session {
     )
     await updateMessage(userMsg)
     for (const part of userParts) {
-      await updatePart(part)
+      await updatePart(part);
     }
 
     // mark session as updated
@@ -592,45 +609,54 @@ export namespace Session {
 
     if (isLocked(input.sessionID)) {
       return new Promise((resolve) => {
-        const queue = state().queued.get(input.sessionID) ?? []
+        const queue = state().queued.get(input.sessionID) ?? [];
         queue.push({
           input: input,
           message: userMsg,
           parts: userParts,
           processed: false,
           callback: resolve,
-        })
-        state().queued.set(input.sessionID, queue)
-      })
+        });
+        state().queued.set(input.sessionID, queue);
+      });
     }
 
     const model = await Provider.getModel(input.providerID, input.modelID)
     let msgs = await messages(input.sessionID)
 
-    const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
-    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+    const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)
+      ?.info as MessageV2.Assistant;
+    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) ||
+      OUTPUT_TOKEN_MAX;
 
     // auto summarize if too long
     if (previous && previous.tokens) {
-      const tokens =
-        previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
-      if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
+      const tokens = previous.tokens.input + previous.tokens.cache.read +
+        previous.tokens.cache.write + previous.tokens.output;
+      if (
+        model.info.limit.context &&
+        tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)
+      ) {
         await summarize({
           sessionID: input.sessionID,
           providerID: input.providerID,
           modelID: input.modelID,
-        })
-        return chat(input)
+        });
+        return chat(input);
       }
     }
 
-    using abort = lock(input.sessionID)
+    using abort = lock(input.sessionID);
 
-    const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
-    if (lastSummary) msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id)
+    const lastSummary = msgs.findLast((msg) =>
+      msg.info.role === "assistant" && msg.info.summary === true
+    );
+    if (lastSummary) {
+      msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id);
+    }
 
     if (msgs.length === 1 && !session.parentID) {
-      const small = (await Provider.getSmallModel(input.providerID)) ?? model
+      const small = (await Provider.getSmallModel(input.providerID)) ?? model;
       generateText({
         maxOutputTokens: small.info.reasoning ? 1024 : 20,
         providerOptions: {
@@ -660,14 +686,14 @@ export namespace Session {
         model: small.language,
       })
         .then((result) => {
-          if (result.text)
+          if (result.text) {
             return Session.update(input.sessionID, (draft) => {
               const cleaned = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "")
               const title = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
               draft.title = title.trim()
             })
         })
-        .catch(() => {})
+        .catch(() => {});
     }
 
     const mode = await Mode.get(inputMode)
@@ -682,8 +708,8 @@ export namespace Session {
     system.push(...(await SystemPrompt.environment()))
     system.push(...(await SystemPrompt.custom()))
     // max 2 system prompt messages for caching purposes
-    const [first, ...rest] = system
-    system = [first, rest.join("\n")]
+    const [first, ...rest] = system;
+    system = [first, rest.join("\n")];
 
     const assistantMsg: MessageV2.Info = {
       id: Identifier.ascending("message"),
@@ -707,11 +733,11 @@ export namespace Session {
         created: Date.now(),
       },
       sessionID: input.sessionID,
-    }
-    await updateMessage(assistantMsg)
-    const tools: Record<string, AITool> = {}
+    };
+    await updateMessage(assistantMsg);
+    const tools: Record<string, AITool> = {};
 
-    const processor = createProcessor(assistantMsg, model.info)
+    const processor = createProcessor(assistantMsg, model.info);
 
     const enabledTools = pipe(
       mode.tools,
@@ -742,7 +768,7 @@ export namespace Session {
             messageID: assistantMsg.id,
             callID: options.toolCallId,
             metadata: async (val) => {
-              const match = processor.partFromToolCall(options.toolCallId)
+              const match = processor.partFromToolCall(options.toolCallId);
               if (match && match.state.status === "running") {
                 await updatePart({
                   ...match,
@@ -755,7 +781,7 @@ export namespace Session {
                       start: Date.now(),
                     },
                   },
-                })
+                });
               }
             },
           })
@@ -774,9 +800,9 @@ export namespace Session {
           return {
             type: "text",
             value: result.output,
-          }
+          };
         },
-      })
+      });
     }
 
     for (const [key, item] of Object.entries(await MCP.tools())) {
@@ -788,19 +814,29 @@ export namespace Session {
         const output = result.content
           .filter((x: any) => x.type === "text")
           .map((x: any) => x.text)
-          .join("\n\n")
+          .join("\n\n");
 
         return {
           output,
-        }
-      }
+        };
+      };
       item.toModelOutput = (result) => {
         return {
           type: "text",
           value: result.output,
+        };
+      };
+      const schema = (item as any).inputSchema ?? (item as any).parameters;
+      if (schema) {
+        const transformedSchema = Provider.transformToolSchema(
+          schema as Provider.FlexibleSchema<any>,
+          input.providerID,
+        );
+        if (transformedSchema) {
+          (item as any).inputSchema = transformedSchema;
         }
       }
-      tools[key] = item
+      tools[key] = item;
     }
 
     const params = {
@@ -825,10 +861,12 @@ export namespace Session {
         })
       },
       async prepareStep({ messages }) {
-        const queue = (state().queued.get(input.sessionID) ?? []).filter((x) => !x.processed)
+        const queue = (state().queued.get(input.sessionID) ?? []).filter((x) =>
+          !x.processed
+        );
         if (queue.length) {
           for (const item of queue) {
-            if (item.processed) continue
+            if (item.processed) continue;
             messages.push(
               ...MessageV2.toModelMessage([
                 {
@@ -836,11 +874,11 @@ export namespace Session {
                   parts: item.parts,
                 },
               ]),
-            )
-            item.processed = true
+            );
+            item.processed = true;
           }
-          assistantMsg.time.completed = Date.now()
-          await updateMessage(assistantMsg)
+          assistantMsg.time.completed = Date.now();
+          await updateMessage(assistantMsg);
           Object.assign(assistantMsg, {
             id: Identifier.ascending("message"),
             role: "assistant",
@@ -863,12 +901,12 @@ export namespace Session {
               created: Date.now(),
             },
             sessionID: input.sessionID,
-          })
-          await updateMessage(assistantMsg)
+          });
+          await updateMessage(assistantMsg);
         }
         return {
           messages,
-        }
+        };
       },
       async experimental_repairToolCall(input) {
         if (InvalidToolInputError.isInstance(input.error)) {
@@ -902,7 +940,7 @@ export namespace Session {
         ),
         ...MessageV2.toModelMessage(msgs),
       ],
-      tools: model.info.tool_call === false ? undefined : tools,
+      tools: model.info.tool_call === false ? undefined : ProviderTransform.tools(tools, input.providerID, input.modelID),
       model: wrapLanguageModel({
         model: model.language,
         middleware: [
@@ -910,26 +948,30 @@ export namespace Session {
             async transformParams(args) {
               if (args.type === "stream") {
                 // @ts-expect-error
-                args.params.prompt = ProviderTransform.message(args.params.prompt, input.providerID, input.modelID)
+                args.params.prompt = ProviderTransform.message(
+                  args.params.prompt,
+                  input.providerID,
+                  input.modelID,
+                );
               }
-              return args.params
+              return args.params;
             },
           },
         ],
       }),
-    })
-    const result = await processor.process(stream)
-    const queued = state().queued.get(input.sessionID) ?? []
-    const unprocessed = queued.find((x) => !x.processed)
+    });
+    const result = await processor.process(stream);
+    const queued = state().queued.get(input.sessionID) ?? [];
+    const unprocessed = queued.find((x) => !x.processed);
     if (unprocessed) {
-      unprocessed.processed = true
-      return chat(unprocessed.input)
+      unprocessed.processed = true;
+      return chat(unprocessed.input);
     }
     for (const item of queued) {
-      item.callback(result)
+      item.callback(result);
     }
-    state().queued.delete(input.sessionID)
-    return result
+    state().queued.delete(input.sessionID);
+    return result;
   }
 
   function createProcessor(assistantMsg: MessageV2.Assistant, model: ModelsDev.Model) {
@@ -941,12 +983,12 @@ export namespace Session {
       },
       async process(stream: StreamTextResult<Record<string, AITool>, never>) {
         try {
-          let currentText: MessageV2.TextPart | undefined
+          let currentText: MessageV2.TextPart | undefined;
 
           for await (const value of stream.fullStream) {
             log.info("part", {
               type: value.type,
-            })
+            });
             switch (value.type) {
               case "start":
                 break
@@ -967,7 +1009,7 @@ export namespace Session {
                 break
 
               case "tool-input-delta":
-                break
+                break;
 
               case "tool-input-end":
                 break
@@ -988,7 +1030,7 @@ export namespace Session {
                   })
                   toolcalls[value.toolCallId] = part as MessageV2.ToolPart
                 }
-                break
+                break;
               }
               case "tool-result": {
                 const match = toolcalls[value.toolCallId]
@@ -1009,7 +1051,7 @@ export namespace Session {
                   })
                   delete toolcalls[value.toolCallId]
                 }
-                break
+                break;
               }
 
               case "tool-error": {
@@ -1029,11 +1071,11 @@ export namespace Session {
                   })
                   delete toolcalls[value.toolCallId]
                 }
-                break
+                break;
               }
 
               case "error":
-                throw value.error
+                throw value.error;
 
               case "start-step":
                 await updatePart({
@@ -1046,9 +1088,13 @@ export namespace Session {
                 break
 
               case "finish-step":
-                const usage = getUsage(model, value.usage, value.providerMetadata)
-                assistantMsg.cost += usage.cost
-                assistantMsg.tokens = usage.tokens
+                const usage = getUsage(
+                  model,
+                  value.usage,
+                  value.providerMetadata,
+                );
+                assistantMsg.cost += usage.cost;
+                assistantMsg.tokens = usage.tokens;
                 await updatePart({
                   id: Identifier.ascending("part"),
                   messageID: assistantMsg.id,
@@ -1084,15 +1130,15 @@ export namespace Session {
                   time: {
                     start: Date.now(),
                   },
-                }
-                break
+                };
+                break;
 
               case "text-delta":
                 if (currentText) {
                   currentText.text += value.text
                   if (currentText.text) await updatePart(currentText)
                 }
-                break
+                break;
 
               case "text-end":
                 if (currentText) {
@@ -1103,25 +1149,25 @@ export namespace Session {
                   }
                   await updatePart(currentText)
                 }
-                currentText = undefined
-                break
+                currentText = undefined;
+                break;
 
               case "finish":
-                assistantMsg.time.completed = Date.now()
-                await updateMessage(assistantMsg)
-                break
+                assistantMsg.time.completed = Date.now();
+                await updateMessage(assistantMsg);
+                break;
 
               default:
                 log.info("unhandled", {
                   ...value,
-                })
-                continue
+                });
+                continue;
             }
           }
         } catch (e) {
           log.error("", {
             error: e,
-          })
+          });
           switch (true) {
             case e instanceof DOMException && e.name === "AbortError":
               assistantMsg.error = new MessageV2.AbortedError(
@@ -1129,11 +1175,11 @@ export namespace Session {
                 {
                   cause: e,
                 },
-              ).toObject()
-              break
+              ).toObject();
+              break;
             case MessageV2.OutputLengthError.isInstance(e):
-              assistantMsg.error = e
-              break
+              assistantMsg.error = e;
+              break;
             case LoadAPIKeyError.isInstance(e):
               assistantMsg.error = new MessageV2.AuthError(
                 {
@@ -1141,18 +1187,22 @@ export namespace Session {
                   message: e.message,
                 },
                 { cause: e },
-              ).toObject()
-              break
+              ).toObject();
+              break;
             case e instanceof Error:
-              assistantMsg.error = new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
-              break
+              assistantMsg.error = new NamedError.Unknown({
+                message: e.toString(),
+              }, { cause: e }).toObject();
+              break;
             default:
-              assistantMsg.error = new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e })
+              assistantMsg.error = new NamedError.Unknown({
+                message: JSON.stringify(e),
+              }, { cause: e });
           }
           Bus.publish(Event.Error, {
             sessionID: assistantMsg.sessionID,
             error: assistantMsg.error,
-          })
+          });
         }
         const p = await getParts(assistantMsg.sessionID, assistantMsg.id)
         for (const part of p) {
@@ -1168,14 +1218,14 @@ export namespace Session {
                 },
                 input: {},
               },
-            })
+            });
           }
         }
-        assistantMsg.time.completed = Date.now()
-        await updateMessage(assistantMsg)
-        return { info: assistantMsg, parts: p }
+        assistantMsg.time.completed = Date.now();
+        await updateMessage(assistantMsg);
+        return { info: assistantMsg, parts: p };
       },
-    }
+    };
   }
 
   export const RevertInput = z.object({
@@ -1276,10 +1326,10 @@ export namespace Session {
       time: {
         created: Date.now(),
       },
-    }
-    await updateMessage(next)
+    };
+    await updateMessage(next);
 
-    const processor = createProcessor(next, model.info)
+    const processor = createProcessor(next, model.info);
     const stream = streamText({
       maxRetries: 10,
       abortSignal: abort.signal,
@@ -1297,39 +1347,44 @@ export namespace Session {
           content: [
             {
               type: "text",
-              text: "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.",
+              text:
+                "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.",
             },
           ],
         },
       ],
-    })
+    });
 
-    const result = await processor.process(stream)
-    return result
+    const result = await processor.process(stream);
+    return result;
   }
 
   function isLocked(sessionID: string) {
-    return state().pending.has(sessionID)
+    return state().pending.has(sessionID);
   }
 
   function lock(sessionID: string) {
-    log.info("locking", { sessionID })
-    if (state().pending.has(sessionID)) throw new BusyError(sessionID)
-    const controller = new AbortController()
-    state().pending.set(sessionID, controller)
+    log.info("locking", { sessionID });
+    if (state().pending.has(sessionID)) throw new BusyError(sessionID);
+    const controller = new AbortController();
+    state().pending.set(sessionID, controller);
     return {
       signal: controller.signal,
       [Symbol.dispose]() {
-        log.info("unlocking", { sessionID })
-        state().pending.delete(sessionID)
+        log.info("unlocking", { sessionID });
+        state().pending.delete(sessionID);
         Bus.publish(Event.Idle, {
           sessionID,
-        })
+        });
       },
-    }
+    };
   }
 
-  function getUsage(model: ModelsDev.Model, usage: LanguageModelUsage, metadata?: ProviderMetadata) {
+  function getUsage(
+    model: ModelsDev.Model,
+    usage: LanguageModelUsage,
+    metadata?: ProviderMetadata,
+  ) {
     const tokens = {
       input: usage.inputTokens ?? 0,
       output: usage.outputTokens ?? 0,
@@ -1341,31 +1396,39 @@ export namespace Session {
           0) as number,
         read: usage.cachedInputTokens ?? 0,
       },
-    }
+    };
     return {
       cost: new Decimal(0)
         .add(new Decimal(tokens.input).mul(model.cost.input).div(1_000_000))
         .add(new Decimal(tokens.output).mul(model.cost.output).div(1_000_000))
-        .add(new Decimal(tokens.cache.read).mul(model.cost.cache_read ?? 0).div(1_000_000))
-        .add(new Decimal(tokens.cache.write).mul(model.cost.cache_write ?? 0).div(1_000_000))
+        .add(
+          new Decimal(tokens.cache.read).mul(model.cost.cache_read ?? 0).div(
+            1_000_000,
+          ),
+        )
+        .add(
+          new Decimal(tokens.cache.write).mul(model.cost.cache_write ?? 0).div(
+            1_000_000,
+          ),
+        )
         .toNumber(),
       tokens,
-    }
+    };
   }
 
   export class BusyError extends Error {
     constructor(public readonly sessionID: string) {
-      super(`Session ${sessionID} is busy`)
+      super(`Session ${sessionID} is busy`);
     }
   }
 
   export async function initialize(input: {
-    sessionID: string
-    modelID: string
-    providerID: string
-    messageID: string
+    sessionID: string;
+    modelID: string;
+    providerID: string;
+    messageID: string;
   }) {
-    const app = App.info()
+    const app = App.info();
     await Session.chat({
       sessionID: input.sessionID,
       messageID: input.messageID,
@@ -1378,7 +1441,7 @@ export namespace Session {
           text: PROMPT_INITIALIZE.replace("${path}", app.path.root),
         },
       ],
-    })
-    await App.initialize()
+    });
+    await App.initialize();
   }
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -88,7 +88,7 @@ export namespace ToolRegistry {
     return {}
   }
 
-  function sanitizeGeminiParameters(schema: z.ZodTypeAny, visited = new Set()): z.ZodTypeAny {
+  export function sanitizeGeminiParameters(schema: z.ZodTypeAny, visited = new Set()): z.ZodTypeAny {
     if (!schema || visited.has(schema)) {
       return schema
     }

--- a/packages/opencode/test/bun.test.ts
+++ b/packages/opencode/test/bun.test.ts
@@ -22,7 +22,7 @@ describe("BunProc registry configuration", () => {
     // Verify that it uses Bun's default resolution
     expect(content).toContain("Bun's default registry resolution")
     expect(content).toContain("Bun will use them automatically")
-    expect(content).toContain("No need to pass --registry flag")
+    expect(content).toContain("Let Bun handle registry resolution:")
   })
 
   test("should have correct command structure without registry", async () => {

--- a/packages/opencode/test/provider.test.ts
+++ b/packages/opencode/test/provider.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import { z } from "zod";
+import { Provider } from "../src/provider/provider";
+
+describe("Gemini Schema Transformation", () => {
+  test("should remove default from union schemas", () => {
+    const schema = z.union([z.string(), z.number()]).default("test");
+    const jsonSchema = Provider.transformToolSchema(schema, "google")!;
+
+    expect(jsonSchema["default"]).toBeUndefined();
+    expect(Array.isArray(jsonSchema["type"])).toBe(true);
+    expect(jsonSchema["type"]).toContain("string");
+    expect(jsonSchema["type"]).toContain("number");
+  });
+
+  test("should remove default from anyOf schemas", () => {
+    const schema = z.union([z.string(), z.object({ id: z.number() })]).default(
+      "test",
+    );
+    const jsonSchema = Provider.transformToolSchema(schema, "google")!;
+
+    expect(jsonSchema["default"]).toBeUndefined();
+    expect(jsonSchema["anyOf"]).toBeDefined();
+  });
+
+  test("should remove additionalProperties", () => {
+    const schema = z
+      .object({
+        name: z.string(),
+        age: z.number(),
+      })
+      .strict();
+
+    const jsonSchema = Provider.transformToolSchema(schema, "google")!;
+    expect(jsonSchema["additionalProperties"]).toBeUndefined();
+  });
+
+  test("should preserve basic schema functionality", () => {
+    const zodSchema = z.object({
+      name: z.string(),
+      age: z.number().optional(),
+    });
+    const result = zodSchema.parse({ name: "John", age: 30 });
+    expect(result).toEqual({ name: "John", age: 30 });
+
+    const result2 = zodSchema.parse({ name: "Jane" });
+    expect(result2).toEqual({ name: "Jane" });
+  });
+
+  test("should handle a complex case with Gemini", () => {
+    // NOTE: From the GitHub MCP server
+    const input = {
+      body: {
+        description: "Review comment text",
+        type: "string",
+      },
+      comments: {
+        description:
+          "Line-specific comments array of objects to place comments on pull request changes. Requires path and body. For line comments use line or position. For multi-line comments use start_line and line with optional side parameters.",
+        type: "array",
+        items: {
+          additionalProperties: false,
+          properties: {
+            body: {
+              description: "comment body",
+              type: "string",
+            },
+            line: {
+              anyOf: [{ type: "number" }, { type: "null" }],
+              description:
+                "line number in the file to comment on. For multi-line comments, the end of the line range",
+            },
+            path: {
+              description: "path to the file",
+              type: "string",
+            },
+            position: {
+              anyOf: [{ type: "number" }, { type: "null" }],
+              description: "position of the comment in the diff",
+            },
+            side: {
+              anyOf: [{ type: "string" }, { type: "null" }],
+              description:
+                "The side of the diff on which the line resides. For multi-line comments, this is the side for the end of the line range. (LEFT or RIGHT)",
+            },
+            start_line: {
+              anyOf: [{ type: "number" }, { type: "null" }],
+              description:
+                "The first line of the range to which the comment refers. Required for multi-line comments.",
+            },
+            start_side: {
+              anyOf: [{ type: "string" }, { type: "null" }],
+              description:
+                "The side of the diff on which the start line resides for multi-line comments. (LEFT or RIGHT)",
+            },
+          },
+          required: [
+            "path",
+            "body",
+            "position",
+            "line",
+            "side",
+            "start_line",
+            "start_side",
+          ],
+          type: "object",
+        },
+      },
+      commitId: {
+        description: "SHA of commit to review",
+        type: "string",
+      },
+      event: {
+        description: "Review action to perform",
+        enum: ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+        type: "string",
+      },
+      owner: {
+        description: "Repository owner",
+        type: "string",
+      },
+      pullNumber: {
+        description: "Pull request number",
+        type: "number",
+      },
+    };
+
+    const fullJsonSchema = {
+      type: "object" as const,
+      properties: input,
+      required: Object.keys(input),
+    };
+
+    const jsonSchema = Provider.transformToolSchema(fullJsonSchema, "google")!;
+    delete (jsonSchema as any)["$schema"]; // Don't compare this
+
+    // The expected schema after Gemini-specific sanitization.
+    // Notably, =additionalProperties= is removed from =comments.items=.
+    const expected = {
+      type: "object",
+      properties: {
+        body: {
+          description: "Review comment text",
+          type: "string",
+        },
+        comments: {
+          description:
+            "Line-specific comments array of objects to place comments on pull request changes. Requires path and body. For line comments use line or position. For multi-line comments use start_line and line with optional side parameters.",
+          type: "array",
+          items: {
+            properties: {
+              body: {
+                description: "comment body",
+                type: "string",
+              },
+              line: {
+                anyOf: [{ type: "number" }, { type: "null" }],
+                description:
+                  "line number in the file to comment on. For multi-line comments, the end of the line range",
+              },
+              path: {
+                description: "path to the file",
+                type: "string",
+              },
+              position: {
+                anyOf: [{ type: "number" }, { type: "null" }],
+                description: "position of the comment in the diff",
+              },
+              side: {
+                anyOf: [{ type: "string" }, { type: "null" }],
+                description:
+                  "The side of the diff on which the line resides. For multi-line comments, this is the side for the end of the line range. (LEFT or RIGHT)",
+              },
+              start_line: {
+                anyOf: [{ type: "number" }, { type: "null" }],
+                description:
+                  "The first line of the range to which the comment refers. Required for multi-line comments.",
+              },
+              start_side: {
+                anyOf: [{ type: "string" }, { type: "null" }],
+                description:
+                  "The side of the diff on which the start line resides for multi-line comments. (LEFT or RIGHT)",
+              },
+            },
+            required: [
+              "path",
+              "body",
+              "position",
+              "line",
+              "side",
+              "start_line",
+              "start_side",
+            ],
+            type: "object",
+          },
+        },
+        commitId: {
+          description: "SHA of commit to review",
+          type: "string",
+        },
+        event: {
+          description: "Review action to perform",
+          enum: ["APPROVE", "REQUEST_CHANGES", "COMMENT"],
+          type: "string",
+        },
+        owner: {
+          description: "Repository owner",
+          type: "string",
+        },
+        pullNumber: {
+          description: "Pull request number",
+          type: "number",
+        },
+      },
+      required: Object.keys(input),
+    };
+
+    expect(jsonSchema).toEqual(expected);
+  });
+});

--- a/packages/opencode/test/tool/__snapshots__/tool.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/tool.test.ts.snap
@@ -7,3 +7,8 @@ exports[`tool.ls basic 1`] = `
   ink.tsx
 "
 `;
+
+exports[`tool.glob tool.ls basic 1`] = `
+"/Users/rami/Code/opencode/packages/opencode/example/
+"
+`;

--- a/packages/opencode/test/tool/tool.test.ts
+++ b/packages/opencode/test/tool/tool.test.ts
@@ -26,10 +26,10 @@ describe("tool.glob", () => {
           path: "../../node_modules",
         },
         ctx,
-      )
-      expect(result.metadata.truncated).toBe(true)
-    })
-  })
+      );
+      expect(result.metadata.truncated).toBe(true);
+    });
+  });
   test("basic", async () => {
     await App.provide({ cwd: projectRoot }, async () => {
       let result = await glob.execute(
@@ -38,7 +38,7 @@ describe("tool.glob", () => {
           path: undefined,
         },
         ctx,
-      )
+      );
       expect(result.metadata).toMatchObject({
         truncated: false,
         count: 2,


### PR DESCRIPTION
In addition to built-in tools in `TOOL_MAPPING`, add Gemini tool sanitization to `MCP.tools()` as well. This should have broader effects -- like fixing #1052 . 