### PR TITLE
fix: type exports in package.json for SDK package

### DIFF
--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -9,15 +9,19 @@
   "exports": {
     ".": {
       "development": "./src/index.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
     "./client": {
       "development": "./src/client.ts",
-      "import": "./dist/client.js"
+      "import": "./dist/client.js",
+      "types": "./dist/client.d.ts"
+
     },
     "./server": {
       "development": "./src/server.ts",
-      "import": "./dist/server.js"
+      "import": "./dist/server.js",
+      "types": "./dist/server.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
There are no types specified for the package. Without them typescript (at least on stricter configs) reports that the package can't be resolved