### PR TITLE
Add granular tool permissions

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -20,8 +20,7 @@ export namespace Agent {
         edit: Config.Permission,
         bash: z.record(z.string(), Config.Permission),
         webfetch: Config.Permission.optional(),
-        mcp: z.record(z.string(), Config.Permission).optional(),
-      }),
+      }).catchall(Config.Permission),
       model: z
         .object({
           modelID: z.string(),
@@ -46,9 +45,7 @@ export namespace Agent {
         "*": "allow",
       },
       webfetch: "allow",
-      mcp: {
-        "*": "ask",
-      },
+      "*": "ask", // Default for all tools
     }
     const agentPermission = mergeAgentPermissions(defaultPermission, cfg.permission ?? {})
 
@@ -57,9 +54,7 @@ export namespace Agent {
         edit: "deny",
         bash: "ask",
         webfetch: "allow",
-        mcp: {
-          "*": "ask",
-        },
+        "*": "ask", // Default for all tools
       },
       cfg.permission ?? {},
     )
@@ -183,6 +178,7 @@ export namespace Agent {
 }
 
 function mergeAgentPermissions(basePermission: any, overridePermission: any): Agent.Info["permission"] {
+  // Handle bash permission normalization
   if (typeof basePermission.bash === "string") {
     basePermission.bash = {
       "*": basePermission.bash,
@@ -193,17 +189,10 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       "*": overridePermission.bash,
     }
   }
-  if (typeof basePermission.mcp === "string") {
-    basePermission.mcp = {
-      "*": basePermission.mcp,
-    }
-  }
-  if (typeof overridePermission.mcp === "string") {
-    overridePermission.mcp = {
-      "*": overridePermission.mcp,
-    }
-  }
+  
   const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {}) as any
+  
+  // Handle bash merging
   let mergedBash
   if (merged.bash) {
     if (typeof merged.bash === "string") {
@@ -219,28 +208,15 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       )
     }
   }
-  
-  let mergedMcp
-  if (merged.mcp) {
-    if (typeof merged.mcp === "string") {
-      mergedMcp = {
-        "*": merged.mcp,
-      }
-    } else if (typeof merged.mcp === "object") {
-      mergedMcp = mergeDeep(
-        {
-          "*": "ask",
-        },
-        merged.mcp,
-      )
-    }
-  }
 
   const result: Agent.Info["permission"] = {
     edit: merged.edit ?? "allow",
     webfetch: merged.webfetch ?? "allow",
     bash: mergedBash ?? { "*": "allow" },
-    mcp: mergedMcp ?? { "*": "ask" },
+    // All other keys are tool permissions - they get merged automatically via mergeDeep
+    ...Object.fromEntries(
+      Object.entries(merged).filter(([key]) => !["edit", "webfetch", "bash"].includes(key))
+    ),
   }
 
   return result

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -20,6 +20,7 @@ export namespace Agent {
         edit: Config.Permission,
         bash: z.record(z.string(), Config.Permission),
         webfetch: Config.Permission.optional(),
+        mcp: z.record(z.string(), Config.Permission).optional(),
       }),
       model: z
         .object({
@@ -45,6 +46,9 @@ export namespace Agent {
         "*": "allow",
       },
       webfetch: "allow",
+      mcp: {
+        "*": "ask",
+      },
     }
     const agentPermission = mergeAgentPermissions(defaultPermission, cfg.permission ?? {})
 
@@ -53,6 +57,9 @@ export namespace Agent {
         edit: "deny",
         bash: "ask",
         webfetch: "allow",
+        mcp: {
+          "*": "ask",
+        },
       },
       cfg.permission ?? {},
     )
@@ -186,6 +193,16 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       "*": overridePermission.bash,
     }
   }
+  if (typeof basePermission.mcp === "string") {
+    basePermission.mcp = {
+      "*": basePermission.mcp,
+    }
+  }
+  if (typeof overridePermission.mcp === "string") {
+    overridePermission.mcp = {
+      "*": overridePermission.mcp,
+    }
+  }
   const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {}) as any
   let mergedBash
   if (merged.bash) {
@@ -202,11 +219,28 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       )
     }
   }
