### PR TITLE
feat: add model management to ACP sessions

### DIFF
--- a/packages/opencode/src/acp/types.ts
+++ b/packages/opencode/src/acp/types.ts
@@ -6,6 +6,10 @@ export interface ACPSessionState {
   mcpServers: McpServer[]
   openCodeSessionId: string
   createdAt: Date
+  model: {
+    providerID: string
+    modelID: string
+  }
 }
 
 export interface ACPConfig {


### PR DESCRIPTION
## Description

When I set up OpenCode ACP on Zed, it connected and worked perfectly but, I quickly realized there was no way to switch models. I took inspiration from how `codex-acp` does the model filtering.

## Summary

- Add model state management to ACP sessions with current model tracking
- Implement `setSessionModel` endpoint for dynamic model switching
- Return available models and current model in session responses

## Changes
- Extend `ACPSessionState` to include model information
- Add `SetSessionModelRequest/Response` types and implementation
- Update `newSession` and `loadSession` to return model metadata
- Add helper methods for model listing and default model resolution

<img width="489" height="988" alt="CleanShot 2025-10-22 at 11 03 27@2x" src="https://github.com/user-attachments/assets/c3796b9e-7cd8-487a-8e53-ca191fb05d26" />

