### PR TITLE
docs: Update README with mise installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ curl -fsSL https://opencode.ai/install | bash
 npm i -g opencode-ai@latest        # or bun/pnpm/yarn
 brew install sst/tap/opencode      # macOS and Linux
 paru -S opencode-bin               # Arch Linux
+mise use --pin -g ubi:sst/opencode # Any OS
 ```
 
 > [!TIP]

--- a/packages/web/src/components/Lander.astro
+++ b/packages/web/src/components/Lander.astro
@@ -131,6 +131,18 @@ if (image) {
           </span>
         </button>
       </div>
+      <div class="col4">
+        <h3>Mise</h3>
+        <button class="command" data-command="mise use --pin -g ubi:sst/opencode">
+          <code>
+            <span>mise use --pin -g</span> <span class="highlight">ubi:sst/opencode</span>
+          </code>
+          <span class="copy">
+            <CopyIcon />
+            <CheckIcon />
+          </span>
+        </button>
+      </div>
     </section>
 
     <section class="images">

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -103,6 +103,12 @@ You can also install it with the following commands:
   npm install -g opencode-ai
   ```
 
+- **Using Mise**
+
+  ```bash
+  mise use --pin -g ubi:sst/opencode
+  ```
+
 Support for installing OpenCode on Windows using Bun is currently in progress.
 
 You can also grab the binary from the [Releases](https://github.com/sst/opencode/releases).


### PR DESCRIPTION
Added installation command for using 

```
mise use --pin -g ubi:sst/opencode
```