### PR TITLE
fix: calculate max output tokens based on budget thinking tokens

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -98,4 +98,18 @@ export namespace ProviderTransform {
     }
     return result
   }
+
+  export function maxOutputTokens(providerID: string, outputLimit: number, options: Record<string, any>): number {
+    if (providerID === "anthropic") {
+      const thinking = options["thinking"]
+      if (typeof thinking === "object" && thinking !== null) {
+        const type = thinking["type"]
+        const budgetTokens = thinking["budgetTokens"]
+        if (type === "enabled" && typeof budgetTokens === "number" && budgetTokens > 0) {
+          return outputLimit - budgetTokens
+        }
+      }
+    }
+    return outputLimit
+  }
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1019,7 +1019,13 @@ export namespace Session {
           : undefined,
       maxRetries: 3,
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
-      maxOutputTokens: outputLimit,
+      maxOutputTokens: Math.max(
+        1,
+        outputLimit -
+          (input.providerID === "anthropic"
+            ? ((params.options as { thinking?: { budgetTokens?: number } } | undefined)?.thinking?.budgetTokens ?? 0)
+            : 0),
+      ),
       abortSignal: abort.signal,
       stopWhen: async ({ steps }) => {
         if (steps.length >= 1000) {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1019,13 +1019,7 @@ export namespace Session {
           : undefined,
       maxRetries: 3,
       activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
-      maxOutputTokens: Math.max(
-        1,
-        outputLimit -
-          (input.providerID === "anthropic"
-            ? ((params.options as { thinking?: { budgetTokens?: number } } | undefined)?.thinking?.budgetTokens ?? 0)
-            : 0),
-      ),
+      maxOutputTokens: ProviderTransform.maxOutputTokens(model.providerID, outputLimit, params.options),
       abortSignal: abort.signal,
       stopWhen: async ({ steps }) => {
         if (steps.length >= 1000) {


### PR DESCRIPTION
this is just a proposal to make the process of enabling reasoning on Anthropic models not a pita.

the current implementation can cause max tokens errors when `budgetTokens` is set, forcing users to debug token limits, etc.

this change fixes that by adjusting the max output tokens automatically.

closes #2055 