### PR TITLE
Build script (`build`, `publish`, `build:install`) and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,29 @@ $ bun install
 $ bun run packages/opencode/src/index.ts
 ```
 
+#### Building and Installing Locally
+
+For development and testing, you can build and install opencode locally:
+
+```bash
+# Build and install for your platform
+bun run build:install <platform>
+
+# Examples:
+bun run build:install darwin-arm64     # macOS Apple Silicon
+bun run build:install darwin-x64      # macOS Intel
+bun run build:install linux-arm64     # Linux ARM64
+bun run build:install linux-x64       # Linux x64
+```
+
+Available platforms:
+
+- `linux-arm64`, `linux-x64`, `linux-x64-baseline`
+- `darwin-arm64`, `darwin-x64`
+- `windows-x64`
+
+This will build the project and install the binary to `~/.opencode/bin/opencode`, allowing you to test your changes locally.
+
 #### Development Notes
 
 **API Client**: After making changes to the TypeScript API endpoints in `packages/opencode/src/server/server.ts`, you will need the opencode team to generate a new stainless sdk for the clients.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "bun run packages/opencode/src/index.ts",
     "typecheck": "bun run --filter='*' typecheck",
     "stainless": "./scripts/stainless",
-    "postinstall": "./scripts/hooks"
+    "postinstall": "./scripts/hooks",
+    "build:install": "./scripts/build.sh"
   },
   "workspaces": {
     "packages": [

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -12,4 +12,64 @@ To run:
 bun run index.ts
 ```
 
+## Build
+
+The publish script (`./script/publish.ts`) handles building and releasing opencode across multiple platforms.
+
+### Target Platforms
+
+The build process creates artifacts for the following platforms:
+
+- **Linux**
+  - `linux-arm64`
+  - `linux-x64`
+  - `linux-x64-baseline`
+- **macOS (Darwin)**
+  - `darwin-x64`
+  - `darwin-arm64`
+- **Windows**
+  - `windows-x64`
+
+### Options
+
+- `--dry` - Perform a dry run without actually publishing packages or creating releases
+- `--snapshot` - Create a snapshot release with timestamp-based version (format: `0.0.0-YYYYMMDDHHMM`)
+
+### Usage
+
+```bash
+# Dry run to test the build process
+./script/publish.ts --dry
+
+# Create a snapshot release (dry run)
+./script/publish.ts --snapshot --dry
+
+# Create a snapshot release
+./script/publish.ts --snapshot
+
+# Create a full release (requires git tag)
+./script/publish.ts
+```
+
+### Build Process
+
+The script performs the following steps:
+
+1. **Version determination**: Uses git tags for releases or timestamp for snapshots
+2. **Cross-platform builds**: Builds for Linux, macOS, and Windows (x64/arm64)
+3. **Package creation**: Creates platform-specific npm packages with optional dependencies
+4. **Publishing**: Publishes to npm with appropriate tags (`latest` or `snapshot`)
+5. **Release artifacts** (non-snapshot only):
+   - Creates GitHub release with changelog
+   - Updates AUR packages (`opencode` and `opencode-bin`)
+   - Updates Homebrew formula in `sst/homebrew-tap`
+
+### Requirements
+
+- Bun runtime
+- Go compiler (for TUI component)
+- Git with appropriate permissions
+- GitHub CLI (`gh`) for releases
+- Environment variable `GITHUB_TOKEN` for Homebrew updates
+
 This project was created using `bun init` in bun v1.2.12. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -34,6 +34,7 @@ The build process creates artifacts for the following platforms:
 
 - `--dry` - Perform a dry run without actually publishing packages or creating releases
 - `--snapshot` - Create a snapshot release with timestamp-based version (format: `0.0.0-YYYYMMDDHHMM`)
+- `--rc` - Create a release candidate with current version + git commit hash (format: `0.0.5-rcabcd123`)
 
 #### Snapshot Versions
 
