### PR TITLE
fix(postinstall): prebuild required workspace packages to prevent bun dev from failing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "cloud/core": {
       "name": "@opencode/cloud-core",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "drizzle-orm": "0.41.0",
@@ -39,7 +39,7 @@
     },
     "cloud/function": {
       "name": "@opencode/cloud-function",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "dependencies": {
         "@ai-sdk/anthropic": "2.0.0",
         "@ai-sdk/openai": "2.0.2",
@@ -59,7 +59,7 @@
     },
     "cloud/web": {
       "name": "@opencode/cloud-web",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "dependencies": {
         "@kobalte/core": "0.13.9",
         "@openauthjs/solid": "0.0.0-20250322224806",
@@ -78,7 +78,7 @@
     },
     "packages/function": {
       "name": "@opencode/function",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "22.0.0",
@@ -93,7 +93,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -143,7 +143,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
       },
@@ -155,7 +155,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "devDependencies": {
         "@hey-api/openapi-ts": "0.80.1",
         "@tsconfig/node22": "catalog:",
@@ -164,7 +164,7 @@
     },
     "packages/web": {
       "name": "@opencode/web",
-      "version": "0.5.5",
+      "version": "0.5.8",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "bun run --conditions=development packages/opencode/src/index.ts",
     "typecheck": "bun run --filter='*' typecheck",
     "generate": "(cd packages/sdk && ./js/script/generate.ts) && (cd packages/sdk/stainless && ./generate.ts)",
-    "postinstall": "./script/hooks"
+    "postinstall": "./script/hooks && bun run --filter='*' pre-build"
   },
   "workspaces": {
     "packages": [

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -4,7 +4,8 @@
   "version": "0.5.8",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "pre-build": "tsc"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
- Fix: Missing prebuild of required workspace packages during postinstall causes `bun run dev` to fail after `bun install` (see [#1579](https://github.com/sst/opencode/issues/1579)).
- Solution: Add generate/build steps for `packages/sdk/js` in the postinstall phase.
- Verification: In a fresh environment, `bun install && bun run dev` starts successfully with no additional manual steps.