### PR TITLE
feat: add experimental hook for permission requested event

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -312,6 +312,13 @@ export namespace Config {
                     .array(),
                 )
                 .optional(),
+              permission_requested: z
+                .object({
+                  command: z.string().array(),
+                  environment: z.record(z.string(), z.string()).optional(),
+                })
+                .array()
+                .optional(),
               session_completed: z
                 .object({
                   command: z.string().array(),

--- a/packages/opencode/src/config/hooks.ts
+++ b/packages/opencode/src/config/hooks.ts
@@ -1,6 +1,7 @@
 import { App } from "../app/app"
 import { Bus } from "../bus"
 import { File } from "../file"
+import { Permission } from "../permission"
 import { Session } from "../session"
 import { Log } from "../util/log"
 import { Config } from "./config"
@@ -28,6 +29,24 @@ export namespace ConfigHooks {
           stdout: "ignore",
           stderr: "ignore",
         })
+      }
+    })
+
+    Bus.subscribe(Permission.Event.Updated, async () => {
+      const cfg = await Config.get()
+      if (cfg.experimental?.hook?.permission_requested) {
+        for (const item of cfg.experimental.hook.permission_requested) {
+          log.info("permission_requested", {
+            command: item.command,
+          })
+          Bun.spawn({
+            cmd: item.command,
+            cwd: App.info().path.cwd,
+            env: item.environment,
+            stdout: "ignore",
+            stderr: "ignore",
+          })
+        }
       }
     })
 


### PR DESCRIPTION
This introduces an experimental `permission_requested` hook that is triggered when permission is requested, similar to the existing `session_completed` hook.

My use case for these hooks is to trigger a sound/notification so I know that it is either blocked or done.