### PR TITLE
fix: command model selection

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -820,6 +820,8 @@ func (a *App) SendCommand(ctx context.Context, command string, args string) (*Ap
 			opencode.SessionCommandParams{
 				Command:   opencode.F(command),
 				Arguments: opencode.F(args),
+				Agent:     opencode.F(a.Agents[a.AgentIndex].Name),
+				Model:     opencode.F(a.State.Provider + "/" + a.State.Model),
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
### Existing behavior seems unintentional?

If I don't set a model w/ a slash command it basically uses my "default model" which is "grok-3-mini" apparently just due to how the defaultModel function finds default model, anyway that model is useless can't send anything to it. 

### Expectation:

If a command doesn't have a set model or agent it should just use the same model I am already using in my chat. That would make more sense to me


### Change in words:
- if command specifies a model use it
- if command specifies an agent use it
- if user has a model selected use it
- if user has an agent selected use it <-- not really necessary but just there for consistency
- use default model otherwise 

