### PR TITLE
feat: set AGENT=1 environment variable to identify AI agent execution

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -19,6 +19,9 @@ import { StatsCommand } from "./cli/cmd/stats"
 import { McpCommand } from "./cli/cmd/mcp"
 import { GithubCommand } from "./cli/cmd/github"
 
+// Set environment variable to indicate this is an AI agent
+process.env["AGENT"] = "1"
+
 const cancel = new AbortController()
 
 process.on("unhandledRejection", (e) => {


### PR DESCRIPTION
## Summary
Sets the env var `AGENT=1` at startup to identify when processes are run by an AI agent.

## Context

### Claude Code Implementation
Claude Code sets `CLAUDECODE=1` environment variable for similar purposes. This is useful when you want to:
- Block AIs from touching certain sensitive scripts
- Enable stricter pre-commit hooks when code is being modified by AI
- Provide clear identification of AI-driven operations

### Bun Test Integration
Bun's test runner already supports AI agent detection through the `AGENT=1` environment variable:
- When `AGENT=1` is detected, Bun shows concise, AI-friendly test reports
- This improves the AI's ability to parse and understand test results
- Documentation: https://bun.com/docs/cli/test#ai-agent-integration