### PR TITLE
docs: mention that opencode picks up CLAUDE.md files

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -335,7 +335,12 @@ export namespace Config {
           ]),
         )
         .optional(),
-      instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
+      instructions: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Additional instruction files or patterns to include (AGENTS.md and local/global CLAUDE.md picked up automatically)",
+        ),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: z
         .object({

--- a/packages/web/src/content/docs/docs/rules.mdx
+++ b/packages/web/src/content/docs/docs/rules.mdx
@@ -5,6 +5,10 @@ description: Set custom instructions for opencode.
 
 You can provide custom instructions to opencode by creating an `AGENTS.md` file. This is similar to `CLAUDE.md` or Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
 
+:::note
+opencode also automatically picks up `CLAUDE.md` files (both local and global `~/.claude/CLAUDE.md`)
+:::
+
 ---
 
 ## Initialize


### PR DESCRIPTION
Saw people on discord mentioning they didn't know this

Fixes:  #1760


### ALSO QUESTION:

should we add an exclude to `instructions` maybe like `"instructions": ["!CLAUDE.md"]` so people can exclude these files if they want? 