### PR TITLE
Agent execution trough CLI "run" command

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -10,6 +10,7 @@ import { bootstrap } from "../bootstrap"
 import { MessageV2 } from "../../session/message-v2"
 import { Mode } from "../../session/mode"
 import { Identifier } from "../../id/id"
+import { Agent } from "../../agent/agent.ts"
 
 const TOOL: Record<string, [string, string]> = {
   todowrite: ["Todo", UI.Style.TEXT_WARNING_BOLD],
@@ -57,6 +58,11 @@ export const RunCommand = cmd({
       .option("mode", {
         type: "string",
         describe: "mode to use",
+      })
+      .option("agent", {
+        type: "string",
+        alias: ["a"],
+        describe: "agent to use",
       })
   },
   handler: async (args) => {
@@ -156,18 +162,23 @@ export const RunCommand = cmd({
         UI.error(err)
       })
 
+      const agent = args.agent ? await Agent.get(args.agent) : undefined
       const mode = args.mode ? await Mode.get(args.mode) : await Mode.list().then((x) => x[0])
 
       const messageID = Identifier.ascending("message")
       const result = await Session.chat({
         sessionID: session.id,
         messageID,
-        ...(mode.model
-          ? mode.model
-          : {
-              providerID,
-              modelID,
-            }),
+        ...(agent?.model
+          ? agent.model
+          : mode.model
+            ? mode.model
+            : {
+                providerID,
+                modelID,
+              }),
+        system: agent?.prompt,
+        tools: agent?.tools,
         mode: mode.name,
         parts: [
           {

--- a/packages/web/src/content/docs/docs/agents.mdx
+++ b/packages/web/src/content/docs/docs/agents.mdx
@@ -130,6 +130,12 @@ Common tools you might want to control:
 
 Agents are automatically available through the Task tool when configured. The main assistant will use them for specialized tasks based on their descriptions.
 
+You can also run agents directly with the `run` command by using the `-a` or `--agent` flag. This is useful for scripting and automating tasks.
+
+```bash
+opencode run -a <agent-name> "your prompt for the agent"
+```
+
 ## Best Practices
 
 1. **Clear descriptions** - Write specific descriptions that help the main assistant know when to use each agent
@@ -157,6 +163,12 @@ Focus on:
 - Proper structure
 - Code examples
 - User-friendly language
+```
+
+You can then pipe a file to the agent to have it generate documentation for that file.
+
+```bash
+cat path/to/your/file.ts | opencode run -a docs-writer "write documentation for this file"
 ```
 
 ### Security Auditor

--- a/packages/web/src/content/docs/docs/cli.mdx
+++ b/packages/web/src/content/docs/docs/cli.mdx
@@ -37,6 +37,12 @@ This is useful for scripting, automation, or when you want a quick answer withou
 opencode run Explain the use of context in Go
 ```
 
+To execute an agent.
+
+```bash "opencode run --agent"
+opencode run --agent <agent-name> "Your prompt for the agent"
+```
+
 #### Flags
 
 | Flag         | Short | Description                                |
@@ -45,7 +51,7 @@ opencode run Explain the use of context in Go
 | `--session`  | `-s`  | Session ID to continue                     |
 | `--share`    |       | Share the session                          |
 | `--model`    | `-m`  | Model to use in the form of provider/model |
-
+| `--agent`    | `-a`  | Agent to use                               |
 ---
 
 ### auth


### PR DESCRIPTION
Thank you @thdxr for prompt implementation of agents. I love them.

Added support to execute agents via run command. It is something I use quite frequently in my personal fork.
Personally, I find agents more fitting in `run` the command than modes.

Here is an example of how to use it:
`bun dev run --agent example-driven-docs-writer "update /Users/marekpazik/src/opencode/packages/web/src/content/docs/docs/cli.mdx. Agents can now be executed using the run command. See /Users/marekpazik/src/opencode/packages/opencode/src/cli/cmd/run.ts"`

Feel free to give suggestions or rewrite the code if needed.