### PR TITLE
feat: Markdown rendering for user messages

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -326,6 +326,7 @@ export namespace Config {
 
   export const TUI = z.object({
     scroll_speed: z.number().min(1).optional().default(2).describe("TUI scroll speed"),
+    render_user_markdown: z.boolean().optional().default(false).describe("Render user messages as markdown"),
   })
 
   export const Layout = z.enum(["auto", "stretch"]).openapi({

--- a/packages/sdk/go/config.go
+++ b/packages/sdk/go/config.go
@@ -1689,6 +1689,8 @@ func (r ConfigShare) IsKnown() bool {
 
 // TUI specific settings
 type ConfigTui struct {
+	// Render user messages as markdown
+	RenderUserMarkdown bool `json:"render_user_markdown"`
 	// TUI scroll speed
 	ScrollSpeed float64       `json:"scroll_speed,required"`
 	JSON        configTuiJSON `json:"-"`
@@ -1696,9 +1698,10 @@ type ConfigTui struct {
 
 // configTuiJSON contains the JSON metadata for the struct [ConfigTui]
 type configTuiJSON struct {
-	ScrollSpeed apijson.Field
-	raw         string
-	ExtraFields map[string]apijson.Field
+	RenderUserMarkdown apijson.Field
+	ScrollSpeed        apijson.Field
+	raw                string
+	ExtraFields        map[string]apijson.Field
 }
 
 func (r *ConfigTui) UnmarshalJSON(data []byte) (err error) {

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -339,12 +339,19 @@ func renderText(
 			result.WriteString(base.Render(text[lastEnd:]))
 		}
 
-		// wrap styled text
-		styledText := result.String()
-		styledText = strings.ReplaceAll(styledText, "-", "\u2011")
-		wrappedText := ansi.WordwrapWc(styledText, width-6, " ")
-		wrappedText = strings.ReplaceAll(wrappedText, "\u2011", "-")
-		content = base.Width(width - 6).Render(wrappedText)
+		// Check if user markdown rendering is enabled
+		if app.Config.Tui.RenderUserMarkdown {
+			// Use markdown rendering for the messages (no highlights)
+			content = util.ToMarkdown(text, width, backgroundColor)
+		} else {
+			// Wrap styled text
+			styledText := result.String()
+			styledText = strings.ReplaceAll(styledText, "-", "\u2011")
+			wrappedText := ansi.WordwrapWc(styledText, width-6, " ")
+			wrappedText = strings.ReplaceAll(wrappedText, "\u2011", "-")
+			content = base.Width(width - 6).Render(wrappedText)
+		}
+
 		if isQueued {
 			queuedStyle := styles.NewStyle().Background(t.Accent()).Foreground(t.BackgroundPanel()).Bold(true).Padding(0, 1)
 			content = queuedStyle.Render("QUEUED") + "\n\n" + content


### PR DESCRIPTION
I'm using Markdown a lot and I'm a little bit sad that OpenCode doesn't render my Markdown-typed messages as Markdown. I have tried to fix it in this PR.

There is one caveat - the highlighting for files and agents is omitted because it breaks the Markdown. Personally I would prefer to have my messages rendered as Markdown than have the references to files and agents highlighted. The feature is disable by default so it doesn't not impact the current user experience in any way.