### PR TITLE
tweak - normalise unix-like identifiers to support git bash for windows

### DIFF
--- a/install
+++ b/install
@@ -10,10 +10,14 @@ NC='\033[0m' # No Color
 
 requested_version=${VERSION:-}
 
-os=$(uname -s | tr '[:upper:]' '[:lower:]')
-if [[ "$os" == "darwin" ]]; then
-    os="darwin"
-fi
+raw_os=$(uname -s)
+os=$(echo "$raw_os" | tr '[:upper:]' '[:lower:]')
+# Normalize various Unix-like identifiers
+case "$raw_os" in
+  Darwin*) os="darwin" ;;
+  Linux*) os="linux" ;;
+  MINGW*|MSYS*|CYGWIN*) os="windows" ;;
+ esac
 arch=$(uname -m)
 
 if [[ "$arch" == "aarch64" ]]; then


### PR DESCRIPTION
Normalise Unix-like identifiers in the install script to support Git Bash for Windows.

Before/After
<img width="1104" height="364" alt="image" src="https://github.com/user-attachments/assets/00612746-7379-477d-be6c-f3cc083592c2" />
