### PR TITLE
feat: Improve editor detection with auto-discovery and better error messages

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1152,9 +1152,9 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 			// status.Warn("Agent is working, please wait...")
 			return a, nil
 		}
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			return a, toast.NewErrorToast("No EDITOR set, can't open editor")
+		editor, err := util.GetEditor()
+		if err != nil || editor == "" {
+			return a, toast.NewErrorToast("No editor found. Set EDITOR environment variable (e.g., export EDITOR=vim)")
 		}
 
 		value := a.editor.Value()
@@ -1398,10 +1398,9 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 		// Format to Markdown
 		markdownContent := formatConversationToMarkdown(messages)
 
-		// Check if EDITOR is set
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			return a, toast.NewErrorToast("No EDITOR set, can't open editor")
+		editor, err := util.GetEditor()
+		if err != nil || editor == "" {
+			return a, toast.NewErrorToast("No editor found. Set EDITOR environment variable (e.g., export EDITOR=vim)")
 		}
 
 		// Create and write to temp file

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -1152,8 +1152,8 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 			// status.Warn("Agent is working, please wait...")
 			return a, nil
 		}
-		editor, err := util.GetEditor()
-		if err != nil || editor == "" {
+		editor := util.GetEditor()
+		if editor == "" {
 			return a, toast.NewErrorToast("No editor found. Set EDITOR environment variable (e.g., export EDITOR=vim)")
 		}
 
@@ -1398,8 +1398,8 @@ func (a Model) executeCommand(command commands.Command) (tea.Model, tea.Cmd) {
 		// Format to Markdown
 		markdownContent := formatConversationToMarkdown(messages)
 
-		editor, err := util.GetEditor()
-		if err != nil || editor == "" {
+		editor := util.GetEditor()
+		if editor == "" {
 			return a, toast.NewErrorToast("No editor found. Set EDITOR environment variable (e.g., export EDITOR=vim)")
 		}
 

--- a/packages/tui/internal/util/util.go
+++ b/packages/tui/internal/util/util.go
@@ -3,6 +3,8 @@ package util
 import (
 	"log/slog"
 	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -44,4 +46,26 @@ func Measure(tag string) func(...any) {
 		args = append(args, []any{"timeTakenMs", time.Since(startTime).Milliseconds()}...)
 		slog.Debug(tag, args...)
 	}
+}
+
+func GetEditor() (string, error) {
+	if editor := os.Getenv("VISUAL"); editor != "" {
+		return editor, nil
+	}
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor, nil
+	}
+
+	commonEditors := []string{"code", "cursor", "nvim", "vim", "zed", "nano", "vi"}
+	if runtime.GOOS == "windows" {
+		commonEditors = []string{"code.cmd", "cursor.cmd", "notepad.exe", "nvim", "vim", "zed", "nano"}
+	}
+
+	for _, editor := range commonEditors {
+		if _, err := exec.LookPath(editor); err == nil {
+			return editor, nil
+		}
+	}
+
+	return "", nil
 }

--- a/packages/tui/internal/util/util.go
+++ b/packages/tui/internal/util/util.go
@@ -48,24 +48,24 @@ func Measure(tag string) func(...any) {
 	}
 }
 
-func GetEditor() (string, error) {
+func GetEditor() string {
 	if editor := os.Getenv("VISUAL"); editor != "" {
-		return editor, nil
+		return editor
 	}
 	if editor := os.Getenv("EDITOR"); editor != "" {
-		return editor, nil
+		return editor
 	}
 
-	commonEditors := []string{"code", "cursor", "nvim", "vim", "zed", "nano", "vi"}
+	commonEditors := []string{"vim", "nvim", "zed", "code", "cursor", "vi", "nano"}
 	if runtime.GOOS == "windows" {
-		commonEditors = []string{"code.cmd", "cursor.cmd", "notepad.exe", "nvim", "vim", "zed", "nano"}
+		commonEditors = []string{"vim", "nvim", "zed", "code.cmd", "cursor.cmd", "notepad.exe", "vi", "nano"}
 	}
 
 	for _, editor := range commonEditors {
 		if _, err := exec.LookPath(editor); err == nil {
-			return editor, nil
+			return editor
 		}
 	}
 
-	return "", nil
+	return ""
 }


### PR DESCRIPTION
## Summary

Improves the `/editor` command UX by automatically detecting available editors and providing helpful error messages when none are found.

## Changes

- Add `GetEditor()` utility function in `packages/tui/internal/util/util.go`:
  - Checks `VISUAL` environment variable first (standard for full-screen editors)
  - Falls back to `EDITOR` environment variable
  - Auto-detects common modern editors: **VSCode** (`code`), **Cursor**, **Zed**, **Neovim** (`nvim`), **Vim**, **nano**, **vi**
  - Platform-specific support (e.g., `.cmd` extensions and `notepad.exe` on Windows)
  
- Update `/editor` command (EditorOpenCommand) to use new detection
- Update `/export` command (SessionExportCommand) to use new detection
- Provide helpful error message: "No editor found. Set EDITOR environment variable (e.g., export EDITOR=vim)"

## Testing

Tested scenarios:
- ✅ EDITOR set: uses specified editor
- ✅ VISUAL set: prefers VISUAL over EDITOR  
- ✅ Neither set but common editor available: auto-detects (VSCode, Cursor, Neovim, Vim, Zed, etc.)
- ✅ No editor available: shows helpful error with instructions

## Related Issues

Resolves the issue where users get unhelpful "No EDITOR set" message without guidance on how to fix it.