### PR TITLE
feat: make npm package install work on windows

### DIFF
--- a/packages/opencode/bin/opencode.cmd
+++ b/packages/opencode/bin/opencode.cmd
@@ -52,5 +52,7 @@ echo It seems that your package manager failed to install the right version of t
 exit /b 1
 
 :execute
-rem Execute the binary with all arguments
-"%resolved%" %*
+rem Execute the binary with all arguments in the same console window
+rem Use start /b /wait to ensure it runs in the current shell context for all shells
+start /b /wait "" "%resolved%" %*
+exit /b %ERRORLEVEL%

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -70,6 +70,11 @@ function findBinary() {
 
 function main() {
   try {
+    if (os.platform() === "win32") {
+      console.log("Windows detected, skipping postinstall")
+      return
+    }
+
     const binaryPath = findBinary()
     const binScript = path.join(__dirname, "bin", "opencode")
 

--- a/packages/opencode/script/preinstall.mjs
+++ b/packages/opencode/script/preinstall.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import fs from "fs"
+import path from "path"
+import os from "os"
+import { fileURLToPath } from "url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function main() {
+  if (os.platform() !== "win32") {
+    console.log("Non-Windows platform detected, skipping preinstall")
+    return
+  }
+
+  const binDir = path.join(__dirname, "bin")
+  const unixScript = path.join(binDir, "opencode")
+
+  console.log("Windows detected: Configuring bin scripts for Windows")
+
+  if (fs.existsSync(unixScript)) {
+    console.log("Removing Unix shell script from bin/")
+    fs.unlinkSync(unixScript)
+  }
+}
+
+try {
+  main()
+} catch (error) {
+  console.error("Preinstall script error:", error.message)
+  process.exit(0)
+}

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -66,15 +66,17 @@ for (const [os, arch] of targets) {
 
 await $`mkdir -p ./dist/${pkg.name}`
 await $`cp -r ./bin ./dist/${pkg.name}/bin`
+await $`cp ./script/preinstall.mjs ./dist/${pkg.name}/preinstall.mjs`
 await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 await Bun.file(`./dist/${pkg.name}/package.json`).write(
   JSON.stringify(
     {
       name: pkg.name + "-ai",
       bin: {
-        [pkg.name]: `./bin/${pkg.name}`,
+        [pkg.name]: `./bin/${pkg.name}${process.platform === "win32" ? ".cmd" : ""}`,
       },
       scripts: {
+        preinstall: "node ./preinstall.mjs",
         postinstall: "node ./postinstall.mjs",
       },
       version,

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -73,7 +73,7 @@ await Bun.file(`./dist/${pkg.name}/package.json`).write(
     {
       name: pkg.name + "-ai",
       bin: {
-        [pkg.name]: `./bin/${pkg.name}${process.platform === "win32" ? ".cmd" : ""}`,
+        [pkg.name]: `./bin/${pkg.name}`,
       },
       scripts: {
         preinstall: "node ./preinstall.mjs",


### PR DESCRIPTION
### Current Issue

Installing opencode via `<npm|bun> install -g opencode-ai` on Windows is a little broken (#631) 

Output -
```
& : The term '/bin/sh.exe' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\Username\AppData\Roaming\npm\opencode.ps1:24 char:7
+     & "/bin/sh$exe"  "$basedir/node_modules/opencode-ai/bin/opencode" ...
+       ~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (/bin/sh.exe:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

This happens because npm looks at the `bin/opencode` command which is a unix shell script, sees the `#!/bin/sh` shebang and generates wrappers for that instead of looking at `bin/opencode.cmd`.

### Fix
1. Add a `preinstall.mjs` hook to the package which only runs on Windows - this hook runs before the npm wrappers are generated and it's sole purpose is to the remove the `bin/opencode` unix shell script.
2. Update `postinstall.mjs` to skip running on Windows. By avoiding binary symlinking, we ensure that the package's entrypoint is `bin/opencode.cmd` and that the namespace doesn't get muddled.
3. Fixed batch file execution: Updated `opencode.cmd` to use `start /b /wait` to ensure the binary runs in the current terminal context across all shells (PowerShell, cmd, Git Bash)

### NPM Wrapper

**Before**
```powershell
...
if ($MyInvocation.ExpectingInput) {
  $input | & "/bin/sh$exe"  "$basedir/node_modules/opencode-ai/bin/opencode" $args
} else {
  & "/bin/sh$exe"  "$basedir/node_modules/opencode-ai/bin/opencode" $args
}
```

**After**
```powershell
...
if ($MyInvocation.ExpectingInput) {
  $input | & "$basedir/node_modules/opencode-ai/bin/opencode.cmd"   $args
} else {
  & "$basedir/node_modules/opencode-ai/bin/opencode.cmd"   $args
}
```

I've tested this on Windows and MacOS with both npm and bun and it seems like the fix works on Windows and does not break anything on MacOS