### PR TITLE
fix: Provider option was triggering immediate timeouts.

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -422,7 +422,7 @@ export namespace Provider {
       const modPath =
         provider.id === "google-vertex-anthropic" ? `${installedPath}/dist/anthropic/index.mjs` : installedPath
       const mod = await import(modPath)
-      if (options["timeout"] !== undefined) {
+      if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false) {
         // Only override fetch if user explicitly sets timeout
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const { signal, ...rest } = init ?? {}


### PR DESCRIPTION
You could see this in the logs:

```
ERROR 2025-10-25T14:52:20 +1ms service=session.prompt session=ses_5e424d302ffeiBHyx2QyU5pzcA error=The operation timed out. process
INFO  2025-10-25T14:52:20 +0ms service=bus type=session.error publishing
ERROR 2025-10-25T14:52:20 +2ms service=session.prompt session=ses_5e424d302ffeiBHyx2QyU5pzcA error=The operation timed out. model=gpt-oss:latest failed to generate title
INFO  2025-10-25T14:52:20 +2ms service=bus type=message.updated publishing
INFO  2025-10-25T14:52:20 +1ms service=bus type=message.updated publishing
INFO  2025-10-25T14:52:20 +1ms service=session.compaction pruning
INFO  2025-10-25T14:52:20 +1ms service=session.lock sessionID=ses_5e424d302ffeiBHyx2QyU5pzcA unlocked
INFO  2025-10-25T14:52:20 +0ms service=session.prompt session=ses_5e424d302ffeiBHyx2QyU5pzcA sessionID=ses_5e424d302ffeiBHyx2QyU5pzcA unlocking
INFO  2025-10-25T14:52:20 +1ms service=bus type=session.idle publishing
INFO  2025-10-25T14:52:20 +0ms service=server duration=180 response
INFO  2025-10-25T14:52:20 +3ms service=bus type=session.updated publishing
INFO  2025-10-25T14:52:20 +0ms service=bus type=message.updated publishing
INFO  2025-10-25T14:52:20 +29ms service=session.compaction pruned=0 total=0 found
ERROR 2025-10-25T14:52:20 +30ms service=tui message=TimeoutError: The operation timed out. name=UnknownError Server error
DEBUG 2025-10-25T14:52:20 +67ms service=tui timeTakenMs=0 messages.renderView
DEBUG 2025-10-25T14:52:20 +72ms service=tui pending render, skipping
```