### PR TITLE
Share link hotfix

### DIFF
--- a/packages/web/public/robots.txt
+++ b/packages/web/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+# Disallow shared content pages
+Disallow: /s/

--- a/packages/web/src/pages/s/[id].astro
+++ b/packages/web/src/pages/s/[id].astro
@@ -71,7 +71,7 @@ const ogImage = `${config.socialCard}/opencode-share/${encodedTitle}.png?model=$
         tag: "meta",
         attrs: {
           name: "robots",
-          content: "noindex",
+          content: "noindex, nofollow, noarchive, nosnippet",
         }
       },
       {


### PR DESCRIPTION
Quick hotfix to add more updates for search engine behaviour. However, this doesn't solve the issue completely.

There are two options here:

1. The links only live for a few hours after the session is closed
2. An account system for the website where you can manage the visibility of threads

@thdxr, let me know what you think is the best call and I can send something through.