### PR TITLE
Documentation: Add editor setup tip

### DIFF
--- a/packages/web/src/content/docs/ide.mdx
+++ b/packages/web/src/content/docs/ide.mdx
@@ -24,6 +24,10 @@ To install opencode on VS Code and popular forks like Cursor, Windsurf, VSCodium
 2. Open the integrated terminal
 3. Run `opencode` - the extension installs automatically
 
+:::tip
+Run Set `export EDITOR="code --wait"` in your terminal to enable `/export` and similar commands. For other editors, check [Editor Setup](https://opencode.ai/docs/tui/#editor-setup).
+:::
+
 ---
 
 ### Manual Install


### PR DESCRIPTION
Added a tip for configuring the editor in the terminal, with the added benefit of linking to `editor setup`, which took me ages to find hidden in the TUI documentation.