### PR TITLE
tui: show orphaned tool calls, even if content is empty

### DIFF
--- a/packages/tui/internal/components/chat/messages.go
+++ b/packages/tui/internal/components/chat/messages.go
@@ -678,6 +678,7 @@ func (m *messagesComponent) renderView() tea.Cmd {
 						false,
 						[]opencode.FilePart{},
 						[]opencode.AgentPart{},
+						orphanedToolCalls...,
 					)
 					partCount++
 					lineCount += lipgloss.Height(content) + 1


### PR DESCRIPTION
Fixes the issue described in #3065. Tool calls are shown immediately again.

It especially seems to occur with GPT-5 Codex, as the model doesn't provide any content before starting with the tool calls.

There is still the issue that the order of the tool calls is not honored. All tool calls are rendered at the end instead at the position when they occur, but I didn't find an easy fix for that.
