### PR TITLE
disable sharing by default

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -133,6 +133,12 @@ export namespace Config {
     if (result.autoshare === true && !result.share) {
       result.share = "auto"
     }
+
+    // Set default share behavior to disabled if not explicitly configured
+    if (result.share === undefined) {
+      result.share = "disabled"
+    }
+
     if (result.keybinds?.messages_revert && !result.keybinds.messages_undo) {
       result.keybinds.messages_undo = result.keybinds.messages_revert
     }

--- a/packages/web/src/content/docs/docs/config.mdx
+++ b/packages/web/src/content/docs/docs/config.mdx
@@ -144,11 +144,11 @@ You can configure the [share](/docs/share) feature through the `share` option.
 
 This takes:
 
-- `"manual"` - Allow manual sharing via commands (default)
+- `"manual"` - Allow manual sharing via commands
 - `"auto"` - Automatically share new conversations
-- `"disabled"` - Disable sharing entirely
+- `"disabled"` - Disable sharing entirely (default)
 
-By default, sharing is set to manual mode where you need to explicitly share conversations using the `/share` command.
+Sharing is disabled by default. You can enable manual sharing to explicitly share conversations using the `/share` command, or auto-sharing to automatically share all new conversations.
 
 ---
 

--- a/packages/web/src/content/docs/docs/share.mdx
+++ b/packages/web/src/content/docs/docs/share.mdx
@@ -27,9 +27,17 @@ opencode supports three sharing modes that control how conversations are shared:
 
 ---
 
-### Manual (default)
+### Disabled (default)
 
-By default, opencode uses manual sharing mode. Sessions are not shared automatically, but you can manually share them using the `/share` command:
+By default, opencode disables sharing for security. No sessions are shared automatically.
+
+To enable sharing, explicitly configure the `share` option to either `"manual"` or `"auto"` in your [config file](/docs/config#sharing).
+
+---
+
+### Manual
+
+In manual sharing mode, you can manually share sessions using the `/share` command:
 
 ```
 /share


### PR DESCRIPTION
## Summary

This PR changes the default sharing behavior from `manual` to `disabled`. Given the sensitive nature of most conversations, requiring explicit configuration to enable sharing is a more sensible default.  

This change builds trust and improves security while still allowing users who have read the documentation to enable the feature if they wish.

## Changes

- Adds default logic to set `share: "disabled"` when no explicit configuration is provided.
- Updates documentation to reflect that "disabled" is now the default sharing mode.