### PR TITLE
fix: update github copilot versions

### DIFF
--- a/packages/opencode/src/auth/github-copilot.ts
+++ b/packages/opencode/src/auth/github-copilot.ts
@@ -37,7 +37,7 @@ export namespace AuthGithubCopilot {
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
-        "User-Agent": "GitHubCopilotChat/0.26.7",
+        "User-Agent": "GitHubCopilotChat/0.31.2",
       },
       body: JSON.stringify({
         client_id: CLIENT_ID,
@@ -60,7 +60,7 @@ export namespace AuthGithubCopilot {
       headers: {
         Accept: "application/json",
         "Content-Type": "application/json",
-        "User-Agent": "GitHubCopilotChat/0.26.7",
+        "User-Agent": "GitHubCopilotChat/0.31.2",
       },
       body: JSON.stringify({
         client_id: CLIENT_ID,
@@ -101,9 +101,9 @@ export namespace AuthGithubCopilot {
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${info.refresh}`,
-        "User-Agent": "GitHubCopilotChat/0.26.7",
-        "Editor-Version": "vscode/1.99.3",
-        "Editor-Plugin-Version": "copilot-chat/0.26.7",
+        "User-Agent": "GitHubCopilotChat/0.31.2",
+        "Editor-Version": "vscode/1.104.1",
+        "Editor-Plugin-Version": "copilot-chat/0.31.2",
       },
     })
 


### PR DESCRIPTION
This pull request updates the user agent and editor version headers used for GitHub Copilot authentication to reflect newer versions. These updates help ensure compatibility with the latest Copilot and VSCode releases.

Version header updates:

* Updated the `User-Agent` header from `"GitHubCopilotChat/0.26.7"` to `"GitHubCopilotChat/0.31.2"` in all authentication requests in `github-copilot.ts`. [[1]](diffhunk://#diff-22b55c0b7a80cc0eb2b8e30ed580e412c4ce087f8aeb4052ea6767c751fb6485L40-R40) [[2]](diffhunk://#diff-22b55c0b7a80cc0eb2b8e30ed580e412c4ce087f8aeb4052ea6767c751fb6485L63-R63) [[3]](diffhunk://#diff-22b55c0b7a80cc0eb2b8e30ed580e412c4ce087f8aeb4052ea6767c751fb6485L104-R106)
* Updated the `Editor-Version` header from `"vscode/1.99.3"` to `"vscode/1.104.1"` and the `Editor-Plugin-Version` header from `"copilot-chat/0.26.7"` to `"copilot-chat/0.31.2"` in the relevant authentication request.

This PR enables gpt-5-codex support. Currently we are receiving this error:

```
AI_APICallError: model gpt-5-codex is not supported in this VS Code version. Please update it to version 1.104.1 or newer
```