### PR TITLE
make file references & grep tool work on windows

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -47,7 +47,7 @@ import { NamedError } from "../util/error"
 import { ulid } from "ulid"
 import { spawn } from "child_process"
 import { Command } from "../command"
-import { $ } from "bun"
+import { $, fileURLToPath } from "bun"
 import { ConfigMarkdown } from "../config/markdown"
 
 export namespace SessionPrompt {
@@ -589,7 +589,7 @@ export namespace SessionPrompt {
               log.info("file", { mime: part.mime })
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
-              const filepath = decodeURIComponent(url.pathname)
+              const filepath = fileURLToPath(part.url)
               const stat = await Bun.file(filepath).stat()
 
               if (stat.isDirectory()) {
@@ -604,14 +604,14 @@ export namespace SessionPrompt {
                   end: url.searchParams.get("end"),
                 }
                 if (range.start != null) {
-                  const filePath = part.url.split("?")[0]
+                  const filePathURI = part.url.split("?")[0]
                   let start = parseInt(range.start)
                   let end = range.end ? parseInt(range.end) : undefined
                   // some LSP servers (eg, gopls) don't give full range in
                   // workspace/symbol searches, so we'll try to find the
                   // symbol in the document to get the full range
                   if (start === end) {
-                    const symbols = await LSP.documentSymbol(filePath)
+                    const symbols = await LSP.documentSymbol(filePathURI)
                     for (const symbol of symbols) {
                       let range: LSP.Range | undefined
                       if ("range" in symbol) {

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -25,6 +25,7 @@ export const GrepTool = Tool.define("grep", {
       args.push("--glob", params.include)
     }
     args.push(searchPath)
+    args.push("--field-match-separator=|")
 
     const proc = Bun.spawn([rgPath, ...args], {
       stdout: "pipe",
@@ -53,11 +54,11 @@ export const GrepTool = Tool.define("grep", {
     for (const line of lines) {
       if (!line) continue
 
-      const [filePath, lineNumStr, ...lineTextParts] = line.split(":")
+      const [filePath, lineNumStr, ...lineTextParts] = line.split("|")
       if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
 
       const lineNum = parseInt(lineNumStr, 10)
-      const lineText = lineTextParts.join(":")
+      const lineText = lineTextParts.join("|")
 
       const file = Bun.file(filePath)
       const stats = await file.stat().catch(() => null)


### PR DESCRIPTION
Related issues - #631

### Issues

Currently, there are a couple of file related features broken in Windows.

- Directly referencing a file path with `@` displays a `failed to send message. 400 Bad Request - Error: ENOENT: no such file or directory, scandir <directory-of-file>` error.
- Searching for a pattern with the grep tool always yields a "No Files Found" message even when there should be matching files.

### Fixes

- Direct file references are converted to file paths using `decodeURIComponent` in `packages/opencode/src/session/prompt.ts`. This results in a Windows file path that looks like this - `/C:/Users/Username/samplefile.ts`. The extra `/` at the start and the `/` separators prevent this from being a valid windows file path. Instead, we use the `fileURLToPath` function in Bun to create a valid, cross-platform filepath from the message part URL.
- The grep tool sets the working directory for ripgrep to be the current directory (in absolute path terms) which causes ripgrep to output matches also in absolute path terms (which includes the Drive letter on Windows. This causes the line splitting logic to fail since the Windows Drive Letter includes a `:`). We use the `--field-match-separator` flag to change the separator to `|` and avoid issues on Windows and having to change the parsing logic