### PR TITLE
set 755 permissions

### DIFF
--- a/install
+++ b/install
@@ -96,6 +96,7 @@ download_and_install() {
     curl -# -L -o "$filename" "$url"
     unzip -q "$filename"
     mv opencode "$INSTALL_DIR"
+    chmod 755 "${INSTALL_DIR}/opencode"
     cd .. && rm -rf opencodetmp
 }
 


### PR DESCRIPTION
This PR makes the installer set 755 permissions on `~/.opencode/bin/opencode`.

Fixes https://github.com/sst/opencode/issues/3238