### PR TITLE
docs: make formatter docs a bit more clear

### DIFF
--- a/packages/web/src/content/docs/docs/formatters.mdx
+++ b/packages/web/src/content/docs/docs/formatters.mdx
@@ -86,16 +86,20 @@ To disable a specific formatter, set `disabled` to `true`:
 
 You can override the built-in formatters or add new ones by specifying the command, environment variables, and file extensions:
 
-```json title="opencode.json" {4-10}
+```json title="opencode.json" {4-14}
 {
   "$schema": "https://opencode.ai/config.json",
   "formatter": {
-    "custom-prettier": {
+    "prettier": {
       "command": ["npx", "prettier", "--write", "$FILE"],
       "environment": {
         "NODE_ENV": "development"
       },
       "extensions": [".js", ".ts", ".jsx", ".tsx"]
+    },
+    "custom-markdown-formatter": {
+      "command": ["deno", "fmt", "$FILE"],
+      "extensions": [".md"]
     }
   }
 }


### PR DESCRIPTION
fixes: #1588

I think having something not called `custom-prettier` will make it a bit more explicit that `prettier` will override prettier, but `custom-markdown-formatter` is just a custom formatter we are adding