### PR TITLE
fix: allow LSP filename matching when extension is missing

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -113,7 +113,7 @@ export namespace LSP {
 
   async function getClients(file: string) {
     const s = await state()
-    const extension = path.parse(file).ext
+    const extension = path.parse(file).ext || file
     const result: LSPClient.Info[] = []
     for (const server of Object.values(s.servers)) {
       if (server.extensions.length && !server.extensions.includes(extension)) continue


### PR DESCRIPTION
Fall back to the filename when no extension is present so servers can target files like 'Dockerfile'. Fixes #2182.