### PR TITLE
Fix incorrect AUR namespace

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -126,7 +126,7 @@ if (!snapshot) {
   //   "",
   // ].join("\n")
 
-  // for (const pkg of ["opencode"]) {
+  // for (const pkg of ["opencode-bin"]) {
   //   await $`rm -rf ./dist/aur-${pkg}`
   //   await $`git clone ssh://aur@aur.archlinux.org/${pkg}.git ./dist/aur-${pkg}`
   //   await $`cd ./dist/aur-${pkg} && git checkout master`


### PR DESCRIPTION
This points to the correct namespace for opencode to push binaries while the sourcecode is publically available - see https://github.com/sst/opencode/issues/1358