### PR TITLE
feat: add `session.started` event that triggers when a new session is created

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -72,6 +72,12 @@ export namespace Session {
   export type ShareInfo = z.output<typeof ShareInfo>
 
   export const Event = {
+    Started: Bus.event(
+      "session.started",
+      z.object({
+        info: Info,
+      }),
+    ),
     Updated: Bus.event(
       "session.updated",
       z.object({
@@ -161,6 +167,9 @@ export namespace Session {
     }
     log.info("created", result)
     await Storage.write(["session", Instance.project.id, result.id], result)
+    Bus.publish(Event.Started, {
+      info: result,
+    })
     const cfg = await Config.get()
     if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto"))
       share(result.id)

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Session } from "../../src/session"
+import { Bus } from "../../src/bus"
+import { Log } from "../../src/util/log"
+import { Instance } from "../../src/project/instance"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session.started event", () => {
+  test("should emit session.started event when session is created", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        let eventReceived = false
+        let receivedInfo: Session.Info | undefined
+
+        const unsub = Bus.subscribe(Session.Event.Started, (event) => {
+          eventReceived = true
+          receivedInfo = event.properties.info as Session.Info
+        })
+
+        const session = await Session.create({})
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        unsub()
+
+        expect(eventReceived).toBe(true)
+        expect(receivedInfo).toBeDefined()
+        expect(receivedInfo?.id).toBe(session.id)
+        expect(receivedInfo?.projectID).toBe(session.projectID)
+        expect(receivedInfo?.directory).toBe(session.directory)
+        expect(receivedInfo?.title).toBe(session.title)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("session.started event should be emitted before session.updated", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const events: string[] = []
+
+        const unsubStarted = Bus.subscribe(Session.Event.Started, () => {
+          events.push("started")
+        })
+
+        const unsubUpdated = Bus.subscribe(Session.Event.Updated, () => {
+          events.push("updated")
+        })
+
+        const session = await Session.create({})
+
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        unsubStarted()
+        unsubUpdated()
+
+        expect(events).toContain("started")
+        expect(events).toContain("updated")
+        expect(events.indexOf("started")).toBeLessThan(events.indexOf("updated"))
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
# Motivation
I want to create a plugin that:
1. Runs when I start a new session
2. Checks if the `AGENTS.md` file is present
3. Warns the user if it's missing

I didn't find an event suited for that.

# Proposed solution
I added an event `session.started` that triggers when a session starts.
I believe this will be useful for other plugins too.

# FYI
- I added a test but I could not test a plugin that uses this event.
- I believe some types need to be updated.
- I think we should update the documentation to clearly list all events that can be used in plugins. I could update the file `/packages/web/src/content/docs/plugins.mdx` but maybe there's a way to keep that list updated in the docs.
