### PR TITLE
Feat: Introduce agent-level configuration for instructions, resources, and MCP server in .md agent config file

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -22,6 +22,9 @@ export namespace Agent {
         .optional(),
       prompt: z.string().optional(),
       tools: z.record(z.boolean()),
+      mcp: z.record(z.string(), Config.Mcp).optional(),
+      instructions: z.array(z.string()).optional(),
+      resources: z.array(z.union([z.string(), Config.Resource])).optional(),
     })
     .openapi({
       ref: "Agent",
@@ -79,6 +82,9 @@ export namespace Agent {
       if (value.temperature != undefined) item.temperature = value.temperature
       if (value.top_p != undefined) item.topP = value.top_p
       if (value.mode) item.mode = value.mode
+      if (value.mcp) item.mcp = value.mcp
+      if (value.instructions) item.instructions = value.instructions
+      if (value.resources) item.resources = value.resources
     }
     return result
   })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -164,6 +164,15 @@ export namespace Config {
   export const Mcp = z.discriminatedUnion("type", [McpLocal, McpRemote])
   export type Mcp = z.infer<typeof Mcp>
 
+  export const Resource = z
+    .object({
+      path: z.string(),
+      description: z.string(),
+    })
+    .openapi({
+      ref: "Resource",
+    })
+
   export const Agent = z
     .object({
       model: z.string().optional(),
@@ -174,6 +183,9 @@ export namespace Config {
       disable: z.boolean().optional(),
       description: z.string().optional().describe("Description of when to use the agent"),
       mode: z.union([z.literal("subagent"), z.literal("primary"), z.literal("all")]).optional(),
+      mcp: z.record(z.string(), Mcp).optional(),
+      instructions: z.array(z.string()).optional(),
+      resources: z.array(z.union([z.string(), Resource])).optional(),
     })
     .openapi({
       ref: "AgentConfig",

--- a/packages/opencode/src/mcp/agent.ts
+++ b/packages/opencode/src/mcp/agent.ts
@@ -1,0 +1,171 @@
+import { experimental_createMCPClient, type Tool } from "ai"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { Config } from "../config/config"
+import { Log } from "../util/log"
+import { NamedError } from "../util/error"
+import { z } from "zod"
+import { Bus } from "../bus"
+import { Session } from "../session"
+import { MCP } from "../mcp"
+
+export namespace AgentMCP {
+  const log = Log.create({ service: "agent-mcp" })
+
+  export const Failed = NamedError.create(
+    "AgentMCPFailed",
+    z.object({
+      name: z.string(),
+      agent: z.string(),
+    }),
+  )
+
+  // Cache agent-specific clients (only for clients not available globally)
+  const agentClients: Map<string, Map<string, Awaited<ReturnType<typeof experimental_createMCPClient>>>> = new Map()
+
+  export async function tools(agentName: string, mcpConfig: Record<string, Config.Mcp>): Promise<Record<string, Tool>> {
+    const result: Record<string, Tool> = {}
+
+    // First, check global MCP clients for reuse
+    const globalClients = await MCP.clients()
+
+    for (const [serverName, mcp] of Object.entries(mcpConfig)) {
+      if (mcp.enabled === false) {
+        log.info("agent mcp server disabled", { server: serverName, agent: agentName })
+        continue
+      }
+
+      let client: Awaited<ReturnType<typeof experimental_createMCPClient>> | undefined
+
+      // Check if this server already exists globally
+      if (globalClients[serverName]) {
+        log.info("reusing global mcp client", { server: serverName, agent: agentName })
+        client = globalClients[serverName]
+      } else {
+        // Launch agent-specific client if not available globally
+        client = await getOrCreateAgentClient(agentName, serverName, mcp)
+      }
+
+      if (client) {
+        try {
+          const serverTools = await client.tools()
+          for (const [toolName, tool] of Object.entries(serverTools)) {
+            // Use same naming as global MCP: serverName_toolName
+            const sanitizedServerName = serverName.replace(/\s+/g, "_")
+            const toolKey = `${sanitizedServerName}_${toolName}`
+            result[toolKey] = tool
+          }
+        } catch (error) {
+          log.error("failed to get mcp tools", {
+            agent: agentName,
+            server: serverName,
+            error,
+          })
+        }
+      }
+    }
+
+    return result
+  }
+
+  async function getOrCreateAgentClient(agentName: string, serverName: string, mcp: Config.Mcp) {
+    if (!agentClients.has(agentName)) {
+      agentClients.set(agentName, new Map())
+    }
+
+    const clients = agentClients.get(agentName)!
+
+    if (clients.has(serverName)) {
+      return clients.get(serverName)!
+    }
+
+    log.info("initializing agent-specific mcp client", { server: serverName, agent: agentName, type: mcp.type })
+
+    try {
+      let client: Awaited<ReturnType<typeof experimental_createMCPClient>> | undefined
+
+      if (mcp.type === "remote") {
+        const transports = [
+          new StreamableHTTPClientTransport(new URL(mcp.url), {
+            requestInit: {
+              headers: mcp.headers,
+            },
+          }),
+          new SSEClientTransport(new URL(mcp.url), {
+            requestInit: {
+              headers: mcp.headers,
+            },
+          }),
+        ]
+
+        for (const transport of transports) {
+          client = await experimental_createMCPClient({
+            name: serverName, // Use same name as global MCP
+            transport,
+          }).catch(() => undefined)
+          if (client) break
+        }
+      }
+
+      if (mcp.type === "local") {
+        const [cmd, ...args] = mcp.command
+        client = await experimental_createMCPClient({
+          name: serverName, // Use same name as global MCP
+          transport: new StdioClientTransport({
+            stderr: "ignore",
+            command: cmd,
+            args,
+            env: {
+              ...process.env,
+              ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+              ...mcp.environment,
+            },
+          }),
+        }).catch(() => undefined)
+      }
+
+      if (client) {
+        clients.set(serverName, client)
+        log.info("agent mcp client initialized", { server: serverName, agent: agentName })
+        return client
+      } else {
+        log.error("failed to initialize agent mcp client", { server: serverName, agent: agentName })
+        Bus.publish(Session.Event.Error, {
+          error: {
+            name: "UnknownError",
+            data: {
+              message: `Agent MCP server ${serverName} (agent: ${agentName}) failed to start`,
+            },
+          },
+        })
+      }
+    } catch (error) {
+      log.error("agent mcp initialization error", { server: serverName, agent: agentName, error })
+    }
+
+    return undefined
+  }
+
+  export async function cleanup(agentName: string) {
+    const clients = agentClients.get(agentName)
+    if (!clients) return
+
+    for (const [serverName, client] of clients.entries()) {
+      try {
+        client.close()
+        log.info("agent mcp client closed", { agent: agentName, server: serverName })
+      } catch (error) {
+        log.error("error closing agent mcp client", { agent: agentName, server: serverName, error })
+      }
+    }
+
+    agentClients.delete(agentName)
+  }
+
+  export async function cleanupAll() {
+    for (const agentName of agentClients.keys()) {
+      await cleanup(agentName)
+    }
+  }
+}

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -25,6 +25,7 @@ import { Flag } from "../flag/flag"
 import { Identifier } from "../id/id"
 import { Installation } from "../installation"
 import { MCP } from "../mcp"
+import { AgentMCP } from "../mcp/agent"
 import { Provider } from "../provider/provider"
 import { ProviderTransform } from "../provider/transform"
 import type { ModelsDev } from "../provider/models"
@@ -33,11 +34,13 @@ import { Snapshot } from "../snapshot"
 import { Storage } from "../storage/storage"
 import { Log } from "../util/log"
 import { NamedError } from "../util/error"
+import { Filesystem } from "../util/filesystem"
 import { SystemPrompt } from "./system"
 import { FileTime } from "../file/time"
 import { MessageV2 } from "./message-v2"
 import { LSP } from "../lsp"
 import { ReadTool } from "../tool/read"
+import { createResourceTool } from "../tool/resource"
 import { mergeDeep, pipe, splitWhen } from "remeda"
 import { ToolRegistry } from "../tool/registry"
 import { Plugin } from "../plugin"
@@ -725,7 +728,7 @@ export namespace Session {
       })(),
     )
     system.push(...(await SystemPrompt.environment()))
-    system.push(...(await SystemPrompt.custom()))
+    system.push(...(await SystemPrompt.custom(agent)))
     // max 2 system prompt messages for caching purposes
     const [first, ...rest] = system
     system = [first, rest.join("\n")]
@@ -824,6 +827,88 @@ export namespace Session {
       })
     }
 
