### PR TITLE
docs: update log level configuration in troubleshooting guide

### DIFF
--- a/packages/web/src/content/docs/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/docs/troubleshooting.mdx
@@ -17,7 +17,7 @@ Log files are written to:
 
 Log files are named with timestamps (e.g., `2025-01-09T123456.log`) and the most recent 10 log files are kept.
 
-You can configure the log level in your [config file](/docs/config#logging) to get more detailed debug information.
+You can set the log level with the `--log-level` command-line option to get more detailed debug information. For example, `opencode --log-level DEBUG`.
 
 ---
 


### PR DESCRIPTION
This PR addresses a missed update in the troubleshooting guide's log level configuration, following up on the changes from #1258.