### PR TITLE
fix: make description parameter optional in bash tool

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -16,7 +16,8 @@ export const BashTool = Tool.define("bash", {
       .string()
       .describe(
         "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-      ),
+      )
+      .optional(),
   }),
   async execute(params, ctx) {
     const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)


### PR DESCRIPTION
The bash tool was requiring a description parameter, but KimiK2 wasn't automatically generating one when calling the tool, regardless of telling it to in the prompts. This caused schema validation errors in build mode and custom modes.

Requiring the description for every call was literally rendering opencode unusable and this seems to completely fix the problem.