### PR TITLE
fix: windows not loading due to getContextId non-hydrating error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.0",
   "scripts": {
-    "dev": "bun --cwd packages/opencode --conditions=browser src/index.ts",
+    "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
     "random": "echo 'Random script'"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.0",
   "scripts": {
-    "dev": "bun run --cwd packages/opencode src/index.ts",
+    "dev": "bun --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
     "random": "echo 'Random script'"


### PR DESCRIPTION
Running `bun dev` from opentui branch resulted in an error message saying to read the error log which contained:

`ERROR 2025-10-26T05:24:50 +241ms service=default name=Error message=getContextId cannot be used under non-hydrating context stack=Error: getContextId cannot be used under non-hydrating context`

Changing the package.json to add `--conditions=browser` seems to have fixed it. 