### PR TITLE
chore: fix null handling in multipartFormRequestOptions test

### DIFF
--- a/packages/sdk/tests/form.test.ts
+++ b/packages/sdk/tests/form.test.ts
@@ -18,7 +18,7 @@ describe('form data validation', () => {
   });
 
   test('null', async () => {
-    await expect(() =>
+    await expect(
       multipartFormRequestOptions(
         {
           body: {


### PR DESCRIPTION
Fix a failing test in `dev` branch

```
bun test ./packages/sdk/tests/form.test.ts --only
bun test v1.2.19 (aad3abea)

packages/sdk/tests/form.test.ts:
25 |             null: null,
26 |           },
27 |         },
28 |         fetch,
29 |       ),
30 |     ).rejects.toThrow(TypeError);
                   ^
error: 

Expected promise           <----------- THE ISSUE
Received: [Function]

      at <anonymous> (/Users/ubi/Developer/github.com/sst/opencode/packages/sdk/tests/form.test.ts:30:15)
      at <anonymous> (/Users/ubi/Developer/github.com/sst/opencode/packages/sdk/tests/form.test.ts:20:21)
✗ form data validation > null [0.44ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [14.00ms]
```