### PR TITLE
fix(TUI): enable general (sub-) agent for @ referencing

### DIFF
--- a/packages/tui/internal/completions/agents.go
+++ b/packages/tui/internal/completions/agents.go
@@ -45,7 +45,7 @@ func (cg *agentsContextGroup) GetChildEntries(
 		if query != "" && !strings.Contains(strings.ToLower(agent.Name), strings.ToLower(query)) {
 			continue
 		}
-		if agent.Mode == opencode.AgentModePrimary || agent.Name == "general" {
+		if agent.Mode == opencode.AgentModePrimary {
 			continue
 		}
 


### PR DESCRIPTION
Per the documentation, you can also reference the included general (sub-)agent via @ in the TUI input. This didn't explicitly work, but this PR enables it as I think it's good for the UX to be able to explicitly use this agent too.

<img width="823" height="441" alt="Bildschirmfoto 2025-08-08 um 09 59 34" src="https://github.com/user-attachments/assets/f06a6e5e-90c9-41a4-8971-5a98394689cd" />
