### PR TITLE
ignore: update json schema for better lsp dx

### DIFF
--- a/packages/opencode/script/schema.ts
+++ b/packages/opencode/script/schema.ts
@@ -32,5 +32,13 @@ const result = zodToJsonSchema(Config.Info, {
 
     return jsonSchema
   },
-})
+}) as Record<string, unknown> & {
+  allowComments?: boolean
+  allowTrailingCommas?: boolean
+}
+
+// used for json lsps since config supports jsonc
+result.allowComments = true
+result.allowTrailingCommas = true
+
 await Bun.write(file, JSON.stringify(result, null, 2))


### PR DESCRIPTION
adding allowComments & allowTrailingCommas will show the lsp that they are valid (since they are)

fixes: #2173