### PR TITLE
fix: markdown table renders

### DIFF
--- a/packages/tui/internal/styles/markdown.go
+++ b/packages/tui/internal/styles/markdown.go
@@ -285,6 +285,8 @@ func generateMarkdownStyleConfig(backgroundColor compat.AdaptiveColor) ansi.Styl
 			StyleBlock: ansi.StyleBlock{
 				StylePrimitive: ansi.StylePrimitive{
 					BlockSuffix: "\n",
+					// TODO: find better way to fix markdown table renders
+					BackgroundColor: stringPtr(""),
 				},
 			},
 			CenterSeparator: stringPtr("┼"),


### PR DESCRIPTION
fixes: #1272

I think there is some glamour bug that causes this but I don't know how much energy is worth investing into an investigation (especially given upcoming opentui migration), this hack seems to get markdown tables to a much better place.

Before:
<img width="2176" height="499" alt="Screenshot 2025-08-05 at 2 23 54 PM" src="https://github.com/user-attachments/assets/c7f45c12-320b-4e2c-8aa8-4583791a5852" />

After:
<img width="2224" height="523" alt="Screenshot 2025-08-05 at 2 23 22 PM" src="https://github.com/user-attachments/assets/e8a44d99-8911-4658-8c84-b99792b015ea" />
