### PR TITLE
fix: remove unsupported mode flag, change to agent

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -55,9 +55,9 @@ export const TuiCommand = cmd({
         type: "string",
         describe: "prompt to use",
       })
-      .option("mode", {
+      .option("agent", {
         type: "string",
-        describe: "mode to use",
+        describe: "agent to use",
       })
       .option("port", {
         type: "number",
@@ -129,7 +129,7 @@ export const TuiCommand = cmd({
             ...cmd,
             ...(args.model ? ["--model", args.model] : []),
             ...(args.prompt ? ["--prompt", args.prompt] : []),
-            ...(args.mode ? ["--mode", args.mode] : []),
+            ...(args.agent ? ["--agent", args.agent] : []),
             ...(sessionID ? ["--session", sessionID] : []),
           ],
           cwd,

--- a/packages/web/src/content/docs/docs/cli.mdx
+++ b/packages/web/src/content/docs/docs/cli.mdx
@@ -346,6 +346,6 @@ The opencode CLI takes the following global flags.
 | `--log-level`  |       | Log level (DEBUG, INFO, WARN, ERROR)       |
 | `--prompt`     | `-p`  | Prompt to use                              |
 | `--model`      | `-m`  | Model to use in the form of provider/model |
-| `--mode`       |       | Mode to use                                |
+| `--agent`      |       | Agent to use                               |
 | `--port`       |       | Port to listen on                          |
 | `--hostname`   |       | Hostname to listen on                      |


### PR DESCRIPTION
No point in keeping `mode` support really, the tui already didn't support it, see below:

<img width="489" height="138" alt="Screenshot 2025-08-15 at 9 43 55 PM" src="https://github.com/user-attachments/assets/038fd315-0d57-475e-bbb4-566d5908458c" />
