### PR TITLE
fix: openai options when using @ai-sdk/azure

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -283,7 +283,8 @@ export namespace SessionPrompt {
         ),
         abortSignal: abort.signal,
         providerOptions: {
-          [model.npm === "@ai-sdk/openai" ? "openai" : model.providerID]: params.options,
+          [model.npm === "@ai-sdk/openai" || model.npm === "@ai-sdk/azure" ? "openai" : model.providerID]:
+            params.options,
         },
         stopWhen: stepCountIs(1),
         temperature: params.temperature,


### PR DESCRIPTION
https://github.com/vercel/ai/blob/main/packages/azure/src/azure-openai-provider.ts#L203-L204
@ai-sdk/azure using the `OpenAIResponsesLanguageModel` from `@ai-sdk/openai`

fix #3044
fix #3293 

my config is work
```
"azure": {
      "env": [
        "AZURE_API"
      ],
      "models": {
        "gpt-5-codex": {
          "name": "GPT-5-codex",
          "options": {
            "parallelToolCalls": false, # or "store": false
          }
        }
      }
    }
```
