### PR TITLE
fix: add type checking for MCP tool path parameters

### DIFF
--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -903,7 +903,9 @@ func renderArgs(args *map[string]any, titleKey string) string {
 			continue
 		}
 		if key == "filePath" || key == "path" {
-			value = util.Relative(value.(string))
+			if strValue, ok := value.(string); ok {
+				value = util.Relative(strValue)
+			}
 		}
 		if key == titleKey {
 			title = fmt.Sprintf("%s", value)


### PR DESCRIPTION
fixes: #2068


Prevents panic when MCP servers send path parameters as arrays instead of strings by safely checking the type before conversion