### PR TITLE
tweak: notify agent it is in build mode when switching from plan mode

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -726,6 +726,18 @@ export namespace Session {
         synthetic: true,
       })
     }
+
+    const lastAssistantMsg = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
+    if (lastAssistantMsg?.mode === "plan" && agent.name === "build") {
+      msgs.at(-1)?.parts.push({
+        id: Identifier.ascending("part"),
+        messageID: userMsg.id,
+        sessionID: input.sessionID,
+        type: "text",
+        text: "You are now in build mode and are permitted to make edits",
+        synthetic: true,
+      })
+    }
     let system = SystemPrompt.header(input.providerID)
     system.push(
       ...(() => {


### PR DESCRIPTION
I've seen people get annoyed that they have to tell llm it is allowed to make edits, I figure this may help address that issue. Idk if this is the best solution or if a more verbose prompt makes sense here but just wanted to open this incase it is worth trying