### PR TITLE
docs: rm winget as a recommended installation method under windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl -fsSL https://opencode.ai/install | bash
 # Package managers
 npm i -g opencode-ai@latest        # or bun/pnpm/yarn
 scoop bucket add extras; scoop install extras/opencode  # Windows
-winget install opencode            # Windows
+choco install opencode             # Windows
 brew install sst/tap/opencode      # macOS and Linux
 paru -S opencode-bin               # Arch Linux
 ```

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -84,12 +84,6 @@ You can also install it with the following commands:
   choco install opencode
   ```
 
-- **Using WinGet**
-
-  ```bash
-  winget install opencode
-  ```
-
 - **Using Scoop**
 
   ```bash


### PR DESCRIPTION
WinGet has been having issues recently with consistently building `opencode` releases. This PR removes it from the recommended installation instructions until we can figure out how to make it more consistent