### PR TITLE
fix(opencode): move `zod-to-json-schema` to `dependencies`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
         "xdg-basedir": "5.1.0",
         "yargs": "18.0.0",
         "zod": "catalog:",
+        "zod-to-json-schema": "3.24.5",
       },
       "devDependencies": {
         "@ai-sdk/amazon-bedrock": "2.2.10",
@@ -222,7 +223,6 @@
         "@typescript/native-preview": "catalog:",
         "typescript": "catalog:",
         "vscode-languageserver-types": "3.17.5",
-        "zod-to-json-schema": "3.24.5",
       },
     },
     "packages/plugin": {

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -29,7 +29,6 @@
     "typescript": "catalog:",
     "@typescript/native-preview": "catalog:",
     "vscode-languageserver-types": "3.17.5",
-    "zod-to-json-schema": "3.24.5",
     "@opencode-ai/script": "workspace:*"
   },
   "dependencies": {
@@ -70,6 +69,7 @@
     "web-tree-sitter": "0.22.6",
     "xdg-basedir": "5.1.0",
     "yargs": "18.0.0",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "zod-to-json-schema": "3.24.5"
   }
 }


### PR DESCRIPTION
Move `zod-to-json-schema` from `devDependencies` to `dependencies` to fix installation errors when running `bun install --production`.

This package is required at runtime for schema validation, not just during development.