### PR TITLE
Fix: Error [ERR_DLOPEN_FAILED]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.17
+          bun-version: 1.2.19
 
       - run: bun install
 

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.17
+          bun-version: 1.2.19
 
       - run: git fetch --force --tags
       - run: bun install -g @vscode/vsce

--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
         "tree-sitter-bash": "0.23.3",
         "turndown": "7.2.0",
         "vscode-jsonrpc": "8.2.1",
+        "web-tree-sitter": "0.22.6",
         "xdg-basedir": "5.1.0",
         "yargs": "18.0.0",
         "zod": "catalog:",
@@ -189,6 +190,9 @@
     "sharp",
     "esbuild",
     "protobufjs",
+    "tree-sitter",
+    "web-tree-sitter",
+    "tree-sitter-bash",
   ],
   "catalog": {
     "@hono/zod-validator": "0.4.2",
@@ -2480,6 +2484,8 @@
     "walk-up-path": ["walk-up-path@3.0.1", "", {}, "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.22.6", "", {}, "sha512-hS87TH71Zd6mGAmYCvlgxeGDjqd9GTeqXNqTT+u0Gs51uIozNIaaq/kUAbV/Zf56jb2ZOyG8BxZs2GG9wbLi6Q=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencode",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.2.14",
+  "packageManager": "bun@1.2.19",
   "scripts": {
     "dev": "bun run --conditions=development packages/opencode/src/index.ts",
     "typecheck": "bun run --filter='*' typecheck",
@@ -46,7 +46,10 @@
   "trustedDependencies": [
     "esbuild",
     "protobufjs",
-    "sharp"
+    "sharp",
+    "tree-sitter",
+    "tree-sitter-bash",
+    "web-tree-sitter"
   ],
   "patchedDependencies": {}
 }

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -52,6 +52,7 @@
     "remeda": "catalog:",
     "tree-sitter": "0.22.4",
     "tree-sitter-bash": "0.23.3",
+    "web-tree-sitter": "0.22.6",
     "turndown": "7.2.0",
     "vscode-jsonrpc": "8.2.1",
     "xdg-basedir": "5.1.0",

--- a/packages/opencode/src/tool/test.ts
+++ b/packages/opencode/src/tool/test.ts
@@ -1,53 +1,70 @@
-import Parser from "tree-sitter";
-import Bash from "tree-sitter-bash";
+const parser = async () => {
+  try {
+    const { default: Parser } = await import("tree-sitter")
+    const Bash = await import("tree-sitter-bash")
+    const p = new Parser()
+    p.setLanguage(Bash.language as any)
+    return p
+  } catch (e) {
+    const { default: Parser } = await import("web-tree-sitter")
+    const { default: treeWasm } = await import("web-tree-sitter/tree-sitter.wasm" as string, { with: { type: "wasm" } })
+    await Parser.init({
+      locateFile() {
+        return treeWasm
+      },
+    })
+    const { default: bashWasm } = await import("tree-sitter-bash/tree-sitter-bash.wasm" as string, {
+      with: { type: "wasm" },
+    })
+    const bashLanguage = await Parser.Language.load(bashWasm)
+    const p = new Parser()
+    p.setLanguage(bashLanguage)
+    return p
+  }
+}
 
-const parser = new Parser();
-parser.setLanguage(Bash.language as any);
+const sourceCode = `cd --foo foo/bar && echo "hello" && cd ../baz`
 
-const sourceCode = `cd --foo foo/bar && echo "hello" && cd ../baz`;
-
-const tree = parser.parse(sourceCode);
+const tree = await parser().then((p) => p.parse(sourceCode))
 
 // Function to extract commands and arguments
-function extractCommands(
-  node: any,
-): Array<{ command: string; args: string[] }> {
-  const commands: Array<{ command: string; args: string[] }> = [];
+function extractCommands(node: any): Array<{ command: string; args: string[] }> {
+  const commands: Array<{ command: string; args: string[] }> = []
 
   function traverse(node: any) {
     if (node.type === "command") {
-      const commandNode = node.child(0);
+      const commandNode = node.child(0)
       if (commandNode) {
-        const command = commandNode.text;
-        const args: string[] = [];
+        const command = commandNode.text
+        const args: string[] = []
 
         // Extract arguments
         for (let i = 1; i < node.childCount; i++) {
-          const child = node.child(i);
+          const child = node.child(i)
           if (child && child.type === "word") {
-            args.push(child.text);
+            args.push(child.text)
           }
         }
 
-        commands.push({ command, args });
+        commands.push({ command, args })
       }
     }
 
     // Traverse children
     for (let i = 0; i < node.childCount; i++) {
-      traverse(node.child(i));
+      traverse(node.child(i))
     }
   }
 
-  traverse(node);
-  return commands;
+  traverse(node)
+  return commands
 }
 
 // Extract and display commands
-console.log("Source code: " + sourceCode);
-const commands = extractCommands(tree.rootNode);
-console.log("Extracted commands:");
+console.log("Source code: " + sourceCode)
+const commands = extractCommands(tree.rootNode)
+console.log("Extracted commands:")
 commands.forEach((cmd, index) => {
-  console.log(`${index + 1}. Command: ${cmd.command}`);
-  console.log(`   Args: [${cmd.args.join(", ")}]`);
-});
+  console.log(`${index + 1}. Command: ${cmd.command}`)
+  console.log(`   Args: [${cmd.args.join(", ")}]`)
+})


### PR DESCRIPTION
# Fix: Error [ERR_DLOPEN_FAILED]

- Fixes: #1509
- Fixes: #1670 

- In arm64 environments, `tree-sitter` and `tree-sitter-bash` may not work properly, and the following error may occur when executing commands.

```shell
Error [ERR_DLOPEN_FAILED]: /tmp/.3bd968e1bc3ef7f7-00000001.node: cannot open shared object file: No such file or directory
```

- This is binary issue on the library side <https://github.com/sst/opencode/pull/1546#issuecomment-3149871705>, so ~this patch temporarily avoids the error by skipping the use of the library and reverting to the previous behavior in environments where `tree-sitter` does not work~ ~<https://github.com/sst/opencode/pull/1546#issuecomment-3150645656>~<https://github.com/sst/opencode/pull/1546#issuecomment-3166653767>.

- Since opencode is completely unusable in environments where this problem occurs and the urgency is high, I am submitting a PR in this format, but if you know of a better solution I would appreciate your information.