### PR TITLE
fix: opencode run shouldn't print to stderr 

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/file.ts
+++ b/packages/opencode/src/cli/cmd/debug/file.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os"
 import { File } from "../../../file"
 import { bootstrap } from "../../bootstrap"
 import { cmd } from "../cmd"
@@ -13,7 +14,7 @@ const FileSearchCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       const results = await File.search({ query: args.query })
-      console.log(results.join("\n"))
+      console.log(results.join(EOL))
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/debug/ripgrep.ts
+++ b/packages/opencode/src/cli/cmd/debug/ripgrep.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os"
 import { Ripgrep } from "../../../file/ripgrep"
 import { Instance } from "../../../project/instance"
 import { bootstrap } from "../../bootstrap"
@@ -48,7 +49,7 @@ const FilesCommand = cmd({
         files.push(file)
         if (args.limit && files.length >= args.limit) break
       }
-      console.log(files.join("\n"))
+      console.log(files.join(EOL))
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -4,6 +4,7 @@ import { cmd } from "./cmd"
 import { bootstrap } from "../bootstrap"
 import { UI } from "../ui"
 import * as prompts from "@clack/prompts"
+import { EOL } from "os"
 
 export const ExportCommand = cmd({
   command: "export [sessionID]",
@@ -67,7 +68,7 @@ export const ExportCommand = cmd({
         }
 
         process.stdout.write(JSON.stringify(exportData, null, 2))
-        process.stdout.write("\n")
+        process.stdout.write(EOL)
       } catch (error) {
         UI.error(`Session not found: ${sessionID!}`)
         process.exit(1)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -20,6 +20,7 @@ import { GithubCommand } from "./cli/cmd/github"
 import { ExportCommand } from "./cli/cmd/export"
 import { AttachCommand } from "./cli/cmd/attach"
 import { AcpCommand } from "./cli/cmd/acp"
+import { EOL } from "os"
 
 const cancel = new AbortController()
 
@@ -130,7 +131,7 @@ try {
   const formatted = FormatError(e)
   if (formatted) UI.error(formatted)
   if (formatted === undefined) {
-    UI.error("Unexpected error, check log file at " + Log.file() + " for more details\n")
+    UI.error("Unexpected error, check log file at " + Log.file() + " for more details" + EOL)
     console.error(e)
   }
   process.exitCode = 1


### PR DESCRIPTION
Relates to https://github.com/sst/opencode/issues/369#issuecomment-3429028716
Tested by:

```
opencode run hi

Hi! How can I help with your software engineering tasks?

$
```

```
opencode run hi | cat
Hi! How can I help with your software engineering tasks?
$
```

```
$ opencode run hi 2>/dev/null
Hi! How can I help with your software engineering tasks?
$
```

```
$ opencode run hi >/dev/null
$
```


```
$ opencode run hi --print-logs --format=json | jq
... prints correct output and jq doesn't print any errors ...
$
```