### PR TITLE
Add configurable time format support

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -381,6 +381,13 @@ export namespace Config {
                 .optional(),
             })
             .optional(),
+          time_format: z
+            .enum(["detect", "12h", "24h"])
+            .optional()
+            .default("detect")
+            .describe(
+              "Time format preference: 'detect' auto-detects system preference (macOS only), '12h' forces 12-hour format, '24h' forces 24-hour format",
+            ),
         })
         .optional(),
     })

--- a/packages/sdk/go/config.go
+++ b/packages/sdk/go/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	Snapshot   bool   `json:"snapshot"`
 	// Theme name to use for the interface
 	Theme string `json:"theme"`
+	// Time format preference: 'detect' auto-detects system preference (macOS only), '12h' forces 12-hour format, '24h' forces 24-hour format
+	TimeFormat string `json:"time_format"`
 	// Custom username to display in conversations instead of system username
 	Username string     `json:"username"`
 	JSON     configJSON `json:"-"`
@@ -108,6 +110,7 @@ type configJSON struct {
 	SmallModel        apijson.Field
 	Snapshot          apijson.Field
 	Theme             apijson.Field
+	TimeFormat        apijson.Field
 	Username          apijson.Field
 	raw               string
 	ExtraFields       map[string]apijson.Field

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -729,6 +729,10 @@ export type Config = {
       }>
     }
   }
