### PR TITLE
fix: add additional encouragement for title gen

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -705,6 +705,28 @@ export namespace Session {
               parts: userParts,
             },
           ]),
+          ...MessageV2.toModelMessage([
+            {
+              info: {
+                id: Identifier.ascending("message"),
+                role: "user",
+                sessionID: input.sessionID,
+                time: {
+                  created: Date.now(),
+                },
+              },
+              parts: [
+                {
+                  type: "text",
+                  id: Identifier.ascending("part"),
+                  messageID: userMsg.id,
+                  sessionID: input.sessionID,
+                  text: "Output only a title for this conversation. No responses to content.",
+                  synthetic: true,
+                },
+              ],
+            },
+          ]),
         ],
         model: small.language,
       })

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -705,6 +705,10 @@ export namespace Session {
               parts: userParts,
             },
           ]),
+          // When dealing with huge blocks of context sometimes the llm will lose sight of
+          // parts of system prompt, you can usually get around this by just adding an additional
+          // reference after large context block that references instructions from system prompt
+          // and llm will "remember" it needs to do X or Y
           ...MessageV2.toModelMessage([
             {
               info: {


### PR DESCRIPTION
fixes: #2235

When given super large prompts title generation can have a hiccup, there are really only 2 viable solutions here:
A) truncate the user prompt
B) add additional prompt after giant context blob to reaffirm to LLM what it needs to do

### Why not adjust system prompt?

When dealing with huge blocks of context sometimes the llm will lose sight of parts of system prompt, you can usually get around this by just adding an additional reference to something in system prompt and llm will "remember" it needs to do X or Y 


showing fix w/ prompt taken from issue:
https://dev.opencode.ai/s/gzWbv3uO