### PR TITLE
feat: add positional argument support to slash commands

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1516,11 +1516,8 @@ export namespace SessionPrompt {
     const agentName = command.agent ?? input.agent ?? "build"
 
     const args = input.arguments.split(/\s+/)
-    let template = command.template.replaceAll(/\$ARGUMENTS\[(\d+)(?:(\*)|:(\d+))?\]/g, (_, index, star, end) => {
-      const start = parseInt(index)
-      if (star) return args.slice(start).join(" ")
-      if (end) return args.slice(start, parseInt(end) + 1).join(" ")
-      return args[start] || ""
+    let template = command.template.replaceAll(/\$(\d+)/g, (_, index) => {
+      return args[parseInt(index) - 1] || ""
     })
     template = template.replaceAll("$ARGUMENTS", input.arguments)
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1515,7 +1515,14 @@ export namespace SessionPrompt {
     const command = await Command.get(input.command)
     const agentName = command.agent ?? input.agent ?? "build"
 
-    let template = command.template.replaceAll("$ARGUMENTS", input.arguments)
+    const args = input.arguments.split(/\s+/)
+    let template = command.template.replaceAll(/\$ARGUMENTS\[(\d+)(?:(\*)|:(\d+))?\]/g, (_, index, star, end) => {
+      const start = parseInt(index)
+      if (star) return args.slice(start).join(" ")
+      if (end) return args.slice(start, parseInt(end) + 1).join(" ")
+      return args[start] || ""
+    })
+    template = template.replaceAll("$ARGUMENTS", input.arguments)
 
     const shell = ConfigMarkdown.shell(template)
     if (shell.length > 0) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1504,6 +1504,9 @@ export namespace SessionPrompt {
   })
   export type CommandInput = z.infer<typeof CommandInput>
   const bashRegex = /!`([^`]+)`/g
+  const argsRegex = /(?:[^\s"']+|"[^"]*"|'[^']*')+/g
+  const placeholderRegex = /\$(\d+)/g
+  const quoteTrimRegex = /^["']|["']$/g
   /**
    * Regular expression to match @ file references in text
    * Matches @ followed by file paths, excluding commas, periods at end of sentences, and backticks
@@ -1515,11 +1518,25 @@ export namespace SessionPrompt {
     const command = await Command.get(input.command)
     const agentName = command.agent ?? input.agent ?? "build"
 
-    const args = input.arguments.split(/\s+/)
-    let template = command.template.replaceAll(/\$(\d+)/g, (_, index) => {
-      return args[parseInt(index) - 1] || ""
+    const raw = input.arguments.match(argsRegex) ?? []
+    const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
+
+    const placeholders = command.template.match(placeholderRegex) ?? []
+    let last = 0
+    for (const item of placeholders) {
+      const value = Number(item.slice(1))
+      if (value > last) last = value
+    }
+
+    // Let the final placeholder swallow any extra arguments so prompts read naturally
+    const withArgs = command.template.replaceAll(placeholderRegex, (_, index) => {
+      const position = Number(index)
+      const argIndex = position - 1
+      if (argIndex >= args.length) return ""
+      if (position === last) return args.slice(argIndex).join(" ")
+      return args[argIndex]
     })
-    template = template.replaceAll("$ARGUMENTS", input.arguments)
+    let template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
 
     const shell = ConfigMarkdown.shell(template)
     if (shell.length > 0) {

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -129,13 +129,12 @@ Run the command with arguments:
 
 And `$ARGUMENTS` will be replaced with `Button`.
 
-You can also access individual arguments or ranges using array notation:
+You can also access individual arguments using positional parameters:
 
-- `$ARGUMENTS[0]` - First argument
-- `$ARGUMENTS[1]` - Second argument
-- `$ARGUMENTS[0*]` - First argument and all following arguments
-- `$ARGUMENTS[1*]` - Second argument and all following arguments
-- `$ARGUMENTS[0:2]` - First through third arguments (inclusive)
+- `$1` - First argument
+- `$2` - Second argument
+- `$3` - Third argument
+- And so on...
 
 For example:
 
@@ -144,8 +143,8 @@ For example:
 description: Create a new file with content
 ---
 
-Create a file named $ARGUMENTS[0] in the directory $ARGUMENTS[1]
-with the following content: $ARGUMENTS[2*]
+Create a file named $1 in the directory $2
+with the following content: $3
 ```
 
 Run the command:
@@ -156,9 +155,9 @@ Run the command:
 
 This replaces:
 
-- `$ARGUMENTS[0]` with `config.json`
-- `$ARGUMENTS[1]` with `src`
-- `$ARGUMENTS[2*]` with `{ "key": "value" }`
+- `$1` with `config.json`
+- `$2` with `src`
+- `$3` with `{ "key": "value" }`
 
 ---
 

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -129,6 +129,37 @@ Run the command with arguments:
 
 And `$ARGUMENTS` will be replaced with `Button`.
 
+You can also access individual arguments or ranges using array notation:
+
+- `$ARGUMENTS[0]` - First argument
+- `$ARGUMENTS[1]` - Second argument
+- `$ARGUMENTS[0*]` - First argument and all following arguments
+- `$ARGUMENTS[1*]` - Second argument and all following arguments
+- `$ARGUMENTS[0:2]` - First through third arguments (inclusive)
+
+For example:
+
+```md title=".opencode/command/create-file.md"
+---
+description: Create a new file with content
+---
+
+Create a file named $ARGUMENTS[0] in the directory $ARGUMENTS[1]
+with the following content: $ARGUMENTS[2*]
+```
+
+Run the command:
+
+```bash frame="none"
+/create-file config.json src "{ \"key\": \"value\" }"
+```
+
+This replaces:
+
+- `$ARGUMENTS[0]` with `config.json`
+- `$ARGUMENTS[1]` with `src`
+- `$ARGUMENTS[2*]` with `{ "key": "value" }`
+
 ---
 
 ### Shell output


### PR DESCRIPTION
- https://github.com/sst/opencode/pull/2199 had a merge conflict that was not resolved, so I am submitting a new PR with the merge conflict resolved.
- Removing `$ARGUMENTS[n+]`, `$ARGUMENTS[n++]` becasue they can be replaced by `$ARGUMENTS[n:n+1]`, `$ARGUMENTS[n:n+2]`.
- You can still use `$ARGUMENTS` as before.

Closes #2199 