### PR TITLE
tweak: better agent create error handling

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -46,7 +46,10 @@ const AgentCreateCommand = cmd({
       const spinner = prompts.spinner()
 
       spinner.start("Generating agent configuration...")
-      const generated = await Agent.generate({ description: query })
+      const generated = await Agent.generate({ description: query }).catch((error) => {
+        spinner.stop(`LLM failed to generate agent: ${error.message}`, 1)
+        throw new UI.CancelledError()
+      })
       spinner.stop(`Agent ${generated.identifier} generated`)
 
       const availableTools = [

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -45,7 +45,7 @@ export const UpgradeCommand = {
     spinner.start("Upgrading...")
     const err = await Installation.upgrade(method, target).catch((err) => err)
     if (err) {
-      spinner.stop("Upgrade failed")
+      spinner.stop("Upgrade failed", 1)
       if (err instanceof Installation.UpgradeFailedError) prompts.log.error(err.data.stderr)
       else if (err instanceof Error) prompts.log.error(err.message)
       prompts.outro("Done")


### PR DESCRIPTION
addresses: #2040

Before (stuck in generating state even after error):
<img width="868" height="217" alt="Screenshot 2025-08-19 at 12 10 15 AM" src="https://github.com/user-attachments/assets/df3b8b38-6e44-456e-b436-d59f4e3edf3a" />

After:
<img width="634" height="222" alt="Screenshot 2025-08-19 at 12 10 27 AM" src="https://github.com/user-attachments/assets/ae9557d9-5a8f-4ae9-83d3-e8405f2a576d" />
