### PR TITLE
fix: sanitize message history to prevent API errors

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -62,6 +62,25 @@ export namespace ProviderTransform {
     return msgs
   }
 
+  function sanitizeMessages(msgs: ModelMessage[]): ModelMessage[] {
+    const out: ModelMessage[] = []
+    for (const msg of msgs) {
+      const c: any = (msg as any).content
+      if (Array.isArray(c)) {
+        const cleaned = c.filter((p: any) => p && p.type !== "reasoning")
+        if (cleaned.length > 0) {
+          ;(msg as any).content = cleaned
+          out.push(msg)
+        }
+      } else if (typeof c === "string") {
+        if (c.trim().length > 0) out.push(msg)
+      } else {
+        out.push(msg)
+      }
+    }
+    return out
+  }
+
   export function message(msgs: ModelMessage[], providerID: string, modelID: string) {
     if (modelID.includes("claude")) {
       msgs = normalizeToolCallIds(msgs)
@@ -69,7 +88,7 @@ export namespace ProviderTransform {
     if (providerID === "anthropic" || modelID.includes("anthropic") || modelID.includes("claude")) {
       msgs = applyCaching(msgs, providerID)
     }
-
+    msgs = sanitizeMessages(msgs)
     return msgs
   }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -286,12 +286,15 @@ export namespace SessionPrompt {
               if (m.info.role !== "assistant" || m.info.error === undefined) {
                 return true
               }
-              if (
-                MessageV2.AbortedError.isInstance(m.info.error) &&
-                m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
-              ) {
-                return true
-              }
+              const hasContentfulPart = m.parts.some((part) => {
+                if (part.type === "text") return true
+                if (part.type === "tool") {
+                  const status = (part as any).state?.status
+                  return status === "completed" || status === "error"
+                }
+                return false
+              })
+              if (MessageV2.AbortedError.isInstance(m.info.error) && hasContentfulPart) return true
 
               return false
             }),


### PR DESCRIPTION
## Summary
- Add `sanitizeMessages()` function to strip reasoning parts and empty messages from provider input
- Update abort error filtering to only include messages with contentful parts (text or completed/errored tools)
- Prevents OpenAI API errors when reasoning parts appear in conversation history

## Changes
1. **transform.ts**: Added `sanitizeMessages()` function that filters out:
   - Messages with only reasoning content type
   - Empty string messages
   - Messages with empty content arrays

2. **prompt.ts**: Improved abort error handling to use `hasContentfulPart` logic:
   - Only includes aborted messages that have text parts
   - Or tool parts with completed/error status
   - Excludes messages with only step-start or reasoning parts

## Test plan
- Verify that conversations with reasoning parts don't cause API errors
- Confirm that aborted messages with meaningful content are still included in history
- Test that empty or reasoning-only messages are filtered out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)