### PR TITLE
feat(sdk) Add session state endpoint

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -292,6 +292,34 @@ export namespace Server {
         },
       )
       .get(
+        "/session/:id/state",
+        describeRoute({
+          description: "Get a session's state",
+          operationId: "session.state",
+          responses: {
+            200: {
+              description: "State object",
+              content: {
+                "application/json": {
+                  schema: resolver(Session.StateInfo),
+                },
+              },
+            },
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            id: z.string(),
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").id
+          const session = await Session.getState(sessionID)
+          return c.json(session)
+        },
+      )
+      .get(
         "/session/:id/children",
         describeRoute({
           description: "Get a session's children",

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -70,6 +70,16 @@ export namespace Session {
     })
   export type ShareInfo = z.output<typeof ShareInfo>
 
+  export const StateInfo = z
+    .object({
+      busy: z.boolean(),
+      queued: z.number(),
+    })
+    .meta({
+      ref: "SessionState",
+    })
+  export type StateInfo = z.output<typeof StateInfo>
+
   export const Event = {
     Updated: Bus.event(
       "session.updated",
@@ -145,6 +155,11 @@ export namespace Session {
 
   export async function getShare(id: string) {
     return Storage.read<ShareInfo>(["share", id])
+  }
+
+  export async function getState(id: string) {
+    const state = SessionPrompt.getState(id)
+    return state as StateInfo
   }
 
   export async function share(id: string) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1153,6 +1153,13 @@ export namespace SessionPrompt {
     return state().pending.has(sessionID)
   }
 
+  export function getState(sessionID: string) {
+    return {
+      busy: isBusy(sessionID),
+      queued: state().queued.get(sessionID)?.length ?? 0,
+    }
+  }
+
   export function abort(sessionID: string) {
     const controller = state().pending.get(sessionID)
     if (!controller) return false

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -27,6 +27,8 @@ import type {
   SessionGetResponses,
   SessionUpdateData,
   SessionUpdateResponses,
+  SessionStateData,
+  SessionStateResponses,
   SessionChildrenData,
   SessionChildrenResponses,
   SessionInitData,
@@ -262,6 +264,16 @@ class Session extends _HeyApiClient {
         "Content-Type": "application/json",
         ...options.headers,
       },
+    })
+  }
+
+  /**
+   * Get a session's state
+   */
+  public state<ThrowOnError extends boolean = false>(options: Options<SessionStateData, ThrowOnError>) {
+    return (options.client ?? this._client).get<SessionStateResponses, unknown, ThrowOnError>({
+      url: "/session/{id}/state",
+      ...options,
     })
   }
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -550,6 +550,11 @@ export type Session = {
   }
 }
 
+export type SessionState = {
+  busy: boolean
+  queued: number
+}
+
 export type UserMessage = {
   id: string
   sessionID: string
@@ -1383,6 +1388,26 @@ export type SessionUpdateResponses = {
 }
 
 export type SessionUpdateResponse = SessionUpdateResponses[keyof SessionUpdateResponses]
+
+export type SessionStateData = {
+  body?: never
+  path: {
+    id: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{id}/state"
+}
+
+export type SessionStateResponses = {
+  /**
+   * State object
+   */
+  200: SessionState
+}
+
+export type SessionStateResponse = SessionStateResponses[keyof SessionStateResponses]
 
 export type SessionChildrenData = {
   body?: never


### PR DESCRIPTION
Expose session state retrieval via server API and JS SDK to facilitate async state polling use-cases.