### PR TITLE
opentui: fix: Dialog button clicks leak through

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -8,7 +8,6 @@ import {
   createEffect,
   untrack,
   ErrorBoundary,
-  createMemo,
   createSignal,
 } from "solid-js"
 import { Installation } from "@/installation"

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -33,7 +33,7 @@ export function DialogAlert(props: DialogAlertProps) {
           paddingLeft={3}
           paddingRight={3}
           backgroundColor={theme.primary}
-          onMouseDown={() => {
+          onMouseUp={() => {
             props.onConfirm?.()
             dialog.clear()
           }}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -47,7 +47,7 @@ export function DialogConfirm(props: DialogConfirmProps) {
               paddingLeft={1}
               paddingRight={1}
               backgroundColor={key === store.active ? theme.primary : undefined}
-              onMouseDown={() => {
+              onMouseUp={(evt) => {
                 if (key === "confirm") props.onConfirm?.()
                 if (key === "cancel") props.onCancel?.()
                 dialog.clear()


### PR DESCRIPTION
When clicking a user message, the "Confirm Redo" dialog shows up. When clicking any of the buttons, the action is applied on the `onMouseDown` event, the dialog closes, and the corresponding `onMouseUp` event then gets triggered on the message element, causing the same dialog to be redisplayed. This PR fixes it by using the `onMouseUp` event in the dialog instead. Made the same change in `DialogAlert` to prevent the same issue there.

https://github.com/user-attachments/assets/26c524bd-ac3a-40f1-859c-bcbc2c869d6a



