### PR TITLE
Fix: Configure monorepo build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "packageManager": "bun@1.2.21",
   "scripts": {
+    "build": "turbo build",
     "dev": "bun run --conditions=development packages/opencode/src/index.ts",
     "typecheck": "bun turbo typecheck",
     "generate": "(cd packages/sdk && ./js/script/generate.ts) && (cd packages/sdk/stainless && ./generate.ts)",

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -29,4 +29,7 @@ export default defineConfig({
   build: {
     target: "esnext",
   },
+  optimizeDeps: {
+    exclude: ["virtua"],
+  },
 })

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -4,19 +4,21 @@
   "version": "0.9.9",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --project tsconfig.build.json",
+    "prepublishOnly": "bun run build"
   },
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./client": {
-      "development": "./src/client.ts",
+      "types": "./dist/client.d.ts",
       "import": "./dist/client.js"
     },
     "./server": {
-      "development": "./src/server.ts",
+      "types": "./dist/server.d.ts",
       "import": "./dist/server.js"
     }
   },

--- a/packages/sdk/js/tsconfig.build.json
+++ b/packages/sdk/js/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "tasks": {
-    "typecheck": {}
+    "typecheck": {},
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    }
   }
 }


### PR DESCRIPTION
The Vercel build was failing because the `@opencode/app` package was trying to import from the `@opencode-ai/sdk` package before the SDK was built.

This change introduces a proper build process for the monorepo using Turborepo:
- Adds a `build` script to the root `package.json` that runs `turbo build`.
- Configures `turbo.json` to define the build pipeline, ensuring that dependencies are built in the correct order.
- Adds a build process for the `@opencode-ai/sdk` package, which compiles the TypeScript source to JavaScript and generates declaration files.
- Updates the `exports` map in the SDK's `package.json` to point to the compiled output.

Additionally, this change includes a workaround for a subsequent build issue with the `virtua` package by excluding it from Vite's dependency optimization in the `@opencode/app` package. This was approved by the user.