### PR TITLE
fix(docs): Fix formatting for Node.js installation section

### DIFF
--- a/packages/web/src/content/docs/docs/index.mdx
+++ b/packages/web/src/content/docs/docs/index.mdx
@@ -41,10 +41,26 @@ You can also install it with the following:
 - **Using Node.js**
 
   <Tabs>
-    <TabItem label="npm">```bash npm install -g opencode-ai ```</TabItem>
-    <TabItem label="Bun">```bash bun install -g opencode-ai ```</TabItem>
-    <TabItem label="pnpm">```bash pnpm install -g opencode-ai ```</TabItem>
-    <TabItem label="Yarn">```bash yarn global add opencode-ai ```</TabItem>
+    <TabItem label="npm">
+      ```bash
+      npm install -g opencode-ai
+      ```
+    </TabItem>
+    <TabItem label="Bun">
+      ```bash
+      bun install -g opencode-ai
+      ```
+    </TabItem>
+    <TabItem label="pnpm">
+      ```bash
+      pnpm install -g opencode-ai
+      ```
+    </TabItem>
+    <TabItem label="Yarn">
+      ```bash
+      yarn global add opencode-ai
+      ```
+    </TabItem>
   </Tabs>
 
 - **Using Homebrew on macOS**


### PR DESCRIPTION
### Problem:
The Node.js installation commands in the documentation were broken. The formatting was broken, causing the installation scripts to render as plain text instead of syntax-highlighted code blocks within the tabs.

<img width="1080" height="676" alt="screenshot" src="https://github.com/user-attachments/assets/68db35e2-2210-43ad-8c84-034683c8a188" />