### PR TITLE
Feat: Add User Custom Instructions to `/compact` Command

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -444,12 +444,13 @@ export namespace Server {
           z.object({
             providerID: z.string(),
             modelID: z.string(),
+            extraInstruction: z.string().optional(),
           }),
         ),
         async (c) => {
           const id = c.req.valid("param").id
           const body = c.req.valid("json")
-          await Session.summarize({ ...body, sessionID: id })
+          await Session.summarize({ ...body, sessionID: id, extraInstruction: body.extraInstruction })
           return c.json(true)
         },
       )

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1288,8 +1288,20 @@ export namespace Session {
     return next
   }
 
-  export async function summarize(input: { sessionID: string; providerID: string; modelID: string }) {
+  export async function summarize(input: {
+    sessionID: string
+    providerID: string
+    modelID: string
+    extraInstruction?: string
+  }) {
     using abort = lock(input.sessionID)
+    return await summarizeInternal(input, abort.signal)
+  }
+
+  async function summarizeInternal(
+    input: { sessionID: string; providerID: string; modelID: string; extraInstruction?: string },
+    abortSignal: AbortSignal,
+  ) {
     const msgs = await messages(input.sessionID)
     const lastSummary = msgs.findLast((msg) => msg.info.role === "assistant" && msg.info.summary === true)
     const filtered = msgs.filter((msg) => !lastSummary || msg.info.id >= lastSummary.info.id)
@@ -1330,7 +1342,7 @@ export namespace Session {
     const processor = createProcessor(next, model.info)
     const stream = streamText({
       maxRetries: 10,
-      abortSignal: abort.signal,
+      abortSignal: abortSignal,
       model: model.language,
       messages: [
         ...system.map(
@@ -1345,7 +1357,9 @@ export namespace Session {
           content: [
             {
               type: "text",
-              text: "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.",
+              text:
+                "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next." +
+                (input.extraInstruction ? "\n\nAdditional instruction: " + input.extraInstruction : ""),
             },
           ],
         },

--- a/packages/sdk/go/session.go
+++ b/packages/sdk/go/session.go
@@ -2267,8 +2267,9 @@ func (r SessionRevertParams) MarshalJSON() (data []byte, err error) {
 }
 
 type SessionSummarizeParams struct {
-	ModelID    param.Field[string] `json:"modelID,required"`
-	ProviderID param.Field[string] `json:"providerID,required"`
+	ModelID          param.Field[string] `json:"modelID,required"`
+	ProviderID       param.Field[string] `json:"providerID,required"`
+	ExtraInstruction param.Field[string] `json:"extraInstruction"`
 }
 
 func (r SessionSummarizeParams) MarshalJSON() (data []byte, err error) {

--- a/packages/sdk/go/session_test.go
+++ b/packages/sdk/go/session_test.go
@@ -291,8 +291,9 @@ func TestSessionSummarize(t *testing.T) {
 		context.TODO(),
 		"id",
 		opencode.SessionSummarizeParams{
-			ModelID:    opencode.F("modelID"),
-			ProviderID: opencode.F("providerID"),
+			ModelID:          opencode.F("modelID"),
+			ProviderID:       opencode.F("providerID"),
+			ExtraInstruction: opencode.F("include action items"),
 		},
 	)
 	if err != nil {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1262,6 +1262,7 @@ export type SessionSummarizeData = {
   body?: {
     providerID: string
     modelID: string
+    extraInstruction?: string
   }
   path: {
     /**

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -526,7 +526,7 @@ func (a *App) InitializeProject(ctx context.Context) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-func (a *App) CompactSession(ctx context.Context) tea.Cmd {
+func (a *App) CompactSession(ctx context.Context, extraInstruction string) tea.Cmd {
 	if a.compactCancel != nil {
 		a.compactCancel()
 	}
@@ -543,8 +543,9 @@ func (a *App) CompactSession(ctx context.Context) tea.Cmd {
 			compactCtx,
 			a.Session.ID,
 			opencode.SessionSummarizeParams{
-				ProviderID: opencode.F(a.Provider.ID),
-				ModelID:    opencode.F(a.Model.ID),
+				ProviderID:       opencode.F(a.Provider.ID),
+				ModelID:          opencode.F(a.Model.ID),
+				ExtraInstruction: opencode.F(extraInstruction),
 			},
 		)
 		if err != nil {

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"log/slog"
@@ -558,6 +559,47 @@ func (m *editorComponent) Length() int {
 
 func (m *editorComponent) Submit() (tea.Model, tea.Cmd) {
 	value := strings.TrimSpace(m.Value())
+	if value == "" {
+		return m, nil
+	}
+
+	// Special handling for slash commands with trailing text (eg: /compact do X)
+	if strings.HasPrefix(value, "/") {
+		// Parse command and remainder
+		raw := strings.TrimSpace(value[1:])
+		if raw != "" {
+			parts := strings.Fields(raw)
+			if len(parts) > 0 {
+				trigger := parts[0]
+				remainderStart := len(trigger)
+				remainder := strings.TrimSpace(raw[remainderStart:])
+				// Locate matching command by trigger
+				var match commands.Command
+				for _, c := range m.app.Commands {
+					if c.MatchesTrigger(trigger) {
+						match = c
+						break
+					}
+				}
+				if match.Name == commands.SessionCompactCommand {
+					// Execute compaction command and optionally send remainder as a normal prompt
+					var teaCmds []tea.Cmd
+					// Clear current editor before executing
+					updated, clearCmd := m.Clear()
+					m = updated.(*editorComponent)
+					teaCmds = append(teaCmds, clearCmd)
+					// Execute compaction with optional extra instruction
+					teaCmds = append(teaCmds, func() tea.Msg {
+						m.app.CompactSession(context.Background(), remainder)
+						return nil
+					})
+					return m, tea.Batch(teaCmds...)
+				}
+			}
+		}
+	}
+
+	// value already trimmed earlier
 	if value == "" {
 		return m, nil
 	}

--- a/packages/tui/internal/components/chat/editor_submit_test.go
+++ b/packages/tui/internal/components/chat/editor_submit_test.go
@@ -1,0 +1,32 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/commands"
+)
+
+func TestSubmitCompactWithRemainder(t *testing.T) {
+	ed := newTestEditor()
+	fakeApp := &app.App{State: app.NewState()}
+	fakeApp.Commands = commands.CommandRegistry{}
+	fakeApp.Commands[commands.SessionCompactCommand] = commands.Command{
+		Name:    commands.SessionCompactCommand,
+		Trigger: []string{"compact", "summarize"},
+	}
+	ed.app = fakeApp
+	ed.SetValue("/compact tell me how this relates to the color blue")
+	_, cmd := ed.Submit()
+	if cmd == nil {
+		return
+	}
+	_ = cmd()
+	if len(fakeApp.State.MessageHistory) != 0 {
+		// Remainder should not be recorded as separate prompt
+		if len(fakeApp.State.MessageHistory) == 1 {
+			t.Fatalf("expected no prompt history entries, got 1: %v", fakeApp.State.MessageHistory[0])
+		}
+		t.Fatalf("expected no prompt history entries, got %d", len(fakeApp.State.MessageHistory))
+	}
+}

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1053,7 +1053,7 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 		// TODO: block until compaction is complete
-		a.app.CompactSession(context.Background())
+		a.app.CompactSession(context.Background(), "")
 	case commands.SessionExportCommand:
 		if a.app.Session.ID == "" {
 			return a, toast.NewErrorToast("No active session to export.")


### PR DESCRIPTION
## Summary
Introduces the ability for users to append custom instructions to the `/compact` command, allowing for more tailored and detailed responses (e.g., `/compact make sure to detail X and explain why it relates to Y`).

### Key Points
- Accepts arbitrary user instructions as part of the `/compact` command.
- Passes these instructions through session, server, and SDK layers for consistent handling.
- Updates TUI and SDKs (Go/JS) to support and test this behavior.
- Works seamlessly with existing compaction and summarization logic.

### Result
This enhancement gives users finer control over the output of the compact command, enabling more specific and context-aware interactions.

#### Dumb Example
<img width="852" height="58" alt="image" src="https://github.com/user-attachments/assets/aaa6e223-c7f8-4aef-9c78-8b932c0a5bb5" />
<img width="835" height="231" alt="image" src="https://github.com/user-attachments/assets/292c5ba9-8c7c-4b3f-be8f-011e923f2752" />

