### PR TITLE
chore: declare OpenAPI version 3.1.1

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -88,7 +88,7 @@ export namespace Server {
               version: "0.0.3",
               description: "opencode api",
             },
-            openapi: "3.0.0",
+            openapi: "3.1.1",
           },
         }),
       )
@@ -1133,7 +1133,7 @@ export namespace Server {
           version: "1.0.0",
           description: "opencode api",
         },
-        openapi: "3.0.0",
+        openapi: "3.1.1",
       },
     })
     return result


### PR DESCRIPTION
Note: I didn't check if the rest of the spec follows OpenAPI 3.0 or 3.1.