### PR TITLE
add OpenAPI annotations to tui.ts control endpoints

### DIFF
--- a/packages/opencode/src/server/tui.ts
+++ b/packages/opencode/src/server/tui.ts
@@ -1,10 +1,14 @@
 import { Hono, type Context } from "hono"
+import { describeRoute, resolver, validator } from "hono-openapi"
+import { z } from "zod"
 import { AsyncQueue } from "../util/queue"
 
-interface Request {
-  path: string
-  body: any
-}
+const TuiRequest = z.object({
+  path: z.string(),
+  body: z.any(),
+})
+
+type Request = z.infer<typeof TuiRequest>
 
 const request = new AsyncQueue<Request>()
 const response = new AsyncQueue<any>()
@@ -19,12 +23,47 @@ export async function callTui(ctx: Context) {
 }
 
 export const TuiRoute = new Hono()
-  .get("/next", async (c) => {
-    const req = await request.next()
-    return c.json(req)
-  })
-  .post("/response", async (c) => {
-    const body = await c.req.json()
-    response.push(body)
-    return c.json(true)
-  })
+  .get(
+    "/next",
+    describeRoute({
+      description: "Get the next TUI request from the queue",
+      operationId: "tui.control.next",
+      responses: {
+        200: {
+          description: "Next TUI request",
+          content: {
+            "application/json": {
+              schema: resolver(TuiRequest),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const req = await request.next()
+      return c.json(req)
+    },
+  )
+  .post(
+    "/response",
+    describeRoute({
+      description: "Submit a response to the TUI request queue",
+      operationId: "tui.control.response",
+      responses: {
+        200: {
+          description: "Response submitted successfully",
+          content: {
+            "application/json": {
+              schema: resolver(z.boolean()),
+            },
+          },
+        },
+      },
+    }),
+    validator("json", z.any()),
+    async (c) => {
+      const body = c.req.valid("json")
+      response.push(body)
+      return c.json(true)
+    },
+  )


### PR DESCRIPTION
I found that the two endpoints defined in `tui.ts` were not included in the openapi spec.

This small change ensures `/tui/control/next` and `/tui/control/response` endpoints are included in the generated OpenAPI specification

## Details

The TUI control endpoints were missing from the OpenAPI specification because they lacked proper documentation annotations. This PR adds:

- Zod schema definition for the TUI request type
- OpenAPI `describeRoute` metadata for both endpoints
- Proper request validation using the `validator` middleware for the POST endpoint

## Testing

Verified that the endpoints now appear in the generated OpenAPI spec by running:

```bash
bun run src/index.ts generate
```

Both endpoints are now properly documented with operation IDs `tui.control.next` and `tui.control.response`.
