### PR TITLE
feat: include stack trace in server error responses

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -71,7 +71,8 @@ export namespace Server {
             status: 400,
           })
         }
-        return c.json(new NamedError.Unknown({ message: err.toString() }).toObject(), {
+        const message = err instanceof Error && err.stack ? err.stack : err.toString()
+        return c.json(new NamedError.Unknown({ message }).toObject(), {
           status: 400,
         })
       })


### PR DESCRIPTION
Makes it much easier to debug unexpected opencode errors by showing the full stack trace in error messages instead of just the error string.