### PR TITLE
fix: Allows reasoning to be reused in responses API.

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1440,7 +1440,7 @@ export namespace Session {
                 if (match && match.state.status === "running") {
                   await updatePart({
                     ...match,
-                    metadata:value.providerMetadata,
+                    // metadata:value.providerMetadata,
                     state: {
                       status: "completed",
                       input: value.input,

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1422,6 +1422,7 @@ export namespace Session {
                   const part = await updatePart({
                     ...match,
                     tool: value.toolName,
+                    metadata:value.providerMetadata,
                     state: {
                       status: "running",
                       input: value.input,
@@ -1439,6 +1440,7 @@ export namespace Session {
                 if (match && match.state.status === "running") {
                   await updatePart({
                     ...match,
+                    metadata:value.providerMetadata,
                     state: {
                       status: "completed",
                       input: value.input,
@@ -1526,6 +1528,7 @@ export namespace Session {
                   id: Identifier.ascending("part"),
                   messageID: assistantMsg.id,
                   sessionID: assistantMsg.sessionID,
+                  metadata:value.providerMetadata,
                   type: "text",
                   text: "",
                   time: {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1440,7 +1440,6 @@ export namespace Session {
                 if (match && match.state.status === "running") {
                   await updatePart({
                     ...match,
-                    // metadata:value.providerMetadata,
                     state: {
                       status: "completed",
                       input: value.input,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -108,6 +108,7 @@ export namespace MessageV2 {
     type: z.literal("text"),
     text: z.string(),
     synthetic: z.boolean().optional(),
+    metadata: z.record(z.any()).optional(),
     time: z
       .object({
         start: z.number(),
@@ -135,6 +136,7 @@ export namespace MessageV2 {
   export const ToolPart = PartBase.extend({
     type: z.literal("tool"),
     callID: z.string(),
+    metadata: z.record(z.any()).optional(),
     tool: z.string(),
     state: ToolState,
   }).openapi({
@@ -503,44 +505,68 @@ export namespace MessageV2 {
       }
 
       if (msg.info.role === "assistant") {
+        const seenReasoningIds = new Set<string>()
         result.push({
           id: msg.info.id,
           role: "assistant",
           parts: msg.parts.flatMap((part): UIMessage["parts"] => {
-            if (part.type === "text")
+            if (part.type === "text") {
               return [
                 {
                   type: "text",
+                  providerMetadata: part.metadata,
                   text: part.text,
                 },
               ]
-            if (part.type === "step-start")
+            }
+            if (part.type === "step-start") {
               return [
                 {
                   type: "step-start",
                 },
               ]
+            }
             if (part.type === "tool") {
-              if (part.state.status === "completed")
+              if (part.state.status === "completed") {
                 return [
                   {
                     type: ("tool-" + part.tool) as `tool-${string}`,
                     state: "output-available",
+                    callProviderMetadata: part.metadata,
                     toolCallId: part.callID,
                     input: part.state.input,
                     output: part.state.output,
                   },
                 ]
-              if (part.state.status === "error")
+              }
+              if (part.state.status === "error") {
                 return [
                   {
                     type: ("tool-" + part.tool) as `tool-${string}`,
                     state: "output-error",
+                    callProviderMetadata: part.metadata,
                     toolCallId: part.callID,
                     input: part.state.input,
                     errorText: part.state.error,
                   },
                 ]
+              }
+            }
+            if (part.type === "reasoning") {
+              const itemId = part.metadata?.openai?.itemId
+              if (itemId && seenReasoningIds.has(itemId)) {
+                return []
+              }
+              if (itemId) {
+                seenReasoningIds.add(itemId)
+              }
+              return [
+                {
+                  type: "reasoning",
+                  text: part.text,
+                  providerMetadata: part.metadata
+                },
+              ]
             }
 
             return []

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -553,7 +553,7 @@ export namespace MessageV2 {
               }
             }
             if (part.type === "reasoning") {
-              const itemId = part.metadata?.openai?.itemId
+              const itemId = part.metadata?.["openai"]?.itemId
               if (itemId && seenReasoningIds.has(itemId)) {
                 return []
               }


### PR DESCRIPTION
Allows openAI reasoning chains to be passed back to the responses API. Uses the itemId if `store:true` and encrypted  content if set to false and    `include: ["reasoning.encrypted_content"]` is used. 

Expect an error like:
```
AI_APICallError: Item with id 'rs_68be1138d72081a18f8e81b24c59fcba00cd1de26313e896' not found. Items are not persisted when `store` is
set to false. Try again with `store` set to true, or remove this item from your input.
```

if store is false and encrypted content is not passed.

Had to debug this issue in the process. Adding ItemIds solved this.
https://github.com/vercel/ai/issues/7099#issuecomment-3066153760


Motivated by:
https://x.com/prashantmital/status/1963801245115904232

```
[@prashantmital](https://x.com/prashantmital)

[Sep 4](https://x.com/prashantmital/status/1963801245115904232)
myth #3: model intelligence is the same regardless of whether you use completions or responses

wrong again.

responses was built for thinking models that call tools within their chain-of-thought (CoT). responses allows persisting the CoT between model invocations when calling tools agentically -- the result is a more intelligent model, and much higher cache utilization; we saw cache rates jump from 40-80% on some workloads.

this one is perhaps the most egregious. developers don't realize how much performance they are leaving on the table. i get it, its hard because you use LiteLLM or some custom harness you built around chat completions or whatever, but prioritizing the switch is crucial if you want GPT-5 to be maximally performant in your agents.

here's our cookbook on function calling with responses:
```
