### PR TITLE
fix(editor): handle UTF-8 characters properly in SetValueWithAttachments

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/v2/spinner"
 	tea "github.com/charmbracelet/bubbletea/v2"
@@ -517,14 +518,18 @@ func (m *editorComponent) SetValueWithAttachments(value string) {
 
 	i := 0
 	for i < len(value) {
+		r, size := utf8.DecodeRuneInString(value[i:])
 		// Check if filepath and add attachment
-		if value[i] == '@' {
-			start := i + 1
+		if r == '@' {
+			start := i + size
 			end := start
-			for end < len(value) && value[end] != ' ' && value[end] != '\t' && value[end] != '\n' && value[end] != '\r' {
-				end++
+			for end < len(value) {
+				nextR, nextSize := utf8.DecodeRuneInString(value[end:])
+				if nextR == ' ' || nextR == '\t' || nextR == '\n' || nextR == '\r' {
+					break
+				}
+				end += nextSize
 			}
-
 			if end > start {
 				filePath := value[start:end]
 				slog.Debug("test", "filePath", filePath)
@@ -541,8 +546,8 @@ func (m *editorComponent) SetValueWithAttachments(value string) {
 		}
 
 		// Not a valid file path, insert the character normally
-		m.textarea.InsertRune(rune(value[i]))
-		i++
+		m.textarea.InsertRune(r)
+		i += size
 	}
 }
 


### PR DESCRIPTION
## Problem

Content returned from `$EDITOR` displays strange characters if it is multi-byte UTF-8 character.


The `SetValueWithAttachments` function was using byte-based string indexing which causes issues.

---

Before:

https://github.com/user-attachments/assets/ead9aa08-53e1-469e-abed-f80d5ddcd189


After:

https://github.com/user-attachments/assets/eac0e121-1bf6-4a2c-9236-5091ce678634

