### PR TITLE
fix: keybind panic

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -207,6 +207,9 @@ func New(
 
 func (a *App) Keybind(commandName commands.CommandName) string {
 	command := a.Commands[commandName]
+	if len(command.Keybindings) == 0 {
+		return ""
+	}
 	kb := command.Keybindings[0]
 	key := kb.Key
 	if kb.RequiresLeader {

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -671,10 +671,22 @@ func renderToolDetails(
 				body = strings.Join(steps, "\n")
 
 				body += "\n\n"
-				body += baseStyle(app.Keybind(commands.SessionChildCycleCommand)) +
-					mutedStyle(", ") +
-					baseStyle(app.Keybind(commands.SessionChildCycleReverseCommand)) +
-					mutedStyle(" navigate child sessions")
+
+				// Build navigation hint with proper spacing
+				cycleKeybind := app.Keybind(commands.SessionChildCycleCommand)
+				cycleReverseKeybind := app.Keybind(commands.SessionChildCycleReverseCommand)
+
+				var navParts []string
+				if cycleKeybind != "" {
+					navParts = append(navParts, baseStyle(cycleKeybind))
+				}
+				if cycleReverseKeybind != "" {
+					navParts = append(navParts, baseStyle(cycleReverseKeybind))
+				}
+
+				if len(navParts) > 0 {
+					body += strings.Join(navParts, mutedStyle(", ")) + mutedStyle(" navigate child sessions")
+				}
 			}
 			body = defaultStyle(body)
 		default:


### PR DESCRIPTION
fixes: #2071

If you set keybinds like:
```
  "keybinds": {
    "session_child_cycle": "none",
    "session_child_cycle_reverse": "none"
  }
```

and the session had subagents, then app.Keybind(...) would panic