### PR TITLE
fix: process.stdout.write instead of console.log for export cmd

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -67,6 +67,7 @@ export const ExportCommand = cmd({
         }
 
         process.stdout.write(JSON.stringify(exportData, null, 2))
+        process.stdout.write("\n")
       } catch (error) {
         UI.error(`Session not found: ${sessionID!}`)
         process.exit(1)

--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -66,7 +66,7 @@ export const ExportCommand = cmd({
           })),
         }
 
-        console.log(JSON.stringify(exportData, null, 2))
+        process.stdout.write(JSON.stringify(exportData, null, 2))
       } catch (error) {
         UI.error(`Session not found: ${sessionID!}`)
         process.exit(1)


### PR DESCRIPTION
This makes sure that all of the output is written before the command exits.

Verified by:

`opencode export <sessionID>`: produces expected output.
`opencode export <sessionID> | jq`: produces expected output.

For very large data, one could try to mock a session with a lot of data. I opted
for the simpler approach of just replacing the changed code with the following:
```js
const data = 'a'.repeat(1024**3) // 1GiB of data should be more than enough safety margin
process.stdout.write(JSON.stringify(exportData, null, 2))
```
and running `opencode export <sessionID> | wc -c`, which printed `1073741824`,
which indeed corresponds to 1GiB.
