### PR TITLE
fix: markdown agents not detected when symlinked

### DIFF
--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -52,6 +52,7 @@ export namespace Filesystem {
           absolute: true,
           onlyFiles: true,
           dot: true,
+          followSymlinks: true
         })) {
           result.push(match)
         }


### PR DESCRIPTION
Closes #1313