### PR TITLE
fix(plugin): prevent compiled binary hang by removing lazy dynamic import

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -4,8 +4,7 @@ import { Config } from "../config/config"
 import { Bus } from "../bus"
 import { Log } from "../util/log"
 import { createOpencodeClient } from "@opencode-ai/sdk"
-// Lazy import to avoid circular dependency with session/tool registry
-// import { Server } from "../server/server"
+import { Server } from "../server/server"
 import { BunProc } from "../bun"
 
 export namespace Plugin {
@@ -14,7 +13,7 @@ export namespace Plugin {
   const state = App.state("plugin", async (app) => {
     const client = createOpencodeClient({
       baseUrl: "http://localhost:4096",
-      fetch: async (...args) => (await import("../server/server")).Server.app().fetch(...args),
+      fetch: async (...args) => Server.app().fetch(...args),
     })
     const config = await Config.get()
     const hooks = []


### PR DESCRIPTION
## Summary
- Fix binary hang in compiled builds by reverting lazy dynamic import in plugin client to direct Server import/call #1792.
- Restores v0.4.2 startup behavior; dev mode unaffected.

## Context
- Regression introduced in v0.4.3 where `packages/opencode/src/plugin/index.ts` switched to `await import('../server/server')` inside fetch callback.
- Bun compile caused startup deadlock before logs; `bun dev` worked.

## Changes
- plugin/index.ts: direct `import { Server } from '../server/server'` and `Server.app().fetch`.

## Test plan
- Build snapshot: `OPENCODE_VERSION=0.0.0-dev OPENCODE_SNAPSHOT=true OPENCODE_DRY=true ./packages/opencode/script/publish.ts`
- Run compiled binary: `./packages/opencode/dist/opencode-<os>-<arch>/bin/opencode run -p "ping" --print-logs --log-level DEBUG`
- Verify no hang; TUI also launches.

🤖 Generated with [opencode](https://opencode.ai)