### PR TITLE
Include step-start and step-finish for cost tracking

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -186,6 +186,14 @@ export const RunCommand = cmd({
           }
         }
 
+        if (part.type === "step-start") {
+          if (outputJsonEvent("step_start", { part })) return
+        }
+
+        if (part.type === "step-finish") {
+          if (outputJsonEvent("step_finish", { part })) return
+        }
+
         if (part.type === "text") {
           text = part.text
 


### PR DESCRIPTION
The new json format excludes step-start and step-finish, which means you can't access the cost via json output. The initial version of the PR included them, but was too verbose. This adds these lines back in:

{"type":"step_start","timestamp":1758919896305,"sessionID":"ses_6783457c2ffeICANaRjenHkVxv","part":{"id":"prt_987cbacef001avphNDsk6GIW22","messageID":"msg_987cba88e001nNnKFuCUiZZqZ3","sessionID":"ses_6783457c2ffeICANaRjenHkVxv","type":"step-start"}}

{"type":"step_finish","timestamp":1758919898483,"sessionID":"ses_6783457c2ffeICANaRjenHkVxv","part":{"id":"prt_987cbb572001dBJeMtv6BrJDTQ","messageID":"msg_987cba88e001nNnKFuCUiZZqZ3","sessionID":"ses_6783457c2ffeICANaRjenHkVxv","type":"step-finish","tokens":{"input":11087,"output":145,"reasoning":0,"cache":{"write":0,"read":0}},"cost":0.0070147}}