### PR TITLE
Add argument `--reasoning-effort` to `opencode run`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -78,6 +78,12 @@ export const RunCommand = cmd({
         array: true,
         describe: "file(s) to attach to message",
       })
+      .option("reasoning-effort", {
+        alias: ["r"],
+        type: "string",
+        choices: ["low", "medium", "high"],
+        describe: "reasoning effort for the model",
+      })
   },
   handler: async (args) => {
     let message = args.message.join(" ")
@@ -260,6 +266,7 @@ export const RunCommand = cmd({
       })
 
       await (async () => {
+        const options = args.reasoningEffort ? { reasoningEffort: args.reasoningEffort } : undefined
         if (args.command) {
           return await SessionPrompt.command({
             messageID,
@@ -268,6 +275,7 @@ export const RunCommand = cmd({
             model: providerID + "/" + modelID,
             command: args.command,
             arguments: message,
+            options,
           })
         }
         return await SessionPrompt.prompt({
@@ -278,6 +286,7 @@ export const RunCommand = cmd({
             modelID,
           },
           agent: agent.name,
+          options,
           parts: [
             ...fileParts,
             {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -97,6 +97,7 @@ export namespace SessionPrompt {
     noReply: z.boolean().optional(),
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
+    options: z.record(z.string(), z.any()).optional(),
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -229,6 +230,7 @@ export namespace SessionPrompt {
           ...ProviderTransform.options(model.providerID, model.modelID, input.sessionID),
           ...model.info.options,
           ...agent.options,
+          ...input.options,
         },
       },
     )
@@ -1489,6 +1491,7 @@ export namespace SessionPrompt {
     model: z.string().optional(),
     arguments: z.string(),
     command: z.string(),
+    options: z.record(z.string(), z.any()).optional(),
   })
   export type CommandInput = z.infer<typeof CommandInput>
   const bashRegex = /!`([^`]+)`/g
@@ -1701,6 +1704,7 @@ export namespace SessionPrompt {
       model,
       agent: agentName,
       parts,
+      options: input.options,
     })
   }
 


### PR DESCRIPTION
Being able to customize the reasoning effort for the CLI without having to create a custom agent file is a big improvement to quality of life, for CLI usages.

This PR introduces `--reasoning-effort / -r` to `opencode run` command, just like in Factory's Droid.

## Does it work?

Yes it does! For example, without this PR, model `gpt-5-pro` cannot be used yet (until PR #3474 is merged).
By being able to customize the reasoning effort, the model can successfully be called.

<img width="988" height="121" alt="image" src="https://github.com/user-attachments/assets/08faf77e-a13c-4cd5-b154-fe2154a5a384" />

_(yes, more than 1m to say hello, that's the power of 5-pro)_


Note that the aim of this PR is **not** to fix gpt-5-pro (#3474 is here for that). Its aim is really to give more flexibility to CLI users of the `run` command.
