### PR TITLE
fix: lsp spawn logic

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -127,11 +127,19 @@ export namespace LSP {
         continue
       }
       log.info("spawning lsp server", { serverID: server.id })
-      const handle = await server.spawn(root).catch((err) => {
-        s.broken.add(root + server.id)
-        log.error(`Failed to spawn LSP server ${server.id}`, { error: err })
-        return undefined
-      })
+      const handle = await server
+        .spawn(root)
+        .then((h) => {
+          if (h === undefined) {
+            s.broken.add(root + server.id)
+          }
+          return h
+        })
+        .catch((err) => {
+          s.broken.add(root + server.id)
+          log.error(`Failed to spawn LSP server ${server.id}`, { error: err })
+          return undefined
+        })
       if (!handle) continue
       const client = await LSPClient.create({
         serverID: server.id,

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -132,6 +132,7 @@ export namespace LSP {
         .then((h) => {
           if (h === undefined) {
             s.broken.add(root + server.id)
+            log.info("LSP server not spawned", { serverID: server.id })
           }
           return h
         })

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -126,13 +126,11 @@ export namespace LSP {
         result.push(match)
         continue
       }
-      log.info("spawning lsp server", { serverID: server.id })
       const handle = await server
         .spawn(root)
         .then((h) => {
           if (h === undefined) {
             s.broken.add(root + server.id)
-            log.info("LSP server not spawned", { serverID: server.id })
           }
           return h
         })
@@ -142,6 +140,8 @@ export namespace LSP {
           return undefined
         })
       if (!handle) continue
+      log.info("spawned lsp server", { serverID: server.id })
+
       const client = await LSPClient.create({
         serverID: server.id,
         server: handle,


### PR DESCRIPTION
if a spawn doesn't throw and instead returns undefined opencode will continue trying to spawn it over and over. 

This probably hasn't affected users much but I would say it is unexpected behavior and introduces at least some latency.