### PR TITLE
fix: preserve metadata from MCP tool results in `tool.execute.after` hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -618,7 +618,7 @@ export namespace SessionPrompt {
 
         return {
           title: "",
-          metadata: {},
+          metadata: result.metadata ?? {},
           output,
         }
       }


### PR DESCRIPTION
Currently updating metadata in `tool.execute.after` hook works for regular tools, but NOT for MCP tools.

This PR fixes it.

```typescript

export const MCPMetadataExamplePlugin = async ({}) => {
  return {
    'tool.execute.after': async (input, output) => {
      // CURRENTLY this works for regular tools, but not for MCP tools
      output.metadata = {
        custom: true,
      }
    },
  }
}

```

closes: #3574
