### PR TITLE
Ask model to be more clever about output truncation in bash

### DIFF
--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -20,7 +20,7 @@ Usage notes:
   - The command argument is required.
   - You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). If not specified, commands will timeout after 120000ms (2 minutes).
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
-  - If the output exceeds 30000 characters, output will be truncated before being returned to you.
+  - VERY IMPORTANT: If the output exceeds 30000 characters, output will be truncated at the end before being returned to you. Always prefer filtering the output using shell piping using `grep`, `head` or `tail` commands like `run-all-tests | grep 'failed'` to limit output size
   - VERY IMPORTANT: You MUST avoid using search commands like `find` and `grep`. Instead use Grep, Glob, or Task to search. You MUST avoid read tools like `cat`, `head`, `tail`, and `ls`, and use Read and List to read files.
   - If you _still_ need to run `grep`, STOP. ALWAYS USE ripgrep at `rg` (or /usr/bin/rg) first, which all opencode users have pre-installed.
   - When issuing multiple commands, use the ';' or '&&' operator to separate them. DO NOT use newlines (newlines are ok in quoted strings).


### PR DESCRIPTION
We want the model to always run bash commands with a mindset that the output will be truncated if its too big.