### PR TITLE
feat: autocompact in opencode.json

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -428,6 +428,7 @@ export namespace Config {
         .describe(
           "Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing",
         ),
+      autocompact: z.boolean().optional().default(true).describe("Automatically compact sessions"),
       autoshare: z
         .boolean()
         .optional()
@@ -616,7 +617,7 @@ export namespace Config {
         if (err.code === "ENOENT") return
         throw new JsonError({ path: filepath }, { cause: err })
       })
-    if (!text) return {}
+    if (!text) return {} as Info
     return load(text, filepath)
   }
 

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -3,6 +3,7 @@ import { Session } from "."
 import { Identifier } from "../id/id"
 import { Instance } from "../project/instance"
 import { Provider } from "../provider/provider"
+import { Config } from "../config/config"
 import { defer } from "../util/defer"
 import { MessageV2 } from "./message-v2"
 import { SystemPrompt } from "./system"
@@ -26,8 +27,9 @@ export namespace SessionCompaction {
     ),
   }
 
-  export function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: ModelsDev.Model }) {
-    if (Flag.OPENCODE_DISABLE_AUTOCOMPACT) return false
+  export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: ModelsDev.Model }) {
+    const config = await Config.get()
+    if (config.autocompact === false || Flag.OPENCODE_DISABLE_AUTOCOMPACT) return false
     const context = input.model.limit.context
     if (context === 0) return false
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -347,10 +347,10 @@ export namespace SessionPrompt {
     const lastAssistant = msgs.findLast((msg) => msg.info.role === "assistant")
     if (
       lastAssistant?.info.role === "assistant" &&
-      SessionCompaction.isOverflow({
+      (await SessionCompaction.isOverflow({
         tokens: lastAssistant.info.tokens,
         model: input.model,
-      })
+      }))
     ) {
       const summaryMsg = await SessionCompaction.run({
         sessionID: input.sessionID,

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -239,6 +239,19 @@ OpenCode will automatically download any new updates when it starts up. You can 
 
 ---
 
+### Autocompact
+
+OpenCode will automatically compact sessions when they exceed the model's context window limits. This helps maintain conversation history while staying within token limits. You can disable this with the `autocompact` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "autocompact": false
+}
+```
+
+---
+
 ### Formatters
 
 You can configure code formatters through the `formatter` option.


### PR DESCRIPTION
Addresses https://github.com/sst/opencode/issues/2945

### Changes
Introduce an `autocompact` boolean to `opencode.json` that defaults to `true`.
It makes the functionality of `OPENCODE_DISABLE_AUTOCOMPACT` more accessible.

Implementation is inspired by implementation of [`autoupdate` boolean](https://opencode.ai/docs/config/#autoupdate).