### PR TITLE
add check for govcloud

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -81,7 +81,8 @@ export namespace Provider {
           switch (regionPrefix) {
             case "us": {
               const modelRequiresPrefix = ["claude", "deepseek"].some((m) => modelID.includes(m))
-              if (modelRequiresPrefix) {
+              const isGovCloud = region.startsWith("us-gov")
+              if (modelRequiresPrefix && !isGovCloud) {
                 modelID = `${regionPrefix}.${modelID}`
               }
               break


### PR DESCRIPTION
This PR adds a check to see if the US region is actually govcloud and if so then it does not add a prefix. I tried to match the style in the rest of the code but let me know if you want it changed.

Closes #2481 