### PR TITLE
Fix Vertex/Anthropic by adding subpath support for provider modules

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -42,6 +42,7 @@ export namespace ModelsDev {
       env: z.array(z.string()),
       id: z.string(),
       npm: z.string().optional(),
+      subpath: z.string().optional(),
       models: z.record(Model),
     })
     .openapi({

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -138,6 +138,11 @@ export namespace Provider {
   const state = App.state("provider", async () => {
     const config = await Config.get()
     const database = await ModelsDev.get()
+    
+    // Add subpath for known providers that need it
+    if (database["google-vertex-anthropic"]) {
+      database["google-vertex-anthropic"].subpath = "anthropic"
+    }
 
     const providers: {
       [providerID: string]: {
@@ -183,6 +188,7 @@ export namespace Provider {
       const parsed: ModelsDev.Provider = {
         id: providerID,
         npm: provider.npm ?? existing?.npm,
+        subpath: provider.subpath ?? existing?.subpath,
         name: provider.name ?? existing?.name ?? providerID,
         env: provider.env ?? existing?.env ?? [],
         api: provider.api ?? existing?.api,
@@ -303,7 +309,10 @@ export namespace Provider {
       const existing = s.sdk.get(provider.id)
       if (existing) return existing
       const pkg = provider.npm ?? provider.id
-      const mod = await import(await BunProc.install(pkg, "latest"))
+      const installPath = await BunProc.install(pkg, "latest")
+      const importPath = provider.subpath ? `${pkg}/${provider.subpath}` : installPath
+      log.info("importing", importPath)
+      const mod = await import(importPath)
       const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
       const loaded = fn({
         name: provider.id,


### PR DESCRIPTION
Added subpath field to provider model and updated import logic to support subpaths for npm packages. This allows providers like google-vertex-anthropic to properly import from specific subpaths.

Tested with 
```json
{
  "$schema": "https://opencode.ai/config.json",
  "model": "google-vertex-anthropic/claude-3-7-sonnet@20250219",
  "provider": {
    "google-vertex-anthropic": {
      "models": {
        "claude-3-7-sonnet@20250219": {},
      },
      "options": {
        "project": "my project",
        "location": "my location"
      }
    }
  }
}
```