### PR TITLE
fix: Opencode fails with ENOENT posix_spawn '/usr/bin/rg'

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -211,6 +211,16 @@ export namespace Ripgrep {
       }
     }
 
+    // Bun.spawn should throw this, but it incorrectly reports that the executable does not exist.
+    // See https://github.com/oven-sh/bun/issues/24012
+    if (!(await fs.stat(input.cwd).catch(() => undefined))?.isDirectory()) {
+      throw Object.assign(new Error(`No such file or directory: '${input.cwd}'`), {
+        code: "ENOENT",
+        errno: -2,
+        path: input.cwd,
+      });
+    }
+
     const proc = Bun.spawn(args, {
       cwd: input.cwd,
       stdout: "pipe",


### PR DESCRIPTION
When cwd does not exist, Bun.spawn throws saying that the executable ("rg") does not exist.

I reported this as an issue to bun https://github.com/oven-sh/bun/issues/24012, but for now, I added a workaround to throw the correct error message so the user is not misled.

Closes #3158.