### PR TITLE
fix: add title cleansing for TUI conversations

### DIFF
--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -926,7 +926,7 @@ func (a *App) DeleteSession(ctx context.Context, sessionID string) error {
 
 func (a *App) UpdateSession(ctx context.Context, sessionID string, title string) error {
 	_, err := a.Client.Session.Update(ctx, sessionID, opencode.SessionUpdateParams{
-		Title: opencode.F(title),
+		Title: opencode.F(util.CleanTitle(title)),
 	})
 	if err != nil {
 		slog.Error("Failed to update session", "error", err)

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -475,7 +475,9 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, toast.NewSuccessToast("Session deleted successfully")
 	case opencode.EventListResponseEventSessionUpdated:
 		if msg.Properties.Info.ID == a.app.Session.ID {
-			a.app.Session = &msg.Properties.Info
+			session := msg.Properties.Info
+			session.Title = util.CleanTitle(session.Title)
+			a.app.Session = &session
 		}
 	case opencode.EventListResponseEventMessagePartUpdated:
 		slog.Debug("message part updated", "message", msg.Properties.Part.MessageID, "part", msg.Properties.Part.ID)

--- a/packages/tui/internal/util/util.go
+++ b/packages/tui/internal/util/util.go
@@ -38,6 +38,31 @@ func IsWsl() bool {
 	return false
 }
 
+func CleanTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if !strings.HasPrefix(title, "```") || !strings.HasSuffix(title, "```") {
+		title = strings.ReplaceAll(title, "\n", " ")
+		return strings.TrimSpace(title)
+	}
+	if len(title) < 6 {
+		return ""
+	}
+	content := title[3 : len(title)-3]
+	if content == "" {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 {
+		first := strings.TrimSpace(lines[0])
+		if first != "" && !strings.Contains(first, " ") && len(first) < 20 {
+			lines = lines[1:]
+		}
+	}
+	title = strings.Join(lines, "\n")
+	title = strings.ReplaceAll(title, "\n", " ")
+	return strings.TrimSpace(title)
+}
+
 func Measure(tag string) func(...any) {
 	startTime := time.Now()
 	return func(args ...any) {

--- a/packages/tui/internal/util/util_test.go
+++ b/packages/tui/internal/util/util_test.go
@@ -1,0 +1,71 @@
+package util
+
+import "testing"
+
+func TestCleanTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal title",
+			input:    "Hello World",
+			expected: "Hello World",
+		},
+		{
+			name:     "multiline title",
+			input:    "Hello\nWorld",
+			expected: "Hello World",
+		},
+		{
+			name:     "code fence json",
+			input:    "```json\n{\"title\": \"Test\"}\n```",
+			expected: "{\"title\": \"Test\"}",
+		},
+		{
+			name:     "code fence with language",
+			input:    "```python\nprint('hello')\n```",
+			expected: "print('hello')",
+		},
+		{
+			name:     "leading and trailing spaces",
+			input:    "  Hello World  ",
+			expected: "Hello World",
+		},
+		{
+			name:     "multiline with spaces",
+			input:    "Hello\n  World\n  Test",
+			expected: "Hello   World   Test",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only code fence",
+			input:    "```",
+			expected: "",
+		},
+		{
+			name:     "code fence without content",
+			input:    "``````",
+			expected: "",
+		},
+		{
+			name:     "code fence with newline",
+			input:    "```\n```",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CleanTitle(tt.input)
+			if result != tt.expected {
+				t.Errorf("CleanTitle(%q) = %q; want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Added `CleanTitle` function to normalize session titles from multi-line or code-fenced AI responses. This prevents titles taking multiple lines in the TUI conversation list.

<img width="538" height="76" alt="image" src="https://github.com/user-attachments/assets/ff39da4b-a4a4-407d-9cfe-bdd386d89ce5" />
<img width="492" height="198" alt="image" src="https://github.com/user-attachments/assets/9c96fc52-719b-4047-8b88-d168b0d469f4" />

> Or... is it a _feature_? 😄 

## Changes

- Implemented `CleanTitle` in `packages/tui/internal/util/util.go` to handle multi-line inputs and code-fenced content
- Applied cleansing in `UpdateSession` and session update event handler in `packages/tui/internal/app/app.go` and `packages/tui/internal/tui/tui.go`
- Added comprehensive tests in `packages/tui/internal/util/util_test.go`

## Reproduction Steps

1. Send a prompt with a constraint like "Answer only in JSON format" or "Respond with code fence"
2. Observe that the generated title includes multi-lines(which naturally comes with code fences), making it malformed on the top of the TUI

## Before & After Examples

### Multi-line title
**Before:** `Hello\nWorld`
**After:** `Hello World`

### Code-fenced JSON
**Before:** ````json\n{"title": "Test"}\n````
**After:** `{"title": "Test"}`

### Normal title
**Before:** `Hello World`
**After:** `Hello World`

## Note

As a TypeScript developer, I used LLM assistance for Go code implementation. However, I faithfully reviewed all code. This commit was written using OpenCode.