### PR TITLE
feat(apikey): Allow apikeys loaded from commands

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -20,6 +20,13 @@ export namespace Auth {
     })
     .meta({ ref: "ApiAuth" })
 
+  export const Cmd = z
+    .object({
+      type: z.literal("cmd"),
+      command: z.array(z.string()),
+    })
+    .meta({ ref: "CmdAuth" })
+
   export const WellKnown = z
     .object({
       type: z.literal("wellknown"),
@@ -28,7 +35,7 @@ export namespace Auth {
     })
     .meta({ ref: "WellKnownAuth" })
 
-  export const Info = z.discriminatedUnion("type", [Oauth, Api, WellKnown]).meta({ ref: "Auth" })
+  export const Info = z.discriminatedUnion("type", [Oauth, Api, Cmd, WellKnown]).meta({ ref: "Auth" })
   export type Info = z.infer<typeof Info>
 
   const filepath = path.join(Global.Path.data, "auth.json")

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -10,6 +10,39 @@ import { Global } from "../../global"
 import { Plugin } from "../../plugin"
 import { Instance } from "../../project/instance"
 
+// Simple command parser that handles quoted strings
+function parseCommand(input: string): string[] {
+  const args: string[] = []
+  let current = ""
+  let inQuotes = false
+  let quoteChar = ""
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i]
+
+    if (!inQuotes && (char === '"' || char === "'")) {
+      inQuotes = true
+      quoteChar = char
+    } else if (inQuotes && char === quoteChar) {
+      inQuotes = false
+      quoteChar = ""
+    } else if (!inQuotes && char === " ") {
+      if (current) {
+        args.push(current)
+        current = ""
+      }
+    } else {
+      current += char
+    }
+  }
+
+  if (current) {
+    args.push(current)
+  }
+
+  return args.filter((arg) => arg.length > 0)
+}
+
 export const AuthCommand = cmd({
   command: "auth",
   describe: "manage credentials",
@@ -253,16 +286,46 @@ export const AuthLoginCommand = cmd({
         prompts.log.info("You can create an api key at https://vercel.link/ai-gateway-token")
       }
 
-      const key = await prompts.password({
-        message: "Enter your API key",
+      const authMethod = await prompts.select({
+        message: "How would you like to provide the API key?",
+        options: [
+          { label: "Enter API key directly", value: "direct" },
+          { label: "Run a command to get the API key", value: "command" },
+        ],
+      })
+      if (prompts.isCancel(authMethod)) throw new UI.CancelledError()
+
+      if (authMethod === "direct") {
+        const key = await prompts.password({
+          message: "Enter your API key",
+          validate: (x) => (x && x.length > 0 ? undefined : "Required"),
+        })
+        if (prompts.isCancel(key)) throw new UI.CancelledError()
+        await Auth.set(provider, {
+          type: "api",
+          key,
+        })
+        prompts.outro("Done")
+        return
+      }
+
+      const commandInput = await prompts.text({
+        message: "Enter the command to run (e.g., 'op read op://vault/item')",
         validate: (x) => (x && x.length > 0 ? undefined : "Required"),
       })
-      if (prompts.isCancel(key)) throw new UI.CancelledError()
-      await Auth.set(provider, {
-        type: "api",
-        key,
-      })
+      if (prompts.isCancel(commandInput)) throw new UI.CancelledError()
 
+      // Parse command string into array with proper quote handling
+      const command = parseCommand(commandInput)
+      if (command.length === 0) {
+        prompts.log.error("Invalid command")
+        return
+      }
+
+      await Auth.set(provider, {
+        type: "cmd",
+        command,
+      })
       prompts.outro("Done")
     })
   },

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -261,7 +261,43 @@ export namespace Provider {
       if (disabled.has(providerID)) continue
       if (provider.type === "api") {
         mergeProvider(providerID, { apiKey: provider.key }, "api")
+        continue
       }
+      if (provider.type !== "cmd") continue
+
+      // Basic security validation
+      const command = provider.command[0]
+      if (!command || typeof command !== "string") {
+        log.error("invalid command", { providerID, command })
+        continue
+      }
+
+      // Prevent potentially dangerous commands
+      const dangerousCommands = ["rm", "del", "format", "fdisk", "mkfs", "dd", "shred"]
+      if (dangerousCommands.some((cmd) => command.includes(cmd))) {
+        log.error("command contains potentially dangerous operation", { providerID, command })
+        continue
+      }
+
+      log.info("executing command for", { providerID, command: provider.command.join(" ") })
+      const proc = Bun.spawn({
+        cmd: provider.command,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const exit = await proc.exited
+      if (exit !== 0) {
+        const stderr = await new Response(proc.stderr).text()
+        log.error("command failed", { providerID, exit, stderr })
+        continue
+      }
+      const apiKey = (await new Response(proc.stdout).text()).trim()
+      if (!apiKey) {
+        log.error("command produced empty output", { providerID })
+        continue
+      }
+      mergeProvider(providerID, { apiKey }, "api")
+      log.info("command executed successfully", { providerID })
     }
 
     // load custom


### PR DESCRIPTION
Heyo, hopefully you don't consider this new functionality, but feel free to reject if you have another plan. Still, I'm filing this under either "fixes for env specific quirks" (this enables environments that load secrets differently) or "missing standard behavior" (some tools that also use api keys already provide this (or similar methods) for loading secrets).

The big thing this partially/kinda helps protect against is rogue users skimming keys. For security reasons, many users avoid leaving secrets in plain text or even environment variables. Some tooling will allow reading secrets from a command instead. For example, [gp.nvim's instructions for password managers](https://github.com/Robitx/gp.nvim?tab=readme-ov-file), or [CodeCompanion's "cmd:" prefix](https://codecompanion.olimorris.dev/configuration/adapters.html#setting-an-api-key)

**The main change here is to allow api keys to (also) be loaded from the output of a command.** `auth.json` would allow for a new "type" of apikey: `cmd`, with the value saved as an array (command plus args). The `opencode auth login` command is also updated to now let you users pick whether to paste just a key, or use the new command format.

Here's what it looks like:

- Configure opencode provider (`opencode auth login` and when it's time for the key, choose to enter a command instead.
- The 1password command I use is `op read "op://some vault/some key/password"`. [See their docs.](https://developer.1password.com/docs/cli/reference/commands/read/)
- The value saved for the provider in `~/.local/share/opencode/auth.json` is saved as an array: `['op', 'read', "op://some vault/some key/password"]` (with type "cmd")
- When I start opencode, if 1password is currently locked I'm prompted to unlock. Once unlocked, if my 1password has access to that key path, then the key is handed to opencode for that session.
- If I shut down and lock my system, then I'll have to re-auth again the next time I try to load that value