### PR TITLE
Issue 1676: Don't eat up the last newline in a multi-line replacement

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -189,7 +189,7 @@ export const LineTrimmedReplacer: Replacer = function* (content, find) {
       let matchEndIndex = matchStartIndex
       for (let k = 0; k < searchLines.length; k++) {
         matchEndIndex += originalLines[i + k].length
-        if (k < searchLines.length) {
+        if (k < searchLines.length - 1) {
           matchEndIndex += 1 // Add newline character except for the last line
         }
       }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -188,7 +188,10 @@ export const LineTrimmedReplacer: Replacer = function* (content, find) {
 
       let matchEndIndex = matchStartIndex
       for (let k = 0; k < searchLines.length; k++) {
-        matchEndIndex += originalLines[i + k].length + 1
+        matchEndIndex += originalLines[i + k].length
+        if (k < searchLines.length) {
+          matchEndIndex += 1 // Add newline character except for the last line
+        }
       }
 
       yield content.substring(matchStartIndex, matchEndIndex)


### PR DESCRIPTION
https://github.com/sst/opencode/issues/1676

Similar to a check in BlockAnchorReplacer, the LineTrimmedReplacer shouldn't match the last newline, so it doesn't get replaced