### PR TITLE
Grep: use `rg --json`

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/grep.ts
+++ b/packages/opencode/src/cli/cmd/debug/grep.ts
@@ -1,0 +1,59 @@
+import { bootstrap } from "../../bootstrap"
+import { cmd } from "../cmd"
+import { GrepTool } from "../../../tool/grep"
+
+export const GrepCommand = cmd({
+  command: "grep <pattern>",
+  builder: (yargs) =>
+    yargs
+      .positional("pattern", {
+        type: "string",
+        demandOption: true,
+        description: "Search pattern",
+      })
+      .option("path", {
+        type: "string",
+        description: "Directory to search in",
+      })
+      .option("include", {
+        type: "string",
+        description: "File pattern to include (e.g. '*.ts', '*.{ts,tsx}')",
+      })
+      .option("json", {
+        type: "boolean",
+        description: "Output raw JSON result",
+      }),
+  async handler(args) {
+    await bootstrap(process.cwd(), async () => {
+      const params = {
+        pattern: args.pattern,
+        path: args.path,
+        include: args.include,
+      }
+
+      try {
+        const tool = await GrepTool.init()
+        const result = await tool.execute(params, {
+          sessionID: "debug",
+          messageID: "debug",
+          agent: "debug",
+          abort: new AbortController().signal,
+          metadata: () => {},
+        })
+
+        if (args.json) {
+          console.log(JSON.stringify(result, null, 2))
+        } else {
+          console.log(result.output)
+          console.log(`\n--- Metadata ---`)
+          console.log(`Pattern: ${result.title}`)
+          console.log(`Matches: ${result.metadata.matches}`)
+          console.log(`Truncated: ${result.metadata.truncated}`)
+        }
+      } catch (error) {
+        console.error("Error:", error instanceof Error ? error.message : error)
+        process.exit(1)
+      }
+    })
+  },
+})

--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -6,6 +6,7 @@ import { LSPCommand } from "./lsp"
 import { RipgrepCommand } from "./ripgrep"
 import { ScrapCommand } from "./scrap"
 import { SnapshotCommand } from "./snapshot"
+import { GrepCommand } from "./grep"
 
 export const DebugCommand = cmd({
   command: "debug",
@@ -13,6 +14,7 @@ export const DebugCommand = cmd({
     yargs
       .command(LSPCommand)
       .command(RipgrepCommand)
+      .command(GrepCommand)
       .command(FileCommand)
       .command(ScrapCommand)
       .command(SnapshotCommand)

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -20,7 +20,7 @@ export const GrepTool = Tool.define("grep", {
     const searchPath = params.path || Instance.directory
 
     const rgPath = await Ripgrep.filepath()
-    const args = ["-n", params.pattern]
+    const args = ["--json", params.pattern]
     if (params.include) {
       args.push("--glob", params.include)
     }
@@ -48,36 +48,54 @@ export const GrepTool = Tool.define("grep", {
     }
 
     const lines = output.trim().split("\n")
-    const matches = []
+    const fileGroups = new Map()
 
     for (const line of lines) {
       if (!line) continue
 
-      const [filePath, lineNumStr, ...lineTextParts] = line.split(":")
-      if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
+      let json
+      try {
+        json = JSON.parse(line)
+      } catch {
+        continue
+      }
 
-      const lineNum = parseInt(lineNumStr, 10)
-      const lineText = lineTextParts.join(":")
+      if (json.type !== "match") continue
 
-      const file = Bun.file(filePath)
-      const stats = await file.stat().catch(() => null)
-      if (!stats) continue
+      const data = json.data
+      const filePath = data.path.text
+      const lineNum = data.line_number
+      const lineText = data.lines.text.trim()
 
-      matches.push({
-        path: filePath,
-        modTime: stats.mtime.getTime(),
+      if (!fileGroups.has(filePath)) {
+        const file = Bun.file(filePath)
+        const stats = await file.stat().catch(() => null)
+        if (!stats) continue
+
+        fileGroups.set(filePath, {
+          modTime: stats.mtime.getTime(),
+          matches: [],
+        })
+      }
+
+      fileGroups.get(filePath).matches.push({
         lineNum,
         lineText,
       })
     }
 
-    matches.sort((a, b) => b.modTime - a.modTime)
+    const sortedFiles = Array.from(fileGroups.entries()).sort(([, a], [, b]) => b.modTime - a.modTime)
+
+    // Count total matches for limit and truncation
+    let totalMatches = 0
+    for (const [, fileData] of sortedFiles) {
+      totalMatches += fileData.matches.length
+    }
 
     const limit = 100
-    const truncated = matches.length > limit
-    const finalMatches = truncated ? matches.slice(0, limit) : matches
+    const truncated = totalMatches > limit
 
-    if (finalMatches.length === 0) {
+    if (totalMatches === 0) {
       return {
         title: params.pattern,
         metadata: { matches: 0, truncated: false },
@@ -85,18 +103,20 @@ export const GrepTool = Tool.define("grep", {
       }
     }
 
-    const outputLines = [`Found ${finalMatches.length} matches`]
+    const outputLines = [`Found ${totalMatches} matches`]
+    let matchesOutput = 0
 
-    let currentFile = ""
-    for (const match of finalMatches) {
-      if (currentFile !== match.path) {
-        if (currentFile !== "") {
-          outputLines.push("")
-        }
-        currentFile = match.path
-        outputLines.push(`${match.path}:`)
+    for (const [filePath, fileData] of sortedFiles) {
+      if (matchesOutput >= limit) break
+
+      outputLines.push("")
+      outputLines.push(`${filePath}:`)
+
+      for (const match of fileData.matches) {
+        if (matchesOutput >= limit) break
+        outputLines.push(`  Line ${match.lineNum}: ${match.lineText}`)
+        matchesOutput++
       }
-      outputLines.push(`  Line ${match.lineNum}: ${match.lineText}`)
     }
 
     if (truncated) {
@@ -107,7 +127,7 @@ export const GrepTool = Tool.define("grep", {
     return {
       title: params.pattern,
       metadata: {
-        matches: finalMatches.length,
+        matches: totalMatches,
         truncated,
       },
       output: outputLines.join("\n"),


### PR DESCRIPTION
Grep tool was _sometimes_ failing for me to find matches.
Instead of understanding and fixing, this just switches to using `rg --json`, similar to the `Ripgrep.search` code.
I briefly tried reusing the latter, but it expects a dir and grep tool works fine with a file path, so I chose not to reuse.

There are further improvements to be had here with reusing `Ripgrep`, or at least the schema.  But not this PR.