### PR TITLE
feat(tui): support cycling recent models in reverse

### DIFF
--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -107,45 +107,46 @@ func (r CommandRegistry) Matches(msg tea.KeyPressMsg, leader bool) []Command {
 }
 
 const (
-	AppHelpCommand              CommandName = "app_help"
-	SwitchAgentCommand          CommandName = "switch_agent"
-	SwitchAgentReverseCommand   CommandName = "switch_agent_reverse"
-	EditorOpenCommand           CommandName = "editor_open"
-	SessionNewCommand           CommandName = "session_new"
-	SessionListCommand          CommandName = "session_list"
-	SessionShareCommand         CommandName = "session_share"
-	SessionUnshareCommand       CommandName = "session_unshare"
-	SessionInterruptCommand     CommandName = "session_interrupt"
-	SessionCompactCommand       CommandName = "session_compact"
-	SessionExportCommand        CommandName = "session_export"
-	ToolDetailsCommand          CommandName = "tool_details"
-	ThinkingBlocksCommand       CommandName = "thinking_blocks"
-	ModelListCommand            CommandName = "model_list"
-	AgentListCommand            CommandName = "agent_list"
-	ModelCycleRecentCommand     CommandName = "model_cycle_recent"
-	ThemeListCommand            CommandName = "theme_list"
-	FileListCommand             CommandName = "file_list"
-	FileCloseCommand            CommandName = "file_close"
-	FileSearchCommand           CommandName = "file_search"
-	FileDiffToggleCommand       CommandName = "file_diff_toggle"
-	ProjectInitCommand          CommandName = "project_init"
-	InputClearCommand           CommandName = "input_clear"
-	InputPasteCommand           CommandName = "input_paste"
-	InputSubmitCommand          CommandName = "input_submit"
-	InputNewlineCommand         CommandName = "input_newline"
-	MessagesPageUpCommand       CommandName = "messages_page_up"
-	MessagesPageDownCommand     CommandName = "messages_page_down"
-	MessagesHalfPageUpCommand   CommandName = "messages_half_page_up"
-	MessagesHalfPageDownCommand CommandName = "messages_half_page_down"
-	MessagesPreviousCommand     CommandName = "messages_previous"
-	MessagesNextCommand         CommandName = "messages_next"
-	MessagesFirstCommand        CommandName = "messages_first"
-	MessagesLastCommand         CommandName = "messages_last"
-	MessagesLayoutToggleCommand CommandName = "messages_layout_toggle"
-	MessagesCopyCommand         CommandName = "messages_copy"
-	MessagesUndoCommand         CommandName = "messages_undo"
-	MessagesRedoCommand         CommandName = "messages_redo"
-	AppExitCommand              CommandName = "app_exit"
+	AppHelpCommand                 CommandName = "app_help"
+	SwitchAgentCommand             CommandName = "switch_agent"
+	SwitchAgentReverseCommand      CommandName = "switch_agent_reverse"
+	EditorOpenCommand              CommandName = "editor_open"
+	SessionNewCommand              CommandName = "session_new"
+	SessionListCommand             CommandName = "session_list"
+	SessionShareCommand            CommandName = "session_share"
+	SessionUnshareCommand          CommandName = "session_unshare"
+	SessionInterruptCommand        CommandName = "session_interrupt"
+	SessionCompactCommand          CommandName = "session_compact"
+	SessionExportCommand           CommandName = "session_export"
+	ToolDetailsCommand             CommandName = "tool_details"
+	ThinkingBlocksCommand          CommandName = "thinking_blocks"
+	ModelListCommand               CommandName = "model_list"
+	AgentListCommand               CommandName = "agent_list"
+	ModelCycleRecentCommand        CommandName = "model_cycle_recent"
+	ModelCycleRecentReverseCommand CommandName = "model_cycle_recent_reverse"
+	ThemeListCommand               CommandName = "theme_list"
+	FileListCommand                CommandName = "file_list"
+	FileCloseCommand               CommandName = "file_close"
+	FileSearchCommand              CommandName = "file_search"
+	FileDiffToggleCommand          CommandName = "file_diff_toggle"
+	ProjectInitCommand             CommandName = "project_init"
+	InputClearCommand              CommandName = "input_clear"
+	InputPasteCommand              CommandName = "input_paste"
+	InputSubmitCommand             CommandName = "input_submit"
+	InputNewlineCommand            CommandName = "input_newline"
+	MessagesPageUpCommand          CommandName = "messages_page_up"
+	MessagesPageDownCommand        CommandName = "messages_page_down"
+	MessagesHalfPageUpCommand      CommandName = "messages_half_page_up"
+	MessagesHalfPageDownCommand    CommandName = "messages_half_page_down"
+	MessagesPreviousCommand        CommandName = "messages_previous"
+	MessagesNextCommand            CommandName = "messages_next"
+	MessagesFirstCommand           CommandName = "messages_first"
+	MessagesLastCommand            CommandName = "messages_last"
+	MessagesLayoutToggleCommand    CommandName = "messages_layout_toggle"
+	MessagesCopyCommand            CommandName = "messages_copy"
+	MessagesUndoCommand            CommandName = "messages_undo"
+	MessagesRedoCommand            CommandName = "messages_redo"
+	AppExitCommand                 CommandName = "app_exit"
 )
 
 func (k Command) Matches(msg tea.KeyPressMsg, leader bool) bool {
@@ -266,8 +267,13 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 		},
 		{
 			Name:        ModelCycleRecentCommand,
-			Description: "cycle recent models",
+			Description: "next recent model",
 			Keybindings: parseBindings("f2"),
+		},
+		{
+			Name:        ModelCycleRecentReverseCommand,
+			Description: "previous recent model",
+			Keybindings: parseBindings("shift+f2"),
 		},
 		{
 			Name:        ThemeListCommand,

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1190,6 +1190,10 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 		updated, cmd := a.app.CycleRecentModel()
 		a.app = updated
 		cmds = append(cmds, cmd)
+	case commands.ModelCycleRecentReverseCommand:
+		updated, cmd := a.app.CycleRecentModelReverse()
+		a.app = updated
+		cmds = append(cmds, cmd)
 	case commands.ThemeListCommand:
 		themeDialog := dialog.NewThemeDialog()
 		a.modal = themeDialog


### PR DESCRIPTION
Currently we can cycle models "forward", but not in "reverse". This can be frustrating when you accidentally cycle one too many times and miss the model you're looking for.

This adds a new keybinding to allow cycling to the previous recent model