### PR TITLE
Reference the actual name of the windows package

### DIFF
--- a/packages/opencode/bin/opencode.cmd
+++ b/packages/opencode/bin/opencode.cmd
@@ -11,7 +11,7 @@ set "script_dir=%~dp0"
 set "script_dir=%script_dir:~0,-1%"
 
 rem Detect platform and architecture
-set "platform=win32"
+set "platform=windows"
 
 rem Detect architecture
 if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -20,7 +20,7 @@ function detectPlatformAndArch() {
       platform = "linux"
       break
     case "win32":
-      platform = "win32"
+      platform = "windows"
       break
     default:
       platform = os.platform()
@@ -50,7 +50,7 @@ function detectPlatformAndArch() {
 function findBinary() {
   const { platform, arch } = detectPlatformAndArch()
   const packageName = `opencode-${platform}-${arch}`
-  const binary = platform === "win32" ? "opencode.exe" : "opencode"
+  const binary = platform === "windows" ? "opencode.exe" : "opencode"
 
   try {
     // Use require.resolve to find the package


### PR DESCRIPTION
This fixes one of the two issues I've been having to work around to install with bun on windows. As seen in [this reply](https://github.com/sst/opencode/issues/631#issuecomment-3094840081) on the windows super issue the postinstall script looks for `opencode-win32-x64` but the actual name of the package is `opencode-windows-x64` which causes it to fail. Same result would be achieved by renaming the package if that would be preferred for some reason.