+  /**
+   * Time format preference: 'detect' auto-detects system preference (macOS only), '12h' forces 12-hour format, '24h' forces 24-hour format
+   */
+  time_format: "detect" | "12h" | "24h"
 }
 
 export type KeybindsConfig = {

--- a/packages/sdk/stainless/generate.ts
+++ b/packages/sdk/stainless/generate.ts
@@ -7,7 +7,7 @@ console.log("=== Generating Stainless SDK ===")
 console.log(process.cwd())
 
 await $`rm -rf go`
-await $`bun run ../../opencode/src/index.ts generate > openapi.json`
+await $`bun run --conditions=development ../../opencode/src/index.ts generate > openapi.json`
 await $`stl builds create --branch dev --pull --allow-empty --+target go`
 
 await $`rm -rf ../go`

--- a/packages/tui/internal/app/state.go
+++ b/packages/tui/internal/app/state.go
@@ -27,19 +27,20 @@ type AgentModel struct {
 }
 
 type State struct {
-	Theme              string                `toml:"theme"`
-	ScrollSpeed        *int                  `toml:"scroll_speed"`
-	AgentModel         map[string]AgentModel `toml:"agent_model"`
-	Provider           string                `toml:"provider"`
-	Model              string                `toml:"model"`
-	Agent              string                `toml:"agent"`
-	RecentlyUsedModels []ModelUsage          `toml:"recently_used_models"`
-	RecentlyUsedAgents []AgentUsage          `toml:"recently_used_agents"`
-	MessagesRight      bool                  `toml:"messages_right"`
-	SplitDiff          bool                  `toml:"split_diff"`
-	MessageHistory     []Prompt              `toml:"message_history"`
-	ShowToolDetails    *bool                 `toml:"show_tool_details"`
-	ShowThinkingBlocks *bool                 `toml:"show_thinking_blocks"`
+	Theme                 string                `toml:"theme"`
+	ScrollSpeed           *int                  `toml:"scroll_speed"`
+	AgentModel            map[string]AgentModel `toml:"agent_model"`
+	Provider              string                `toml:"provider"`
+	Model                 string                `toml:"model"`
+	Agent                 string                `toml:"agent"`
+	RecentlyUsedModels    []ModelUsage          `toml:"recently_used_models"`
+	RecentlyUsedAgents    []AgentUsage          `toml:"recently_used_agents"`
+	MessagesRight         bool                  `toml:"messages_right"`
+	SplitDiff             bool                  `toml:"split_diff"`
+	MessageHistory        []Prompt              `toml:"message_history"`
+	ShowToolDetails       *bool                 `toml:"show_tool_details"`
+	ShowThinkingBlocks    *bool                 `toml:"show_thinking_blocks"`
+	DetectedTimeFormat24h *bool                 `toml:"detected_time_format_24h"`
 }
 
 func NewState() *State {

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -25,35 +25,38 @@ import (
 )
 
 // shouldUse24HourFormat determines if 24-hour time format should be used
-// based on config and system detection
-func shouldUse24HourFormat(config *opencode.Config) bool {
+// based on config and lazy system detection
+func shouldUse24HourFormat(config *opencode.Config, state *app.State) bool {
 	switch config.TimeFormat {
 	case "24h":
 		return true
 	case "12h":
 		return false
 	default:
-		// Default to detect behavior
-		if runtime.GOOS == "darwin" {
-			return detectMacOS24HourFormat()
+		// Lazy evaluation: detect and cache on first use
+		if state.DetectedTimeFormat24h == nil {
+			detected := detectSystemTimeFormat()
+			state.DetectedTimeFormat24h = &detected
 		}
-		return false // fallback to 12h on other platforms
+		return *state.DetectedTimeFormat24h
 	}
 }
 
-// detectMacOS24HourFormat checks if macOS system prefers 24-hour format
-func detectMacOS24HourFormat() bool {
-	cmd := exec.Command("date", "+%X")
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
+// detectSystemTimeFormat detects if the system prefers 24-hour format
+func detectSystemTimeFormat() bool {
+	// Only try detection on macOS
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("date", "+%X")
+		output, err := cmd.Output()
+		if err != nil {
+			return false
+		}
 
-	sysTime := strings.TrimSpace(string(output))
-	// If system time format contains AM/PM indicators, use 12h format
-	hasAmPm := strings.Contains(strings.ToUpper(sysTime), "AM") ||
-		strings.Contains(strings.ToUpper(sysTime), "PM")
-	return !hasAmPm
+		sysTime := strings.TrimSpace(string(output))
+		// If system time contains AM/PM, it's 12-hour format
+		return !strings.Contains(sysTime, "AM") && !strings.Contains(sysTime, "PM")
+	}
+	return false // fallback to 12h on other platforms
 }
 
 type blockRenderer struct {
@@ -366,7 +369,7 @@ func renderText(
 	}
 
 	var timeFormat string
-	if shouldUse24HourFormat(app.Config) {
+	if shouldUse24HourFormat(app.Config, app.State) {
 		timeFormat = "02 Jan 2006 15:04"
 	} else {
 		timeFormat = "02 Jan 2006 03:04 PM"

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os/exec"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -21,6 +23,38 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
+
+// shouldUse24HourFormat determines if 24-hour time format should be used
+// based on config and system detection
+func shouldUse24HourFormat(config *opencode.Config) bool {
+	switch config.TimeFormat {
+	case "24h":
+		return true
+	case "12h":
+		return false
+	default:
+		// Default to detect behavior
+		if runtime.GOOS == "darwin" {
+			return detectMacOS24HourFormat()
+		}
+		return false // fallback to 12h on other platforms
+	}
+}
+
+// detectMacOS24HourFormat checks if macOS system prefers 24-hour format
+func detectMacOS24HourFormat() bool {
+	cmd := exec.Command("date", "+%X")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	sysTime := strings.TrimSpace(string(output))
+	// If system time format contains AM/PM indicators, use 12h format
+	hasAmPm := strings.Contains(strings.ToUpper(sysTime), "AM") ||
+		strings.Contains(strings.ToUpper(sysTime), "PM")
+	return !hasAmPm
+}
 
 type blockRenderer struct {
 	textColor       compat.AdaptiveColor
@@ -331,9 +365,14 @@ func renderText(
 		content = base.Width(width - 6).Render(wrappedText)
 	}
 
-	timestamp := ts.
-		Local().
-		Format("02 Jan 2006 03:04 PM")
+	var timeFormat string
+	if shouldUse24HourFormat(app.Config) {
+		timeFormat = "02 Jan 2006 15:04"
+	} else {
+		timeFormat = "02 Jan 2006 03:04 PM"
+	}
+
+	timestamp := ts.Local().Format(timeFormat)
 	if time.Now().Format("02 Jan 2006") == timestamp[:11] {
 		timestamp = timestamp[12:]
 	}


### PR DESCRIPTION
- Add time_format config option: 'detect', '12h', '24h'
- Auto-detects system preference on macOS, defaults to 12h elsewhere
- Updates TUI to display timestamps in user's preferred format