### PR TITLE
rm: removing deadcode

### DIFF
--- a/packages/web/src/components/share/part.tsx
+++ b/packages/web/src/components/share/part.tsx
@@ -148,11 +148,7 @@ export function Part(props: PartProps) {
                   DateTime.DATETIME_MED,
                 )}
                 {` | ${props.message.modelID}`}
-                {props.message.mode && (
-                  <span style={{ "font-weight": "bold", color: "var(--sl-color-accent)" }}>
-                    {` | ${props.message.mode}`}
-                  </span>
-                )}
+                {` | ${props.message.mode}`}
               </Footer>
             )}
           </div>
@@ -171,11 +167,7 @@ export function Part(props: PartProps) {
                 DateTime.DATETIME_MED,
               )}
               {` | ${props.message.modelID}`}
-              {props.message.mode && (
-                <span style={{ "font-weight": "bold", color: "var(--sl-color-accent)" }}>
-                  {` | ${props.message.mode}`}
-                </span>
-              )}
+              {` | ${props.message.mode}`}
             </div>
           </div>
         )}


### PR DESCRIPTION
Looks cleaner without the bold
<img width="228" height="25" alt="image" src="https://github.com/user-attachments/assets/091d925b-6124-45a2-b3d9-4ee1278aec08" />
