### PR TITLE
fix: dependency for nixos build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
       "devDependencies": {
         "@ai-sdk/amazon-bedrock": "2.2.10",
         "@ai-sdk/anthropic": "1.2.12",
+        "@octokit/rest": "22.0.0",
         "@octokit/webhooks-types": "7.6.1",
         "@standard-schema/spec": "1.0.0",
         "@tsconfig/bun": "1.0.7",

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@clack/prompts": "0.11.0",
         "@hono/zod-validator": "0.4.2",
         "@modelcontextprotocol/sdk": "1.15.1",
+        "@octokit/rest": "22.0.0",
         "@openauthjs/openauth": "0.4.3",
         "@standard-schema/spec": "1.0.0",
         "@zip.js/zip.js": "2.7.62",
@@ -56,7 +57,6 @@
       "devDependencies": {
         "@ai-sdk/amazon-bedrock": "2.2.10",
         "@ai-sdk/anthropic": "1.2.12",
-        "@octokit/rest": "22.0.0",
         "@octokit/webhooks-types": "7.6.1",
         "@standard-schema/spec": "1.0.0",
         "@tsconfig/bun": "1.0.7",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "2.2.10",
     "@ai-sdk/anthropic": "1.2.12",
+    "@octokit/rest": "22.0.0",
     "@octokit/webhooks-types": "7.6.1",
     "@standard-schema/spec": "1.0.0",
     "@tsconfig/bun": "1.0.7",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "2.2.10",
     "@ai-sdk/anthropic": "1.2.12",
-    "@octokit/rest": "22.0.0",
     "@octokit/webhooks-types": "7.6.1",
     "@standard-schema/spec": "1.0.0",
     "@tsconfig/bun": "1.0.7",
@@ -34,6 +33,7 @@
     "@clack/prompts": "0.11.0",
     "@hono/zod-validator": "0.4.2",
     "@modelcontextprotocol/sdk": "1.15.1",
+    "@octokit/rest": "22.0.0",
     "@openauthjs/openauth": "0.4.3",
     "@standard-schema/spec": "1.0.0",
     "@zip.js/zip.js": "2.7.62",


### PR DESCRIPTION
octokit/rest is a required dependency in open code. The Nix package [filters on opencode dependencies](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/op/opencode/package.nix#L84) so it is impossible to build the latest versions of opencode now. This change fixed it for me. I haven't figured out what commit/change caused the nix package to fail. To me it looks like more packages are missing than just this one, but it works with only this change so I am just PR'ing this in hopes to not need to do this on a fork forever.

```
┃        > 6 | import { Octokit } from "@octokit/rest"
┃        >                             ^
┃        > error: Could not resolve: "@octokit/rest". Maybe you need to "bun install"?
┃        >     at /build/source/packages/opencode/src/cli/cmd/github.ts:6:25
```