### PR TITLE
feat: Add session initialize plugin event and ability to override model in chat.params

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -141,6 +141,24 @@ export namespace SessionPrompt {
     const session = await Session.get(input.sessionID)
     await SessionRevert.cleanup(session)
 
+    const agent = await Agent.get(input.agent ?? "build")
+    let model = await resolveModel({
+      agent,
+      model: input.model,
+    }).then((x) => Provider.getModel(x.providerID, x.modelID))
+
+    if (session.time.created === session.time.updated) {
+      await Plugin.trigger(
+        "chat.session",
+        {},
+        {
+          sessionID: session.id,
+          model: model.info,
+          provider: await Provider.getProvider(model.providerID),
+        },
+      )
+    }
+
     const userMsg = await createUserMessage(input)
     await Session.touch(input.sessionID)
 
@@ -154,13 +172,34 @@ export namespace SessionPrompt {
         state().queued.set(input.sessionID, queue)
       })
     }
-    const agent = await Agent.get(input.agent ?? "build")
-    const model = await resolveModel({
-      agent,
-      model: input.model,
-    }).then((x) => Provider.getModel(x.providerID, x.modelID))
 
     using abort = lock(input.sessionID)
+
+    const params = await Plugin.trigger(
+      "chat.params",
+      {
+        model: model.info,
+        provider: await Provider.getProvider(model.providerID),
+        message: userMsg,
+      },
+      {
+        modelID: model.modelID,
+        providerID: model.providerID,
+        temperature: model.info.temperature
+          ? (agent.temperature ?? ProviderTransform.temperature(model.providerID, model.modelID))
+          : undefined,
+        topP: agent.topP ?? ProviderTransform.topP(model.providerID, model.modelID),
+        options: {
+          ...ProviderTransform.options(model.providerID, model.modelID, input.sessionID),
+          ...model.info.options,
+          ...agent.options,
+        },
+      },
+    )
+
+    if (params.modelID !== model.modelID || params.providerID !== model.providerID) {
+      model = await Provider.getModel(params.providerID, params.modelID)
+    }
 
     const system = await resolveSystemPrompt({
       providerID: model.providerID,
@@ -186,26 +225,6 @@ export namespace SessionPrompt {
       tools: input.tools,
       processor,
     })
-
-    const params = await Plugin.trigger(
-      "chat.params",
-      {
-        model: model.info,
-        provider: await Provider.getProvider(model.providerID),
-        message: userMsg,
-      },
-      {
-        temperature: model.info.temperature
-          ? (agent.temperature ?? ProviderTransform.temperature(model.providerID, model.modelID))
-          : undefined,
-        topP: agent.topP ?? ProviderTransform.topP(model.providerID, model.modelID),
-        options: {
-          ...ProviderTransform.options(model.providerID, model.modelID, input.sessionID),
-          ...model.info.options,
-          ...agent.options,
-        },
-      },
-    )
 
     let step = 0
     while (true) {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -84,6 +84,10 @@ export interface Hooks {
     )[]
   }
   /**
+   * Called when a new session is initialized
+   */
+  "chat.session"?: (input: {}, output: { sessionID: string; model: Model; provider: Provider }) => Promise<void>
+  /**
    * Called when a new message is received
    */
   "chat.message"?: (input: {}, output: { message: UserMessage; parts: Part[] }) => Promise<void>
@@ -92,7 +96,7 @@ export interface Hooks {
    */
   "chat.params"?: (
     input: { model: Model; provider: Provider; message: UserMessage },
-    output: { temperature: number; topP: number; options: Record<string, any> },
+    output: { modelID: string; providerID: string; temperature: number; topP: number; options: Record<string, any> },
   ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "tool.execute.before"?: (


### PR DESCRIPTION
This pull request introduces enhancements to the plugin hook system and refactors session initialization and model parameter handling in the `SessionPrompt` namespace. The changes streamline how model and provider information are passed to plugins, allow plugins to dynamically update model selection, and add a new initialization hook for chat sessions.

### Plugin hook system improvements

* Added a new `chat.session` plugin hook, which is triggered when a new session is initialized, providing session, model, and provider information to plugins. (`packages/plugin/src/index.ts`)
* Updated the `chat.params` plugin hook to allow plugins to override the selected model and provider by including `modelID` and `providerID` in the output parameters. (`packages/plugin/src/index.ts`)

### Session initialization and model parameter handling

* Refactored session initialization in `SessionPrompt` to trigger the new `chat.session` hook when a session is first created, passing model and provider details to plugins. (`packages/opencode/src/session/prompt.ts`)
* Changed the model parameter resolution flow: after invoking the `chat.params` hook, the code checks for plugin-supplied model and provider overrides and updates the model accordingly. (`packages/opencode/src/session/prompt.ts`)