### PR TITLE
fix: patch marked-shiki

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,7 @@
     "protobufjs",
     "sharp"
   ],
-  "patchedDependencies": {}
+  "patchedDependencies": {
+    "marked-shiki@1.2.0": "patches/marked-shiki@1.2.0.patch"
+  }
 }

--- a/patches/marked-shiki@1.2.0.patch
+++ b/patches/marked-shiki@1.2.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/marked-shiki/.bun-tag-5eae3435af8a0229 b/.bun-tag-5eae3435af8a0229
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/index.js b/dist/index.js
+index 535885e8569626d08f205e76c4944e4ebd0decab..92b5695c1b05fc7db5d26128c8f948d43c91f88a 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -4,7 +4,7 @@ function o(s = {}) {
+     async: !0,
+     async walkTokens(t) {
+       if (t.type !== "code" || typeof e != "function") return;
+-      const [a = "text", ...i] = t.lang.split(" "), { text: c } = t, r = await e(c, a, i), l = n ? n.replace("%l", String(a).toUpperCase()).replace("%s", r).replace("%t", c) : r;
++      const [a = "text", ...i] = t.lang?.split(" "), { text: c } = t, r = await e(c, a, i), l = n ? n.replace("%l", String(a).toUpperCase()).replace("%s", r).replace("%t", c) : r;
+       Object.assign(t, {
+         type: "html",
+         block: !0,


### PR DESCRIPTION
Fixes: #1568


Patch marked-shiki package using null check, also have a PR open on their lib but this will fix share links here for time being.

See https://opencode.ai/s/lJJWv8c7 (cannot load share link)
But locally using this patch I can:

<img width="1512" height="578" alt="Screenshot 2025-08-03 at 1 26 52 PM" src="https://github.com/user-attachments/assets/8f759d96-238e-4d2d-b1ed-a10529a272d3" />
