### PR TITLE
feat: add 'deny' option to permission configuration system

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -224,7 +224,7 @@ export namespace Config {
   })
   export type Layout = z.infer<typeof Layout>
 
-  export const Permission = z.union([z.literal("ask"), z.literal("allow")])
+  export const Permission = z.union([z.literal("ask"), z.literal("allow"), z.literal("deny")])
   export type Permission = z.infer<typeof Permission>
 
   export const Info = z

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -93,7 +93,7 @@ export const BashTool = Tool.define("bash", {
 
       // always allow cd if it passes above check
       if (!needsAsk && command[0] !== "cd") {
-        const ask = (() => {
+        const action = (() => {
           for (const [pattern, value] of Object.entries(permissions)) {
             const match = Wildcard.match(node.text, pattern)
             log.info("checking", { text: node.text.trim(), pattern, match })
@@ -101,7 +101,10 @@ export const BashTool = Tool.define("bash", {
           }
           return "ask"
         })()
-        if (ask === "ask") needsAsk = true
+        if (action === "ask") needsAsk = true
+        if (action === "deny") {
+          throw new Error(`Command "${node.text.trim()}" is not allowed by permission configuration`)
+        }
       }
     }
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -60,6 +60,8 @@ export const EditTool = Tool.define("edit", {
               diff,
             },
           })
+        } else if (cfg.permission?.edit === "deny") {
+          throw new Error(`File editing is not allowed by permission configuration`)
         }
         await Bun.write(filePath, params.newString)
         await Bus.publish(File.Event.Edited, {
@@ -89,6 +91,8 @@ export const EditTool = Tool.define("edit", {
             diff,
           },
         })
+      } else if (cfg.permission?.edit === "deny") {
+        throw new Error(`File editing is not allowed by permission configuration`)
       }
 
       await file.write(contentNew)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -42,6 +42,9 @@ export const WriteTool = Tool.define("write", {
           exists,
         },
       })
+    else if (cfg.permission?.edit === "deny") {
+      throw new Error(`File writing is not allowed by permission configuration`)
+    }
 
     await Bun.write(filepath, params.content)
     await Bus.publish(File.Event.Edited, {


### PR DESCRIPTION
Users can now permanently block specific bash commands or file operations by setting permission values to "deny" instead of just "ask" or "allow". This provides stronger security controls by preventing the AI from executing potentially dangerous commands or modifying files when explicitly forbidden.

The deny option works for both bash command patterns and file editing permissions:
- bash: { "rm *": "deny", "sudo *": "deny" }
- edit: "deny"

This is super important for us to be able to set certain high-risk tools/commands to always deny, such as the `aws` cli or `terraform`.

🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>
