### PR TITLE
fix: resolve Windows spawn ENOENT error in SDK

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -30,6 +30,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
 
   const proc = spawn(`opencode`, [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`], {
     signal: options.signal,
+    shell: true,
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}),
@@ -105,6 +106,7 @@ export function createOpencodeTui(options?: TuiOptions) {
 
   const proc = spawn(`opencode`, args, {
     signal: options?.signal,
+    shell: true,
     stdio: "inherit",
     env: {
       ...process.env,


### PR DESCRIPTION
Adds shell: true to spawn calls in createOpencodeServer and createOpencodeTui functions. This allows Node.js to properly resolve opencode executable on Windows while maintaining Unix compatibility. Fixes #2812