### PR TITLE
[opentui] fix: dev script cannot find jsx import source

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.0",
   "scripts": {
-    "dev": "bun run packages/opencode/src/index.ts",
+    "dev": "bun run --cwd packages/opencode src/index.ts",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
     "random": "echo 'Random script'"


### PR DESCRIPTION
```bash
 ❯ bun run dev
$ bun run packages/opencode/src/index.ts
error: Cannot find module 'react/jsx-dev-runtime' from '/home/geril/code/oss/opencode/packages/opencode/src/cli/cmd/tui/app.tsx'

Bun v1.3.0 (Linux x64)
error: script "dev" exited with code 1
```

problema: bun can’t resolve JSX when running from the root dir






`bun run --cwd packages/opencode dev` also seems fine and is better ig
