### PR TITLE
fix: more permissive owner/repo detection

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -188,8 +188,12 @@ export const GithubInstallCommand = cmd({
         const info = await $`git remote get-url origin`.quiet().nothrow().text()
         // match https or git pattern
         // ie. https://github.com/sst/opencode.git
+        // ie. https://github.com/sst/opencode
         // ie. git@github.com:sst/opencode.git
-        const parsed = info.match(/git@github\.com:(.*)\.git/) ?? info.match(/github\.com\/(.*)\.git/)
+        // ie. git@github.com:sst/opencode
+        // ie. ssh://git@github.com/sst/opencode.git
+        // ie. ssh://git@github.com/sst/opencode
+        const parsed = info.match(/git@github\.com:(.*)(?:\.git)?$/) ?? info.match(/github\.com\/(.*)(?:\.git)?$/)
         if (!parsed) {
           prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
           throw new UI.CancelledError()


### PR DESCRIPTION
fixes: #1361

just to show it works:
```ts
const patterns = [
  "https://github.com/sst/opencode.git",
  "https://github.com/sst/opencode",
  "git@github.com:sst/opencode.git",
  "git@github.com:sst/opencode",
  "ssh://git@github.com/sst/opencode.git",
  "ssh://git@github.com/sst/opencode",
]

patterns.forEach((pattern) => {
  const parsed = pattern.match(/^(?:(?:https?|ssh):\/\/)?(?:git@)?github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/)
  if (!parsed) {
    console.error(`Invalid pattern: ${pattern}`)
  } else {
    const [, owner, repo] = parsed
    console.log(`pattern: ${pattern}\n  Owner: ${owner}, Repo: ${repo}\n`)
  }
})

```

```zsh
$ bun run script.local.ts
pattern: https://github.com/sst/opencode.git
  Owner: sst, Repo: opencode

pattern: https://github.com/sst/opencode
  Owner: sst, Repo: opencode

pattern: git@github.com:sst/opencode.git
  Owner: sst, Repo: opencode

pattern: git@github.com:sst/opencode
  Owner: sst, Repo: opencode

pattern: ssh://git@github.com/sst/opencode.git
  Owner: sst, Repo: opencode

pattern: ssh://git@github.com/sst/opencode
  Owner: sst, Repo: opencode
```