### PR TITLE
fix: attachment bugs

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -419,9 +419,7 @@ export namespace Session {
             case "file:":
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
-              const pathname = decodeURIComponent(url.pathname)
-              const relativePath = pathname.replace(app.path.cwd, ".")
-              const filePath = path.join(app.path.cwd, relativePath)
+              const filePath = decodeURIComponent(url.pathname)
 
               if (part.mime === "text/plain") {
                 let offset: number | undefined = undefined
@@ -501,7 +499,7 @@ export namespace Session {
                   messageID: userMsg.id,
                   sessionID: input.sessionID,
                   type: "text",
-                  text: `Called the Read tool with the following input: {\"filePath\":\"${pathname}\"}`,
+                  text: `Called the Read tool with the following input: {\"filePath\":\"${filePath}\"}`,
                   synthetic: true,
                 },
                 {

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -732,7 +731,7 @@ func (m *editorComponent) createAttachmentFromFile(filePath string) *attachment.
 			ID:        uuid.NewString(),
 			Type:      "file",
 			Display:   "@" + filePath,
-			URL:       fmt.Sprintf("file://./%s", filePath),
+			URL:       fmt.Sprintf("file://%s", absolutePath),
 			Filename:  filePath,
 			MediaType: mediaType,
 			Source: &attachment.FileSource{
@@ -783,7 +782,7 @@ func (m *editorComponent) createAttachmentFromPath(filePath string) *attachment.
 		ID:        uuid.NewString(),
 		Type:      "file",
 		Display:   "@" + filePath,
-		URL:       fmt.Sprintf("file://./%s", url.PathEscape(filePath)),
+		URL:       fmt.Sprintf("file://%s", absolutePath),
 		Filename:  filePath,
 		MediaType: mediaType,
 		Source: &attachment.FileSource{


### PR DESCRIPTION
fixes: #1330

- file URLs should not have their paths percent-encoded
- always uses absolute paths for file resolution

Now I have tested this a variety of ways:
@ references (text & image)
drag & drop files that live within and outside of the cwd (text & image)

Maybe there is something I am missing here but at least for me this fixes all attachment bugs I have ran into