### PR TITLE
Make NPM package install work on Windows

### DIFF
--- a/packages/opencode/bin/opencode.cmd
+++ b/packages/opencode/bin/opencode.cmd
@@ -52,5 +52,7 @@ echo It seems that your package manager failed to install the right version of t
 exit /b 1
 
 :execute
-rem Execute the binary with all arguments
-"%resolved%" %*
+rem Execute the binary with all arguments in the same console window
+rem Use start /b /wait to ensure it runs in the current shell context for all shells
+start /b /wait "" "%resolved%" %*
+exit /b %ERRORLEVEL%

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -72,7 +72,7 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
     {
       name: pkg.name + "-ai",
       bin: {
-        [pkg.name]: `./bin/${pkg.name}`,
+        [pkg.name]: `./bin/${pkg.name}${process.platform === "win32" ? ".cmd" : ""}`,
       },
       scripts: {
         postinstall: "node ./postinstall.mjs",


### PR DESCRIPTION
### Current Issue

Installing opencode via `<npm|bun> install -g opencode-ai` on Windows and then running `opencode` displays the following message - 

```
& : The term '/bin/sh.exe' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\Username\AppData\Roaming\npm\opencode.ps1:24 char:7
+     & "/bin/sh$exe"  "$basedir/node_modules/opencode-ai/bin/opencode" ...
+       ~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (/bin/sh.exe:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

This happens because npm looks at the `bin/opencode` command which is a unix shell script, sees the `#!/bin/sh` shebang and generates wrappers for that instead of looking at `bin/opencode.cmd`.

### Fix
1. Updated bin entrypoint: Modified `publish.ts` to use the `.cmd` extension for Windows in the `package.json` bin field, ensuring npm correctly identifies it as a Windows batch file
2. Fixed batch file execution: Updated `opencode.cmd` to use `start /b /wait` to ensure the binary runs in the current terminal context across all shells (PowerShell, cmd, Git Bash)

### NPM Wrapper

**Before**
```powershell
...
if ($MyInvocation.ExpectingInput) {
  $input | & "/bin/sh$exe"  "$basedir/node_modules/opencode-ai/bin/opencode" $args
} else {
  & "/bin/sh$exe"  "$basedir/node_modules/opencode-ai/bin/opencode" $args
}
```

**After**
```powershell
...
if ($MyInvocation.ExpectingInput) {
  $input | & "$basedir/node_modules/opencode-ai/bin/opencode.cmd"   $args
} else {
  & "$basedir/node_modules/opencode-ai/bin/opencode.cmd"   $args
}
```

I've tested this on Windows and MacOS with both npm and bun and it seems like the fix works on Windows and does not break anything on MacOS