+    // Agent-specific resource tools
+    if (agent.resources && agent.resources.length > 0) {
+      const { cwd, root } = app.path
+      for (const resource of agent.resources) {
+        try {
+          // Handle both string paths and resource objects
+          const resourcePath = typeof resource === "string" ? resource : resource.path
+          const resourceDescription = typeof resource === "object" ? resource.description : undefined
+
+          const matches = await Filesystem.globUp(resourcePath, cwd, root)
+          for (const matchedPath of matches) {
+            const basePath = path.dirname(matchedPath)
+            const resourceTool = createResourceTool(matchedPath, basePath, resourceDescription)
+            const toolDef = await resourceTool.init()
+
+            if (enabledTools[resourceTool.id] === false) continue
+
+            tools[resourceTool.id] = tool({
+              id: resourceTool.id as any,
+              description: toolDef.description,
+              inputSchema: toolDef.parameters as ZodSchema,
+              async execute(args, options) {
+                await Plugin.trigger(
+                  "tool.execute.before",
+                  {
+                    tool: resourceTool.id,
+                    sessionID: input.sessionID,
+                    callID: options.toolCallId,
+                  },
+                  {
+                    args,
+                  },
+                )
+                const result = await toolDef.execute(args, {
+                  sessionID: input.sessionID,
+                  messageID: assistantMsg.id,
+                  callID: options.toolCallId,
+                  abort: options.abortSignal || new AbortController().signal,
+                  metadata: async (val) => {
+                    const match = processor.partFromToolCall(options.toolCallId)
+                    if (match && match.state.status === "running") {
+                      await updatePart({
+                        ...match,
+                        state: {
+                          title: val.title,
+                          metadata: val.metadata,
+                          status: "running",
+                          input: args,
+                          time: {
+                            start: Date.now(),
+                          },
+                        },
+                      })
+                    }
+                  },
+                })
+                await Plugin.trigger(
+                  "tool.execute.after",
+                  {
+                    tool: resourceTool.id,
+                    sessionID: input.sessionID,
+                    callID: options.toolCallId,
+                  },
+                  {
+                    args,
+                    result,
+                  },
+                )
+                return result
+              },
+            })
+          }
+        } catch (error) {
+          log.error("failed to load resource tools", {
+            resource: typeof resource === "string" ? resource : resource.path,
+            agent: agent.name,
+            error,
+          })
+        }
+      }
+    }
+
     for (const [key, item] of Object.entries(await MCP.tools())) {
       if (enabledTools[key] === false) continue
       const execute = item.execute
@@ -846,6 +931,34 @@ export namespace Session {
         }
       }
       tools[key] = item
