### PR TITLE
opentui: port flags (-m, -a)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -12,7 +12,6 @@ import { Log } from "../../util/log"
 import { Ide } from "../../ide"
 
 import { Flag } from "../../flag/flag"
-import { Session } from "../../session"
 import { $ } from "bun"
 import { bootstrap } from "../bootstrap"
 
@@ -40,16 +39,17 @@ export const TuiCommand = cmd({
         alias: ["m"],
         describe: "model to use in the format of provider/model",
       })
-      .option("continue", {
-        alias: ["c"],
-        describe: "continue the last session",
-        type: "boolean",
-      })
-      .option("session", {
-        alias: ["s"],
-        describe: "session id to continue",
-        type: "string",
-      })
+      // Migrated to opentui
+      // .option("continue", {
+      //   alias: ["c"],
+      //   describe: "continue the last session",
+      //   type: "boolean",
+      // })
+      // .option("session", {
+      //   alias: ["s"],
+      //   describe: "session id to continue",
+      //   type: "string",
+      // })
       .option("prompt", {
         alias: ["p"],
         type: "string",
@@ -73,32 +73,36 @@ export const TuiCommand = cmd({
   handler: async (args) => {
     while (true) {
       const cwd = args.project ? path.resolve(args.project) : process.cwd()
-      try {
-        process.chdir(cwd)
-      } catch (e) {
-        UI.error("Failed to change directory to " + cwd)
-        return
-      }
+
+      // MIGRATED TO OPENTUI:
+      // try {
+      //   process.chdir(cwd)
+      // } catch (e) {
+      //   UI.error("Failed to change directory to " + cwd)
+      //   return
+      // }
       const result = await bootstrap(cwd, async () => {
-        const sessionID = await (async () => {
-          if (args.continue) {
-            const it = Session.list()
-            try {
-              for await (const s of it) {
-                if (s.parentID === undefined) {
-                  return s.id
-                }
-              }
-              return
-            } finally {
-              await it.return()
-            }
-          }
-          if (args.session) {
-            return args.session
-          }
-          return undefined
-        })()
+        const sessionID = "make-typechecker-happy"
+        // MIGRATED TO OPENTUI:
+        // const sessionID = await (async () => {
+        //   if (args.continue) {
+        //     const it = Session.list()
+        //     try {
+        //       for await (const s of it) {
+        //         if (s.parentID === undefined) {
+        //           return s.id
+        //         }
+        //       }
+        //       return
+        //     } finally {
+        //       await it.return()
+        //     }
+        //   }
+        //   if (args.session) {
+        //     return args.session
+        //   }
+        //   return undefined
+        // })()
         const providers = await Provider.list()
         if (Object.keys(providers).length === 0) {
           return "needs_provider"

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -98,11 +98,10 @@ function App() {
     if (route.data.type === "session") {
       const data = route.data as SessionRoute
       await sync.session.sync(data.sessionID)
-        .catch((err) => {
+        .catch(() => {
           toast.show({
-            message: `Failed to load session ${data.sessionID}: ${err.data?.message ?? err.error?.[0]?.message ?? "Unknown error"}`,
+            message: `Session not found: ${data.sessionID}`,
             type: "error",
-            duration: 5000
           })
           return route.navigate({ type: "home" })
         })

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -20,6 +20,7 @@ import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { PromptHistoryProvider } from "./component/prompt/history"
 import { DialogAlert } from "./ui/dialog-alert"
+import { ToastProvider } from "./ui/toast"
 import { ExitProvider } from "./context/exit"
 
 export async function tui(input: { url: string; sessionID?: string; onExit?: () => Promise<void> }) {
@@ -39,13 +40,15 @@ export async function tui(input: { url: string; sessionID?: string; onExit?: () 
                 <SyncProvider>
                   <LocalProvider>
                     <KeybindProvider>
-                      <DialogProvider>
-                        <CommandProvider>
-                          <PromptHistoryProvider>
-                            <App />
-                          </PromptHistoryProvider>
-                        </CommandProvider>
-                      </DialogProvider>
+                      <ToastProvider>
+                        <DialogProvider>
+                          <CommandProvider>
+                            <PromptHistoryProvider>
+                              <App />
+                            </PromptHistoryProvider>
+                          </CommandProvider>
+                        </DialogProvider>
+                      </ToastProvider>
                     </KeybindProvider>
                   </LocalProvider>
                 </SyncProvider>

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -24,7 +24,7 @@ import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider } from "./context/exit"
 import type { SessionRoute } from "./context/route"
 
-export async function tui(input: { url: string; sessionID?: string; model?: string; onExit?: () => Promise<void> }) {
+export async function tui(input: { url: string; sessionID?: string; model?: string; agent?: string; onExit?: () => Promise<void> }) {
   const routeData: Route | undefined = input.sessionID
     ? {
       type: "session",
@@ -40,7 +40,7 @@ export async function tui(input: { url: string; sessionID?: string; model?: stri
               <RouteProvider data={routeData}>
                 <SDKProvider url={input.url}>
                   <SyncProvider>
-                    <LocalProvider initialModel={input.model}>
+                    <LocalProvider initialModel={input.model} initialAgent={input.agent}>
                       <KeybindProvider>
                         <DialogProvider>
                           <CommandProvider>

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -36,12 +36,12 @@ export async function tui(input: { url: string; sessionID?: string; onExit?: () 
       return (
         <ErrorBoundary fallback={<text>Something went wrong</text>}>
           <ExitProvider onExit={input.onExit}>
-            <RouteProvider data={routeData}>
-              <SDKProvider url={input.url}>
-                <SyncProvider>
-                  <LocalProvider>
-                    <KeybindProvider>
-                      <ToastProvider>
+            <ToastProvider>
+              <RouteProvider data={routeData}>
+                <SDKProvider url={input.url}>
+                  <SyncProvider>
+                    <LocalProvider>
+                      <KeybindProvider>
                         <DialogProvider>
                           <CommandProvider>
                             <PromptHistoryProvider>
@@ -49,12 +49,12 @@ export async function tui(input: { url: string; sessionID?: string; onExit?: () 
                             </PromptHistoryProvider>
                           </CommandProvider>
                         </DialogProvider>
-                      </ToastProvider>
-                    </KeybindProvider>
-                  </LocalProvider>
-                </SyncProvider>
-              </SDKProvider>
-            </RouteProvider>
+                      </KeybindProvider>
+                    </LocalProvider>
+                  </SyncProvider>
+                </SDKProvider>
+              </RouteProvider>
+            </ToastProvider>
           </ExitProvider>
         </ErrorBoundary>
       )

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -24,7 +24,7 @@ import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider } from "./context/exit"
 import type { SessionRoute } from "./context/route"
 
-export async function tui(input: { url: string; sessionID?: string; onExit?: () => Promise<void> }) {
+export async function tui(input: { url: string; sessionID?: string; model?: string; onExit?: () => Promise<void> }) {
   const routeData: Route | undefined = input.sessionID
     ? {
       type: "session",
@@ -40,7 +40,7 @@ export async function tui(input: { url: string; sessionID?: string; onExit?: () 
               <RouteProvider data={routeData}>
                 <SDKProvider url={input.url}>
                   <SyncProvider>
-                    <LocalProvider>
+                    <LocalProvider initialModel={input.model}>
                       <KeybindProvider>
                         <DialogProvider>
                           <CommandProvider>

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,7 +1,7 @@
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { TextAttributes } from "@opentui/core"
-import { RouteProvider, useRoute } from "@tui/context/route"
+import { RouteProvider, useRoute, type Route } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary } from "solid-js"
 import { Installation } from "@/installation"
 import { Global } from "@/global"
@@ -22,13 +22,19 @@ import { PromptHistoryProvider } from "./component/prompt/history"
 import { DialogAlert } from "./ui/dialog-alert"
 import { ExitProvider } from "./context/exit"
 
-export async function tui(input: { url: string; onExit?: () => Promise<void> }) {
+export async function tui(input: { url: string; sessionID?: string; onExit?: () => Promise<void> }) {
+  const routeData: Route | undefined = input.sessionID
+    ? {
+      type: "session",
+      sessionID: input.sessionID,
+    }
+    : undefined
   await render(
     () => {
       return (
         <ErrorBoundary fallback={<text>Something went wrong</text>}>
           <ExitProvider onExit={input.onExit}>
-            <RouteProvider>
+            <RouteProvider data={routeData}>
               <SDKProvider url={input.url}>
                 <SyncProvider>
                   <LocalProvider>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -48,24 +48,26 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           setAgentStore("current", name)
         },
         move(direction: 1 | -1) {
-          let next = agents().findIndex((x) => x.name === agentStore.current) + direction
-          if (next < 0) next = agents().length - 1
-          if (next >= agents().length) next = 0
-          const value = agents()[next]
-          setAgentStore("current", value.name)
-          if (value.model) {
-            if (isModelValid(sync.data.provider, value.model))
-              model.set({
-                providerID: value.model.providerID,
-                modelID: value.model.modelID,
-              })
-            else
-              toast.show({
-                type: "warning",
-                message: `Agent's configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
-                duration: 2000,
-              })
-          }
+          batch(() => {
+            let next = agents().findIndex((x) => x.name === agentStore.current) + direction
+            if (next < 0) next = agents().length - 1
+            if (next >= agents().length) next = 0
+            const value = agents()[next]
+            setAgentStore("current", value.name)
+            if (value.model) {
+              if (isModelValid(sync.data.provider, value.model))
+                model.set({
+                  providerID: value.model.providerID,
+                  modelID: value.model.modelID,
+                })
+              else
+                toast.show({
+                  type: "warning",
+                  message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
+                  duration: 2000,
+                })
+            }
+          })
         },
         color(name: string) {
           const index = agents().findIndex((x) => x.name === name)

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -1,14 +1,16 @@
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
 
-export type Route =
-  | {
-    type: "home"
-  }
-  | {
-    type: "session"
-    sessionID: string
-  }
+export type HomeRoute = {
+  type: "home"
+}
+
+export type SessionRoute = {
+  type: "session"
+  sessionID: string
+}
+
+export type Route = HomeRoute | SessionRoute
 
 export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
   name: "Route",

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -1,24 +1,27 @@
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
 
-type Route =
+export type Route =
   | {
-      type: "home"
-    }
+    type: "home"
+  }
   | {
-      type: "session"
-      sessionID: string
-    }
+    type: "session"
+    sessionID: string
+  }
 
 export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
   name: "Route",
-  init: () => {
+  init: (props: { data?: Route }) => {
     const [store, setStore] = createStore<Route>(
-      process.env["OPENCODE_ROUTE"]
-        ? JSON.parse(process.env["OPENCODE_ROUTE"])
-        : {
+      props.data ??
+      (
+        process.env["OPENCODE_ROUTE"]
+          ? JSON.parse(process.env["OPENCODE_ROUTE"])
+          : {
             type: "home",
-          },
+          }
+      ),
     )
 
     return {

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -246,7 +246,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         },
         async sync(sessionID: string) {
           const [session, messages, todo] = await Promise.all([
-            sdk.client.session.get({ path: { id: sessionID } }),
+            sdk.client.session.get({ path: { id: sessionID }, throwOnError: true }),
             sdk.client.session.messages({ path: { id: sessionID } }),
             sdk.client.session.todo({ path: { id: sessionID } }),
           ])

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -6,6 +6,7 @@ import type { KeybindsConfig } from "@opencode-ai/sdk"
 import { Logo } from "../component/logo"
 import { Locale } from "@/util/locale"
 import { useSync } from "../context/sync"
+import { Toast } from "../ui/toast"
 
 export function Home() {
   const sync = useSync()
@@ -44,6 +45,7 @@ export function Home() {
       <box width="100%" maxWidth={75} zIndex={1000} paddingTop={1}>
         <Prompt hint={Hint} />
       </box>
+      <Toast />
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -184,13 +184,13 @@ export function Session() {
         })
           .then((res) =>
             Clipboard.copy(res.data!.share!.url).catch(() =>
-              toast.show({ message: "Failed to copy URL to clipboard", type: "error", duration: 3000 })
+              toast.show({ message: "Failed to copy URL to clipboard", type: "error" })
             )
           )
           .then(() =>
-            toast.show({ message: "Share URL copied to clipboard!", type: "success", duration: 3000 })
+            toast.show({ message: "Share URL copied to clipboard!", type: "success" })
           )
-          .catch(() => toast.show({ message: "Failed to share session", type: "error", duration: 3000 }))
+          .catch(() => toast.show({ message: "Failed to share session", type: "error" }))
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -177,19 +177,20 @@ export function Session() {
       disabled: !!session()?.share?.url,
       category: "Session",
       onSelect: async (dialog) => {
-        try {
-          const response = await sdk.client.session.share({
-            path: {
-              id: route.sessionID,
-            },
-          })
-          Clipboard.copy(response.data!.share!.url).catch(() =>
-            toast.show({ message: "Failed to copy URL to clipboard", type: "error", duration: 3000 })
+        await sdk.client.session.share({
+          path: {
+            id: route.sessionID,
+          },
+        })
+          .then((res) =>
+            Clipboard.copy(res.data!.share!.url).catch(() =>
+              toast.show({ message: "Failed to copy URL to clipboard", type: "error", duration: 3000 })
+            )
           )
-          toast.show({ message: "Share URL copied to clipboard!", type: "success", duration: 3000 })
-        } catch {
-          toast.show({ message: "Failed to share session", type: "error", duration: 3000 })
-        }
+          .then(() =>
+            toast.show({ message: "Share URL copied to clipboard!", type: "success", duration: 3000 })
+          )
+          .catch(() => toast.show({ message: "Failed to share session", type: "error", duration: 3000 }))
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -500,6 +500,7 @@ export function Session() {
               />
             </box>
           </Show>
+          <Toast />
         </box>
         <Show when={sidebarVisible()}>
           <Sidebar sessionID={route.sessionID} />

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -32,6 +32,10 @@ export const TuiThreadCommand = cmd({
         describe: "session id to continue",
         type: "string",
       })
+      .option("agent", {
+        type: "string",
+        describe: "agent to use",
+      })
       .option("port", {
         type: "number",
         describe: "port to listen on",
@@ -91,6 +95,7 @@ export const TuiThreadCommand = cmd({
         url: server.url,
         sessionID,
         model: args.model,
+        agent: args.agent,
         onExit: async () => {
           await client.call("shutdown", undefined)
         },

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -17,6 +17,11 @@ export const TuiThreadCommand = cmd({
         type: "string",
         describe: "path to start opencode in",
       })
+      .option("model", {
+        type: "string",
+        alias: ["m"],
+        describe: "model to use in the format of provider/model",
+      })
       .option("continue", {
         alias: ["c"],
         describe: "continue the last session",
@@ -85,6 +90,7 @@ export const TuiThreadCommand = cmd({
       await tui({
         url: server.url,
         sessionID,
+        model: args.model,
         onExit: async () => {
           await client.call("shutdown", undefined)
         },

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -5,7 +5,7 @@ import { SplitBorder } from "../component/border"
 
 export interface ToastOptions {
   message: string | null
-  duration: number
+  duration?: number
   type: "info" | "success" | "warning" | "error"
 }
 
@@ -51,7 +51,7 @@ function init() {
       if (timeoutHandle) clearTimeout(timeoutHandle)
       timeoutHandle = setTimeout(() => {
         setStore("currentToast", null)
-      }, duration).unref()
+      }, duration ?? 5000).unref()
     },
     get currentToast(): ToastOptions | null {
       return store.currentToast

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -1,0 +1,81 @@
+import { createContext, useContext, type ParentProps, Show } from "solid-js"
+import { createStore } from "solid-js/store"
+import { Theme } from "@tui/context/theme"
+import { SplitBorder } from "../component/border"
+
+export interface ToastOptions {
+  message: string | null
+  duration: number
+  type: "info" | "success" | "warning" | "error"
+}
+
+export function Toast() {
+  const toast = useToast()
+
+  return (
+    <Show when={toast.currentToast}>
+      {(current) => (
+        <box
+          position="absolute"
+          justifyContent="center"
+          alignItems="center"
+          top={2}
+          right={2}
+          paddingLeft={2}
+          paddingRight={2}
+          paddingTop={1}
+          paddingBottom={1}
+          backgroundColor={Theme.backgroundPanel}
+          borderColor={Theme[current().type]}
+          border={["left", "right"]}
+          customBorderChars={SplitBorder.customBorderChars}
+        >
+          <text>{current().message}</text>
+        </box>
+      )}
+    </Show>
+  )
+}
+
+function init() {
+  const [store, setStore] = createStore({
+    currentToast: null as ToastOptions | null,
+  })
+
+  let timeoutHandle: NodeJS.Timeout | null = null
+
+  return {
+    show(options: ToastOptions) {
+      const { duration, ...currentToast } = options
+      setStore("currentToast", currentToast)
+      if (timeoutHandle) clearTimeout(timeoutHandle)
+      timeoutHandle = setTimeout(() => {
+        setStore("currentToast", null)
+      }, duration).unref()
+    },
+    get currentToast(): ToastOptions | null {
+      return store.currentToast
+    },
+  }
+}
+
+export type ToastContext = ReturnType<typeof init>
+
+const ctx = createContext<ToastContext>()
+
+export function ToastProvider(props: ParentProps) {
+  const value = init()
+  return (
+    <ctx.Provider value={value}>
+      {props.children}
+    </ctx.Provider>
+  )
+}
+
+export function useToast() {
+  const value = useContext(ctx)
+  if (!value) {
+    throw new Error("useToast must be used within a ToastProvider")
+  }
+  return value
+}


### PR DESCRIPTION
Prolly gonna rebase and resolve conflicts that are likely to arise with the opentui branch.

- Side effect: Added validation of model, which prevents a crash when you select an agent with a nonexistent model

(still need to test thoroughly)

Test matrix:
- [x] `bun dev`
- [x] `bun dev                     --agent existing`
- [ ] `bun dev                     --agent nonexistent               # warning toast`
- [ ] `bun dev                     --agent existing-with-wrong-model # warning toast`
- [ ] `bun dev --model existing`
- [ ] `bun dev --model existing    --agent existing`
- [ ] `bun dev --model existing    --agent nonexistent               # warning toast`
- [ ] `bun dev --model existing    --agent existing-with-wrong-model # warning toast`
- [ ] `bun dev --model nonexistent                                   # warning toast`
- [ ] `bun dev --model nonexistent --agent existing                  # warning toast`
- [ ] `bun dev --model nonexistent --agent nonexistent               # warning toast`
- [ ] `bun dev --model nonexistent --agent existing-with-wrong-model # warning toast`