### PR TITLE
fix: preserve process.env when spawning formatter commands

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -71,7 +71,7 @@ export namespace Format {
         const proc = Bun.spawn({
           cmd: item.command.map((x) => x.replace("$FILE", file)),
           cwd: App.info().path.cwd,
-          env: item.environment,
+          env: { ...process.env, ...item.environment },
           stdout: "ignore",
           stderr: "ignore",
         })


### PR DESCRIPTION
Fixes issue where custom formatter environment variables would overwrite all process.env variables, causing commands to fail when they need access to system environment variables like PATH.

The formatter now merges process.env with custom environment variables, ensuring system variables are preserved while still allowing custom overrides.

Repro case in opencode.json:
```json
"custom-markdown-formatter": {
  "command": ["deno", "fmt", "$FILE"],
  "environment": {
    "NODE_ENV": "development"
  },
  "extensions": [".md"]
}
```

🤖 Generated with [opencode](https://opencode.ai)