### PR TITLE
fix: `rg` hanging forever when run in bash, waiting for stdin

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -146,7 +146,6 @@ export const BashTool = Tool.define("bash", {
     }
 
     const process = spawn(params.command, {
-      shell: 'bash',
       cwd: Instance.directory,
       signal: ctx.abort,
       stdio: ["ignore", "pipe", "pipe"],

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -146,6 +146,7 @@ export const BashTool = Tool.define("bash", {
     }
 
     const process = spawn(params.command, {
+      shell: true,
       cwd: Instance.directory,
       signal: ctx.abort,
       stdio: ["ignore", "pipe", "pipe"],

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -1,6 +1,5 @@
 import z from "zod/v4"
-import { exec } from "child_process"
-
+import { spawn } from "child_process"
 import { Tool } from "./tool"
 import DESCRIPTION from "./bash.txt"
 import { Permission } from "../permission"
@@ -146,9 +145,10 @@ export const BashTool = Tool.define("bash", {
       })
     }
 
-    const process = exec(params.command, {
+    const process = spawn(params.command, {
       cwd: Instance.directory,
       signal: ctx.abort,
+      stdio: ["ignore", "pipe", "pipe"],
       timeout,
     })
 

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -146,6 +146,7 @@ export const BashTool = Tool.define("bash", {
     }
 
     const process = spawn(params.command, {
+      shell: 'bash',
       cwd: Instance.directory,
       signal: ctx.abort,
       stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
Pass ignore to stdin so that rg does not wait for stdin input. This probably fixes other commands hanging

Fix https://github.com/sst/opencode/issues/3089