### PR TITLE
fix: default to last used model

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -450,7 +450,12 @@ export namespace Provider {
           }
         }
       })
-      .catch(() => undefined)
+      .catch((error) => {
+        log.error("failed to find last used model", {
+          error,
+        })
+        return undefined
+      })
 
     if (lastused) return lastused
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -425,6 +425,9 @@ export namespace Provider {
 
     // this will be adjusted when migration to opentui is complete,
     // for now we just read the tui state toml file directly
+    //
+    // NOTE: cannot just import file as toml without cleaning due to lack of
+    // support for date/time references in Bun toml parser: https://github.com/oven-sh/bun/issues/22426
     const lastused = await Bun.file(path.join(Global.Path.state, "tui"))
       .text()
       .then((text) => {


### PR DESCRIPTION
fixes: #2439, #736


**The thing is we can't use the bun toml parser directly because it breaks for all date / time values that aren't wrapped in strings.**

These values are valid TOML tho, see: https://toml.io/en/v1.0.0#offset-date-time

I filed a bug report in bun repo to track support for date / time things 