### PR TITLE
fix: prevent title regeneration on auto compact

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -52,8 +52,8 @@ export namespace Session {
   const parentSessionTitlePrefix = "New session - "
   const childSessionTitlePrefix = "Child session - "
 
-  function createDefaultTitle(parentID?: string) {
-    return (parentID ? childSessionTitlePrefix : parentSessionTitlePrefix) + new Date().toISOString()
+  function createDefaultTitle(isChild = false) {
+    return (isChild ? childSessionTitlePrefix : parentSessionTitlePrefix) + new Date().toISOString()
   }
 
   function isDefaultTitle(title: string) {
@@ -165,7 +165,7 @@ export namespace Session {
       id: Identifier.descending("session"),
       version: Installation.VERSION,
       parentID,
-      title: createDefaultTitle(parentID),
+      title: createDefaultTitle(!!parentID),
       time: {
         created: Date.now(),
         updated: Date.now(),

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -49,6 +49,17 @@ export namespace Session {
 
   const OUTPUT_TOKEN_MAX = 32_000
 
+  const parentSessionTitlePrefix = "New session - "
+  const childSessionTitlePrefix = "Child session - "
+
+  function createDefaultTitle(parentID?: string) {
+    return (parentID ? childSessionTitlePrefix : parentSessionTitlePrefix) + new Date().toISOString()
+  }
+
+  function isDefaultTitle(title: string) {
+    return title.startsWith(parentSessionTitlePrefix)
+  }
+
   export const Info = z
     .object({
       id: Identifier.schema("session"),
@@ -154,7 +165,7 @@ export namespace Session {
       id: Identifier.descending("session"),
       version: Installation.VERSION,
       parentID,
-      title: (parentID ? "Child session - " : "New Session - ") + new Date().toISOString(),
+      title: createDefaultTitle(parentID),
       time: {
         created: Date.now(),
         updated: Date.now(),
@@ -632,7 +643,7 @@ export namespace Session {
     const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
     if (lastSummary) msgs = msgs.filter((msg) => msg.info.id >= lastSummary.info.id)
 
-    if (msgs.length === 1 && !session.parentID) {
+    if (msgs.length === 1 && !session.parentID && isDefaultTitle(session.title)) {
       const small = (await Provider.getSmallModel(input.providerID)) ?? model
       generateText({
         maxOutputTokens: small.info.reasoning ? 1024 : 20,


### PR DESCRIPTION
The previous title generation check only checked if the message count is 1. This could cause the title generation to be re-triggered on auto compact, as there could again be a state where only one message is present.

This PR fixed this by only triggering the title generation if the title format is the default title.