### PR TITLE
fix: make permission always behavior match expectation

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -83,7 +83,7 @@ export namespace Permission {
       toolCallID: input.callID,
       pattern: input.pattern,
     })
-    if (approved[input.sessionID]?.[input.pattern ?? input.type]) return
+    if (approved[input.sessionID]?.[input.type]) return
     const info: Info = {
       id: Identifier.ascending("permission"),
       type: input.type,
@@ -141,9 +141,9 @@ export namespace Permission {
     })
     if (input.response === "always") {
       approved[input.sessionID] = approved[input.sessionID] || {}
-      approved[input.sessionID][match.info.pattern ?? match.info.type] = true
+      approved[input.sessionID][match.info.type] = true
       for (const item of Object.values(pending[input.sessionID])) {
-        if ((item.info.pattern ?? item.info.type) === (match.info.pattern ?? match.info.type)) {
+        if (item.info.type === match.info.type) {
           respond({ sessionID: item.info.sessionID, permissionID: item.info.id, response: input.response })
         }
       }


### PR DESCRIPTION
fixes: #2570

permissions accept always don't match behavior of other tools which is unexpected