### PR TITLE
fix: handle absolute paths correctly in drag & drop file attachments (#1330)

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -420,8 +420,13 @@ export namespace Session {
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
               const pathname = decodeURIComponent(url.pathname)
-              const relativePath = pathname.replace(app.path.cwd, ".")
-              const filePath = path.join(app.path.cwd, relativePath)
+              let filePath: string
+              if (path.isAbsolute(pathname)) {
+                filePath = pathname
+              } else {
+                const relativePath = pathname.replace(app.path.cwd, ".")
+                filePath = path.join(app.path.cwd, relativePath)
+              }
 
               if (part.mime === "text/plain") {
                 let offset: number | undefined = undefined


### PR DESCRIPTION
## Summary
- Fixes issue where drag & drop of files from outside the working directory results in ENOENT error
- The server was incorrectly joining absolute paths with the cwd, creating invalid double paths like `/cwd/path/Users/username/Desktop/file.txt`

## Changes
- Added a check in `session/index.ts` to detect if the pathname is already absolute
- If absolute, use the path directly without joining with cwd
- If relative, continue with the existing logic

## Test plan
- [x] Tested locally by dragging a file from Desktop into opencode
- [x] Verified the file attachment works correctly without ENOENT errors
- [x] Existing relative path functionality remains unchanged

Fixes #1330