### PR TITLE
fix: header width to display header in one line when sharing disabled

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -670,15 +670,21 @@ func (m *messagesComponent) renderHeader() string {
 	isSubscriptionModel := m.app.Model != nil &&
 		m.app.Model.Cost.Input == 0 && m.app.Model.Cost.Output == 0
 
+	sessionInfoText := formatTokensAndCost(tokens, contextWindow, cost, isSubscriptionModel)
 	sessionInfo = styles.NewStyle().
 		Foreground(t.TextMuted()).
 		Background(t.Background()).
-		Render(formatTokensAndCost(tokens, contextWindow, cost, isSubscriptionModel))
+		Render(sessionInfoText)
 
 	shareEnabled := m.app.Config.Share != opencode.ConfigShareDisabled
+	headerTextWidth := headerWidth
+	if !shareEnabled {
+		// +1 is to ensure there is always at least one space between header and session info
+		headerTextWidth -= len(sessionInfoText) + 1
+	}
 	headerText := util.ToMarkdown(
 		"# "+m.app.Session.Title,
-		headerWidth,
+		headerTextWidth,
 		t.Background(),
 	)
 
@@ -705,11 +711,9 @@ func (m *messagesComponent) renderHeader() string {
 		items...,
 	)
 
-	var headerLines []string
+	headerLines := []string{headerRow}
 	if shareEnabled {
 		headerLines = []string{headerText, headerRow}
-	} else {
-		headerLines = []string{headerRow}
 	}
 
 	header := strings.Join(headerLines, "\n")


### PR DESCRIPTION
This fixes #1309

This was partially reverted in 3fdd23df16a44150afc3564f16fe486b0785f7aa to fix a bug with the width calculation causing #1271. This was due to using `len(sessionInfo)` as the offset which is incorrect as it also includes other formatting. 

This PR updates to measure the offset correctly by measuring the unformatted text.

The below video also demonstrates that the previous bug does not appear with these changes.

https://github.com/user-attachments/assets/9762eef8-819f-41d2-8b2d-88b3a3a8b158