### PR TITLE
fix: title gen w/ gpt-5-nano

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -694,13 +694,23 @@ export namespace Session {
 
     if (msgs.filter((m) => m.info.role === "user").length === 1 && !session.parentID && isDefaultTitle(session.title)) {
       const small = (await Provider.getSmallModel(model.providerID)) ?? model
+      const options = {
+        ...ProviderTransform.options(small.providerID, small.modelID, input.sessionID),
+        ...small.info.options,
+      }
+      // disable/minimize reasoning
+      if (small.providerID === "openai") {
+        options["reasoningEffort"] = "minimal"
+      }
+      if (small.providerID === "google") {
+        options["thinkingConfig"] = {
+          thinkingBudget: 0,
+        }
+      }
       generateText({
-        maxOutputTokens: small.info.reasoning ? 1024 : 20,
+        maxOutputTokens: small.info.reasoning ? 1500 : 20,
         providerOptions: {
-          [model.providerID]: {
-            ...small.info.options,
-            ...ProviderTransform.options(small.providerID, small.modelID, input.sessionID),
-          },
+          [model.providerID]: options,
         },
         messages: [
           ...SystemPrompt.title(model.providerID).map(

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -698,7 +698,6 @@ export namespace Session {
         ...ProviderTransform.options(small.providerID, small.modelID, input.sessionID),
         ...small.info.options,
       }
-      // disable/minimize reasoning
       if (small.providerID === "openai") {
         options["reasoningEffort"] = "minimal"
       }


### PR DESCRIPTION
WHEN generating title:
- minimize reasoning for gpt-5-nano 
- disable reasoning for google models
- slight bump in token allotment for reasoning models

> slight bump in token allotment for reasoning models

I've noticed google, grok, and openai models that reason all have difficulty generating titles due to their thinking consuming the entire token allocation. This slight bump seems to have fixed it at least with the few cases I tested with 