### PR TITLE
opentui: fix: Dialog command evt.preventDefault()

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -76,6 +76,7 @@ export function CommandProvider(props: ParentProps) {
 
   useKeyboard((evt) => {
     if (keybind.match("command_list", evt)) {
+      evt.preventDefault()
       dialog.replace(() => <DialogCommand options={value.options} />)
       return
     }


### PR DESCRIPTION
I bound `command_list` to `<leader>p`, and the dialog did show up, but the `p` was inserted into the search box. This PR fixes that.