### PR TITLE
feat(prompt): add `extend: true` to the config to append/replace agent's system prompt

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -27,6 +27,7 @@ export namespace Agent {
         })
         .optional(),
       prompt: z.string().optional(),
+      promptMode: z.enum(["append", "replace"]).optional(),
       tools: z.record(z.boolean()),
       options: z.record(z.string(), z.any()),
     })

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -27,7 +27,7 @@ export namespace Agent {
         })
         .optional(),
       prompt: z.string().optional(),
-      promptMode: z.enum(["append", "replace"]).optional(),
+      extend: z.boolean().optional(),
       tools: z.record(z.boolean()),
       options: z.record(z.string(), z.any()),
     })

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -726,14 +726,19 @@ export namespace Session {
         synthetic: true,
       })
     }
-    let system = SystemPrompt.header(input.providerID)
-    system.push(
-      ...(() => {
-        if (input.system) return [input.system]
-        if (agent.prompt) return [agent.prompt]
-        return SystemPrompt.provider(input.modelID)
-      })(),
-    )
+    let system: string[] = []
+    if (input.system) {
+      system = [...SystemPrompt.header(input.providerID), input.system]
+    }
+    if (!input.system && agent.prompt && agent.promptMode === "replace") {
+      // Replace default system prompt with agent prompt
+      system = [agent.prompt]
+    }
+    if (!input.system && (!agent.prompt || agent.promptMode !== "replace")) {
+      // Default: append agent prompt if present
+      system = [...SystemPrompt.header(input.providerID)]
+      if (agent.prompt) system.push(agent.prompt)
+    }
     system.push(...(await SystemPrompt.environment()))
     system.push(...(await SystemPrompt.custom()))
     // max 2 system prompt messages for caching purposes

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -726,19 +726,12 @@ export namespace Session {
         synthetic: true,
       })
     }
-    let system: string[] = []
-    if (input.system) {
-      system = [...SystemPrompt.header(input.providerID), input.system]
-    }
-    if (!input.system && agent.prompt && agent.promptMode === "replace") {
-      // Replace default system prompt with agent prompt
-      system = [agent.prompt]
-    }
-    if (!input.system && (!agent.prompt || agent.promptMode !== "replace")) {
-      // Default: append agent prompt if present
-      system = [...SystemPrompt.header(input.providerID)]
-      if (agent.prompt) system.push(agent.prompt)
-    }
+    let system = (() => {
+      if (input.system) return [...SystemPrompt.header(input.providerID), input.system]
+      if (!input.system && agent.prompt && !agent.extend) return [agent.prompt]
+      if (!input.system && agent.prompt && agent.extend) return [...SystemPrompt.header(input.providerID), agent.prompt]
+      return [...SystemPrompt.header(input.providerID), ...SystemPrompt.provider(input.modelID)]
+    })()
     system.push(...(await SystemPrompt.environment()))
     system.push(...(await SystemPrompt.custom()))
     // max 2 system prompt messages for caching purposes


### PR DESCRIPTION
## Summary
Introduce a new `optional` config parameter to agents: `promptMode`

The `promptMode` param has 2 possible values: `append` and `replace`
- `append`: Appends the agent's system prompt to opencode's default prompt (example: keep beastmode prompt for gpt 4.1 while adding something to the system prompt of your custom agent)
- `replace`: Using `replace` or not specifying promptMode is the same thing - it will replace opencode's default system prompt with yours

Maybe this should a boolean instead?