### PR TITLE
chore: remove unnecessary TypeScript error suppression

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -63,10 +63,8 @@ export namespace Plugin {
     if (!fn) return output
     const path = fn.split(".")
     for (const hook of await state().then((x) => x.hooks)) {
-      // @ts-expect-error
       const fn = pathOr(hook, path, undefined)
       if (!fn) continue
-      // @ts-expect-error
       await fn(input, output)
     }
     return output


### PR DESCRIPTION
```
bun run --filter='*' typecheck
```
```
│ src/plugin/index.ts(66,7): error TS2578: Unused '@ts-expect-error' directive.
│ src/plugin/index.ts(69,7): error TS2578: Unused '@ts-expect-error' directive.
```