### PR TITLE
fix: preserve cache dir on cleanup

### DIFF
--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -35,6 +35,9 @@ const version = await Bun.file(path.join(Global.Path.cache, "version"))
   .catch(() => "0")
 
 if (version !== CACHE_VERSION) {
-  await fs.rm(Global.Path.cache, { recursive: true, force: true })
+  const contents = await fs.readdir(Global.Path.cache)
+  await Promise.all(
+    contents.map((item) => fs.rm(path.join(Global.Path.cache, item), { recursive: true, force: true })),
+  )
   await Bun.file(path.join(Global.Path.cache, "version")).write(CACHE_VERSION)
 }


### PR DESCRIPTION
The cache directory should be preserved to avoid potential permission issues per xdg spec[^1]:

> If the destination directory exists already the permissions should not be changed.

Usecase: on my system (NixOS with impermanence) the root fs is mounted with `noexec`, and specific directories have the exec flag set [as needed](https://github.com/meatcar/dots/blob/f57263f969edbd6378a838fc0ae06de1c09eb4e6/modules/impermanence/meatcar.nix#L38).

[^1]: https://specifications.freedesktop.org/basedir-spec/latest