### PR TITLE
Fix: run was hardcoded to linux shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.0",
   "scripts": {
-    "dev": "bun --cwd packages/opencode --conditions=browser src/index.ts",
+    "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
     "random": "echo 'Random script'"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "bun@1.3.0",
   "scripts": {
-    "dev": "bun run --cwd packages/opencode src/index.ts",
+    "dev": "bun --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
     "random": "echo 'Random script'"

--- a/packages/opencode/bin/run.js
+++ b/packages/opencode/bin/run.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const command = process.platform === 'win32' ? 'opencode.cmd' : 'opencode';
+const commandPath = path.join(__dirname, command);
+const args = process.argv.slice(2);
+
+const child = spawn(commandPath, args, {
+  stdio: 'inherit',
+  shell: process.platform === 'win32'
+});
+
+child.on('exit', (code) => {
+  process.exit(code === null ? 1 : code);
+});
+
+child.on('error', (err) => {
+  console.error(`Failed to start subprocess: ${err}`);
+  process.exit(1);
+});

--- a/packages/opencode/bin/run.js
+++ b/packages/opencode/bin/run.js
@@ -1,25 +1,25 @@
 #!/usr/bin/env node
-import { spawn } from 'child_process';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { spawn } from "child_process"
+import path from "path"
+import { fileURLToPath } from "url"
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
-const command = process.platform === 'win32' ? 'opencode.cmd' : 'opencode';
-const commandPath = path.join(__dirname, command);
-const args = process.argv.slice(2);
+const command = process.platform === "win32" ? "opencode.cmd" : "opencode"
+const commandPath = path.join(__dirname, command)
+const args = process.argv.slice(2)
 
 const child = spawn(commandPath, args, {
-  stdio: 'inherit',
-  shell: process.platform === 'win32'
-});
+  stdio: "inherit",
+  shell: process.platform === "win32",
+})
 
-child.on('exit', (code) => {
-  process.exit(code === null ? 1 : code);
-});
+child.on("exit", (code) => {
+  process.exit(code === null ? 1 : code)
+})
 
-child.on('error', (err) => {
-  console.error(`Failed to start subprocess: ${err}`);
-  process.exit(1);
-});
+child.on("error", (err) => {
+  console.error(`Failed to start subprocess: ${err}`)
+  process.exit(1)
+})

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -12,7 +12,7 @@
     "random": "echo 'Random script updated at $(date)'"
   },
   "bin": {
-    "opencode": "./bin/opencode"
+    "opencode": "./bin/run.js"
   },
   "exports": {
     "./*": "./src/*.ts"

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun"
 
-if (process.versions.bun !== "1.3.0") {
-  throw new Error("This script requires bun@1.3.0")
+if (!process.versions.bun.startsWith("1.3.")) {
+  throw new Error("This script requires bun@1.3+")
 }
 
 const CHANNEL = process.env["OPENCODE_CHANNEL"] ?? (await $`git branch --show-current`.text().then((x) => x.trim()))


### PR DESCRIPTION
Running `bun x opencode@opentui` was giving `error: interpreter executable "/bin/sh" not found in %PATH%` when running `bun x opencode-ai@opentui` 

The package.json bin was hardcoded to the linux `./bin/opencode`
This puts a shim in place to figure out whether to execute `./bin/opencode` or `./bin/opencode.cmd`