### PR TITLE
fix: subdirectory subagents on local instance not being picked up

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -45,7 +45,7 @@ export namespace Config {
     result.agent = result.agent || {}
     const markdownAgents = [
       ...(await Filesystem.globUp("agent/**/*.md", Global.Path.config, Global.Path.config)),
-      ...(await Filesystem.globUp(".opencode/agent/*.md", Instance.directory, Instance.worktree)),
+      ...(await Filesystem.globUp(".opencode/agent/**/*.md", Instance.directory, Instance.worktree)),
     ]
     for (const item of markdownAgents) {
       const content = await Bun.file(item).text()


### PR DESCRIPTION
- Small fix making search pattern for markdown agents of the local instance to be similar to that of the Global config.

fixes: #2369 