### PR TITLE
fix: AI_APICallError: prompt is too long: 209045 tokens > 200000 maximum due to large file read

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -21,20 +21,10 @@ import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 
 import { App } from "../app/app"
-import { Bus } from "../bus"
-import { Config } from "../config/config"
-import { Flag } from "../flag/flag"
+import { Agent } from "../agent/agent"
 import { Identifier } from "../id/id"
-import { Installation } from "../installation"
-import { MCP } from "../mcp"
-import { Provider } from "../provider/provider"
-import { ProviderTransform } from "../provider/transform"
-import type { ModelsDev } from "../provider/models"
-import { Share } from "../share/share"
-import { Snapshot } from "../snapshot"
-import { Storage } from "../storage/storage"
-import { Log } from "../util/log"
 import { NamedError } from "../util/error"
+import { TokenEstimator } from "../util/token"
 import { SystemPrompt } from "./system"
 import { FileTime } from "../file/time"
 import { MessageV2 } from "./message-v2"
@@ -43,13 +33,24 @@ import { ReadTool } from "../tool/read"
 import { mergeDeep, pipe, splitWhen } from "remeda"
 import { ToolRegistry } from "../tool/registry"
 import { Plugin } from "../plugin"
-import { Agent } from "../agent/agent"
 import { Permission } from "../permission"
 import { Wildcard } from "../util/wildcard"
 import { ulid } from "ulid"
 import { defer } from "../util/defer"
 import { Command } from "../command"
 import { $ } from "bun"
+import { Log } from "../util/log"
+import { Bus } from "../bus"
+import { Storage } from "../storage/storage"
+import { Provider } from "../provider/provider"
+import { ProviderTransform } from "../provider/transform"
+import { Config } from "../config/config"
+import { Flag } from "../flag/flag"
+import { Share } from "../share/share"
+import { Installation } from "../installation"
+import { Snapshot } from "../snapshot"
+import { MCP } from "../mcp"
+import { ModelsDev } from "../provider/models"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
@@ -442,6 +443,13 @@ export namespace Session {
         draft.revert = undefined
       })
     }
+    // Load model early to get context limits for file processing
+    const modelForLimits = await Provider.getModel(input.providerID, input.modelID)
+    const modelOutputLimit = Math.min(modelForLimits.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+    const contextLimit = modelForLimits.info.limit.context || 200_000 // fallback to 200k if not specified
+    // Use 75% of context limit for file content, leaving room for system prompts and conversation
+    const maxFileTokens = Math.floor((contextLimit - modelOutputLimit) * 0.75)
+
     const userMsg: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
       role: "user",
@@ -532,7 +540,7 @@ export namespace Session {
                     abort: new AbortController().signal,
                     agent: input.agent!,
                     messageID: userMsg.id,
-                    extra: { bypassCwdCheck: true },
+                    extra: { bypassCwdCheck: true, maxFileTokens },
                     metadata: async () => {},
                   }),
                 )
