### PR TITLE
feat: pass mode into task tool

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -373,6 +373,7 @@ export namespace Session {
     const userMsg: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
       role: "user",
+      mode: input.mode ?? "build",
       sessionID: input.sessionID,
       time: {
         created: Date.now(),
@@ -597,6 +598,7 @@ export namespace Session {
               info: {
                 id: Identifier.ascending("message"),
                 role: "user",
+                mode: input.mode ?? "build",
                 sessionID: input.sessionID,
                 time: {
                   created: Date.now(),
@@ -630,6 +632,7 @@ export namespace Session {
       id: Identifier.ascending("message"),
       role: "assistant",
       system,
+      mode: input.mode ?? "build",
       path: {
         cwd: app.path.cwd,
         root: app.path.root,
@@ -1122,6 +1125,7 @@ export namespace Session {
       role: "assistant",
       sessionID: input.sessionID,
       system,
+      mode: "build",
       path: {
         cwd: app.path.cwd,
         root: app.path.root,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -370,10 +370,11 @@ export namespace Session {
     const l = log.clone().tag("session", input.sessionID)
     l.info("chatting")
 
+    const inputMode = input.mode ?? "build"
     const userMsg: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
       role: "user",
-      mode: input.mode ?? "build",
+      mode: inputMode,
       sessionID: input.sessionID,
       time: {
         created: Date.now(),
@@ -495,7 +496,7 @@ export namespace Session {
         ]
       }),
     ).then((x) => x.flat())
-    if (input.mode === "plan")
+    if (inputMode === "plan")
       userParts.push({
         id: Identifier.ascending("part"),
         messageID: userMsg.id,
@@ -598,7 +599,7 @@ export namespace Session {
               info: {
                 id: Identifier.ascending("message"),
                 role: "user",
-                mode: input.mode ?? "build",
+                mode: inputMode,
                 sessionID: input.sessionID,
                 time: {
                   created: Date.now(),
@@ -619,7 +620,7 @@ export namespace Session {
         .catch(() => {})
     }
 
-    const mode = await Mode.get(input.mode ?? "build")
+    const mode = await Mode.get(inputMode)
     let system = input.providerID === "anthropic" ? [PROMPT_ANTHROPIC_SPOOF.trim()] : []
     system.push(...(mode.prompt ? [mode.prompt] : SystemPrompt.provider(input.modelID)))
     system.push(...(await SystemPrompt.environment()))
@@ -632,7 +633,7 @@ export namespace Session {
       id: Identifier.ascending("message"),
       role: "assistant",
       system,
-      mode: input.mode ?? "build",
+      mode: inputMode,
       path: {
         cwd: app.path.cwd,
         root: app.path.root,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -374,7 +374,6 @@ export namespace Session {
     const userMsg: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
       role: "user",
-      mode: inputMode,
       sessionID: input.sessionID,
       time: {
         created: Date.now(),
@@ -599,7 +598,6 @@ export namespace Session {
               info: {
                 id: Identifier.ascending("message"),
                 role: "user",
-                mode: inputMode,
                 sessionID: input.sessionID,
                 time: {
                   created: Date.now(),

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -190,11 +190,11 @@ export namespace MessageV2 {
   const Base = z.object({
     id: z.string(),
     sessionID: z.string(),
+    mode: z.string(),
   })
 
   export const User = Base.extend({
     role: z.literal("user"),
-    mode: z.string(),
     time: z.object({
       created: z.number(),
     }),
@@ -227,7 +227,6 @@ export namespace MessageV2 {
     system: z.string().array(),
     modelID: z.string(),
     providerID: z.string(),
-    mode: z.string(),
     path: z.object({
       cwd: z.string(),
       root: z.string(),

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -190,7 +190,6 @@ export namespace MessageV2 {
   const Base = z.object({
     id: z.string(),
     sessionID: z.string(),
-    mode: z.string(),
   })
 
   export const User = Base.extend({
@@ -227,6 +226,7 @@ export namespace MessageV2 {
     system: z.string().array(),
     modelID: z.string(),
     providerID: z.string(),
+    mode: z.string(),
     path: z.object({
       cwd: z.string(),
       root: z.string(),
@@ -370,7 +370,6 @@ export namespace MessageV2 {
         id: v1.id,
         sessionID: v1.metadata.sessionID,
         role: "user",
-        mode: "build",
         time: {
           created: v1.metadata.time.created,
         },

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -194,6 +194,7 @@ export namespace MessageV2 {
 
   export const User = Base.extend({
     role: z.literal("user"),
+    mode: z.string(),
     time: z.object({
       created: z.number(),
     }),
@@ -226,6 +227,7 @@ export namespace MessageV2 {
     system: z.string().array(),
     modelID: z.string(),
     providerID: z.string(),
+    mode: z.string(),
     path: z.object({
       cwd: z.string(),
       root: z.string(),
@@ -290,6 +292,7 @@ export namespace MessageV2 {
         modelID: v1.metadata.assistant!.modelID,
         providerID: v1.metadata.assistant!.providerID,
         system: v1.metadata.assistant!.system,
+        mode: "build",
         error: v1.metadata.error,
       }
       const parts = v1.parts.flatMap((part): Part[] => {
@@ -368,6 +371,7 @@ export namespace MessageV2 {
         id: v1.id,
         sessionID: v1.metadata.sessionID,
         role: "user",
+        mode: "build",
         time: {
           created: v1.metadata.time.created,
         },

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -72,6 +72,22 @@ export namespace Storage {
         } catch (e) {}
       }
     },
+    async (dir: string) => {
+      const files = new Bun.Glob("session/message/*/*.json").scanSync({
+        cwd: dir,
+        absolute: true,
+      })
+      for (const file of files) {
+        try {
+          const content = await Bun.file(file).json()
+          if (!content.mode) {
+            log.info("adding mode field to message", { file })
+            content.mode = "build"
+            await Bun.write(file, JSON.stringify(content, null, 2))
+          }
+        } catch (e) {}
+      }
+    },
   ]
 
   const state = App.state("storage", async () => {

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -80,7 +80,7 @@ export namespace Storage {
       for (const file of files) {
         try {
           const content = await Bun.file(file).json()
-          if (!content.mode) {
+          if (content.role === "assistant" && !content.mode) {
             log.info("adding mode field to message", { file })
             content.mode = "build"
             await Bun.write(file, JSON.stringify(content, null, 2))

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -41,6 +41,7 @@ export const TaskTool = Tool.define({
       sessionID: session.id,
       modelID: msg.modelID,
       providerID: msg.providerID,
+      mode: msg.mode,
       tools: {
         todoread: false,
         todowrite: false,


### PR DESCRIPTION
Currently the task tool is always called with the `build` mode. In some cases this can cause unexpected behaviour, e.g. even if you have disabled write/edit/bash access in a custom mode, it can get around this restriction by calling the task tool to spawn a `build` session.

This PR updates the task tool to use the same mode as the parent session. It also updates the message format to store the mode that the message was called under (and uses this to access the parent message's mode).