### PR TITLE
fix: clang formatter name 

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -15,7 +15,10 @@ export namespace Format {
     const enabled: Record<string, boolean> = {}
     const cfg = await Config.get()
 
-    const formatters = { ...Formatter } as Record<string, Formatter.Info>
+    const formatters: Record<string, Formatter.Info> = {}
+    for (const item of Object.values(Formatter as Record<string, Formatter.Info>)) {
+      formatters[item.name] = item
+    }
     for (const [name, item] of Object.entries(cfg.formatter ?? {})) {
       if (item.disabled) {
         delete formatters[name]

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -16,7 +16,7 @@ export namespace Format {
     const cfg = await Config.get()
 
     const formatters: Record<string, Formatter.Info> = {}
-    for (const item of Object.values(Formatter as Record<string, Formatter.Info>)) {
+    for (const item of Object.values(Formatter)) {
       formatters[item.name] = item
     }
     for (const [name, item] of Object.entries(cfg.formatter ?? {})) {


### PR DESCRIPTION
## My Report

My project have a .clang-format file in the home directory, opencode will ALWAYS run clang-format if that file exists. using custom configurations like disableing formatters is totally ignored, so i had to apply this fix to tell it not to ignore me.

## Grok Explanation of the bug and the fix

The bug was that the formatters object was keyed by the export names from the Formatter module (e.g., 'clang'), but the configuration uses the name property of each formatter (e.g., "clang-format"). This mismatch meant that disabling a formatter in the config, like setting "clang-format": { "disabled": true }, wouldn't actually remove it because delete formatters["clang-format"] was trying to delete a key that didn't exist.

I fixed this by rebuilding the formatters object to use the name property as keys instead of the export names. Now the keys match what the config expects, so disabling formatters works correctly.