### PR TITLE
fix: disable GPG signing in snapshot tests

### DIFF
--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
       await Bun.write(`${dir}/a.txt`, aContent)
       await Bun.write(`${dir}/b.txt`, bContent)
       await $`git add .`.cwd(dir).quiet()
-      await $`git commit -m init`.cwd(dir).quiet()
+      await $`git commit --no-gpg-sign -m init`.cwd(dir).quiet()
       return {
         aContent,
         bContent,


### PR DESCRIPTION
This prevents unnecessary prompting when developers have GPG signing enabled globally. Ensures tests run consistently regardless of local git configuration.