### PR TITLE
Vercel AI Gateway key deeplinks into the dashboard

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -245,7 +245,7 @@ export const AuthLoginCommand = cmd({
       }
 
       if (provider === "vercel") {
-        prompts.log.info("You can create an api key in the dashboard")
+        prompts.log.info("Create an API key at https://vercel.link/ai-gateway-token")
       }
 
       const key = await prompts.password({

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -245,7 +245,7 @@ export const AuthLoginCommand = cmd({
       }
 
       if (provider === "vercel") {
-        prompts.log.info("Create an API key at https://vercel.link/ai-gateway-token")
+        prompts.log.info("You can create an api key at https://vercel.link/ai-gateway-token")
       }
 
       const key = await prompts.password({


### PR DESCRIPTION
Adding a clickable deeplink into the vercel dashboard to make getting set up easier.

https://vercel.link/ai-gateway-token

Example:
<img width="1334" height="514" alt="CleanShot 2025-08-27 at 22 13 03@2x" src="https://github.com/user-attachments/assets/650e40ac-97d0-41b3-91b5-450e7a2fc49f" />