### PR TITLE
feat(cli): Add -h as alias for --help option, close #1594

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -39,6 +39,7 @@ process.on("uncaughtException", (e) => {
 const cli = yargs(hideBin(process.argv))
   .scriptName("opencode")
   .help("help", "show help")
+  .alias("help", "h")
   .version("version", "show version number", Installation.VERSION)
   .alias("version", "v")
   .option("print-logs", {


### PR DESCRIPTION
This change introduces -h as an alias for the existing --help option.

Previously, the application only responded to --help for displaying usage information in the terminal. This commit ensures that -h provides the same behavior, aligning with common CLI conventions and improving user experience.