### PR TITLE
feat: implement `$ARGUMENTS` indexing and splitting for `/commands`

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1177,7 +1177,32 @@ export namespace Session {
       command.model ??
       (await Agent.get(agent).then((x) => (x.model ? `${x.model.providerID}/${x.model.modelID}` : undefined))) ??
       (await Provider.defaultModel().then((x) => `${x.providerID}/${x.modelID}`))
-    let template = command.template.replace("$ARGUMENTS", input.arguments)
+    const args = input.arguments.split(/\s+/)
+    let template = command.template.replace(
+      /\$ARGUMENTS\[(\d+)(?:(\*)|(\+)|(\+\+)|:(\d+))?\]/g,
+      (_, index, star, plus, doublePlus, end) => {
+        const start = parseInt(index)
+        switch (star ? "star" : doublePlus ? "doublePlus" : plus ? "plus" : end ? "range" : "single") {
+          case "star":
+            // $ARGUMENTS[1*] - all from index onwards
+            return args.slice(start).join(" ")
+          case "doublePlus":
+            // $ARGUMENTS[1++] - index, index+1, index+2
+            return args.slice(start, start + 3).join(" ")
+          case "plus":
+            // $ARGUMENTS[1+] - index, index+1
+            return args.slice(start, start + 2).join(" ")
+          case "range":
+            // $ARGUMENTS[1:5] - range from index to end
+            return args.slice(start, parseInt(end) + 1).join(" ")
+          case "single":
+          default:
+            // $ARGUMENTS[1] - single index
+            return args[start] || ""
+        }
+      },
+    )
+    template = template.replace("$ARGUMENTS", input.arguments)
 
     const bash = Array.from(template.matchAll(bashRegex))
     if (bash.length > 0) {

--- a/packages/web/src/content/docs/docs/commands.mdx
+++ b/packages/web/src/content/docs/docs/commands.mdx
@@ -36,7 +36,9 @@ Use the command by typing `/` followed by the command name.
 
 ## Use arguments
 
-Pass arguments to commands using the `$ARGUMENTS` placeholder.
+Pass arguments to commands using the `$ARGUMENTS` placeholder. Arguments are split by spaces and can be accessed individually or in groups.
+
+### Basic usage
 
 Create `.opencode/command/component.md`:
 
@@ -54,6 +56,45 @@ Run the command with arguments:
 ```bash frame="none"
 "/component Button"
 ```
+
+### Advanced argument patterns
+
+Access specific arguments using indexed placeholders:
+
+- **`$ARGUMENTS[n]`** - Single argument at index `n` (0-based)
+- **`$ARGUMENTS[n*]`** - All arguments from index `n` onwards
+- **`$ARGUMENTS[n+]`** - Arguments at index `n` and `n+1`
+- **`$ARGUMENTS[n++]`** - Arguments at index `n`, `n+1`, and `n+2`
+- **`$ARGUMENTS[n:m]`** - Range of arguments from index `n` to `m` (inclusive)
+
+Create `.opencode/command/hello.md`:
+
+```md title=".opencode/command/hello.md"
+---
+description: Demonstrate all argument splitting patterns
+---
+
+Argument Splitting Examples
+Command: `/hello hello world foo bar baz . -y`
+
+**Full arguments:** $ARGUMENTS
+
+**Single index [6]:** $ARGUMENTS[6] (7th argument)
+**Star pattern [1*]:** $ARGUMENTS[1*] (all from index 1 onwards)
+**Plus pattern [2+]:** $ARGUMENTS[2+] (index 2 and 3)
+**Double plus [3++]:** $ARGUMENTS[3++] (index 3, 4, and 5)
+**Range [1:4]:** $ARGUMENTS[1:4] (from index 1 to 4 inclusive)
+
+This demonstrates all available argument splitting patterns!
+```
+
+Run the command:
+
+```bash frame="none"
+"/hello hello world foo bar baz . -y"
+```
+
+This produces a comprehensive demonstration of all argument patterns in a single command!
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds powerful new argument handling capabilities for custom commands, making them more flexible for complex workflows.

### New Features

Argument Patterns:

- `$ARGUMENTS[n]` - Single argument at index n
- `$ARGUMENTS[n*]` - All arguments from index n onwards
- `$ARGUMENTS[n+]` - Arguments at index n and n+1
- `$ARGUMENTS[n++]` - Arguments at index n, n+1, and n+2
- `$ARGUMENTS[n:m]` - Range from index n to m

#### Example

With "/hello hello world foo bar baz . -y"

$ARGUMENTS[0]       → "hello"
$ARGUMENTS[1*]     → "world foo bar baz . -y"
$ARGUMENTS[2+]     → "foo bar"
$ARGUMENTS[3++]   → "bar baz ."
$ARGUMENTS[1:4]    → "world foo bar baz"

The implementation handles out-of-bounds indices gracefully