### PR TITLE
Add timeout option to LSP config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -14,6 +14,7 @@ import matter from "gray-matter"
 import { Flag } from "../flag/flag"
 import { Auth } from "../auth"
 import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
+import { LSPServer } from "../lsp/server"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -303,20 +304,30 @@ export namespace Config {
       lsp: z
         .record(
           z.string(),
-          z.union([
-            z.object({
-              disabled: z.literal(true),
-            }),
-            z.object({
-              command: z.array(z.string()),
+          z
+            .object({
+              command: z.array(z.string()).optional(),
               extensions: z.array(z.string()).optional(),
               disabled: z.boolean().optional(),
               env: z.record(z.string(), z.string()).optional(),
               initialization: z.record(z.string(), z.any()).optional(),
-            }),
-          ]),
+              timeout: z.number().optional(),
+            })
+            .strict(),
         )
-        .optional(),
+        .optional()
+        .refine(
+          (lspConfig) => {
+            if (!lspConfig) return true
+
+            return Object.entries(lspConfig).every(
+              ([serverName, config]) => serverName in LSPServer.DEFAULTS || config.command,
+            )
+          },
+          {
+            message: `Custom LSP servers require a 'command' field. Built-in servers are: ${Object.keys(LSPServer.DEFAULTS).join(", ")}`,
+          },
+        ),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: z

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -34,7 +34,7 @@ export namespace LSPClient {
     ),
   }
 
-  export async function create(input: { serverID: string; server: LSPServer.Handle; root: string }) {
+  export async function create(input: { serverID: string; server: LSPServer.Handle; root: string; timeout?: number }) {
     const app = App.info()
     const l = log.clone().tag("serverID", input.serverID)
     l.info("starting client")
@@ -113,8 +113,11 @@ export namespace LSPClient {
       [path: string]: number
     } = {}
 
+    const timeout = input.timeout ?? 3000
+
     const result = {
       root: input.root,
+      timeout,
       get serverID() {
         return input.serverID
       },
@@ -168,7 +171,7 @@ export namespace LSPClient {
               }
             })
           }),
-          3000,
+          result.timeout,
         )
           .catch(() => {})
           .finally(() => {

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -53,39 +53,60 @@ export namespace LSP {
     })
   export type DocumentSymbol = z.infer<typeof DocumentSymbol>
 
+  function createServerInfo(name: string, config: LSPServer.Config, existing?: LSPServer.Info): LSPServer.Info {
+    const base = existing ?? {
+      id: name,
+      root: async (_file, app) => app.path.root,
+      extensions: [],
+      spawn: async () => undefined,
+    }
+
+    return {
+      ...base,
+      id: name,
+      extensions: config.extensions ?? base.extensions,
+      spawn: async (app, root) => {
+        if (config.command) {
+          return {
+            process: spawn(config.command[0], config.command.slice(1), {
+              cwd: root,
+              env: { ...process.env, ...config.env },
+            }),
+            initialization: config.initialization,
+          }
+        }
+
+        const handle = await base.spawn(app, root)
+        return handle
+          ? {
+              ...handle,
+              initialization: { ...handle.initialization, ...config.initialization },
+            }
+          : handle
+      },
+    }
+  }
+
   const state = App.state(
     "lsp",
     async () => {
       const clients: LSPClient.Info[] = []
-      const servers: Record<string, LSPServer.Info> = LSPServer
-      const cfg = await Config.get()
+      const servers: Record<string, LSPServer.Info> = LSPServer.DEFAULTS
+      const serverConfigs: Record<string, LSPServer.Config> = {}
+      const cfg = await Config.state()
       for (const [name, item] of Object.entries(cfg.lsp ?? {})) {
-        const existing = servers[name]
         if (item.disabled) {
           delete servers[name]
           continue
         }
-        servers[name] = {
-          ...existing,
-          root: existing?.root ?? (async (_file, app) => app.path.root),
-          extensions: item.extensions ?? existing.extensions,
-          spawn: async (_app, root) => {
-            return {
-              process: spawn(item.command[0], item.command.slice(1), {
-                cwd: root,
-                env: {
-                  ...process.env,
-                  ...item.env,
-                },
-              }),
-              initialization: item.initialization,
-            }
-          },
-        }
+        serverConfigs[name] = item
+        const existing = servers[name]
+        servers[name] = createServerInfo(name, item, existing)
       }
       return {
         broken: new Set<string>(),
         servers,
+        serverConfigs,
         clients,
       }
     },
@@ -104,7 +125,7 @@ export namespace LSP {
     const s = await state()
     const extension = path.parse(file).ext
     const result: LSPClient.Info[] = []
-    for (const server of Object.values(LSPServer)) {
+    for (const server of Object.values(s.servers)) {
       if (server.extensions.length && !server.extensions.includes(extension)) continue
       const root = await server.root(file, App.info())
       if (!root) continue
@@ -121,6 +142,7 @@ export namespace LSP {
         serverID: server.id,
         server: handle,
         root,
+        timeout: s.serverConfigs[server.id]?.timeout,
       }).catch((err) => {
         s.broken.add(root + server.id)
         handle.process.kill()

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -362,3 +362,24 @@ export namespace LSPServer {
     },
   }
 }
+
+export namespace LSPServer {
+  export type Config = {
+    command?: string[]
+    extensions?: string[]
+    disabled?: boolean
+    env?: Record<string, string>
+    initialization?: Record<string, any>
+    timeout?: number
+  }
+
+  export const DEFAULTS = {
+    typescript: LSPServer.Typescript,
+    golang: LSPServer.Gopls,
+    "ruby-lsp": LSPServer.RubyLsp,
+    pyright: LSPServer.Pyright,
+    "elixir-ls": LSPServer.ElixirLS,
+    zls: LSPServer.Zls,
+    csharp: LSPServer.CSharp,
+  } as const
+}

--- a/packages/web/src/content/docs/docs/lsp.mdx
+++ b/packages/web/src/content/docs/docs/lsp.mdx
@@ -11,7 +11,7 @@ opencode integrates with your Language Server Protocol (LSP) to help the LLM int
 
 opencode comes with several built-in LSP servers for popular languages:
 
-| LSP Server | Extensions                         | Requirements                        |
+| LSP Server | Extensions                                   | Requirements                        |
 | ---------- | -------------------------------------------- | ----------------------------------- |
 | typescript | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts | `typescript` dependency in project  |
 | gopls      | .go                                          | `go` command available              |
@@ -49,11 +49,12 @@ Each LSP server supports the following:
 
 | Property         | Type     | Description                                       |
 | ---------------- | -------- | ------------------------------------------------- |
-| `disabled`       | boolean  | Set this to `true` to disable the LSP server           |
+| `disabled`       | boolean  | Set this to `true` to disable the LSP server      |
 | `command`        | string[] | The command to start the LSP server               |
 | `extensions`     | string[] | File extensions this LSP server should handle     |
 | `env`            | object   | Environment variables to set when starting server |
 | `initialization` | object   | Initialization options to send to the LSP server  |
+| `timeout`        | number   | Timeout in milliseconds for LSP operations        |
 
 Let's look at some examples.
 


### PR DESCRIPTION
### Summary

* Add `timeout` option to the LSP server config schema.
* Update documentation with description.
* Allow configuration for built-in LSP servers.

This is a potential solution to #742 