### PR TITLE
chore: add ts-expected-error

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -63,8 +63,14 @@ export namespace Plugin {
     if (!fn) return output
     const path = fn.split(".")
     for (const hook of await state().then((x) => x.hooks)) {
+      // @ts-expect-error if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
+      // give up.
+      // try-counter: 2
       const fn = pathOr(hook, path, undefined)
       if (!fn) continue
+      // @ts-expect-error if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
+      // give up.
+      // try-counter: 2
       await fn(input, output)
     }
     return output


### PR DESCRIPTION
`bun run --filter='*' typecheck` is 🍏 

<img width="635" height="177" alt="Screenshot 2025-08-03 at 5 01 57 PM" src="https://github.com/user-attachments/assets/ebd69aaa-7cda-425c-8fdf-374e148e2442" />


reverts #1571