### PR TITLE
validate file part bounds to prevent panic

### DIFF
--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -221,22 +221,31 @@ func renderText(
 		lastEnd := int64(0)
 
 		// Apply highlighting to filenames and base style to rest of text
+		textLen := int64(len(text))
 		for _, filePart := range fileParts {
 			highlight := base.Foreground(t.Secondary())
 			start, end := filePart.Source.Text.Start, filePart.Source.Text.End
 
+			if end > textLen {
+				end = textLen
+			}
+			if start > textLen {
+				start = textLen
+			}
+
 			if start > lastEnd {
 				result.WriteString(base.Render(text[lastEnd:start]))
 			}
-			result.WriteString(highlight.Render(text[start:end]))
+			if start < end {
+				result.WriteString(highlight.Render(text[start:end]))
+			}
 
 			lastEnd = end
 		}
 
-		if lastEnd < int64(len(text)) {
+		if lastEnd < textLen {
 			result.WriteString(base.Render(text[lastEnd:]))
 		}
-
 		content = base.Width(width - 6).Render(result.String())
 	}
 
@@ -244,7 +253,6 @@ func renderText(
 		Local().
 		Format("02 Jan 2006 03:04 PM")
 	if time.Now().Format("02 Jan 2006") == timestamp[:11] {
-		// don't show the date if it's today
 		timestamp = timestamp[12:]
 	}
 	info := fmt.Sprintf("%s (%s)", author, timestamp)

--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -303,7 +303,9 @@ func (m *messagesComponent) renderView() tea.Cmd {
 						for _, part := range remainingParts {
 							switch part := part.(type) {
 							case opencode.FilePart:
-								fileParts = append(fileParts, part)
+								if part.Source.Text.Start >= 0 && part.Source.Text.End >= part.Source.Text.Start {
+									fileParts = append(fileParts, part)
+								}
 							}
 						}
 						flexItems := []layout.FlexItem{}


### PR DESCRIPTION
When the terminal is resized (in my case I was using Ghostty's split zoom), messages
containing file references would cause a panic:

```bash
Caught panic:

runtime error: slice bounds out of range [:91] with length 90

Restoring terminal...

goroutine 70 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x64
github.com/charmbracelet/bubbletea/v2.(*Program).recoverFromPanic(0x1400015f200, {0x1057b9b20, 0x14004bce2b8})
        /Users/Shaarawi/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4/tea.go:1139 +0x10c
github.com/charmbracelet/bubbletea/v2.(*Program).handleCommands.func1.1.1()
        /Users/Shaarawi/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4/tea.go:479 +0x40
panic({0x1057b9b20?, 0x14004bce2b8?})
        /usr/local/go/src/runtime/panic.go:792 +0x124
github.com/sst/opencode/internal/components/chat.renderText(0x1400217e488, {0x105813e40, 0x1400061e540}, {0x1400235acbd, 0x5b}, {0x1400002826e, 0x8}, 0x1, 0x51, {0x140000344e0, ...}, ...)
        /Users/Shaarawi/git/opencode/packages/tui/internal/components/chat/message.go:231 +0x11f0
github.com/sst/opencode/internal/components/chat.(*messagesComponent).renderView.func2()
        /Users/Shaarawi/git/opencode/packages/tui/internal/components/chat/messages.go:347 +0x332c
github.com/charmbracelet/bubbletea/v2.(*Program).handleCommands.func1.1()
        /Users/Shaarawi/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4/tea.go:484 +0x64
created by github.com/charmbracelet/bubbletea/v2.(*Program).handleCommands.func1 in goroutine 86
        /Users/Shaarawi/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4/tea.go:474 +0x10c
````

File part positions reference positions in the original text, but when the terminal is resized, the text gets re-wrapped to fit the new width. The rendering code was using these original positions to slice the wrapped text without validating they were still within bounds. Now this only append file parts with valid bounds