### PR TITLE
fix "working" spinner animation (#1054)

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -176,7 +176,7 @@ func (m *editorComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case dialog.ThemeSelectedMsg:
 		m.textarea = updateTextareaStyles(m.textarea)
 		m.spinner = createSpinner()
-		return m, m.textarea.Focus()
+		return m, tea.Batch(m.textarea.Focus(), m.spinner.Tick)
 	case dialog.CompletionSelectedMsg:
 		switch msg.Item.ProviderID {
 		case "commands":


### PR DESCRIPTION
This fixed #1054 for me.

The `dialog.ThemeSelectedMsg` creates a new spinner but never triggers the `m.spinner.Tick` event to restart the animation.

On my terminal, the `dialog.ThemeSelectedMsg` is always triggered at the start of the session, as the `tea.BackgroundColorMsg` is triggered when it detects the dark theme.
