### PR TITLE
fix: webfetch prompt mistake

### DIFF
--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -5,7 +5,7 @@
 - Use this tool when you need to retrieve and analyze web content
 
 Usage notes:
-  - IMPORTANT: If an MCP-provided web fetch tool is available, prefer using that tool instead of this one, as it may have fewer restrictions. All MCP-provided tools start with "mcp__".
+  - IMPORTANT: if another tool is present that offers better web fetching capabilities, is more targeted to the task, or has fewer restrictions, prefer using that tool instead of this one.
   - The URL must be a fully-formed valid URL
   - HTTP URLs will be automatically upgraded to HTTPS
   - The prompt should describe what information you want to extract from the page


### PR DESCRIPTION
fixes:  #2421

mcp servers don't have an mcp prefix
