### PR TITLE
Check if modelID includes "claude" for antropic/claude prompt caching

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -3,7 +3,7 @@ import { unique } from "remeda"
 
 export namespace ProviderTransform {
   export function message(msgs: ModelMessage[], providerID: string, modelID: string) {
-    if (providerID === "anthropic" || modelID.includes("anthropic")) {
+    if (providerID === "anthropic" || modelID.includes("anthropic") || modelID.includes("claude")) {
       const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
       const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
 


### PR DESCRIPTION
Not all providers explictly add "anthropic" in the model ID. GCP Vertext for example. See the model IDs listed here: https://docs.anthropic.com/en/docs/about-claude/models/overview