### PR TITLE
fix: grep failing when pattern started with a dash

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -367,6 +367,7 @@ export namespace Ripgrep {
       args.push(`--max-count=${input.limit}`)
     }
 
+    args.push("--")
     args.push(input.pattern)
 
     const command = args.join(" ")

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -20,7 +20,7 @@ export const GrepTool = Tool.define("grep", {
     const searchPath = params.path || Instance.directory
 
     const rgPath = await Ripgrep.filepath()
-    const args = ["-nH", "--field-match-separator=|", params.pattern]
+    const args = ["-nH", "--field-match-separator=|", "--regexp", params.pattern]
     if (params.include) {
       args.push("--glob", params.include)
     }


### PR DESCRIPTION
Reproduced and tested using:

In TUI: `search the codebase for --agent pattern`
Via REST API: `GET /find?pattern=--test`

Closes #3524.