### PR TITLE
add --title flag to opencode run

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -78,6 +78,10 @@ export const RunCommand = cmd({
         array: true,
         describe: "file(s) to attach to message",
       })
+      .option("title", {
+        type: "string",
+        describe: "title for the session (uses truncated prompt if no value provided)",
+      })
   },
   handler: async (args) => {
     let message = args.message.join(" ")
@@ -143,7 +147,19 @@ export const RunCommand = cmd({
 
         if (args.session) return Session.get(args.session)
 
-        return Session.create({})
+        const title = (() => {
+          if (args.title !== undefined) {
+            if (args.title === "") {
+              return message.slice(0, 50) + (message.length > 50 ? "..." : "")
+            }
+            return args.title
+          }
+          return undefined
+        })()
+
+        return Session.create({
+          title,
+        })
       })()
 
       if (!session) {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -23,11 +23,17 @@ import { Snapshot } from "@/snapshot"
 export namespace Session {
   const log = Log.create({ service: "session" })
 
-  const parentSessionTitlePrefix = "New session - "
-  const childSessionTitlePrefix = "Child session - "
+  const parentTitlePrefix = "New session - "
+  const childTitlePrefix = "Child session - "
 
   function createDefaultTitle(isChild = false) {
-    return (isChild ? childSessionTitlePrefix : parentSessionTitlePrefix) + new Date().toISOString()
+    return (isChild ? childTitlePrefix : parentTitlePrefix) + new Date().toISOString()
+  }
+
+  export function isDefaultTitle(title: string) {
+    return new RegExp(
+      `^(${parentTitlePrefix}|${childTitlePrefix})\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$`,
+    ).test(title)
   }
 
   export const Info = z

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1703,6 +1703,7 @@ export namespace SessionPrompt {
     modelID: string
   }) {
     if (input.session.parentID) return
+    if (!Session.isDefaultTitle(input.session.title)) return
     const isFirst =
       input.history.filter((m) => m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic))
         .length === 1


### PR DESCRIPTION
fixes: #1237

--title allows you to set the title of the session when doing `opencode run` it defaults to a truncated version of your prompt if no argument provided

This argument is optional and it does not change existing behavior