### PR TITLE
fix(plugins): improve session idle event

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -122,6 +122,7 @@ export namespace Session {
       const sessions = new Map<string, Info>()
       const messages = new Map<string, MessageV2.Info[]>()
       const pending = new Map<string, AbortController>()
+      const autoCompacting = new Map<string, boolean>()
       const queued = new Map<
         string,
         {
@@ -137,6 +138,7 @@ export namespace Session {
         sessions,
         messages,
         pending,
+        autoCompacting,
         queued,
       }
     },
@@ -615,6 +617,8 @@ export namespace Session {
       const tokens =
         previous.tokens.input + previous.tokens.cache.read + previous.tokens.cache.write + previous.tokens.output
       if (model.info.limit.context && tokens > Math.max((model.info.limit.context - outputLimit) * 0.9, 0)) {
+        state().autoCompacting.set(input.sessionID, true)
+
         await summarize({
           sessionID: input.sessionID,
           providerID: input.providerID,
@@ -623,7 +627,6 @@ export namespace Session {
         return chat(input)
       }
     }
-
     using abort = lock(input.sessionID)
 
     const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
@@ -1322,9 +1325,16 @@ export namespace Session {
       [Symbol.dispose]() {
         log.info("unlocking", { sessionID })
         state().pending.delete(sessionID)
-        Bus.publish(Event.Idle, {
-          sessionID,
-        })
+
+        // Only fire session.idle if we're not in the middle of auto-compacting
+        const isAutoCompacting = state().autoCompacting.get(sessionID) ?? false
+        if (isAutoCompacting) {
+          state().autoCompacting.delete(sessionID)
+        } else {
+          Bus.publish(Event.Idle, {
+            sessionID,
+          })
+        }
       },
     }
   }
@@ -1344,8 +1354,8 @@ export namespace Session {
     }
     return {
       cost: new Decimal(0)
-        .add(new Decimal(tokens.input).mul(model.cost?.input?? 0).div(1_000_000))
-        .add(new Decimal(tokens.output).mul(model.cost?.output?? 0).div(1_000_000))
+        .add(new Decimal(tokens.input).mul(model.cost?.input ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.output).mul(model.cost?.output ?? 0).div(1_000_000))
         .add(new Decimal(tokens.cache.read).mul(model.cost?.cache_read ?? 0).div(1_000_000))
         .add(new Decimal(tokens.cache.write).mul(model.cost?.cache_write ?? 0).div(1_000_000))
         .toNumber(),

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1322,19 +1322,22 @@ export namespace Session {
     state().pending.set(sessionID, controller)
     return {
       signal: controller.signal,
-      [Symbol.dispose]() {
+      async [Symbol.dispose]() {
         log.info("unlocking", { sessionID })
         state().pending.delete(sessionID)
 
-        // Only fire session.idle if we're not in the middle of auto-compacting
         const isAutoCompacting = state().autoCompacting.get(sessionID) ?? false
         if (isAutoCompacting) {
           state().autoCompacting.delete(sessionID)
-        } else {
-          Bus.publish(Event.Idle, {
-            sessionID,
-          })
+          return
         }
+
+        const session = await get(sessionID)
+        if (session.parentID) return
+
+        Bus.publish(Event.Idle, {
+          sessionID,
+        })
       },
     }
   }


### PR DESCRIPTION
This improves the session idle event in the following ways:

- doesn't fire on the auto-compact feature (as this basically initializes a new chat)
- doesn't fire for child sessions (e.g. that are spawned via the task tool)

I think both were unexpected, e.g., when sending notifications for finished agent runs.

In the future, we can add specific events for those two occasions if needed.