### PR TITLE
fix: config loading not considering symlinks

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -120,7 +120,12 @@ export namespace Config {
   async function assertValid(dir: string) {
     const ALLOWED_DIRS = new Set(["agent", "command", "mode", "plugin", "tool", "themes"])
     const UNEXPECTED_DIR_GLOB = new Bun.Glob("*/")
-    for await (const item of UNEXPECTED_DIR_GLOB.scan({ absolute: true, cwd: dir, onlyFiles: false })) {
+    for await (const item of UNEXPECTED_DIR_GLOB.scan({
+      absolute: true,
+      followSymlinks: true,
+      cwd: dir,
+      onlyFiles: false,
+    })) {
       const dirname = path.basename(item)
       if (!ALLOWED_DIRS.has(dirname)) {
         throw new InvalidError({
@@ -134,7 +139,7 @@ export namespace Config {
   const COMMAND_GLOB = new Bun.Glob("command/**/*.md")
   async function loadCommand(dir: string) {
     const result: Record<string, Command> = {}
-    for await (const item of COMMAND_GLOB.scan({ absolute: true, cwd: dir })) {
+    for await (const item of COMMAND_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
       const content = await Bun.file(item).text()
       const md = matter(content)
       if (!md.data) continue
@@ -169,7 +174,7 @@ export namespace Config {
   async function loadAgent(dir: string) {
     const result: Record<string, Agent> = {}
 
-    for await (const item of AGENT_GLOB.scan({ absolute: true, cwd: dir })) {
+    for await (const item of AGENT_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
       const content = await Bun.file(item).text()
       const md = matter(content)
       if (!md.data) continue
@@ -207,7 +212,7 @@ export namespace Config {
   const MODE_GLOB = new Bun.Glob("mode/*.md")
   async function loadMode(dir: string) {
     const result: Record<string, Agent> = {}
-    for await (const item of MODE_GLOB.scan({ absolute: true, cwd: dir })) {
+    for await (const item of MODE_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
       const content = await Bun.file(item).text()
       const md = matter(content)
       if (!md.data) continue
@@ -233,7 +238,7 @@ export namespace Config {
   async function loadPlugin(dir: string) {
     const plugins: string[] = []
 
-    for await (const item of PLUGIN_GLOB.scan({ absolute: true, cwd: dir })) {
+    for await (const item of PLUGIN_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
       plugins.push("file://" + item)
     }
     return plugins

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -123,6 +123,7 @@ export namespace Config {
     for await (const item of UNEXPECTED_DIR_GLOB.scan({
       absolute: true,
       followSymlinks: true,
+      dot: true,
       cwd: dir,
       onlyFiles: false,
     })) {
@@ -139,7 +140,7 @@ export namespace Config {
   const COMMAND_GLOB = new Bun.Glob("command/**/*.md")
   async function loadCommand(dir: string) {
     const result: Record<string, Command> = {}
-    for await (const item of COMMAND_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
+    for await (const item of COMMAND_GLOB.scan({ absolute: true, followSymlinks: true, dot: true, cwd: dir })) {
       const content = await Bun.file(item).text()
       const md = matter(content)
       if (!md.data) continue
@@ -174,7 +175,7 @@ export namespace Config {
   async function loadAgent(dir: string) {
     const result: Record<string, Agent> = {}
 
-    for await (const item of AGENT_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
+    for await (const item of AGENT_GLOB.scan({ absolute: true, followSymlinks: true, dot: true, cwd: dir })) {
       const content = await Bun.file(item).text()
       const md = matter(content)
       if (!md.data) continue
@@ -212,7 +213,7 @@ export namespace Config {
   const MODE_GLOB = new Bun.Glob("mode/*.md")
   async function loadMode(dir: string) {
     const result: Record<string, Agent> = {}
-    for await (const item of MODE_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
+    for await (const item of MODE_GLOB.scan({ absolute: true, followSymlinks: true, dot: true, cwd: dir })) {
       const content = await Bun.file(item).text()
       const md = matter(content)
       if (!md.data) continue
@@ -238,7 +239,7 @@ export namespace Config {
   async function loadPlugin(dir: string) {
     const plugins: string[] = []
 
-    for await (const item of PLUGIN_GLOB.scan({ absolute: true, followSymlinks: true, cwd: dir })) {
+    for await (const item of PLUGIN_GLOB.scan({ absolute: true, followSymlinks: true, dot: true, cwd: dir })) {
       plugins.push("file://" + item)
     }
     return plugins


### PR DESCRIPTION
fixes #2797

This PR fixes an issue where configs that rely on symlinks or paths starting with a dot are not correctly loaded. 

This was previously not an issue because it relied on [this method](https://github.com/sst/opencode/blob/39917a35ce04c00a79c018edc0f0a4fea23f2da3/packages/opencode/src/util/filesystem.ts#L50-L56) which sets `followSymlinks` and `dot` to true.