### PR TITLE
feat(cli): add session option to attach command

### DIFF
--- a/packages/opencode/src/cli/cmd/attach.ts
+++ b/packages/opencode/src/cli/cmd/attach.ts
@@ -10,10 +10,16 @@ export const AttachCommand = cmd({
   command: "attach <server>",
   describe: "attach to a running opencode server",
   builder: (yargs) =>
-    yargs.positional("server", {
-      type: "string",
-      describe: "http://localhost:4096",
-    }),
+    yargs
+      .positional("server", {
+        type: "string",
+        describe: "http://localhost:4096",
+      })
+      .option("session", {
+        alias: ["s"],
+        describe: "session id to continue",
+        type: "string",
+      }),
   handler: async (args) => {
     let cmd = [] as string[]
     const tui = Bun.embeddedFiles.find((item) => (item as File).name.includes("tui")) as File
@@ -35,6 +41,9 @@ export const AttachCommand = cmd({
       let binaryName = `./dist/tui${process.platform === "win32" ? ".exe" : ""}`
       await $`go build -o ${binaryName} ./main.go`.cwd(dir)
       cmd = [path.join(dir, binaryName)]
+    }
+    if (args.session) {
+      cmd.push("--session", args.session)
     }
     Log.Default.info("tui", {
       cmd,


### PR DESCRIPTION
Add `--session` flag to the `attach` command to allow continuing existing sessions. 
The session ID is passed through to the TUI binary when specified.


https://github.com/user-attachments/assets/68dd7de0-1ff0-43b1-8072-8cfe6e9c551c

