### PR TITLE
fix(session): await cleanupRevert() to prevent dupe msgs after undo

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -463,7 +463,7 @@ export namespace Session {
     // Process revert cleanup first, before creating new messages
     const session = await get(input.sessionID)
     if (session.revert) {
-      cleanupRevert(session)
+      await cleanupRevert(session)
     }
     const userMsg: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
@@ -1131,7 +1131,7 @@ export namespace Session {
     using abort = lock(input.sessionID)
     const session = await get(input.sessionID)
     if (session.revert) {
-      cleanupRevert(session)
+      await cleanupRevert(session)
     }
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),


### PR DESCRIPTION
Implemented a fix for a race condition that could duplicate the last message when a user quickly performs an undo followed by an immediate send. I didn't realize how frequently this was happening to me until I built some tooling to analyze the reasoning traces from gpt-oss-120b. Here's an example of two instances displayed in the TUI (also confirmed via packet capture):

<img width="932" height="533" alt="image" src="https://github.com/user-attachments/assets/14fb7c11-2c74-445c-b5aa-b3edaa24f3ed" />

<img width="930" height="439" alt="image" src="https://github.com/user-attachments/assets/1ea21082-8825-4363-816f-ce696930905c" />


It's fairly easy to repro manually, at least on my machine (M3 Max). I use `<leader>`, then press `u` + `enter` in quick succession and get a near 100% hit rate on the bug.

I don't know how many folks would be impacted by this. But I do run into this issue frequently because I do a ton of best-of-N sampling, both programmatically and manually.