@@ -564,6 +572,34 @@ export namespace Session {
 
               let file = Bun.file(filePath)
               FileTime.read(input.sessionID, filePath)
+
+              // Check file size and estimate tokens
+              const fileContent = await file.text()
+              const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+              if (estimatedTokens > maxFileTokens) {
+                // File is too large, use the Read tool instead with truncation
+                const truncatedContent = TokenEstimator.truncateToTokenLimit(fileContent, maxFileTokens)
+                return [
+                  {
+                    id: Identifier.ascending("part"),
+                    messageID: userMsg.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: `File ${filePath} is too large (${estimatedTokens} estimated tokens, limit: ${maxFileTokens} for model ${modelForLimits.info.id}). Showing truncated content.`,
+                  },
+                  {
+                    id: Identifier.ascending("part"),
+                    messageID: userMsg.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    text: truncatedContent,
+                    synthetic: false,
+                  },
+                ]
+              }
+
               return [
                 {
                   id: Identifier.ascending("part"),
@@ -649,11 +685,12 @@ export namespace Session {
       })
     }
 
-    const model = await Provider.getModel(input.providerID, input.modelID)
+    // Model already loaded earlier as modelForLimits
+    const model = modelForLimits
     let msgs = await messages(input.sessionID)
 
     const previous = msgs.filter((x) => x.info.role === "assistant").at(-1)?.info as MessageV2.Assistant
-    const outputLimit = Math.min(model.info.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+    const outputLimit = modelOutputLimit
 
     // auto summarize if too long
     if (previous && previous.tokens) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -7,9 +7,11 @@ import { FileTime } from "../file/time"
 import DESCRIPTION from "./read.txt"
 import { App } from "../app/app"
 import { Filesystem } from "../util/filesystem"
+import { TokenEstimator } from "../util/token"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
+const DEFAULT_MAX_FILE_TOKENS = 150_000 // Conservative default limit for file content
 
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
@@ -55,7 +57,25 @@ export const ReadTool = Tool.define("read", {
     if (isImage) throw new Error(`This is an image file of type: ${isImage}\nUse a different tool to process images`)
     const isBinary = await isBinaryFile(filepath, file)
     if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
-    const lines = await file.text().then((text) => text.split("\n"))
+
+    const fullText = await file.text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fullText)
+
+    // Get max tokens from context or use default
+    const maxFileTokens = ctx.extra?.["maxFileTokens"] || DEFAULT_MAX_FILE_TOKENS
+
+    // If file is extremely large and no specific range requested, suggest using offset/limit
+    if (estimatedTokens > maxFileTokens && !params.offset && !params.limit) {
+      const lines = fullText.split("\n")
+      const suggestedLimit = Math.min(2000, Math.floor((maxFileTokens / estimatedTokens) * lines.length))
+      throw new Error(
+        `File is too large (${lines.length} lines, ~${estimatedTokens} tokens).\n` +
+          `Please use offset and limit parameters to read specific sections.\n` +
+          `Suggested: limit=${suggestedLimit} to stay within token limits.`,
+      )
+    }
+
+    const lines = fullText.split("\n")
     const raw = lines.slice(offset, offset + limit).map((line) => {
       return line.length > MAX_LINE_LENGTH ? line.substring(0, MAX_LINE_LENGTH) + "..." : line
     })

--- a/packages/opencode/src/util/token.ts
+++ b/packages/opencode/src/util/token.ts
@@ -1,0 +1,76 @@
+export namespace TokenEstimator {
+  // Rough estimate: 1 token ≈ 4 characters for English text
+  // This is a conservative estimate that works reasonably well
+  const CHARS_PER_TOKEN = 3
+
+  export function estimateTokens(text: string): number {
+    // Handle edge case of empty or very short text
+    if (text.length === 0) return 0
+    if (text.length <= 2) return 1 // Very short text like "Hi" should be 1 token
+
+    // More accurate estimation considering common patterns
+    // Whitespace and punctuation tend to be part of tokens
+    const charCount = text.length
+    const wordCount = text.split(/\s+/).filter(Boolean).length
+
+    // Use a weighted average of character and word-based estimates
+    // Words average ~1.3 tokens, chars average ~3-4 per token
+    const charEstimate = charCount / CHARS_PER_TOKEN
+    const wordEstimate = wordCount * 1.3
+
+    // Return the higher estimate to be conservative
+    return Math.ceil(Math.max(charEstimate, wordEstimate))
+  }
+
+  export function estimateFileTokens(content: string, encoding: "utf-8" | "base64" = "utf-8"): number {
+    if (encoding === "base64") {
+      // Base64 increases size by ~33%
+      const decodedSize = (content.length * 3) / 4
+      return estimateTokens(content) + Math.ceil(decodedSize / CHARS_PER_TOKEN)
+    }
+    return estimateTokens(content)
+  }
+
+  export function isWithinLimit(text: string, maxTokens: number): boolean {
+    return estimateTokens(text) <= maxTokens
+  }
+
+  export function truncateToTokenLimit(text: string, maxTokens: number): string {
+    const estimate = estimateTokens(text)
+    if (estimate <= maxTokens) return text
+
+    // Reserve tokens for the truncation message
+    const truncationMessage = "\n\n[Content truncated due to size limits]"
+    const truncationTokens = estimateTokens(truncationMessage)
+    const effectiveLimit = maxTokens - truncationTokens
+
+    // Binary search for the right truncation point with more conservative approach
+    let left = 0
+    let right = text.length
+    let result = ""
+
+    while (left <= right) {
+      const mid = Math.floor((left + right) / 2)
+      const substr = text.substring(0, mid)
+      const substrTokens = estimateTokens(substr)
+
+      if (substrTokens <= effectiveLimit) {
+        result = substr
+        left = mid + 1
+      } else {
+        right = mid - 1
+      }
+    }
+
+    // Try to break at a natural boundary (line or word)
+    const lastNewline = result.lastIndexOf("\n")
+    const lastSpace = result.lastIndexOf(" ")
+    const breakPoint = Math.max(lastNewline, lastSpace)
+
+    if (breakPoint > result.length * 0.8) {
+      result = result.substring(0, breakPoint)
+    }
+
+    return result + truncationMessage
+  }
+}

--- a/packages/opencode/test/session/file-handling.test.ts
+++ b/packages/opencode/test/session/file-handling.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test"
+import { TokenEstimator } from "../../src/util/token"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "os"
+
+let tempDir: string
+let tempFiles: string[] = []
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(tmpdir(), "session-test-"))
+  tempFiles = []
+})
+
+afterEach(async () => {
+  // Cleanup temp files
+  for (const file of tempFiles) {
+    try {
+      await fs.unlink(file)
+    } catch {}
+  }
+  try {
+    await fs.rmdir(tempDir, { recursive: true })
+  } catch {}
+})
+
+async function createTempFile(filename: string, content: string): Promise<string> {
+  const filepath = path.join(tempDir, filename)
+  await fs.writeFile(filepath, content)
+  tempFiles.push(filepath)
+  return filepath
+}
+
+describe("Session File Handling", () => {
+  test("should handle small files normally", async () => {
+    const content = "Small file content for testing"
+    const filepath = await createTempFile("small.txt", content)
+
+    // Test that small files are processed normally
+    const fileContent = await Bun.file(filepath).text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+    expect(estimatedTokens).toBeLessThan(1000) // Should be very small
+    expect(fileContent).toBe(content)
+  })
+
+  test("should detect large files that exceed token limits", async () => {
+    // Create a file that would exceed the 150k token limit
+    const largeContent = "word ".repeat(200000) // Should exceed MAX_FILE_TOKENS
+    const filepath = await createTempFile("large.txt", largeContent)
+
+    const fileContent = await Bun.file(filepath).text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+    expect(estimatedTokens).toBeGreaterThan(150000)
+  })
+
+  test("should truncate content when file exceeds token limits", async () => {
+    const largeContent = "test line\\n".repeat(50000) // Large content
+    const filepath = await createTempFile("huge.txt", largeContent)
+
+    const fileContent = await Bun.file(filepath).text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+    if (estimatedTokens > 150000) {
+      const truncated = TokenEstimator.truncateToTokenLimit(fileContent, 150000)
+      const truncatedTokens = TokenEstimator.estimateTokens(truncated)
+
+      expect(truncatedTokens).toBeLessThanOrEqual(150000)
+      expect(truncated.length).toBeLessThan(fileContent.length)
+      expect(truncated).toContain("[Content truncated due to size limits]")
+    }
+  })
+
+  test("should handle different file encodings appropriately", async () => {
+    const content = "Hello world with unicode: 世界 🌍"
+    const filepath = await createTempFile("unicode.txt", content)
+
+    const fileContent = await Bun.file(filepath).text()
+    const utf8Tokens = TokenEstimator.estimateFileTokens(fileContent, "utf-8")
+    const base64Tokens = TokenEstimator.estimateFileTokens(fileContent, "base64")
+
+    expect(base64Tokens).toBeGreaterThan(utf8Tokens)
+    expect(utf8Tokens).toBeGreaterThan(0)
+  })
+
+  test("should properly estimate tokens for code content", async () => {
+    const codeContent = `
+function complexFunction(param1, param2, param3) {
+  const result = [];
+  for (let i = 0; i < param1.length; i++) {
+    if (param1[i].property === param2) {
+      result.push({
+        ...param1[i],
+        newProperty: param3.transform(param1[i].value)
+      });
+    }
+  }
+  return result.filter(item => item.newProperty !== null);
+}
+`
+    const filepath = await createTempFile("code.js", codeContent)
+
+    const fileContent = await Bun.file(filepath).text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+    // Code typically has more tokens per character due to symbols and structure
+    expect(estimatedTokens).toBeGreaterThan(50)
+    expect(estimatedTokens).toBeLessThan(200) // Still reasonable for this amount of code
+  })
+
+  test("should handle binary file detection correctly", async () => {
+    // Create a file with binary content (null bytes)
+    const binaryContent = Buffer.from([0, 1, 2, 3, 255, 254, 0, 0, 127, 128])
+    const filepath = path.join(tempDir, "binary.bin")
+    await fs.writeFile(filepath, binaryContent)
+    tempFiles.push(filepath)
+
+    const file = Bun.file(filepath)
+    const buffer = await file.arrayBuffer()
+    const bytes = new Uint8Array(buffer.slice(0, Math.min(4096, buffer.byteLength)))
+
+    // Check for null bytes (binary indicator)
+    const hasNullBytes = Array.from(bytes).some((byte) => byte === 0)
+    expect(hasNullBytes).toBe(true)
+  })
+
+  test("should handle empty files gracefully", async () => {
+    const filepath = await createTempFile("empty.txt", "")
+
+    const fileContent = await Bun.file(filepath).text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+    expect(fileContent).toBe("")
+    expect(estimatedTokens).toBe(0)
+  })
+
+  test("should handle files with only whitespace", async () => {
+    const whitespaceContent = "   \\n\\t\\n   \\n"
+    const filepath = await createTempFile("whitespace.txt", whitespaceContent)
+
+    const fileContent = await Bun.file(filepath).text()
+    const estimatedTokens = TokenEstimator.estimateTokens(fileContent)
+
+    expect(estimatedTokens).toBeGreaterThan(0)
+    expect(estimatedTokens).toBeLessThan(10) // Should be minimal
+  })
+})
+
+describe("Token Estimation Edge Cases", () => {
+  test("should handle very short text", () => {
+    const shortText = "Hi"
+    const tokens = TokenEstimator.estimateTokens(shortText)
+    expect(tokens).toBe(1) // Should round up to at least 1
+  })
+
+  test("should handle repetitive content", () => {
+    const repetitive = "test ".repeat(1000)
+    const tokens = TokenEstimator.estimateTokens(repetitive)
+
+    // Should be roughly 1000 tokens (one per word) + some overhead
+    expect(tokens).toBeGreaterThan(900)
+    expect(tokens).toBeLessThan(2000)
+  })
+
+  test("should handle mixed content types", () => {
+    const mixed = `
+    # Title
+    
+    Regular paragraph with some text.
+    
+    \`\`\`javascript
+    function code() {
+      return "mixed content";
+    }
+    \`\`\`
+    
+    - List item 1
+    - List item 2
+    - List item 3
+    `
+
+    const tokens = TokenEstimator.estimateTokens(mixed)
+    expect(tokens).toBeGreaterThan(20)
+    expect(tokens).toBeLessThan(100)
+  })
+
+  test("should provide conservative estimates", () => {
+    const text = "This is a test sentence with exactly ten words in it."
+    const tokens = TokenEstimator.estimateTokens(text)
+
+    // Should be conservative (higher rather than lower)
+    // 10 words * 1.3 = 13, ~60 chars / 3 = 20, max(13, 20) = 20
+    expect(tokens).toBeGreaterThanOrEqual(13) // At least the word count * 1.3
+  })
+
+  test("should break at natural boundaries when truncating", () => {
+    const text = "Word one. Word two. Word three. ".repeat(100)
+    const truncated = TokenEstimator.truncateToTokenLimit(text, 50)
+
+    // Should try to break at natural boundaries and include truncation message
+    expect(truncated).toContain("[Content truncated due to size limits]")
+    expect(truncated.length).toBeLessThan(text.length)
+  })
+})

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test, afterEach, beforeEach } from "bun:test"
+import { App } from "../../src/app/app"
+import { ReadTool } from "../../src/tool/read"
+import { TokenEstimator } from "../../src/util/token"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "os"
+
+const ctx = {
+  sessionID: "test",
+  messageID: "",
+  toolCallID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  metadata: async () => {},
+  extra: { bypassCwdCheck: true },
+}
+
+let tempDir: string
+let tempFiles: string[] = []
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(tmpdir(), "read-test-"))
+  tempFiles = []
+})
+
+afterEach(async () => {
+  // Cleanup temp files
+  for (const file of tempFiles) {
+    try {
+      await fs.unlink(file)
+    } catch {}
+  }
+  try {
+    await fs.rmdir(tempDir, { recursive: true })
+  } catch {}
+})
+
+async function createTempFile(filename: string, content: string): Promise<string> {
+  const filepath = path.join(tempDir, filename)
+  await fs.writeFile(filepath, content)
+  tempFiles.push(filepath)
+  return filepath
+}
+
+describe("ReadTool", () => {
+  test("should read small file successfully", async () => {
+    const content = "Hello, world!\nThis is a test file.\n"
+    const filepath = await createTempFile("test.txt", content)
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const result = await ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, ctx))
+
+      expect(result.output).toContain("Hello, world!")
+      expect(result.output).toContain("This is a test file.")
+      expect(result.title).toBe(path.relative(tempDir, filepath))
+    })
+  })
+
+  test("should handle file with offset and limit", async () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`)
+    const content = lines.join("\\n")
+    const filepath = await createTempFile("large.txt", content)
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const result = await ReadTool.init().then((tool) =>
+        tool.execute({ filePath: filepath, offset: 10, limit: 5 }, ctx),
+      )
+
+      expect(result.output).toContain("Line 11")
+      expect(result.output).toContain("Line 15")
+      expect(result.output).not.toContain("Line 10")
+      expect(result.output).not.toContain("Line 16")
+    })
+  })
+
+  test("should reject very large files without offset/limit", async () => {
+    // Create a file that exceeds MAX_FILE_TOKENS (150,000)
+    const largeContent = "x".repeat(500_000) // ~500k chars should exceed 150k tokens
+    const filepath = await createTempFile("huge.txt", largeContent)
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const promise = ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, ctx))
+      expect(promise).rejects.toThrow("File is too large")
+    })
+  })
+
+  test("should handle large files with offset/limit parameters", async () => {
+    // Create a large file but read only a small portion
+    const lines = Array.from({ length: 10000 }, (_, i) => `Line number ${i + 1}`)
+    const largeContent = lines.join("\\n")
+    const filepath = await createTempFile("verylarge.txt", largeContent)
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const result = await ReadTool.init().then((tool) =>
+        tool.execute({ filePath: filepath, offset: 5000, limit: 10 }, ctx),
+      )
+
+      expect(result.output).toContain("Line number 5001")
+      expect(result.output).toContain("Line number 5010")
+      expect(result.output).not.toContain("Line number 4999")
+      expect(result.output).not.toContain("Line number 5012")
+    })
+  })
+
+  test("should reject non-existent files with helpful suggestions", async () => {
+    await createTempFile("actual_file.txt", "content")
+    const nonExistentPath = path.join(tempDir, "missing_file.txt")
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const promise = ReadTool.init().then((tool) => tool.execute({ filePath: nonExistentPath }, ctx))
+      expect(promise).rejects.toThrow("Did you mean one of these?")
+    })
+  })
+
+  test("should reject binary files", async () => {
+    // Create a binary-like file (with null bytes)
+    const binaryContent = Buffer.from([0, 1, 2, 3, 4, 5, 0, 0, 0])
+    const filepath = path.join(tempDir, "binary.bin")
+    await fs.writeFile(filepath, binaryContent)
+    tempFiles.push(filepath)
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const promise = ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, ctx))
+      expect(promise).rejects.toThrow("Cannot read binary file")
+    })
+  })
+
+  test("should reject image files", async () => {
+    const filepath = await createTempFile("image.png", "fake png content")
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const promise = ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, ctx))
+      expect(promise).rejects.toThrow("This is an image file of type: PNG")
+    })
+  })
+
+  test("should truncate very long lines", async () => {
+    const longLine = "x".repeat(3000) // Exceeds MAX_LINE_LENGTH (2000)
+    const filepath = await createTempFile("longline.txt", longLine)
+
+    await App.provide({ cwd: tempDir }, async () => {
+      const result = await ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, ctx))
+
+      expect(result.output).toContain("x".repeat(2000) + "...")
+      expect(result.output).not.toContain("x".repeat(2001))
+    })
+  })
+
+  test("should enforce working directory restrictions by default", async () => {
+    const filepath = await createTempFile("restricted.txt", "secret content")
+
+    // Try to read from different working directory without bypass
+    await App.provide({ cwd: "/" }, async () => {
+      const promise = ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, { ...ctx, extra: {} }))
+      expect(promise).rejects.toThrow("not in the current working directory")
+    })
+  })
+
+  test("should bypass working directory restrictions when requested", async () => {
+    const filepath = await createTempFile("allowed.txt", "accessible content")
+
+    // Should work with bypassCwdCheck
+    await App.provide({ cwd: "/" }, async () => {
+      const result = await ReadTool.init().then((tool) => tool.execute({ filePath: filepath }, ctx))
+
+      expect(result.output).toContain("accessible content")
+    })
+  })
+})
+
+describe("TokenEstimator", () => {
+  test("should estimate tokens for regular text", () => {
+    const text = "Hello world! This is a test."
+    const estimate = TokenEstimator.estimateTokens(text)
+
+    // Should be reasonable estimate (text is ~30 chars, expect ~10 tokens)
+    expect(estimate).toBeGreaterThan(5)
+    expect(estimate).toBeLessThan(20)
+  })
+
+  test("should estimate tokens for code-like content", () => {
+    const code = `
+function example() {
+  const x = 5;
+  return x * 2;
+}
+`
+    const estimate = TokenEstimator.estimateTokens(code)
+
+    // Code should have more tokens due to symbols and structure
+    expect(estimate).toBeGreaterThan(10)
+    expect(estimate).toBeLessThan(50)
+  })
+
+  test("should identify content within token limits", () => {
+    const shortText = "Hello world"
+    const longText = "x".repeat(100000)
+
+    expect(TokenEstimator.isWithinLimit(shortText, 1000)).toBe(true)
+    expect(TokenEstimator.isWithinLimit(longText, 1000)).toBe(false)
+  })
+
+  test("should truncate content to token limits", () => {
+    const longText = "word ".repeat(1000) // ~5000 chars
+    const truncated = TokenEstimator.truncateToTokenLimit(longText, 100)
+
+    expect(truncated.length).toBeLessThan(longText.length)
+    expect(truncated).toContain("[Content truncated due to size limits]")
+    expect(TokenEstimator.estimateTokens(truncated)).toBeLessThanOrEqual(100)
+  })
+
+  test("should not truncate content already within limits", () => {
+    const shortText = "Hello world"
+    const result = TokenEstimator.truncateToTokenLimit(shortText, 1000)
+
+    expect(result).toBe(shortText)
+  })
+
+  test("should handle base64 encoding estimates", () => {
+    const content = "Hello world"
+    const base64Estimate = TokenEstimator.estimateFileTokens(content, "base64")
+    const utf8Estimate = TokenEstimator.estimateFileTokens(content, "utf-8")
+
+    expect(base64Estimate).toBeGreaterThan(utf8Estimate)
+  })
+})

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -20,9 +20,6 @@ export type Event =
       type: "message.part.removed"
     } & EventMessagePartRemoved)
   | ({
-      type: "storage.write"
-    } & EventStorageWrite)
-  | ({
       type: "permission.updated"
     } & EventPermissionUpdated)
   | ({
@@ -31,6 +28,9 @@ export type Event =
   | ({
       type: "file.edited"
     } & EventFileEdited)
+  | ({
+      type: "storage.write"
+    } & EventStorageWrite)
   | ({
       type: "session.updated"
     } & EventSessionUpdated)
@@ -420,14 +420,6 @@ export type EventMessagePartRemoved = {
   }
 }
 
-export type EventStorageWrite = {
-  type: "storage.write"
-  properties: {
-    key: string
-    content?: unknown
-  }
-}
-
 export type EventPermissionUpdated = {
   type: "permission.updated"
   properties: Permission
@@ -462,6 +454,14 @@ export type EventFileEdited = {
   type: "file.edited"
   properties: {
     file: string
+  }
+}
+
+export type EventStorageWrite = {
+  type: "storage.write"
+  properties: {
+    key: string
+    content?: unknown
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

The code was attempting to read files that were too large to fit in the model's context window, resulting in "prompt is too long" errors. We fixed this by:

### 1. Added Token Estimation Utility (packages/opencode/src/util/token.ts)

• Created a conservative token estimation algorithm • Added truncation logic that breaks at natural boundaries (lines/words) • Handles both UTF-8 and base64 encoded content

### 2. Pre-emptive File Size Checking (packages/opencode/src/session/index.ts)

• Load model early to get its actual context limit • Check file size before including it in messages
• Use 75% of context limit for files (leaving room for system prompts and conversation) • Automatically truncate large files with informative messages • Pass model-specific limits to the Read tool

### 3. Updated Read Tool (packages/opencode/src/tool/read.ts)

• Accept dynamic token limits from the model context • Provide helpful error messages suggesting offset/limit parameters for large files • Calculate suggested limits based on actual file size and model capacity

### Key Improvements:

• Dynamic Limits: Uses each model's actual context window instead of hardcoded values
• Conservative Approach: Uses 75% of available context for files to ensure safety
• Graceful Degradation: Truncates content rather than failing completely
• Informative Messages: Tells users exactly why truncation occurred and the limits involved
• Model-Aware: Different models with different context windows are handled appropriately

The fix ensures that files are checked before being added to messages, preventing the API error from occurring in the first place.