### PR TITLE
Merge default agent permissions with global config

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -44,6 +44,26 @@ export namespace Agent {
       },
       webfetch: "allow",
     }
+    const merged =  mergeDeep(defaultPermission, cfg.permission ?? {})
+    if (merged.edit) defaultPermission.edit = merged.edit
+    if (merged.webfetch) defaultPermission.webfetch = merged.webfetch
+    if (merged.bash) {
+        if (typeof merged.bash === "string") {
+          defaultPermission.bash = {
+            "*": merged.bash,
+          }
+        }
+        // if granular permissions are provided, default to "ask"
+        if (typeof merged.bash === "object") {
+          defaultPermission.bash = mergeDeep(
+            {
+              "*": "ask",
+            },
+            merged.bash,
+          )
+        }
+    }
+
     const result: Record<string, Info> = {
       general: {
         name: "general",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -44,25 +44,7 @@ export namespace Agent {
       },
       webfetch: "allow",
     }
-    const merged =  mergeDeep(defaultPermission, cfg.permission ?? {})
-    if (merged.edit) defaultPermission.edit = merged.edit
-    if (merged.webfetch) defaultPermission.webfetch = merged.webfetch
-    if (merged.bash) {
-        if (typeof merged.bash === "string") {
-          defaultPermission.bash = {
-            "*": merged.bash,
-          }
-        }
-        // if granular permissions are provided, default to "ask"
-        if (typeof merged.bash === "object") {
-          defaultPermission.bash = mergeDeep(
-            {
-              "*": "ask",
-            },
-            merged.bash,
-          )
-        }
-    }
+    const agentPermission = mergeAgentPermissions(defaultPermission, cfg.permission ?? {})
 
     const result: Record<string, Info> = {
       general: {
@@ -74,20 +56,20 @@ export namespace Agent {
           todowrite: false,
         },
         options: {},
-        permission: defaultPermission,
+        permission: agentPermission,
         mode: "subagent",
       },
       build: {
         name: "build",
         tools: {},
         options: {},
-        permission: defaultPermission,
+        permission: agentPermission,
         mode: "primary",
       },
       plan: {
         name: "plan",
         options: {},
-        permission: defaultPermission,
+        permission: agentPermission,
         tools: {
           write: false,
           edit: false,
@@ -106,7 +88,7 @@ export namespace Agent {
         item = result[key] = {
           name: key,
           mode: "all",
-          permission: defaultPermission,
+          permission: agentPermission,
           options: {},
           tools: {},
         }
@@ -128,25 +110,7 @@ export namespace Agent {
       if (mode) item.mode = mode
 
       if (permission ?? cfg.permission) {
-        const merged = mergeDeep(cfg.permission ?? {}, permission ?? {})
-        if (merged.edit) item.permission.edit = merged.edit
-        if (merged.webfetch) item.permission.webfetch = merged.webfetch
-        if (merged.bash) {
-          if (typeof merged.bash === "string") {
-            item.permission.bash = {
-              "*": merged.bash,
-            }
-          }
-          // if granular permissions are provided, default to "ask"
-          if (typeof merged.bash === "object") {
-            item.permission.bash = mergeDeep(
-              {
-                "*": "ask",
-              },
-              merged.bash,
-            )
-          }
-        }
+        item.permission = mergeAgentPermissions(cfg.permission ?? {}, permission ?? {})
       }
     }
     return result
@@ -189,4 +153,33 @@ export namespace Agent {
     })
     return result.object
   }
+}
+
+function mergeAgentPermissions(basePermission: any, overridePermission: any): Agent.Info["permission"] {
+  const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {}) as any
+  let mergedBash
+  if (merged.bash) {
+    if (typeof merged.bash === "string") {
+      mergedBash = {
+        "*": merged.bash,
+      }
+    }
+    // if granular permissions are provided, default to "ask"
+    if (typeof merged.bash === "object") {
+      mergedBash = mergeDeep(
+        {
+          "*": "ask",
+        },
+        merged.bash,
+      )
+    }
+  }
+
+  const result: Agent.Info["permission"] = {
+    edit: merged.edit ?? "allow",
+    webfetch: merged.webfetch ?? "allow",
+    bash: mergedBash ?? { "*": "allow" },
+  }
+
+  return result
 }


### PR DESCRIPTION
Merge the default agent permissions with the global user provided permissions. If the user does not have a key for a given agent in the "agents" section of their config, the agent permissions will not be merged with the global config. This PR makes it so the default agent permissions are already merged with the global. Per-agent permission overrides are still honored.