### PR TITLE
fix: strip thinking blocks from title

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -611,7 +611,9 @@ export namespace Session {
         .then((result) => {
           if (result.text)
             return Session.update(input.sessionID, (draft) => {
-              draft.title = result.text
+              const cleaned = result.text.replace(/<think>[\s\S]*?<\/think>\s*/g, "")
+              const title = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
+              draft.title = title
             })
         })
         .catch(() => {})


### PR DESCRIPTION
Strip thinking blocks from title and truncate if too long.

Would use [extractReasoningMiddleware](https://ai-sdk.dev/docs/ai-sdk-core/middleware#extract-reasoning) but it only seems to work for streaming

Fixes: #1324
