### PR TITLE
fix: ignore case when checking Qwen in model ID for todos

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -86,7 +86,7 @@ export namespace ToolRegistry {
       result["webfetch"] = false
     }
 
-    if (modelID.includes("qwen")) {
+    if (modelID.toLowerCase().includes("qwen")) {
       result["todowrite"] = false
       result["todoread"] = false
     }


### PR DESCRIPTION
In my case, model ID is `Qwen/Qwen3-235B-A22B-Instruct-2507`.