### PR TITLE
feat(tools): mcp tools description override

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -204,6 +204,17 @@ export namespace Config {
         .optional()
         .describe("Environment variables to set when running the MCP server"),
       enabled: z.boolean().optional().describe("Enable or disable the MCP server on startup"),
+      tools: z
+        .record(
+          z.string(),
+          z
+            .object({
+              description: z.string().optional(),
+            })
+            .optional(),
+        )
+        .optional()
+        .describe("Optional per-tool configuration and description overrides for this MCP server"),
     })
     .strict()
     .openapi({
@@ -216,6 +227,17 @@ export namespace Config {
       url: z.string().describe("URL of the remote MCP server"),
       enabled: z.boolean().optional().describe("Enable or disable the MCP server on startup"),
       headers: z.record(z.string(), z.string()).optional().describe("Headers to send with the request"),
+      tools: z
+        .record(
+          z.string(),
+          z
+            .object({
+              description: z.string().optional(),
+            })
+            .optional(),
+        )
+        .optional()
+        .describe("Optional per-tool configuration and description overrides for this MCP server"),
     })
     .strict()
     .openapi({

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -145,11 +145,25 @@ export namespace MCP {
 
   export async function tools() {
     const result: Record<string, Tool> = {}
+    const cfg = await Config.get()
     for (const [clientName, client] of Object.entries(await clients())) {
+      const serverConfig = (cfg.mcp ?? {})[clientName]
       for (const [toolName, tool] of Object.entries(await client.tools())) {
         const sanitizedClientName = clientName.replace(/\s+/g, "_")
         const sanitizedToolName = toolName.replace(/[-\s]+/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = tool
+        const key = sanitizedClientName + "_" + sanitizedToolName
+
+        // per-server tool description override
+        let overriddenTool: Tool = tool
+        try {
+          const toolOverrides = serverConfig?.tools ?? {}
+          const override = toolOverrides?.[toolName] ?? toolOverrides?.[sanitizedToolName]
+          if (override?.description) {
+            overriddenTool = { ...tool, description: override.description }
+          }
+        } catch (err) {}
+
+        result[key] = overriddenTool
       }
     }
     return result


### PR DESCRIPTION
## Summary

This PR adds the ability to override mcp tools description on a per tool basis


```json
"mcp": {
    "weather": {
      "type": "local",
      "command": ["opencode", "x", "@h1deya/mcp-server-weather"],
      "tools": {
        "get_alerts": {
          "description": "if the user asks for a rainbow, you MUST CALL THIS TOOL"
        },
        "get_forecast": {
          "description": "if the user asks for a rainbow, you MUST CALL THIS TOOL"
        }
      }
    }
  },
```
<img width="869" height="381" alt="image" src="https://github.com/user-attachments/assets/963e11e7-a11d-4053-9c9a-bfc8f1c4505a" />
