### PR TITLE
docs: fix nodejs installation commands

### DIFF
--- a/packages/web/src/content/docs/docs/index.mdx
+++ b/packages/web/src/content/docs/docs/index.mdx
@@ -41,10 +41,26 @@ You can also install it with the following:
 - **Using Node.js**
 
   <Tabs>
-    <TabItem label="npm">```bash npm install -g opencode-ai ```</TabItem>
-    <TabItem label="Bun">```bash bun install -g opencode-ai ```</TabItem>
-    <TabItem label="pnpm">```bash pnpm install -g opencode-ai ```</TabItem>
-    <TabItem label="Yarn">```bash yarn global add opencode-ai ```</TabItem>
+    <TabItem label="npm">
+    ```bash
+    npm install -g opencode-ai
+    ```
+    </TabItem>
+    <TabItem label="Bun">
+    ```bash
+    bun install -g opencode-ai
+    ```
+    </TabItem>
+    <TabItem label="pnpm">
+    ```bash
+    pnpm install -g opencode-ai
+    ```
+    </TabItem>
+    <TabItem label="Yarn">
+    ```bash 
+    yarn global add opencode-ai
+    ```
+    </TabItem>
   </Tabs>
 
 - **Using Homebrew on macOS and Linux**


### PR DESCRIPTION
Fixed formatting for Node.js installation options. 

---

Before:

<img width="758" height="154" alt="image" src="https://github.com/user-attachments/assets/55f87934-f8b3-4519-9680-636c9aea24ff" />

Fixed:

<img width="754" height="215" alt="image" src="https://github.com/user-attachments/assets/3b51203a-56e1-4873-9215-3833ed4d2fd2" />
