### PR TITLE
docs: fix instructions

### DIFF
--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -318,7 +318,7 @@ Use `{file:path/to/file}` to substitute the contents of a file:
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "instructions": ["{file:./custom-instructions.md}"],
+  "instructions": ["./custom-instructions.md"],
   "provider": {
     "openai": {
       "options": {


### PR DESCRIPTION
fixes: #1240

`file:` references ARE NOT supported by instructions