### PR TITLE
fix(TUI): make it less shimmer

### DIFF
--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -382,11 +382,9 @@ func (m *editorComponent) Content() string {
 			status = "waiting for permission"
 		}
 		if m.interruptKeyInDebounce && m.app.CurrentPermission.ID == "" {
-			bright := t.Accent()
-			if status == "waiting for permission" {
-				bright = t.Warning()
-			}
-			hint = util.Shimmer(status, t.Background(), t.TextMuted(), bright) + m.spinner.View() + muted(
+			hint = muted(
+				status,
+			) + m.spinner.View() + muted(
 				"  ",
 			) + base(
 				keyText+" again",
@@ -394,11 +392,7 @@ func (m *editorComponent) Content() string {
 				" interrupt",
 			)
 		} else {
-			bright := t.Accent()
-			if status == "waiting for permission" {
-				bright = t.Warning()
-			}
-			hint = util.Shimmer(status, t.Background(), t.TextMuted(), bright) + m.spinner.View()
+			hint = muted(status) + m.spinner.View()
 			if m.app.CurrentPermission.ID == "" {
 				hint += muted("  ") + base(keyText) + muted(" interrupt")
 			}

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -213,6 +213,7 @@ func renderText(
 	extra string,
 	isThinking bool,
 	isQueued bool,
+	shimmer bool,
 	fileParts []opencode.FilePart,
 	agentParts []opencode.AgentPart,
 	toolCalls ...opencode.ToolPart,
@@ -234,7 +235,12 @@ func renderText(
 		}
 		content = util.ToMarkdown(text, width, backgroundColor)
 		if isThinking {
-			label := util.Shimmer("Thinking...", backgroundColor, t.TextMuted(), t.Accent())
+			var label string
+			if shimmer {
+				label = util.Shimmer("Thinking...", backgroundColor, t.TextMuted(), t.Accent())
+			} else {
+				label = styles.NewStyle().Background(backgroundColor).Foreground(t.TextMuted()).Render("Thinking...")
+			}
 			label = styles.NewStyle().Background(backgroundColor).Width(width - 6).Render(label)
 			content = label + "\n\n" + content
 		} else if strings.TrimSpace(text) == "Generating..." {


### PR DESCRIPTION
- Remove shimmer from the "working" indicator  
-  Only make the currently streaming block shimmer

Should result in only one thing shimmering at a time. (Generating text, active tool call, thinking block, etc.)