### PR TITLE
Added: Inherit environment when starting new process in 'bash' tool.

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -149,6 +149,8 @@ export const BashTool = Tool.define("bash", {
     const process = exec(params.command, {
       cwd: Instance.directory,
       signal: ctx.abort,
+      // Inherit the environment variables. May be important if user set env vars before starting the process.
+      env: { ...globalThis.process.env },
       timeout,
     })
 


### PR DESCRIPTION
This changes the `bash` tool such that it inherits the environment variables from the parent shell.

Currently, running with the `bash` tool; no environment is inherited. This may be undesirable if the software you're developing requires environment variables to be set. For example, an authentication key for staging/development or a config.

In my specific case, I'm on NixOS, and I've activated `nix-ld` for convenience using `export LD_LIBRARY_PATH=$NIX_LD_LIBRARY_PATH`. (This is to work around another unrelated problem)
Without this env var, I can't really develop on one of my projects as I can't run it.