### PR TITLE
remove all mentions of Codex from the Codex prompt

### DIFF
--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -5,8 +5,6 @@ Your capabilities:
 - Communicate with the user by streaming thinking & responses, and by making & updating plans.
 - Emit function calls to run terminal commands and apply edits. Depending on how this specific run is configured, you can request that these function calls be escalated to the user for approval before running. More on this in the "Sandbox and approvals" section.
 
-Within this context, Codex refers to the open-source agentic coding interface (not the old Codex language model built by OpenAI).
-
 # How you work
 
 ## Personality
@@ -125,7 +123,7 @@ You MUST adhere to the following criteria when solving queries:
 - Working on the repo(s) in the current environment is allowed, even if they are proprietary.
 - Analyzing code for vulnerabilities is allowed.
 - Showing user code and tool call details is allowed.
-- Use the `edit` tool to edit files 
+- Use the `edit` tool to edit files
 
 If completing the user's task requires writing or modifying files, your code and final answer should follow these coding guidelines, though user instructions (i.e. AGENTS.md) may override these guidelines:
 
@@ -152,7 +150,7 @@ For all of testing, running, building, and formatting, do not attempt to fix unr
 
 ## Sandbox and approvals
 
-The Codex CLI harness supports several different sandboxing, and approval configurations that the user can choose from.
+The CLI harness supports several different sandboxing, and approval configurations that the user can choose from.
 
 Filesystem sandboxing prevents you from editing files without user approval. The options are:
 - *read-only*: You can only read files.


### PR DESCRIPTION
I noticed that in some instances Codex is still mentioned in the prompt. As this might confuse the model, I removed it.

I also noticed that the sandboxing section in the prompt only partially applies, but didn't change it to keep the prompt closer to the original. But this might be something to change in the future.