### PR TITLE
Use latest Vue LSP and integrate with Typescript LSP

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 import { Config } from "../config/config"
 import { spawn } from "child_process"
 import { Instance } from "../project/instance"
+import { VueIntegration } from "./vue"
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
@@ -146,6 +147,12 @@ export namespace LSP {
       s.clients.push(client)
       result.push(client)
     }
+
+    // Set up Vue/TypeScript integration for .vue files
+    if (VueIntegration.shouldSetupVueIntegration(file)) {
+      await VueIntegration.setupVueTypeScriptBridge(s.clients, result, App.info(), state)
+    }
+
     return result
   }
 

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -150,7 +150,7 @@ export namespace LSP {
 
     // Set up Vue/TypeScript integration for .vue files
     if (path.parse(file).ext === ".vue") {
-      await VueIntegration.setupVueTypeScriptBridge(s.clients, result, App.info(), state)
+      await VueIntegration.setupVueTypeScriptBridge(s.clients, result, state)
     }
 
     return result

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -149,7 +149,7 @@ export namespace LSP {
     }
 
     // Set up Vue/TypeScript integration for .vue files
-    if (VueIntegration.shouldSetupVueIntegration(file)) {
+    if (path.parse(file).ext === ".vue") {
       await VueIntegration.setupVueTypeScriptBridge(s.clients, result, App.info(), state)
     }
 

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -8,6 +8,7 @@ import fs from "fs/promises"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
+import { VueIntegration } from "./vue"
 
 export namespace LSPServer {
   const log = Log.create({ service: "lsp.server" })
@@ -44,10 +45,11 @@ export namespace LSPServer {
   export const Typescript: Info = {
     id: "typescript",
     root: NearestRoot(["tsconfig.json", "package.json", "jsconfig.json"]),
-    extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+    extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".vue"],
     async spawn(root) {
       const tsserver = await Bun.resolve("typescript/lib/tsserver.js", Instance.directory).catch(() => {})
       if (!tsserver) return
+
       const proc = spawn(BunProc.which(), ["x", "typescript-language-server", "--stdio"], {
         cwd: root,
         env: {
@@ -55,13 +57,23 @@ export namespace LSPServer {
           BUN_BE_BUN: "1",
         },
       })
+
+      // Standard TypeScript server configuration
+      let initialization: Record<string, any> = {
+        tsserver: {
+          path: tsserver,
+        },
+      }
+
+      // Add Vue integration only if Vue files are detected in the project
+      const hasVueFiles = await VueIntegration.hasVueFiles(root)
+      if (hasVueFiles) {
+        initialization = await VueIntegration.createVueEnabledTypeScriptConfig(root)
+      }
+
       return {
         process: proc,
-        initialization: {
-          tsserver: {
-            path: tsserver,
-          },
-        },
+        initialization,
       }
     },
   }
@@ -122,7 +134,11 @@ export namespace LSPServer {
       return {
         process: proc,
         initialization: {
-          // Leave empty; the server will auto-detect workspace TypeScript.
+          typescript: {
+            preferences: {
+              includePackageJsonAutoImports: "on",
+            },
+          },
         },
       }
     },

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -133,13 +133,7 @@ export namespace LSPServer {
       })
       return {
         process: proc,
-        initialization: {
-          typescript: {
-            preferences: {
-              includePackageJsonAutoImports: "on",
-            },
-          },
-        },
+        initialization: {},
       }
     },
   }

--- a/packages/opencode/src/lsp/vue.ts
+++ b/packages/opencode/src/lsp/vue.ts
@@ -156,18 +156,4 @@ export namespace VueIntegration {
 
     return initialization
   }
-
-  /**
-   * Check if file should trigger Vue integration setup
-   */
-  export function shouldSetupVueIntegration(file: string): boolean {
-    return path.parse(file).ext === ".vue"
-  }
-
-  /**
-   * Clear the Vue project detection cache (useful for testing or when project structure changes)
-   */
-  export function clearVueProjectCache(): void {
-    vueProjectCache.clear()
-  }
 }

