### PR TITLE
feat(server): add unix domain socket support

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -18,6 +18,10 @@ export const ServeCommand = cmd({
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",
+      })
+      .option("unix", {
+        type: "string",
+        describe: "unix socket path to bind to (overrides port/hostname)",
       }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
@@ -34,9 +38,14 @@ export const ServeCommand = cmd({
       const server = Server.listen({
         port,
         hostname,
+        unix: args.unix,
       })
 
-      console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+      if (args.unix) {
+        console.log(`opencode server listening on unix socket: ${args.unix}`)
+      } else {
+        console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+      }
 
       await new Promise(() => {})
 

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -69,6 +69,10 @@ export const TuiCommand = cmd({
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",
+      })
+      .option("unix", {
+        type: "string",
+        describe: "unix socket path to bind to (overrides port/hostname)",
       }),
   handler: async (args) => {
     while (true) {
@@ -108,6 +112,7 @@ export const TuiCommand = cmd({
         const server = Server.listen({
           port: args.port,
           hostname: args.hostname,
+          unix: args.unix,
         })
 
         let cmd = ["go", "run", "./main.go"]

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1235,13 +1235,20 @@ export namespace Server {
     return result
   }
 
-  export function listen(opts: { port: number; hostname: string }) {
-    const server = Bun.serve({
-      port: opts.port,
-      hostname: opts.hostname,
+  export function listen(opts: { port?: number; hostname?: string; unix?: string }) {
+    const serverOpts: any = {
       idleTimeout: 0,
       fetch: app().fetch,
-    })
+    }
+
+    if (opts.unix) {
+      serverOpts.unix = opts.unix
+    } else {
+      serverOpts.port = opts.port || 0
+      serverOpts.hostname = opts.hostname || "127.0.0.1"
+    }
+
+    const server = Bun.serve(serverOpts)
     return server
   }
 }


### PR DESCRIPTION
- Add --unix option to serve and tui commands
- Update Server.listen() to accept unix socket path
- Unix socket overrides port/hostname when specified
- Enables parallel testing with isolated instances

Fixes issue where multiple opencode instances needed unique socket addresses for parallel testing. Unix sockets provide deterministic addresses without port conflicts. Addresses: https://github.com/sst/opencode/issues/2119
