### PR TITLE
wip: add /client to expose the TUI via HTTP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,7 @@
         "gray-matter": "4.0.3",
         "hono": "catalog:",
         "hono-openapi": "1.0.7",
+        "bun-pty": "https://github.com/CefBoud/bun-pty#feat-use-env",
         "ignore": "7.0.5",
         "jsonc-parser": "3.3.1",
         "minimatch": "10.0.3",
@@ -252,7 +253,7 @@
     "@types/node": "22.13.9",
     "ai": "5.0.8",
     "fuzzysort": "3.1.0",
-    "hono": "4.7.10",
+    "hono": "4.9.8",
     "luxon": "3.6.1",
     "remeda": "2.26.0",
     "solid-js": "1.9.9",
@@ -1310,6 +1311,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "bun-pty": ["bun-pty@github:CefBoud/bun-pty#77fa7ff", {}, "CefBoud-bun-pty-77fa7ff"],
+
     "bun-types": ["bun-types@1.2.21", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-sa2Tj77Ijc/NTLS0/Odjq/qngmEPZfbfnOERi0KRUYhT9R8M4VBioWVmMWE5GrYbKMc+5lVybXygLdibHaqVqw=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
@@ -1768,7 +1771,7 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
-    "hono": ["hono@4.7.10", "", {}, "sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ=="],
+    "hono": ["hono@4.9.8", "", {}, "sha512-JW8Bb4RFWD9iOKxg5PbUarBYGM99IcxFl2FPBo2gSJO11jjUDqlP1Bmfyqt8Z/dGhIQ63PMA9LdcLefXyIasyg=="],
 
     "hono-openapi": ["hono-openapi@1.0.7", "", { "peerDependencies": { "@hono/standard-validator": "^0.1.2", "@standard-community/standard-json": "^0.3.1", "@standard-community/standard-openapi": "^0.2.4", "@types/json-schema": "^7.0.15", "hono": "^4.8.3", "openapi-types": "^12.1.3" }, "optionalPeers": ["@hono/standard-validator", "hono"] }, "sha512-rMn+nn4/HMisyi549L3zT7WCmVvmpiKsyt790GcGfqvJf9mJfhq6txw09l0IhSBxpJpA0pXVKxFijcsnGfshUA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "@types/node": "22.13.9",
       "@tsconfig/node22": "22.0.2",
       "ai": "5.0.8",
-      "hono": "4.7.10",
+      "hono": "4.9.8",
       "fuzzysort": "3.1.0",
       "luxon": "3.6.1",
       "typescript": "5.8.2",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -38,6 +38,7 @@
     "@standard-schema/spec": "1.0.0",
     "@zip.js/zip.js": "2.7.62",
     "ai": "catalog:",
+    "bun-pty": "https://github.com/CefBoud/bun-pty#feat-use-env",
     "chokidar": "4.0.3",
     "decimal.js": "10.5.0",
     "diff": "8.0.2",

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -11,6 +11,7 @@ import { Bus } from "../../bus"
 import { Log } from "../../util/log"
 import { FileWatcher } from "../../file/watcher"
 import { Ide } from "../../ide"
+import { SetTuiCmdArgs, TuiCmdArgs } from "../../web"
 
 import { Flag } from "../../flag/flag"
 import { Session } from "../../session"
@@ -134,7 +135,8 @@ export const TuiCommand = cmd({
         Log.Default.info("tui", {
           cmd,
         })
-        const proc = Bun.spawn({
+
+        SetTuiCmdArgs({
           cmd: [
             ...cmd,
             ...(args.model ? ["--model", args.model] : []),
@@ -151,6 +153,9 @@ export const TuiCommand = cmd({
             CGO_ENABLED: "0",
             OPENCODE_SERVER: server.url.toString(),
           },
+        })
+        const proc = Bun.spawn({
+          ...TuiCmdArgs,
           onExit: () => {
             server.stop()
           },

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -3,6 +3,8 @@ import { Bus } from "../bus"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
 import { Hono } from "hono"
 import { cors } from "hono/cors"
+import { upgradeWebSocket, websocket } from "hono/bun"
+import { spawn, type IPty } from "bun-pty"
 import { streamSSE } from "hono/streaming"
 import { Session } from "../session"
 import z from "zod/v4"
@@ -30,6 +32,8 @@ import { SessionCompaction } from "../session/compaction"
 import { SessionRevert } from "../session/revert"
 import { lazy } from "../util/lazy"
 import { InstanceBootstrap } from "../project/bootstrap"
+import { TuiCmdArgs } from "../web"
+import ClientHTML from "../web/client.html" with { type: "text" }
 
 const ERRORS = {
   400: {
@@ -1176,6 +1180,91 @@ export namespace Server {
         }),
         async (c) => c.json(await callTui(c)),
       )
+      // HTML client endpoint - serves a web-based interface for interacting with opencode
+      // Provides session management, messaging, and permission handling through a browser
+      .get(
+        "/client",
+        describeRoute({
+          description:
+            "Serve the HTML client interface that spawns a PTY with TUI and displays it in the browser using xterm, streaming changes via WebSocket",
+          operationId: "client.serve",
+          responses: {
+            200: {
+              description: "HTML client interface",
+              content: {
+                "text/html": {
+                  schema: resolver(z.string()),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          // const content = await Bun.file(new URL("../web/client.html", import.meta.url)).text()
+          return c.html(ClientHTML.toString())
+        },
+      )
+      .get(
+        "/ws",
+        describeRoute({
+          description:
+            "WebSocket endpoint for terminal streaming - spawns a PTY with TUI command and streams output to browser client using xterm",
+          operationId: "ws.terminal",
+          responses: {
+            101: {
+              description: "WebSocket connection established for terminal streaming",
+            },
+          },
+        }),
+        upgradeWebSocket((_c) => {
+          let terminal: IPty
+          return {
+            async onOpen(_event, ws) {
+              log.info("ws open")
+              const cmd = TuiCmdArgs.cmd as string[]
+              terminal = spawn(cmd[0], cmd.slice(1), {
+                name: "xterm-256color",
+                cwd: TuiCmdArgs.cwd,
+                env: (TuiCmdArgs.env as Record<string, string>) || {},
+              })
+              // PTY -> WebSocket
+              terminal.onData((data) => {
+                ws.send(data)
+              })
+              // Handle terminal exit
+              terminal.onExit(({ exitCode, signal }) => {
+                log.info(`Terminal process exited with code ${exitCode}, signal ${signal}`)
+                ws.close()
+              })
+            },
+            onClose: () => {
+              log.info("WS Connection closed")
+              terminal.kill()
+            },
+            onError: (error) => {
+              log.error("upgrade error", { error })
+            },
+            onMessage: (event) => {
+              try {
+                const msg = JSON.parse(event.data as string)
+                if (msg.type === "resize") {
+                  terminal.resize(msg.cols, msg.rows)
+                  return
+                }
+              } catch (error) {
+                // log.error("WS failed to parse JSON data", { error })
+              }
+
+              if (typeof event.data === "string") {
+                terminal.write(event.data)
+              } else {
+                // handle binary if needed
+                terminal.write(new TextDecoder().decode(event.data as AllowSharedBufferSource))
+              }
+            },
+          }
+        }),
+      )
       .post(
         "/tui/open-themes",
         describeRoute({
@@ -1396,6 +1485,7 @@ export namespace Server {
       hostname: opts.hostname,
       idleTimeout: 0,
       fetch: App().fetch,
+      websocket,
     })
     return server
   }

--- a/packages/opencode/src/web/client.html
+++ b/packages/opencode/src/web/client.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Opencode</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css" />
+    <style>html,body,#terminal{height:100%;margin:0}</style>
+  </head>
+  <body>
+    <div id="terminal"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.js"></script>
+     <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+    <script>
+      const term = new Terminal();
+      const fitAddon = new FitAddon.FitAddon();
+      term.loadAddon(fitAddon);
+      term.open(document.getElementById("terminal"));
+      fitAddon.fit(); // Fit to initial size
+    
+      // binary websocket so we can send/receive raw bytes
+      const protocol = location.protocol === "https:" ? "wss" : "ws";
+      const socket = new WebSocket(`${protocol}://${location.host}/ws`);
+      socket.binaryType = "arraybuffer";
+
+      socket.addEventListener("open", () => {
+        console.log("ws open");
+        // trigger resize
+        window.dispatchEvent(new Event('resize'))
+
+      });
+
+      socket.addEventListener("message", (ev) => {
+        // ev.data is an ArrayBuffer or string
+        if (typeof ev.data === "string") {
+          term.write(ev.data);
+        } else {
+          const arr = new Uint8Array(ev.data);
+          // decode as bytes and write to xterm
+          const decoder = new TextDecoder();
+          term.write(decoder.decode(arr));
+        }
+      });
+
+      // send key presses to server
+      term.onData((data) => {
+        socket.send(data);
+      });
+
+      // resize -- tell backend if you support resizing (you need to implement)
+      window.addEventListener("resize", () => {
+        fitAddon.fit();
+        const cols = term.cols;
+        const rows = term.rows;
+        const msg = JSON.stringify({ type: "resize", cols, rows });
+        socket.send(msg);
+      });
+      
+    </script>
+  </body>
+</html>

--- a/packages/opencode/src/web/index.ts
+++ b/packages/opencode/src/web/index.ts
@@ -1,0 +1,16 @@
+import type { SpawnOptions } from "bun"
+
+// Define the full args type (using Bun's internal spawn types)
+export type TuiCmdArgsType = SpawnOptions.OptionsObject<"inherit", "inherit", "inherit"> & {
+  cmd: string[]
+}
+
+// Define and export the args object
+export let TuiCmdArgs: TuiCmdArgsType = {
+  cmd: [],
+}
+
+// Setter function with correct types
+export function SetTuiCmdArgs(args: TuiCmdArgsType): void {
+  TuiCmdArgs = args
+}


### PR DESCRIPTION
This PR adds a `/client` and `/ws` endpoints to expose the TUI via HTTP, making it accessible from the browser and remotely using [[Xterm](https://xtermjs.org/)](https://xtermjs.org/). The endpoint spawns a new TUI for each request via a PTY.

The implementation relies on `bun-pty`, but there was a small issue with environment variables, so I am using a slightly modified fork ([https://github.com/CefBoud/bun-pty#feat-use-env](https://github.com/CefBoud/bun-pty#feat-use-env)) for now.

```
# Very much temporary workaround
cd path/to/opencode
cd ./node_modules/bun-pty/rust-pty && cargo build --release && cd -
# bun-pty might need an architecture-specific binary name; in my case, I am running:
cp ./node_modules/bun-pty/rust-pty/target/release/librust_pty.dylib ./node_modules/bun-pty/rust-pty/target/release/librust_pty_arm64.dylib
```

Then, run:

```
bun run dev --port 8080 --hostname 0.0.0.0
```

Head over to your browser at `localhost:8080` or `<IP>:8080`, and the TUI will now be accessible remotely.

<img src="https://github.com/user-attachments/assets/ca18d34c-2657-47e1-af3e-c0ae2dafc013" width="300" height="175" style="display:inline-block; margin-right:10px;">
<img src="https://github.com/user-attachments/assets/119318d5-6b9d-47ca-94f3-63c6e9d1cacd" width="250" height="450" style="display:inline-block;">

