### PR TITLE
docs: add full list of tools to permissions page

### DIFF
--- a/packages/web/src/content/docs/docs/permissions.mdx
+++ b/packages/web/src/content/docs/docs/permissions.mdx
@@ -15,11 +15,19 @@ Permissions are configured in your `opencode.json` file under the `permission` k
 
 ### Tool Permission Support
 
-| Tool       | Description                     |
-| ---------- | ------------------------------- |
-| `edit`     | Control file editing operations |
-| `bash`     | Control bash command execution  |
-| `webfetch` | Control web content fetching    |
+| Tool        | Description                     |
+| ----------- | ------------------------------- |
+| `bash`      | Execute shell commands          |
+| `edit`      | Modify existing files           |
+| `write`     | Create new files                |
+| `read`      | Read file contents              |
+| `grep`      | Search file contents            |
+| `glob`      | Find files by pattern           |
+| `list`      | List directory contents         |
+| `patch`     | Apply patches to files          |
+| `todowrite` | Manage todo lists               |
+| `todoread`  | Read todo lists                 |
+| `webfetch`  | Fetch web content               |
 
 They can also be configured per agent, see [Agent Configuration](/docs/agents#agent-configuration) for more details.
 


### PR DESCRIPTION
Updated docs to include the full list of tools on the permissions page for easy reference.