### PR TITLE
feat: lsp diagnostic severity configuration

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -14,6 +14,7 @@ import matter from "gray-matter"
 import { Flag } from "../flag/flag"
 import { Auth } from "../auth"
 import { type ParseError as JsoncParseError, parse as parseJsonc, printParseErrorCode } from "jsonc-parser"
+import { LSP } from "../lsp"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -382,11 +383,15 @@ export namespace Config {
               disabled: z.literal(true),
             }),
             z.object({
-              command: z.array(z.string()),
+              command: z.array(z.string()).optional(),
               extensions: z.array(z.string()).optional(),
               disabled: z.boolean().optional(),
               env: z.record(z.string(), z.string()).optional(),
               initialization: z.record(z.string(), z.any()).optional(),
+              severity: z
+                .enum(Object.keys(LSP.Diagnostic.Severity) as [string, ...string[]])
+                .optional()
+                .describe("Minimum diagnostic severity level to show to agent"),
             }),
           ]),
         )

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -7,6 +7,7 @@ import { BunProc } from "../bun"
 import { $ } from "bun"
 import fs from "fs/promises"
 import { Filesystem } from "../util/filesystem"
+import { Severity } from "./severity"
 
 export namespace LSPServer {
   const log = Log.create({ service: "lsp.server" })
@@ -34,6 +35,7 @@ export namespace LSPServer {
 
   export interface Info {
     id: string
+    severity?: Severity
     extensions: string[]
     global?: boolean
     root: RootFunction
@@ -128,6 +130,8 @@ export namespace LSPServer {
 
   export const ESLint: Info = {
     id: "eslint",
+    // most ESLint feedback has severity HINT
+    severity: Severity.HINT,
     root: NearestRoot([
       "eslint.config.js",
       "eslint.config.mjs",

--- a/packages/opencode/src/lsp/severity.ts
+++ b/packages/opencode/src/lsp/severity.ts
@@ -1,0 +1,13 @@
+export enum Severity {
+  ERROR = 1,
+  WARN = 2,
+  INFO = 3,
+  HINT = 4,
+}
+
+export const SeverityMap: Record<string, Severity> = {
+  ERROR: Severity.ERROR,
+  WARN: Severity.WARN,
+  INFO: Severity.INFO,
+  HINT: Severity.HINT,
+}

--- a/packages/sdk/go/.stats.yml
+++ b/packages/sdk/go/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 39
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/opencode%2Fopencode-e4b6496e5f2c68fa8b3ea1b88e40041eaf5ce2652001344df80bf130675d1766.yml
-openapi_spec_hash: df474311dc9e4a89cd483bd8b8d971d8
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/opencode%2Fopencode-ae6510226d1ce153e1cc099a479b0b1cf0c2f5c905c6330b3fed9efac93f6086.yml
+openapi_spec_hash: 88261dd50416e611c62cbaf31b8a430d
 config_hash: eab3723c4c2232a6ba1821151259d6da

--- a/packages/sdk/go/config.go
+++ b/packages/sdk/go/config.go
@@ -79,7 +79,8 @@ type Config struct {
 	SmallModel string `json:"small_model"`
 	Snapshot   bool   `json:"snapshot"`
 	// Theme name to use for the interface
-	Theme string `json:"theme"`
+	Theme string          `json:"theme"`
+	Tools map[string]bool `json:"tools"`
 	// TUI specific settings
 	Tui ConfigTui `json:"tui"`
 	// Custom username to display in conversations instead of system username
@@ -110,6 +111,7 @@ type configJSON struct {
 	SmallModel        apijson.Field
 	Snapshot          apijson.Field
 	Theme             apijson.Field
+	Tools             apijson.Field
 	Tui               apijson.Field
 	Username          apijson.Field
 	raw               string
@@ -803,9 +805,11 @@ type ConfigLsp struct {
 	// This field can have the runtime type of [[]string].
 	Extensions interface{} `json:"extensions"`
 	// This field can have the runtime type of [map[string]interface{}].
-	Initialization interface{}   `json:"initialization"`
-	JSON           configLspJSON `json:"-"`
-	union          ConfigLspUnion
+	Initialization interface{} `json:"initialization"`
+	// Minimum diagnostic severity level to show to agent
+	Severity ConfigLspSeverity `json:"severity"`
+	JSON     configLspJSON     `json:"-"`
+	union    ConfigLspUnion
 }
 
 // configLspJSON contains the JSON metadata for the struct [ConfigLsp]
@@ -815,6 +819,7 @@ type configLspJSON struct {
 	Env            apijson.Field
 	Extensions     apijson.Field
 	Initialization apijson.Field
+	Severity       apijson.Field
 	raw            string
 	ExtraFields    map[string]apijson.Field
 }
@@ -898,12 +903,14 @@ func (r ConfigLspDisabledDisabled) IsKnown() bool {
 }
 
 type ConfigLspObject struct {
-	Command        []string               `json:"command,required"`
+	Command        []string               `json:"command"`
 	Disabled       bool                   `json:"disabled"`
 	Env            map[string]string      `json:"env"`
 	Extensions     []string               `json:"extensions"`
 	Initialization map[string]interface{} `json:"initialization"`
-	JSON           configLspObjectJSON    `json:"-"`
+	// Minimum diagnostic severity level to show to agent
+	Severity ConfigLspObjectSeverity `json:"severity"`
+	JSON     configLspObjectJSON     `json:"-"`
 }
 
 // configLspObjectJSON contains the JSON metadata for the struct [ConfigLspObject]
@@ -913,6 +920,7 @@ type configLspObjectJSON struct {
 	Env            apijson.Field
 	Extensions     apijson.Field
 	Initialization apijson.Field
+	Severity       apijson.Field
 	raw            string
 	ExtraFields    map[string]apijson.Field
 }
@@ -926,6 +934,42 @@ func (r configLspObjectJSON) RawJSON() string {
 }
 
 func (r ConfigLspObject) implementsConfigLsp() {}
+
+// Minimum diagnostic severity level to show to agent
+type ConfigLspObjectSeverity string
+
+const (
+	ConfigLspObjectSeverityError ConfigLspObjectSeverity = "ERROR"
+	ConfigLspObjectSeverityWarn  ConfigLspObjectSeverity = "WARN"
+	ConfigLspObjectSeverityInfo  ConfigLspObjectSeverity = "INFO"
+	ConfigLspObjectSeverityHint  ConfigLspObjectSeverity = "HINT"
+)
+
+func (r ConfigLspObjectSeverity) IsKnown() bool {
+	switch r {
+	case ConfigLspObjectSeverityError, ConfigLspObjectSeverityWarn, ConfigLspObjectSeverityInfo, ConfigLspObjectSeverityHint:
+		return true
+	}
+	return false
+}
+
+// Minimum diagnostic severity level to show to agent
+type ConfigLspSeverity string
+
+const (
+	ConfigLspSeverityError ConfigLspSeverity = "ERROR"
+	ConfigLspSeverityWarn  ConfigLspSeverity = "WARN"
+	ConfigLspSeverityInfo  ConfigLspSeverity = "INFO"
+	ConfigLspSeverityHint  ConfigLspSeverity = "HINT"
+)
+
+func (r ConfigLspSeverity) IsKnown() bool {
+	switch r {
+	case ConfigLspSeverityError, ConfigLspSeverityWarn, ConfigLspSeverityInfo, ConfigLspSeverityHint:
+		return true
+	}
+	return false
+}
 
 type ConfigMcp struct {
 	// Type of MCP server connection
@@ -1760,6 +1804,8 @@ type KeybindsConfig struct {
 	SessionNew string `json:"session_new,required"`
 	// Share current session
 	SessionShare string `json:"session_share,required"`
+	// Show session timeline
+	SessionTimeline string `json:"session_timeline,required"`
 	// Unshare current session
 	SessionUnshare string `json:"session_unshare,required"`
 	// @deprecated use agent_cycle. Next agent
@@ -1821,6 +1867,7 @@ type keybindsConfigJSON struct {
 	SessionList              apijson.Field
 	SessionNew               apijson.Field
 	SessionShare             apijson.Field
+	SessionTimeline          apijson.Field
 	SessionUnshare           apijson.Field
 	SwitchAgent              apijson.Field
 	SwitchAgentReverse       apijson.Field

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -701,7 +701,7 @@ export type Config = {
           disabled: true
         }
       | {
-          command: Array<string>
+          command?: Array<string>
           extensions?: Array<string>
           disabled?: boolean
           env?: {
@@ -710,6 +710,10 @@ export type Config = {
           initialization?: {
             [key: string]: unknown
           }
+          /**
+           * Minimum diagnostic severity level to show to agent
+           */
+          severity?: "ERROR" | "WARN" | "INFO" | "HINT"
         }
   }
   /**


### PR DESCRIPTION
Heard some people mentioning the llm not seeing feedback from eslint LSP, figured I would address the TODO and add a configuration option here

Example in action:

<img width="1096" height="286" alt="Screenshot 2025-08-19 at 11 21 01 PM" src="https://github.com/user-attachments/assets/faac221c-ec90-4abd-a0d3-1f54184fae25" />
