### PR TITLE
fix: add "src" to "files" in SDK package.json

### DIFF
--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -13,7 +13,8 @@
     "./server": "./src/server.ts"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "devDependencies": {
     "typescript": "catalog:",


### PR DESCRIPTION
## Problem

The current package.json configuration causes build failures when using the SDK in development environments. The issue occurs because:

1. The `exports` field references "src" in development mode:
    ```json
    "exports": {
      ".": {
        "development": "./src/index.ts",
        "import": "./dist/index.js"
      }
    }

2. However, the files field only includes the dist directory:
    ```
    "files": ["dist"]
    ```

This mismatch means that when bundlers like Vite try to resolve the development exports, they can't find the source files because they weren't included in the published package.

### Error Example

```
Failed to resolve entry for package "@opencode-ai/sdk".
The package may have incorrect main/module/exports specified in its package.json.
```

## Solution

Add "src" to the files array in package.json to ensure source files are included in the published package:

```
"files": [
  "dist",
  "src"
]
```

- Fixes development builds for bundlers like Vite while maintaining full backward compatibility.
- Tested with Vite and confirmed both development and production builds work correctly.
- This ensures package exports function properly in all environments.

## ⚠️ Temporary workaround until this PR is merged

Add this to your `vite.config.js`:

```
resolve: {
  conditions: ["import", "module", "browser", "default"],
}
``` 