### PR TITLE
feat: add configurable time format for conversation exports and interface

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -18,6 +18,41 @@ import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErro
 export namespace Config {
   const log = Log.create({ service: "config" })
 
+  function detectSystemTimeFormat(): "12h" | "24h" {
+    try {
+      // First try to use LC_TIME if set
+      let locale = undefined
+      if (process.env["LC_TIME"]) {
+        // Convert LC_TIME format (de_DE.UTF-8) to BCP 47 format (de-DE)
+        locale = process.env["LC_TIME"].replace(/\..*$/, "").replace(/_/g, "-")
+      }
+
+      // Use explicit locale if available, otherwise system default
+      const formatter = new Intl.DateTimeFormat(locale, {
+        hour: "numeric",
+        minute: "numeric",
+      })
+
+      // Create a test date and format it
+      const testDate = new Date(2024, 0, 1, 15, 30) // 3:30 PM
+      const formatted = formatter.format(testDate)
+
+      // Check for 24h indicators: contains "15", or contains time without AM/PM
+      // Also handle different separators (: vs .)
+      const has24hHour = formatted.includes("15")
+      const hasNoAmPm = !formatted.match(/AM|PM|am|pm/i)
+      const hasTimeDigits = formatted.match(/\d+[:.]\d+/)
+
+      if (has24hHour || (hasTimeDigits && hasNoAmPm)) {
+        return "24h"
+      }
+      return "12h"
+    } catch (error) {
+      log.warn("Failed to detect system time format, defaulting to 12h", { error })
+      return "12h"
+    }
+  }
+
   export const state = App.state("config", async (app) => {
     const auth = await Auth.all()
     let result = await global()
@@ -131,6 +166,11 @@ export namespace Config {
     if (!result.username) {
       const os = await import("os")
       result.username = os.userInfo().username
+    }
+
+    // Auto-detect time format if set to "auto"
+    if (result.timeFormat === "auto") {
+      result.timeFormat = detectSystemTimeFormat()
     }
 
     log.info("loaded", result)
@@ -285,6 +325,13 @@ export namespace Config {
         .string()
         .optional()
         .describe("Custom username to display in conversations instead of system username"),
+      timeFormat: z
+        .enum(["auto", "12h", "24h"])
+        .optional()
+        .default("auto")
+        .describe(
+          "Time format for conversation exports: 'auto' detects from system, '12h' for 12-hour format, '24h' for 24-hour format",
+        ),
       mode: z
         .object({
           build: Agent.optional(),
@@ -425,7 +472,7 @@ export namespace Config {
         if (err.code === "ENOENT") return
         throw new JsonError({ path: filepath }, { cause: err })
       })
-    if (!text) return {}
+    if (!text) return { timeFormat: "auto" } as Info
     return load(text, filepath)
   }
 

--- a/packages/sdk/go/config.go
+++ b/packages/sdk/go/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	Snapshot   bool   `json:"snapshot"`
 	// Theme name to use for the interface
 	Theme string `json:"theme"`
+	// Time format for conversation exports: 'auto' detects from system, '12h' for 12-hour format, '24h' for 24-hour format
+	TimeFormat string `json:"timeFormat"`
 	// Custom username to display in conversations instead of system username
 	Username string     `json:"username"`
 	JSON     configJSON `json:"-"`
@@ -108,6 +110,7 @@ type configJSON struct {
 	SmallModel        apijson.Field
 	Snapshot          apijson.Field
 	Theme             apijson.Field
+	TimeFormat        apijson.Field
 	Username          apijson.Field
 	raw               string
 	ExtraFields       map[string]apijson.Field

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -331,9 +331,17 @@ func renderText(
 		content = base.Width(width - 6).Render(wrappedText)
 	}
 
-	timestamp := ts.
-		Local().
-		Format("02 Jan 2006 03:04 PM")
+	// Get the appropriate time format based on config
+	timeFormat := util.GetTimeFormat(app.Config.TimeFormat)
+	// For interface display, we need day + time format
+	var interfaceTimeFormat string
+	if timeFormat == "2006-01-02 15:04:05" { // 24h format
+		interfaceTimeFormat = "02 Jan 2006 15:04"
+	} else { // 12h format
+		interfaceTimeFormat = "02 Jan 2006 03:04 PM"
+	}
+
+	timestamp := ts.Local().Format(interfaceTimeFormat)
 	if time.Now().Format("02 Jan 2006") == timestamp[:11] {
 		timestamp = timestamp[12:]
 	}

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1115,7 +1115,7 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 		}
 
 		// Format to Markdown
-		markdownContent := formatConversationToMarkdown(messages)
+		markdownContent := formatConversationToMarkdown(messages, a.app)
 
 		// Check if EDITOR is set
 		editor := os.Getenv("EDITOR")
@@ -1322,7 +1322,7 @@ func NewModel(app *app.App) tea.Model {
 	return model
 }
 
-func formatConversationToMarkdown(messages []app.Message) string {
+func formatConversationToMarkdown(messages []app.Message, app *app.App) string {
 	var builder strings.Builder
 
 	builder.WriteString("# Conversation History\n\n")
@@ -1344,8 +1344,11 @@ func formatConversationToMarkdown(messages []app.Message) string {
 			continue
 		}
 
+		// Get the appropriate time format based on config
+		timeFormat := util.GetTimeFormat(app.Config.TimeFormat)
+
 		builder.WriteString(
-			fmt.Sprintf("**%s** (*%s*)\n\n", role, timestamp.Format("2006-01-02 15:04:05")),
+			fmt.Sprintf("**%s** (*%s*)\n\n", role, timestamp.Format(timeFormat)),
 		)
 
 		for _, part := range msg.Parts {

--- a/packages/tui/internal/util/util.go
+++ b/packages/tui/internal/util/util.go
@@ -9,6 +9,18 @@ import (
 	tea "github.com/charmbracelet/bubbletea/v2"
 )
 
+// GetTimeFormat returns the appropriate Go time format string based on config
+func GetTimeFormat(config string) string {
+	switch config {
+	case "24h":
+		return "2006-01-02 15:04:05"
+	case "12h":
+		return "2006-01-02 03:04:05 PM"
+	default:
+		return "2006-01-02 15:04:05" // fallback to 24h
+	}
+}
+
 func CmdHandler(msg tea.Msg) tea.Cmd {
 	return func() tea.Msg {
 		return msg


### PR DESCRIPTION
- Add timeFormat config option with "auto", "12h", "24h" values
- Auto-detect system time preference using Intl.DateTimeFormat
- Apply time format to both conversation exports and TUI interface
- Add shared utility function for consistent time formatting

I've only been able to test on macOS.