### PR TITLE
Document Ref MCP server

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -252,6 +252,42 @@ Below are examples of some common MCP servers. You can submit a PR if you want t
 
 ---
 
+### Ref
+
+[Ref MCP server](https://github.com/ref-tools/ref-tools-mcp) provides your agent with token-efficient search over public and private docs so your agent doesn't make mistakes working with libraries.
+
+```json title="opencode.json" {4-7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "Ref": {
+      "type": "remote",
+      "url": "https://api.ref.tools/mcp",
+      "headers": {
+        "x-ref-api-key": "{env:REF_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Ref is used in two ways:
+
+1) Update your `AGENTS.md` so that when it finds errors related to libraries it knows to check the docs.
+
+```md title="AGENTS.md"
+When working with libraries, check the docs with Ref.
+```
+
+2) Your task will require working with libraries so you guide the agent to check the docs.
+
+```txt 
+<prompt for your coding task>
+
+check (the docs|my docs) with ref
+```
+
+
 ### Context7
 
 Add the [Context7 MCP server](https://github.com/context-labs/mcp-server-context7) to search through docs.


### PR DESCRIPTION
Added documentation for Ref MCP server with examples.

Ref website: https://ref.tools/

Recent talk from MCP Dev Summit: https://www.youtube.com/watch?v=cGki4V11sPs