### PR TITLE
fix: only load the first local and global rule file

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -51,10 +51,14 @@ export namespace SystemPrompt {
     ]
   }
 
-  const CUSTOM_FILES = [
+  const LOCAL_RULE_FILES = [
     "AGENTS.md",
     "CLAUDE.md",
     "CONTEXT.md", // deprecated
+  ]
+  const GLOBAL_RULE_FILES = [
+    path.join(Global.Path.config, "AGENTS.md"),
+    path.join(os.homedir(), ".claude", "CLAUDE.md"),
   ]
 
   export async function custom() {
@@ -62,13 +66,20 @@ export namespace SystemPrompt {
     const config = await Config.get()
     const paths = new Set<string>()
 
-    for (const item of CUSTOM_FILES) {
-      const matches = await Filesystem.findUp(item, cwd, root)
-      matches.forEach((path) => paths.add(path))
+    for (const localRuleFile of LOCAL_RULE_FILES) {
+      const matches = await Filesystem.findUp(localRuleFile, cwd, root)
+      if (matches.length > 0) {
+        matches.forEach((path) => paths.add(path))
+        break
+      }
     }
 
-    paths.add(path.join(Global.Path.config, "AGENTS.md"))
-    paths.add(path.join(os.homedir(), ".claude", "CLAUDE.md"))
+    for (const globalRuleFile of GLOBAL_RULE_FILES) {
+      if (await Bun.file(globalRuleFile).exists()) {
+        paths.add(globalRuleFile)
+        break
+      }
+    }
 
     if (config.instructions) {
       for (const instruction of config.instructions) {


### PR DESCRIPTION
Only load the first found local and global rule file.

Priority AGENTS.md, CLAUDE.md 