### PR TITLE
feat: Add pinned flag to model config and surface pinned models to the top of the selector

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -29,6 +29,7 @@ export namespace ModelsDev {
         output: z.number(),
       }),
       options: z.record(z.any()),
+      pinned: z.boolean().optional(),
     })
     .openapi({
       ref: "Model",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -228,6 +228,7 @@ export namespace Provider {
               context: 0,
               output: 0,
             },
+          pinned: model.pinned ?? false,
         }
         parsed.models[modelID] = parsedModel
       }

--- a/packages/sdk/go/app.go
+++ b/packages/sdk/go/app.go
@@ -306,6 +306,7 @@ type Model struct {
 	ReleaseDate string                 `json:"release_date,required"`
 	Temperature bool                   `json:"temperature,required"`
 	ToolCall    bool                   `json:"tool_call,required"`
+	Pinned      bool                   `json:"pinned"`
 	JSON        modelJSON              `json:"-"`
 }
 
@@ -321,6 +322,7 @@ type modelJSON struct {
 	ReleaseDate apijson.Field
 	Temperature apijson.Field
 	ToolCall    apijson.Field
+	Pinned      apijson.Field
 	raw         string
 	ExtraFields map[string]apijson.Field
 }

--- a/packages/tui/internal/components/dialog/models.go
+++ b/packages/tui/internal/components/dialog/models.go
@@ -268,7 +268,7 @@ func (m *modelDialog) buildDisplayList(query string) []list.Item {
 		// Search mode: use fuzzy matching
 		return m.buildSearchResults(query)
 	} else {
-		// Grouped mode: show Recent section and provider groups
+		// Grouped mode: show Pinned, Recent section and provider groups
 		return m.buildGroupedResults()
 	}
 }
@@ -314,9 +314,18 @@ func (m *modelDialog) buildSearchResults(query string) []list.Item {
 	return items
 }
 
-// buildGroupedResults creates a grouped list with Recent section and provider groups
+// buildGroupedResults creates a grouped list with Pinned, Recent section and provider groups
 func (m *modelDialog) buildGroupedResults() []list.Item {
 	var items []list.Item
+
+	// Add Pinned section
+	pinnedModels := m.getPinnedModels()
+	if len(pinnedModels) > 0 {
+		items = append(items, list.HeaderItem("Pinned"))
+		for _, model := range pinnedModels {
+			items = append(items, modelItem{model: model})
+		}
+	}
 
 	// Add Recent section
 	recentModels := m.getRecentModels(maxRecentModels)
@@ -386,6 +395,16 @@ func (m *modelDialog) buildGroupedResults() []list.Item {
 	}
 
 	return items
+}
+
+func (m *modelDialog) getPinnedModels() []ModelWithProvider {
+	var pinned []ModelWithProvider
+	for _, model := range m.allModels {
+		if model.Model.Pinned {
+			pinned = append(pinned, model)
+		}
+	}
+	return pinned
 }
 
 // getRecentModels returns the most recently used models

--- a/packages/web/src/content/docs/docs/models.mdx
+++ b/packages/web/src/content/docs/docs/models.mdx
@@ -68,23 +68,25 @@ If you've configured a [custom provider](/docs/providers#custom), the `provider_
 
 You can globally configure a model's options through the config.
 
-```jsonc title="opencode.jsonc" {7-11}
+```jsonc title="opencode.jsonc" {7-12}
 {
   "$schema": "https://opencode.ai/config.json",
   "provider": {
     "openai": {
       "models": {
         "gpt-5": {
+          // Pin this model so it appears at the top of the selector
+          "pinned": true,
           "options": {
             "reasoningEffort": "high",
             "textVerbosity": "low",
             "reasoningSummary": "auto",
-            "include": ["reasoning.encrypted_content"]
-          }
-        }
-      }
-    }
-  }
+            "include": ["reasoning.encrypted_content"],
+          },
+        },
+      },
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
This is a small QOL change that I have been wanting for a while. It adds the ability to set a model as "pinned" in it's config, and pinned models will show up at the top of the model selector. This makes it easy to access a subset of "favorite" models

![CleanShot 2025-08-22 at 13 14 40](https://github.com/user-attachments/assets/e0a0c2bf-5621-4a6a-8206-fbd6df662b55)

Note: If no pinned models are set, then the section won't appear at all