### PR TITLE
fix(tui): Allow modals to handle ESC key before force closing

### DIFF
--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -162,9 +162,15 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// 1. Handle active modal
 		if a.modal != nil {
 			switch keyString {
-			// Escape always closes current modal
+			// Escape closes current modal, but give modal a chance to handle it first
 			case "esc":
-				cmd := a.modal.Close()
+				// give the modal a chance to handle the esc
+				updatedModal, cmd := a.modal.Update(msg)
+				a.modal = updatedModal.(layout.Modal)
+				if cmd != nil {
+					return a, cmd
+				}
+				cmd = a.modal.Close()
 				a.modal = nil
 				return a, cmd
 			case "ctrl+c":


### PR DESCRIPTION
## Summary

Fixes the issue where pressing ESC in modal dialogs (like `/agent` and `/model`) appeared to do nothing.

## Problem

Previously, the TUI would immediately close any modal when ESC was pressed, without giving the modal component a chance to handle the key event first. This prevented search dialogs from properly processing the ESC key and emitting the `SearchCancelledMsg`.

## Solution

This change makes ESC handling consistent with Ctrl+C by:
- Passing the ESC key event to the modal first  
- Only force-closing the modal if the modal doesn't handle it
- Allowing SearchDialog to emit `SearchCancelledMsg` before closing

## Testing

Tested on Windows by:
1. Opening `/agent` dialog
2. Pressing ESC
3. Confirming the dialog closes properly

## Changes

- `packages/tui/internal/tui/tui.go` - Modified ESC key handling to give modals a chance to process the event before force-closing