### PR TITLE
feat(sdk): enhance createOpencodeTui with all CLI options

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -12,8 +12,14 @@ export type ServerOptions = {
 export type TuiOptions = {
   project?: string
   model?: string
+  continue?: boolean
   session?: string
+  prompt?: string
   agent?: string
+  port?: number
+  hostname?: string
+  printLogs?: boolean
+  logLevel?: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
   signal?: AbortSignal
   config?: Config
 }
@@ -91,16 +97,34 @@ export function createOpencodeTui(options?: TuiOptions) {
   const args = []
 
   if (options?.project) {
-    args.push(`--project=${options.project}`)
+    args.push(options.project)
   }
   if (options?.model) {
-    args.push(`--model=${options.model}`)
+    args.push('--model', options.model)
+  }
+  if (options?.continue) {
+    args.push('--continue')
   }
   if (options?.session) {
-    args.push(`--session=${options.session}`)
+    args.push('--session', options.session)
+  }
+  if (options?.prompt) {
+    args.push('--prompt', options.prompt)
   }
   if (options?.agent) {
-    args.push(`--agent=${options.agent}`)
+    args.push('--agent', options.agent)
+  }
+  if (options?.port !== undefined) {
+    args.push('--port', String(options.port))
+  }
+  if (options?.hostname) {
+    args.push('--hostname', options.hostname)
+  }
+  if (options?.printLogs) {
+    args.push('--print-logs')
+  }
+  if (options?.logLevel) {
+    args.push('--log-level', options.logLevel)
   }
 
   const proc = spawn(`opencode`, args, {


### PR DESCRIPTION
## Summary
- Enhanced `TuiOptions` type to include all available CLI options
- Updated `createOpencodeTui` function to properly pass through all options
- Added support for: continue, prompt, port, hostname, printLogs, and logLevel options

## Changes
- Expanded `TuiOptions` interface with all CLI flags from the TUI command
- Modified argument building in `createOpencodeTui` to use proper CLI flag format
- Each option is now correctly formatted with appropriate flag prefixes