### PR TITLE
Provide configuration options to the project tree in system prompt

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -503,6 +503,7 @@ export namespace Config {
             .object({
               limit: z.number().int().min(0).optional(),
               glob: z.array(z.string()).optional(),
+              format: z.string().optional(),
             })
             .optional()
         })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -505,7 +505,7 @@ export namespace Config {
               glob: z.array(z.string()).optional(),
               format: z.string().optional(),
             })
-            .optional()
+            .optional(),
         })
         .optional(),
     })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -499,6 +499,12 @@ export namespace Config {
                 .optional(),
             })
             .optional(),
+          project_tree: z
+            .object({
+              limit: z.number().int().min(0).optional(),
+              glob: z.array(z.string()).optional(),
+            })
+            .optional()
         })
         .optional(),
     })

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -219,8 +219,12 @@ export namespace Ripgrep {
     return result.split("\n").filter(Boolean)
   }
 
-  export async function tree(input: { cwd: string; limit?: number }) {
-    const files = await Ripgrep.files({ cwd: input.cwd })
+  export async function tree(input: {
+    cwd: string;
+    limit?: number;
+    glob?: string[]
+  }) {
+    const files = await Ripgrep.files({ cwd: input.cwd, glob: input.glob })
     interface Node {
       path: string[]
       children: Node[]

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -219,12 +219,7 @@ export namespace Ripgrep {
     return result.split("\n").filter(Boolean)
   }
 
-  export async function tree(input: {
-    cwd: string;
-    limit?: number;
-    glob?: string[];
-    format?: string,
-  }) {
+  export async function tree(input: { cwd: string; limit?: number; glob?: string[]; format?: string }) {
     const files = await Ripgrep.files({ cwd: input.cwd, glob: input.glob })
     interface Node {
       path: string[]
@@ -313,7 +308,7 @@ export namespace Ripgrep {
 
     const lines: string[] = []
 
-    if (input.format === 'markdown') {
+    if (input.format === "markdown") {
       function renderPretty(node: Node) {
         const files = node.children.filter((c) => c.children.length === 0)
         const dirs = node.children.filter((c) => c.children.length > 0)

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -222,7 +222,8 @@ export namespace Ripgrep {
   export async function tree(input: {
     cwd: string;
     limit?: number;
-    glob?: string[]
+    glob?: string[];
+    format?: string,
   }) {
     const files = await Ripgrep.files({ cwd: input.cwd, glob: input.glob })
     interface Node {
@@ -311,6 +312,30 @@ export namespace Ripgrep {
     }
 
     const lines: string[] = []
+
+    if (input.format === 'markdown') {
+      function renderPretty(node: Node) {
+        const files = node.children.filter((c) => c.children.length === 0)
+        const dirs = node.children.filter((c) => c.children.length > 0)
+        const hasTrunc = files.some((f) => /^\[\d+ truncated\]$/.test(f.path.at(-1) || ""))
+
+        if (files.length || hasTrunc) {
+          lines.push("#" + node.path.join("/"))
+          for (const f of files) {
+            lines.push(f.path.at(-1)!)
+          }
+          lines.push("")
+        }
+        for (const d of dirs) {
+          renderPretty(d)
+        }
+      }
+
+      for (const child of result.children) {
+        renderPretty(child)
+      }
+      return lines.join("\n")
+    }
 
     function render(node: Node, depth: number) {
       const indent = "\t".repeat(depth)

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -34,7 +34,7 @@ export namespace SystemPrompt {
     const config = await Config.get()
     const limit = config.experimental?.project_tree?.limit ?? 200
     const glob = config.experimental?.project_tree?.glob
-    const format = config.experimental?.project_tree?.format ?? 'tree'
+    const format = config.experimental?.project_tree?.format ?? "tree"
 
     const project = Instance.project
     return [
@@ -53,7 +53,7 @@ export namespace SystemPrompt {
                 cwd: Instance.directory,
                 limit,
                 glob,
-                format
+                format,
               })
             : ""
         }`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -34,6 +34,7 @@ export namespace SystemPrompt {
     const config = await Config.get()
     const limit = config.experimental?.project_tree?.limit ?? 200
     const glob = config.experimental?.project_tree?.glob
+    const format = config.experimental?.project_tree?.format ?? 'tree'
 
     const project = Instance.project
     return [
@@ -51,7 +52,8 @@ export namespace SystemPrompt {
             ? await Ripgrep.tree({
                 cwd: Instance.directory,
                 limit,
-                glob
+                glob,
+                format
               })
             : ""
         }`,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -31,6 +31,10 @@ export namespace SystemPrompt {
   }
 
   export async function environment() {
+    const config = await Config.get()
+    const limit = config.experimental?.project_tree?.limit ?? 200
+    const glob = config.experimental?.project_tree?.glob
+
     const project = Instance.project
     return [
       [
@@ -43,10 +47,11 @@ export namespace SystemPrompt {
         `</env>`,
         `<project>`,
         `  ${
-          project.vcs === "git"
+          project.vcs === "git" && limit > 0
             ? await Ripgrep.tree({
                 cwd: Instance.directory,
-                limit: 200,
+                limit,
+                glob
               })
             : ""
         }`,


### PR DESCRIPTION
This PR provides three experimental options to the project tree file listing in the system prompt

```
limit: integer
glob: string[]
format: string
```

limit makes the default 200 files/dirs configurable to allow control over the where the system cuts off
glob: an array of ripgrep style glob strings (these require foo/**)
format: set this to markdown to get a markdown formatted output

the default output format uses tab indents that is the most concise but also separates files from their parent directories which can cause a disconnect in the connection between the two.

setting to markdown will provide an output like this

```
# src/this
foo.ts
bar.ts
# src/this/that
foo.ts
bar.ts
```

Making the dirs markdown headers with a file list hopefully keep token locality closer together.

Closes #2541 