### PR TITLE
fix(tool): follow symlinks when looking for tools

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -42,7 +42,7 @@ export namespace ToolRegistry {
     const glob = new Bun.Glob("tool/*.{js,ts}")
 
     for (const dir of await Config.directories()) {
-      for await (const match of glob.scan({ cwd: dir, absolute: true })) {
+      for await (const match of glob.scan({ cwd: dir, absolute: true, followSymlinks: true, dot: true })) {
         const namespace = path.basename(match, path.extname(match))
         const mod = await import(match)
         for (const [id, def] of Object.entries<ToolDefinition>(mod)) {


### PR DESCRIPTION
Custom tools were not found when symlinked in the global config.