### PR TITLE
feat: add copy slash command to copy last message

### DIFF
--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -364,6 +364,7 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 			Name:        MessagesCopyCommand,
 			Description: "copy message",
 			Keybindings: parseBindings("<leader>y"),
+			Trigger:     []string{"copy"},
 		},
 		{
 			Name:        MessagesUndoCommand,

--- a/packages/web/src/content/docs/docs/tui.mdx
+++ b/packages/web/src/content/docs/docs/tui.mdx
@@ -61,6 +61,18 @@ Compact the current session. _Alias_: `/summarize`
 
 ---
 
+### copy
+
+Copy the last assistant message to clipboard.
+
+```bash frame="none"
+/copy
+```
+
+**Keybind:** `ctrl+x y`
+
+---
+
 ### details
 
 Toggle tool execution details.


### PR DESCRIPTION
## Summary

This PR introduces a `/copy` command for copying messages via the existing `MessagesCopyCommand`. 

Doing so follows the established pattern used by ⁠`undo` and `⁠redo`. Exposing the command in the UI improves discoverability for users who may not be familiar with the keyboard shortcut.

## Changes

- Adds trigger to the existing `MessagesCopyCommand`
- Updates docs accordingly

Closes #2118