### PR TITLE
Fix: Respect agent's preferred model at TUI startup

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -381,7 +381,18 @@ func (a *App) InitializeProvider() tea.Cmd {
 		}
 	}
 
-	// Priority 3: Recent model usage (most recently used model)
+	// Priority 3: Current agent's preferred model
+	if selectedProvider == nil && a.Agent().Model.ModelID != "" {
+		if provider, model := findModelByProviderAndModelID(providers, a.Agent().Model.ProviderID, a.Agent().Model.ModelID); provider != nil && model != nil {
+			selectedProvider = provider
+			selectedModel = model
+			slog.Debug("Selected model from current agent", "provider", provider.ID, "model", model.ID, "agent", a.Agent().Name)
+		} else {
+			slog.Debug("Agent model not found", "provider", a.Agent().Model.ProviderID, "model", a.Agent().Model.ModelID, "agent", a.Agent().Name)
+		}
+	}
+
+	// Priority 4: Recent model usage (most recently used model)
 	if selectedProvider == nil && len(a.State.RecentlyUsedModels) > 0 {
 		recentUsage := a.State.RecentlyUsedModels[0] // Most recent is first
 		if provider, model := findModelByProviderAndModelID(providers, recentUsage.ProviderID, recentUsage.ModelID); provider != nil &&
@@ -400,7 +411,7 @@ func (a *App) InitializeProvider() tea.Cmd {
 		}
 	}
 
-	// Priority 4: State-based model (backwards compatibility)
+	// Priority 5: State-based model (backwards compatibility)
 	if selectedProvider == nil && a.State.Provider != "" && a.State.Model != "" {
 		if provider, model := findModelByProviderAndModelID(providers, a.State.Provider, a.State.Model); provider != nil &&
 			model != nil {
@@ -412,7 +423,7 @@ func (a *App) InitializeProvider() tea.Cmd {
 		}
 	}
 
-	// Priority 5: Internal priority fallback (Anthropic preferred, then first available)
+	// Priority 6: Internal priority fallback (Anthropic preferred, then first available)
 	if selectedProvider == nil {
 		// Try Anthropic first as internal priority
 		if provider := findProviderByID(providers, "anthropic"); provider != nil {


### PR DESCRIPTION
### Summary

- Fixed TUI not using mode's preferred model when booting into a specific mode
- Added mode model selection as Priority 3 in the model selection chain during app initialization

### Description

Previously, when opencode TUI started up and loaded a mode (either the last-used mode or a manually specified one), it wouldn't automatically switch to that mode's preferred model defined in the mode's YAML frontmatter. The auto-switching only worked when manually changing modes during an active session.

This fix adds the current mode's preferred model as Priority 3 in the model selection chain, ensuring that when the app boots with a specific mode, it will use that mode's preferred model unless overridden by higher-priority settings (command line flags or config file).

### Changes

- Added Priority 3 check for **a.Mode.Model** in **InitializeProvider()**
- Fixed backwards compatibility logic to check current mode (**a.Mode.Name**) instead of saved state mode
- Updated priority comments to reflect new ordering

### Model Selection Priority (after fix)

1. Command line **--model** flag
2. Config file model setting
3. **Current mode's preferred model**← NEW
4. Recent model usage
5. State-based model (backwards compatibility)
6. Internal priority fallback