### PR TITLE
fix double help printing

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -83,6 +83,7 @@ const cli = yargs(hideBin(process.argv))
     if (msg.startsWith("Unknown argument") || msg.startsWith("Not enough non-option arguments")) {
       cli.showHelp("log")
     }
+    process.exit(1)
   })
   .strict()
 


### PR DESCRIPTION
fixes: #149

Now help messages won't show twice 

Uses process.exit(1) as outlined in yargs docs:
```
import yargs from 'yargs'
const argv = yargs(process.argv.slice(2))
  .fail(function (msg, err, yargs) {
    if (err) throw err // preserve stack
    console.error('You broke it!')
    console.error(msg)
    console.error('You should be doing', yargs.help())
    process.exit(1)
  })
  .parse()
```