--- a/packages/opencode/src/lsp/vue.ts
+++ b/packages/opencode/src/lsp/vue.ts
@@ -1,0 +1,173 @@
+import { LSPClient } from "./client"
+import { LSPServer } from "./server"
+import type { App } from "../app/app"
+import { Log } from "../util/log"
+import path from "path"
+import { Global } from "../global"
+
+const log = Log.create({ service: "lsp.vue" })
+
+// Cache Vue project detection to avoid repeated file system scans
+const vueProjectCache = new Map<string, boolean>()
+
+export namespace VueIntegration {
+  /**
+   * Detects if a project contains Vue files (with caching)
+   */
+  export async function hasVueFiles(root: string): Promise<boolean> {
+    // Check cache first
+    if (vueProjectCache.has(root)) {
+      return vueProjectCache.get(root)!
+    }
+
+    try {
+      const proc = Bun.spawn(["find", root, "-name", "*.vue", "-type", "f", "-print", "-quit"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const result = await new Response(proc.stdout).text()
+      const hasVue = result.trim().length > 0
+
+      // Cache the result
+      vueProjectCache.set(root, hasVue)
+      return hasVue
+    } catch {
+      vueProjectCache.set(root, false)
+      return false
+    }
+  }
+
+  /**
+   * Gets the path to the Vue language server if available
+   */
+  export async function getVueLanguageServerPath(): Promise<string | undefined> {
+    try {
+      const vueLsPath = path.join(Global.Path.bin, "node_modules", "@vue", "language-server", "package.json")
+      if (await Bun.file(vueLsPath).exists()) {
+        return path.dirname(vueLsPath)
+      }
+    } catch {}
+    return undefined
+  }
+
+  /**
+   * Sets up Vue TypeScript integration by creating and bridging TypeScript and Vue language servers
+   */
+  export async function setupVueTypeScriptBridge(
+    allClients: LSPClient.Info[],
+    currentClients: LSPClient.Info[],
+    app: App.Info,
+    getState: () => Promise<{ broken: Set<string>, clients: LSPClient.Info[] }>
+  ): Promise<void> {
+    const vueClient = currentClients.find(c => c.serverID === "vue")
+    if (!vueClient) return
+
+    // Find or create TypeScript client for the same root
+    let tsClient = allClients.find(c => c.serverID === "typescript" && c.root === vueClient.root)
+
+    if (!tsClient) {
+      // Try to create TypeScript client for Vue integration
+      const tsServer = LSPServer.Typescript
+      const root = vueClient.root
+      const s = await getState()
+      if (!s.broken.has(root + tsServer.id)) {
+        const handle = await tsServer.spawn(app, root)
+        if (handle) {
+          tsClient = await LSPClient.create({
+            serverID: "typescript",
+            server: handle,
+            root,
+          }).catch(async (err) => {
+            (await getState()).broken.add(root + tsServer.id)
+            handle.process.kill()
+            log.error("Failed to create TypeScript client for Vue integration", { error: err })
+            return undefined
+          })
+          if (tsClient) {
+            const s = await getState()
+            s.clients.push(tsClient)
+            currentClients.push(tsClient)
+          }
+        }
+      }
+    }
+
+    if (tsClient) {
+      setupTsServerBridge(vueClient, tsClient)
+    }
+  }
+
+  /**
+   * Sets up the bridge between Vue language server and TypeScript language server
+   */
+  function setupTsServerBridge(vueClient: LSPClient.Info, tsClient: LSPClient.Info) {
+    log.info("Setting up Vue/TypeScript tsserver bridge", {
+      vueRoot: vueClient.root,
+      tsRoot: tsClient.root
+    })
+
+    // Bridge tsserver requests from Vue LS to TypeScript LS
+    vueClient.connection.onNotification(
+      "tsserver/request",
+      async ([id, command, payload]: [number, string, unknown]) => {
+        try {
+          log.info("Bridging tsserver request", { id, command })
+          const result = await tsClient.connection.sendRequest("workspace/executeCommand", {
+            command: "typescript.tsserverRequest",
+            arguments: [command, payload]
+          } as never)
+          const body = (result as any)?.body ?? result
+          vueClient.connection.sendNotification("tsserver/response", [id, body])
+        } catch (error) {
+          log.error("Error bridging tsserver request", { id, command, error })
+          // Send error response back to Vue LS
+          vueClient.connection.sendNotification("tsserver/response", [id, { error: error?.toString() }])
+        }
+      }
+    )
+  }
+
+  /**
+   * Creates TypeScript server configuration with Vue integration enabled
+   * This should only be called when Vue files are confirmed to exist in the project
+   */
+  export async function createVueEnabledTypeScriptConfig(root: string): Promise<Record<string, any>> {
+    const tsserver = await Bun.resolve("typescript/lib/tsserver.js", process.cwd()).catch(() => undefined)
+
+    // Start with standard TypeScript configuration
+    const initialization: Record<string, any> = {
+      tsserver: {
+        path: tsserver,
+      },
+    }
+
+    // Add Vue TypeScript plugin integration
+    const vueLsPath = await getVueLanguageServerPath()
+    if (vueLsPath) {
+      log.info("Enabling Vue TypeScript plugin integration", { root, vueLsPath })
+      initialization["plugins"] = [{
+        name: "@vue/typescript-plugin",
+        location: path.dirname(vueLsPath),
+        languages: ["vue"]
+      }]
+    } else {
+      log.warn("Vue language server not found - Vue features will be limited", { root })
+    }
+
+    return initialization
+  }
+
+  /**
+   * Check if file should trigger Vue integration setup
+   */
+  export function shouldSetupVueIntegration(file: string): boolean {
+    return path.parse(file).ext === ".vue"
+  }
+
+  /**
+   * Clear the Vue project detection cache (useful for testing or when project structure changes)
+   */
+  export function clearVueProjectCache(): void {
+    vueProjectCache.clear()
+  }
+}

--- a/packages/opencode/src/lsp/vue.ts
+++ b/packages/opencode/src/lsp/vue.ts
@@ -1,6 +1,5 @@
 import { LSPClient } from "./client"
 import { LSPServer } from "./server"
-import type { App } from "../app/app"
 import { Log } from "../util/log"
 import path from "path"
 import { Global } from "../global"
@@ -56,7 +55,6 @@ export namespace VueIntegration {
   export async function setupVueTypeScriptBridge(
     allClients: LSPClient.Info[],
     currentClients: LSPClient.Info[],
-    app: App.Info,
     getState: () => Promise<{ broken: Set<string>, clients: LSPClient.Info[] }>
   ): Promise<void> {
     const vueClient = currentClients.find(c => c.serverID === "vue")
@@ -71,7 +69,7 @@ export namespace VueIntegration {
       const root = vueClient.root
       const s = await getState()
       if (!s.broken.has(root + tsServer.id)) {
-        const handle = await tsServer.spawn(app, root)
+        const handle = await tsServer.spawn(root)
         if (handle) {
           tsClient = await LSPClient.create({
             serverID: "typescript",


### PR DESCRIPTION
- In my last PR, I added the Vue LSP (#1952).  
- Turns out [@vue/language-tools v3 was released 3 weeks ago](https://github.com/vuejs/language-tools/releases/tag/v3.0.0).  
- Updates in this PR:  
  - Integrated changes from `@vue/language-tools v3`.  
  - Correctly wired Vue + TypeScript LSP so `.vue` files report TypeScript errors.  
  - Added [`/src/lsp/vue.ts`](https://github.com/drevantonder/opencode/blob/3b99f23da25b90153ae9150f1bcd8917262235b6/packages/opencode/src/lsp/vue.ts) to isolate Vue complexity from `server.ts` and `index.ts`.  
  
  If helpful, here's a minimal test I put together of what it takes to get Vue + Typescript working in isolation: https://gist.github.com/drevantonder/29f70c9629e9234866285c2dab98e021
