### PR TITLE
Use a single rust LSP server instance for entire cargo workspace

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -515,7 +515,35 @@ export namespace LSPServer {
 
   export const RustAnalyzer: Info = {
     id: "rust",
-    root: NearestRoot(["Cargo.toml", "Cargo.lock"]),
+    root: async (file, app) => {
+      const crateRoot = await NearestRoot(["Cargo.toml", "Cargo.lock"])(file, app)
+      if (crateRoot === undefined) {
+        return undefined
+      }
+      let currentDir = crateRoot
+
+      while (currentDir !== path.dirname(currentDir)) {
+        // Stop at filesystem root
+        const cargoTomlPath = path.join(currentDir, "Cargo.toml")
+        try {
+          const cargoTomlContent = await Bun.file(cargoTomlPath).text()
+          if (cargoTomlContent.includes("[workspace]")) {
+            return currentDir
+          }
+        } catch (err) {
+          // File doesn't exist or can't be read, continue searching up
+        }
+
+        const parentDir = path.dirname(currentDir)
+        if (parentDir === currentDir) break // Reached filesystem root
+        currentDir = parentDir
+
+        // Stop if we've gone above the app root
+        if (!currentDir.startsWith(app.path.root)) break
+      }
+
+      return crateRoot
+    },
     extensions: [".rs"],
     async spawn(_, root) {
       const bin = Bun.which("rust-analyzer")


### PR DESCRIPTION
Previous: multiple rust lsp servers started, one for each crate within a cargo workspace.  Each was inevitably reading the entire worksapce, consuming large amount of RAM, often leading to OOM.

Now: launch one single lsp server for the entire workspace.