### PR TITLE
opentui: fix: Show toasts while in session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -56,6 +56,7 @@ import { DialogTimeline } from "./dialog-timeline"
 import { Sidebar } from "./sidebar"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
 import parsers from "../../../../../../parsers-config.json"
+import { Toast } from "../../ui/toast"
 
 addDefaultParsers(parsers.parsers)
 
@@ -528,6 +529,7 @@ export function Session() {
               />
             </box>
           </Show>
+          <Toast />
         </box>
         <Show when={sidebarVisible()}>
           <Sidebar sessionID={route.sessionID} />


### PR DESCRIPTION
Issue: Toasts would only be displayed in the home route, not while a session is active.