### PR TITLE
Docs: Homebrew can install Opencode on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -fsSL https://opencode.ai/install | bash
 
 # Package managers
 npm i -g opencode-ai@latest        # or bun/pnpm/yarn
-brew install sst/tap/opencode      # macOS
+brew install sst/tap/opencode      # macOS and Linux
 paru -S opencode-bin               # Arch Linux
 ```
 

--- a/packages/web/src/content/docs/docs/index.mdx
+++ b/packages/web/src/content/docs/docs/index.mdx
@@ -63,7 +63,7 @@ You can also install it with the following:
     </TabItem>
   </Tabs>
 
-- **Using Homebrew on macOS**
+- **Using Homebrew on macOS and Linux**
 
   ```bash
   brew install sst/tap/opencode


### PR DESCRIPTION
Background: Homebrew is now the default package manager on "immutable" Linux distributions like Bazzite and Bluefin,