### PR TITLE
build: add @octokit/rest to opencode dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@clack/prompts": "0.11.0",
         "@hono/zod-validator": "0.4.2",
         "@modelcontextprotocol/sdk": "1.15.1",
+        "@octokit/graphql": "9.0.1",
         "@octokit/rest": "22.0.0",
         "@openauthjs/openauth": "0.4.3",
         "@standard-schema/spec": "1.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@clack/prompts": "0.11.0",
         "@hono/zod-validator": "0.4.2",
         "@modelcontextprotocol/sdk": "1.15.1",
+        "@octokit/rest": "22.0.0",
         "@openauthjs/openauth": "0.4.3",
         "@standard-schema/spec": "1.0.0",
         "@zip.js/zip.js": "2.7.62",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -33,6 +33,7 @@
     "@clack/prompts": "0.11.0",
     "@hono/zod-validator": "0.4.2",
     "@modelcontextprotocol/sdk": "1.15.1",
+    "@octokit/rest": "22.0.0",
     "@openauthjs/openauth": "0.4.3",
     "@standard-schema/spec": "1.0.0",
     "@zip.js/zip.js": "2.7.62",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -33,6 +33,7 @@
     "@clack/prompts": "0.11.0",
     "@hono/zod-validator": "0.4.2",
     "@modelcontextprotocol/sdk": "1.15.1",
+    "@octokit/graphql": "9.0.1",
     "@octokit/rest": "22.0.0",
     "@openauthjs/openauth": "0.4.3",
     "@standard-schema/spec": "1.0.0",


### PR DESCRIPTION
Closes #1392 .

Adds `@octokit/rest` to the dependencies for the `opencode` package.