### PR TITLE
csharp LSP - use glob to match a solution or project file

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -20,8 +20,8 @@ export namespace LSPServer {
 
   const NearestRoot = (patterns: string[]): RootFunction => {
     return async (file, app) => {
-      const files = Filesystem.up({
-        targets: patterns,
+      const files = Filesystem.globsUp({
+        patterns,
         start: path.dirname(file),
         stop: app.path.root,
       })
@@ -402,7 +402,7 @@ export namespace LSPServer {
 
   export const CSharp: Info = {
     id: "csharp",
-    root: NearestRoot([".sln", ".csproj", "global.json"]),
+    root: NearestRoot(["*.sln", "*.csproj", "global.json"]),
     extensions: [".cs"],
     async spawn(_, root) {
       let bin = Bun.which("csharp-ls", {

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -66,4 +66,31 @@ export namespace Filesystem {
     }
     return result
   }
+
+  export async function* globsUp(options: { patterns: string[]; start: string; stop?: string }) {
+    const { patterns, start, stop } = options
+    let current = start
+    while (true) {
+      for (const pattern of patterns) {
+        try {
+          const glob = new Bun.Glob(pattern)
+          for await (const match of glob.scan({
+            cwd: current,
+            absolute: true,
+            onlyFiles: true,
+            followSymlinks: true,
+            dot: true,
+          })) {
+            yield match
+          }
+        } catch {
+          // Skip invalid glob patterns
+        }
+      }
+      if (stop === current) break
+      const parent = dirname(current)
+      if (parent === current) break
+      current = parent
+    }
+  }
 }


### PR DESCRIPTION
This fixes #1808 
Searching for a .sln or .csproj file doesnt work, since its always prefixed with a name. For example: `MySolution.sln`

Added a `globsUp` function based on the `globUp` and `up` functions which were already present.