### PR TITLE
Fix broken version parsing in installation script

### DIFF
--- a/install
+++ b/install
@@ -46,7 +46,7 @@ mkdir -p "$INSTALL_DIR"
 
 if [ -z "$requested_version" ]; then
     url="https://github.com/sst/opencode/releases/latest/download/$filename"
-    specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | sed -n 's/.*"tag_name"[ ]*:[ ]*"v*\([^"]*\)".*/\1/p')
+    specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
 
     if [[ $? -ne 0 || -z "$specific_version" ]]; then
         echo -e "${RED}Failed to fetch version information${NC}"

--- a/install
+++ b/install
@@ -46,7 +46,7 @@ mkdir -p "$INSTALL_DIR"
 
 if [ -z "$requested_version" ]; then
     url="https://github.com/sst/opencode/releases/latest/download/$filename"
-    specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | awk -F'"' '/"tag_name":\s?"/ {gsub(/^v/, "", $4); print $4}')
+    specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | sed -n 's/.*"tag_name"[ ]*:[ ]*"v*\([^"]*\)".*/\1/p')
 
     if [[ $? -ne 0 || -z "$specific_version" ]]; then
         echo -e "${RED}Failed to fetch version information${NC}"

--- a/install
+++ b/install
@@ -46,7 +46,7 @@ mkdir -p "$INSTALL_DIR"
 
 if [ -z "$requested_version" ]; then
     url="https://github.com/sst/opencode/releases/latest/download/$filename"
-    specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | awk -F'"' '/"tag_name": "/ {gsub(/^v/, "", $4); print $4}')
+    specific_version=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | awk -F'"' '/"tag_name":\s?"/ {gsub(/^v/, "", $4); print $4}')
 
     if [[ $? -ne 0 || -z "$specific_version" ]]; then
         echo -e "${RED}Failed to fetch version information${NC}"


### PR DESCRIPTION
The installation script fails for me with the following error message:

```
> curl -fsSL https://opencode.ai/install | bash
Failed to fetch version information
```

The culprit is the reliance on a space in the targeted `"tag_name": "` string segment when going through the releases API response.

Currently, the API response contains this version of the string:
```
"tag_name":"v1.11.0"
```

As such, the regular expression with the hardcoded whitespace fails to match this.

This PR adds an optional whitespace marker into the regular expression so that it will match the `tag_name` both with or without a space in-between key and value.