### PR TITLE
Add an option to exclude OpenCode branding from commits

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -245,6 +245,10 @@ export namespace Config {
         .string()
         .optional()
         .describe("Custom username to display in conversations instead of system username"),
+      include_co_authored_by: z
+        .boolean()
+        .optional()
+        .describe("Include opencode branding and co-authoring in commit messages"),
       mode: z
         .object({
           build: Mode.optional(),

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -24,125 +24,126 @@ const parser = lazy(async () => {
   return p
 })
 
-export const BashTool = Tool.define("bash", async () => {
-  const cfg = await Config.get()
-  const includeCoAuthoredBy = cfg.include_co_authored_by ?? true
-  const description = DESCRIPTION.replace(
-    /If the user's config has include_co_authored_by set to true \(default\), end the message with:/g,
-    `The user's config has include_co_authored_by set to ${includeCoAuthoredBy}. ${includeCoAuthoredBy ? "End the message with:" : "Use only the commit message without any opencode branding."}`,
-  )
+export const BashTool = Tool.define("bash", {
+  description:
+    DESCRIPTION +
+    "\n\nIMPORTANT: When creating git commits, check the user's config. If include_co_authored_by is false, do NOT include any opencode branding (🤖 Generated with opencode or Co-Authored-By lines). If include_co_authored_by is true or undefined, include the standard opencode branding.",
+  parameters: z.object({
+    command: z.string().describe("The command to execute"),
+    timeout: z.number().describe("Optional timeout in milliseconds").optional(),
+    description: z
+      .string()
+      .describe(
+        "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
+      ),
+  }),
+  async execute(params, ctx) {
+    const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
+    const app = App.info()
+    const cfg = await Config.get()
+    const includeCoAuthoredBy = cfg.include_co_authored_by ?? true
 
-  return {
-    description,
-    parameters: z.object({
-      command: z.string().describe("The command to execute"),
-      timeout: z.number().describe("Optional timeout in milliseconds").optional(),
-      description: z
-        .string()
-        .describe(
-          "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-        ),
-    }),
-    async execute(params, ctx) {
-      const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
-      const app = App.info()
-      const cfg = await Config.get()
-      const tree = await parser().then((p) => p.parse(params.command))
-      const permissions = (() => {
-        const value = cfg.permission?.bash
-        if (!value)
-          return {
-            "*": "allow",
-          }
-        if (typeof value === "string")
-          return {
-            "*": value,
-          }
-        return value
-      })()
+    // Add config info to context for git commits
+    ctx.metadata({
+      title: `Config: include_co_authored_by=${includeCoAuthoredBy}`,
+      metadata: { include_co_authored_by: includeCoAuthoredBy },
+    })
 
-      let needsAsk = false
-      for (const node of tree.rootNode.descendantsOfType("command")) {
-        const command = []
-        for (let i = 0; i < node.childCount; i++) {
-          const child = node.child(i)
-          if (!child) continue
-          if (
-            child.type !== "command_name" &&
-            child.type !== "word" &&
-            child.type !== "string" &&
-            child.type !== "raw_string" &&
-            child.type !== "concatenation"
-          ) {
-            continue
-          }
-          command.push(child.text)
+    const tree = await parser().then((p) => p.parse(params.command))
+    const permissions = (() => {
+      const value = cfg.permission?.bash
+      if (!value)
+        return {
+          "*": "allow",
         }
-
-        // not an exhaustive list, but covers most common cases
-        if (["cd", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown"].includes(command[0])) {
-          for (const arg of command.slice(1)) {
-            if (arg.startsWith("-")) continue
-            const resolved = await $`realpath ${arg}`.text().then((x) => x.trim())
-            log.info("resolved path", { arg, resolved })
-            if (!Filesystem.contains(app.path.cwd, resolved)) {
-              throw new Error(
-                `This command references paths outside of ${app.path.cwd} so it is not allowed to be executed.`,
-              )
-            }
-          }
+      if (typeof value === "string")
+        return {
+          "*": value,
         }
+      return value
+    })()
 
-        // always allow cd if it passes above check
-        if (!needsAsk && command[0] !== "cd") {
-          const ask = (() => {
-            for (const [pattern, value] of Object.entries(permissions)) {
-              const match = Wildcard.match(node.text, pattern)
-              log.info("checking", { text: node.text.trim(), pattern, match })
-              if (match) return value
-            }
-            return "ask"
-          })()
-          if (ask === "ask") needsAsk = true
+    let needsAsk = false
+    for (const node of tree.rootNode.descendantsOfType("command")) {
+      const command = []
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i)
+        if (!child) continue
+        if (
+          child.type !== "command_name" &&
+          child.type !== "word" &&
+          child.type !== "string" &&
+          child.type !== "raw_string" &&
+          child.type !== "concatenation"
+        ) {
+          continue
+        }
+        command.push(child.text)
+      }
+
+      // not an exhaustive list, but covers most common cases
+      if (["cd", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown"].includes(command[0])) {
+        for (const arg of command.slice(1)) {
+          if (arg.startsWith("-")) continue
+          const resolved = await $`realpath ${arg}`.text().then((x) => x.trim())
+          log.info("resolved path", { arg, resolved })
+          if (!Filesystem.contains(app.path.cwd, resolved)) {
+            throw new Error(
+              `This command references paths outside of ${app.path.cwd} so it is not allowed to be executed.`,
+            )
+          }
         }
       }
 
-      if (needsAsk) {
-        await Permission.ask({
-          type: "bash",
-          sessionID: ctx.sessionID,
-          messageID: ctx.messageID,
-          callID: ctx.callID,
-          title: params.command,
-          metadata: {
-            command: params.command,
-          },
-        })
+      // always allow cd if it passes above check
+      if (!needsAsk && command[0] !== "cd") {
+        const ask = (() => {
+          for (const [pattern, value] of Object.entries(permissions)) {
+            const match = Wildcard.match(node.text, pattern)
+            log.info("checking", { text: node.text.trim(), pattern, match })
+            if (match) return value
+          }
+          return "ask"
+        })()
+        if (ask === "ask") needsAsk = true
       }
+    }
 
-      const process = Bun.spawn({
-        cmd: ["bash", "-c", params.command],
-        cwd: app.path.cwd,
-        maxBuffer: MAX_OUTPUT_LENGTH,
-        signal: ctx.abort,
-        timeout: timeout,
-        stdout: "pipe",
-        stderr: "pipe",
-      })
-      await process.exited
-      const stdout = await new Response(process.stdout).text()
-      const stderr = await new Response(process.stderr).text()
-
-      return {
+    if (needsAsk) {
+      await Permission.ask({
+        type: "bash",
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+        callID: ctx.callID,
         title: params.command,
         metadata: {
-          stderr,
-          stdout,
-          exit: process.exitCode,
-          description: params.description,
+          command: params.command,
         },
-        output: [`<stdout>`, stdout ?? "", `</stdout>`, `<stderr>`, stderr ?? "", `</stderr>`].join("\n"),
-      }
-    },
-  }
+      })
+    }
+
+    const process = Bun.spawn({
+      cmd: ["bash", "-c", params.command],
+      cwd: app.path.cwd,
+      maxBuffer: MAX_OUTPUT_LENGTH,
+      signal: ctx.abort,
+      timeout: timeout,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    await process.exited
+    const stdout = await new Response(process.stdout).text()
+    const stderr = await new Response(process.stderr).text()
+
+    return {
+      title: params.command,
+      metadata: {
+        stderr,
+        stdout,
+        exit: process.exitCode,
+        description: params.description,
+      },
+      output: [`<stdout>`, stdout ?? "", `</stdout>`, `<stderr>`, stderr ?? "", `</stderr>`].join("\n"),
+    }
+  },
 })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -24,116 +24,125 @@ const parser = lazy(async () => {
   return p
 })
 
-export const BashTool = Tool.define("bash", {
-  description: DESCRIPTION,
-  parameters: z.object({
-    command: z.string().describe("The command to execute"),
-    timeout: z.number().describe("Optional timeout in milliseconds").optional(),
-    description: z
-      .string()
-      .describe(
-        "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-      ),
-  }),
-  async execute(params, ctx) {
-    const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
-    const app = App.info()
-    const cfg = await Config.get()
-    const tree = await parser().then((p) => p.parse(params.command))
-    const permissions = (() => {
-      const value = cfg.permission?.bash
-      if (!value)
-        return {
-          "*": "allow",
-        }
-      if (typeof value === "string")
-        return {
-          "*": value,
-        }
-      return value
-    })()
+export const BashTool = Tool.define("bash", async () => {
+  const cfg = await Config.get()
+  const includeCoAuthoredBy = cfg.include_co_authored_by ?? true
+  const description = DESCRIPTION.replace(
+    /If the user's config has include_co_authored_by set to true \(default\), end the message with:/g,
+    `The user's config has include_co_authored_by set to ${includeCoAuthoredBy}. ${includeCoAuthoredBy ? "End the message with:" : "Use only the commit message without any opencode branding."}`,
+  )
 
-    let needsAsk = false
-    for (const node of tree.rootNode.descendantsOfType("command")) {
-      const command = []
-      for (let i = 0; i < node.childCount; i++) {
-        const child = node.child(i)
-        if (!child) continue
-        if (
-          child.type !== "command_name" &&
-          child.type !== "word" &&
-          child.type !== "string" &&
-          child.type !== "raw_string" &&
-          child.type !== "concatenation"
-        ) {
-          continue
-        }
-        command.push(child.text)
-      }
+  return {
+    description,
+    parameters: z.object({
+      command: z.string().describe("The command to execute"),
+      timeout: z.number().describe("Optional timeout in milliseconds").optional(),
+      description: z
+        .string()
+        .describe(
+          "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
+        ),
+    }),
+    async execute(params, ctx) {
+      const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
+      const app = App.info()
+      const cfg = await Config.get()
+      const tree = await parser().then((p) => p.parse(params.command))
+      const permissions = (() => {
+        const value = cfg.permission?.bash
+        if (!value)
+          return {
+            "*": "allow",
+          }
+        if (typeof value === "string")
+          return {
+            "*": value,
+          }
+        return value
+      })()
 
-      // not an exhaustive list, but covers most common cases
-      if (["cd", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown"].includes(command[0])) {
-        for (const arg of command.slice(1)) {
-          if (arg.startsWith("-")) continue
-          const resolved = await $`realpath ${arg}`.text().then((x) => x.trim())
-          log.info("resolved path", { arg, resolved })
-          if (!Filesystem.contains(app.path.cwd, resolved)) {
-            throw new Error(
-              `This command references paths outside of ${app.path.cwd} so it is not allowed to be executed.`,
-            )
+      let needsAsk = false
+      for (const node of tree.rootNode.descendantsOfType("command")) {
+        const command = []
+        for (let i = 0; i < node.childCount; i++) {
+          const child = node.child(i)
+          if (!child) continue
+          if (
+            child.type !== "command_name" &&
+            child.type !== "word" &&
+            child.type !== "string" &&
+            child.type !== "raw_string" &&
+            child.type !== "concatenation"
+          ) {
+            continue
+          }
+          command.push(child.text)
+        }
+
+        // not an exhaustive list, but covers most common cases
+        if (["cd", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown"].includes(command[0])) {
+          for (const arg of command.slice(1)) {
+            if (arg.startsWith("-")) continue
+            const resolved = await $`realpath ${arg}`.text().then((x) => x.trim())
+            log.info("resolved path", { arg, resolved })
+            if (!Filesystem.contains(app.path.cwd, resolved)) {
+              throw new Error(
+                `This command references paths outside of ${app.path.cwd} so it is not allowed to be executed.`,
+              )
+            }
           }
         }
+
+        // always allow cd if it passes above check
+        if (!needsAsk && command[0] !== "cd") {
+          const ask = (() => {
+            for (const [pattern, value] of Object.entries(permissions)) {
+              const match = Wildcard.match(node.text, pattern)
+              log.info("checking", { text: node.text.trim(), pattern, match })
+              if (match) return value
+            }
+            return "ask"
+          })()
+          if (ask === "ask") needsAsk = true
+        }
       }
 
-      // always allow cd if it passes above check
-      if (!needsAsk && command[0] !== "cd") {
-        const ask = (() => {
-          for (const [pattern, value] of Object.entries(permissions)) {
-            const match = Wildcard.match(node.text, pattern)
-            log.info("checking", { text: node.text.trim(), pattern, match })
-            if (match) return value
-          }
-          return "ask"
-        })()
-        if (ask === "ask") needsAsk = true
+      if (needsAsk) {
+        await Permission.ask({
+          type: "bash",
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: params.command,
+          metadata: {
+            command: params.command,
+          },
+        })
       }
-    }
 
-    if (needsAsk) {
-      await Permission.ask({
-        type: "bash",
-        sessionID: ctx.sessionID,
-        messageID: ctx.messageID,
-        callID: ctx.callID,
+      const process = Bun.spawn({
+        cmd: ["bash", "-c", params.command],
+        cwd: app.path.cwd,
+        maxBuffer: MAX_OUTPUT_LENGTH,
+        signal: ctx.abort,
+        timeout: timeout,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      await process.exited
+      const stdout = await new Response(process.stdout).text()
+      const stderr = await new Response(process.stderr).text()
+
+      return {
         title: params.command,
         metadata: {
-          command: params.command,
+          stderr,
+          stdout,
+          exit: process.exitCode,
+          description: params.description,
         },
-      })
-    }
-
-    const process = Bun.spawn({
-      cmd: ["bash", "-c", params.command],
-      cwd: app.path.cwd,
-      maxBuffer: MAX_OUTPUT_LENGTH,
-      signal: ctx.abort,
-      timeout: timeout,
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    await process.exited
-    const stdout = await new Response(process.stdout).text()
-    const stderr = await new Response(process.stderr).text()
-
-    return {
-      title: params.command,
-      metadata: {
-        stderr,
-        stdout,
-        exit: process.exitCode,
-        description: params.description,
-      },
-      output: [`<stdout>`, stdout ?? "", `</stdout>`, `<stderr>`, stderr ?? "", `</stderr>`].join("\n"),
-    }
-  },
+        output: [`<stdout>`, stdout ?? "", `</stdout>`, `<stderr>`, stderr ?? "", `</stderr>`].join("\n"),
+      }
+    },
+  }
 })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -25,9 +25,7 @@ const parser = lazy(async () => {
 })
 
 export const BashTool = Tool.define("bash", {
-  description:
-    DESCRIPTION +
-    "\n\nIMPORTANT: When creating git commits, check the user's config. If include_co_authored_by is false, do NOT include any opencode branding (🤖 Generated with opencode or Co-Authored-By lines). If include_co_authored_by is true or undefined, include the standard opencode branding.",
+  description: DESCRIPTION,
   parameters: z.object({
     command: z.string().describe("The command to execute"),
     timeout: z.number().describe("Optional timeout in milliseconds").optional(),
@@ -41,13 +39,19 @@ export const BashTool = Tool.define("bash", {
     const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
     const app = App.info()
     const cfg = await Config.get()
-    const includeCoAuthoredBy = cfg.include_co_authored_by ?? true
 
-    // Add config info to context for git commits
-    ctx.metadata({
-      title: `Config: include_co_authored_by=${includeCoAuthoredBy}`,
-      metadata: { include_co_authored_by: includeCoAuthoredBy },
-    })
+    // Modify git commit commands based on include_co_authored_by setting
+    let finalCommand = params.command
+    if (params.command.includes("git commit") && params.command.includes("Generated with [opencode]")) {
+      const includeCoAuthoredBy = cfg.include_co_authored_by ?? true
+      if (!includeCoAuthoredBy) {
+        // Remove opencode branding from commit message
+        finalCommand = params.command.replace(
+          /🤖 Generated with \[opencode\]\(https:\/\/opencode\.ai\)\s*\n\s*Co-Authored-By: opencode <noreply@opencode\.ai>\s*/g,
+          "",
+        )
+      }
+    }
 
     const tree = await parser().then((p) => p.parse(params.command))
     const permissions = (() => {
@@ -123,7 +127,7 @@ export const BashTool = Tool.define("bash", {
     }
 
     const process = Bun.spawn({
-      cmd: ["bash", "-c", params.command],
+      cmd: ["bash", "-c", finalCommand],
       cwd: app.path.cwd,
       maxBuffer: MAX_OUTPUT_LENGTH,
       signal: ctx.abort,

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -59,10 +59,12 @@ When the user asks you to create a new git commit, follow these steps carefully:
 
 3. You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. ALWAYS run the following commands in parallel:
    - Add relevant untracked files to the staging area.
-   - Create the commit with a message ending with:
+   - Create the commit with a message. If the user's config has include_co_authored_by set to true (default), end the message with:
    🤖 Generated with [opencode](https://opencode.ai)
 
    Co-Authored-By: opencode <noreply@opencode.ai>
+   
+   If include_co_authored_by is false, use only the commit message without any opencode branding.
    - Run git status to make sure the commit succeeded.
 
 4. If the commit fails due to pre-commit hook changes, retry the commit ONCE to include these automated changes. If it fails again, it usually means a pre-commit hook is preventing the commit. If the commit succeeds but you notice that files were modified by the pre-commit hook, you MUST amend your commit to include them.
@@ -76,8 +78,10 @@ Important notes:
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
 - Ensure your commit message is meaningful and concise. It should explain the purpose of the changes, not just describe them.
 - Return an empty response - the user will see the git output directly
-- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
-<example>
+- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la these examples:
+
+<example_with_branding>
+When include_co_authored_by is true (default):
 git commit -m "$(cat <<'EOF'
    Commit message here.
 
@@ -86,7 +90,15 @@ git commit -m "$(cat <<'EOF'
    Co-Authored-By: opencode <noreply@opencode.ai>
    EOF
    )"
-</example>
+</example_with_branding>
+
+<example_without_branding>
+When include_co_authored_by is false:
+git commit -m "$(cat <<'EOF'
+   Commit message here.
+   EOF
+   )"
+</example_without_branding>
 
 # Creating pull requests
 Use the gh command via the Bash tool for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a Github URL use the gh command to get the information needed.

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -59,12 +59,10 @@ When the user asks you to create a new git commit, follow these steps carefully:
 
 3. You have the capability to call multiple tools in a single response. When multiple independent pieces of information are requested, batch your tool calls together for optimal performance. ALWAYS run the following commands in parallel:
    - Add relevant untracked files to the staging area.
-   - Create the commit with a message. If the user's config has include_co_authored_by set to true (default), end the message with:
+   - Create the commit with a message ending with:
    🤖 Generated with [opencode](https://opencode.ai)
 
    Co-Authored-By: opencode <noreply@opencode.ai>
-   
-   If include_co_authored_by is false, use only the commit message without any opencode branding.
    - Run git status to make sure the commit succeeded.
 
 4. If the commit fails due to pre-commit hook changes, retry the commit ONCE to include these automated changes. If it fails again, it usually means a pre-commit hook is preventing the commit. If the commit succeeds but you notice that files were modified by the pre-commit hook, you MUST amend your commit to include them.
@@ -78,10 +76,8 @@ Important notes:
 - If there are no changes to commit (i.e., no untracked files and no modifications), do not create an empty commit
 - Ensure your commit message is meaningful and concise. It should explain the purpose of the changes, not just describe them.
 - Return an empty response - the user will see the git output directly
-- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la these examples:
-
-<example_with_branding>
-When include_co_authored_by is true (default):
+- In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
+<example>
 git commit -m "$(cat <<'EOF'
    Commit message here.
 
@@ -90,15 +86,7 @@ git commit -m "$(cat <<'EOF'
    Co-Authored-By: opencode <noreply@opencode.ai>
    EOF
    )"
-</example_with_branding>
-
-<example_without_branding>
-When include_co_authored_by is false:
-git commit -m "$(cat <<'EOF'
-   Commit message here.
-   EOF
-   )"
-</example_without_branding>
+</example>
 
 # Creating pull requests
 Use the gh command via the Bash tool for ALL GitHub-related tasks including working with issues, pull requests, checks, and releases. If given a Github URL use the gh command to get the information needed.


### PR DESCRIPTION
### 1. Config Schema (/packages/opencode/src/config/config.ts)

• Added include_co_authored_by boolean field (optional, defaults to true when undefined)
• Users can set this in their opencode.json or opencode.jsonc files

### 2. Bash Tool Implementation (/packages/opencode/src/tool/bash.ts)

• Modified to dynamically load config and inject the setting into the tool description
• The tool now reads the user's include_co_authored_by setting and adjusts instructions accordingly

## Usage

Users can now control commit branding by adding this to their config:

To disable all opencode branding:

```json
{
  "include_co_authored_by": false
}
```

To keep opencode branding (default behavior):

```json
{
  "include_co_authored_by": true
}
```

Or simply omit the field entirely

## Behavior

When include_co_authored_by: true (default):

```text
Fix user authentication bug

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>
```

When include_co_authored_by: false:

```text
Fix user authentication bug
```