### PR TITLE
fix: get session api

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -220,7 +220,7 @@ export namespace Server {
         },
       )
       .get(
-        "/session/:sessionID",
+        "/session/:id",
         describeRoute({
           description: "Get session",
           operationId: "session.get",


### PR DESCRIPTION
The new get session API didn't work because of the wrong parameter name.