### PR TITLE
chore: add OPENCODE env var

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -58,6 +58,8 @@ const cli = yargs(hideBin(process.argv))
       })(),
     })
 
+    process.env["OPENCODE"] = "1"
+
     Log.Default.info("opencode", {
       version: Installation.VERSION,
       args: process.argv.slice(2),


### PR DESCRIPTION
Adds `OPENCODE=1` env var as per https://github.com/sst/opencode/issues/1775