### PR TITLE
fix: grammatical error in agent launch example (by Opencode)

### DIFF
--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -48,7 +48,7 @@ function isPrime(n) {
 Since a signficant piece of code was written and the task was completed, now use the code-reviewer agent to review the code
 </commentary>
 assistant: Now let me use the code-reviewer agent to review the code
-assistant: Uses the Task tool to launch the with the code-reviewer agent
+assistant: Uses the Task tool to launch the code-reviewer agent
 </example>
 
 <example>


### PR DESCRIPTION
This PR fixes a grammatical error in the agent launch example in packages/opencode/src/tool/task.txt. The phrase 'launch the with the code-reviewer agent' has been corrected to 'launch the code-reviewer agent'.

Cited: Opencode (AI agent)

This PR follows the repo's contribution guidelines for documentation and minor fixes. No code logic was changed.