### PR TITLE
fix: use ai-sdk openai chat language model instead of completion language model

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -69,7 +69,7 @@ export namespace Provider {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           if (options?.["useCompletionUrls"]) {
-            return sdk.completion(modelID)
+            return sdk.chat(modelID)
           } else {
             return sdk.responses(modelID)
           }


### PR DESCRIPTION
the fix is super small but the reason is kind of interesting.

IIUC, the intention of #2528 was to allow Azure users to hit a chat completions endpoint
(`%baseURL%/deployments/%Model%/chat/completions?api-version=%apiVersion%`) instead of a responses endpoint.

i work somewhere that currently only has access to a chat completions endpoint, but when i tried this out, the appropriate configuration still errored. i was connecting to the expected endpoint, but AI SDK was complaining that the prompt was invalid.

turns out, both `sdk.completion` and `sdk.chat` ultimately hit a `/chat/completions` endpoint when called here by opencode. however, i'm pretty sure `sdk.completion` is *supposed to* hit `/completions` instead of `/chat/completions`; i haven't tracked down why, but that's what happens AFAICT.

anyway, the code paths for a chat language model differ a bit from a completion language model. most notably, a completion language model [complains if the prompt has more than one system message](https://github.com/vercel/ai/blob/34407b23b8c276359ac8dbeb42cc06f9db301b99/packages/openai/src/completion/convert-to-openai-completion-prompt.ts#L31) while a chat language model does not care.

since opencode [may include more than one system message](https://github.com/sst/opencode/blob/1c59530115d05e0f18f381023f639accc851825c/packages/opencode/src/session/prompt.ts#L413), the completions model would complain.

swapping to a chat language model solves this problem. also, i think it's just more accurate with respect to what functionality is supposed to be exposed.

related: #2528 , #1508 , #3150 