### PR TITLE
add optional headers field to model config 

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -37,6 +37,7 @@ export namespace ModelsDev {
       experimental: z.boolean().optional(),
       status: z.enum(["alpha", "beta"]).optional(),
       options: z.record(z.string(), z.any()),
+      headers: z.record(z.string(), z.string()).optional(),
       provider: z.object({ npm: z.string() }).optional(),
     })
     .meta({

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -270,6 +270,10 @@ export namespace Provider {
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
         const existing = parsed.models[modelID]
+        const hdrs = [existing?.headers, model.headers].filter(
+          (item): item is Record<string, string> => Boolean(item),
+        )
+        const headers = hdrs.length ? Object.assign({}, ...hdrs) : undefined
         const parsedModel: ModelsDev.Model = {
           id: modelID,
           name: model.name ?? existing?.name ?? modelID,
@@ -306,6 +310,7 @@ export namespace Provider {
               input: ["text"],
               output: ["text"],
             },
+          headers,
           provider: model.provider ?? existing?.provider,
         }
         if (model.id && model.id !== modelID) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -270,10 +270,6 @@ export namespace Provider {
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
         const existing = parsed.models[modelID]
-        const hdrs = [existing?.headers, model.headers].filter(
-          (item): item is Record<string, string> => Boolean(item),
-        )
-        const headers = hdrs.length ? Object.assign({}, ...hdrs) : undefined
         const parsedModel: ModelsDev.Model = {
           id: modelID,
           name: model.name ?? existing?.name ?? modelID,
@@ -310,7 +306,7 @@ export namespace Provider {
               input: ["text"],
               output: ["text"],
             },
-          headers,
+          headers: model.headers,
           provider: model.provider ?? existing?.provider,
         }
         if (model.id && model.id !== modelID) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -131,6 +131,15 @@ export namespace ProviderTransform {
     }
   }
 
+  export function headers(
+    base?: Record<string, string>,
+    extra?: Record<string, string>,
+  ): Record<string, string> | undefined {
+    const items = [base, extra].filter((item): item is Record<string, string> => Boolean(item))
+    if (items.length === 0) return undefined
+    return Object.assign({}, ...items)
+  }
+
   export function maxOutputTokens(
     providerID: string,
     options: Record<string, any>,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -131,15 +131,6 @@ export namespace ProviderTransform {
     }
   }
 
-  export function headers(
-    base?: Record<string, string>,
-    extra?: Record<string, string>,
-  ): Record<string, string> | undefined {
-    const items = [base, extra].filter((item): item is Record<string, string> => Boolean(item))
-    if (items.length === 0) return undefined
-    return Object.assign({}, ...items)
-  }
-
   export function maxOutputTokens(
     providerID: string,
     options: Record<string, any>,

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -150,6 +150,7 @@ export namespace SessionCompaction {
         maxRetries: 0,
         model: model.language,
         providerOptions: ProviderTransform.providerOptions(model.npm, model.providerID, model.info.options),
+        headers: ProviderTransform.headers(undefined, model.info.headers),
         abortSignal: signal,
         onError(error) {
           log.error("stream error", {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -150,7 +150,7 @@ export namespace SessionCompaction {
         maxRetries: 0,
         model: model.language,
         providerOptions: ProviderTransform.providerOptions(model.npm, model.providerID, model.info.options),
-        headers: ProviderTransform.headers(undefined, model.info.headers),
+        headers: model.info.headers,
         abortSignal: signal,
         onError(error) {
           log.error("stream error", {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -241,6 +241,13 @@ export namespace SessionPrompt {
       await using _ = defer(async () => {
         await processor.end()
       })
+      const sessionHeaders =
+        model.providerID === "opencode"
+          ? {
+              "x-opencode-session": input.sessionID,
+              "x-opencode-request": userMsg.info.id,
+            }
+          : undefined
       const doStream = () =>
         streamText({
           onError(error) {
@@ -269,13 +276,7 @@ export namespace SessionPrompt {
               toolName: "invalid",
             }
           },
-          headers:
-            model.providerID === "opencode"
-              ? {
-                  "x-opencode-session": input.sessionID,
-                  "x-opencode-request": userMsg.info.id,
-                }
-              : undefined,
+          headers: ProviderTransform.headers(sessionHeaders, model.info.headers),
           // set to 0, we handle loop
           maxRetries: 0,
           activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
@@ -1769,6 +1770,7 @@ export namespace SessionPrompt {
           },
         ]),
       ],
+      headers: ProviderTransform.headers(undefined, small.info.headers),
       model: small.language,
     })
       .then((result) => {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -241,13 +241,6 @@ export namespace SessionPrompt {
       await using _ = defer(async () => {
         await processor.end()
       })
-      const sessionHeaders =
-        model.providerID === "opencode"
-          ? {
-              "x-opencode-session": input.sessionID,
-              "x-opencode-request": userMsg.info.id,
-            }
-          : undefined
       const doStream = () =>
         streamText({
           onError(error) {
@@ -277,8 +270,13 @@ export namespace SessionPrompt {
             }
           },
           headers: {
-            ...sessionHeaders,
-            ...model.info.headers
+            ...(model.providerID === "opencode"
+              ? {
+                  "x-opencode-session": input.sessionID,
+                  "x-opencode-request": userMsg.info.id,
+                }
+              : undefined),
+            ...model.info.headers,
           },
           // set to 0, we handle loop
           maxRetries: 0,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -276,7 +276,10 @@ export namespace SessionPrompt {
               toolName: "invalid",
             }
           },
-          headers: ProviderTransform.headers(sessionHeaders, model.info.headers),
+          headers: {
+            ...sessionHeaders,
+            ...model.info.headers
+          },
           // set to 0, we handle loop
           maxRetries: 0,
           activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
@@ -1770,7 +1773,7 @@ export namespace SessionPrompt {
           },
         ]),
       ],
-      headers: ProviderTransform.headers(undefined, small.info.headers),
+      headers: small.info.headers,
       model: small.language,
     })
       .then((result) => {

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -84,6 +84,7 @@ export namespace SessionSummary {
             content: textPart?.text ?? "",
           },
         ],
+        headers: ProviderTransform.headers(undefined, small.info.headers),
         model: small.language,
       })
       log.info("title", { title: result.text })
@@ -116,6 +117,7 @@ export namespace SessionSummary {
             `,
             },
           ],
+          headers: ProviderTransform.headers(undefined, small.info.headers),
         })
         summary = result.text
       }

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -84,7 +84,7 @@ export namespace SessionSummary {
             content: textPart?.text ?? "",
           },
         ],
-        headers: ProviderTransform.headers(undefined, small.info.headers),
+        headers:small.info.headers,
         model: small.language,
       })
       log.info("title", { title: result.text })
@@ -117,7 +117,7 @@ export namespace SessionSummary {
             `,
             },
           ],
-          headers: ProviderTransform.headers(undefined, small.info.headers),
+          headers: small.info.headers
         })
         summary = result.text
       }


### PR DESCRIPTION
closes #3499 

example on the config:

```
{
  "provider": {
    "anthropic": {
      "api": "https://api.anthropic.com",
      "models": {
        "claude-sonnet-4": {
          "id": "claude-sonnet-4",
          "headers": {
            "anthropic-beta": "my-experimental-feature",
            "x-trace-id": "session-42"
          }
        }
      }
    },
    "opencode": {
      "models": {
        "claude-sonnet-4": {
          "headers": {
            "x-custom-routing": "gold-tier"
          }
        }
      }
    }
  }
}
```