### PR TITLE
vscode extension - implement external terminal and add problems

### DIFF
--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -26,7 +26,7 @@
     "commands": [
       {
         "command": "opencode.openTerminal",
-        "title": "Open opencode",
+        "title": "Opencode - Open Terminal",
         "icon": {
           "light": "images/button-dark.svg",
           "dark": "images/button-light.svg"
@@ -34,7 +34,7 @@
       },
       {
         "command": "opencode.openNewTerminal",
-        "title": "Open opencode in new tab",
+        "title": "Opencode - Open in new tab",
         "icon": {
           "light": "images/button-dark.svg",
           "dark": "images/button-light.svg"
@@ -42,7 +42,15 @@
       },
       {
         "command": "opencode.addFilepathToTerminal",
-        "title": "Add Filepath to Terminal"
+        "title": "Opencode - Add Filepath to Terminal"
+      },
+      {
+       "command": "opencode.registerTerminal",
+        "title": "Opencode - Register Terminal"
+      },
+      {
+        "command": "opencode.addProblemsToTerminal",
+        "title": "Opencode - Add Problems to Terminal"
       }
     ],
     "menus": {

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,9 +1,10 @@
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }
 
 import * as vscode from "vscode"
 
 const TERMINAL_NAME = "opencode"
+let registeredExternalPort: number | null = null
 
 export function activate(context: vscode.ExtensionContext) {
   let openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
@@ -25,18 +26,86 @@ export function activate(context: vscode.ExtensionContext) {
     const fileRef = getActiveFile()
     if (!fileRef) return
 
-    const terminal = vscode.window.activeTerminal
-    if (!terminal) return
+    await sendTextToTerminal(fileRef)
+  })
 
-    if (terminal.name === TERMINAL_NAME) {
-      // @ts-ignore
-      const port = terminal.creationOptions.env?.["_EXTENSION_OPENCODE_PORT"]
-      port ? await appendPrompt(parseInt(port), fileRef) : terminal.sendText(fileRef)
-      terminal.show()
+  // Register command to connect to external terminal
+  let registerTerminalDisposable = vscode.commands.registerCommand("opencode.registerTerminal", async () => {
+    const port = await vscode.window.showInputBox({
+      prompt: "Enter port number for external terminal",
+      placeHolder: "e.g. 3000",
+      validateInput: (value) => {
+        const num = parseInt(value)
+        if (isNaN(num) || num < 1 || num > 65535) {
+          return "Please enter a valid port number (1-65535)"
+        }
+        return null
+      }
+    })
+
+    if (!port) return
+
+    const portNum = parseInt(port)
+
+    try {
+      const response = await fetch(`http://localhost:${portNum}/app`)
+      if (response.ok) {
+        registeredExternalPort = portNum
+        vscode.window.showInformationMessage(`Successfully connected to external terminal on port ${portNum}`)
+
+        const fileRef = getActiveFile()
+        if (fileRef) {
+          await sendTextToTerminal(`In ${fileRef}`)
+        }
+      } else {
+        vscode.window.showErrorMessage(`Failed to connect to terminal on port ${portNum}`)
+      }
+    } catch (error) {
+      vscode.window.showErrorMessage(`Unable to connect to terminal on port ${portNum}. Make sure the terminal is running.`)
     }
   })
 
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
+  let addProblemsDisposable = vscode.commands.registerCommand("opencode.addProblemsToTerminal", async () => {
+    let problems = vscode.languages.getDiagnostics()
+    if (!problems.length) {
+      vscode.window.showInformationMessage("No problems found in the workspace.")
+      return
+    }
+
+    let errors = []
+
+    for (const [uri, diagnostics] of problems) {
+      for (const diagnostic of diagnostics) {
+        if (diagnostic.severity === vscode.DiagnosticSeverity.Error) {
+          errors.push(diagnostic)
+        }
+      }
+    }
+
+    await sendTextToTerminal(JSON.stringify(errors));
+  });
+
+  context.subscriptions.push(
+    openTerminalDisposable,
+    addFilepathDisposable,
+    registerTerminalDisposable,
+    addProblemsDisposable
+  )
+
+  async function sendTextToTerminal(text: string) {
+    const terminal = vscode.window.activeTerminal
+
+    if (terminal && terminal.name === TERMINAL_NAME) {
+      // @ts-ignore
+      const port = terminal.creationOptions.env?.["_EXTENSION_OPENCODE_PORT"]
+      port ? await appendPrompt(parseInt(port), text) : terminal.sendText(text)
+      terminal.show()
+    } else if (registeredExternalPort) {
+      await appendPrompt(registeredExternalPort, text)
+    } else {
+      vscode.window.showWarningMessage("No opencode terminal or registered external terminal found")
+    }
+  }
 
   async function openTerminal() {
     // Create a new terminal in split screen
@@ -71,7 +140,7 @@ export function activate(context: vscode.ExtensionContext) {
         await fetch(`http://localhost:${port}/app`)
         connected = true
         break
-      } catch (e) {}
+      } catch (e) { }
 
       tries--
     } while (tries > 0)


### PR DESCRIPTION
**External terminals**
Enable connecting to external terminals via port number input, allowing users to work with terminals outside VS Code. This allows sending context to prompts in external terminals. I work with 2 instances of vscode open, frontend and backend. This allows me to have a single terminal open with Opencode.

    Start opencode in a terminal specifying a port
    Run command "Opencode - Register External Terminal"
    Enter port

<img width="664" height="119" alt="image" src="https://github.com/user-attachments/assets/8929761f-fee6-44e8-94d9-0c9463d0c38c" />
<img width="639" height="91" alt="image" src="https://github.com/user-attachments/assets/7dbe0079-8c08-4094-99de-4582a8042a4f" />


**Problems**
I find myself copy/pasting the content of the problems window to Opencode a lot. This adds a command which sends the content to Opencode.

<img width="1701" height="879" alt="image" src="https://github.com/user-attachments/assets/8c7b47e4-59ed-461f-835b-7ca6fbd31418" />
