### PR TITLE
fix: model flag in none interactive mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -171,12 +171,17 @@ export const RunCommand = cmd({
       const result = await Session.chat({
         sessionID: session.id,
         messageID,
-        ...(agent.model
-          ? agent.model
-          : {
+        ...(args.model
+          ? {
               providerID,
               modelID,
-            }),
+            }
+          : agent.model
+            ? agent.model
+            : {
+                providerID,
+                modelID,
+              }),
         agent: agent.name,
         parts: [
           {

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -171,17 +171,8 @@ export const RunCommand = cmd({
       const result = await Session.chat({
         sessionID: session.id,
         messageID,
-        ...(args.model
-          ? {
-              providerID,
-              modelID,
-            }
-          : agent.model
-            ? agent.model
-            : {
-                providerID,
-                modelID,
-              }),
+        providerID,
+        modelID,
         agent: agent.name,
         parts: [
           {


### PR DESCRIPTION
When using the `run` command, the model defined in the currently used agent was preferred even if a specific model was given with the --model flag.

This reverses the logic and prefers the --model flag by removing unnecessary logic (choosing the right model is already handled in line 46).