### PR TITLE
feat(tui): retain cache when cycling between subagent/parent sessions for perf

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -171,7 +171,11 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.showThinkingBlocks = !m.showThinkingBlocks
 		m.app.State.ShowThinkingBlocks = &m.showThinkingBlocks
 		return m, tea.Batch(m.renderView(), m.app.SaveState())
-	case app.SessionLoadedMsg, app.SessionClearedMsg:
+	case app.SessionLoadedMsg:
+		m.tail = true
+		m.loading = true
+		return m, m.renderView()
+	case app.SessionClearedMsg:
 		m.cache.Clear()
 		m.tail = true
 		m.loading = true
@@ -183,6 +187,21 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.renderView()
 		}
 	case app.SessionSelectedMsg:
+		currentParent := m.app.Session.ParentID
+		if currentParent == "" {
+			currentParent = m.app.Session.ID
+		}
+
+		targetParent := msg.ParentID
+		if targetParent == "" {
+			targetParent = msg.ID
+		}
+
+		// Clear cache only if switching between different session families
+		if currentParent != targetParent {
+			m.cache.Clear()
+		}
+
 		m.viewport.GotoBottom()
 	case app.MessageRevertedMsg:
 		if msg.Session.ID == m.app.Session.ID {

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -621,6 +621,10 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			},
 		}
 	case app.SessionSelectedMsg:
+		updated, cmd := a.messages.Update(msg)
+		a.messages = updated.(chat.MessagesComponent)
+		cmds = append(cmds, cmd)
+
 		messages, err := a.app.ListMessages(context.Background(), msg.ID)
 		if err != nil {
 			slog.Error("Failed to list messages", "error", err.Error())
@@ -628,7 +632,8 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		a.app.Session = msg
 		a.app.Messages = messages
-		return a, util.CmdHandler(app.SessionLoadedMsg{})
+		cmds = append(cmds, util.CmdHandler(app.SessionLoadedMsg{}))
+		return a, tea.Batch(cmds...)
 	case app.SessionCreatedMsg:
 		a.app.Session = msg.Session
 	case dialog.ScrollToMessageMsg:


### PR DESCRIPTION
fixes #1980

This PR updates the parts cache to not be cleared when switching between related sessions, i.e. parent/child sessions. This improves performance when cycling between subagent sessions, particularly with larger sessions.

The cache is still cleared when switching to unrelated sessions via the `/sessions` command

before:

https://github.com/user-attachments/assets/7f94c276-6d8e-4bae-9091-193fc8789b63

after:

https://github.com/user-attachments/assets/8be54208-5712-46ad-87b6-9ea2abfcc4b0