### PR TITLE
Load MCP in parallel and cache MCP tools

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -128,8 +128,22 @@ export namespace MCP {
         }
       }
 
+      const clientsTools = await Promise.all(
+        Object.entries(clients).map(async ([clientName, client]) => [clientName, await client.tools()] as const),
+      )
+
+      const tools: Record<string, Tool> = {}
+      for (const [clientName, clientTools] of clientsTools) {
+        const sanitizedClientName = clientName.replace(/\s+/g, "_")
+        for (const [toolName, tool] of Object.entries(clientTools)) {
+          const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
+          tools[sanitizedClientName + "_" + sanitizedToolName] = tool
+        }
+      }
+
       return {
         clients,
+        tools,
       }
     },
     async (state) => {
@@ -144,14 +158,6 @@ export namespace MCP {
   }
 
   export async function tools() {
-    const result: Record<string, Tool> = {}
-    for (const [clientName, client] of Object.entries(await clients())) {
-      for (const [toolName, tool] of Object.entries(await client.tools())) {
-        const sanitizedClientName = clientName.replace(/\s+/g, "_")
-        const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = tool
-      }
-    }
-    return result
+    return (await state()).tools
   }
 }


### PR DESCRIPTION
The remote MCP servers are painfully slow to load, especially since I am currently in China and coding over VPN.

I noticed that loading sequentially doesn't help. After conducting a few tests, I found that the initial client was the slowest.

## Test Results

Config
```
  "mcp": {
    "context7": {
      "type": "remote",
      "url": "https://mcp.context7.com/sse"
    },
    "coin": {
      "type": "remote",
      "url": "https://mcp.api.coingecko.com/sse"
    },
    "fetch": {
      "type": "remote",
      "url": "https://remote.mcpservers.org/fetch/mcp"
    }
  }
```

Below are the results from my simple benchmark of three runs:

Original implementation:
- Clients load: 8436ms - 12622ms
- Tools load (per message): 1192ms - 1387ms

Parallel client and tool loading:
- Clients load: 2437ms - 3412ms
- Tools load (per message): 367ms - 569ms

After caching:
- Clients and tools load together
- No additional loading per message
- Drawback: Need to restart opencode on MCP server changes but as it is API I assume it will change very infrequently.