### PR TITLE
feat(server): enable CORS wildcard via Hono middleware

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2,6 +2,7 @@ import { Log } from "../util/log"
 import { Bus } from "../bus"
 import { describeRoute, generateSpecs, openAPISpecs } from "hono-openapi"
 import { Hono } from "hono"
+import { cors } from "hono/cors"
 import { streamSSE } from "hono/streaming"
 import { Session } from "../session"
 import { resolver, validator as zValidator } from "hono-openapi/zod"
@@ -90,6 +91,7 @@ export namespace Server {
         status: 400,
       })
     })
+    .use("*", cors())
     .use(async (c, next) => {
       const skipLogging = c.req.path === "/log"
       if (!skipLogging) {


### PR DESCRIPTION
Adds Hono cors() middleware at top-level (app.use("*", cors())). This sets Access-Control-Allow-Origin: * for all routes, including preflight. If credentialed requests are needed later, we can switch to a dynamic origin function and set credentials: true.