### PR TITLE
Support prompt references (@file.txt and $`ls src`)  for modes and agents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -5,6 +5,7 @@ import { Provider } from "../provider/provider"
 import { generateObject, type ModelMessage } from "ai"
 import PROMPT_GENERATE from "./generate.txt"
 import { SystemPrompt } from "../session/system"
+import path from "path"
 
 export namespace Agent {
   export const Info = z
@@ -19,6 +20,7 @@ export namespace Agent {
       description: z.string(),
       prompt: z.string().optional(),
       tools: z.record(z.boolean()),
+      path: z.string().optional(),
     })
     .openapi({
       ref: "Agent",
@@ -48,6 +50,7 @@ export namespace Agent {
             todowrite: false,
             todoread: false,
           },
+          path: value.path,
         }
       const model = value.model ?? cfg.model
       if (model) item.model = Provider.parseModel(model)
@@ -98,5 +101,12 @@ export namespace Agent {
       }),
     })
     return result.object
+  }
+
+  export async function resolvePrompt(agent: Info): Promise<string | undefined> {
+    if (!agent.prompt) return
+    if (!agent.path) return agent.prompt
+
+    return SystemPrompt.resolve(agent.prompt, path.dirname(agent.path), agent.name)
   }
 }

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -1,6 +1,7 @@
 import { Config } from "../config/config"
 import { MCP } from "../mcp"
 import { UI } from "./ui"
+import { SystemPrompt } from "../session/system.ts"
 
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
@@ -11,6 +12,9 @@ export function FormatError(input: unknown) {
       `Config file at ${input.data.path} is invalid`,
       ...(input.data.issues?.map((issue) => "↳ " + issue.message + " " + issue.path.join(".")) ?? []),
     ].join("\n")
