### PR TITLE
handle the optional `v` in upgrade command when using curl

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -32,7 +32,7 @@ export const UpgradeCommand = {
       return
     }
     prompts.log.info("Using method: " + method)
-    const target = args.target ?? (await Installation.latest())
+    const target = args.target ? args.target.replace(/^v/, "") : await Installation.latest()
 
     if (Installation.VERSION === target) {
       prompts.log.warn(`opencode upgrade skipped: ${target} is already installed`)


### PR DESCRIPTION
the example in [documentation](https://opencode.ai/docs/cli/#upgrade) is `opencode upgrade v0.1.48`, and the description of the CLI command is 
```
version to upgrade to, for ex '0.1.48' or 'v0.1.48'
```

but when the method is curl, running `opencode upgrade v0.3.110` will fail because the `v` is already hardcoded in the install script:

```bash
url="https://github.com/sst/opencode/releases/download/v${requested_version}/$filename"
```

this should fix the optional `v` prefix (`/^v/` only matches when the `v` is the first character).

