### PR TITLE
fix: make AUR publishing fail gracefully

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -97,46 +97,52 @@ if (!snapshot) {
   const macX64Sha = await $`sha256sum ./dist/opencode-darwin-x64.zip | cut -d' ' -f1`.text().then((x) => x.trim())
   const macArm64Sha = await $`sha256sum ./dist/opencode-darwin-arm64.zip | cut -d' ' -f1`.text().then((x) => x.trim())
 
-  /* AUR package - commented out as AUR is down
-  const pkgbuild = [
-    "# Maintainer: dax",
-    "# Maintainer: adam",
-    "",
-    "pkgname='${pkg}'",
-    `pkgver=${version.split("-")[0]}`,
-    "options=('!debug' '!strip')",
-    "pkgrel=1",
-    "pkgdesc='The AI coding agent built for the terminal.'",
-    "url='https://github.com/sst/opencode'",
-    "arch=('aarch64' 'x86_64')",
-    "license=('MIT')",
-    "provides=('opencode')",
-    "conflicts=('opencode')",
-    "depends=('fzf' 'ripgrep')",
-    "",
-    `source_aarch64=("\${pkgname}_\${pkgver}_aarch64.zip::https://github.com/sst/opencode/releases/download/v${version}/opencode-linux-arm64.zip")`,
-    `sha256sums_aarch64=('${arm64Sha}')`,
-    "",
-    `source_x86_64=("\${pkgname}_\${pkgver}_x86_64.zip::https://github.com/sst/opencode/releases/download/v${version}/opencode-linux-x64.zip")`,
-    `sha256sums_x86_64=('${x64Sha}')`,
-    "",
-    "package() {",
-    '  install -Dm755 ./opencode "${pkgdir}/usr/bin/opencode"',
-    "}",
-    "",
-  ].join("\n")
+  try {
+    console.log("\n=== Publishing to AUR ===\n")
 
-  for (const pkg of ["opencode-bin"]) {
-    await $`rm -rf ./dist/aur-${pkg}`
-    await $`git clone ssh://aur@aur.archlinux.org/${pkg}.git ./dist/aur-${pkg}`
-    await $`cd ./dist/aur-${pkg} && git checkout master`
-    await Bun.file(`./dist/aur-${pkg}/PKGBUILD`).write(pkgbuild.replace("${pkg}", pkg))
-    await $`cd ./dist/aur-${pkg} && makepkg --printsrcinfo > .SRCINFO`
-    await $`cd ./dist/aur-${pkg} && git add PKGBUILD .SRCINFO`
-    await $`cd ./dist/aur-${pkg} && git commit -m "Update to v${version}"`
-    if (!dry) await $`cd ./dist/aur-${pkg} && git push`
+    const pkgbuild = [
+      "# Maintainer: dax",
+      "# Maintainer: adam",
+      "",
+      "pkgname='${pkg}'",
+      `pkgver=${version.split("-")[0]}`,
+      "options=('!debug' '!strip')",
+      "pkgrel=1",
+      "pkgdesc='The AI coding agent built for the terminal.'",
+      "url='https://github.com/sst/opencode'",
+      "arch=('aarch64' 'x86_64')",
+      "license=('MIT')",
+      "provides=('opencode')",
+      "conflicts=('opencode')",
+      "depends=('fzf' 'ripgrep')",
+      "",
+      `source_aarch64=("\${pkgname}_\${pkgver}_aarch64.zip::https://github.com/sst/opencode/releases/download/v${version}/opencode-linux-arm64.zip")`,
+      `sha256sums_aarch64=('${arm64Sha}')`,
+      "",
+      `source_x86_64=("\${pkgname}_\${pkgver}_x86_64.zip::https://github.com/sst/opencode/releases/download/v${version}/opencode-linux-x64.zip")`,
+      `sha256sums_x86_64=('${x64Sha}')`,
+      "",
+      "package() {",
+      '  install -Dm755 ./opencode "${pkgdir}/usr/bin/opencode"',
+      "}",
+      "",
+    ].join("\n")
+
+    for (const pkg of ["opencode-bin"]) {
+      await $`rm -rf ./dist/aur-${pkg}`
+      await $`git clone ssh://aur@aur.archlinux.org/${pkg}.git ./dist/aur-${pkg}`
+      await $`cd ./dist/aur-${pkg} && git checkout master`
+      await Bun.file(`./dist/aur-${pkg}/PKGBUILD`).write(pkgbuild.replace("${pkg}", pkg))
+      await $`cd ./dist/aur-${pkg} && makepkg --printsrcinfo > .SRCINFO`
+      await $`cd ./dist/aur-${pkg} && git add PKGBUILD .SRCINFO`
+      await $`cd ./dist/aur-${pkg} && git commit -m "Update to v${version}"`
+      if (!dry) await $`cd ./dist/aur-${pkg} && git push`
+    }
+
+    console.log("✓ AUR package updated successfully")
+  } catch (error: any) {
+    console.warn("⚠️  AUR publishing failed (continuing with release):", error.message || error)
   }
-  */
 
   // Homebrew formula
   const homebrewFormula = [


### PR DESCRIPTION
AUR can experience downtime, which currently blocks the entire release process. This PR wraps AUR publishing in try-catch to provide best-effort updates while ensuring releases can continue even when AUR is unavailable.

The AUR package will be updated when the service is available, but releases won't be blocked if it's down.

Fixes #2042