### PR TITLE
fix: Pause text updates during active tool calls (gemini-2.5-pro bug)

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1150,6 +1150,7 @@ export namespace Session {
         try {
           let currentText: MessageV2.TextPart | undefined
           let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
+          let tollCalled = false;
 
           for await (const value of stream.fullStream) {
             log.info("part", {
@@ -1219,6 +1220,7 @@ export namespace Session {
                 break
 
               case "tool-call": {
+                tollCalled = true;
                 const match = toolcalls[value.toolCallId]
                 if (match) {
                   const part = await updatePart({
@@ -1254,6 +1256,7 @@ export namespace Session {
                     },
                   })
                   delete toolcalls[value.toolCallId]
+                  tollCalled = false;
                 }
                 break
               }
@@ -1337,14 +1340,14 @@ export namespace Session {
                 break
 
               case "text-delta":
-                if (currentText) {
+                if (currentText && !tollCalled) {
                   currentText.text += value.text
                   if (currentText.text) await updatePart(currentText)
                 }
                 break
 
               case "text-end":
-                if (currentText) {
+                if (currentText && !tollCalled) {
                   currentText.text = currentText.text.trimEnd()
                   currentText.time = {
                     start: Date.now(),


### PR DESCRIPTION
Originally I found this issue with Gemini 2.5 Pro models in OpenRouter and AI Studio. The problem is in the example below

<img width="1220" height="224" alt="image" src="https://github.com/user-attachments/assets/215d375b-332d-4d32-95b8-6954bf07db26" />

Most of the times, it breaks the AI for the rest of the conversation, sometimes it doesn't.

The issue is that Gemini returns a tool call in the stream, then it sends the same tool but this time in `content`:

```jsonl
data: {"id":"gen-1755460677-sseVdUiRiZKHTQpgBrkm","provider":"Google AI Studio","model":"google/gemini-2.5-pro","object":"chat.completion.chunk","created":1755460677,"choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"tool_0_glob","type":"function","function":{"name":"glob","arguments":"{\"pattern\":\"**/*.test.ts\"}"}}]},"finish_reason":"tool_calls","native_finish_reason":null,"logprobs":null}]}
data: {"id":"gen-1755460677-sseVdUiRiZKHTQpgBrkm","provider":"Google AI Studio","model":"google/gemini-2.5-pro","object":"chat.completion.chunk","created":1755460677,"choices":[{"index":0,"delta":{"role":"assistant","content":"call:glob{pattern:","reasoning":null,"reasoning_details":[]},"finish_reason":"stop","native_finish_reason":"STOP","logprobs":null}]}
data: {"id":"gen-1755460677-sseVdUiRiZKHTQpgBrkm","provider":"Google AI Studio","model":"google/gemini-2.5-pro","object":"chat.completion.chunk","created":1755460677,"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"native_finish_reason":null,"logprobs":null}],"usage":{"prompt_tokens":13280,"completion_tokens":280,"total_tokens":13560,"prompt_tokens_details":{"cached_tokens":0}}}
data: [DONE]
```

This commit prevents this by not appending any assistant messages after a tool call is made, until it gets a response.