### PR TITLE
fix: language model ID for custom models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -427,7 +427,7 @@ export namespace Provider {
     const sdk = await getSDK(provider.info, info)
 
     try {
-      const language = provider.getModel ? await provider.getModel(sdk, modelID) : sdk.languageModel(modelID)
+      const language = provider.getModel ? await provider.getModel(sdk, info.id) : sdk.languageModel(modelID)
       log.info("found", { providerID, modelID })
       s.models.set(key, {
         providerID,


### PR DESCRIPTION
Regarding the solution proposed [here](https://github.com/sst/opencode/issues/2829#issuecomment-3342072689), the language is currently not built with the original model ID, so the API will return 'model not found'.

---
## How to reproduce:

`opencore.json`
```json
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "openai": {
      "models": {
        "gpt-5-nano-flex": {
          "id": "gpt-5-nano",
          "name": "GPT 5 Nano Flex Tier",
          "cost": {
            "input": 0.025,
            "cache_read": 0.0025,
            "output": 0.2
          },
          "limit": {
            "context": 400000,
            "output": 128000
          },
          "options": {
            "reasoningEffort": "high",
            "textVerbosity": "medium",
            "reasoningSummary": "auto",
            "serviceTier": "flex"
          }
        }
      }
    }
  }
} 
```

Then, when you set the model to be the gpt-5-nano-flex, you encounter the error:
`AI_APICallError: The requested model 'gpt-5-nano-flex' does not exist.`

From the dev logs, I found this error:
```json
{
    "error": {
        "message": "The requested model 'gpt-5-nano-flex' does not exist.",
        "type": "invalid_request_error",
        "param": "model",
        "code": "model_not_found"
    }
}
``` 

While debugging, I found where the model name was being retrieved to send to the API.
https://github.com/sst/opencode/blob/cd528ae78fd20c8eaa84933bf8afd3e99f4ca8f5/packages/opencode/src/session/prompt.ts#L307