### PR TITLE
fix: add directory validation for session creation and retrieval

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -188,8 +188,14 @@ export namespace Session {
   }
 
   export const get = fn(Identifier.schema("session"), async (id) => {
-    const read = await Storage.read<Info>(["session", Instance.project.id, id])
-    return read as Info
+    try {
+      const read = await Storage.read<Info>(["session", Instance.project.id, id])
+      return read as Info
+    } catch {
+      // Fallback to global if not found in current project
+      const read = await Storage.read<Info>(["session", "global", id])
+      return read as Info
+    }
   })
 
   export const getShare = fn(Identifier.schema("session"), async (id) => {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -188,14 +188,14 @@ export namespace Session {
   }
 
   export const get = fn(Identifier.schema("session"), async (id) => {
-    try {
-      const read = await Storage.read<Info>(["session", Instance.project.id, id])
-      return read as Info
-    } catch {
-      // Fallback to global if not found in current project
-      const read = await Storage.read<Info>(["session", "global", id])
-      return read as Info
+    const projects = [Instance.project.id, "global"]
+    for (const projectID of projects) {
+      try {
+        const read = await Storage.read<Info>(["session", projectID, id])
+        return read as Info
+      } catch {}
     }
+    throw new Error(`Session ${id} not found`)
   })
 
   export const getShare = fn(Identifier.schema("session"), async (id) => {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -5,6 +5,7 @@ import { type LanguageModelUsage, type ProviderMetadata } from "ai"
 import PROMPT_INITIALIZE from "../session/prompt/initialize.txt"
 
 import { Bus } from "../bus"
+import { Filesystem } from "../util/filesystem"
 import { Config } from "../config/config"
 import { Flag } from "../flag/flag"
 import { Identifier } from "../id/id"
@@ -101,6 +102,14 @@ export namespace Session {
       })
       .optional(),
     async (input) => {
+      try {
+        const stat = await Bun.file(Instance.directory).stat()
+        if (!stat.isDirectory) throw new Error("Path is not a directory")
+      } catch {
+        throw new Error("Directory does not exist")
+      }
+      if (Instance.project.id !== "global" && !Filesystem.contains(Instance.worktree, Instance.directory))
+        throw new Error("Directory outside project")
       return createNext({
         parentID: input?.parentID,
         directory: Instance.directory,


### PR DESCRIPTION
### Issues
Session creation allowed nonexistent directories or paths outside the project scope, causing invalid sessions. Retrieval failed when accessing sessions created in different project contexts.

### Fixes
- Added async directory existence and project boundary checks in `Session.create` using Bun's native APIs to prevent invalid session creation.
- Improved `Session.get` with loop-based fallback to global project, enabling cross-project session access.

### Question
Is allowing arbitrary directory specification (e.g., /root/ for a project in /user/foo) intentional? This enables cross-project work but may confuse users. Should we restrict to project-related directories?

Fixes API inconsistency reported in bug analysis.