### PR TITLE
Fix cross-platform path resolution in build script

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,11 @@
 #!/usr/bin/env bun
 import path from "path"
-const dir = new URL("..", import.meta.url).pathname
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const dir = path.resolve(__dirname, "..")
+
 process.chdir(dir)
 import { $ } from "bun"
 


### PR DESCRIPTION
# Fix cross-platform path resolution in build script

## Problem
The build script at `packages/opencode/script/build.ts` was failing on Windows due to improper path resolution. The script used `new URL("..", import.meta.url).pathname` which doesn't work correctly on Windows, causing the build to fail with "ENOENT: no such file or directory" errors.

## Root Cause
The original path resolution approach:
```typescript
const dir = new URL("..", import.meta.url).pathname
process.chdir(dir)
```

This approach works on Linux/macOS but fails on Windows because:
1. `import.meta.url.pathname` on Windows returns a path without a drive letter
2. The `chdir` operation fails because the resolved path is invalid

## Solution
Updated to path resolution to use cross-platform compatible methods:
```typescript
import { fileURLToPath } from "url"

// Fix cross-platform path resolution
const __filename = fileURLToPath(import.meta.url)
const __dirname = path.dirname(__filename)
const dir = path.resolve(__dirname, "..")

process.chdir(dir)
```

This approach:
- Uses `fileURLToPath()` to properly convert the file URL to a system path
- Works correctly on both Windows and Linux/macOS
- Maintains backward compatibility
- Follows Node.js best practices for ES module path resolution

## Testing
- ✅ Script now runs successfully on Windows
- ✅ Build process starts correctly and builds for Windows x64 platform
- ✅ Cross-platform builds still work (Linux/macOS builds may fail on Windows due to missing cross-platform binaries, but this is expected behavior)
- ✅ No regression in functionality

## Impact
This change enables Windows developers to build the opencode project without having to manually fix path resolution issues. The fix is minimal and focused, maintaining all existing functionality while adding proper Windows support.

Files changed:
- `packages/opencode/script/build.ts` - Updated path resolution logic