### PR TITLE
fix: silent error if bad flag was passed

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -84,7 +84,11 @@ const cli = yargs(hideBin(process.argv))
   .command(ExportCommand)
   .command(GithubCommand)
   .fail((msg) => {
-    if (msg.startsWith("Unknown argument") || msg.startsWith("Not enough non-option arguments")) {
+    if (
+      msg.startsWith("Unknown argument") ||
+      msg.startsWith("Not enough non-option arguments") ||
+      msg.startsWith("Invalid values:")
+    ) {
       cli.showHelp("log")
     }
     process.exit(1)


### PR DESCRIPTION
saw someone from Effect tweet that when they ran:

```
opencode --log-level debug ....
```

nothing happened


This fixes that 