### PR TITLE
Brew can install OpenCode on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -fsSL https://opencode.ai/install | bash
 
 # Package managers
 npm i -g opencode-ai@latest        # or bun/pnpm/yarn
-brew install sst/tap/opencode      # macOS
+brew install sst/tap/opencode      # macOS and Linux
 paru -S opencode-bin               # Arch Linux
 ```
 


### PR DESCRIPTION
Brew is now the default package manager for "immutable" Linux distributions like Bazzite and Bluefin and can work on pretty much any Linux distribution.