### PR TITLE
fix(tui): preserve scroll position when reflowing due to message stream

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -210,7 +210,18 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.clipboard = msg.clipboard
 		m.loading = false
 		m.tail = m.viewport.AtBottom()
+
+		// Preserve scroll across reflow
+		// if the user was at bottom, keep following; otherwise restore the previous offset.
+		wasAtBottom := m.viewport.AtBottom()
+		prevYOffset := m.viewport.YOffset
 		m.viewport = msg.viewport
+		if wasAtBottom {
+			m.viewport.GotoBottom()
+		} else {
+			m.viewport.YOffset = prevYOffset
+		}
+
 		m.header = msg.header
 		if m.dirty {
 			cmds = append(cmds, m.renderView())
@@ -218,7 +229,6 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	m.tail = m.viewport.AtBottom()
-
 	viewport, cmd := m.viewport.Update(msg)
 	m.viewport = viewport
 	cmds = append(cmds, cmd)


### PR DESCRIPTION
fixes #1715

This PR preserves the scroll position on reflow, and also reduces some stuttering that seems to happen when scrolling while a message is streaming in.


https://github.com/user-attachments/assets/390f6825-1af9-47ee-922e-169d679dc704

