### PR TITLE
fix: token counting visual bug

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -899,7 +899,6 @@ func (m *messagesComponent) renderHeader() string {
 				}
 				tokens = (usage.Input +
 					usage.Cache.Write +
-					usage.Cache.Read +
 					usage.Output +
 					usage.Reasoning)
 			}


### PR DESCRIPTION
fixes:  #1937


I managed to replicate the bug example:
```
 "tokens": {
        "input": 12112,
        "output": 11,
        "reasoning": 0,
        "cache": {
          "write": 0,
          "read": 12032
        }
      },
 ``` 
 
 ```
       "tokens": {
        "input": 12112,
        "output": 11,
        "reasoning": 0,
        "cache": {
          "write": 0,
          "read": 0
        }
      },
```

Even tho these 2 amount to same # of tokens, the TUI was showing #1 as ~24k tokens and #2 as ~12k 