### PR TITLE
Enhance theme documentation with links

### DIFF
--- a/packages/web/src/content/docs/themes.mdx
+++ b/packages/web/src/content/docs/themes.mdx
@@ -25,18 +25,18 @@ Without truecolor support, themes may appear with reduced color accuracy or fall
 
 opencode comes with several built-in themes.
 
-| Name         | Description                                                                    |
-| ------------ | ------------------------------------------------------------------------------  |
-| `system`     | Adapts to your terminal's background color                                     |
-| `tokyonight` | Based on the [Tokyonight](https://github.com/folke/tokyonight.nvim) theme      |
-| `everforest` | Based on the [Everforest](https://github.com/sainnhe/everforest) theme         |
-| `ayu`        | Based on the [Ayu](https://github.com/ayu-theme) dark theme                    |
-| `catppuccin` | Based on the [Catppuccin](https://github.com/catppuccin) theme                 |
-| `gruvbox`    | Based on the [Gruvbox](https://github.com/morhetz/gruvbox) theme               |
-| `kanagawa`   | Based on the [Kanagawa](https://github.com/rebelot/kanagawa.nvim) theme        |
-| `nord`       | Based on the [Nord](https://github.com/nordtheme/nord) theme                   |
-| `matrix`     | Hacker-style green on black theme                                              |
-| `one-dark`   | Based on the [Atom One](https://github.com/Th3Whit3Wolf/one-nvim) Dark theme   |
+| Name         | Description                                                                  |
+| ------------ | ---------------------------------------------------------------------------- |
+| `system`     | Adapts to your terminal's background color                                   |
+| `tokyonight` | Based on the [Tokyonight](https://github.com/folke/tokyonight.nvim) theme    |
+| `everforest` | Based on the [Everforest](https://github.com/sainnhe/everforest) theme       |
+| `ayu`        | Based on the [Ayu](https://github.com/ayu-theme) dark theme                  |
+| `catppuccin` | Based on the [Catppuccin](https://github.com/catppuccin) theme               |
+| `gruvbox`    | Based on the [Gruvbox](https://github.com/morhetz/gruvbox) theme             |
+| `kanagawa`   | Based on the [Kanagawa](https://github.com/rebelot/kanagawa.nvim) theme      |
+| `nord`       | Based on the [Nord](https://github.com/nordtheme/nord) theme                 |
+| `matrix`     | Hacker-style green on black theme                                            |
+| `one-dark`   | Based on the [Atom One](https://github.com/Th3Whit3Wolf/one-nvim) Dark theme |
 
 And more, we are constantly adding new themes.
 

--- a/packages/web/src/content/docs/themes.mdx
+++ b/packages/web/src/content/docs/themes.mdx
@@ -25,18 +25,18 @@ Without truecolor support, themes may appear with reduced color accuracy or fall
 
 opencode comes with several built-in themes.
 
-| Name         | Description                                |
-| ------------ | ------------------------------------------ |
-| `system`     | Adapts to your terminal's background color |
-| `tokyonight` | Based on the Tokyonight theme              |
-| `everforest` | Based on the Everforest theme              |
-| `ayu`        | Based on the Ayu dark theme                |
-| `catppuccin` | Based on the Catppuccin theme              |
-| `gruvbox`    | Based on the Gruvbox theme                 |
-| `kanagawa`   | Based on the Kanagawa theme                |
-| `nord`       | Based on the Nord theme                    |
-| `matrix`     | Hacker-style green on black theme          |
-| `one-dark`   | Based on the Atom One Dark theme           |
+| Name         | Description                                                                    |
+| ------------ | ------------------------------------------------------------------------------  |
+| `system`     | Adapts to your terminal's background color                                     |
+| `tokyonight` | Based on the [Tokyonight](https://github.com/folke/tokyonight.nvim) theme      |
+| `everforest` | Based on the [Everforest](https://github.com/sainnhe/everforest) theme         |
+| `ayu`        | Based on the [Ayu](https://github.com/ayu-theme) dark theme                    |
+| `catppuccin` | Based on the [Catppuccin](https://github.com/catppuccin) theme                 |
+| `gruvbox`    | Based on the [Gruvbox](https://github.com/morhetz/gruvbox) theme               |
+| `kanagawa`   | Based on the [Kanagawa](https://github.com/rebelot/kanagawa.nvim) theme        |
+| `nord`       | Based on the [Nord](https://github.com/nordtheme/nord) theme                   |
+| `matrix`     | Hacker-style green on black theme                                              |
+| `one-dark`   | Based on the [Atom One](https://github.com/Th3Whit3Wolf/one-nvim) Dark theme   |
 
 And more, we are constantly adding new themes.
 


### PR DESCRIPTION
fixes: #2624

Updated theme descriptions to include links to their respective repositories.
<img width="1334" height="1418" alt="image" src="https://github.com/user-attachments/assets/88bf442d-da01-4c29-b72e-a6e6190b3abd" />
