### PR TITLE
docs: java-lsp support

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -25,7 +25,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | rust       | .rs                                                  | `rust-analyzer` command available   |
 | clangd     | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects    |
 | svelte     | .svelte                                              | Auto-installs for Svelte projects   |
-| JDT-LS     | .java                                                | `Java SDK (version 21+)` installed  |
+| jdtls      | .java                                                | `Java SDK (version 21+)` installed  |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -25,6 +25,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | rust       | .rs                                                  | `rust-analyzer` command available   |
 | clangd     | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects    |
 | svelte     | .svelte                                              | Auto-installs for Svelte projects   |
+| JDT-LS     | .java                                                | `Java SDK (version 21+)` installed  |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 


### PR DESCRIPTION
Add documentation for Java LSP server introduced in https://github.com/sst/opencode/pull/2547