### PR TITLE
Fix TypeError in session summarization when no messages to summarize

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -1010,11 +1010,13 @@ export namespace Session {
               providerID: model.providerID,
               modelID: model.info.id,
             })
-            const msgs = await Session.messages(input.sessionID).then((x) =>
-              x.filter((x) => x.info.id >= summarized.id),
-            )
-            return {
-              messages: MessageV2.toModelMessage(msgs),
+            if (summarized) {
+              const msgs = await Session.messages(input.sessionID).then((x) =>
+                x.filter((x) => x.info.id >= summarized.id),
+              )
+              return {
+                messages: MessageV2.toModelMessage(msgs),
+              }
             }
           }
         }
@@ -1775,7 +1777,11 @@ export namespace Session {
     return next
   }
 
-  export async function summarize(input: { sessionID: string; providerID: string; modelID: string }) {
+  export async function summarize(input: {
+    sessionID: string
+    providerID: string
+    modelID: string
+  }): Promise<MessageV2.Info | undefined> {
     await update(input.sessionID, (draft) => {
       draft.time.compacting = Date.now()
     })
@@ -1792,6 +1798,7 @@ export namespace Session {
     const split = start + Math.floor((msgs.length - start) / 2)
     log.info("summarizing", { start, split })
     const toSummarize = msgs.slice(start, split)
+    if (toSummarize.length === 0) return
     const model = await Provider.getModel(input.providerID, input.modelID)
     const system = [
       ...SystemPrompt.summarize(model.providerID),


### PR DESCRIPTION
## Summary

Fix TypeError in session summarization when no messages are available to summarize.

## Changes Made

 - Added a guard in the `summarize` function to return early if `toSummarize.length === 0`.
 - Updated the return type of `summarize` to `Promise<MessageV2.Info | undefined>`.
 - Modified the `prepareStep` callback to only process summarized results if they exist.

## Why This Fix
The error occurred because `toSummarize.at(-1)` was accessed on an empty array, returning `undefined`. This fix prevents the error by skipping summarization when there are no messages to process, ensuring the application doesn't crash in edge cases.
