### PR TITLE
Allow tool use right after a rejection.

### DIFF
--- a/packages/opencode/src/session/prompt/permissions.txt
+++ b/packages/opencode/src/session/prompt/permissions.txt
@@ -1,0 +1,1 @@
+Some tools may require user permission before executing. Permission rejections are specific to individual tool calls, not permanent restrictions.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -14,7 +14,6 @@ import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 import PROMPT_SUMMARIZE from "./prompt/summarize.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
 import PROMPT_COPILOT_GPT_5 from "./prompt/copilot-gpt-5.txt"
-import PROMPT_CODEX from "./prompt/codex.txt"
 import PROMPT_PERMISSIONS from "./prompt/permissions.txt"
 
 export namespace SystemPrompt {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -14,6 +14,8 @@ import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 import PROMPT_SUMMARIZE from "./prompt/summarize.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
 import PROMPT_COPILOT_GPT_5 from "./prompt/copilot-gpt-5.txt"
+import PROMPT_CODEX from "./prompt/codex.txt"
+import PROMPT_PERMISSIONS from "./prompt/permissions.txt"
 
 export namespace SystemPrompt {
   export function header(providerID: string) {
@@ -39,6 +41,7 @@ export namespace SystemPrompt {
         `  Is directory a git repo: ${app.git ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
         `  Today's date: ${new Date().toDateString()}`,
+        `  Permissions system: ${PROMPT_PERMISSIONS}`,
         `</env>`,
         `<project>`,
         `  ${


### PR DESCRIPTION
Add disclaimer about tool use after rejection to the system prompt, makes it so the model knows it's okay to use a tool even right after it was rejected.