### PR TITLE
docs: fix gopls LSP name in config

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -193,7 +193,7 @@ export namespace LSPServer {
   }
 
   export const Gopls: Info = {
-    id: "golang",
+    id: "gopls",
     root: async (file, app) => {
       const work = await NearestRoot(["go.work"])(file, app)
       if (work) return work

--- a/packages/web/src/content/docs/docs/lsp.mdx
+++ b/packages/web/src/content/docs/docs/lsp.mdx
@@ -15,7 +15,7 @@ opencode comes with several built-in LSP servers for popular languages:
 | ---------- | ---------------------------------------------------- | ----------------------------------- |
 | typescript | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project  |
 | eslint     | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project      |
-| golang     | .go                                                  | `go` command available              |
+| gopls      | .go                                                  | `go` command available              |
 | ruby-lsp   | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available |
 | pyright    | .py, .pyi                                            | `pyright` dependency installed      |
 | elixir-ls  | .ex, .exs                                            | `elixir` command available          |

--- a/packages/web/src/content/docs/docs/lsp.mdx
+++ b/packages/web/src/content/docs/docs/lsp.mdx
@@ -15,7 +15,7 @@ opencode comes with several built-in LSP servers for popular languages:
 | ---------- | ---------------------------------------------------- | ----------------------------------- |
 | typescript | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project  |
 | eslint     | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project      |
-| gopls      | .go                                                  | `go` command available              |
+| golang     | .go                                                  | `go` command available              |
 | ruby-lsp   | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available |
 | pyright    | .py, .pyi                                            | `pyright` dependency installed      |
 | elixir-ls  | .ex, .exs                                            | `elixir` command available          |


### PR DESCRIPTION
Using `gopls` in the `opencode.json` config isn't working, instead we need to use `golang`.

The matching is currently based on the `id` field in the LSP servers: https://github.com/rekram1-node/opencode-sst/blob/73792b37b122a87cae837178969ee82c61a904cb/packages/opencode/src/lsp/server.ts#L190

Although the column title seems to refer to the underlying LSP server name (e.g. for pyright), this naming follows the way `rust` LSP is documented below.