### PR TITLE
Use responses API for Azure

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,15 +1,15 @@
+import { NoSuchModelError, type LanguageModel, type Provider as SDK } from "ai"
+import { mergeDeep, sortBy } from "remeda"
 import z from "zod"
 import { App } from "../app/app"
-import { Config } from "../config/config"
-import { mergeDeep, sortBy } from "remeda"
-import { NoSuchModelError, type LanguageModel, type Provider as SDK } from "ai"
-import { Log } from "../util/log"
-import { BunProc } from "../bun"
+import { Auth } from "../auth"
 import { AuthAnthropic } from "../auth/anthropic"
 import { AuthCopilot } from "../auth/copilot"
-import { ModelsDev } from "./models"
+import { BunProc } from "../bun"
+import { Config } from "../config/config"
 import { NamedError } from "../util/error"
-import { Auth } from "../auth"
+import { Log } from "../util/log"
+import { ModelsDev } from "./models"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -118,6 +118,15 @@ export namespace Provider {
       }
     },
     openai: async () => {
+      return {
+        autoload: false,
+        async getModel(sdk: any, modelID: string) {
+          return sdk.responses(modelID)
+        },
+        options: {},
+      }
+    },
+    azure: async () => {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,15 +1,15 @@
-import { NoSuchModelError, type LanguageModel, type Provider as SDK } from "ai"
-import { mergeDeep, sortBy } from "remeda"
 import z from "zod"
 import { App } from "../app/app"
-import { Auth } from "../auth"
+import { Config } from "../config/config"
+import { mergeDeep, sortBy } from "remeda"
+import { NoSuchModelError, type LanguageModel, type Provider as SDK } from "ai"
+import { Log } from "../util/log"
+import { BunProc } from "../bun"
 import { AuthAnthropic } from "../auth/anthropic"
 import { AuthCopilot } from "../auth/copilot"
-import { BunProc } from "../bun"
-import { Config } from "../config/config"
-import { NamedError } from "../util/error"
-import { Log } from "../util/log"
 import { ModelsDev } from "./models"
+import { NamedError } from "../util/error"
+import { Auth } from "../auth"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -74,7 +74,8 @@ export namespace ToolRegistry {
       modelID.toLowerCase().includes("qwen") ||
       modelID.includes("gpt-") ||
       modelID.includes("o1") ||
-      modelID.includes("o3")
+      modelID.includes("o3") ||
+      modelID.includes("codex")
     ) {
       return {
         patch: false,


### PR DESCRIPTION
This uses the same implementation as the openai provider to allow for use of models which require the responses API.

Tested on o4-mini, codex-mini and gpt-4.1 without any obvious issues.
I am getting a warning about the weather mcp tool but that happens with upstream dev as well.

Fixes #1413 