### PR TITLE
allow Plugin type to be synchronous

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -6,7 +6,7 @@ export type PluginInput = {
   app: App
   $: BunShell
 }
-export type Plugin = (input: PluginInput) => Promise<Hooks>
+export type Plugin = (input: PluginInput) => Promise<Hooks> | Hooks;
 
 export interface Hooks {
   event?: (input: { event: Event }) => Promise<void>

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -9,23 +9,23 @@ export type PluginInput = {
 export type Plugin = (input: PluginInput) => Promise<Hooks> | Hooks;
 
 export interface Hooks {
-  event?: (input: { event: Event }) => Promise<void>
+  event?: (input: { event: Event }) => Promise<void> | void
   /**
    * Called when a new message is received
    */
-  "chat.message"?: (input: {}, output: { message: UserMessage; parts: Part[] }) => Promise<void>
+  "chat.message"?: (input: {}, output: { message: UserMessage; parts: Part[] }) => Promise<void> | void
   /**
    * Modify parameters sent to LLM
    */
   "chat.params"?: (
     input: { model: Model; provider: Provider; message: UserMessage },
     output: { temperature: number; topP: number },
-  ) => Promise<void>
-  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  ) => Promise<void> | void
+  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void> | void
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },
     output: { args: any },
-  ) => Promise<void>
+  ) => Promise<void> | void
   "tool.execute.after"?: (
     input: { tool: string; sessionID: string; callID: string },
     output: {
@@ -33,5 +33,5 @@ export interface Hooks {
       output: string
       metadata: any
     },
-  ) => Promise<void>
+  ) => Promise<void> | void
 }


### PR DESCRIPTION
This is a very small change but I have a pretty strict ESLint config, and I don't want to disable it for every plugin I write

<img width="1359" height="263" alt="image" src="https://github.com/user-attachments/assets/f6633a17-f907-42a8-9b22-bae172884896" />

From my testing synchronous function for plugins works just fine