### PR TITLE
feature(fork session): introduce fork session feature with `<leader>f` or `f` in session timeline modal

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -373,6 +373,30 @@ export namespace Server {
           return c.json(todos)
         },
       )
+      .get(
+        "/session/:id/forks",
+        describeRoute({
+          description: "Get forked sessions",
+          operationId: "session.forks",
+          responses: {
+            200: {
+              description: "List of forked sessions",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info.array()),
+                },
+              },
+            },
+            ...ERRORS,
+          },
+        }),
+        validator("param", z.object({ id: z.string() })),
+        async (c) => {
+          const sessionID = c.req.valid("param").id
+          const session = await Session.forks(sessionID)
+          return c.json(session)
+        },
+      )
       .post(
         "/session",
         describeRoute({
@@ -893,6 +917,40 @@ export namespace Server {
           const permissionID = params.permissionID
           Permission.respond({ sessionID: id, permissionID, response: c.req.valid("json").response })
           return c.json(true)
+        },
+      )
+      .post(
+        "/session/clone",
+        describeRoute({
+          description: "Clone a session with all its messages",
+          operationId: "session.clone",
+          responses: {
+            200: {
+              description: "Successfully cloned session",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.Info),
+                },
+              },
+            },
+            ...ERRORS,
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            sourceSessionID: z.string().meta({ description: "Source session ID to clone" }),
+            title: z.string().optional().meta({ description: "Title for the cloned session" }),
+            upToMessageIndex: z
+              .number()
+              .optional()
+              .meta({ description: "Only copy messages up to this index (inclusive)" }),
+          }),
+        ),
+        async (c) => {
+          const { sourceSessionID, title, upToMessageIndex } = c.req.valid("json")
+          const clonedSession = await Session.cloneSession(sourceSessionID, title, upToMessageIndex)
+          return c.json(clonedSession)
         },
       )
       .get(

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -35,6 +35,7 @@ export namespace Session {
       projectID: z.string(),
       directory: z.string(),
       parentID: Identifier.schema("session").optional(),
+      forkParentID: Identifier.schema("session").optional(),
       share: z
         .object({
           url: z.string(),
@@ -146,13 +147,20 @@ export namespace Session {
     })
   })
 
-  export async function createNext(input: { id?: string; title?: string; parentID?: string; directory: string }) {
+  export async function createNext(input: {
+    id?: string
+    title?: string
+    parentID?: string
+    forkParentID?: string
+    directory: string
+  }) {
     const result: Info = {
       id: Identifier.descending("session", input.id),
       version: Installation.VERSION,
       projectID: Instance.project.id,
       directory: input.directory,
       parentID: input.parentID,
+      forkParentID: input.forkParentID,
       title: input.title ?? createDefaultTitle(!!input.parentID),
       time: {
         created: Date.now(),
@@ -288,28 +296,46 @@ export namespace Session {
     return result
   })
 
-  export const remove = fn(Identifier.schema("session"), async (sessionID) => {
+  export async function forks(forkParentID: string) {
     const project = Instance.project
-    try {
-      const session = await get(sessionID)
-      for (const child of await children(sessionID)) {
-        await remove(child.id)
-      }
-      await unshare(sessionID).catch(() => {})
-      for (const msg of await Storage.list(["message", sessionID])) {
-        for (const part of await Storage.list(["part", msg.at(-1)!])) {
-          await Storage.remove(part)
-        }
-        await Storage.remove(msg)
-      }
-      await Storage.remove(["session", project.id, sessionID])
-      Bus.publish(Event.Deleted, {
-        info: session,
-      })
-    } catch (e) {
-      log.error(e)
+    const result = [] as Session.Info[]
+    for (const item of await Storage.list(["session", project.id])) {
+      const session = await Storage.read<Info>(item)
+      if (session.forkParentID !== forkParentID) continue
+      result.push(session)
     }
-  })
+    return result
+  }
+
+  export const remove = fn(
+    z.union([Identifier.schema("session"), z.tuple([Identifier.schema("session"), z.boolean()])]),
+    async (input, emitEvent = true) => {
+      const sessionID = Array.isArray(input) ? input[0] : input
+      if (Array.isArray(input)) emitEvent = input[1]
+      const project = Instance.project
+      try {
+        const session = await get(sessionID)
+        for (const child of await children(sessionID)) {
+          await remove([child.id, false])
+        }
+        await unshare(sessionID).catch(() => {})
+        for (const msg of await Storage.list(["message", sessionID])) {
+          for (const part of await Storage.list(["part", msg.at(-1)!])) {
+            await Storage.remove(part)
+          }
+          await Storage.remove(msg)
+        }
+        await Storage.remove(["session", project.id, sessionID])
+        if (emitEvent) {
+          Bus.publish(Event.Deleted, {
+            info: session,
+          })
+        }
+      } catch (e) {
+        log.error(e)
+      }
+    },
+  )
 
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
     await Storage.write(["message", msg.sessionID, msg.id], msg)
@@ -405,4 +431,48 @@ export namespace Session {
       await Project.setInitialized(Instance.project.id)
     },
   )
+
+  export async function cloneSession(sourceSessionID: string, title?: string, upToMessageIndex?: number) {
+    const sourceSession = await get(sourceSessionID)
+    const sourceMessages = await messages(sourceSessionID)
+
+    const clonedSession = await createNext({
+      title: title ?? `Fork of ${sourceSession.title}`,
+      directory: sourceSession.directory,
+      forkParentID: sourceSessionID,
+    })
+
+    const messagesToCopy =
+      upToMessageIndex !== undefined ? sourceMessages.slice(0, upToMessageIndex + 1) : sourceMessages
+
+    for (let i = messagesToCopy.length - 1; i >= 0; i--) {
+      const message = messagesToCopy[i]
+      const newMessageID = Identifier.descending("message")
+      const copiedMessage = {
+        ...message.info,
+        id: newMessageID,
+        sessionID: clonedSession.id,
+      }
+      await Storage.write(["message", clonedSession.id, newMessageID], copiedMessage)
+      Bus.publish(MessageV2.Event.Updated, {
+        info: copiedMessage,
+      })
+
+      for (const part of message.parts) {
+        const newPartID = Identifier.ascending("part")
+        const copiedPart = {
+          ...part,
+          id: newPartID,
+          messageID: newMessageID,
+          sessionID: clonedSession.id,
+        }
+        await Storage.write(["part", newMessageID, newPartID], copiedPart)
+        Bus.publish(MessageV2.Event.PartUpdated, {
+          part: copiedPart,
+        })
+      }
+    }
+
+    return clonedSession
+  }
 }

--- a/packages/sdk/go/session.go
+++ b/packages/sdk/go/session.go
@@ -1280,31 +1280,33 @@ func (r ReasoningPartType) IsKnown() bool {
 }
 
 type Session struct {
-	ID        string        `json:"id,required"`
-	Directory string        `json:"directory,required"`
-	ProjectID string        `json:"projectID,required"`
-	Time      SessionTime   `json:"time,required"`
-	Title     string        `json:"title,required"`
-	Version   string        `json:"version,required"`
-	ParentID  string        `json:"parentID"`
-	Revert    SessionRevert `json:"revert"`
-	Share     SessionShare  `json:"share"`
-	JSON      sessionJSON   `json:"-"`
+	ID           string        `json:"id,required"`
+	Directory    string        `json:"directory,required"`
+	ProjectID    string        `json:"projectID,required"`
+	Time         SessionTime   `json:"time,required"`
+	Title        string        `json:"title,required"`
+	Version      string        `json:"version,required"`
+	ParentID     string        `json:"parentID"`
+	ForkParentID string        `json:"forkParentID"`
+	Revert       SessionRevert `json:"revert"`
+	Share        SessionShare  `json:"share"`
+	JSON         sessionJSON   `json:"-"`
 }
 
 // sessionJSON contains the JSON metadata for the struct [Session]
 type sessionJSON struct {
-	ID          apijson.Field
-	Directory   apijson.Field
-	ProjectID   apijson.Field
-	Time        apijson.Field
-	Title       apijson.Field
-	Version     apijson.Field
-	ParentID    apijson.Field
-	Revert      apijson.Field
-	Share       apijson.Field
-	raw         string
-	ExtraFields map[string]apijson.Field
+	ID           apijson.Field
+	Directory    apijson.Field
+	ProjectID    apijson.Field
+	Time         apijson.Field
+	Title        apijson.Field
+	Version      apijson.Field
+	ParentID     apijson.Field
+	ForkParentID apijson.Field
+	Revert       apijson.Field
+	Share        apijson.Field
+	raw          string
+	ExtraFields  map[string]apijson.Field
 }
 
 func (r *Session) UnmarshalJSON(data []byte) (err error) {

--- a/packages/tui/internal/app/app.go
+++ b/packages/tui/internal/app/app.go
@@ -970,6 +970,92 @@ func (a *App) ListProviders(ctx context.Context) ([]opencode.Provider, error) {
 	return providers.Providers, nil
 }
 
+// ForkSession forks the current session at the current boundary (respects undo state)
+func (a *App) ForkSession(ctx context.Context) (*opencode.Session, error) {
+	// If no revert state, fork the entire session
+	if a.Session.Revert.MessageID == "" {
+		return a.cloneSession(ctx, a.Session.ID, "Fork of "+a.Session.Title)
+	}
+
+	// Find the index of the revert message (first message to exclude)
+	revertIndex := -1
+	for i, message := range a.Messages {
+		if message.Info != nil {
+			switch casted := message.Info.(type) {
+			case opencode.UserMessage:
+				if casted.ID == a.Session.Revert.MessageID {
+					revertIndex = i
+					break
+				}
+			case opencode.AssistantMessage:
+				if casted.ID == a.Session.Revert.MessageID {
+					revertIndex = i
+					break
+				}
+			}
+		}
+		if revertIndex != -1 {
+			break
+		}
+	}
+
+	// If revert message not found, fork entire session as fallback
+	if revertIndex == -1 {
+		return a.cloneSession(ctx, a.Session.ID, "Fork of "+a.Session.Title)
+	}
+
+	// Fork up to (but not including) the revert message
+	upToIndex := revertIndex - 1
+	if upToIndex < 0 {
+		// Edge case: revert to beginning, create empty session by cloning with no messages
+		// We'll use upToIndex = -1 to signal no messages should be copied
+		return a.cloneSessionUpTo(ctx, a.Session.ID, "Fork of "+a.Session.Title, -1)
+	}
+
+	return a.cloneSessionUpTo(ctx, a.Session.ID, "Fork of "+a.Session.Title, upToIndex)
+}
+
+// ForkSessionFromMessage creates a copy of the session up to and including the specified message index
+func (a *App) ForkSessionFromMessage(ctx context.Context, messageIndex int) (*opencode.Session, error) {
+	// Fork only up to the specified message index
+	return a.cloneSessionUpTo(ctx, a.Session.ID, "Fork of "+a.Session.Title, messageIndex)
+}
+
+// cloneSession calls the /session/clone API using the authenticated client
+func (a *App) cloneSession(ctx context.Context, sourceSessionID, title string) (*opencode.Session, error) {
+	// Create request body
+	requestBody := map[string]interface{}{
+		"sourceSessionID": sourceSessionID,
+		"title":           title,
+	}
+
+	var result *opencode.Session
+	err := a.Client.Post(ctx, "/session/clone", requestBody, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone session: %w", err)
+	}
+
+	return result, nil
+}
+
+// cloneSessionUpTo calls the /session/clone API with upToMessageIndex parameter
+func (a *App) cloneSessionUpTo(ctx context.Context, sourceSessionID, title string, upToMessageIndex int) (*opencode.Session, error) {
+	// Create request body
+	requestBody := map[string]interface{}{
+		"sourceSessionID":  sourceSessionID,
+		"title":            title,
+		"upToMessageIndex": upToMessageIndex,
+	}
+
+	var result *opencode.Session
+	err := a.Client.Post(ctx, "/session/clone", requestBody, &result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone session: %w", err)
+	}
+
+	return result, nil
+}
+
 // func (a *App) loadCustomKeybinds() {
 //
 // }

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -127,6 +127,7 @@ const (
 	SessionNewCommand               CommandName = "session_new"
 	SessionListCommand              CommandName = "session_list"
 	SessionTimelineCommand          CommandName = "session_timeline"
+	SessionForkCommand              CommandName = "session_fork"
 	SessionShareCommand             CommandName = "session_share"
 	SessionUnshareCommand           CommandName = "session_unshare"
 	SessionInterruptCommand         CommandName = "session_interrupt"
@@ -227,6 +228,12 @@ func LoadFromConfig(config *opencode.Config, customCommands []opencode.Command) 
 			Description: "show session timeline",
 			Keybindings: parseBindings("<leader>g"),
 			Trigger:     []string{"timeline", "history", "goto"},
+		},
+		{
+			Name:        SessionForkCommand,
+			Description: "fork current session",
+			Keybindings: parseBindings("<leader>f"),
+			Trigger:     []string{"fork"},
 		},
 		{
 			Name:        SessionShareCommand,

--- a/packages/tui/internal/components/dialog/timeline.go
+++ b/packages/tui/internal/components/dialog/timeline.go
@@ -34,6 +34,12 @@ type RestoreToMessageMsg struct {
 	Index     int
 }
 
+// ForkFromMessageMsg is sent when a new session should be forked from a specific message
+type ForkFromMessageMsg struct {
+	MessageID string
+	Index     int
+}
+
 // timelineItem represents a user message in the timeline list
 type timelineItem struct {
 	messageID string
@@ -194,6 +200,16 @@ func (n *timelineDialog) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					util.CmdHandler(modal.CloseModalMsg{}),
 				)
 			}
+		case "f":
+			// Fork session from selected message
+			if item, idx := n.list.GetSelectedItem(); idx >= 0 {
+				// Find the last message in the assistant's response to this user message
+				endIndex := n.findResponseEndIndex(item.index)
+				return n, tea.Sequence(
+					util.CmdHandler(ForkFromMessageMsg{MessageID: item.messageID, Index: endIndex}),
+					util.CmdHandler(modal.CloseModalMsg{}),
+				)
+			}
 		case "enter":
 			// Keep Enter functionality for closing the modal
 			if _, idx := n.list.GetSelectedItem(); idx >= 0 {
@@ -226,7 +242,11 @@ func (n *timelineDialog) Render(background string) string {
 	) + keyStyle(
 		"r",
 	) + mutedStyle(
-		" restore",
+		" restore   ",
+	) + keyStyle(
+		"f",
+	) + mutedStyle(
+		" fork",
 	)
 
 	bgColor := t.BackgroundPanel()
@@ -279,6 +299,25 @@ func countToolsInResponse(messages []app.Message, userMessageIndex int) int {
 		}
 	}
 	return count
+}
+
+// findResponseEndIndex finds the last message index of the assistant's response to a user message
+func (n *timelineDialog) findResponseEndIndex(userMessageIndex int) int {
+	messages := n.app.Messages
+	endIndex := userMessageIndex // Default to the user message index
+
+	// Look ahead to find the end of the assistant's response
+	for i := userMessageIndex + 1; i < len(messages); i++ {
+		message := messages[i]
+		// If we hit another user message, stop (don't include it)
+		if _, isUser := message.Info.(opencode.UserMessage); isUser {
+			break
+		}
+		// This is part of the assistant's response, include it
+		endIndex = i
+	}
+
+	return endIndex
 }
 
 // NewTimelineDialog creates a new session timeline dialog

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -723,6 +723,27 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return app.MessageRevertedMsg{Session: *response, Message: app.Message{}}
 		}
 		cmds = append(cmds, cmd)
+	case dialog.ForkFromMessageMsg:
+		cmd := func() tea.Msg {
+			// Fork session from selected message using the app layer
+			forkedSession, err := a.app.ForkSessionFromMessage(context.Background(), msg.Index)
+			if err != nil {
+				return toast.NewErrorToast("Failed to fork session: " + err.Error())
+			}
+
+			// Switch to the forked session
+			a.app.Session = forkedSession
+
+			// Load messages for the forked session
+			messages, err := a.app.ListMessages(context.Background(), forkedSession.ID)
+			if err != nil {
+				return toast.NewErrorToast("Failed to load forked session messages: " + err.Error())
+			}
+			a.app.Messages = messages
+
+			return app.SessionLoadedMsg{}
+		}
+		cmds = append(cmds, cmd)
 	case app.MessageRevertedMsg:
 		if msg.Session.ID == a.app.Session.ID {
 			a.app.Session = &msg.Session
@@ -1209,6 +1230,30 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 		}
 		navigationDialog := dialog.NewTimelineDialog(a.app)
 		a.modal = navigationDialog
+	case commands.SessionForkCommand:
+		if a.app.Session.ID == "" {
+			return a, toast.NewErrorToast("No active session")
+		}
+		cmd := func() tea.Msg {
+			// Fork the current session using the app layer
+			forkedSession, err := a.app.ForkSession(context.Background())
+			if err != nil {
+				return toast.NewErrorToast("Failed to fork session: " + err.Error())
+			}
+
+			// Switch to the forked session
+			a.app.Session = forkedSession
+
+			// Load messages for the forked session
+			messages, err := a.app.ListMessages(context.Background(), forkedSession.ID)
+			if err != nil {
+				return toast.NewErrorToast("Failed to load forked session messages: " + err.Error())
+			}
+			a.app.Messages = messages
+
+			return app.SessionLoadedMsg{}
+		}
+		return a, cmd
 	case commands.SessionShareCommand:
 		if a.app.Session.ID == "" {
 			return a, nil


### PR DESCRIPTION
## Summary
Fork the active session into a brand‑new one.
The fork copies existing messages (and their parts) into a new session titled: `Fork of <original title>`

### Usage
1. Full fork: `<leader>f`
   - Copies the visible conversation.

2. Partial fork from a point:
   - Open the timeline: `<leader>g`
   - Move to a user message (↑/↓)
   - Press `f`
   - Copies session up to the selected message (inclusive, with assistant response)

### Typical Uses

- Explore an alternative approach without losing current progress.
- Branch before a long assistant/tool sequence and try a different prompt.
- Save a clean starting point after pruning via revert, then iterate separately.

### Notes

- Does not mutate the source session.
- Forking during an in‑progress assistant response only captures what has completed so far. (source session streaming is not interupted)