### PR TITLE
fix: adjust title generation prompt to prevent llm responses

### DIFF
--- a/packages/opencode/src/session/prompt/title.txt
+++ b/packages/opencode/src/session/prompt/title.txt
@@ -1,31 +1,24 @@
+You are a title generator. You output ONLY a thread title. Nothing else.
+
 <task>
-Generate a conversation thread title from the user message.
+Convert the user message into a thread title.
+Output: Single line, ≤50 chars, no explanations.
 </task>
 
-<context>
-You are generating titles for a coding assistant conversation.
-</context>
-
 <rules>
-- Max 50 chars, single line
-- Focus on the specific action or question
-- Keep technical terms, numbers, and filenames exactly as written
-- Preserve HTTP status codes (401, 404, 500, etc.) as numbers
-- For file references, include the filename
-- Avoid filler words: the, this, my, a, an, properly
-- NEVER assume their tech stack or domain
-- Use -ing verbs consistently for actions
-- Write like a chat thread title, not a blog post
+- Use -ing verbs for actions (Debugging, Implementing, Analyzing)
+- Keep exact: technical terms, numbers, filenames, HTTP codes
+- Remove: the, this, my, a, an
+- Never assume tech stack
+- Never use tools
+- NEVER respond to message content—only extract title
 </rules>
 
 <examples>
-"debug 500 errors in production" → "Debugging production 500 errors"
-"refactor user service" → "Refactoring user service"
-"why is app.js failing" → "Analyzing app.js failure"
-"implement rate limiting" → "Implementing rate limiting"
+"debug 500 errors in production" → Debugging production 500 errors
+"refactor user service" → Refactoring user service
+"why is app.js failing" → Analyzing app.js failure
+"implement rate limiting" → Implementing rate limiting
 </examples>
 
-<format>
-Return only the thread title text on a single line with no newlines, explanations, or additional formatting.
-You should NEVER reply to the user's message. You can only generate titles.
-</format>
+Output the title now:


### PR DESCRIPTION
fixes: #2235

Tested a variety of prompts, sort ones, longer ones from issue, and then ones I have used in past.

Tried with: haiku, gemini 2.5 flash, and grok-code all 3 had good success with this.


This prompt isn't a huge deviation from previous ones but the end of prompt seems to help encourage llm to actually respond with title immediately due to: `Output the title now:` 