### PR TITLE
fix(config): keybinds should not be required in config schema

### DIFF
--- a/packages/opencode/script/schema.ts
+++ b/packages/opencode/script/schema.ts
@@ -7,6 +7,7 @@ const file = process.argv[2]
 console.log(file)
 
 const result = z.toJSONSchema(Config.Info, {
+  io: "input", // Generate input shape (treats optional().default() as not required)
   /**
    * We'll use the `default` values of the field as the only value in `examples`.
    * This will ensure no docs are needed to be read, as the configuration is
@@ -14,8 +15,15 @@ const result = z.toJSONSchema(Config.Info, {
    *
    * See https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.9.5
    */
-  override(input) {
-    const schema = input.jsonSchema
+  override(ctx) {
+    const schema = ctx.jsonSchema
+
+    // Preserve strictness: set additionalProperties: false for objects
+    if (schema && typeof schema === "object" && schema.type === "object" && schema.additionalProperties === undefined) {
+      schema.additionalProperties = false
+    }
+
+    // Add examples and default descriptions for string fields with defaults
     if (schema && typeof schema === "object" && "type" in schema && schema.type === "string" && schema?.default) {
       if (!schema.examples) {
         schema.examples = [schema.default]


### PR DESCRIPTION
## Problem

The generated JSON schema incorrectly marked all keybind properties as required, even though
they're defined as optional with defaults in the Zod schema
(`z.string().optional().default("value")`).

## Root Cause

Zod's `toJSONSchema()` defaults to "output" mode, which treats `optional().default()` fields as
always-defined (hence required) in the generated schema, even though they're optional in the
input config.

## Solution

Switch to input mode schema generation using io: "input" parameter, which correctly treats
optional fields with defaults as not required. Also preserve strict validation by ensuring
additionalProperties: false is set for object schemas (this is not done automatically in "input" mode).

## Changes

• Modified packages/opencode/script/schema.ts to use io: "input" mode
• Added override to preserve additionalProperties: false for strict validation

## Warning

For the future we now have to keep this in mind: When adding new Zod schema fields, avoid these patterns as they don't work well with io: "input" mode for user-facing JSON schema generation:

• ❌ .transform() - Input/output types will differ
• ❌ .preprocess() - Preprocessing logic won't be reflected in schema
• ❌ Complex .refine() or .superRefine() - Custom validation logic may not translate to JSON
schema
• ✅ Use simple types, .optional(), .default(), .min(), .max(), enums, and unions instead