### PR TITLE
fix(provider/azure): use languageModel to avoid duplicate reasoning p…

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -58,7 +58,7 @@ export namespace Provider {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string) {
-          return sdk.responses(modelID)
+          return sdk.languageModel(modelID)
         },
         options: {},
       }


### PR DESCRIPTION
…arams

When using Azure provider, a duplicate `reasoningEffort` param is included in the response. 

This only affect Azure providers.

opencode Version:
```
INFO  2025-09-17T17:32:47 +38ms service=default version=0.9.11
```

Partial Request Snippet:
```
{"model":"gpt-5","max_tokens":32000,"reasoningEffort":"high","textVerbosity":"low","reasoning_effort":"high",
```


Error Snippet:
```["description","prompt","subagent_type"],"additionalProperties":false}}}],"tool_choice":"auto","stream":true},"statusCode":400,"responseHeaders":{"connection":"keep-alive","content-length":"288","content-type":"application/json","date":"Wed, 17 Sep 2025 17:32:54 GMT","strict-transport-security":"max-age=31536000; includeSubDomains, max-age: 31536000; includeSubDomains","vary":"Origin","x-kong-proxy-latency":"77","x-kong-request-id":"114fec6027942a1de2f57d3655af9e4f","x-kong-upstream-latency":"367","x-kong-upstream-status":"400","x-litellm-call-id":"ba031e87-7369-4dc7-8287-5b59dbb48309","x-litellm-key-max-budget":"100.0","x-litellm-key-rpm-limit":"200","x-litellm-key-spend":"0.61532725","x-litellm-key-tpm-limit":"200000","x-litellm-response-cost":"0","x-litellm-timeout":"300.0"},"responseBody":"{\"error\":{\"message\":\"litellm.BadRequestError: AzureException BadRequestError - Unknown parameter: 'reasoningEffort'. Did you mean 'reasoning_effort'?. Received Model Group=gpt-5\\nAvailable Model Group Fallbacks=None\",\"type\":\"invalid_request_error\",\"param\":\"reasoningEffort\",\"code\":\"400\"}}","isRetryable":false,"data":{"error":{"message":"litellm.BadRequestError: AzureException BadRequestError - Unknown parameter: 'reasoningEffort'. Did you mean 'reasoning_effort'?. Received Model Group=gpt-5\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":"reasoningEffort","code":"400"}}}} stream error
INFO  2025-09-17T17:32:54 +1ms service=session.prompt session=ses_6a7437ccdffea6UFW5BrkxLSEM type=error part
ERROR 2025-09-17T17:32:54 +1ms service=session.prompt session=ses_6a7437ccdffea6UFW5BrkxLSEM error=litellm.BadRequestError: AzureException BadRequestError - Unknown parameter: 'reasoningEffort'. Did you mean 'reasoning_effort'?. Received Model Group=gpt-5```
