### PR TITLE
Disable `BlockAnchorReplacer` edit replacer

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -599,7 +599,7 @@ export function replace(content: string, oldString: string, newString: string, r
   for (const replacer of [
     SimpleReplacer,
     LineTrimmedReplacer,
-    BlockAnchorReplacer,
+    // BlockAnchorReplacer,
     WhitespaceNormalizedReplacer,
     IndentationFlexibleReplacer,
     EscapeNormalizedReplacer,


### PR DESCRIPTION
Fix #2433 

Let's try disabling this tool, Claude Code currently does a super simple search replace. Adding more heuristics only confuses the model. Better have the edit fail than create invalid code that model is not aware of