### PR TITLE
Fix/pyright empty event

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -158,21 +158,31 @@ export namespace LSPClient {
         input.path = path.isAbsolute(input.path) ? input.path : path.resolve(app.path.cwd, input.path)
         log.info("waiting for diagnostics", input)
         let unsub: () => void
-        return await withTimeout(
-          new Promise<void>((resolve) => {
-            let eventCount = 0
-            const maxEvents = result.serverID === "pyright" ? 2 : 1
 
-            unsub = Bus.subscribe(Event.Diagnostics, (event) => {
-              if (event.properties.path === input.path && event.properties.serverID === result.serverID) {
-                eventCount++
-                log.info("got diagnostics", { ...input, eventCount, maxEvents })
-
-                if (eventCount >= maxEvents) {
-                  log.info("diagnostics complete", input)
-                  unsub?.()
+        if (result.serverID === "pyright") {
+          await withTimeout(
+            new Promise<void>((resolve) => {
+              const initialUnsub = Bus.subscribe(Event.Diagnostics, (event) => {
+                if (event.properties.path === input.path && event.properties.serverID === result.serverID) {
+                  log.info("consumed initial pyright event", input)
+                  initialUnsub()
                   resolve()
                 }
+              })
+            }),
+            50,
+          ).catch(() => {
+            log.info("no initial pyright event, continuing", input)
+          })
+        }
+
+        return await withTimeout(
+          new Promise<void>((resolve) => {
+            unsub = Bus.subscribe(Event.Diagnostics, (event) => {
+              if (event.properties.path === input.path && event.properties.serverID === result.serverID) {
+                log.info("got diagnostics", input)
+                unsub?.()
+                resolve()
               }
             })
           }),

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -160,11 +160,19 @@ export namespace LSPClient {
         let unsub: () => void
         return await withTimeout(
           new Promise<void>((resolve) => {
+            let eventCount = 0
+            const maxEvents = result.serverID === "pyright" ? 2 : 1
+
             unsub = Bus.subscribe(Event.Diagnostics, (event) => {
               if (event.properties.path === input.path && event.properties.serverID === result.serverID) {
-                log.info("got diagnostics", input)
-                unsub?.()
-                resolve()
+                eventCount++
+                log.info("got diagnostics", { ...input, eventCount, maxEvents })
+
+                if (eventCount >= maxEvents) {
+                  log.info("diagnostics complete", input)
+                  unsub?.()
+                  resolve()
+                }
               }
             })
           }),


### PR DESCRIPTION
Pyright LSP server likes to throw a empty event at first. 

This ensures the errors are caught properly

before 
<img width="870" height="401" alt="image" src="https://github.com/user-attachments/assets/644982f6-fa18-41c8-ba76-3f27518b4e91" />

after 
<img width="839" height="299" alt="image" src="https://github.com/user-attachments/assets/2cdef7e4-dcf7-4901-b7e1-ca4374292d5c" />
