### PR TITLE
Fix/separate publish script to prevent half release

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+const dir = new URL("..", import.meta.url).pathname
+process.chdir(dir)
+import { $ } from "bun"
+import pkg from "../package.json"
+
+const version = process.env["OPENCODE_VERSION"]!
+
+console.log(`building ${version}`)
+
+const GOARCH: Record<string, string> = {
+  arm64: "arm64",
+  x64: "amd64",
+  "x64-baseline": "amd64",
+}
+
+const targets = [
+  ["windows", "x64"],
+  ["linux", "arm64"],
+  ["linux", "x64"],
+  ["linux", "x64-baseline"],
+  ["darwin", "x64"],
+  ["darwin", "x64-baseline"],
+  ["darwin", "arm64"],
+]
+
+await $`rm -rf dist`
+
+const optionalDependencies: Record<string, string> = {}
+for (const [os, arch] of targets) {
+  console.log(`building ${os}-${arch}`)
+  const name = `${pkg.name}-${os}-${arch}`
+  await $`mkdir -p dist/${name}/bin`
+  await $`CGO_ENABLED=0 GOOS=${os} GOARCH=${GOARCH[arch]} go build -ldflags="-s -w -X main.Version=${version}" -o ../opencode/dist/${name}/bin/tui ../tui/cmd/opencode/main.go`.cwd(
+    "../tui",
+  )
+  await $`bun build --define OPENCODE_TUI_PATH="'../../../dist/${name}/bin/tui'" --define OPENCODE_VERSION="'${version}'" --compile --target=bun-${os}-${arch} --outfile=dist/${name}/bin/opencode ./src/index.ts`
+
+  // smoke test only on matching OS/arch
+  if (
+    process.platform === (os === "windows" ? "win32" : os) &&
+    (process.arch === arch || (process.arch === "x64" && arch === "x64-baseline"))
+  ) {
+    console.log(`smoke test: running dist/${name}/bin/opencode --version`)
+    await $`./dist/${name}/bin/opencode --version`
+  }
+
+  await $`rm -rf ./dist/${name}/bin/tui`
+  await Bun.file(`dist/${name}/package.json`).write(
+    JSON.stringify(
+      {
+        name,
+        version,
+        os: [os === "windows" ? "win32" : os],
+        cpu: [arch],
+      },
+      null,
+      2,
+    ),
+  )
+  optionalDependencies[name] = version
+}
+
+// write meta-package
+await $`mkdir -p ./dist/${pkg.name}`
+await $`cp -r ./bin ./dist/${pkg.name}/bin`
+await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
+await Bun.file(`./dist/${pkg.name}/package.json`).write(
+  JSON.stringify(
+    {
+      name: pkg.name + "-ai",
+      bin: {
+        [pkg.name]: `./bin/${pkg.name}`,
+      },
+      scripts: {
+        postinstall: "node ./postinstall.mjs",
+      },
+      version,
+      optionalDependencies,
+    },
+    null,
+    2,
+  ),
+)
+
+// save optionalDependencies separately for publish step
+await Bun.file("./dist/optionalDependencies.json").write(JSON.stringify(optionalDependencies, null, 2))

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -2,7 +2,6 @@
 const dir = new URL("..", import.meta.url).pathname
 process.chdir(dir)
 import { $ } from "bun"
-
 import pkg from "../package.json"
 
 const dry = process.env["OPENCODE_DRY"] === "true"
@@ -11,79 +10,19 @@ const snapshot = process.env["OPENCODE_SNAPSHOT"] === "true"
 
 console.log(`publishing ${version}`)
 
-const GOARCH: Record<string, string> = {
-  arm64: "arm64",
-  x64: "amd64",
-  "x64-baseline": "amd64",
-}
-
-const targets = [
-  ["windows", "x64"],
-  ["linux", "arm64"],
-  ["linux", "x64"],
-  ["linux", "x64-baseline"],
-  ["darwin", "x64"],
-  ["darwin", "x64-baseline"],
-  ["darwin", "arm64"],
-]
-
-await $`rm -rf dist`
-
-const optionalDependencies: Record<string, string> = {}
 const npmTag = snapshot ? "snapshot" : "latest"