+  
+  let mergedMcp
+  if (merged.mcp) {
+    if (typeof merged.mcp === "string") {
+      mergedMcp = {
+        "*": merged.mcp,
+      }
+    } else if (typeof merged.mcp === "object") {
+      mergedMcp = mergeDeep(
+        {
+          "*": "ask",
+        },
+        merged.mcp,
+      )
+    }
+  }
 
   const result: Agent.Info["permission"] = {
     edit: merged.edit ?? "allow",
     webfetch: merged.webfetch ?? "allow",
     bash: mergedBash ?? { "*": "allow" },
+    mcp: mergedMcp ?? { "*": "ask" },
   }
 
   return result

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -16,15 +16,13 @@ export namespace Agent {
       builtIn: z.boolean(),
       topP: z.number().optional(),
       temperature: z.number().optional(),
-      permission: z.record(z.string(), z.union([
-        Config.Permission,
-        z.record(z.string(), Config.Permission)
-      ])).refine((data) => {
-        // Ensure required fields exist and have correct types
-        return 'edit' in data && 
-               'bash' in data && 
-               (typeof data.bash === 'string' || typeof data.bash === 'object');
-      }),
+      permission: z
+        .object({
+          edit: Config.Permission.optional(),
+          bash: z.union([Config.Permission, z.record(z.string(), Config.Permission)]).optional(),
+          webfetch: Config.Permission.optional(),
+        })
+        .catchall(z.union([Config.Permission, z.record(z.string(), Config.Permission)])),
       model: z
         .object({
           modelID: z.string(),
@@ -181,7 +179,10 @@ export namespace Agent {
   }
 }
 
-function mergeAgentPermissions(basePermission: any, overridePermission: any): Agent.Info["permission"] {
+function mergeAgentPermissions(
+  basePermission: Partial<Agent.Info["permission"]>,
+  overridePermission: Partial<Agent.Info["permission"]>,
+): Agent.Info["permission"] {
   // Handle bash permission normalization
   if (typeof basePermission.bash === "string") {
     basePermission.bash = {
@@ -193,9 +194,9 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       "*": overridePermission.bash,
     }
   }
-  
-  const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {}) as any
-  
+
+  const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {})
+
   // Handle bash merging
   let mergedBash
   if (merged.bash) {

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -16,11 +16,15 @@ export namespace Agent {
       builtIn: z.boolean(),
       topP: z.number().optional(),
       temperature: z.number().optional(),
-      permission: z.object({
-        edit: Config.Permission,
-        bash: z.record(z.string(), Config.Permission),
-        webfetch: Config.Permission.optional(),
-      }).catchall(Config.Permission),
+      permission: z.record(z.string(), z.union([
+        Config.Permission,
+        z.record(z.string(), Config.Permission)
+      ])).refine((data) => {
+        // Ensure required fields exist and have correct types
+        return 'edit' in data && 
+               'bash' in data && 
+               (typeof data.bash === 'string' || typeof data.bash === 'object');
+      }),
       model: z
         .object({
           modelID: z.string(),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -323,6 +323,7 @@ export namespace Config {
           edit: Permission.optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
+          mcp: z.union([Permission, z.record(z.string(), Permission)]).optional(),
         })
         .optional(),
     })
@@ -554,6 +555,7 @@ export namespace Config {
           edit: Permission.optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
+          mcp: z.union([Permission, z.record(z.string(), Permission)]).optional(),
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -323,8 +323,8 @@ export namespace Config {
           edit: Permission.optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
-          mcp: z.union([Permission, z.record(z.string(), Permission)]).optional(),
         })
+        .catchall(Permission)
         .optional(),
     })
     .catchall(z.any())
@@ -555,8 +555,8 @@ export namespace Config {
           edit: Permission.optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
-          mcp: z.union([Permission, z.record(z.string(), Permission)]).optional(),
         })
