### PR TITLE
fix(session): restore chat.message plugin hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -709,6 +709,15 @@ export namespace SessionPrompt {
       }),
     ).then((x) => x.flat())
 
+    await Plugin.trigger(
+      "chat.message",
+      {},
+      {
+        message: info,
+        parts,
+      },
+    )
+
     await Session.updateMessage(info)
     for (const part of parts) {
       await Session.updatePart(part)


### PR DESCRIPTION
Looks like 9bb25a9 reverted the previous hook functionality of the `chat.message` event being triggered.

If this was intentional for some reason, no big deal. I can handle separately in my fork if so. But I do use this to paper over lots of issues with tool calling and env awareness for a few different models in my RL environments. Only caught this because tool call failure rates spiked in the related evals.