### PR TITLE
Fix: Improve bash tool timeout and output handling

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -152,7 +152,11 @@ export const BashTool = Tool.define("bash", {
       timeout,
     })
 
+    let terminated = false
+    let terminatedByTimeout = true
     let output = ""
+    let stderr = ""
+    let stdout = ""
 
     // Initialize metadata with empty output
     ctx.metadata({
@@ -164,6 +168,7 @@ export const BashTool = Tool.define("bash", {
 
     process.stdout?.on("data", (chunk) => {
       output += chunk.toString()
+      stdout += chunk.toString()
       ctx.metadata({
         metadata: {
           output: output,
@@ -174,6 +179,7 @@ export const BashTool = Tool.define("bash", {
 
     process.stderr?.on("data", (chunk) => {
       output += chunk.toString()
+      stderr += chunk.toString()
       ctx.metadata({
         metadata: {
           output: output,
@@ -182,8 +188,15 @@ export const BashTool = Tool.define("bash", {
       })
     })
 
+    process.on("error", () => {
+      terminatedByTimeout = false
+    })
+
     await new Promise<void>((resolve) => {
-      process.on("close", () => {
+      process.on("close", (_, signal) => {
+        if (signal) {
+          terminated = true
+        }
         resolve()
       })
     })
@@ -195,6 +208,10 @@ export const BashTool = Tool.define("bash", {
         description: params.description,
       },
     })
+    let forLLM = `<stdout>${stdout}</stdout>\n<stderr>${stderr}</stderr>\n<exitCode>${process.exitCode}</exitCode>`
+    if (terminated && terminatedByTimeout) {
+      forLLM += `\n<timeout>Process was terminated by timeout after ${timeout}ms. Consider increasing the timeout parameter for the bash tool and trying again.</timeout>`
+    }
 
     if (output.length > MAX_OUTPUT_LENGTH) {
       output = output.slice(0, MAX_OUTPUT_LENGTH)
@@ -208,7 +225,7 @@ export const BashTool = Tool.define("bash", {
         exit: process.exitCode,
         description: params.description,
       },
-      output,
+      output: forLLM,
     }
   },
 })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -29,6 +29,7 @@ describe("tool.bash", () => {
       )
       expect(result.metadata.exit).toBe(0)
       expect(result.metadata.output).toContain("test")
+      expect(result.output).not.toContain("<timeout>")
     })
   })
 
@@ -43,6 +44,34 @@ describe("tool.bash", () => {
           ctx,
         ),
       ).rejects.toThrow("This command references paths outside of")
+    })
+  })
+
+  test("timeout error should be emitted for long running commands", async () => {
+    await App.provide({ cwd: projectRoot }, async () => {
+      const result = await bash.execute(
+        {
+          command: "sleep 1",
+          description: "Sleep for 1 seconds",
+          timeout: 500,
+        },
+        ctx,
+      )
+      expect(result.output).toContain("<timeout>")
+    })
+  })
+
+  test("exit code should be captured for failing commands", async () => {
+    await App.provide({ cwd: projectRoot }, async () => {
+      const result = await bash.execute(
+        {
+          command: 'bun --eval "process.exit(42)"',
+          description: "Exit with code 42",
+        },
+        ctx,
+      )
+      expect(result.metadata.exit).toBe(42)
+      expect(result.output).toContain("<exitCode>42</exitCode>")
     })
   })
 })


### PR DESCRIPTION
My attempt to resolve #1721 

2 key changes:

1. Detects timeouts and report to the LLM
2. create separate output for the LLM which identifies the stdout, stderr, exitCode and timeout

10 minute max timeout is still too short. I am not sure why its there though so not changing it