### PR TITLE
Fix: Sanitize MCP Tool Names for Consistency in User Expectations

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -149,7 +149,8 @@ export namespace MCP {
     for (const [clientName, client] of Object.entries(await clients())) {
       for (const [toolName, tool] of Object.entries(await client.tools())) {
         const sanitizedClientName = clientName.replace(/\s+/g, "_")
-        result[sanitizedClientName + "_" + toolName] = tool
+        const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
+        result[sanitizedClientName + "_" + sanitizedToolName] = tool
       }
     }
     return result


### PR DESCRIPTION
MCP tool names were inconsistent, mixing `server_tool-name` and `server_tool_name` formats
Added sanitization of tool names by replacing hyphens and spaces with underscores

This edit ensures that when users configure MCP servers, they'll have predictable naming conventions regardless of how the original tool names are formatted.

Tools like `context7_resolve-library-id` will now become `context7_resolve_library_id`, maintaining consistency across all MCP tool names.

<img width="375" height="282" alt="image" src="https://github.com/user-attachments/assets/ae597741-f726-40eb-8f84-75d8f938d6ce" />
