### PR TITLE
Add support for `GITHUB_TOKEN` env variable to access Copilot models

### DIFF
--- a/packages/opencode/src/auth/github-copilot.ts
+++ b/packages/opencode/src/auth/github-copilot.ts
@@ -95,6 +95,30 @@ export namespace AuthGithubCopilot {
     const info = await Auth.get("github-copilot")
     if (!info || info.type !== "oauth") return
     if (info.access && info.expires > Date.now()) return info.access
+    const githubToken = process.env["GITHUB_TOKEN"]
+    if (githubToken) {
+      const response = await fetch(COPILOT_API_KEY_URL, {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${githubToken}`,
+          "User-Agent": "GitHubCopilotChat/0.26.7",
+          "Editor-Version": "vscode/1.99.3",
+          "Editor-Plugin-Version": "copilot-chat/0.26.7",
+        },
+      })
+
+      if (response.ok) {
+        const tokenData: CopilotTokenResponse = await response.json()
+        await Auth.set("github-copilot", {
+          type: "oauth",
+          refresh: githubToken,
+          access: tokenData.token,
+          expires: tokenData.expires_at * 1000,
+        })
+
+        return tokenData.token
+      }
+    }
 
     // Get new Copilot API token
     const response = await fetch(COPILOT_API_KEY_URL, {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -9,6 +9,7 @@ import { Plugin } from "../plugin"
 import { ModelsDev } from "./models"
 import { NamedError } from "../util/error"
 import { Auth } from "../auth"
+import { AuthGithubCopilot } from "../auth/github-copilot"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -34,6 +35,19 @@ export namespace Provider {
               "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
           },
         },
+      }
+    },
+    async "github-copilot"() {
+      try {
+        const accessToken = await AuthGithubCopilot.access()
+        if (!accessToken) return { autoload: false }
+
+        return {
+          autoload: true,
+          options: { apiKey: accessToken },
+        }
+      } catch (error) {
+        return { autoload: false }
       }
     },
     async opencode(input) {


### PR DESCRIPTION
Now if user is not logged in via Oauth for Copilot opencode will try to get a Copilot access token via GITHUB_TOKEN env variable


Fix https://github.com/sst/opencode/issues/1341