+  if (SystemPrompt.PromptResolveError.isInstance(input))
+    return `Failed to resolve prompt for: "${input.data.name}" for the reference: "${input.data.reference}"
+${input.data.error}`
 
   if (UI.CancelledError.isInstance(input)) return ""
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -35,6 +35,7 @@ export namespace Config {
 
       const config = {
         name: path.basename(item, ".md"),
+        path: item,
         ...md.data,
         prompt: md.content.trim(),
       }
@@ -102,6 +103,7 @@ export namespace Config {
       prompt: z.string().optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
       disable: z.boolean().optional(),
+      path: z.string().optional(),
     })
     .openapi({
       ref: "ModeConfig",
@@ -327,6 +329,12 @@ export namespace Config {
       if (!parsed.data.$schema) {
         parsed.data.$schema = "https://opencode.ai/config.json"
         await Bun.write(configPath, JSON.stringify(parsed.data, null, 2))
+      }
+
+      if (parsed.data.mode) {
+        Object.values(parsed.data.mode).forEach((mode) => {
+          mode.path = configPath
+        })
       }
       return parsed.data
     }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -620,11 +620,14 @@ export namespace Session {
     const mode = await Mode.get(inputMode)
     let system = SystemPrompt.header(input.providerID)
     system.push(
-      ...(() => {
+      ...(await (async () => {
         if (input.system) return [input.system]
-        if (mode.prompt) return [mode.prompt]
+        if (mode.prompt) {
+          if (mode.path) return [(await Mode.resolvePrompt(mode))!]
+          return [mode.prompt]
+        }
         return SystemPrompt.provider(input.modelID)
-      })(),
+      })()),
     )
     system.push(...(mode.prompt ? [mode.prompt] : SystemPrompt.provider(input.modelID)))
     system.push(...(await SystemPrompt.environment()))

--- a/packages/opencode/src/session/mode.ts
+++ b/packages/opencode/src/session/mode.ts
@@ -2,6 +2,8 @@ import { App } from "../app/app"
 import { Config } from "../config/config"
 import z from "zod"
 import { Provider } from "../provider/provider"
+import { SystemPrompt } from "./system.ts"
+import path from "path"
 
 export namespace Mode {
   export const Info = z
@@ -15,6 +17,7 @@ export namespace Mode {
         .optional(),
       prompt: z.string().optional(),
       tools: z.record(z.boolean()),
+      path: z.string().optional(),
     })
     .openapi({
       ref: "Mode",
@@ -50,6 +53,7 @@ export namespace Mode {
         item.model = Provider.parseModel(model)
       }
       if (value.prompt) item.prompt = value.prompt
+      if (value.path) item.path = value.path
       if (value.tools)
         item.tools = {
           ...value.tools,
@@ -66,5 +70,12 @@ export namespace Mode {
 
   export async function list() {
     return state().then((x) => Object.values(x))
+  }
+
+  export async function resolvePrompt(mode: Info): Promise<string | undefined> {
+    if (!mode.prompt) return
+    if (!mode.path) return mode.prompt
+
+    return SystemPrompt.resolve(mode.prompt, path.dirname(mode.path), mode.name)
   }
 }

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -5,6 +5,7 @@ import { Filesystem } from "../util/filesystem"
 import { Config } from "../config/config"
 import path from "path"
 import os from "os"
+import { z } from "zod"
 
 import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
 import PROMPT_BEAST from "./prompt/beast.txt"
@@ -12,8 +13,11 @@ import PROMPT_GEMINI from "./prompt/gemini.txt"
 import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 import PROMPT_SUMMARIZE from "./prompt/summarize.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import { NamedError } from "../util/error.ts"
 
 export namespace SystemPrompt {
+  const MAX_PROMPT_LENGTH = 50000
+
   export function header(providerID: string) {
     if (providerID.includes("anthropic")) return [PROMPT_ANTHROPIC_SPOOF.trim()]
     return []
@@ -105,4 +109,130 @@ export namespace SystemPrompt {
         return [PROMPT_TITLE]
     }
   }
+
+  const commandPattern = /(?<!\\)\$`([^`]+)`/g
+  async function resolveBashCommands(content: string, basePath: string, name: string): Promise<string> {
+    let result = content
+    let totalLength = content.length
+
+    const matches = Array.from(content.matchAll(commandPattern))
+
+    for (const match of matches) {
+      const [fullMatch, command] = match
+
+      const proc = Bun.spawn(["sh", "-c", command], {
+        cwd: basePath,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+
+      const output = await new Response(proc.stdout).text()
+      const error = await new Response(proc.stderr).text()
+
+      await proc.exited
+
+      if (proc.exitCode !== 0) {
+        throw new PromptResolveError({
+          name,
+          reference: command,
+          error: `Command failed: ${command}\n${error}`,
+        })
+      }
+
+      const trimmedOutput = output.trim()
+      totalLength = totalLength - fullMatch.length + trimmedOutput.length
+
+      if (totalLength > MAX_PROMPT_LENGTH) {
+        throw new PromptResolveError({
+          name,
+          reference: command,
+          error: `Prompt length exceeds ${MAX_PROMPT_LENGTH} characters after resolving commands`,
+        })
+      }
+
+      result = result.replace(fullMatch, trimmedOutput)
+    }
+
+    result = result.replace(/\\\$/g, "$")
+
+    return result
+  }
+
+  const linkPattern = /(?<!\\)(?<=^|\s)@([^\s]+)/gm
+  async function resolveLinks(
+    content: string,
+    basePath: string,
+    name: string,
+    visited: Set<string> = new Set(),
+  ): Promise<string> {
+    let result = content
+    let totalLength = content.length
+
+    const matches = Array.from(content.matchAll(linkPattern))
+
+    for (const match of matches) {
+      const [fullMatch, linkPath] = match
+      const resolvedPath = path.resolve(basePath, linkPath)
+
+      if (visited.has(resolvedPath)) {
+        throw new PromptResolveError({
+          name,
+          reference: resolvedPath,
+          error: `Circular dependency detected: ${resolvedPath}`,
+        })
+      }
+
+      const file = Bun.file(resolvedPath)
+      const exists = await file.exists()
+
+      if (!exists) {
+        continue
+      }
+
+      visited.add(resolvedPath)
+
+      let fileContent: string
+      try {
+        fileContent = await file.text()
+      } catch {
+        throw new PromptResolveError({
+          name,
+          reference: resolvedPath,
+          error: `File is not a text file: ${resolvedPath}`,
+        })
+      }
+
+      const resolvedContent = await resolveLinks(fileContent, path.dirname(resolvedPath), name, visited)
+
+      totalLength = totalLength - fullMatch.length + resolvedContent.length
+      if (totalLength > MAX_PROMPT_LENGTH) {
+        throw new PromptResolveError({
+          name,
+          reference: resolvedPath,
+          error: `Prompt length exceeds ${MAX_PROMPT_LENGTH} characters after resolving links`,
+        })
+      }
+
+      result = result.replace(fullMatch, resolvedContent)
+      visited.delete(resolvedPath)
+    }
+
+    result = result.replace(/\\@/g, "@")
+
+    return result
+  }
+
+  export async function resolve(prompt: string, basePath: string, name: string) {
+    const resolvedLinks = await resolveLinks(prompt, basePath, name)
+    return resolveBashCommands(resolvedLinks, basePath, name)
+  }
+
+  export const PromptResolveError = NamedError.create(
+    "PromptResolveError",
+    z.object({
+      name: z.string(),
+      reference: z.string(),
+      error: z.string(),
+    }),
+  )
 }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -52,7 +52,7 @@ export const TaskTool = Tool.define(async () => {
         modelID: model.modelID,
         providerID: model.providerID,
         mode: msg.mode,
-        system: agent.prompt,
+        system: await Agent.resolvePrompt(agent),
         tools: agent.tools,
         parts: [
           {


### PR DESCRIPTION
Support for file references `@file.txt` and bash execution ``$`bash command` `` in agent markdown and mode configuration.

These features allow more complex context loading.

## More about the feature on anthropic docs
https://docs.anthropic.com/en/docs/claude-code/common-workflows#reference-files-and-directories
https://docs.anthropic.com/en/docs/claude-code/slash-commands#bash-command-execution

## Implementation details
- Lazy execution when mode and agent are invoked
- Support nested include
- Break on circular dependencies
- Limit of 50000 tokens
- Custom error when prompt resoultion failed

## Missing
- Documentation - added when
- Integration with https://github.com/sst/opencode/pull/1303 (easy)

## Notes
- I had trouble providing a base directory for relative paths. My solution is not perfect as the path is included in the config schema, so users could possibly override it. An alternative was to have ConfigPriv with this extra path, but that would be overkill just for this single use case.
- Not a big fan of the prompt resolution place. Ideally, it would be resolved for both modes and agents inside the `session/index.ts`, but we don't pass the agent. Possible solutions:
  - Specialized chat for mode and chat for agent variant of the chat method
  - Mode and agent unified so we don't need to pass both of them
- Would be great to opt out from `await SystemPrompt.custom()` as sometimes it provides redundant or misleading information (I have agents that get custom dir structure)