### PR TITLE
feat: Improve logging

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -133,6 +133,8 @@ export const TuiCommand = cmd({
         Log.Default.info("tui", {
           cmd,
         })
+        // Collect logs in the background to prevent them from messing up the TUI
+        Log.setBackgroundMode(true)
         const proc = Bun.spawn({
           cmd: [
             ...cmd,
@@ -178,6 +180,8 @@ export const TuiCommand = cmd({
         })()
 
         await proc.exited
+        Log.setBackgroundMode(false)
+        Log.flushBackgroundLogs()
         server.stop()
 
         return "done"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1223,7 +1223,7 @@ export namespace SessionPrompt {
             }
           }
         } catch (e) {
-          log.error("process", {
+          log.opt({ important: false }).error("process", {
             error: e,
           })
           const error = MessageV2.fromError(e, { providerID: input.providerID })


### PR DESCRIPTION
### Changes

- **TUI Disruption Prevention**: Logs were previously written directly to stderr, potentially corrupting the TUI display. Background mode buffers non-critical logs during TUI operation and flushes them afterward.
- **Log Importance**: The `opt()` method allows marking logs as "important" (always visible, even without --print-logs), so users can discover issues more easily
  - The default importance behavior when not explicitly specified is to treat ERROR messages as important, i.e. logged to stderr even without `--print-logs`
  -  State disposal warnings are marked important, so users understand why OC is hanging, and to reduce the steps needed to guide the user while debugging
  - Session.prompt errors are marked unimportant to avoid clutter (i.e. printed only with `--print-logs`)

### Example broken TUI due to `--print-logs` (before change)
<img width="1048" height="789" alt="image" src="https://github.com/user-attachments/assets/7e9ea01c-3f71-4a4e-9e5c-1d7c5827c082" />

### Example messages with the improved logging
(in order for the below example to actually be implemented, `.opt({ important: true })` will need to be applied to those logs after https://github.com/sst/opencode/pull/3481 is merged)
```
$ opencode run hi
Hi!
WARN 2025-10-20T20:38:54 +1000ms service=default waiting for state disposal to complete... (this is usually a saving operation or subprocess shutdown)
WARN 2025-10-20T20:39:03 +8999ms service=default state disposal is taking an unusually long time - if it does not complete in a reasonable time, please report this as a bug
```