### PR TITLE
feat: add -f/--file flag to opencode run command

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -1,4 +1,5 @@
 import type { Argv } from "yargs"
+import path from "path"
 import { Bus } from "../../bus"
 import { Provider } from "../../provider/provider"
 import { Session } from "../../session"
@@ -70,9 +71,30 @@ export const RunCommand = cmd({
         default: "default",
         describe: "format: default (formatted) or json (raw JSON events)",
       })
+      .option("file", {
+        alias: ["f"],
+        type: "string",
+        describe: "file to read and prepend to the message",
+      })
   },
   handler: async (args) => {
     let message = args.message.join(" ")
+
+    if (args.file) {
+      try {
+        const filePath = path.resolve(process.cwd(), args.file)
+        const file = Bun.file(filePath)
+        if (!(await file.exists())) {
+          UI.error(`File not found: ${args.file}`)
+          process.exit(1)
+        }
+        const fileContent = await file.text()
+        message = fileContent + "\n\n" + message
+      } catch (error) {
+        UI.error(`Failed to read file: ${args.file}`)
+        process.exit(1)
+      }
+    }
 
     if (!process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())
 

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -81,9 +81,9 @@ export const RunCommand = cmd({
   handler: async (args) => {
     let message = args.message.join(" ")
 
+    let fileParts: any[] = []
     if (args.file) {
       const files = Array.isArray(args.file) ? args.file : [args.file]
-      const fileContents: string[] = []
 
       for (const filePath of files) {
         try {
@@ -93,15 +93,21 @@ export const RunCommand = cmd({
             UI.error(`File not found: ${filePath}`)
             process.exit(1)
           }
-          const content = await file.text()
-          fileContents.push(content)
+
+          const stat = await file.stat()
+          const mime = stat.isDirectory() ? "application/x-directory" : "text/plain"
+
+          fileParts.push({
+            type: "file",
+            url: `file://${resolvedPath}`,
+            filename: path.basename(resolvedPath),
+            mime,
+          })
         } catch (error) {
           UI.error(`Failed to read file: ${filePath}`)
           process.exit(1)
         }
       }
-
-      message = fileContents.join("\n\n") + "\n\n" + message
     }
 
     if (!process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())
@@ -274,6 +280,7 @@ export const RunCommand = cmd({
           },
           agent: agent.name,
           parts: [
+            ...fileParts,
             {
               id: Identifier.ascending("part"),
               type: "text",

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -74,26 +74,34 @@ export const RunCommand = cmd({
       .option("file", {
         alias: ["f"],
         type: "string",
-        describe: "file to read and prepend to the message",
+        array: true,
+        describe: "file(s) to read and prepend to the message (can be used multiple times)",
       })
   },
   handler: async (args) => {
     let message = args.message.join(" ")
 
     if (args.file) {
-      try {
-        const filePath = path.resolve(process.cwd(), args.file)
-        const file = Bun.file(filePath)
-        if (!(await file.exists())) {
-          UI.error(`File not found: ${args.file}`)
+      const files = Array.isArray(args.file) ? args.file : [args.file]
+      const fileContents: string[] = []
+
+      for (const filePath of files) {
+        try {
+          const resolvedPath = path.resolve(process.cwd(), filePath)
+          const file = Bun.file(resolvedPath)
+          if (!(await file.exists())) {
+            UI.error(`File not found: ${filePath}`)
+            process.exit(1)
+          }
+          const content = await file.text()
+          fileContents.push(content)
+        } catch (error) {
+          UI.error(`Failed to read file: ${filePath}`)
           process.exit(1)
         }
-        const fileContent = await file.text()
-        message = fileContent + "\n\n" + message
-      } catch (error) {
-        UI.error(`Failed to read file: ${args.file}`)
-        process.exit(1)
       }
+
+      message = fileContents.join("\n\n") + "\n\n" + message
     }
 
     if (!process.stdin.isTTY) message += "\n" + (await Bun.stdin.text())

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -75,7 +75,7 @@ export const RunCommand = cmd({
         alias: ["f"],
         type: "string",
         array: true,
-        describe: "file(s) to read and prepend to the message (can be used multiple times)",
+        describe: "file(s) to attach to message",
       })
   },
   handler: async (args) => {
@@ -86,27 +86,27 @@ export const RunCommand = cmd({
       const files = Array.isArray(args.file) ? args.file : [args.file]
 
       for (const filePath of files) {
-        try {
-          const resolvedPath = path.resolve(process.cwd(), filePath)
-          const file = Bun.file(resolvedPath)
-          if (!(await file.exists())) {
-            UI.error(`File not found: ${filePath}`)
-            process.exit(1)
-          }
-
-          const stat = await file.stat()
-          const mime = stat.isDirectory() ? "application/x-directory" : "text/plain"
-
-          fileParts.push({
-            type: "file",
-            url: `file://${resolvedPath}`,
-            filename: path.basename(resolvedPath),
-            mime,
-          })
-        } catch (error) {
-          UI.error(`Failed to read file: ${filePath}`)
+        const resolvedPath = path.resolve(process.cwd(), filePath)
+        const file = Bun.file(resolvedPath)
+        const stats = await file.stat().catch(() => {})
+        if (!stats) {
+          UI.error(`File not found: ${filePath}`)
           process.exit(1)
         }
+        if (!(await file.exists())) {
+          UI.error(`File not found: ${filePath}`)
+          process.exit(1)
+        }
+
+        const stat = await file.stat()
+        const mime = stat.isDirectory() ? "application/x-directory" : "text/plain"
+
+        fileParts.push({
+          type: "file",
+          url: `file://${resolvedPath}`,
+          filename: path.basename(resolvedPath),
+          mime,
+        })
       }
     }
 


### PR DESCRIPTION
## Summary

Add support for reading and prepending file content to messages in the `opencode run` command using the `-f/--file` flag.

## Changes

- **New Feature**: Added `-f/--file` option to the run command
- **Functionality**: Reads file content and prepends it to the message with proper spacing
- **Path Resolution**: Resolves relative paths from current working directory
- **Error Handling**: Comprehensive error handling for:
  - File not found errors
  - Permission issues
  - Other I/O failures
- **CLI Experience**: Both `-f` (short) and `--file` (long) options supported

## Usage

```bash
# Read file and prepend to message
opencode run -f config.json "update this configuration"

# Long form also works
opencode run --file instructions.txt "follow these instructions"

# Support multiple files
opencode run -f config.json -f schema.json -f data.json "analyze these configs"
```