### PR TITLE
fix: default value for models with no cost object

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1344,10 +1344,10 @@ export namespace Session {
     }
     return {
       cost: new Decimal(0)
-        .add(new Decimal(tokens.input).mul(model.cost.input).div(1_000_000))
-        .add(new Decimal(tokens.output).mul(model.cost.output).div(1_000_000))
-        .add(new Decimal(tokens.cache.read).mul(model.cost.cache_read ?? 0).div(1_000_000))
-        .add(new Decimal(tokens.cache.write).mul(model.cost.cache_write ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.input).mul(model.cost?.input?? 0).div(1_000_000))
+        .add(new Decimal(tokens.output).mul(model.cost?.output?? 0).div(1_000_000))
+        .add(new Decimal(tokens.cache.read).mul(model.cost?.cache_read ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.cache.write).mul(model.cost?.cache_write ?? 0).div(1_000_000))
         .toNumber(),
       tokens,
     }


### PR DESCRIPTION
fixes issue caused by chutes models from [model.dev](https://models.dev/api.json) json not having a cost object for chutes models.

I think it is also related to #1166 and #1017 

