### PR TITLE
fix: mcp client name

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -55,7 +55,7 @@ export namespace MCP {
           let lastError: Error | undefined
           for (const { name, transport } of transports) {
             const client = await experimental_createMCPClient({
-              name: key,
+              name: "opencode",
               transport,
             }).catch((error) => {
               lastError = error instanceof Error ? error : new Error(String(error))
@@ -92,7 +92,7 @@ export namespace MCP {
         if (mcp.type === "local") {
           const [cmd, ...args] = mcp.command
           const client = await experimental_createMCPClient({
-            name: key,
+            name: "opencode",
             transport: new StdioClientTransport({
               stderr: "ignore",
               command: cmd,


### PR DESCRIPTION
Currently, Opencode uses the MCP config server name as the MCP `clientInfo.name`, which prevents MCP servers from easily identifying that the client is actually Opencode. This fix changes the `clientInfo.name` to a hardcoded value: "opencode". This ensures the Opencode MCP client is clearly identifiable by MCP servers, allowing them to adapt the features exposed based on supported specification features.

We are working on a package to address this, as the protocol does not support it yet. We would like to add Opencode, but without this change, we cannot: https://github.com/apify/mcp-client-capabilities

For example, if you configure `opencode.json` like this, the `clientInfo.name` in the [MCP initialize request](https://modelcontextprotocol.io/specification/2025-06-18/schema#initializerequest) will be "testing-client" instead of a consistent identifier such as "opencode". Since each MCP client supports a different feature set, this makes it impossible to reliably identify Opencode.

```json
{
  "$schema": "https://opencode.ai/config.json",
  "mcp": {
    "testing-client": {
      "type": "remote",
      "url": "http://localhost:3001",
      "enabled": true,
      "headers": {
        "Authorization": "Bearer MY_API_KEY"
      }
    }
  }
}
```

MCP initialize request with this config, which cannot be easily identified as Opencode:
```text
{"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"testing-client","version":"1.0.0"}},"jsonrpc":"2.0","id":0}
```

MCP initialize request with this config **patched**, now clearly identifiable by the "opencode" client name:
```text
{"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"opencode","version":"1.0.0"}},"jsonrpc":"2.0","id":0}
```