### PR TITLE
feat: top level tool config

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -38,6 +38,7 @@ export namespace Agent {
 
   const state = App.state("agent", async () => {
     const cfg = await Config.get()
+    const defaultTools = cfg.tools ?? {}
     const defaultPermission: Info["permission"] = {
       edit: "allow",
       bash: {
@@ -55,6 +56,7 @@ export namespace Agent {
         tools: {
           todoread: false,
           todowrite: false,
+          ...defaultTools,
         },
         options: {},
         permission: agentPermission,
@@ -63,7 +65,7 @@ export namespace Agent {
       },
       build: {
         name: "build",
-        tools: {},
+        tools: { ...defaultTools },
         options: {},
         permission: agentPermission,
         mode: "primary",
@@ -77,6 +79,7 @@ export namespace Agent {
           write: false,
           edit: false,
           patch: false,
+          ...defaultTools,
         },
         mode: "primary",
         builtIn: true,
@@ -109,6 +112,10 @@ export namespace Agent {
           ...item.tools,
           ...tools,
         }
+      item.tools = {
+        ...defaultTools,
+        ...item.tools,
+      }
       if (description) item.description = description
       if (temperature != undefined) item.temperature = temperature
       if (top_p != undefined) item.topP = top_p

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -384,6 +384,7 @@ export namespace Config {
           webfetch: Permission.optional(),
         })
         .optional(),
+      tools: z.record(z.string(), z.boolean()).optional(),
       experimental: z
         .object({
           hook: z


### PR DESCRIPTION
I've heard the following a few times: "I want to enable an mcp server only for a particular agent"

currently it is kinda messy to disable a tool for each agent, then only not disable for one, having a top level configuration option can allow someone to disable an mcp server by default and only enable for the particular agent they want.

This follows existing pattern that permissions uses


## note
**if this isn't wanted feel free to close**, ik there was talk of combining tools + permissions