### PR TITLE
feat: delete entire attachment if file agent or symbol

### DIFF
--- a/packages/tui/internal/components/textarea/textarea.go
+++ b/packages/tui/internal/components/textarea/textarea.go
@@ -678,6 +678,14 @@ func (m *Model) removeAttachmentAtCursor() bool {
 	if att == nil {
 		return false
 	}
+
+	if att.Type == "file" || att.Type == "symbol" || att.Type == "agent" {
+		m.value[m.row] = slices.Delete(m.value[m.row], startIdx, startIdx+1)
+		m.col = startIdx
+		m.SetCursorColumn(m.col)
+		return true
+	}
+
 	// Replace the attachment element with the display runes
 	before := m.value[m.row][:startIdx]
 	after := m.value[m.row][startIdx+1:]


### PR DESCRIPTION
I actually wonder if this was like this on purpose or if it's a feature that other people would like but I hate that if I tag the wrong file/symbol I need to remove the entire thing and thought it made more sense to delete entirely

before vs after video:

https://github.com/user-attachments/assets/e4b736a8-0689-41f6-8be6-c56a8e235070
