### PR TITLE
Feat: --no-ignore-vcs option for ripgrep

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -435,6 +435,16 @@ export namespace Config {
           ignore: z.array(z.string()).optional(),
         })
         .optional(),
+      file: z
+        .object({
+          no_ignore_vcs: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe("Do not respect VCS ignore files like .gitignore when searching files"),
+        })
+        .optional()
+        .describe("File search configuration"),
       plugin: z.string().array().optional(),
       snapshot: z.boolean().optional(),
       share: z

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -10,6 +10,7 @@ import { Log } from "../util/log"
 import { Instance } from "../project/instance"
 import { Ripgrep } from "./ripgrep"
 import fuzzysort from "fuzzysort"
+import { Config } from "../config/config"
 
 export namespace File {
   const log = Log.create({ service: "file" })
@@ -126,7 +127,9 @@ export namespace File {
     const fn = async (result: Entry) => {
       fetching = true
       const set = new Set<string>()
-      for await (const file of Ripgrep.files({ cwd: Instance.directory })) {
+      const cfg = await Config.get()
+      const noIgnoreVcs = cfg.file?.no_ignore_vcs ?? false
+      for await (const file of Ripgrep.files({ cwd: Instance.directory, noIgnoreVcs })) {
         result.files.push(file)
         let current = file
         while (true) {

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -203,8 +203,13 @@ export namespace Ripgrep {
     return filepath
   }
 
-  export async function* files(input: { cwd: string; glob?: string[] }) {
+  export async function* files(input: { cwd: string; glob?: string[]; noIgnoreVcs?: boolean }) {
     const args = [await filepath(), "--files", "--follow", "--hidden", "--glob=!.git/*"]
+
+    if (input.noIgnoreVcs) {
+      args.push("--no-ignore-vcs")
+    }
+
     if (input.glob) {
       for (const g of input.glob) {
         args.push(`--glob=${g}`)

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -4,6 +4,7 @@ import { Tool } from "./tool"
 import DESCRIPTION from "./glob.txt"
 import { Ripgrep } from "../file/ripgrep"
 import { Instance } from "../project/instance"
+import { Config } from "../config/config"
 
 export const GlobTool = Tool.define("glob", {
   description: DESCRIPTION,
@@ -20,12 +21,16 @@ export const GlobTool = Tool.define("glob", {
     let search = params.path ?? Instance.directory
     search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
 
+    const cfg = await Config.get()
+    const noIgnoreVcs = cfg.file?.no_ignore_vcs ?? false
+
     const limit = 100
     const files = []
     let truncated = false
     for await (const file of Ripgrep.files({
       cwd: search,
       glob: [params.pattern],
+      noIgnoreVcs,
     })) {
       if (files.length >= limit) {
         truncated = true

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -337,6 +337,15 @@ export type Config = {
   watcher?: {
     ignore?: Array<string>
   }
+  /**
+   * File search configuration
+   */
+  file?: {
+    /**
+     * Do not respect VCS ignore files like .gitignore when searching files
+     */
+    no_ignore_vcs?: boolean
+  }
   plugin?: Array<string>
   snapshot?: boolean
   /**

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -120,6 +120,33 @@ You can manage the tools an LLM can use through the `tools` option.
 
 ---
 
+### File Search
+
+You can configure file search behavior through the `file` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "file": {
+    "no_ignore_vcs": true
+  }
+}
+```
+
+**Options:**
+
+- `no_ignore_vcs` - When set to `true`, OpenCode will not respect VCS ignore files like `.gitignore` when searching for files. This is useful when you want to include files that are normally ignored by version control (such as `node_modules`, build artifacts, etc.). Defaults to `false`.
+
+By default, OpenCode respects `.gitignore` rules when:
+
+- Searching files in the TUI with `@` file search
+- Using the Glob tool to match file patterns
+- Listing files for context
+
+When `no_ignore_vcs` is enabled, all files will be searchable except for the `.git` directory itself, which is always excluded.
+
+---
+
 ### Models
 
 You can configure the providers and models you want to use in your OpenCode config through the `provider`, `model` and `small_model` options.


### PR DESCRIPTION
- Find files in .gitignore if user set config explicitly like below
```json
{
  "$schema": "https://opencode.ai/config.json",
  "file": {
    "no_ignore_vcs": true
  }
}
```
- If you want to change field name or add other options like `--no-ignore`, `--no-ignore-dot`, `--no-ignore-exclude` and so on, please leave a comment.