### PR TITLE
docs: clarify the effects of the subtask command option with primary …

### DIFF
--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -247,7 +247,8 @@ This is an **optional** config option. If not specified, defaults to your curren
 ### Subtask
 
 Use the `subtask` boolean to force the command to trigger a [subagent](/docs/agents/#subagents) invocation.
-This useful if you want the command to not pollute your primary context.
+This useful if you want the command to not pollute your primary context and will **force** the agent to act as a subagent,
+even if `mode` is set to `primary` on the [agent](/docs/agents) configuration.
 
 ```json title="opencode.json"
 {


### PR DESCRIPTION
As per #3222, setting `subtask=true` on a command configuration, the invoked agent will act as a `subagent`, even if configured with `mode=primary`.

Updating docs to reflect this behaviour.