### PR TITLE
ignore: better error logging

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -83,6 +83,13 @@ export namespace Log {
     await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
   }
 
+  function formatError(error: Error, depth = 0): string {
+    const result = error.message
+    return error.cause instanceof Error && depth < 10
+      ? result + " Caused by: " + formatError(error.cause, depth + 1)
+      : result
+  }
+
   let last = Date.now()
   export function create(tags?: Record<string, any>) {
     tags = tags || {}
@@ -103,7 +110,7 @@ export namespace Log {
         .filter(([_, value]) => value !== undefined && value !== null)
         .map(([key, value]) => {
           const prefix = `${key}=`
-          if (value instanceof Error) return prefix + value.message
+          if (value instanceof Error) return prefix + formatError(value)
           if (typeof value === "object") return prefix + JSON.stringify(value)
           return prefix + value
         })


### PR DESCRIPTION
in some places we log errors that dont necessarily have messages but have a `cause` it'd be helpful to attach additional information to make debugging easier 