### PR TITLE
docs: fix Grep by Vercel link in documentation

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -304,7 +304,7 @@ When you need to search docs, use `context7` tools.
 
 ### Grep by Vercel
 
-Add the [Grep by Vercel](https://github.com/vercel/grep-by-vercel) MCP server to search through code snippets on GitHub.
+Add the [Grep by Vercel](https://grep.app) MCP server to search through code snippets on GitHub.
 
 ```json title="opencode.json" {4-7}
 {


### PR DESCRIPTION
The https://github.com/vercel/grep-by-vercel does not exist anymore. I guess it is closed source now.