### PR TITLE
Added Amazon Nova models to us-* prefix requirement list

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -95,7 +95,14 @@ export namespace Provider {
 
           switch (regionPrefix) {
             case "us": {
-              const modelRequiresPrefix = ["claude", "deepseek"].some((m) => modelID.includes(m))
+              const modelRequiresPrefix = [
+                "nova-micro",
+                "nova-lite",
+                "nova-pro",
+                "nova-premier",
+                "claude",
+                "deepseek"
+              ].some((m) => modelID.includes(m))
               const isGovCloud = region.startsWith("us-gov")
               if (modelRequiresPrefix && !isGovCloud) {
                 modelID = `${regionPrefix}.${modelID}`


### PR DESCRIPTION
All Amazon Nova models now require the use of cross-region inference endpoints. This adds the `nova-*` models to the criteria for adding the `us` region prefix to the model id.

**This fixes the following error when attempting to use `nova-*` models:**
<img width="1480" height="66" alt="image" src="https://github.com/user-attachments/assets/8feca097-b6a0-4e14-b3ad-673cd06762af" />

Tested locally and verified. 