### PR TITLE
chore: use stable URLs in PKGBUILD

### DIFF
--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -51,13 +51,16 @@ if (!Script.preview) {
   const macX64Sha = await $`sha256sum ./dist/opencode-darwin-x64.zip | cut -d' ' -f1`.text().then((x) => x.trim())
   const macArm64Sha = await $`sha256sum ./dist/opencode-darwin-arm64.zip | cut -d' ' -f1`.text().then((x) => x.trim())
 
+  const [pkgver, _subver = ""] = Script.version.split(/(-.*)/, 2)
+
   // arch
   const binaryPkgbuild = [
     "# Maintainer: dax",
     "# Maintainer: adam",
     "",
     "pkgname='opencode-bin'",
-    `pkgver=${Script.version.split("-")[0]}`,
+    `pkgver=${pkgver}`,
+    `_subver=${_subver}`,
     "options=('!debug' '!strip')",
     "pkgrel=1",
     "pkgdesc='The AI coding agent built for the terminal.'",
@@ -68,10 +71,10 @@ if (!Script.preview) {
     "conflicts=('opencode')",
     "depends=('fzf' 'ripgrep')",
     "",
-    `source_aarch64=("\${pkgname}_\${pkgver}_aarch64.zip::https://github.com/sst/opencode/releases/download/v${Script.version}/opencode-linux-arm64.zip")`,
+    `source_aarch64=("\${pkgname}_\${pkgver}_aarch64.zip::https://github.com/sst/opencode/releases/download/v\${pkgver}\${_subver}/opencode-linux-arm64.zip")`,
     `sha256sums_aarch64=('${arm64Sha}')`,
     "",
-    `source_x86_64=("\${pkgname}_\${pkgver}_x86_64.zip::https://github.com/sst/opencode/releases/download/v${Script.version}/opencode-linux-x64.zip")`,
+    `source_x86_64=("\${pkgname}_\${pkgver}_x86_64.zip::https://github.com/sst/opencode/releases/download/v\${pkgver}\${_subver}/opencode-linux-x64.zip")`,
     `sha256sums_x86_64=('${x64Sha}')`,
     "",
     "package() {",
@@ -86,7 +89,8 @@ if (!Script.preview) {
     "# Maintainer: adam",
     "",
     "pkgname='opencode'",
-    `pkgver=${Script.version.split("-")[0]}`,
+    `pkgver=${pkgver}`,
+    `_subver=${_subver}`,
     "options=('!debug' '!strip')",
     "pkgrel=1",
     "pkgdesc='The AI coding agent built for the terminal.'",
@@ -98,7 +102,7 @@ if (!Script.preview) {
     "depends=('fzf' 'ripgrep')",
     "makedepends=('git' 'bun-bin' 'go')",
     "",
-    `source=("opencode-\${pkgver}.tar.gz::https://github.com/sst/opencode/archive/v${Script.version}.tar.gz")`,
+    `source=("opencode-\${pkgver}.tar.gz::https://github.com/sst/opencode/archive/v\${pkgver}\${_subver}.tar.gz")`,
     `sha256sums=('SKIP')`,
     "",
     "build() {",


### PR DESCRIPTION
Currently, when opencode releases a new version (e.g., 1.2.3-beta.4), the PKGBUILD files embed the full version string directly in the source URLs.

When users update the package, they must verify the entire URL in the diff. This is tedious because the URL changes with every release, even though only the version number is different:

```diff
-pkgver=1.2.3
+pkgver=1.2.4

-source_aarch64=("${pkgname}_${pkgver}_aarch64.zip::https://github.com/sst/opencode/releases/download/v1.2.3-beta.4/opencode-linux-arm64.zip")
+source_aarch64=("${pkgname}_${pkgver}_aarch64.zip::https://github.com/sst/opencode/releases/download/v1.2.4-beta.5/opencode-linux-arm64.zip")
```

This PR introduces a `_subver` variable that separates the version prefix from the suffix:

```diff
-pkgver=1.2.3
-_subver=-beta.4
+pkgver=1.2.4
+_subver=-beta.5
```

Now the URL template is constant across all versions. Users only need to verify the `pkgver` and `_subver` variables change correctly, not the entire URL string.