### PR TITLE
Patch Start to preload route css in SSR

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "cloud/core": {
       "name": "@opencode/cloud-core",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@opencode/cloud-resource": "workspace:*",
@@ -43,7 +43,7 @@
     },
     "cloud/function": {
       "name": "@opencode/cloud-function",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@ai-sdk/anthropic": "2.0.0",
         "@ai-sdk/openai": "2.0.2",
@@ -69,7 +69,7 @@
     },
     "packages/function": {
       "name": "@opencode/function",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "22.0.0",
@@ -84,7 +84,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -134,7 +134,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
       },
@@ -145,7 +145,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@hey-api/openapi-ts": "0.81.0",
       },
@@ -157,7 +157,7 @@
     },
     "packages/web": {
       "name": "@opencode/web",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",
@@ -196,6 +196,9 @@
     "web-tree-sitter",
     "tree-sitter-bash",
   ],
+  "patchedDependencies": {
+    "@solidjs/start@1.1.7": "patches/@solidjs%2Fstart@1.1.7.patch",
+  },
   "overrides": {
     "zod": "3.25.76",
   },
@@ -477,7 +480,7 @@
 
     "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.0.6", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0", "lodash": "^4.17.21" } }, "sha512-yktiFZoWPtEW8QKS65eqKwA5MTKp88CyiL8q72WynrBs/73SAaxlSWlA2zW/DZlywZ5hX1OYzrCC0wFdvO9c2w=="],
 
-    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.81.0", "", { "dependencies": { "@hey-api/json-schema-ref-parser": "1.0.6", "ansi-colors": "4.1.3", "c12": "2.0.1", "color-support": "1.1.3", "commander": "13.0.0", "handlebars": "4.7.8", "js-yaml": "4.1.0", "open": "10.1.2", "semver": "7.7.2" }, "peerDependencies": { "typescript": "^5.5.3" }, "bin": { "openapi-ts": "bin/index.cjs" } }, "sha512-PoJukNBkUfHOoMDpN33bBETX49TUhy7Hu8Sa0jslOvFndvZ5VjQr4Nl/Dzjb9LG1Lp5HjybyTJMA6a1zYk/q6A=="],
+    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.80.1", "", { "dependencies": { "@hey-api/json-schema-ref-parser": "1.0.6", "ansi-colors": "4.1.3", "c12": "2.0.1", "color-support": "1.1.3", "commander": "13.0.0", "handlebars": "4.7.8", "open": "10.1.2", "semver": "7.7.2" }, "peerDependencies": { "typescript": "^5.5.3" }, "bin": { "openapi-ts": "bin/index.cjs" } }, "sha512-AC478kg36vmmrseLZNFonZ/cmXXmDzW5yWz4PVg1S8ebJsRtVRJ/QU+mtnXfzf9avN2P0pz/AO4WAe4jyFY2gA=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.4.2", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-1rrlBg+EpDPhzOV4hT9pxr5+xDVmKuz6YJl+la7VCwK6ass5ldyKm5fD+umJdV2zhHD6jROoCCv8NbTwyfhT0g=="],
 
@@ -3062,6 +3065,8 @@
     "@openauthjs/openauth/aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "@openauthjs/openauth/jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
+
+    "@opencode-ai/sdk/@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.81.0", "", { "dependencies": { "@hey-api/json-schema-ref-parser": "1.0.6", "ansi-colors": "4.1.3", "c12": "2.0.1", "color-support": "1.1.3", "commander": "13.0.0", "handlebars": "4.7.8", "js-yaml": "4.1.0", "open": "10.1.2", "semver": "7.7.2" }, "peerDependencies": { "typescript": "^5.5.3" }, "bin": { "openapi-ts": "bin/index.cjs" } }, "sha512-PoJukNBkUfHOoMDpN33bBETX49TUhy7Hu8Sa0jslOvFndvZ5VjQr4Nl/Dzjb9LG1Lp5HjybyTJMA6a1zYk/q6A=="],
 
     "@opencode/cloud-resource/@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250830.0", "", {}, "sha512-uAGZFqEBFnCiwIokxMnrrtjIkT8qyGT1LACSScEUyW7nKmtD0Viykp9QZWrIlssyEp/MDB6XsdALF8y6upxpcg=="],
 

--- a/package.json
+++ b/package.json
@@ -55,5 +55,7 @@
   "overrides": {
     "zod": "3.25.76"
   },
-  "patchedDependencies": {}
+  "patchedDependencies": {
+  "@solidjs/start@1.1.7": "patches/@solidjs%2Fstart@1.1.7.patch"
+}
 }

--- a/patches/@solidjs%2Fstart@1.1.7.patch
+++ b/patches/@solidjs%2Fstart@1.1.7.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/server/StartServer.jsx b/dist/server/StartServer.jsx
+index 0c6a9fe3121a88520db252570a8b5997a36e0452..b3479cdb78c70d7a655d302d8e6ab536b4ff07a3 100644
+--- a/dist/server/StartServer.jsx
++++ b/dist/server/StartServer.jsx
+@@ -52,11 +52,11 @@ export function StartServer(props) {
+             else if (import.meta.env.DEV)
+                 console.warn("No route matched for preloading js assets");
+         }
+-        assets = await Promise.all(assetPromises).then(a => 
++        assets = await Promise.all(assetPromises).then(a =>
+         // dedupe assets
+         [...new Map(a.flat().map(item => [item.attrs.key, item])).values()].filter(asset => import.meta.env.START_ISLANDS
+             ? false
+-            : asset.attrs.rel === "modulepreload" &&
++            : (asset.attrs.rel === "modulepreload" || asset.attrs.rel === "stylesheet") &&
+                 !context.assets.find((a) => a.attrs.key === asset.attrs.key)));
+     });
+     useAssets(() => (assets.length ? assets.map(m => renderAsset(m)) : undefined));


### PR DESCRIPTION
Solid Start currently doesn't preload CSS imported by route files in SSR, resulting in FOUC in production.
While this will be addressed by other changes in devinxi, here's a temporary fix that will add `<link rel="stylesheet">` for the appropriate route's CSS.