### PR TITLE
fix: Use process.stdout.write instead of console.log

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/config.ts
+++ b/packages/opencode/src/cli/cmd/debug/config.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os"
 import { Config } from "../../../config/config"
 import { bootstrap } from "../../bootstrap"
 import { cmd } from "../cmd"
@@ -8,7 +9,7 @@ export const ConfigCommand = cmd({
   async handler() {
     await bootstrap(process.cwd(), async () => {
       const config = await Config.get()
-      console.log(JSON.stringify(config, null, 2))
+      process.stdout.write(JSON.stringify(config, null, 2) + EOL)
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/debug/file.ts
+++ b/packages/opencode/src/cli/cmd/debug/file.ts
@@ -14,7 +14,7 @@ const FileSearchCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       const results = await File.search({ query: args.query })
-      console.log(results.join(EOL))
+      process.stdout.write(results.join(EOL) + EOL)
     })
   },
 })
@@ -30,7 +30,7 @@ const FileReadCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       const content = await File.read(args.path)
-      console.log(content)
+      process.stdout.write(JSON.stringify(content, null, 2) + EOL)
     })
   },
 })
@@ -41,7 +41,7 @@ const FileStatusCommand = cmd({
   async handler() {
     await bootstrap(process.cwd(), async () => {
       const status = await File.status()
-      console.log(JSON.stringify(status, null, 2))
+      process.stdout.write(JSON.stringify(status, null, 2) + EOL)
     })
   },
 })
@@ -57,7 +57,7 @@ const FileListCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       const files = await File.list(args.path)
-      console.log(JSON.stringify(files, null, 2))
+      process.stdout.write(JSON.stringify(files, null, 2) + EOL)
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/debug/lsp.ts
+++ b/packages/opencode/src/cli/cmd/debug/lsp.ts
@@ -2,6 +2,7 @@ import { LSP } from "../../../lsp"
 import { bootstrap } from "../../bootstrap"
 import { cmd } from "../cmd"
 import { Log } from "../../../util/log"
+import { EOL } from "os"
 
 export const LSPCommand = cmd({
   command: "lsp",
@@ -16,7 +17,7 @@ const DiagnosticsCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       await LSP.touchFile(args.file, true)
-      console.log(JSON.stringify(await LSP.diagnostics(), null, 2))
+      process.stdout.write(JSON.stringify(await LSP.diagnostics(), null, 2) + EOL)
     })
   },
 })
@@ -28,7 +29,7 @@ export const SymbolsCommand = cmd({
     await bootstrap(process.cwd(), async () => {
       using _ = Log.Default.time("symbols")
       const results = await LSP.workspaceSymbol(args.query)
-      console.log(JSON.stringify(results, null, 2))
+      process.stdout.write(JSON.stringify(results, null, 2) + EOL)
     })
   },
 })
@@ -40,7 +41,7 @@ export const DocumentSymbolsCommand = cmd({
     await bootstrap(process.cwd(), async () => {
       using _ = Log.Default.time("document-symbols")
       const results = await LSP.documentSymbol(args.uri)
-      console.log(JSON.stringify(results, null, 2))
+      process.stdout.write(JSON.stringify(results, null, 2) + EOL)
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/debug/ripgrep.ts
+++ b/packages/opencode/src/cli/cmd/debug/ripgrep.ts
@@ -18,7 +18,7 @@ const TreeCommand = cmd({
     }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
-      console.log(await Ripgrep.tree({ cwd: Instance.directory, limit: args.limit }))
+      process.stdout.write(await Ripgrep.tree({ cwd: Instance.directory, limit: args.limit }) + EOL)
     })
   },
 })
@@ -49,7 +49,7 @@ const FilesCommand = cmd({
         files.push(file)
         if (args.limit && files.length >= args.limit) break
       }
-      console.log(files.join(EOL))
+      process.stdout.write(files.join(EOL) + EOL)
     })
   },
 })
@@ -78,6 +78,6 @@ const SearchCommand = cmd({
       glob: args.glob as string[] | undefined,
       limit: args.limit,
     })
-    console.log(JSON.stringify(results, null, 2))
+    process.stdout.write(JSON.stringify(results, null, 2) + EOL)
   },
 })

--- a/packages/opencode/src/cli/cmd/debug/scrap.ts
+++ b/packages/opencode/src/cli/cmd/debug/scrap.ts
@@ -1,3 +1,4 @@
+import { EOL } from "os"
 import { Project } from "../../../project/project"
 import { Log } from "../../../util/log"
 import { cmd } from "../cmd"
@@ -8,7 +9,7 @@ export const ScrapCommand = cmd({
   async handler() {
     const timer = Log.Default.time("scrap")
     const list = await Project.list()
-    console.log(list)
+    process.stdout.write(JSON.stringify(list, null, 2) + EOL)
     timer.stop()
   },
 })


### PR DESCRIPTION
Found a few places in the CLI that would benefit from using process.stdout.write
instead of console.log, to prevent issues similar to #3049