@@ -45,11 +46,25 @@ Snapshot versions are temporary builds used for testing and development. They:
 - Are useful for testing builds before creating official releases
 - Can be installed with `npm install opencode-ai@snapshot`
 
+#### Release Candidate Versions
+
+Release candidate versions are pre-release builds that use the current package version with an RC suffix:
+
+- Use current version + RC + 7-character git commit hash (e.g., `0.0.5-rcabcd123`)
+- Are published to npm with the `rc` tag instead of `latest`
+- Don't create GitHub releases, AUR packages, or Homebrew formula updates
+- Are useful for testing specific versions before full releases
+- Can be installed with `npm install opencode-ai@rc`
+- The git hash ensures the version corresponds to the exact code being built
+
 ### Usage
 
 ```bash
-# Build and test locally (equivalent to: bun run publish --snapshot --dry)
+# Build and test locally (equivalent to: bun run publish --rc --dry)
 bun run build
+
+# Publish a release candidate
+bun run publish --rc
 
 # Publish a snapshot release
 bun run publish --snapshot
@@ -62,8 +77,8 @@ bun run publish
 
 The build process uses two main commands:
 
-- **`bun run build`** - This is a shorthand for `bun run publish --snapshot --dry`
-  - `--snapshot`: Creates a timestamp-based version for testing
+- **`bun run build`** - This is a shorthand for `bun run publish --rc --dry`
+  - `--rc`: Creates a release candidate with current version + git commit hash
   - `--dry`: Performs a dry run without actually publishing anything
 - **`bun run publish`** - Actually publishes packages and creates releases.
   Short hand for `./script/publish.ts`.
@@ -74,11 +89,11 @@ This separation allows you to safely test the build process before publishing.
 
 The script performs the following steps:
 
-1. **Version determination**: Uses git tags for releases or timestamp for snapshots
+1. **Version determination**: Uses git tags for releases, timestamp for snapshots, or current version + git hash for RC
 2. **Cross-platform builds**: Builds for Linux, macOS, and Windows (x64/arm64)
 3. **Package creation**: Creates platform-specific npm packages with optional dependencies
-4. **Publishing**: Publishes to npm with appropriate tags (`latest` or `snapshot`)
-5. **Release artifacts** (non-snapshot only):
+4. **Publishing**: Publishes to npm with appropriate tags (`latest`, `snapshot`, or `rc`)
+5. **Release artifacts** (non-snapshot and non-RC only):
    - Creates GitHub release with changelog
    - Updates AUR packages (`opencode` and `opencode-bin`)
    - Updates Homebrew formula in `sst/homebrew-tap`

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -35,21 +35,40 @@ The build process creates artifacts for the following platforms:
 - `--dry` - Perform a dry run without actually publishing packages or creating releases
 - `--snapshot` - Create a snapshot release with timestamp-based version (format: `0.0.0-YYYYMMDDHHMM`)
 
+#### Snapshot Versions
+
+Snapshot versions are temporary builds used for testing and development. They:
+
+- Use timestamp-based versioning (e.g., `0.0.0-202412151430` for Dec 15, 2024 at 14:30)
+- Are published to npm with the `snapshot` tag instead of `latest`
+- Don't create GitHub releases, AUR packages, or Homebrew formula updates
+- Are useful for testing builds before creating official releases
+- Can be installed with `npm install opencode-ai@snapshot`
+
 ### Usage
 
 ```bash
-# Dry run to test the build process
-./script/publish.ts --dry
+# Build and test locally (equivalent to: bun run publish --snapshot --dry)
+bun run build
 
-# Create a snapshot release (dry run)
-./script/publish.ts --snapshot --dry
+# Publish a snapshot release
+bun run publish --snapshot
 
