### PR TITLE
Use Bun.which to locate opencode command

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -28,7 +28,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
     options ?? {},
   )
 
-  const proc = spawn(`opencode`, [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`], {
+  const proc = spawn(Bun.which(`opencode`), [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`], {
     signal: options.signal,
     env: {
       ...process.env,


### PR DESCRIPTION
This pull request makes a targeted improvement to the `createOpencodeServer` function by ensuring that the `opencode` executable is located using Bun's `which` utility, rather than relying on the system path. This change increases reliability when spawning the server process.

- Improved process spawning:
  * Updated the `spawn` call in `server.ts` to use `Bun.which('opencode')` for locating the `opencode` executable, ensuring the correct binary is used.

## Reasoning

Currently i have never been able to successfully use createOpencodeServer without forking the file over and performing some modification. Bun.which should solve this by giving an absolute path to the opencode binary