### PR TITLE
Feat: Render tool metadata after permission rejection.

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -62,7 +62,7 @@ export namespace Permission {
     async (state) => {
       for (const pending of Object.values(state.pending)) {
         for (const item of Object.values(pending)) {
-          item.reject(new RejectedError(item.info.sessionID, item.info.id, item.info.callID))
+          item.reject(new RejectedError(item.info.sessionID, item.info.id, item.info.callID, item.info.metadata))
         }
       }
     },
@@ -105,7 +105,7 @@ export namespace Permission {
       }).then((x) => x.status)
     ) {
       case "deny":
-        throw new RejectedError(info.sessionID, info.id, info.callID)
+        throw new RejectedError(info.sessionID, info.id, info.callID, info.metadata)
       case "allow":
         return
     }
@@ -131,7 +131,7 @@ export namespace Permission {
     if (!match) return
     delete pending[input.sessionID][input.permissionID]
     if (input.response === "reject") {
-      match.reject(new RejectedError(input.sessionID, input.permissionID, match.info.callID))
+      match.reject(new RejectedError(input.sessionID, input.permissionID, match.info.callID, match.info.metadata))
       return
     }
     match.resolve()
@@ -156,6 +156,7 @@ export namespace Permission {
       public readonly sessionID: string,
       public readonly permissionID: string,
       public readonly toolCallID?: string,
+      public readonly metadata?: Record<string, any>,
     ) {
       super(`The user rejected permission to use this specific tool call. You may try again with different parameters.`)
     }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1260,6 +1260,7 @@ export namespace Session {
                       status: "error",
                       input: value.input,
                       error: (value.error as any).toString(),
+                      metadata: value.error instanceof Permission.RejectedError ? value.error.metadata : undefined,
                       time: {
                         start: match.state.time.start,
                         end: Date.now(),

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -64,6 +64,7 @@ export namespace MessageV2 {
       status: z.literal("error"),
       input: z.record(z.any()),
       error: z.string(),
+      metadata: z.record(z.any()).optional(),
       time: z.object({
         start: z.number(),
         end: z.number(),

--- a/packages/sdk/go/session.go
+++ b/packages/sdk/go/session.go
@@ -2023,17 +2023,19 @@ func (r toolStateCompletedTimeJSON) RawJSON() string {
 }
 
 type ToolStateError struct {
-	Error  string                 `json:"error,required"`
-	Input  map[string]interface{} `json:"input,required"`
-	Status ToolStateErrorStatus   `json:"status,required"`
-	Time   ToolStateErrorTime     `json:"time,required"`
-	JSON   toolStateErrorJSON     `json:"-"`
+	Error    string                 `json:"error,required"`
+	Input    map[string]interface{} `json:"input,required"`
+	Metadata map[string]interface{} `json:"metadata"`
+	Status   ToolStateErrorStatus   `json:"status,required"`
+	Time     ToolStateErrorTime     `json:"time,required"`
+	JSON     toolStateErrorJSON     `json:"-"`
 }
 
 // toolStateErrorJSON contains the JSON metadata for the struct [ToolStateError]
 type toolStateErrorJSON struct {
 	Error       apijson.Field
 	Input       apijson.Field
+	Metadata    apijson.Field
 	Status      apijson.Field
 	Time        apijson.Field
 	raw         string

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -347,6 +347,9 @@ export type ToolStateError = {
   input: {
     [key: string]: unknown
   }
+  metadata: {
+    [key: string]: unknown
+  }
   error: string
   time: {
     start: number

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -554,6 +554,17 @@ func renderToolDetails(
 					title := renderToolTitle(toolCall, width)
 					title = style.Render(title)
 					content := title + "\n" + body
+
+					if toolCall.State.Status == opencode.ToolPartStateStatusError {
+						errorStyle := styles.NewStyle().
+							Background(backgroundColor).
+							Foreground(t.Error()).
+							Padding(1, 2).
+							Width(width - 4)
+						errorContent := errorStyle.Render(toolCall.State.Error)
+						content += "\n" + errorContent
+					}
+
 					if permissionContent != "" {
 						permissionContent = styles.NewStyle().
 							Background(backgroundColor).
@@ -579,6 +590,7 @@ func renderToolDetails(
 					if diagnostics := renderDiagnostics(metadata, filename, backgroundColor, width-4); diagnostics != "" {
 						body += "\n\n" + diagnostics
 					}
+
 				}
 			}
 		case "bash":
@@ -652,11 +664,17 @@ func renderToolDetails(
 	}
 
 	if error != "" {
-		body = styles.NewStyle().
+		errorContent := styles.NewStyle().
 			Width(width - 6).
 			Foreground(t.Error()).
 			Background(backgroundColor).
 			Render(error)
+
+		if body == "" {
+			body = errorContent
+		} else {
+			body += "\n\n" + errorContent
+		}
 	}
 
 	if body == "" && error == "" && result != nil {

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -590,7 +590,6 @@ func renderToolDetails(
 					if diagnostics := renderDiagnostics(metadata, filename, backgroundColor, width-4); diagnostics != "" {
 						body += "\n\n" + diagnostics
 					}
-
 				}
 			}
 		case "bash":


### PR DESCRIPTION
Keep tool metadata around even after a permission rejection. This allows referencing specific details when asking for minor changes rather than a complete do over. This works for the 3 tools that support permissions today:
<img width="2551" height="1336" alt="image" src="https://github.com/user-attachments/assets/42e0813a-89a5-456a-9ef8-56761d41e234" />
And should work for all other ones as long as the pattern of storing metadata in the Permission itself is still followed.