### PR TITLE
feat: add support for CLAUDE.md and GEMINI.md rules in /init command

### DIFF
--- a/packages/opencode/src/session/prompt/initialize.txt
+++ b/packages/opencode/src/session/prompt/initialize.txt
@@ -3,6 +3,6 @@ Please analyze this codebase and create an AGENTS.md file containing:
 2. Code style guidelines including imports, formatting, types, naming conventions, error handling, etc.
 
 The file you create will be given to agentic coding agents (such as yourself) that operate in this repository. Make it about 20 lines long.
-If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (in .github/copilot-instructions.md), make sure to include them.
+If there are Cursor rules (in .cursor/rules/ or .cursorrules), Copilot rules (in .github/copilot-instructions.md), CLAUDE.md, or GEMINI.md, make sure to include them.
 
 If there's already an AGENTS.md, improve it if it's located in ${path}


### PR DESCRIPTION
- Extends initialize.txt to include CLAUDE.md and GEMINI.md
- Improves migration experience for users from Claude and Gemini coding tools
- Aligns with provider-agnostic goals