### PR TITLE
fix(tui): issue with rendering markdown tables

### DIFF
--- a/packages/tui/internal/util/file.go
+++ b/packages/tui/internal/util/file.go
@@ -86,7 +86,7 @@ func Extension(path string) string {
 func ToMarkdown(content string, width int, backgroundColor compat.AdaptiveColor) string {
 	r := styles.GetMarkdownRenderer(width-6, backgroundColor)
 	content = strings.ReplaceAll(content, RootPath+"/", "")
-	hyphenRegex := regexp.MustCompile(`-([^ ]|$)`)
+	hyphenRegex := regexp.MustCompile(`-([^ \-|]|$)`)
 	content = hyphenRegex.ReplaceAllString(content, "\u2011$1")
 	rendered, _ := r.Render(content)
 	lines := strings.Split(rendered, "\n")


### PR DESCRIPTION
fixes #1940

before:

<img width="844" height="484" alt="image" src="https://github.com/user-attachments/assets/8882596a-1aa6-470a-9efb-fae30cf0ba1c" />

after:

<img width="845" height="630" alt="image" src="https://github.com/user-attachments/assets/8fd41730-b839-4803-8397-d70fe41eecd0" />
