### PR TITLE
fix(tui): text selection is sometimes not cleared when click+release without dragging

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -134,15 +134,18 @@ func (m *messagesComponent) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.MouseReleaseMsg:
-		if m.selection != nil && len(m.clipboard) > 0 {
-			content := strings.Join(m.clipboard, "\n")
+		if m.selection != nil {
 			m.selection = nil
-			m.clipboard = []string{}
-			return m, tea.Sequence(
-				m.renderView(),
-				app.SetClipboard(content),
-				toast.NewSuccessToast("Copied to clipboard"),
-			)
+			if len(m.clipboard) > 0 {
+				content := strings.Join(m.clipboard, "\n")
+				m.clipboard = []string{}
+				return m, tea.Sequence(
+					m.renderView(),
+					app.SetClipboard(content),
+					toast.NewSuccessToast("Copied to clipboard"),
+				)
+			}
+			return m, m.renderView()
 		}
 	case tea.WindowSizeMsg:
 		effectiveWidth := msg.Width - 4


### PR DESCRIPTION
fixes #1992

(Note, as described in the issue, this is difficult to reproduce - but I've observed this many times since earlier versions)

https://github.com/user-attachments/assets/25292b3e-c13e-4fa3-bdab-43067c75a588