### PR TITLE
Make shimmer animations optional

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -326,6 +326,7 @@ export namespace Config {
 
   export const TUI = z.object({
     scroll_speed: z.number().min(1).optional().default(2).describe("TUI scroll speed"),
+    animation: z.boolean().optional().describe("Enable shimmer animations"),
   })
 
   export const Layout = z.enum(["auto", "stretch"]).openapi({

--- a/packages/sdk/go/config.go
+++ b/packages/sdk/go/config.go
@@ -1690,13 +1690,16 @@ func (r ConfigShare) IsKnown() bool {
 // TUI specific settings
 type ConfigTui struct {
 	// TUI scroll speed
-	ScrollSpeed float64       `json:"scroll_speed,required"`
-	JSON        configTuiJSON `json:"-"`
+	ScrollSpeed float64 `json:"scroll_speed,required"`
+	// Enable shimmer animations
+	Animation bool          `json:"animation,required"`
+	JSON      configTuiJSON `json:"-"`
 }
 
 // configTuiJSON contains the JSON metadata for the struct [ConfigTui]
 type configTuiJSON struct {
 	ScrollSpeed apijson.Field
+	Animation   apijson.Field
 	raw         string
 	ExtraFields map[string]apijson.Field
 }

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -51,6 +51,7 @@ type App struct {
 	IsLeaderSequence  bool
 	IsBashMode        bool
 	ScrollSpeed       int
+	Animation         bool
 }
 
 func (a *App) Agent() *opencode.Agent {
@@ -209,6 +210,7 @@ func New(
 		InitialAgent:   initialAgent,
 		InitialSession: initialSession,
 		ScrollSpeed:    int(configInfo.Tui.ScrollSpeed),
+		Animation:      configInfo.Tui.Animation,
 	}
 
 	return app, nil
@@ -663,6 +665,10 @@ func (a *App) IsBusy() bool {
 }
 
 func (a *App) HasAnimatingWork() bool {
+	if !a.Animation {
+		return false
+	}
+
 	for _, msg := range a.Messages {
 		switch casted := msg.Info.(type) {
 		case opencode.AssistantMessage:

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -235,18 +235,10 @@ func renderText(
 		}
 		content = util.ToMarkdown(text, width, backgroundColor)
 		if isThinking {
-			var label string
-			if shimmer {
-				label = util.Shimmer("Thinking...", backgroundColor, t.TextMuted(), t.Accent())
-			} else {
-				label = styles.NewStyle().Background(backgroundColor).Foreground(t.TextMuted()).Render("Thinking...")
-			}
-			label = styles.NewStyle().Background(backgroundColor).Width(width - 6).Render(label)
+			label := util.RenderTextWithAnimation("Thinking...", backgroundColor, t.TextMuted(), t.Accent(), width-6, shimmer && app.Animation)
 			content = label + "\n\n" + content
 		} else if strings.TrimSpace(text) == "Generating..." {
-			label := util.Shimmer(text, backgroundColor, t.TextMuted(), t.Text())
-			label = styles.NewStyle().Background(backgroundColor).Width(width - 6).Render(label)
-			content = label
+			content = util.RenderTextWithAnimation(text, backgroundColor, t.TextMuted(), t.Accent(), width-6, shimmer && app.Animation)
 		}
 	case opencode.UserMessage:
 		ts = time.UnixMilli(int64(casted.Time.Created))
@@ -398,7 +390,7 @@ func renderText(
 	}
 	if !showToolDetails && toolCalls != nil && len(toolCalls) > 0 {
 		for _, toolCall := range toolCalls {
-			title := renderToolTitle(toolCall, width-2)
+			title := renderToolTitle(app.Animation, toolCall, width-2)
 			style := styles.NewStyle()
 			if toolCall.State.Status == opencode.ToolPartStateStatusError {
 				style = style.Foreground(t.Error())
@@ -465,7 +457,7 @@ func renderToolDetails(
 	}
 
 	if toolCall.State.Status == opencode.ToolPartStateStatusPending {
-		title := renderToolTitle(toolCall, width)
+		title := renderToolTitle(app.Animation, toolCall, width)
 		return renderContentBlock(app, title, width)
 	}
 
@@ -575,7 +567,7 @@ func renderToolDetails(
 						body += "\n" + diagnostics
 					}
 
-					title := renderToolTitle(toolCall, width)
+					title := renderToolTitle(app.Animation, toolCall, width)
 					title = style.Render(title)
 					content := title + "\n" + body
 
@@ -664,7 +656,7 @@ func renderToolDetails(
 					data, _ := json.Marshal(item)
 					var toolCall opencode.ToolPart
 					_ = json.Unmarshal(data, &toolCall)
-					step := renderToolTitle(toolCall, width-2)
+					step := renderToolTitle(app.Animation, toolCall, width-2)
 					step = "∟ " + step
 					steps = append(steps, step)
 				}
@@ -729,7 +721,7 @@ func renderToolDetails(
 		body = defaultStyle("")
 	}
 
-	title := renderToolTitle(toolCall, width)
+	title := renderToolTitle(app.Animation, toolCall, width)
 	content := title + "\n\n" + body
 
 	if permissionContent != "" {
@@ -798,14 +790,14 @@ func getTodoTitle(toolCall opencode.ToolPart) string {
 }
 
 func renderToolTitle(
+	animationEnabled bool,
 	toolCall opencode.ToolPart,
 	width int,
 ) string {
 	if toolCall.State.Status == opencode.ToolPartStateStatusPending {
 		title := renderToolAction(toolCall.Tool)
 		t := theme.CurrentTheme()
-		shiny := util.Shimmer(title, t.BackgroundPanel(), t.TextMuted(), t.Accent())
-		return styles.NewStyle().Background(t.BackgroundPanel()).Width(width - 6).Render(shiny)
+		return util.RenderTextWithAnimation(title, t.BackgroundPanel(), t.TextMuted(), t.Accent(), width-6, animationEnabled)
 	}
 
 	toolArgs := ""

--- a/packages/tui/internal/util/shimmer.go
+++ b/packages/tui/internal/util/shimmer.go
@@ -141,3 +141,14 @@ func hex2(v int) string {
 	const digits = "0123456789abcdef"
 	return string([]byte{digits[(v>>4)&0xF], digits[v&0xF]})
 }
+
+// RenderTextWithAnimation renders text with shimmer animation if enabled, otherwise static
+func RenderTextWithAnimation(text string, bg compat.AdaptiveColor, dim compat.AdaptiveColor, bright compat.AdaptiveColor, width int, animationEnabled bool) string {
+	var rendered string
+	if animationEnabled {
+		rendered = Shimmer(text, bg, dim, bright)
+	} else {
+		rendered = styles.NewStyle().Background(bg).Foreground(dim).Render(text)
+	}
+	return styles.NewStyle().Background(bg).Width(width).Render(rendered)
+}


### PR DESCRIPTION
The animations can be distracting in some environments, plus they also cause continuous rerendering.
This adds a config to disable them.

Example configuration:
```jsonc opencode.json
...
"tui": {
  "animation": false
}
```