### PR TITLE
fix: file fuzzy search

### DIFF
--- a/packages/tui/internal/components/dialog/complete.go
+++ b/packages/tui/internal/components/dialog/complete.go
@@ -94,7 +94,7 @@ func (c *completionDialogComponent) getAllCompletions(query string) tea.Cmd {
 		}
 
 		// If there's a query, fuzzy-rank within each provider, then concatenate by provider order
-		if query != "" && providersWithResults > 0 {
+		if query != "" && providersWithResults > 1 {
 			t := theme.CurrentTheme()
 			baseStyle := styles.NewStyle().Background(t.BackgroundElement())
 


### PR DESCRIPTION
All of the completion providers already do ordering, if there is only 1 provider we don't need to reshuffle again.

The most noticeable improvement here is for @ w/ file searches. Because the BE already uses rg to filter/sort w/ the user query, resorting with fuzzy gives worse results 

Fixes: #2388