### PR TITLE
feat: deno lsp

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -11,26 +11,31 @@ OpenCode integrates with your Language Server Protocol (LSP) to help the LLM int
 
 OpenCode comes with several built-in LSP servers for popular languages:
 
-| LSP Server | Extensions                                           | Requirements                        |
-| ---------- | ---------------------------------------------------- | ----------------------------------- |
-| typescript | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project  |
-| eslint     | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project      |
-| gopls      | .go                                                  | `go` command available              |
-| ruby-lsp   | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available |
-| pyright    | .py, .pyi                                            | `pyright` dependency installed      |
-| elixir-ls  | .ex, .exs                                            | `elixir` command available          |
-| zls        | .zig, .zon                                           | `zig` command available             |
-| csharp     | .cs                                                  | `.NET SDK` installed                |
-| vue        | .vue                                                 | Auto-installs for Vue projects      |
-| rust       | .rs                                                  | `rust-analyzer` command available   |
-| clangd     | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects    |
-| svelte     | .svelte                                              | Auto-installs for Svelte projects   |
-| jdtls      | .java                                                | `Java SDK (version 21+)` installed  |
+| LSP Server | Extensions                                           | Requirements                                                 |
+| ---------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| typescript | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project                           |
+| deno       | .ts, .tsx, .js, .jsx, .mjs                           | `deno` command available (auto-detects deno.json/deno.jsonc) |
+| eslint     | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project                               |
+| gopls      | .go                                                  | `go` command available                                       |
+| ruby-lsp   | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available                          |
+| pyright    | .py, .pyi                                            | `pyright` dependency installed                               |
+| elixir-ls  | .ex, .exs                                            | `elixir` command available                                   |
+| zls        | .zig, .zon                                           | `zig` command available                                      |
+| csharp     | .cs                                                  | `.NET SDK` installed                                         |
+| vue        | .vue                                                 | Auto-installs for Vue projects                               |
+| rust       | .rs                                                  | `rust-analyzer` command available                            |
+| clangd     | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |
+| svelte     | .svelte                                              | Auto-installs for Svelte projects                            |
+| jdtls      | .java                                                | `Java SDK (version 21+)` installed                           |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 
 :::note
 You can disable automatic LSP server downloads by setting the `OPENCODE_DISABLE_LSP_DOWNLOAD` environment variable to `true`.
+:::
+
+:::note
+Deno LSP takes precedence when deno.json/deno.jsonc files are detected, and TypeScript LSP is excluded in Deno projects.
 :::
 
 ---

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -34,10 +34,6 @@ LSP servers are automatically enabled when one of the above file extensions are 
 You can disable automatic LSP server downloads by setting the `OPENCODE_DISABLE_LSP_DOWNLOAD` environment variable to `true`.
 :::
 
-:::note
-Deno LSP takes precedence when deno.json/deno.jsonc files are detected, and TypeScript LSP is excluded in Deno projects.
-:::
-
 ---
 
 ## How It Works


### PR DESCRIPTION
# Add Deno LSP Support

## Summary

Adds Deno LSP server support with mutual exclusion from TypeScript LSP to prevent conflicting diagnostics.

## Changes

• Added Deno LSP: Detects deno.json/deno.jsonc, supports .ts, .tsx, .js, .jsx, .mjs
• Enhanced NearestRoot: Added optional excludePatterns parameter
• Updated TypeScript LSP: Excludes itself when Deno markers are found

## Behavior

• Deno projects (deno.json present) → Deno LSP only
• Node/Bun projects (package-lock.json, etc.) → TypeScript LSP only
• No conflicts - single LSP per file

## Requirements

• Deno CLI must be pre-installed (like TypeScript)
• Uses built-in deno lsp command

## Testing

### Deno Project
LSP Attachment Log - filtered log on a folder that contain a deno.json file
```
INFO  2025-10-16T09:45:44 +2ms service=lsp serverIds=deno, typescript, vue, eslint, gopls, ruby-lsp, pyright, elixir-ls, zls, csharp, rust, clangd, svelte, jdtls enabled LSP servers
INFO  2025-10-16T09:47:03 +5ms service=lsp serverID=deno spawned lsp server
INFO  2025-10-16T09:47:03 +0ms service=lsp.client serverID=deno starting client
INFO  2025-10-16T09:47:03 +2ms service=lsp.client serverID=deno sending initialize
INFO  2025-10-16T09:47:03 +21ms service=lsp.client serverID=deno initialized
INFO  2025-10-16T09:47:03 +3ms service=lsp.client serverID=deno  textDocument/didOpen
INFO  2025-10-16T09:47:04 +410ms service=lsp.client serverID=deno  textDocument/publishDiagnostics
INFO  2025-10-16T09:47:20 +1ms service=lsp.client serverID=deno  waiting for diagnostics
INFO  2025-10-16T09:47:20 +0ms service=lsp.client serverID=deno  version=1 textDocument/didChange
INFO  2025-10-16T09:47:20 +11ms service=lsp.client serverID=deno  textDocument/publishDiagnostics
INFO  2025-10-16T09:47:20 +0ms service=lsp.client serverID=deno  got diagnostics
```

