### PR TITLE
Allow passing custom provider options to `opencode run`

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -78,6 +78,11 @@ export const RunCommand = cmd({
         array: true,
         describe: "file(s) to attach to message",
       })
+      .option("provider-options", {
+        type: "string",
+        describe:
+          'JSON object with provider-specific options, passed to the AI SDK. Example: \'{"reasoningEffort": "high"}\'. See https://ai-sdk.dev/providers',
+      })
   },
   handler: async (args) => {
     let message = args.message.join(" ")
@@ -116,6 +121,26 @@ export const RunCommand = cmd({
     if (message.trim().length === 0 && !args.command) {
       UI.error("You must provide a message or a command")
       process.exit(1)
+    }
+
+    // Parse and validate custom options
+    let customProviderOptions: Record<string, unknown> | undefined
+    if (args.providerOptions) {
+      try {
+        customProviderOptions = JSON.parse(args.providerOptions)
+        if (
+          typeof customProviderOptions !== "object" ||
+          customProviderOptions === null ||
+          Array.isArray(customProviderOptions)
+        ) {
+          UI.error("--provider-options must be a JSON object")
+          process.exit(1)
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        UI.error(`Invalid JSON in --provider-options: ${msg}`)
+        process.exit(1)
+      }
     }
 
     await bootstrap(process.cwd(), async () => {
@@ -268,6 +293,7 @@ export const RunCommand = cmd({
             model: providerID + "/" + modelID,
             command: args.command,
             arguments: message,
+            providerOptions: customProviderOptions,
           })
         }
         return await SessionPrompt.prompt({
@@ -286,6 +312,7 @@ export const RunCommand = cmd({
               text: message,
             },
           ],
+          providerOptions: customProviderOptions,
         })
       })()
       if (errorMsg) process.exit(1)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -97,6 +97,7 @@ export namespace SessionPrompt {
     noReply: z.boolean().optional(),
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
+    providerOptions: z.record(z.string(), z.unknown()).optional(),
     parts: z.array(
       z.discriminatedUnion("type", [
         MessageV2.TextPart.omit({
@@ -158,6 +159,7 @@ export namespace SessionPrompt {
         state().queued.set(input.sessionID, queue)
       })
     }
+
     const agent = await Agent.get(input.agent ?? "build")
     const model = await resolveModel({
       agent,
@@ -207,6 +209,7 @@ export namespace SessionPrompt {
           ...ProviderTransform.options(model.providerID, model.modelID, input.sessionID),
           ...model.info.options,
           ...agent.options,
+          ...input.providerOptions,
         },
       },
     )
@@ -1467,6 +1470,7 @@ export namespace SessionPrompt {
     model: z.string().optional(),
     arguments: z.string(),
     command: z.string(),
+    providerOptions: z.record(z.string(), z.unknown()).optional(),
   })
   export type CommandInput = z.infer<typeof CommandInput>
   const bashRegex = /!`([^`]+)`/g
@@ -1679,6 +1683,7 @@ export namespace SessionPrompt {
       model,
       agent: agentName,
       parts,
+      providerOptions: input.providerOptions,
     })
   }
 


### PR DESCRIPTION
The goal of this PR is to provide users of `opencode run` the flexibility to set and use every possible provider option proposed by the AI SDK.

This is a compromise with https://github.com/sst/opencode/pull/3475, in which I proposed a dedicated argument for an openai-specific property.

This new approach is more technical (users need to check with Vercel docs for what is available), but has the large advantage to deport the maintenance from opencode devs to vercel devs:
- new models will be customizable without having to their properties to the code
- no headache to find how to generalize a property (like reasoning effort) to all models
- no arbitrary choice to make (mapping of reasoning effort from gemini's numbers to openai's enum)

Of course, dedicated arguments for important parameters will always be welcome, but at least now there will always be a workaround for missing arguments.

## Does it work?

The best way to check that is to pass an invalid value and see if Vercel's AI SDK shows the correct error.
Here I tested it with `reasoningEffort` for openai models.

<img width="1225" height="123" alt="image" src="https://github.com/user-attachments/assets/e598c6f4-5c4b-4a76-8420-ae8cbbf120f0" />

<img width="1229" height="117" alt="image" src="https://github.com/user-attachments/assets/8f5cbbd7-2ffe-4f13-953a-fad4b02ac9d2" />

## Note

Aiden, of course this is a proposal, feel free to discard it if that's not the way Opencode wants to go.