### PR TITLE
docs: fix permissions link

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -495,9 +495,7 @@ For quick reference, here are common setups.
 }
 ```
 
-See the full permissions guide for more patterns.
-
-- /docs/permissions
+See the full [permissions guide](/docs/permissions) for more patterns.
 
 ---
 


### PR DESCRIPTION
Fixed the permissions guide link in [Agents](https://opencode.ai/docs/agents/).