### PR TITLE
tweak: make bash permissions key off of command pattern

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -82,7 +82,6 @@ export const EditTool = Tool.define("edit", {
           sessionID: ctx.sessionID,
           messageID: ctx.messageID,
           callID: ctx.callID,
-          pattern: filePath,
           title: "Edit this file: " + filePath,
           metadata: {
             filePath,

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -28,7 +28,6 @@ export const WebFetchTool = Tool.define("webfetch", {
     if (cfg.permission?.webfetch === "ask")
       await Permission.ask({
         type: "webfetch",
-        pattern: params.url,
         sessionID: ctx.sessionID,
         messageID: ctx.messageID,
         callID: ctx.callID,


### PR DESCRIPTION
This updates bash permissions to mimic behaviors of similar coding tools for a more consistent and expected experience 

Example:

if llm runs: "echo hello"

and I approve always, that should apply as "echo *"

if llm runs "git log -n 5" and I say approve always, that should apply as "git log *"

similarly for chained commands like:

echo hello && git log -n 5

an approve always applies as:

echo * and git log * 