### PR TITLE
Disable default reasoning effort for `gpt-5-pro`

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -92,7 +92,9 @@ export namespace ProviderTransform {
     }
 
     if (modelID.includes("gpt-5") && !modelID.includes("gpt-5-chat")) {
-      if (!modelID.includes("codex")) result["reasoningEffort"] = "medium"
+      if (!modelID.includes("codex") && !modelID.includes("gpt-5-pro")) {
+        result["reasoningEffort"] = "medium"
+      }
 
       if (providerID !== "azure") {
         result["textVerbosity"] = modelID.includes("codex") ? "medium" : "low"


### PR DESCRIPTION
## What is the issue?

`gpt-5-pro` (recently introduced in models.dev) does not support setting the reasoning effort to anything else than `high` (its default). As a consequence, it should not inherit the default `medium` reasoning effort of all gpt-5 models.

Source: https://platform.openai.com/docs/models/gpt-5-pro

<img width="947" height="58" alt="image" src="https://github.com/user-attachments/assets/98cd8e95-143e-4bba-9fe4-dc32931b65eb" />

## Does it work now?

Yes, with that change, `gpt-5-pro` is accepted as expected.

<img width="789" height="123" alt="image" src="https://github.com/user-attachments/assets/0cda55be-253c-4198-8306-9a7c569c23e8" />

## Extra info from openai

<img width="987" height="256" alt="image" src="https://github.com/user-attachments/assets/2bbcbf16-e0ec-4f78-8cfe-67f8efa8b59f" />

<img width="637" height="221" alt="image" src="https://github.com/user-attachments/assets/2040f7de-f721-4cf8-99e7-b888ccaf2098" />
