### PR TITLE
fix(shell): commands expecting stdin will be "working" indefinitely

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1076,6 +1076,7 @@ export namespace Session {
     const proc = spawn(shell, args, {
       cwd: app.path.cwd,
       signal: abort.signal,
+      stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
         TERM: "dumb",


### PR DESCRIPTION
Running a command that expects an input from stdin will be stuck on `working...` indefinitely. (Can interrupt with escape)

An example of this is running `!cat`

Setting stdin to `ignore` will allow these cases to terminate.