### PR TITLE
remove edit tool from plan agent

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -50,7 +50,7 @@ export namespace Agent {
 
     const planPermission = mergeAgentPermissions(
       {
-        edit: "ask",
+        edit: "deny",
         bash: "ask",
         webfetch: "allow",
       },


### PR DESCRIPTION
Discussed w/ Dax:

Plan agent originally had edit tool to create plan .md files but it does a shit job at that, so we are removing the tool altogether 