### PR TITLE
fix(plugin): add missing types to package.json exports for tool imports

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -3,15 +3,19 @@
   "name": "@opencode-ai/plugin",
   "version": "0.9.11",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "development": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./tool": {
+      "types": "./dist/tool.d.ts",
       "development": "./src/tool.ts",
       "import": "./dist/tool.js"
     }


### PR DESCRIPTION
## Problem

Fixes #2678 - Cannot import tool helper from @opencode-ai/plugin in external repos

Installing `@opencode-ai/plugin@^0.9.11` causes TypeScript import errors:
- `import { tool } from "@opencode-ai/plugin"` → TS2305 (no exported member)
- `import { tool } from "@opencode-ai/plugin/tool"` → TS2307 (cannot find module)

This blocks defining custom tools in `.opencode/tool/*.ts` files.

## Root Cause
Package.json `exports` field was missing explicit `"types"` mappings for both root and subpath imports, preventing TypeScript from resolving `.d.ts` files.

## Solution
- Add top-level `main` and `types` fields for legacy compatibility
- Add `"types"` to both `.` and `"./tool"` exports pointing to existing declaration files
- No functional changes, only improves TypeScript module resolution

## Verification
After this fix, consumers can reliably import:
```ts
import { tool } from "@opencode-ai/plugin"       
```

