### PR TITLE
docs: add Hugging Face Inference Providers documentation

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -446,6 +446,45 @@ To use Google Vertex AI with OpenCode:
 
 ---
 
+### Hugging Face
+
+[Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers) provides access to open models supported by 17+ providers.
+
+1. Head over to [Hugging Face settings](https://huggingface.co/settings/tokens), click **Create new token**. Ensure you create a token with permission to make calls to Inference Providers.
+
+2. Run `opencode auth login` and select **Hugging Face**.
+
+   ```bash
+   $ opencode auth login
+
+   ┌  Add credential
+   │
+   ◆  Select provider
+   │  ● Hugging Face
+   │  ...
+   └
+   ```
+
+3. Enter your Hugging Face token.
+
+   ```bash
+   $ opencode auth login
+
+   ┌  Add credential
+   │
+   ◇  Select provider
+   │  Hugging Face
+   │
+   ◇  Enter your API key
+   │  _
+   └
+   ```
+
+4. Run the `/models` command to select a model like _Kimi-K2-Instruct_ or _GLM-4.6_.
+
+
+---
+
 ### LM Studio
 
 You can configure opencode to use local models through LM Studio.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -450,7 +450,7 @@ To use Google Vertex AI with OpenCode:
 
 [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers) provides access to open models supported by 17+ providers.
 
-1. Head over to [Hugging Face settings](https://huggingface.co/settings/tokens), click **Create new token**. Ensure you create a token with permission to make calls to Inference Providers.
+1. Head over to [Hugging Face settings](https://huggingface.co/settings/tokens/new?ownUserPermissions=inference.serverless.write&tokenType=fineGrained) to create a token with permission to make calls to Inference Providers.
 
 2. Run `opencode auth login` and select **Hugging Face**.
 


### PR DESCRIPTION
Adds documentation for using Hugging Face Inference Providers with OpenCode

## Changes
- Adds Hugging Face section to provider directory (alphabetically positioned between Groq and LM Studio)
- Documents authentication setup using HF_TOKEN
- Links to Inference Providers documentation

## Context
Hugging Face Inference Providers is already supported in OpenCode via models.dev, but was missing from the provider documentation. 

## Testing
Tested authentication flow and model selection with multiple models including Kimi K2 Instruct and GLM-4.6 in both TUI and CLI modes.