### PR TITLE
feat: allow using gitignore'd files with a config option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -164,6 +164,10 @@ export namespace Config {
         .string()
         .optional()
         .describe("Custom username to display in conversations instead of system username"),
+      include_ignored_files: z
+        .boolean()
+        .optional()
+        .describe("Include files ignored by .gitignore in file search results"),
       mode: z
         .object({
           build: Mode.optional(),

--- a/packages/opencode/src/file/ripgrep.test.ts
+++ b/packages/opencode/src/file/ripgrep.test.ts
@@ -1,0 +1,38 @@
+import "zod-openapi/extend"
+
+import { describe, expect, test } from "bun:test"
+import { Ripgrep } from "./ripgrep"
+
+describe("Ripgrep.buildRipgrepCommand", () => {
+  test("excludes --no-ignore when include_ignored_files is false", () => {
+    const config = { include_ignored_files: false }
+    const cmd = Ripgrep.buildRipgrepCommand(config, "/path/to/rg")
+    expect(cmd).not.toContain("--no-ignore")
+    expect(cmd).toContain("--files --follow --hidden --glob='!.git/*'")
+  })
+
+  test("includes --no-ignore when include_ignored_files is true", () => {
+    const config = { include_ignored_files: true }
+    const cmd = Ripgrep.buildRipgrepCommand(config, "/path/to/rg")
+    expect(cmd).toContain("--no-ignore")
+    expect(cmd).toContain("--files --follow --hidden --glob='!.git/*'")
+  })
+
+  test("handles missing config gracefully", () => {
+    const cmd = Ripgrep.buildRipgrepCommand(undefined, "/path/to/rg")
+    expect(cmd).not.toContain("--no-ignore")
+    expect(cmd).toContain("--files --follow --hidden --glob='!.git/*'")
+  })
+
+  test("escapes filepath correctly", () => {
+    const config = {}
+    const cmd = Ripgrep.buildRipgrepCommand(config, "/path with spaces/rg")
+    expect(cmd).toContain(`"/path with spaces/rg"`)
+  })
+
+  test("builds complete command string", () => {
+    const config = { include_ignored_files: true }
+    const cmd = Ripgrep.buildRipgrepCommand(config, "/usr/bin/rg")
+    expect(cmd).toBe("/usr/bin/rg --files --follow --hidden --glob='!.git/*' --no-ignore")
+  })
+})

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -7,6 +7,7 @@ import { NamedError } from "../util/error"
 import { lazy } from "../util/lazy"
 import { $ } from "bun"
 import { Fzf } from "./fzf"
+import { Config } from "../config/config"
 
 export namespace Ripgrep {
   const Stats = z.object({
@@ -187,8 +188,17 @@ export namespace Ripgrep {
     return filepath
   }
 
+  export function buildRipgrepCommand(config: Config.Info | undefined, filepath: string): string {
+    const baseFlags = ["--files", "--follow", "--hidden", "--glob='!.git/*'"]
+    if (config?.include_ignored_files) {
+      baseFlags.push("--no-ignore")
+    }
+    return `${$.escape(filepath)} ${baseFlags.join(" ")}`
+  }
+
   export async function files(input: { cwd: string; query?: string; glob?: string[]; limit?: number }) {
-    const commands = [`${$.escape(await filepath())} --files --follow --hidden --glob='!.git/*'`]
+    const config = await Config.get().catch(() => undefined)
+    const commands = [buildRipgrepCommand(config, await filepath())]
 
     if (input.glob) {
       for (const g of input.glob) {

--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -211,15 +211,13 @@ You can configure opencode to include files that are normally ignored by `.gitig
 }
 ```
 
-By default, opencode will skip files listed in `.gitignore` and similar ignore files. Setting `include_ignored_files` to `true` will include these files in searches, edits, and other operations.
+By default, opencode will skip files listed in `.gitignore` and similar ignore files. Setting `include_ignored_files` to `true` will include these files in operations like attachment auto suggestions (`@`).
 
 This is useful for:
 
 - Working with files that are intentionally ignored from version control but still relevant to your workflow
 - Including build artifacts or generated files in your analysis
 - Accessing configuration files that may be gitignored
-
-Note that enabling this option may impact performance if your project has many ignored files.
 
 ---
 

--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -219,6 +219,8 @@ This is useful for:
 - Including build artifacts or generated files in your analysis
 - Accessing configuration files that may be gitignored
 
+Note that this would include files like `node_modules`, so use it with caution.
+
 ---
 
 ## Variables

--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -200,6 +200,29 @@ The `disabled_providers` option accepts an array of provider IDs. When a provide
 
 ---
 
+### Include ignored files
+
+You can configure opencode to include files that are normally ignored by `.gitignore` or other ignore mechanisms through the `include_ignored_files` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "include_ignored_files": true
+}
+```
+
+By default, opencode will skip files listed in `.gitignore` and similar ignore files. Setting `include_ignored_files` to `true` will include these files in searches, edits, and other operations.
+
+This is useful for:
+
+- Working with files that are intentionally ignored from version control but still relevant to your workflow
+- Including build artifacts or generated files in your analysis
+- Accessing configuration files that may be gitignored
+
+Note that enabling this option may impact performance if your project has many ignored files.
+
+---
+
 ## Variables
 
 You can use variable substitution in your config files to reference environment variables and file contents.


### PR DESCRIPTION
## Problem

- .gitignore'd files don't show up in @ attachment autocomplete
- Some people keep AI context notes gitignore'd ([see discord convo](https://discord.com/channels/1391832426048651334/1397365333878243378/1397770448044818575))

## Solution

- Add *include_ignored_files* config option to allow users to include ignored files

## How did I test this?

- `bun test packages/opencode/src/file/ripgrep.test.ts`
- Manually test it via `cd packages/opencode; bun run src/index.ts`