+        .catchall(Permission)
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
       experimental: z

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -522,6 +522,13 @@ export namespace SessionPrompt {
         const mcpPermissions = input.agent.permission.mcp
         if (mcpPermissions) {
           const permission = mcpPermissions[key] ?? mcpPermissions["*"] ?? "ask"
+
+          if (permission === "deny") {
+            throw new Error(
+              `The user has specifically restricted access to this MCP tool, you are not allowed to execute it. Tool: ${key}`,
+            )
+          }
+
           if (permission === "ask") {
             await Permission.ask({
               type: "mcp",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -518,31 +518,35 @@ export namespace SessionPrompt {
       const execute = item.execute
       if (!execute) continue
       item.execute = async (args, opts) => {
-        // Check MCP permissions
-        const mcpPermissions = input.agent.permission.mcp
-        if (mcpPermissions) {
-          const permission = mcpPermissions[key] ?? mcpPermissions["*"] ?? "ask"
+        // Check tool permissions using wildcard matching directly on permission object
+        // Exclude known non-tool fields
+        const toolPermissions = Object.fromEntries(
+          Object.entries(input.agent.permission).filter(
+            ([k]) => !["edit", "bash", "webfetch"].includes(k)
+          )
+        )
+        
+        const permission = Wildcard.all(key, toolPermissions)
 
-          if (permission === "deny") {
-            throw new Error(
-              `The user has specifically restricted access to this MCP tool, you are not allowed to execute it. Tool: ${key}`,
-            )
-          }
+        if (permission === "deny") {
+          throw new Error(
+            `The user has specifically restricted access to this tool, you are not allowed to execute it. Tool: ${key}`,
+          )
+        }
 
-          if (permission === "ask") {
-            await Permission.ask({
-              type: "mcp",
-              pattern: key,
-              sessionID: input.sessionID,
-              messageID: input.processor.message.id,
-              callID: opts.toolCallId,
-              title: `Use MCP tool "${key}"`,
-              metadata: {
-                tool: key,
-                args,
-              },
-            })
-          }
+        if (permission === "ask") {
+          await Permission.ask({
+            type: "tool",
+            pattern: key,
+            sessionID: input.sessionID,
+            messageID: input.processor.message.id,
+            callID: opts.toolCallId,
+            title: `Use tool "${key}"`,
+            metadata: {
+              tool: key,
+              args,
+            },
+          })
         }
 
         await Plugin.trigger(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -518,6 +518,26 @@ export namespace SessionPrompt {
       const execute = item.execute
       if (!execute) continue
       item.execute = async (args, opts) => {
+        // Check MCP permissions
+        const mcpPermissions = input.agent.permission.mcp
+        if (mcpPermissions) {
+          const permission = mcpPermissions[key] ?? mcpPermissions["*"] ?? "ask"
+          if (permission === "ask") {
+            await Permission.ask({
+              type: "mcp",
+              pattern: key,
+              sessionID: input.sessionID,
+              messageID: input.processor.message.id,
+              callID: opts.toolCallId,
+              title: `Use MCP tool "${key}"`,
+              metadata: {
+                tool: key,
+                args,
+              },
+            })
+          }
+        }
+
         await Plugin.trigger(
           "tool.execute.before",
           {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -57,7 +57,10 @@ export const BashTool = Tool.define("bash", {
   async execute(params, ctx) {
     const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
     const tree = await parser().then((p) => p.parse(params.command))
-    const permissions = await Agent.get(ctx.agent).then((x) => x.permission.bash)
+    const bashPermission = await Agent.get(ctx.agent).then((x) => x.permission.bash)
+    const permissions = typeof bashPermission === "string" 
+      ? { "*": bashPermission } 
+      : bashPermission
 
     const askPatterns = new Set<string>()
     for (const node of tree.rootNode.descendantsOfType("command")) {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -57,10 +57,10 @@ export const BashTool = Tool.define("bash", {
   async execute(params, ctx) {
     const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
     const tree = await parser().then((p) => p.parse(params.command))
-    const bashPermission = await Agent.get(ctx.agent).then((x) => x.permission.bash)
+    const bashPermission = await Agent.get(ctx.agent).then((x) => x.permission.bash!)
     const permissions = typeof bashPermission === "string"
       ? { "*": bashPermission }
-      : (bashPermission ?? { "*": "ask" })
+      : bashPermission
 
     const askPatterns = new Set<string>()
     for (const node of tree.rootNode.descendantsOfType("command")) {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -58,9 +58,9 @@ export const BashTool = Tool.define("bash", {
     const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
     const tree = await parser().then((p) => p.parse(params.command))
     const bashPermission = await Agent.get(ctx.agent).then((x) => x.permission.bash)
-    const permissions = typeof bashPermission === "string" 
-      ? { "*": bashPermission } 
-      : bashPermission
+    const permissions = typeof bashPermission === "string"
+      ? { "*": bashPermission }
+      : (bashPermission ?? { "*": "ask" })
 
     const askPatterns = new Set<string>()
     for (const node of tree.rootNode.descendantsOfType("command")) {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -121,7 +121,11 @@ export namespace ToolRegistry {
       result["patch"] = false
       result["write"] = false
     }
-    if (agent.permission.bash["*"] === "deny" && Object.keys(agent.permission.bash).length === 1) {
+    if (typeof agent.permission.bash === "object" && 
+        agent.permission.bash["*"] === "deny" && 
+        Object.keys(agent.permission.bash).length === 1) {
+      result["bash"] = false
+    } else if (agent.permission.bash === "deny") {
       result["bash"] = false
     }
     if (agent.permission.webfetch === "deny") {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -18,6 +18,7 @@ import path from "path"
 import { type ToolDefinition } from "@opencode-ai/plugin"
 import z from "zod/v4"
 import { Plugin } from "../plugin"
+import { Wildcard } from "../util/wildcard"
 
 export namespace ToolRegistry {
   export const state = Instance.state(async () => {
@@ -127,24 +128,22 @@ export namespace ToolRegistry {
       result["webfetch"] = false
     }
     
-    // Check MCP tool permissions
-    if (agent.permission.mcp) {
-      const mcpPermissions = agent.permission.mcp
-      if (mcpPermissions["*"] === "deny" && Object.keys(mcpPermissions).length === 1) {
-        // If global MCP permission is deny and no specific overrides, disable all MCP tools
-        const mcpTools = await import("../mcp").then(m => m.MCP.tools()).catch(() => ({}))
-        for (const toolName of Object.keys(mcpTools)) {
-          result[toolName] = false
-        }
-      } else {
-        // Check individual MCP tool permissions
-        const mcpTools = await import("../mcp").then(m => m.MCP.tools()).catch(() => ({}))
-        for (const toolName of Object.keys(mcpTools)) {
-          const permission = mcpPermissions[toolName] ?? mcpPermissions["*"] ?? "ask"
-          if (permission === "deny") {
-            result[toolName] = false
-          }
-        }
+    // Check tool permissions for all tools (including MCP tools)
+    // Extract tool permissions from the flattened permission object
+    const toolPermissions = Object.fromEntries(
+      Object.entries(agent.permission).filter(
+        ([key]) => !["edit", "bash", "webfetch"].includes(key)
+      )
+    )
+    
+    // Get all available MCP tools
+    const mcpTools = await import("../mcp").then(m => m.MCP.tools()).catch(() => ({}))
+    
+    // Check each tool's permission using wildcard matching
+    for (const toolName of Object.keys(mcpTools)) {
+      const permission = Wildcard.all(toolName, toolPermissions)
+      if (permission === "deny") {
+        result[toolName] = false
       }
     }
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -126,6 +126,27 @@ export namespace ToolRegistry {
     if (agent.permission.webfetch === "deny") {
       result["webfetch"] = false
     }
+    
+    // Check MCP tool permissions
+    if (agent.permission.mcp) {
+      const mcpPermissions = agent.permission.mcp
+      if (mcpPermissions["*"] === "deny" && Object.keys(mcpPermissions).length === 1) {
+        // If global MCP permission is deny and no specific overrides, disable all MCP tools
+        const mcpTools = await import("../mcp").then(m => m.MCP.tools()).catch(() => ({}))
+        for (const toolName of Object.keys(mcpTools)) {
+          result[toolName] = false
+        }
+      } else {
+        // Check individual MCP tool permissions
+        const mcpTools = await import("../mcp").then(m => m.MCP.tools()).catch(() => ({}))
+        for (const toolName of Object.keys(mcpTools)) {
+          const permission = mcpPermissions[toolName] ?? mcpPermissions["*"] ?? "ask"
+          if (permission === "deny") {
+            result[toolName] = false
+          }
+        }
+      }
+    }
 
     return result
   }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -234,6 +234,11 @@ export type AgentConfig = {
           [key: string]: "ask" | "allow" | "deny"
         }
     webfetch?: "ask" | "allow" | "deny"
+    mcp?:
+      | ("ask" | "allow" | "deny")
+      | {
+          [key: string]: "ask" | "allow" | "deny"
+        }
   }
   [key: string]:
     | unknown
@@ -252,6 +257,11 @@ export type AgentConfig = {
               [key: string]: "ask" | "allow" | "deny"
             }
         webfetch?: "ask" | "allow" | "deny"
+        mcp?:
+          | ("ask" | "allow" | "deny")
+          | {
+              [key: string]: "ask" | "allow" | "deny"
+            }
       }
     | undefined
 }
@@ -484,6 +494,11 @@ export type Config = {
           [key: string]: "ask" | "allow" | "deny"
         }
     webfetch?: "ask" | "allow" | "deny"
+    mcp?:
+      | ("ask" | "allow" | "deny")
+      | {
+          [key: string]: "ask" | "allow" | "deny"
+        }
   }
   tools?: {
     [key: string]: boolean
@@ -1013,6 +1028,9 @@ export type Agent = {
       [key: string]: "ask" | "allow" | "deny"
     }
     webfetch?: "ask" | "allow" | "deny"
+    mcp?: {
+      [key: string]: "ask" | "allow" | "deny"
+    }
   }
   model?: {
     modelID: string

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -234,11 +234,7 @@ export type AgentConfig = {
           [key: string]: "ask" | "allow" | "deny"
         }
     webfetch?: "ask" | "allow" | "deny"
-    mcp?:
-      | ("ask" | "allow" | "deny")
-      | {
-          [key: string]: "ask" | "allow" | "deny"
-        }
+    [key: string]: "ask" | "allow" | "deny" | undefined | (("ask" | "allow" | "deny") | {[key: string]: "ask" | "allow" | "deny"})
   }
   [key: string]:
     | unknown
@@ -257,11 +253,7 @@ export type AgentConfig = {
               [key: string]: "ask" | "allow" | "deny"
             }
         webfetch?: "ask" | "allow" | "deny"
-        mcp?:
-          | ("ask" | "allow" | "deny")
-          | {
-              [key: string]: "ask" | "allow" | "deny"
-            }
+        [key: string]: "ask" | "allow" | "deny" | undefined | (("ask" | "allow" | "deny") | {[key: string]: "ask" | "allow" | "deny"})
       }
     | undefined
 }
@@ -494,11 +486,7 @@ export type Config = {
           [key: string]: "ask" | "allow" | "deny"
         }
     webfetch?: "ask" | "allow" | "deny"
-    mcp?:
-      | ("ask" | "allow" | "deny")
-      | {
-          [key: string]: "ask" | "allow" | "deny"
-        }
+    [key: string]: "ask" | "allow" | "deny" | undefined | (("ask" | "allow" | "deny") | {[key: string]: "ask" | "allow" | "deny"})
   }
   tools?: {
     [key: string]: boolean
@@ -1028,9 +1016,7 @@ export type Agent = {
       [key: string]: "ask" | "allow" | "deny"
     }
     webfetch?: "ask" | "allow" | "deny"
-    mcp?: {
-      [key: string]: "ask" | "allow" | "deny"
-    }
+    [key: string]: "ask" | "allow" | "deny" | undefined | {[key: string]: "ask" | "allow" | "deny"}
   }
   model?: {
     modelID: string

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -145,6 +145,61 @@ Use the `permission.webfetch` key to control whether the LLM can fetch web pages
 
 ---
 
+## Tool Permissions
+
+In addition to the core tools (`edit`, `bash`, `webfetch`), you can control permissions for any tool using wildcard patterns directly in the permission object.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "allow",
+    "bash": "ask", 
+    "webfetch": "deny",
+    "read": "allow",
+    "write": "ask",
+    "mcp_*": "ask",
+    "context7_*": "deny",
+    "my_custom_tool": "allow"
+  }
+}
+```
+
+This allows fine-grained control over:
+- **Built-in tools** — `read`, `write`, `grep`, `glob`, `list`, `patch`, `todowrite`, etc.
+- **MCP tools** — Any tool from MCP servers using patterns like `mcp_*` or `server_name_*`
+- **Custom tools** — Tools you've created in your configuration
+
+---
+
+### Wildcards for Tools
+
+You can use wildcard patterns to control groups of tools efficiently.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "edit": "allow",
+    "bash": "ask",
+    "webfetch": "deny",
+    "*": "deny",              
+    "read": "allow",          
+    "grep": "allow",          
+    "mcp_*": "ask",           
+    "developer_*": "allow"    
+  }
+}
+```
+
+In this example:
+- All tools are denied by default (`"*": "deny"`)
+- Specific tools like `read` and `grep` are allowed
+- All MCP tools require approval (`mcp_*`)
+- Tools from a specific developer server are allowed (`developer_*`)
+
+---
+
 ## Agents
 
 You can also configure permissions per agent. Where the agent specific config


### PR DESCRIPTION
I had Claude make these changes to support permissions for MCP tool calls. There are some MCP servers I use that I just can't trust an AI to call freely.