### PR TITLE
Make entire session available for `session.idle` event

### DIFF
--- a/packages/opencode/src/config/hooks.ts
+++ b/packages/opencode/src/config/hooks.ts
@@ -34,7 +34,7 @@ export namespace ConfigHooks {
     Bus.subscribe(Session.Event.Idle, async (payload) => {
       const cfg = await Config.get()
       if (cfg.experimental?.hook?.session_completed) {
-        const session = await Session.get(payload.properties.sessionID)
+        const session = payload.properties.info
         // Only fire hook for top-level sessions (not subagent sessions)
         if (session.parentID) return
 

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -113,7 +113,7 @@ export namespace Session {
     Idle: Bus.event(
       "session.idle",
       z.object({
-        sessionID: z.string(),
+        info: Info,
       }),
     ),
     Error: Bus.event(
@@ -1381,7 +1381,7 @@ export namespace Session {
         if (session.parentID) return
 
         Bus.publish(Event.Idle, {
-          sessionID,
+          info: session,
         })
       },
     }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -488,7 +488,7 @@ export type EventSessionDeleted = {
 export type EventSessionIdle = {
   type: string
   properties: {
-    sessionID: string
+    info: Session
   }
 }
 

--- a/packages/web/src/content/docs/docs/plugins.mdx
+++ b/packages/web/src/content/docs/docs/plugins.mdx
@@ -73,9 +73,10 @@ Send notifications when certain events occur:
 export const NotificationPlugin = async ({ client, $ }) => {
   return {
     event: async ({ event }) => {
-      // Send notification on session completion
+      // Send notification on session completion with session title
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        const sessionTitle = event.properties.info.title
+        await $`osascript -e 'display notification "Session ${sessionTitle} completed!" with title "opencode"'`
       }
     },
   }


### PR DESCRIPTION
Hey there,
I was playing around with opencode for the last week and already started to customize my experience with agents, plugins, etc. Your example for the desktop notification when a session is idle is really cool. But one thing that's missing for me is the session title, so you can print it in your notification.
And since every other session event (`session.deleted`, `session.updated`) already includes the full session information, I sent Copilot to also add the full info to the `session.idle` event. So far it looks good to me.

If you have any feedback on this or any additional changes need to be made feel free to reach out.