### PR TITLE
fix(docs): typo in web agents.mdx

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -543,7 +543,7 @@ For example, with OpenAI's reasoning models, you can control the reasoning effor
 These additional options are model and provider-specific. Check your provider's documentation for available parameters.
 
 :::tip
-Run `opencode models` to see a lit of the available models.
+Run `opencode models` to see a list of the available models.
 :::
 
 ---


### PR DESCRIPTION
fix typo in `packages/web/src/content/docs/agents.mdx`
`lit` -> `list`