### PR TITLE
better configuration error messages

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -411,16 +411,24 @@ export namespace Config {
     const errors: JsoncParseError[] = []
     const data = parseJsonc(text, errors, { allowTrailingComma: true })
     if (errors.length) {
+      const lines = text.split("\n")
+      const errorDetails = errors
+        .map((e) => {
+          const beforeOffset = text.substring(0, e.offset).split("\n")
+          const line = beforeOffset.length
+          const column = beforeOffset[beforeOffset.length - 1].length + 1
+          const problemLine = lines[line - 1]
+
+          const error = `${printParseErrorCode(e.error)} at line ${line}, column ${column}`
+          if (!problemLine) return error
+
+          return `${error}\n   Line ${line}: ${problemLine}\n${"".padStart(column + 9)}^`
+        })
+        .join("\n")
+
       throw new JsonError({
         path: configPath,
-        message: errors
-          .map((e) => {
-            const lines = text.substring(0, e.offset).split("\n")
-            const line = lines.length
-            const column = lines[lines.length - 1].length + 1
-            return `${printParseErrorCode(e.error)} at line ${line}, column ${column}`
-          })
-          .join("; "),
+        message: `\n--- JSONC Input ---\n${text}\n--- Errors ---\n${errorDetails}\n--- End ---`,
       })
     }
 


### PR DESCRIPTION
Fixes: #1514

Before:
<img width="1566" height="49" alt="Screenshot 2025-08-01 at 5 02 16 PM" src="https://github.com/user-attachments/assets/9b8a6a4e-ed5f-4af8-9838-135515e1fdaf" />

After:
<img width="730" height="354" alt="Screenshot 2025-08-01 at 5 02 28 PM" src="https://github.com/user-attachments/assets/414b585c-29b9-4227-90dd-e56a7f9a8719" />


