### PR TITLE
expose chat message agent to plugin

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -636,6 +636,7 @@ export namespace Session {
       "chat.message",
       {},
       {
+        agent: input.agent,
         message: userMsg,
         parts: userParts,
       },

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -78,7 +78,7 @@ export interface Hooks {
   /**
    * Called when a new message is received
    */
-  "chat.message"?: (input: {}, output: { message: UserMessage; parts: Part[] }) => Promise<void>
+  "chat.message"?: (input: {}, output: { message: UserMessage; parts: Part[], agent?: string }) => Promise<void>
   /**
    * Modify parameters sent to LLM
    */


### PR DESCRIPTION
After attempting to retrieve the agent for a particular message in my plugin, this seemed like the only available option. I believe this fits under _Missing standard behavior_ for plugins :crossed_fingers: 

Looking at the design, I'm sure there's a better place to expose this information. Feedback would be greatly appreciated