### PR TITLE
fix: system theme not getting updated

### DIFF
--- a/packages/tui/internal/components/dialog/theme.go
+++ b/packages/tui/internal/components/dialog/theme.go
@@ -50,10 +50,16 @@ func (t *themeDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return t, nil
 					}
 					t.themeApplied = true
-					return t, tea.Sequence(
+
+					var cmds []tea.Cmd
+					if selectedTheme == "system" && !util.IsWsl() {
+						cmds = append(cmds, tea.RequestBackgroundColor)
+					}
+					cmds = append(cmds, 
 						util.CmdHandler(modal.CloseModalMsg{}),
 						util.CmdHandler(ThemeSelectedMsg{ThemeName: selectedTheme}),
 					)
+					return t, tea.Sequence(cmds...)
 				}
 			}
 

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -364,6 +364,11 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				ThemeName: theme.CurrentThemeName(),
 			}
 		}
+	case tea.FocusMsg:
+		if theme.CurrentThemeName() == "system" && !util.IsWsl() {
+			return a, tea.RequestBackgroundColor
+		}
+		return a, nil
 	case modal.CloseModalMsg:
 		a.editor.Focus()
 		var cmd tea.Cmd


### PR DESCRIPTION
Currently RequestBackgroundColor only gets used on init, resulting in stale colors when we change the system theme. Not a perfect fix as ideally we should listen for the theme change itself somehow, but couldn't find an event for this in bubbletea (which makes sense I suppose)

Fixes #1587 