### PR TITLE
implement the includeCoAuthoredBy option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -233,6 +233,10 @@ export namespace Config {
       mcp: z.record(z.string(), Mcp).optional().describe("MCP (Model Context Protocol) server configurations"),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
+      include_co_authored_by: z
+        .boolean()
+        .optional()
+        .describe("Whether to include the co-authored-by opencode byline in git commits and pull requests"),
       experimental: z
         .object({
           hook: z

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -2,47 +2,73 @@ import { z } from "zod"
 import { Tool } from "./tool"
 import DESCRIPTION from "./bash.txt"
 import { App } from "../app/app"
+import { Config } from "../config/config"
 
 const MAX_OUTPUT_LENGTH = 30000
 const DEFAULT_TIMEOUT = 1 * 60 * 1000
 const MAX_TIMEOUT = 10 * 60 * 1000
 
-export const BashTool = Tool.define("bash", {
-  description: DESCRIPTION,
-  parameters: z.object({
-    command: z.string().describe("The command to execute"),
-    timeout: z.number().min(0).max(MAX_TIMEOUT).describe("Optional timeout in milliseconds").optional(),
-    description: z
-      .string()
-      .describe(
-        "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-      ),
-  }),
-  async execute(params, ctx) {
-    const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
+function replaceCoAuthoredMessage(includeCoAuthoredBy = true) {
+  if (!includeCoAuthoredBy) {
+    return DESCRIPTION.replace("${commitCoAuthored1}", ".")
+      .replace("${commitCoAuthored2}", "")
+      .replace("${prCoAuthored}", "")
+  }
 
-    const process = Bun.spawn({
-      cmd: ["bash", "-c", params.command],
-      cwd: App.info().path.cwd,
-      maxBuffer: MAX_OUTPUT_LENGTH,
-      signal: ctx.abort,
-      timeout: timeout,
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    await process.exited
-    const stdout = await new Response(process.stdout).text()
-    const stderr = await new Response(process.stderr).text()
+  const generatedWith = "🤖 Generated with [opencode](https://opencode.ai)"
+  const coAuthoredBy = `${generatedWith}
 
-    return {
-      title: params.command,
-      metadata: {
-        stderr,
-        stdout,
-        exit: process.exitCode,
-        description: params.description,
-      },
-      output: [`<stdout>`, stdout ?? "", `</stdout>`, `<stderr>`, stderr ?? "", `</stderr>`].join("\n"),
-    }
-  },
+   Co-Authored-By: opencode <noreply@opencode.ai>`
+
+  const commitCoAuthored1 = ` ending with:\n   ${coAuthoredBy}`
+  const commitCoAuthored2 = `\n\n   ${coAuthoredBy}`
+  const prCoAuthored = `\n\n${generatedWith}`
+
+  return DESCRIPTION.replace("${commitCoAuthored1}", commitCoAuthored1)
+    .replace("${commitCoAuthored2}", commitCoAuthored2)
+    .replace("${prCoAuthored}", prCoAuthored)
+}
+
+export const BashTool = Tool.define("bash", async () => {
+  const cfg = await Config.get()
+  const description = replaceCoAuthoredMessage(cfg.include_co_authored_by ?? true)
+  return {
+    description,
+    parameters: z.object({
+      command: z.string().describe("The command to execute"),
+      timeout: z.number().min(0).max(MAX_TIMEOUT).describe("Optional timeout in milliseconds").optional(),
+      description: z
+        .string()
+        .describe(
+          "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
+        ),
+    }),
+    async execute(params, ctx) {
+      const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
+
+      const process = Bun.spawn({
+        cmd: ["bash", "-c", params.command],
+        cwd: App.info().path.cwd,
+        maxBuffer: MAX_OUTPUT_LENGTH,
+        signal: ctx.abort,
+        timeout: timeout,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      await process.exited
+      const stdout = await new Response(process.stdout).text()
+      const stderr = await new Response(process.stderr).text()
+
+      return {
+        title: params.command,
+        metadata: {
+          stderr,
+          stdout,
+          exit: process.exitCode,
+          description: params.description,
+        },
+        output: [`<stdout>`, stdout ?? "", `</stdout>`, `<stderr>`, stderr ?? "", `</stderr>`].join("\n"),
+      }
+    },
+  }
 })

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -59,10 +59,7 @@ When the user asks you to create a new git commit, follow these steps carefully:
 
 3. You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. ALWAYS run the following commands in parallel:
    - Add relevant untracked files to the staging area.
-   - Create the commit with a message ending with:
-   🤖 Generated with [opencode](https://opencode.ai)
-
-   Co-Authored-By: opencode <noreply@opencode.ai>
+   - Create the commit with a message${commitCoAuthored1}
    - Run git status to make sure the commit succeeded.
 
 4. If the commit fails due to pre-commit hook changes, retry the commit ONCE to include these automated changes. If it fails again, it usually means a pre-commit hook is preventing the commit. If the commit succeeds but you notice that files were modified by the pre-commit hook, you MUST amend your commit to include them.
@@ -79,11 +76,7 @@ Important notes:
 - In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
 <example>
 git commit -m "$(cat <<'EOF'
-   Commit message here.
-
-   🤖 Generated with [opencode](https://opencode.ai)
-
-   Co-Authored-By: opencode <noreply@opencode.ai>
+   Commit message here.${commitCoAuthored2}
    EOF
    )"
 </example>
@@ -126,9 +119,7 @@ gh pr create --title "the pr title" --body "$(cat <<'EOF'
 <1-3 bullet points>
 
 ## Test plan
-[Checklist of TODOs for testing the pull request...]
-
-🤖 Generated with [opencode](https://opencode.ai)
+[Checklist of TODOs for testing the pull request...]${prCoAuthored}
 EOF
 )"
 </example>


### PR DESCRIPTION
let me know if you want to merge this. I'll resolve the conflicts
and feel free to just close this PR if you don't want this to be added.

---

fix #919 

Add the `include_co_authored_by` option. The behavior is copied from Claude Code.

When it's true (default) the prompt remains unchanged. I copied the original prompt and verified it with a temporary test:

```ts
test("bash.txt", () => {
  const bashTxtPath = join(process.cwd(), "packages/opencode/src/tool/bash-backup.txt")
  const currentContent = readFileSync(bashTxtPath, "utf-8")
  expect(replaceCoAuthoredMessage()).toBe(currentContent)
})
```

And this is how the three places look when it's false. This should be the same as Claude Code:

1
<img width="578" height="108" alt="commit 1" src="https://github.com/user-attachments/assets/143815bc-5e85-4b6b-913a-1e4197074fc2" />

2
<img width="438" height="171" alt="commit 2" src="https://github.com/user-attachments/assets/719c7e89-d0ae-41a0-959b-725666cf4569" />

3
<img width="602" height="281" alt="commit 3" src="https://github.com/user-attachments/assets/82bb2172-2dae-4c5f-9fdd-dab075d16fa4" />

---

actual usage:

true:
<img width="575" height="286" alt="true" src="https://github.com/user-attachments/assets/1bd18f9b-b1a9-43c6-be23-427a1e1662f1" />

false:
<img width="487" height="179" alt="false" src="https://github.com/user-attachments/assets/08508ea5-68b7-41ec-abd6-8727e6006c0a" />