### PR TITLE
feat: add session id to task tool metadata

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -33,6 +33,14 @@ export const TaskTool = Tool.define("task", async () => {
       })
       const msg = await Session.getMessage({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
+
+      ctx.metadata({
+        title: params.description,
+        metadata: {
+          sessionId: session.id,
+        },
+      })
+
       const messageID = Identifier.ascending("message")
       const parts: Record<string, MessageV2.ToolPart> = {}
       const unsub = Bus.subscribe(MessageV2.Event.PartUpdated, async (evt) => {
@@ -44,6 +52,7 @@ export const TaskTool = Tool.define("task", async () => {
           title: params.description,
           metadata: {
             summary: Object.values(parts).sort((a, b) => a.id?.localeCompare(b.id)),
+            sessionId: session.id,
           },
         })
       })
@@ -87,6 +96,7 @@ export const TaskTool = Tool.define("task", async () => {
         title: params.description,
         metadata: {
           summary: all,
+          sessionId: session.id,
         },
         output: (result.parts.findLast((x: any) => x.type === "text") as any)?.text ?? "",
       }


### PR DESCRIPTION
When an agent invokes a Task/subagent, it has no good way of knowing the session that the subagent created (as far as I'm aware). While you are able to get it from the summary, this array is only populated when tools are called, so there could be a delay or not appear at all if the subagent does not invoke a tool.

This PR surfaces the subagent's session ID to the invoking agent right after the session is created. This allows the invoking agent to have a UI around the specific subagent's session in a more first class way.

Thank you! 