### PR TITLE
⚠️ DEPRECATED - Feat: Add Interactive Tool Management Modal to TUI

### DIFF
--- a/packages/opencode/src/cli/bootstrap.ts
+++ b/packages/opencode/src/cli/bootstrap.ts
@@ -5,6 +5,7 @@ import { LSP } from "../lsp"
 import { Plugin } from "../plugin"
 import { Share } from "../share/share"
 import { Snapshot } from "../snapshot"
+import { MCP } from "../mcp"
 
 export async function bootstrap<T>(input: App.Input, cb: (app: App.Info) => Promise<T>) {
   return App.provide(input, async (app) => {
@@ -14,6 +15,11 @@ export async function bootstrap<T>(input: App.Input, cb: (app: App.Info) => Prom
     ConfigHooks.init()
     LSP.init()
     Snapshot.init()
+
+    // Initialize MCP servers early so tools are available immediately
+    MCP.clients().catch(() => {
+      // Ignore errors during startup - MCP servers will be retried when needed
+    })
 
     return cb(app)
   })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -20,6 +20,8 @@ import { callTui, TuiRoute } from "./tui"
 import { Permission } from "../permission"
 import { lazy } from "../util/lazy"
 import { Agent } from "../agent/agent"
+import { MCP } from "../mcp"
+import { ToolRegistry } from "../tool/registry"
 
 const ERRORS = {
   400: {
@@ -890,6 +892,73 @@ export namespace Server {
         async (c) => {
           const modes = await Agent.list()
           return c.json(modes)
+        },
+      )
+      .get(
+        "/app/tools",
+        describeRoute({
+          description: "List all available tools",
+          operationId: "app.tools",
+          responses: {
+            200: {
+              description: "List of tools",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z.record(
+                      z.string(),
+                      z.object({
+                        name: z.string(),
+                        description: z.string().optional(),
+                        source: z.enum(["builtin", "mcp"]),
+                      }),
+                    ),
+                  ),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          const tools: Record<string, { name: string; description?: string; source: "builtin" | "mcp" }> = {}
+
+          // Add built-in tools dynamically from registry
+          try {
+            const builtinTools = await ToolRegistry.tools("", "") // provider/model not needed for getting tool info
+            for (const tool of builtinTools) {
+              tools[tool.id] = {
+                name: tool.id,
+                description: tool.description,
+                source: "builtin",
+              }
+            }
+          } catch (error) {
+            // Fallback to just tool IDs if registry fails
+            const builtinToolIds = ToolRegistry.ids()
+            for (const toolName of builtinToolIds) {
+              tools[toolName] = {
+                name: toolName,
+                source: "builtin",
+              }
+            }
+          }
+
+          // Add MCP tools
+          try {
+            const mcpTools = await MCP.tools()
+            for (const [toolName, tool] of Object.entries(mcpTools)) {
+              tools[toolName] = {
+                name: toolName,
+                description: tool.description,
+                source: "mcp",
+              }
+            }
+          } catch (error) {
+            // MCP tools might not be available, that's okay
+            log.warn("Failed to load MCP tools", { error })
+          }
+
+          return c.json(tools)
         },
       )
       .post(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -20,8 +20,7 @@ import { callTui, TuiRoute } from "./tui"
 import { Permission } from "../permission"
 import { lazy } from "../util/lazy"
 import { Agent } from "../agent/agent"
-import { MCP } from "../mcp"
-import { ToolRegistry } from "../tool/registry"
+import { ToolService } from "../tool/service"
 
 const ERRORS = {
   400: {
@@ -911,6 +910,7 @@ export namespace Server {
                         name: z.string(),
                         description: z.string().optional(),
                         source: z.enum(["builtin", "mcp"]),
+                        defaultEnabled: z.boolean().optional().default(true),
                       }),
                     ),
                   ),
@@ -920,45 +920,7 @@ export namespace Server {
           },
         }),
         async (c) => {
-          const tools: Record<string, { name: string; description?: string; source: "builtin" | "mcp" }> = {}
-
-          // Add built-in tools dynamically from registry
-          try {
-            const builtinTools = await ToolRegistry.tools("", "") // provider/model not needed for getting tool info
-            for (const tool of builtinTools) {
-              tools[tool.id] = {
-                name: tool.id,
-                description: tool.description,
-                source: "builtin",
-              }
-            }
-          } catch (error) {
-            // Fallback to just tool IDs if registry fails
-            const builtinToolIds = ToolRegistry.ids()
-            for (const toolName of builtinToolIds) {
-              tools[toolName] = {
-                name: toolName,
-                source: "builtin",
-              }
-            }
-          }
-
-          // Add MCP tools
-          try {
-            const mcpTools = await MCP.tools()
-            for (const [toolName, tool] of Object.entries(mcpTools)) {
-              tools[toolName] = {
-                name: toolName,
-                description: tool.description,
-                source: "mcp",
-              }
-            }
-          } catch (error) {
-            // MCP tools might not be available, that's okay
-            log.warn("Failed to load MCP tools", { error })
-          }
-
-          return c.json(tools)
+          return c.json(await ToolService.getAllTools())
         },
       )
       .post(

--- a/packages/opencode/src/tool/service.ts
+++ b/packages/opencode/src/tool/service.ts
@@ -1,0 +1,122 @@
+import { App } from "../app/app"
+import { Log } from "../util/log"
+import { ToolRegistry } from "./registry"
+import { MCP } from "../mcp"
+import { z } from "zod"
+
+export namespace ToolService {
+  const log = Log.create({ service: "tool-service" })
+
+  export const ToolInfo = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    source: z.enum(["builtin", "mcp"]),
+    defaultEnabled: z.boolean().optional().default(true), // NEW: explicit default enabled flag
+  })
+  export type ToolInfo = z.infer<typeof ToolInfo>
+
+  // Tool-specific metadata - documents why certain tools are disabled by default
+  const TOOL_DEFAULTS: Record<string, { defaultEnabled: boolean; reason?: string }> = {
+    patch: { defaultEnabled: false, reason: "Experimental/deprecated tool marked 'do not use'" },
+    invalid: { defaultEnabled: false, reason: "Internal error handling tool" },
+  }
+
+  const state = App.state("tool-service", async () => {
+    return {
+      cache: new Map<string, Record<string, ToolInfo>>(),
+      cacheTimestamps: new Map<string, number>(),
+    }
+  })
+
+  const CACHE_TTL = 60 * 1000 // 1 minute
+
+  export async function getAllTools(): Promise<Record<string, ToolInfo>> {
+    const cacheKey = "all-tools"
+    const serviceState = await state()
+    const now = Date.now()
+
+    // Check cache first
+    const cached = serviceState.cache.get(cacheKey)
+    const cacheTime = serviceState.cacheTimestamps.get(cacheKey) ?? 0
+
+    if (cached && now - cacheTime < CACHE_TTL) {
+      log.debug("returning cached tools", { count: Object.keys(cached).length })
+      return cached
+    }
+
+    log.debug("fetching fresh tools")
+    const tools: Record<string, ToolInfo> = {}
+
+    // Add built-in tools dynamically from registry
+    try {
+      const builtinTools = await ToolRegistry.tools("", "") // provider/model not needed for getting tool info
+      for (const tool of builtinTools) {
+        const defaults = TOOL_DEFAULTS[tool.id]
+        tools[tool.id] = {
+          name: tool.id,
+          description: tool.description,
+          source: "builtin",
+          defaultEnabled: defaults?.defaultEnabled ?? true, // Use metadata or default to true
+        }
+      }
+    } catch (error) {
+      log.warn("Failed to load builtin tools, falling back to IDs", { error })
+      // Fallback to just tool IDs if registry fails
+      const builtinToolIds = ToolRegistry.ids()
+      for (const toolName of builtinToolIds) {
+        const defaults = TOOL_DEFAULTS[toolName]
+        tools[toolName] = {
+          name: toolName,
+          source: "builtin",
+          defaultEnabled: defaults?.defaultEnabled ?? true,
+        }
+      }
+    }
+
+    // Add MCP tools (always enabled by default since they're explicitly configured)
+    try {
+      const mcpTools = await MCP.tools()
+      for (const [toolName, tool] of Object.entries(mcpTools)) {
+        tools[toolName] = {
+          name: toolName,
+          description: tool.description,
+          source: "mcp",
+          defaultEnabled: true, // MCP tools are always enabled by default
+        }
+      }
+    } catch (error) {
+      // MCP tools might not be available, that's okay
+      log.debug("MCP tools not available", { error })
+    }
+
+    // Update cache
+    serviceState.cache.set(cacheKey, tools)
+    serviceState.cacheTimestamps.set(cacheKey, now)
+
+    log.debug("cached fresh tools", { count: Object.keys(tools).length })
+    return tools
+  }
+
+  export function isToolDefaultEnabled(name: string): boolean {
+    const defaults = TOOL_DEFAULTS[name]
+    return defaults?.defaultEnabled ?? true
+  }
+
+  export async function getToolDefaults(): Promise<Record<string, boolean>> {
+    const allTools = await getAllTools()
+    const result: Record<string, boolean> = {}
+
+    for (const [name, tool] of Object.entries(allTools)) {
+      result[name] = tool.defaultEnabled ?? true
+    }
+
+    return result
+  }
+
+  export async function invalidateCache(): Promise<void> {
+    const serviceState = await state()
+    serviceState.cache.clear()
+    serviceState.cacheTimestamps.clear()
+    log.debug("cache invalidated")
+  }
+}

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"log/slog"
 
@@ -27,27 +30,30 @@ type Message struct {
 }
 
 type App struct {
-	Info              opencode.App
-	Agents            []opencode.Agent
-	Providers         []opencode.Provider
-	Version           string
-	StatePath         string
-	Config            *opencode.Config
-	Client            *opencode.Client
-	State             *State
-	AgentIndex        int
-	Provider          *opencode.Provider
-	Model             *opencode.Model
-	Session           *opencode.Session
-	Messages          []Message
-	Permissions       []opencode.Permission
-	CurrentPermission opencode.Permission
-	Commands          commands.CommandRegistry
-	InitialModel      *string
-	InitialPrompt     *string
-	InitialAgent      *string
-	compactCancel     context.CancelFunc
-	IsLeaderSequence  bool
+	Info                 opencode.App
+	Agents               []opencode.Agent
+	Providers            []opencode.Provider
+	Version              string
+	StatePath            string
+	Config               *opencode.Config
+	Client               *opencode.Client
+	State                *State
+	AgentIndex           int
+	Provider             *opencode.Provider
+	Model                *opencode.Model
+	Session              *opencode.Session
+	Messages             []Message
+	Permissions          []opencode.Permission
+	CurrentPermission    opencode.Permission
+	Commands             commands.CommandRegistry
+	InitialModel         *string
+	InitialPrompt        *string
+	InitialAgent         *string
+	compactCancel        context.CancelFunc
+	IsLeaderSequence     bool
+	SessionToolOverrides map[string]map[string]bool // session-scoped tool overrides (not persisted)
+	toolCache            map[string]ToolInfo        // cached tools by name
+	toolCacheTS          time.Time                  // timestamp of last fetch
 }
 
 func (a *App) Agent() *opencode.Agent {
@@ -81,6 +87,17 @@ type FileRenderedMsg struct {
 }
 type PermissionRespondedToMsg struct {
 	Response opencode.SessionPermissionRespondParamsResponse
+}
+
+// ToolsUpdatedMsg is emitted when tool overrides for an agent are updated via the dialog
+// Overrides contains only explicit deviations (true/false) from defaults for that agent
+// Agent is the agent name whose overrides were changed
+// When Overrides is empty the entry for the agent should be removed
+// The dialog implementation will compute these overrides prior to emitting the message
+// NOTE: Overrides are session-scoped and NOT persisted to disk.
+type ToolsUpdatedMsg struct {
+	Agent     string
+	Overrides map[string]bool
 }
 
 func New(
@@ -172,20 +189,21 @@ func New(
 	slog.Debug("Loaded config", "config", configInfo)
 
 	app := &App{
-		Info:          appInfo,
-		Agents:        agents,
-		Version:       version,
-		StatePath:     appStatePath,
-		Config:        configInfo,
-		State:         appState,
-		Client:        httpClient,
-		AgentIndex:    agentIndex,
-		Session:       &opencode.Session{},
-		Messages:      []Message{},
-		Commands:      commands.LoadFromConfig(configInfo),
-		InitialModel:  initialModel,
-		InitialPrompt: initialPrompt,
-		InitialAgent:  initialAgent,
+		Info:                 appInfo,
+		Agents:               agents,
+		Version:              version,
+		StatePath:            appStatePath,
+		Config:               configInfo,
+		State:                appState,
+		Client:               httpClient,
+		AgentIndex:           agentIndex,
+		Session:              &opencode.Session{},
+		Messages:             []Message{},
+		Commands:             commands.LoadFromConfig(configInfo),
+		InitialModel:         initialModel,
+		InitialPrompt:        initialPrompt,
+		InitialAgent:         initialAgent,
+		SessionToolOverrides: make(map[string]map[string]bool),
 	}
 
 	return app, nil
@@ -590,13 +608,17 @@ func (a *App) SendPrompt(ctx context.Context, prompt Prompt) (*App, tea.Cmd) {
 	a.Messages = append(a.Messages, message)
 
 	cmds = append(cmds, func() tea.Msg {
-		_, err := a.Client.Session.Chat(ctx, a.Session.ID, opencode.SessionChatParams{
+		params := opencode.SessionChatParams{
 			ProviderID: opencode.F(a.Provider.ID),
 			ModelID:    opencode.F(a.Model.ID),
 			Agent:      opencode.F(a.Agent().Name),
 			MessageID:  opencode.F(messageID),
 			Parts:      opencode.F(message.ToSessionChatParams()),
-		})
+		}
+		if ov, ok := a.SessionToolOverrides[a.Agent().Name]; ok && len(ov) > 0 {
+			params.Tools = opencode.F(ov)
+		}
+		_, err := a.Client.Session.Chat(ctx, a.Session.ID, params)
 		if err != nil {
 			errormsg := fmt.Sprintf("failed to send message: %v", err)
 			slog.Error(errormsg)
@@ -681,6 +703,49 @@ func (a *App) ListProviders(ctx context.Context) ([]opencode.Provider, error) {
 	return providers.Providers, nil
 }
 
+type ToolInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Source      string `json:"source"` // "builtin" or "mcp"
+}
+
+// IsToolDefaultEnabled returns whether a tool is enabled by default before any
+// agent-specific settings or overrides are applied.
+func IsToolDefaultEnabled(name string) bool { return name != "patch" && name != "invalid" }
+
+func (a *App) ListTools(ctx context.Context) (map[string]ToolInfo, error) {
+	if a.toolCache != nil && time.Since(a.toolCacheTS) < time.Minute {
+		return a.toolCache, nil
+	}
+	u := os.Getenv("OPENCODE_SERVER")
+	if u == "" {
+		return nil, fmt.Errorf("OPENCODE_SERVER environment variable not set")
+	}
+	u = strings.TrimSuffix(u, "/") + "/app/tools"
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create tools request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch tools: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("tools API status %d", resp.StatusCode)
+	}
+	var tools map[string]ToolInfo
+	if err := json.NewDecoder(resp.Body).Decode(&tools); err != nil {
+		return nil, fmt.Errorf("decode tools: %w", err)
+	}
+	a.toolCache = tools
+	a.toolCacheTS = time.Now()
+	return tools, nil
+}
+
+// Removed getFallbackTools() - server is the single source of truth
 // func (a *App) loadCustomKeybinds() {
 //
 // }

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -52,8 +52,6 @@ type App struct {
 	compactCancel        context.CancelFunc
 	IsLeaderSequence     bool
 	SessionToolOverrides map[string]map[string]bool // session-scoped tool overrides (not persisted)
-	toolCache            map[string]ToolInfo        // cached tools by name
-	toolCacheTS          time.Time                  // timestamp of last fetch
 }
 
 func (a *App) Agent() *opencode.Agent {
@@ -704,19 +702,28 @@ func (a *App) ListProviders(ctx context.Context) ([]opencode.Provider, error) {
 }
 
 type ToolInfo struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Source      string `json:"source"` // "builtin" or "mcp"
+	Name           string `json:"name"`
+	Description    string `json:"description,omitempty"`
+	Source         string `json:"source"`         // "builtin" or "mcp"
+	DefaultEnabled *bool  `json:"defaultEnabled"` // pointer to allow nil detection
+}
+
+// IsToolDefaultEnabled returns whether a tool is enabled by default before any
+// agent-specific settings or overrides are applied. Now uses API response data.
+func IsToolDefaultEnabledFromToolInfo(toolInfo ToolInfo) bool {
+	if toolInfo.DefaultEnabled != nil {
+		return *toolInfo.DefaultEnabled
+	}
+	// Fallback for older API responses that don't include defaultEnabled
+	return toolInfo.Name != "patch" && toolInfo.Name != "invalid"
 }
 
 // IsToolDefaultEnabled returns whether a tool is enabled by default before any
 // agent-specific settings or overrides are applied.
+// DEPRECATED: Use IsToolDefaultEnabledFromToolInfo for new code
 func IsToolDefaultEnabled(name string) bool { return name != "patch" && name != "invalid" }
 
 func (a *App) ListTools(ctx context.Context) (map[string]ToolInfo, error) {
-	if a.toolCache != nil && time.Since(a.toolCacheTS) < time.Minute {
-		return a.toolCache, nil
-	}
 	u := os.Getenv("OPENCODE_SERVER")
 	if u == "" {
 		return nil, fmt.Errorf("OPENCODE_SERVER environment variable not set")
@@ -740,8 +747,6 @@ func (a *App) ListTools(ctx context.Context) (map[string]ToolInfo, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&tools); err != nil {
 		return nil, fmt.Errorf("decode tools: %w", err)
 	}
-	a.toolCache = tools
-	a.toolCacheTS = time.Now()
 	return tools, nil
 }
 

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -119,6 +119,7 @@ const (
 	SessionExportCommand        CommandName = "session_export"
 	ToolDetailsCommand          CommandName = "tool_details"
 	ModelListCommand            CommandName = "model_list"
+	ToolListCommand             CommandName = "tool_list"
 	ThemeListCommand            CommandName = "theme_list"
 	FileListCommand             CommandName = "file_list"
 	FileCloseCommand            CommandName = "file_close"
@@ -247,6 +248,12 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 			Description: "list models",
 			Keybindings: parseBindings("<leader>m"),
 			Trigger:     []string{"models"},
+		},
+		{
+			Name:        ToolListCommand,
+			Description: "toggle tools",
+			Keybindings: parseBindings("<leader>o"),
+			Trigger:     []string{"tools"},
 		},
 		{
 			Name:        ThemeListCommand,

--- a/packages/tui/internal/components/dialog/tools.go
+++ b/packages/tui/internal/components/dialog/tools.go
@@ -37,11 +37,12 @@ type toolsDialog struct {
 }
 
 type toolItem struct {
-	name        string
-	displayName string
-	enabled     bool
-	source      string // "builtin" or "mcp"
-	overridden  bool   // differs from default (agent default + global default)
+	name           string
+	displayName    string
+	enabled        bool
+	source         string // "builtin" or "mcp"
+	overridden     bool   // differs from default (agent default + global default)
+	defaultEnabled bool   // cached default enabled value from API
 }
 
 func (t toolItem) Render(selected bool, width int, baseStyle styles.Style) string {
@@ -92,7 +93,7 @@ func (d *toolsDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if d.allTools[i].name == selectedName {
 					d.allTools[i].enabled = !d.allTools[i].enabled
 				}
-				base := app.IsToolDefaultEnabled(d.allTools[i].name)
+				base := d.allTools[i].defaultEnabled
 				if agentSetting, ok := agent.Tools[d.allTools[i].name]; ok {
 					base = agentSetting
 				}
@@ -206,11 +207,12 @@ func (d *toolsDialog) setupAllTools() {
 	}
 
 	// Build deterministic ordered list: collect names, sort by source then name
-	// Filter out tools that should not be shown to users
+	// Only show tools that are meant to be user-manageable (defaultEnabled indicates this)
 	keys := make([]string, 0, len(availableTools))
-	for k := range availableTools {
-		// Skip patch and invalid tools as they are not meant to be user-manageable
-		if k == "patch" || k == "invalid" {
+	for k, toolInfo := range availableTools {
+		// Only include tools that have a default enabled state
+		// Tools without defaultEnabled (nil) or explicitly disabled are not user-manageable
+		if toolInfo.DefaultEnabled != nil && !*toolInfo.DefaultEnabled {
 			continue
 		}
 		keys = append(keys, k)
@@ -234,7 +236,7 @@ func (d *toolsDialog) setupAllTools() {
 	d.allTools = make([]toolItem, 0, len(keys))
 	for _, toolName := range keys {
 		toolInfo := availableTools[toolName]
-		defaultEnabled := app.IsToolDefaultEnabled(toolName)
+		defaultEnabled := app.IsToolDefaultEnabledFromToolInfo(toolInfo)
 		if agentSetting, exists := agent.Tools[toolName]; exists {
 			defaultEnabled = agentSetting
 		}
@@ -244,7 +246,14 @@ func (d *toolsDialog) setupAllTools() {
 		}
 		overridden := enabled != defaultEnabled
 		displayName := toolName
-		d.allTools = append(d.allTools, toolItem{name: toolName, displayName: displayName, enabled: enabled, source: toolInfo.Source, overridden: overridden})
+		d.allTools = append(d.allTools, toolItem{
+			name:           toolName,
+			displayName:    displayName,
+			enabled:        enabled,
+			source:         toolInfo.Source,
+			overridden:     overridden,
+			defaultEnabled: app.IsToolDefaultEnabledFromToolInfo(toolInfo),
+		})
 	}
 
 	ordered := make([]string, 0, len(d.allTools))

--- a/packages/tui/internal/components/dialog/tools.go
+++ b/packages/tui/internal/components/dialog/tools.go
@@ -1,0 +1,342 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	tea "github.com/charmbracelet/bubbletea/v2"
+	"github.com/lithammer/fuzzysearch/fuzzy"
+	"github.com/sst/opencode/internal/app"
+	"github.com/sst/opencode/internal/components/list"
+	"github.com/sst/opencode/internal/components/modal"
+	"github.com/sst/opencode/internal/layout"
+	"github.com/sst/opencode/internal/styles"
+	"github.com/sst/opencode/internal/theme"
+	"github.com/sst/opencode/internal/util"
+)
+
+const (
+	numVisibleTools    = 10
+	minToolDialogWidth = 40
+	maxToolDialogWidth = 80
+)
+
+// ToolsDialog interface (parity with other dialogs)
+type ToolsDialog interface{ layout.Modal }
+
+type toolsDialog struct {
+	app          *app.App
+	allTools     []toolItem
+	modal        *modal.Modal
+	searchDialog *SearchDialog
+	dialogWidth  int
+	width        int
+	height       int
+}
+
+type toolItem struct {
+	name        string
+	displayName string
+	enabled     bool
+	source      string // "builtin" or "mcp"
+	overridden  bool   // differs from default (agent default + global default)
+}
+
+func (t toolItem) Render(selected bool, width int, baseStyle styles.Style) string {
+	theme := theme.CurrentTheme()
+
+	itemStyle := baseStyle.
+		Background(theme.BackgroundPanel()).
+		Foreground(theme.Text())
+
+	if selected {
+		itemStyle = itemStyle.Foreground(theme.Primary())
+	} else if t.overridden { // non-selected overridden items get warning color
+		itemStyle = itemStyle.Foreground(theme.Warning())
+	}
+
+	// Show toggle state
+	toggleIndicator := "[ ]"
+	if t.enabled {
+		toggleIndicator = "[✓]"
+	}
+
+	text := fmt.Sprintf("%s %s", toggleIndicator, t.displayName)
+	return itemStyle.
+		PaddingLeft(1).
+		Render(text)
+}
+
+func (t toolItem) Selectable() bool {
+	return true
+}
+
+type cancelToolsMsg struct{}
+
+func (d *toolsDialog) Init() tea.Cmd {
+	d.setupAllTools()
+	return d.searchDialog.Init()
+}
+
+func (d *toolsDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case SearchSelectionMsg:
+		// Toggle selection without closing modal (single pass recompute)
+		if t, ok := msg.Item.(toolItem); ok {
+			agent := d.app.Agent()
+			overrides := make(map[string]bool)
+			selectedName := t.name
+			for i := range d.allTools {
+				if d.allTools[i].name == selectedName {
+					d.allTools[i].enabled = !d.allTools[i].enabled
+				}
+				base := app.IsToolDefaultEnabled(d.allTools[i].name)
+				if agentSetting, ok := agent.Tools[d.allTools[i].name]; ok {
+					base = agentSetting
+				}
+				d.allTools[i].overridden = d.allTools[i].enabled != base
+				if d.allTools[i].overridden {
+					overrides[d.allTools[i].name] = d.allTools[i].enabled
+				}
+			}
+			// rebuild visual list preserving selection by name
+			curQuery := d.searchDialog.GetQuery()
+			items := d.buildItems(curQuery)
+			d.searchDialog.SetItems(items)
+			for i, it := range d.searchDialog.list.GetItems() {
+				if ti, ok := it.(toolItem); ok && ti.name == selectedName {
+					d.searchDialog.list.SetSelectedIndex(i)
+					break
+				}
+			}
+			return d, util.CmdHandler(app.ToolsUpdatedMsg{Agent: agent.Name, Overrides: overrides})
+		}
+		return d, nil
+	case SearchCancelledMsg:
+		return d, util.CmdHandler(modal.CloseModalMsg{})
+
+	case SearchQueryChangedMsg:
+		// Update the list based on search query
+		items := d.buildItems(msg.Query)
+		d.searchDialog.SetItems(items)
+		return d, nil
+
+	case tea.WindowSizeMsg:
+		d.width = msg.Width
+		d.height = msg.Height
+		d.searchDialog.SetWidth(d.dialogWidth)
+		d.searchDialog.SetHeight(msg.Height)
+
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "esc":
+			return d, func() tea.Msg { return cancelToolsMsg{} }
+		case "tab":
+			// Cycle to next agent (forward)
+			updated, _ := d.app.SwitchAgent()
+			d.app = updated
+			// capture currently selected tool name to attempt preservation across agents if exists in new list
+			var selName string
+			if si, idx := d.searchDialog.list.GetSelectedItem(); idx >= 0 {
+				if ti, ok := si.(toolItem); ok {
+					selName = ti.name
+				}
+			}
+			d.setupAllTools()
+			// try to reselect by name
+			if selName != "" {
+				items := d.searchDialog.list.GetItems()
+				for i, it := range items {
+					if ti, ok := it.(toolItem); ok && ti.name == selName {
+						d.searchDialog.list.SetSelectedIndex(i)
+						break
+					}
+				}
+			}
+			return d, nil
+		}
+	case cancelToolsMsg:
+		return d, util.CmdHandler(modal.CloseModalMsg{})
+	}
+
+	// For non-key messages, pass to search dialog
+
+	updatedDialog, cmd := d.searchDialog.Update(msg)
+	d.searchDialog = updatedDialog.(*SearchDialog)
+	return d, cmd
+}
+
+func (d *toolsDialog) View() string {
+	return d.searchDialog.View()
+}
+
+func (d *toolsDialog) Render(background string) string {
+	return d.modal.Render(d.View(), background)
+}
+
+func (d *toolsDialog) Close() tea.Cmd {
+	return nil
+}
+
+func (d *toolsDialog) setupAllTools() {
+	agent := d.app.Agent()
+	slog.Debug("Setting up tools dialog", "agent", agent.Name, "tools", agent.Tools)
+
+	// Get all available tools from the API
+	ctx := context.Background()
+	availableTools, err := d.app.ListTools(ctx)
+	if err != nil {
+		slog.Error("Failed to fetch tools from API", "error", err)
+		// If we can't get tools, we can't show the dialog
+		// This should be rare since the server should be running
+		availableTools = make(map[string]app.ToolInfo)
+	}
+
+	if agent.Tools == nil {
+		slog.Warn("Agent has no tools", "agent", agent.Name)
+		agent.Tools = make(map[string]bool)
+	}
+
+	// Use session-scoped overrides (not persisted)
+	overrides := d.app.SessionToolOverrides[agent.Name]
+	if overrides == nil {
+		overrides = make(map[string]bool)
+	}
+
+	// Build deterministic ordered list: collect names, sort by source then name
+	// Filter out tools that should not be shown to users
+	keys := make([]string, 0, len(availableTools))
+	for k := range availableTools {
+		// Skip patch and invalid tools as they are not meant to be user-manageable
+		if k == "patch" || k == "invalid" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		aInfo := availableTools[keys[i]]
+		bInfo := availableTools[keys[j]]
+		if aInfo.Source == bInfo.Source {
+			return keys[i] < keys[j]
+		}
+		if aInfo.Source == "builtin" && bInfo.Source == "mcp" {
+			return true
+		}
+		if aInfo.Source == "mcp" && bInfo.Source == "builtin" {
+			return false
+		}
+		return aInfo.Source < bInfo.Source
+	})
+
+	// Build tool items with current state (defaults + agent settings + overrides)
+	d.allTools = make([]toolItem, 0, len(keys))
+	for _, toolName := range keys {
+		toolInfo := availableTools[toolName]
+		defaultEnabled := app.IsToolDefaultEnabled(toolName)
+		if agentSetting, exists := agent.Tools[toolName]; exists {
+			defaultEnabled = agentSetting
+		}
+		enabled := defaultEnabled
+		if override, exists := overrides[toolName]; exists {
+			enabled = override
+		}
+		overridden := enabled != defaultEnabled
+		displayName := toolName
+		d.allTools = append(d.allTools, toolItem{name: toolName, displayName: displayName, enabled: enabled, source: toolInfo.Source, overridden: overridden})
+	}
+
+	ordered := make([]string, 0, len(d.allTools))
+	for _, t := range d.allTools {
+		ordered = append(ordered, fmt.Sprintf("%s(%s)=%v", t.name, t.source, t.enabled))
+	}
+	slog.Debug("Built tool items", "count", len(d.allTools), "order", ordered)
+
+	// Calculate optimal width
+	d.dialogWidth = d.calculateOptimalWidth()
+
+	// Initialize or update search dialog
+	if d.searchDialog == nil {
+		d.searchDialog = NewSearchDialog("Search tool...", numVisibleTools)
+	} else {
+		// Reset query when switching agents for clarity
+		d.searchDialog.SetQuery("")
+	}
+	d.searchDialog.SetWidth(d.dialogWidth)
+
+	// Build initial display list
+	items := d.buildItems("")
+	d.searchDialog.SetItems(items)
+}
+func (d *toolsDialog) calculateOptimalWidth() int {
+	maxWidth := minToolDialogWidth
+	for _, tool := range d.allTools {
+		// Account for toggle indicator "[✓] " (4 chars) plus display name
+		itemWidth := len(tool.displayName) + 4 + 2 // +2 for padding
+		if itemWidth > maxWidth {
+			maxWidth = itemWidth
+		}
+	}
+	if maxWidth > maxToolDialogWidth {
+		maxWidth = maxToolDialogWidth
+	}
+	return maxWidth
+}
+
+func (d *toolsDialog) buildItems(query string) []list.Item {
+	if query == "" {
+		var items []list.Item
+		currentHeader := ""
+		for _, tool := range d.allTools { // already sorted builtin first
+			if tool.source == "builtin" {
+				if currentHeader != "builtin" {
+					items = append(items, list.HeaderItem("Builtin Tools"))
+					currentHeader = "builtin"
+				}
+			} else if tool.source == "mcp" {
+				if currentHeader != "mcp" {
+					items = append(items, list.HeaderItem("MCP Tools"))
+					currentHeader = "mcp"
+				}
+			}
+			items = append(items, tool)
+		}
+		return items
+	}
+	matches := make([]toolItem, 0, len(d.allTools))
+	for _, tool := range d.allTools {
+		if fuzzy.MatchFold(query, tool.name) || fuzzy.MatchFold(query, tool.displayName) {
+			matches = append(matches, tool)
+		}
+	}
+	if len(matches) == 0 {
+		return []list.Item{}
+	}
+	names := make([]string, len(matches))
+	for i, m := range matches {
+		names[i] = m.displayName
+	}
+	ranked := fuzzy.RankFindFold(query, names)
+	sort.Sort(ranked)
+	items := make([]list.Item, 0, len(ranked))
+	for _, r := range ranked {
+		items = append(items, matches[r.OriginalIndex])
+	}
+	return items
+}
+
+// NewToolsDialog builds the dialog using agent defaults + persisted overrides.
+func NewToolsDialog(app *app.App) ToolsDialog {
+	dialog := &toolsDialog{
+		app: app,
+	}
+
+	dialog.setupAllTools()
+
+	dialog.modal = modal.New(
+		modal.WithTitle("Toggle Tools"),
+		modal.WithMaxWidth(dialog.dialogWidth+4),
+	)
+	return dialog
+}

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -595,6 +595,17 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.app.State.UpdateModelUsage(msg.Provider.ID, msg.Model.ID)
 		cmds = append(cmds, a.app.SaveState())
+	case app.ToolsUpdatedMsg:
+		// Session-scoped overrides only; do not persist to state
+		if len(msg.Overrides) == 0 {
+			delete(a.app.SessionToolOverrides, msg.Agent)
+		} else {
+			if a.app.SessionToolOverrides == nil {
+				a.app.SessionToolOverrides = make(map[string]map[string]bool)
+			}
+			a.app.SessionToolOverrides[msg.Agent] = msg.Overrides
+		}
+		cmds = append(cmds, toast.NewSuccessToast("Tools updated (session only)"))
 	case dialog.ThemeSelectedMsg:
 		a.app.State.Theme = msg.ThemeName
 		cmds = append(cmds, a.app.SaveState())
@@ -645,6 +656,9 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "/tui/open-models":
 			modelDialog := dialog.NewModelDialog(a.app)
 			a.modal = modelDialog
+		case "/tui/open-tools":
+			toolsDialog := dialog.NewToolsDialog(a.app)
+			a.modal = toolsDialog
 		case "/tui/append-prompt":
 			var body struct {
 				Text string `json:"text"`
@@ -1115,6 +1129,9 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 	case commands.ModelListCommand:
 		modelDialog := dialog.NewModelDialog(a.app)
 		a.modal = modelDialog
+	case commands.ToolListCommand:
+		toolsDialog := dialog.NewToolsDialog(a.app)
+		a.modal = toolsDialog
 	case commands.ThemeListCommand:
 		themeDialog := dialog.NewThemeDialog()
 		a.modal = themeDialog


### PR DESCRIPTION
This PR introduces a new `Tools` modal to the TUI, allowing users to easily toggle tools on/off per agent during their session, accessible via `<leader>o` or `/tools`

<img width="379" height="286" alt="image" src="https://github.com/user-attachments/assets/4b6fab93-87ec-48e8-931c-b3cddcaf7177" />

This feature provides users with fine-grained control over their AI assistant's capabilities while
maintaining a clean, intuitive interface that integrates seamlessly with the existing TUI experience.

### Core Features
- Interactive Tool Toggle: Modal interface with searchable tool list and checkbox-style toggles
- Agent-Scoped: Tool settings are specific to each agent
- Session-Scoped: Tool overrides apply only to the current session (not persisted to disk)
- Smart Filtering: Tools are automatically filtered to show only user-manageable tools (excludes internal tools like patch and invalid)
- Organized Display: Tools grouped by source (Built-in and MCP Tools) with fuzzy search support
- Overridden tools show with a `warning` color
- Allows TAB key to cycle through agents while tool modal is open

###  Implementation Details
- New ToolsDialog component following existing modal patterns (dialog/tools.go)
- New /app/tools endpoint for fetching available tools with metadata
- Tools include name, description, source (builtin/mcp), and defaultEnabled fields(2nd commit)
- Early MCP initialization in bootstrap for immediate tool availability

###  Architecture & Maintainability
The PR includes two logical commits. The second commit is not required for the feature to work but improves maintainability.

1. Core Feature Implementation: Basic tool modal with hardcoded filtering (for `patch` and `invalid` tools)
2. Centralized Tool Service Refactor (optional):
 • Introduces ToolService with App.state() caching patterns
 • Centralizes tool defaults in documented TOOL_DEFAULTS object
 • Replaces hardcoded logic with API-driven approach
 • Maintains backward compatibility



