### PR TITLE
Add support for biome.jsonc config file

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -110,8 +110,14 @@ export const biome: Info = {
   ],
   async enabled() {
     const app = App.info()
-    const items = await Filesystem.findUp("biome.json", app.path.cwd, app.path.root)
-    return items.length > 0
+    const configs = ["biome.json", "biome.jsonc"]
+    for (const config of configs) {
+      const found = await Filesystem.findUp(config, app.path.cwd, app.path.root)
+      if (found.length > 0) {
+        return true
+      }
+    }
+    return false
   },
 }
 

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -76,7 +76,7 @@ export const prettier: Info = {
 
 export const biome: Info = {
   name: "biome",
-  command: [BunProc.which(), "x", "biome", "format", "--write", "$FILE"],
+  command: [BunProc.which(), "x", "@biomejs/biome", "format", "--write", "$FILE"],
   environment: {
     BUN_BE_BUN: "1",
   },

--- a/packages/web/src/content/docs/docs/formatters.mdx
+++ b/packages/web/src/content/docs/docs/formatters.mdx
@@ -16,7 +16,7 @@ opencode comes with several built-in formatters for popular languages and framew
 | gofmt          | .go                                                                                                      | `gofmt` command available             |
 | mix            | .ex, .exs, .eex, .heex, .leex, .neex, .sface                                                             | `mix` command available               |
 | prettier       | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://prettier.io/docs/en/index.html) | `prettier` dependency in `package.json` |
-| biome          | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://biomejs.dev/)                   | `biome.json` config file              |
+| biome          | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://biomejs.dev/)                   | `biome.json(c)` config file           |
 | zig            | .zig, .zon                                                                                               | `zig` command available               |
 | clang-format   | .c, .cpp, .h, .hpp, .ino, and [more](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config file           |
 | ktlint         | .kt, .kts                                                                                                | `ktlint` command available            |


### PR DESCRIPTION
Currently opencode only picks up `biome.json` as the config file for biome formatter.
Biome also supports `biome.jsonc` which I prefer to use, so this PR adds that option and updates the docs accordingly.