+    }
+
+    // Agent-specific MCP tools
+    if (agent.mcp && Object.keys(agent.mcp).length > 0) {
+      const agentMCPTools = await AgentMCP.tools(agent.name, agent.mcp)
+      for (const [key, item] of Object.entries(agentMCPTools)) {
+        if (enabledTools[key] === false) continue
+        const execute = item.execute
+        if (!execute) continue
+        item.execute = async (args, opts) => {
+          const result = await execute(args, opts)
+          const output = result.content
+            .filter((x: any) => x.type === "text")
+            .map((x: any) => x.text)
+            .join("\n\n")
+
+          return {
+            output,
+          }
+        }
+        item.toModelOutput = (result) => {
+          return {
+            type: "text",
+            value: result.output,
+          }
+        }
+        tools[key] = item
+      }
     }
 
     const params = {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -3,6 +3,7 @@ import { Ripgrep } from "../file/ripgrep"
 import { Global } from "../global"
 import { Filesystem } from "../util/filesystem"
 import { Config } from "../config/config"
+import { Agent } from "../agent/agent"
 import path from "path"
 import os from "os"
 
@@ -57,7 +58,7 @@ export namespace SystemPrompt {
     "CONTEXT.md", // deprecated
   ]
 
-  export async function custom() {
+  export async function custom(agent?: Agent.Info) {
     const { cwd, root } = App.info().path
     const config = await Config.get()
     const paths = new Set<string>()
@@ -70,8 +71,17 @@ export namespace SystemPrompt {
     paths.add(path.join(Global.Path.config, "AGENTS.md"))
     paths.add(path.join(os.homedir(), ".claude", "CLAUDE.md"))
 
+    // Global instructions
     if (config.instructions) {
       for (const instruction of config.instructions) {
+        const matches = await Filesystem.globUp(instruction, cwd, root).catch(() => [])
+        matches.forEach((path) => paths.add(path))
+      }
+    }
+
+    // Agent-specific instructions
+    if (agent?.instructions) {
+      for (const instruction of agent.instructions) {
         const matches = await Filesystem.globUp(instruction, cwd, root).catch(() => [])
         matches.forEach((path) => paths.add(path))
       }

--- a/packages/opencode/src/tool/resource.ts
+++ b/packages/opencode/src/tool/resource.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { App } from "../app/app"
+import { Filesystem } from "../util/filesystem"
+
+export function createResourceTool(resourcePath: string, basePath: string, customDescription?: string) {
+  const resourceName = path.basename(resourcePath, path.extname(resourcePath))
+  const toolId = `resource_${resourceName.replace(/[^a-zA-Z0-9]/g, "_")}`
+
+  const description = customDescription
+    ? `${customDescription}`
+    : `This tool provides access to the resource file: ${resourcePath}`
+
+  return Tool.define(toolId, {
+    description,
+    parameters: z.object({
+      // No parameters needed - tool is specific to one resource file
+    }),
+    async execute(_params, _ctx) {
+      let filepath = resourcePath
+      if (!path.isAbsolute(filepath)) {
+        filepath = path.resolve(basePath, filepath)
+      }
+
+      const app = App.info()
+      if (!Filesystem.contains(app.path.cwd, filepath)) {
+        throw new Error(`Resource ${filepath} is not in the current working directory`)
+      }
+
+      try {
+        const content = await Bun.file(filepath).text()
+        return {
+          title: `Resource: ${path.basename(resourcePath)}`,
+          metadata: {
+            resourcePath,
+            size: content.length,
+          },
+          output: content,
+        }
+      } catch (err: any) {
+        if (err.code === "ENOENT") {
+          throw new Error(`Resource file not found: ${filepath}`)
+        }
+        throw new Error(`Failed to read resource file: ${err.message}`)
+      }
+    },
+  })
+}


### PR DESCRIPTION
## Summary
The agent markdown config files now support:
- Instructions files
- MCP servers
- Resources (new feature, presenting a resource file as a tool for the LLM to call)
<img width="772" height="405" alt="image" src="https://github.com/user-attachments/assets/3ae3c9b2-cefd-4016-8d91-c57cf30406ee" />

## Core Feature
- Extended agent configuration to support `mcp`, `instructions`, and `resources` fields
- Added `Resource` schema for specifying file resources with descriptions
- Implemented dynamic resource tool creation from file paths
- Added agent-specific MCP client management with `AgentMCP` module
- Enhanced system prompt loading to include agent-level instruction files

## Steps to test it:
- Run `npx openmodes install example` at the root to install the agent file, its instructions and resources
- Run opencode with `bun dev`
- Press tab and select the "EXAMPLE" agent/mode
- Ask: `echo the verbatim list of tools you have access to, and give me the magic words`

#### Success should show:
- 3 repomix MCP tools out of 6 totals
- 1 `resource_the_other_magic_word` tool according to our resource file name
- Echo the first "magic word" supplied to the request through an instruction file
- Get the resource with a tool call and echo the second "magic word"

## Opening avenues
This ties in with the https://openmodes.dev project I've been working on lately (https://github.com/spoons-and-mirrors/openmodes.dev) and with the `openmodes` CLI tool, creating a simple way to discovering and using agents in OC.

Agents being integral to our agentic coding experience, I believe this PR allows for a better UX all around.