### PR TITLE
feat: add yaml language server support

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -367,7 +367,15 @@ export namespace LSPServer {
     root: NearestRoot(["package.json", ".git"]),
     extensions: [".yml", ".yaml"],
     async spawn(_, root) {
-      const proc = spawn(BunProc.which(), ["x", "yaml-language-server", "--stdio"], {
+      const bin = Bun.which("yaml-language-server", {
+        PATH: process.env["PATH"] + ":" + Global.Path.bin,
+      })
+      if (!bin) {
+        log.error("yaml-language-server is not available. Please install it and try again.")
+        return
+      }
+
+      const proc = spawn(bin, ["--stdio"], {
         cwd: root,
         env: {
           ...process.env,

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -361,4 +361,22 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const YamlLanguageServer: Info = {
+    id: "yaml",
+    root: NearestRoot(["package.json", ".git"]),
+    extensions: [".yml", ".yaml"],
+    async spawn(_, root) {
+      const proc = spawn(BunProc.which(), ["x", "yaml-language-server", "--stdio"], {
+        cwd: root,
+        env: {
+          ...process.env,
+          BUN_BE_BUN: "1",
+        },
+      })
+      return {
+        process: proc,
+      }
+    },
+  }
 }


### PR DESCRIPTION
## Summary
- Add YAML language server support to opencode
- Enables syntax highlighting, error detection, and schema validation for `.yml` and `.yaml` files
- Uses yaml-language-server via Bun's package runner for automatic installation

## Testing
- ✅ Verified LSP starts correctly: `service=lsp.client serverID=yaml starting client` and `initialized`
- ✅ Tested with multiple YAML file formats (.yml, .yaml)

## Fixes
- Closes #1343