### PR TITLE
feat: jsonc configuration file support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "hono": "catalog:",
         "hono-openapi": "0.4.8",
         "isomorphic-git": "1.32.1",
+        "jsonc-parser": "3.3.1",
         "open": "10.1.2",
         "remeda": "2.22.3",
         "turndown": "7.2.0",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -45,6 +45,7 @@
     "hono": "catalog:",
     "hono-openapi": "0.4.8",
     "isomorphic-git": "1.32.1",
+    "jsonc-parser": "3.3.1",
     "open": "10.1.2",
     "remeda": "2.22.3",
     "turndown": "7.2.0",

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -5,7 +5,11 @@ import { UI } from "./ui"
 export function FormatError(input: unknown) {
   if (MCP.Failed.isInstance(input))
     return `MCP server "${input.data.name}" failed. Note, opencode does not support MCP authentication yet.`
-  if (Config.JsonError.isInstance(input)) return `Config file at ${input.data.path} is not valid JSON`
+  if (Config.JsonError.isInstance(input)) {
+    return (
+      `Config file at ${input.data.path} is not valid JSON(C)` + (input.data.message ? `: ${input.data.message}` : "")
+    )
+  }
   if (Config.InvalidError.isInstance(input))
     return [
       `Config file at ${input.data.path} is invalid`,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -12,6 +12,7 @@ import { NamedError } from "../util/error"
 import matter from "gray-matter"
 import { Flag } from "../flag/flag"
 import { Auth } from "../auth"
+import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -336,11 +337,20 @@ export namespace Config {
       }
     }
 
-    let data: any
-    try {
-      data = JSON.parse(text)
-    } catch (err) {
-      throw new JsonError({ path: configPath }, { cause: err as Error })
+    const errors: JsoncParseError[] = []
+    const data = parseJsonc(text, errors, { allowTrailingComma: true })
+    if (errors.length) {
+      throw new JsonError({
+        path: configPath,
+        message: errors
+          .map((e) => {
+            const lines = text.substring(0, e.offset).split("\n")
+            const line = lines.length
+            const column = lines[lines.length - 1].length + 1
+            return `${printParseErrorCode(e.error)} at line ${line}, column ${column}`
+          })
+          .join("; "),
+      })
     }
 
     const parsed = Info.safeParse(data)
@@ -357,6 +367,7 @@ export namespace Config {
     "ConfigJsonError",
     z.object({
       path: z.string(),
+      message: z.string().optional(),
     }),
   )
 

--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -5,9 +5,14 @@ description: Using the opencode JSON config.
 
 You can configure opencode using a JSON config file.
 
-```json title="opencode.json"
+## Format
+
+opencode supports both JSON and JSONC (JSON with Comments) formats. You can use comments in your configuration files:
+
+```jsonc title="opencode.jsonc"
 {
   "$schema": "https://opencode.ai/config.json",
+  // Theme configuration
   "theme": "opencode",
   "model": "anthropic/claude-sonnet-4-20250514",
   "autoupdate": true
@@ -199,7 +204,7 @@ about rules here](/docs/rules).
 
 You can configure specialized agents for specific tasks through the `agent` option.
 
-```json title="opencode.json"
+```jsonc title="opencode.jsonc"
 {
   "$schema": "https://opencode.ai/config.json",
   "agent": {
@@ -208,6 +213,7 @@ You can configure specialized agents for specific tasks through the `agent` opti
       "model": "anthropic/claude-sonnet-4-20250514",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
       "tools": {
+        // Disable file modification tools for review-only agent
         "write": false,
         "edit": false
       }


### PR DESCRIPTION
addresses: #995 

This is fairly simple, uses the standard jsonc parsing lib by microsoft. 

Very similar pattern is seen in wrangler see [here](https://github.com/cloudflare/workers-sdk/blob/6e6d4a8c95b720bf8b1d64b5d21c7c737454e6d4/packages/wrangler/src/parse.ts#L174)

I noticed opencode already picks up `opencode.jsonc` but ofc it will break if the person actually has any comments since JSON.parse was used instead of jsonc parsing.