### PR TITLE
fix: add TypeScript path mapping for workspace packages in development mode

### DIFF
--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -9,6 +9,15 @@
     ],
     "customConditions": [
       "development"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@opencode-ai/sdk": [
+        "../sdk/js/src/index.ts"
+      ],
+      "@opencode-ai/plugin": [
+        "../plugin/src/index.ts"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Problem
On Windows 11,  `@opencode-ai/sdk` package could not be resolved when running `bun dev`, causing the error:
```
error: Cannot find module '@opencode-ai/sdk' from 'packages/opencode/src/plugin/index.ts'
```

## Solution
Added TypeScript path mapping to `packages/opencode/tsconfig.json`:
- Added `baseUrl` and `paths` configuration  
- Maps `@opencode-ai/sdk` and `@opencode-ai/plugin` to their source TypeScript files
- Only affects development mode with `--conditions=development`
- Production builds continue to use the proper workspace package resolution

## Testing
- ✅ `bun dev` now starts successfully
- ✅ Module imports resolve correctly in development
- ✅ Production builds unaffected (uses `dist/` files via package.json exports)
- ✅ All typecheck tests pass

## Changes
- Modified `packages/opencode/tsconfig.json` to include path mapping for workspace packages
- This is a development-only fix that maintains proper package abstractions