### PR TITLE
feat: add createOpencodeTui() function to SDK for programmatic TUI launching

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -9,6 +9,15 @@ export type ServerOptions = {
   config?: Config
 }
 
+export type TuiOptions = {
+  project?: string
+  model?: string
+  session?: string
+  agent?: string
+  signal?: AbortSignal
+  config?: Config
+}
+
 export async function createOpencodeServer(options?: ServerOptions) {
   options = Object.assign(
     {
@@ -72,6 +81,38 @@ export async function createOpencodeServer(options?: ServerOptions) {
 
   return {
     url,
+    close() {
+      proc.kill()
+    },
+  }
+}
+
+export function createOpencodeTui(options?: TuiOptions) {
+  const args = []
+
+  if (options?.project) {
+    args.push(`--project=${options.project}`)
+  }
+  if (options?.model) {
+    args.push(`--model=${options.model}`)
+  }
+  if (options?.session) {
+    args.push(`--session=${options.session}`)
+  }
+  if (options?.agent) {
+    args.push(`--agent=${options.agent}`)
+  }
+
+  const proc = spawn(`opencode`, args, {
+    signal: options?.signal,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      OPENCODE_CONFIG_CONTENT: JSON.stringify(options?.config ?? {}),
+    },
+  })
+
+  return {
     close() {
       proc.kill()
     },


### PR DESCRIPTION
This PR adds a new `createOpencodeTui()` function to the JavaScript SDK that allows programmatic launching of the opencode TUI interface.

## Changes
- Added `TuiOptions` type with optional `project`, `model`, `session`, and `agent` parameters
- Added `createOpencodeTui()` function that spawns the opencode TUI process with inherited stdio
- Function takes over the current terminal for interactive TUI experience

## Usage
```javascript
import { createOpencodeTui } from '@opencode/sdk'

const tui = createOpencodeTui({
  project: '/path/to/project',
  model: 'claude-3-5-sonnet',
  session: 'session-id',
  agent: 'agent-name'
})
```

The TUI will launch and take over the current terminal, providing an interactive coding experience.