### PR TITLE
fix(tui): text selection for copying messages is not cleared when clicking and releasing without dragging

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -131,15 +131,18 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.MouseReleaseMsg:
-		if m.selection != nil && len(m.clipboard) > 0 {
-			content := strings.Join(m.clipboard, "\n")
+		if m.selection != nil {
 			m.selection = nil
-			m.clipboard = []string{}
-			return m, tea.Sequence(
-				m.renderView(),
-				app.SetClipboard(content),
-				toast.NewSuccessToast("Copied to clipboard"),
-			)
+			if len(m.clipboard) > 0 {
+				content := strings.Join(m.clipboard, "\n")
+				m.clipboard = []string{}
+				return m, tea.Sequence(
+					m.renderView(),
+					app.SetClipboard(content),
+					toast.NewSuccessToast("Copied to clipboard"),
+				)
+			}
+			return m, m.renderView()
 		}
 	case tea.WindowSizeMsg:
 		effectiveWidth := msg.Width - 4


### PR DESCRIPTION
> [!NOTE]
> This issue was only observed when running within tmux; couldn't replicate when running outside of tmux.

This fixes an issue where clicking on message text and releasing without dragging causes the user to be stuck in a text selection state. Moving the mouse around in this state causes text to be highlighted. The user can only get out of this state by successfully triggering a copy by clicking and dragging.

Before:

https://github.com/user-attachments/assets/86d93c65-27c6-4807-9275-85fe34d66386

After:

https://github.com/user-attachments/assets/bae8eeaf-3ebf-4c32-a01d-df3563dc8eef