### PR TITLE
Fix relative paths for getGitFiles

### DIFF
--- a/packages/tui/internal/completions/files.go
+++ b/packages/tui/internal/completions/files.go
@@ -38,10 +38,11 @@ func (cg *filesContextGroup) getGitFiles() []CompletionSuggestion {
 			return files[i].Added+files[i].Removed > files[j].Added+files[j].Removed
 		})
 
+		cwd, err := os.Getwd()
 		for _, file := range files {
 			// Convert path from relative to git repo root to relative to current working directory
 			relativePath := file.Path
-			if cwd, err := os.Getwd(); err == nil {
+			if err == nil {
 				if absPath := filepath.Join(cg.app.Project.Worktree, file.Path); absPath != "" {
 					if relPath, err := filepath.Rel(cwd, absPath); err == nil {
 						relativePath = relPath

--- a/packages/tui/internal/completions/files.go
+++ b/packages/tui/internal/completions/files.go
@@ -3,6 +3,8 @@ package completions
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,11 +39,21 @@ func (cg *filesContextGroup) getGitFiles() []CompletionSuggestion {
 		})
 
 		for _, file := range files {
+			// Convert path from relative to git repo root to relative to current working directory
+			relativePath := file.Path
+			if cwd, err := os.Getwd(); err == nil {
+				if absPath := filepath.Join(cg.app.Project.Worktree, file.Path); absPath != "" {
+					if relPath, err := filepath.Rel(cwd, absPath); err == nil {
+						relativePath = relPath
+					}
+				}
+			}
+
 			displayFunc := func(s styles.Style) string {
 				t := theme.CurrentTheme()
 				green := s.Foreground(t.Success()).Render
 				red := s.Foreground(t.Error()).Render
-				display := file.Path
+				display := relativePath
 				if file.Added > 0 {
 					display += green(" +" + strconv.Itoa(int(file.Added)))
 				}
@@ -52,7 +64,7 @@ func (cg *filesContextGroup) getGitFiles() []CompletionSuggestion {
 			}
 			item := CompletionSuggestion{
 				Display:    displayFunc,
-				Value:      file.Path,
+				Value:      relativePath,
 				ProviderID: cg.GetId(),
 				RawData:    file,
 			}


### PR DESCRIPTION
## Problem

When working in a large monorepo, sometimes we open opencode from a sub package rather than from the github repository root. If you select a file with `@` files with git diffs will show at the top, but they are relative to the git repository root and not to the current working directory, so the file path that gets read is incorrect. 

## Fix 

By using the relative path based on the working directory, opencode successfully reads the file from the git diff selection.