-for (const [os, arch] of targets) {
-  console.log(`building ${os}-${arch}`)
-  const name = `${pkg.name}-${os}-${arch}`
-  await $`mkdir -p dist/${name}/bin`
-  await $`CGO_ENABLED=0 GOOS=${os} GOARCH=${GOARCH[arch]} go build -ldflags="-s -w -X main.Version=${version}" -o ../opencode/dist/${name}/bin/tui ../tui/cmd/opencode/main.go`.cwd(
-    "../tui",
-  )
-  await $`bun build --define OPENCODE_TUI_PATH="'../../../dist/${name}/bin/tui'" --define OPENCODE_VERSION="'${version}'" --compile --target=bun-${os}-${arch} --outfile=dist/${name}/bin/opencode ./src/index.ts`
-  // Run the binary only if it matches current OS/arch
-  if (
-    process.platform === (os === "windows" ? "win32" : os) &&
-    (process.arch === arch || (process.arch === "x64" && arch === "x64-baseline"))
-  ) {
-    console.log(`smoke test: running dist/${name}/bin/opencode --version`)
-    await $`./dist/${name}/bin/opencode --version`
-  }
-  await $`rm -rf ./dist/${name}/bin/tui`
-  await Bun.file(`dist/${name}/package.json`).write(
-    JSON.stringify(
-      {
-        name,
-        version,
-        os: [os === "windows" ? "win32" : os],
-        cpu: [arch],
-      },
-      null,
-      2,
-    ),
-  )
+
+// load optionalDependencies from build step
+const optionalDependencies: Record<string, string> = JSON.parse(
+  await Bun.file("./dist/optionalDependencies.json").text(),
+)
+
+// publish per-target packages
+for (const name of Object.keys(optionalDependencies)) {
   if (!dry) await $`cd dist/${name} && chmod 777 -R . && bun publish --access public --tag ${npmTag}`
-  optionalDependencies[name] = version
 }
 
-await $`mkdir -p ./dist/${pkg.name}`
-await $`cp -r ./bin ./dist/${pkg.name}/bin`
-await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
-await Bun.file(`./dist/${pkg.name}/package.json`).write(
-  JSON.stringify(
-    {
-      name: pkg.name + "-ai",
-      bin: {
-        [pkg.name]: `./bin/${pkg.name}`,
-      },
-      scripts: {
-        postinstall: "node ./postinstall.mjs",
-      },
-      version,
-      optionalDependencies,
-    },
-    null,
-    2,
-  ),
-)
+// publish meta-package
 if (!dry) await $`cd ./dist/${pkg.name} && bun publish --access public --tag ${npmTag}`
 
 if (!snapshot) {

--- a/packages/plugin/script/build.ts
+++ b/packages/plugin/script/build.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+
+const dir = new URL("..", import.meta.url).pathname
+process.chdir(dir)
+
+import { $ } from "bun"
+
+await $`bun tsc`

--- a/packages/plugin/script/publish.ts
+++ b/packages/plugin/script/publish.ts
@@ -7,8 +7,6 @@ import { $ } from "bun"
 
 const snapshot = process.env["OPENCODE_SNAPSHOT"] === "true"
 
-await $`bun tsc`
-
 if (snapshot) {
   await $`bun publish --tag snapshot --access public`
   await $`git checkout package.json`

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+
+const dir = new URL("..", import.meta.url).pathname
+process.chdir(dir)
+
+import { $ } from "bun"
+
+await import("./generate")
+await $`rm -rf dist`
+await $`bun tsc`

--- a/packages/sdk/js/script/publish.ts
+++ b/packages/sdk/js/script/publish.ts
@@ -1,19 +1,14 @@
 #!/usr/bin/env bun
 
-const dir = new URL("..", import.meta.url).pathname
-process.chdir(dir)
-
 import { $ } from "bun"
 
-await import("./generate")
-await $`rm -rf dist`
-await $`bun tsc`
+const dir = new URL("..", import.meta.url).pathname
+process.chdir(dir)
 
 const snapshot = process.env["OPENCODE_SNAPSHOT"] === "true"
 
 if (snapshot) {
   await $`bun publish --tag snapshot`
-}
-if (!snapshot) {
+} else {
   await $`bun publish`
 }

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -33,6 +33,9 @@ console.log("\n====== build stage ======\n")
 console.log("\n=== build opencode ===\n")
 await import(`../packages/opencode/script/build.ts`)
 
+console.log("\n=== build sdk ===\n")
+await import(`../packages/sdk/js/script/build.ts`)
+
 console.log("\n====== publish stage ======\n")
 
 console.log("\n=== publish opencode ===\n")

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -36,6 +36,9 @@ await import(`../packages/opencode/script/build.ts`)
 console.log("\n=== build sdk ===\n")
 await import(`../packages/sdk/js/script/build.ts`)
 
+console.log("\n=== build plugin ===\n")
+await import(`../packages/plugin/script/build.ts`)
+
 console.log("\n====== publish stage ======\n")
 
 console.log("\n=== publish opencode ===\n")

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -29,13 +29,19 @@ for (const file of pkgjsons) {
 }
 await $`bun install`
 
-console.log("\n=== opencode ===\n")
+console.log("\n====== build stage ======\n")
+console.log("\n=== build opencode ===\n")
+await import(`../packages/opencode/script/build.ts`)
+
+console.log("\n====== publish stage ======\n")
+
+console.log("\n=== publish opencode ===\n")
 await import(`../packages/opencode/script/publish.ts`)
 
-console.log("\n=== sdk ===\n")
+console.log("\n=== publish sdk ===\n")
 await import(`../packages/sdk/js/script/publish.ts`)
 
-console.log("\n=== plugin ===\n")
+console.log("\n=== publish plugin ===\n")
 await import(`../packages/plugin/script/publish.ts`)
 
 const dir = new URL("..", import.meta.url).pathname


### PR DESCRIPTION
There's been a few case where AUR, Homebrew or other package repo are linking to an unreleased version of opencode, this is usually caused by build failing on one of the steps where the componenet before it has been publish

This PR try fix to this "half-release" state by changing the order of build and publish

Before:
Build opencode --> Publish Opencode --> Build sdk --> Publish sdk --> Build plugin --> Publish plugin --> Github Release

After;
Build opencode --> Build sdk  --> Build plugin --> Publish Opencode --> Publish sdk -->  Publish plugin --> Github Release