### PR TITLE
fix: Only block paths outside working dir if non prompting

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -88,9 +88,12 @@ export const BashTool = Tool.define("bash", {
             .then((x) => x.trim())
           log.info("resolved path", { arg, resolved })
           if (resolved && !Filesystem.contains(Instance.directory, resolved)) {
-            throw new Error(
-              `This command references paths outside of ${Instance.directory} so it is not allowed to be executed.`,
-            )
+            const action = Wildcard.all(resolved, permissions)
+            if (action !== "ask") {
+              throw new Error(
+                `This command references paths outside of ${Instance.directory} so it is not allowed to be executed.`,
+              )
+            }
           }
         }
       }


### PR DESCRIPTION
This modifies the blocking of access outside of the working dir to allow `ask` permissions since the user has an opportunity to review the command being executed.

I often go outside of the working dir if I have the model create files in /tmp or am debugging a system issue where it needs to read config files in /etc.