-# Create a snapshot release
-./script/publish.ts --snapshot
-
-# Create a full release (requires git tag)
-./script/publish.ts
+# Publish a full release (requires git tag)
+bun run publish
 ```
+
+### Publishing
+
+The build process uses two main commands:
+
+- **`bun run build`** - This is a shorthand for `bun run publish --snapshot --dry`
+  - `--snapshot`: Creates a timestamp-based version for testing
+  - `--dry`: Performs a dry run without actually publishing anything
+- **`bun run publish`** - Actually publishes packages and creates releases.
+  Short hand for `./script/publish.ts`.
+
+This separation allows you to safely test the build process before publishing.
 
 ### Build Process
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "dev": "bun run ./src/index.ts",
-    "build": "bun run ./script/publish.ts --snapshot --dry",
+    "build": "bun run ./script/publish.ts --rc --dry",
     "publish": "bun run ./script/publish.ts"
   },
   "bin": {

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -6,7 +6,9 @@
   "private": true,
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "dev": "bun run ./src/index.ts"
+    "dev": "bun run ./src/index.ts",
+    "build": "bun run ./script/publish.ts --snapshot --dry",
+    "publish": "bun run ./script/publish.ts"
   },
   "bin": {
     "opencode": "./bin/opencode"

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -6,9 +6,14 @@ import pkg from "../package.json"
 
 const dry = process.argv.includes("--dry")
 const snapshot = process.argv.includes("--snapshot")
+const rc = process.argv.includes("--rc")
+
+const shortcode = async () => await $`git rev-parse HEAD`.text().then(x => x.trim().slice(0, 7))
 
 const version = snapshot
   ? `0.0.0-${new Date().toISOString().slice(0, 16).replace(/[-:T]/g, "")}`
+  : rc
+  ? `${pkg.version}-rc${await shortcode()}`
   : await $`git describe --tags --abbrev=0`
       .text()
       .then((x) => x.substring(1).trim())
@@ -37,7 +42,7 @@ const targets = [
 await $`rm -rf dist`
 
 const optionalDependencies: Record<string, string> = {}
-const npmTag = snapshot ? "snapshot" : "latest"
+const npmTag = snapshot ? "snapshot" : rc ? "rc" : "latest"
 for (const [os, arch] of targets) {
   console.log(`building ${os}-${arch}`)
   const name = `${pkg.name}-${os}-${arch}`
@@ -85,7 +90,7 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
 )
 if (!dry) await $`cd ./dist/${pkg.name} && bun publish --access public --tag ${npmTag}`
 
-if (!snapshot) {
+if (!snapshot && !rc) {
   // Github Release
   for (const key of Object.keys(optionalDependencies)) {
     await $`cd dist/${key}/bin && zip -r ../../${key}.zip *`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Function to show usage
+usage() {
+    echo "Usage: $0 <platform>"
+    echo "Available platforms:"
+    echo "  linux-arm64"
+    echo "  linux-x64"
+    echo "  linux-x64-baseline"
+    echo "  darwin-arm64"
+    echo "  darwin-x64"
+    echo "  windows-x64"
+    echo ""
+    echo "Example: $0 darwin-arm64"
+    exit 1
+}
+
+# Check if platform argument is provided
+if [ $# -eq 0 ]; then
+    echo "Error: Platform argument is required"
+    usage
+fi
+
+PLATFORM=$1
+
+# Validate platform
+case "$PLATFORM" in
+    linux-arm64|linux-x64|linux-x64-baseline|darwin-arm64|darwin-x64|windows-x64)
+        ;;
+    *)
+        echo "Error: Invalid platform '$PLATFORM'"
+        usage
+        ;;
+esac
+
+# Build the project
+echo "Building opencode for $PLATFORM..."
+cd packages/opencode
+bun run build
+
+# Determine binary name (Windows uses .exe)
+BINARY_NAME="opencode"
+if [[ "$PLATFORM" == windows-* ]]; then
+    BINARY_NAME="opencode.exe"
+fi
+
+# Source path
+SOURCE_PATH="dist/opencode-$PLATFORM/bin/$BINARY_NAME"
+
+# Check if built binary exists
+if [ ! -f "$SOURCE_PATH" ]; then
+    echo "Error: Built binary not found at $SOURCE_PATH"
+    echo "Available files in dist/:"
+    ls -la dist/ || echo "dist/ directory not found"
+    exit 1
+fi
+
+# Create target directory
+TARGET_DIR="$HOME/.opencode/bin"
+mkdir -p "$TARGET_DIR"
+
+# Copy binary to target location
+TARGET_PATH="$TARGET_DIR/opencode"
+echo "Installing binary to $TARGET_PATH..."
+cp "$SOURCE_PATH" "$TARGET_PATH"
+
+# Make it executable
+chmod +x "$TARGET_PATH"
+
+echo "✅ Successfully installed opencode to $TARGET_PATH"
+echo "You can now run: ~/.opencode/bin/opencode" 


### PR DESCRIPTION
## Motivation

I wanted an easy way to build and then install the build on my system. So I had to figure out how the publish script is also the build script. I mad `build` and `publish` scripts for opencode package. Once we have those, I made a `build:install` script at the top of the repo which runs build and them moves the binary to an install location.

The rest below is AI slop to explain the details.

---

## 🚀 Improve Build System and Developer Experience

This PR significantly enhances the build system and developer workflow with better tooling, documentation, and local development capabilities.

### ✨ Features Added

#### 📦 Enhanced Build Scripts
- **New `build` and `publish` npm scripts** with clear separation of concerns
  - `bun run build` - Safe dry-run testing (equivalent to `publish --rc --dry`)
  - `bun run publish` - Actual publishing with various options
- **Release Candidate (RC) versions** with `--rc` flag
  - Format: `0.0.5-rcabcd123` (current version + git commit hash)
  - Published to npm with `rc` tag for pre-release testing
  - Git hash ensures versions correspond to exact code being built

#### 🛠 Local Development Tools
- **New `build:install` script** for local binary installation
  - Supports all target platforms with validation
  - Installs to `~/.opencode/bin/opencode` for local testing
  - Platform examples: `bun run build:install darwin-arm64`

#### 📋 Comprehensive Documentation
- **Target Platforms section** listing all supported build artifacts:
  - Linux: `arm64`, `x64`, `x64-baseline`
  - macOS: `arm64`, `x64` 
  - Windows: `x64`
- **Complete build workflow documentation** with usage examples
- **RC and snapshot version explanations** with installation instructions

### 🔧 Technical Improvements

#### Build System
- **Safer default workflow**: `build` now uses RC versions instead of snapshots
- **Git-based versioning**: RC versions use actual commit hashes for traceability
- **Platform validation**: Build script validates target platforms with helpful error messages
- **Cross-platform support**: Handles Windows `.exe` extension automatically

#### Developer Experience
- **Clear separation**: Build (testing) vs Publish (releasing)
- **Better version tracking**: RC versions tied to specific git commits
- **Local testing**: Easy installation of development builds
- **Comprehensive docs**: Clear usage examples and explanations

### 📚 Documentation Updates

- Added target platforms list to build section
- Comprehensive RC workflow documentation
- Local development build instructions
- Updated all usage examples to reflect new scripts
- Added installation instructions for different version types

### 🎯 Benefits

- **Safer development**: Default `build` command won't accidentally publish
- **Better version tracking**: RC versions correspond to exact git commits
- **Easier local testing**: One command to build and install locally
- **Clear workflow**: Separation between testing and publishing
- **Comprehensive docs**: Everything developers need to contribute

### 🔄 Migration

No breaking changes - existing workflows continue to work. New scripts provide enhanced developer experience while maintaining backward compatibility.

---

**Commits:**
- feat(build): add --rc flag for release candidate versions
- feat(build): add build:install script for local development  
- feat(build): add build and publish npm scripts with improved workflow
- docs(build): add target platforms list to build section