### PR TITLE
fix: installation via volta broken due to symbolic links pointing to tmp file

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -119,7 +119,7 @@ async function main() {
     }
 
     // Create symlink to the actual binary
-    fs.symlinkSync(binaryPath, binScript)
+    fs.symlinkSync(path.relative(path.dirname(binScript), binaryPath), binScript)
     console.log(`opencode binary symlinked: ${binScript} -> ${binaryPath}`)
   } catch (error) {
     console.error("Failed to create opencode binary symlink:", error.message)


### PR DESCRIPTION
The PR uses a relative path for symbolic link

See https://github.com/sst/opencode/issues/197
Fix verified locally by running local npm registry:

```
cat > ./verdaccio.local.yaml <<'YAML'
max_body_size: 200mb

storage: ./storage
uplinks:
  npmjs:
    url: https://registry.npmjs.org/
packages:
  "@*/*":
    access: $all
    publish: $all
    proxy: npmjs
  "**":
    access: $all
    publish: $all
    proxy: npmjs
YAML

npx verdaccio@latest --listen 4873 --config ./verdaccio.local.yaml

```

And publishing opencode to that:

```
OPENCODE_VERSION="1.0.0-local" OPENCODE_DRY="false" bun run script/publish.ts
```

The `packages/opencode/script/publish.ts` was updated to publish to local registry by appending
`--registry http://localhost:4873` to the `bun publish` commands.

Volta was then used to install from the local registry:

```
NPM_CONFIG_REGISTRY=http://localhost:4873 npm_config_registry=http://localhost:4873 volta install opencode-ai@1.0.0-local
```
