### PR TITLE
fix(headless): respect mode passed to /message endpoint

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -765,6 +765,7 @@ export namespace Session {
             },
             modelID: input.modelID,
             providerID: input.providerID,
+            mode: inputMode,
             time: {
               created: Date.now(),
             },


### PR DESCRIPTION
The headless server was overwriting the incoming `mode` on POST /message and always using `build`.

Change: use the provided `mode` if present; fall back to `build` only when not set.

Tested locally: sending { mode: "plan" } now runs in plan mode; the agent on the current build uses bash to bypass write tools being gated as the system prompt is inconsistent.

