### PR TITLE
fix: ensure shell cmds can be properly aborted

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1141,11 +1141,17 @@ export namespace Session {
     const proc = spawn(shell, args, {
       cwd: app.path.cwd,
       signal: abort.signal,
+      detached: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
         TERM: "dumb",
       },
+    })
+
+    abort.signal.addEventListener("abort", () => {
+      if (!proc.pid) return
+      process.kill(-proc.pid)
     })
 
     let output = ""


### PR DESCRIPTION
fixes: #2337


Before, aborting shell commands only killed the main process, leaving child processes running. Now we kill the whole process group, so everything stops