### PR TITLE
fix: allow `tool.execute.after` hook to modify MCP tool output

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -588,10 +588,7 @@ export namespace SessionPrompt {
           },
         )
         const result = await execute(args, opts)
-        const output = result.content
-          .filter((x: any) => x.type === "text")
-          .map((x: any) => x.text)
-          .join("\n\n")
+
         await Plugin.trigger(
           "tool.execute.after",
           {
@@ -601,6 +598,11 @@ export namespace SessionPrompt {
           },
           result,
         )
+
+        const output = result.content
+          .filter((x: any) => x.type === "text")
+          .map((x: any) => x.text)
+          .join("\n\n")
 
         return {
           title: "",


### PR DESCRIPTION
Previously, the output string was extracted from MCP tool `result.content` before calling the `"tool.execute.after"` plugin hook, preventing plugins from modifying the output.

This fix moves the output extraction to after the hook is triggered, allowing plugins to modify `result.content` and have those changes reflected in the final tool output. 

fixes: #3384
