### PR TITLE
feat: subagents allow-list (global + per-agent wildcard control)

### DIFF
--- a/packages/opencode/src/agent/subagents.ts
+++ b/packages/opencode/src/agent/subagents.ts
@@ -1,0 +1,75 @@
+import { Agent } from "./agent"
+import { Config } from "../config/config"
+
+// Simple wildcard match: '*' matches any sequence. We keep it minimal, no extglob.
+function match(pattern: string, value: string) {
+  if (pattern === "*") return true
+  // Escape regex special chars except * then replace * with .*
+  const regex = new RegExp("^" + pattern.split(/([*])/).map((p) => (p === "*" ? ".*" : p.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&"))).join("") + "$")
+  return regex.test(value)
+}
+
+// Determine precedence: longer non-wildcard prefix length first, then last index (later override) if tie.
+function specificity(pattern: string) {
+  const firstWildcard = pattern.indexOf("*")
+  return firstWildcard === -1 ? pattern.length : firstWildcard
+}
+
+interface Resolved { pattern: string; value: boolean; index: number }
+
+function resolvePattern(map: Record<string, boolean> | undefined, name: string): Resolved | undefined {
+  if (!map) return
+  const entries = Object.entries(map)
+  const matched: Resolved[] = []
+  entries.forEach(([pat, val], idx) => {
+    if (match(pat, name)) matched.push({ pattern: pat, value: val, index: idx })
+  })
+  if (!matched.length) return
+  matched.sort((a, b) => {
+    const sa = specificity(a.pattern)
+    const sb = specificity(b.pattern)
+    if (sa !== sb) return sb - sa // longer first
+    return b.index - a.index // later first
+  })
+  return matched[0]
+}
+
+export async function accessibleSubagents(forAgent: string) {
+  const cfg = await Config.get()
+  const agents = await Agent.list()
+  const caller = await Agent.get(forAgent)
+  if (!caller) return []
+
+  // gather candidate subagents (mode=subagent or all) excluding self unless its mode allows
+  const candidates = agents.filter((a) => a.name !== caller.name && (a.mode === "subagent" || a.mode === "all"))
+
+  const globalMap = (cfg as any).subagents as Record<string, boolean> | undefined
+  const perAgentMap = (cfg.agent?.[caller.name] as any)?.subagents as Record<string, boolean> | undefined
+
+  // Determine if global default deny is active ("*": false exact)
+  const globalDefaultDeny = globalMap?.["*"] === false
+
+  return candidates.filter((cand) => {
+    // Start with default (true unless global default deny)
+    let allowed = !globalDefaultDeny
+    const g = resolvePattern(globalMap, cand.name)
+    if (g) allowed = g.value
+    const p = resolvePattern(perAgentMap, cand.name)
+    if (p) allowed = p.value
+    return allowed
+  })
+}
+
+export function isSubagentEnabled(forAgent: string, subagentName: string, context: { global?: Record<string, boolean>; perAgent?: Record<string, boolean> }) {
+  const globalMap = context.global
+  const perAgentMap = context.perAgent
+  const globalDefaultDeny = globalMap?.["*"] === false
+  let allowed = !globalDefaultDeny
+  const g = resolvePattern(globalMap, subagentName)
+  if (g) allowed = g.value
+  const p = resolvePattern(perAgentMap, subagentName)
+  if (p) allowed = p.value
+  return allowed
+}
+
+export const _internal = { match, resolvePattern }

--- a/packages/opencode/src/agent/subagents.ts
+++ b/packages/opencode/src/agent/subagents.ts
@@ -60,7 +60,7 @@ export async function accessibleSubagents(forAgent: string) {
   })
 }
 
-export function isSubagentEnabled(forAgent: string, subagentName: string, context: { global?: Record<string, boolean>; perAgent?: Record<string, boolean> }) {
+export function isSubagentEnabled(_forAgent: string, subagentName: string, context: { global?: Record<string, boolean>; perAgent?: Record<string, boolean> }) {
   const globalMap = context.global
   const perAgentMap = context.perAgent
   const globalDefaultDeny = globalMap?.["*"] === false

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -266,6 +266,12 @@ export namespace Config {
       top_p: z.number().optional(),
       prompt: z.string().optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
+      subagents: z
+        .record(z.string(), z.boolean())
+        .optional()
+        .describe(
+          "Per-agent subagent enable/disable map. Supports wildcards. Evaluated after global 'subagents' map.",
+        ),
       disable: z.boolean().optional(),
       description: z.string().optional().describe("Description of when to use the agent"),
       mode: z.union([z.literal("subagent"), z.literal("primary"), z.literal("all")]).optional(),
@@ -493,6 +499,12 @@ export namespace Config {
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
+      subagents: z
+        .record(z.string(), z.boolean())
+        .optional()
+        .describe(
+          "Global subagent enable/disable map. Use \"*\": false to disable all then re-enable per agent. Supports wildcards.",
+        ),
       experimental: z
         .object({
           hook: z

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -48,6 +48,7 @@ import { ulid } from "ulid"
 import { spawn } from "child_process"
 import { Command } from "../command"
 import { $ } from "bun"
+import { Config } from "../config/config"
 
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
@@ -1446,7 +1447,17 @@ export namespace SessionPrompt {
 
     const agent = await Agent.get(agentName)
     if ((agent.mode === "subagent" && command.subtask !== false) || command.subtask === true) {
-      using abort = lock(input.sessionID)
+      // Allow list enforcement for subagent auto invocation
+      const cfg = await Config.get()
+      const globalMap = (cfg as any).subagents as Record<string, boolean> | undefined
+      const invoking = input.agent ?? "build"
+      const perAgentMap = (cfg.agent?.[invoking] as any)?.subagents as Record<string, boolean> | undefined
+      const { isSubagentEnabled } = await import("../agent/subagents")
+      const allowed = isSubagentEnabled(invoking, agent.name, { global: globalMap, perAgent: perAgentMap })
+      if (!allowed) {
+        log.info("blocked subagent auto invocation", { invoking, subagent: agent.name })
+      } else {
+        using abort = lock(input.sessionID)
 
       const userMsg: MessageV2.User = {
         id: Identifier.ascending("message"),
@@ -1553,7 +1564,8 @@ export namespace SessionPrompt {
         await Session.updatePart(toolPart)
       }
 
-      return { info: assistantMsg, parts: [toolPart] }
+        return { info: assistantMsg, parts: [toolPart] }
+      }
     }
 
     return prompt({

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -6,7 +6,7 @@ import { Bus } from "../bus"
 import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Agent } from "../agent/agent"
-import { accessibleSubagents, isSubagentEnabled } from "../agent/subagents"
+import { accessibleSubagents } from "../agent/subagents"
 import { Config } from "../config/config"
 import { SessionPrompt } from "../session/prompt"
 
@@ -24,8 +24,6 @@ export const TaskTool = Tool.define("task", async () => {
       const cfg = await Config.get()
       const caller = await Agent.get(ctx.agent)
       if (!caller) throw new Error(`Unknown invoking agent: ${ctx.agent}`)
-      const globalMap = (cfg as any).subagents as Record<string, boolean> | undefined
-      const perAgentMap = (cfg.agent?.[caller.name] as any)?.subagents as Record<string, boolean> | undefined
       const allowedList = await accessibleSubagents(caller.name)
       const agent = await Agent.get(params.subagent_type)
       if (!agent) throw new Error(`Unknown subagent: ${params.subagent_type}`)

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -6,16 +6,13 @@ import { Bus } from "../bus"
 import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Agent } from "../agent/agent"
+import { accessibleSubagents, isSubagentEnabled } from "../agent/subagents"
+import { Config } from "../config/config"
 import { SessionPrompt } from "../session/prompt"
 
 export const TaskTool = Tool.define("task", async () => {
-  const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
-  const description = DESCRIPTION.replace(
-    "{agents}",
-    agents
-      .map((a) => `- ${a.name}: ${a.description ?? "This subagent should only be called manually by the user."}`)
-      .join("\n"),
-  )
+  // Build dynamic description placeholder – actual agent list inserted at execution time
+  const description = DESCRIPTION.replace("{agents}", "(computed per invoking agent)")
   return {
     description,
     parameters: z.object({
@@ -24,8 +21,22 @@ export const TaskTool = Tool.define("task", async () => {
       subagent_type: z.string().describe("The type of specialized agent to use for this task"),
     }),
     async execute(params, ctx) {
+      const cfg = await Config.get()
+      const caller = await Agent.get(ctx.agent)
+      if (!caller) throw new Error(`Unknown invoking agent: ${ctx.agent}`)
+      const globalMap = (cfg as any).subagents as Record<string, boolean> | undefined
+      const perAgentMap = (cfg.agent?.[caller.name] as any)?.subagents as Record<string, boolean> | undefined
+      const allowedList = await accessibleSubagents(caller.name)
       const agent = await Agent.get(params.subagent_type)
-      if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
+      if (!agent) throw new Error(`Unknown subagent: ${params.subagent_type}`)
+      if (!allowedList.find((a) => a.name === agent.name)) {
+        const enabledHint = allowedList.length
+          ? `Enabled subagents: ${allowedList.map((a) => a.name).join(", ")}`
+          : `No subagents are enabled for agent '${caller.name}'.`
+        throw new Error(
+          `Subagent '${agent.name}' is not enabled for agent '${caller.name}'. ${enabledHint} Configure via global 'subagents' or agent '${caller.name}'.subagents map.`,
+        )
+      }
       const session = await Session.create(ctx.sessionID, params.description + ` (@${agent.name} subagent)`)
       const msg = await Session.getMessage(ctx.sessionID, ctx.messageID)
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -7,7 +7,6 @@ import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Agent } from "../agent/agent"
 import { accessibleSubagents } from "../agent/subagents"
-import { Config } from "../config/config"
 import { SessionPrompt } from "../session/prompt"
 
 export const TaskTool = Tool.define("task", async () => {
@@ -21,7 +20,6 @@ export const TaskTool = Tool.define("task", async () => {
       subagent_type: z.string().describe("The type of specialized agent to use for this task"),
     }),
     async execute(params, ctx) {
-      const cfg = await Config.get()
       const caller = await Agent.get(ctx.agent)
       if (!caller) throw new Error(`Unknown invoking agent: ${ctx.agent}`)
       const allowedList = await accessibleSubagents(caller.name)

--- a/packages/opencode/test/agent/subagents.test.ts
+++ b/packages/opencode/test/agent/subagents.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, test, beforeAll } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { accessibleSubagents, _internal } from "../../src/agent/subagents"
 import { Instance } from "../../src/project/instance"
 import { Config } from "../../src/config/config"
-import { Agent } from "../../src/agent/agent"
-import { mergeDeep } from "remeda"
+// removed unused imports
 
 // Utility to provide a synthetic config for tests
 async function withConfig<T>(cfg: any, fn: () => Promise<T>) {

--- a/packages/opencode/test/agent/subagents.test.ts
+++ b/packages/opencode/test/agent/subagents.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test, beforeAll } from "bun:test"
+import { accessibleSubagents, _internal } from "../../src/agent/subagents"
+import { Instance } from "../../src/project/instance"
+import { Config } from "../../src/config/config"
+import { Agent } from "../../src/agent/agent"
+import { mergeDeep } from "remeda"
+
+// Utility to provide a synthetic config for tests
+async function withConfig<T>(cfg: any, fn: () => Promise<T>) {
+  return await Instance.provide({
+    directory: process.cwd(),
+    fn: async () => {
+      // Monkey patch Config.get within this Instance scope
+      const original = Config.get
+      ;(Config as any).get = async () => cfg
+      try {
+        // Force Agent state to rebuild each time by accessing private state indirectly
+        return await fn()
+      } finally {
+        ;(Config as any).get = original
+      }
+    },
+  })
+}
+
+describe("subagents access", () => {
+  const base = {
+    agent: {
+      build: {},
+      general: { mode: "subagent" },
+      helper: { mode: "subagent" },
+      "doc-reader": { mode: "subagent" },
+      "doc-extractor": { mode: "subagent" },
+      "git-committer": { mode: "subagent" },
+    },
+  }
+
+  test("default all allowed when no maps", async () => {
+    const names = await withConfig(base, async () => (await accessibleSubagents("build")).map((a) => a.name).sort())
+    expect(names).toEqual(["doc-extractor", "doc-reader", "general", "git-committer", "helper"]) // all except build itself
+  })
+
+  test("global disable all then enable single per agent", async () => {
+    const cfg = {
+      ...base,
+      subagents: { "*": false },
+      agent: { ...base.agent, build: { subagents: { general: true } } },
+    }
+    const names = await withConfig(cfg, async () => (await accessibleSubagents("build")).map((a) => a.name))
+    expect(names).toEqual(["general"]) // helper remains disabled
+  })
+
+  test("wildcard group enable", async () => {
+    const cfg = {
+      ...base,
+      subagents: { "*": false },
+      agent: { ...base.agent, build: { subagents: { "doc-*": true } } },
+    }
+    const names = await withConfig(cfg, async () => (await accessibleSubagents("build")).map((a) => a.name).sort())
+    expect(names).toEqual(["doc-extractor", "doc-reader"]) // only doc-*
+  })
+
+  test("specific override after broad enable", async () => {
+    const cfg = {
+      ...base,
+      subagents: { "*": false },
+      agent: { ...base.agent, build: { subagents: { "*": true, "git-committer": false } } },
+    }
+    const names = await withConfig(cfg, async () => (await accessibleSubagents("build")).map((a) => a.name).sort())
+    expect(names).toEqual(["doc-extractor", "doc-reader", "general", "helper"]) // git-committer excluded
+  })
+})
+
+describe("pattern resolver specificity", () => {
+  test("longer literal prefix wins", () => {
+    const { resolvePattern } = _internal as any
+    const map = { "git-*": true, "git-commit*": false }
+    const r = resolvePattern(map, "git-committer")
+    expect(r.value).toBe(false)
+  })
+})

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -519,6 +519,85 @@ The `mode` option can be set to `primary`, `subagent`, or `all`. If no `mode` is
 
 ---
 
+### Subagents access
+
+You can globally disable all subagents and selectively enable them per primary agent. This reduces token usage and decision overhead when most subagents are irrelevant for a workflow.
+
+Global control uses the top-level `subagents` map. Per-agent overrides use `agent.<name>.subagents`.
+
+If you do nothing, current behavior is unchanged: all subagents are available.
+
+```json title="Disable every subagent everywhere"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "subagents": { "*": false }
+}
+```
+
+Enable one subagent back for a specific primary agent:
+
+```json title="Enable only general for build"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "subagents": { "*": false },
+  "agent": {
+    "build": {
+      "subagents": { "general": true }
+    }
+  }
+}
+```
+
+Use wildcards to enable a group:
+
+```json title="Enable doc-* for plan, doc-* plus git-committer for build"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "subagents": { "*": false },
+  "agent": {
+    "plan": { "subagents": { "doc-*": true } },
+    "build": { "subagents": { "doc-*": true, "git-committer": true } }
+  }
+}
+```
+
+Enable everything except one:
+
+```json title="All except git-committer"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "subagents": { "*": false },
+  "agent": {
+    "build": { "subagents": { "*": true, "git-committer": false } }
+  }
+}
+```
+
+Refine globally enabled patterns per agent:
+
+```json title="Refine git-* off for plan"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "subagents": { "*": false, "general": true, "git-*": true },
+  "agent": {
+    "plan": { "subagents": { "git-*": false } }
+  }
+}
+```
+
+Resolution rules:
+
+- Start allow = true unless `"*": false` is present globally (default deny mode)
+- Most specific matching pattern wins (longer literal prefix first; later definition on tie)
+- Per-agent overrides always applied after global
+
+If a subagent is disabled:
+
+- It won't appear in the Task tool list
+- `@mention` attempts return a short advisory message
+
+---
+
 ### Additional
 
 Any other options you specify in your agent configuration will be **passed through directly** to the provider as model options. This allows you to use provider-specific features and parameters.

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -268,6 +268,24 @@ You can configure MCP servers you want to use through the `mcp` option.
 
 ---
 
+### Subagents
+
+Control global subagent availability with the `subagents` map. Use `"*": false` to disable all, then re-enable per primary agent with `agent.<name>.subagents`.
+
+```json title="Disable all; enable general for build"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "subagents": { "*": false },
+  "agent": {
+    "build": { "subagents": { "general": true } }
+  }
+}
+```
+
+See more patterns in the Agents guide.
+
+---
+
 ### Instructions
 
 You can configure the instructions for the model you're using through the `instructions` option.


### PR DESCRIPTION
## Summary
Adds configuration-driven allow/deny control over subagent invocation using a global `subagents` map plus per-agent `subagents` overrides. Supports wildcard patterns, precedence (longer literal prefix first, later definition wins on ties), and default-deny mode via `"*": false`.

## Key Changes
- config: Added `subagents` to global schema and per-agent schema (`packages/opencode/src/config/config.ts`).
- logic: New helper `packages/opencode/src/agent/subagents.ts` providing `accessibleSubagents()` and `isSubagentEnabled()` with wildcard + specificity resolution.
- task tool: Enforces subagent allow list and errors with guidance when a disallowed subagent is requested (`packages/opencode/src/tool/task.ts`).
- auto escalation: `SessionPrompt.command()` now checks allow list before auto-invoking a subagent (`packages/opencode/src/session/prompt.ts`).
- tests: Added `packages/opencode/test/agent/subagents.test.ts` covering default allow, global deny + per-agent allow, wildcard group enable, override, specificity precedence.
- docs: Updated `agents.mdx` and `config.mdx` with usage patterns, resolution rules, and examples.

## Behavior
- If no `subagents` maps are defined, all subagents remain available (backwards compatible).
- Adding `{ "*": false }` globally switches to default deny; selectively re-enable with explicit patterns or names.
- Per-agent map evaluated after global map.
- Wildcards use simple `*` → greedy match; specificity = index of first `*` (longer literal prefix wins), then later definition wins.
- Disabled subagents do not appear as allowed for Task tool invocation; attempts result in a clear error message pointing to config.

## Tests
`subagents.test.ts` passes (all 5 cases). Existing unrelated failing tests (tool registry initialization ReferenceError and some EditTool replacer cases) are pre-existing and unchanged by this PR.

## Typecheck & Build
All packages pass `bun turbo typecheck` after removing unused variables introduced during development.

## Follow-up (Not in Scope Here)
- Optional: Lightweight advisory on manual @mention of disabled subagent.
- Optional: Enumerate accessible subagents dynamically in Task tool description.
- Optional: Fix ToolRegistry cyclic initialization (separate PR).

## Migration
No action required. Omit `subagents` to retain prior behavior.

## Risk
Low. Additive config; defaults preserve existing behavior.