### PR TITLE
fix: update file name extraction in uploads test to use __filename

### DIFF
--- a/packages/sdk/tests/uploads.test.ts
+++ b/packages/sdk/tests/uploads.test.ts
@@ -51,7 +51,7 @@ describe('toFile', () => {
   });
 
   it('extracts a file name from a ReadStream', async () => {
-    const input = fs.createReadStream('tests/uploads.test.ts');
+    const input = fs.createReadStream(__filename);
     const file = await toFile(input);
     expect(file.name).toEqual('uploads.test.ts');
   });


### PR DESCRIPTION
Fixing:

```
ENOENT: no such file or directory, open '/Users/ubi/Developer/github.com/sst/opencode/tests/uploads.test.ts'
    path: "/Users/ubi/Developer/github.com/sst/opencode/tests/uploads.test.ts",
 syscall: "open",
   errno: -2,
    code: "ENOENT"

✗ toFile > extracts a file name from a ReadStream [3.94ms]
```