### PR TITLE
fix: make bash tool respect $SHELL

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -150,7 +150,7 @@ export const BashTool = Tool.define("bash", {
       shell:
         process.platform === "win32"
           ? true // process.env.ComSpec on Windows
-          : (process.env.SHELL ?? true), // $SHELL - *default shell for new sessions* if set, otherwise /bun/sh
+          : (process.env.SHELL ?? true), // $SHELL - *default shell for new sessions* if set, otherwise /bin/sh
       cwd: Instance.directory,
       stdio: ["ignore", "pipe", "pipe"],
       detached: process.platform !== "win32",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -147,7 +147,10 @@ export const BashTool = Tool.define("bash", {
     }
 
     const proc = spawn(params.command, {
-      shell: true,
+      shell:
+        process.platform === "win32"
+          ? true // process.env.ComSpec on Windows
+          : (process.env.SHELL ?? true), // $SHELL - *default shell for new sessions* if set, otherwise /bun/sh
       cwd: Instance.directory,
       stdio: ["ignore", "pipe", "pipe"],
       detached: process.platform !== "win32",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -147,10 +147,7 @@ export const BashTool = Tool.define("bash", {
     }
 
     const proc = spawn(params.command, {
-      shell:
-        process.platform === "win32"
-          ? true // process.env.ComSpec on Windows
-          : (process.env.SHELL ?? true), // $SHELL - *default shell for new sessions* if set, otherwise /bin/sh
+      shell: process.env.SHELL ?? true, // $SHELL if set, otherwise default shell
       cwd: Instance.directory,
       stdio: ["ignore", "pipe", "pipe"],
       detached: process.platform !== "win32",


### PR DESCRIPTION
For spawn: 
- Nothing changes for windows users.
- Uses $SHELL env variable - *default shell for new sessions* if set, othewise fallback on previous /bin/sh behaviour

Fixes #3479