### PR TITLE
feat: add pattern-based external file access permission

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -20,6 +20,7 @@ export namespace Agent {
         edit: Config.Permission,
         bash: z.record(z.string(), Config.Permission),
         webfetch: Config.Permission.optional(),
+        external_files: z.record(z.string(), Config.Permission),
       }),
       model: z
         .object({
@@ -45,6 +46,9 @@ export namespace Agent {
         "*": "allow",
       },
       webfetch: "allow",
+      external_files: {
+        "*": "ask",
+      },
     }
     const agentPermission = mergeAgentPermissions(defaultPermission, cfg.permission ?? {})
 
@@ -90,6 +94,9 @@ export namespace Agent {
           "*": "ask",
         },
         webfetch: "allow",
+        external_files: {
+          "*": "ask",
+        },
       },
       cfg.permission ?? {},
     )
@@ -143,7 +150,18 @@ export namespace Agent {
           tools: {},
           builtIn: false,
         }
-      const { name, model, prompt, tools, description, temperature, top_p, mode, permission, ...extra } = value
+      const {
+        name,
+        model,
+        prompt,
+        tools,
+        description,
+        temperature,
+        top_p,
+        mode,
+        permission,
+        ...extra
+      } = value
       item.options = {
         ...item.options,
         ...extra,
@@ -212,7 +230,10 @@ export namespace Agent {
   }
 }
 
-function mergeAgentPermissions(basePermission: any, overridePermission: any): Agent.Info["permission"] {
+function mergeAgentPermissions(
+  basePermission: any,
+  overridePermission: any,
+): Agent.Info["permission"] {
   if (typeof basePermission.bash === "string") {
     basePermission.bash = {
       "*": basePermission.bash,
@@ -223,6 +244,18 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       "*": overridePermission.bash,
     }
   }
+
+  if (typeof basePermission.external_files === "string") {
+    basePermission.external_files = {
+      "*": basePermission.external_files,
+    }
+  }
+  if (typeof overridePermission.external_files === "string") {
+    overridePermission.external_files = {
+      "*": overridePermission.external_files,
+    }
+  }
+
   const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {}) as any
   let mergedBash
   if (merged.bash) {
@@ -240,10 +273,27 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
     }
   }
 
+  let mergedExternalFiles
+  if (merged.external_files) {
+    if (typeof merged.external_files === "string") {
+      mergedExternalFiles = {
+        "*": merged.external_files,
+      }
+    } else if (typeof merged.external_files === "object") {
+      mergedExternalFiles = mergeDeep(
+        {
+          "*": "ask",
+        },
+        merged.external_files,
+      )
+    }
+  }
+
   const result: Agent.Info["permission"] = {
     edit: merged.edit ?? "allow",
     webfetch: merged.webfetch ?? "allow",
     bash: mergedBash ?? { "*": "allow" },
+    external_files: mergedExternalFiles ?? { "*": "ask" },
   }
 
   return result

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -383,6 +383,7 @@ export namespace Config {
           edit: Permission.optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
+          external_files: z.union([Permission, z.record(z.string(), Permission)]).optional(),
         })
         .optional(),
     })
@@ -706,6 +707,7 @@ export namespace Config {
           edit: Permission.optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
+          external_files: z.union([Permission, z.record(z.string(), Permission)]).optional(),
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -17,14 +17,20 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 import { Snapshot } from "@/snapshot"
+import { Wildcard } from "../util/wildcard"
 
 export const EditTool = Tool.define("edit", {
   description: DESCRIPTION,
   parameters: z.object({
     filePath: z.string().describe("The absolute path to the file to modify"),
     oldString: z.string().describe("The text to replace"),
-    newString: z.string().describe("The text to replace it with (must be different from oldString)"),
-    replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
+    newString: z
+      .string()
+      .describe("The text to replace it with (must be different from oldString)"),
+    replaceAll: z
+      .boolean()
+      .optional()
+      .describe("Replace all occurrences of oldString (default false)"),
   }),
   async execute(params, ctx) {
     if (!params.filePath) {
@@ -35,9 +41,37 @@ export const EditTool = Tool.define("edit", {
       throw new Error("oldString and newString must be different")
     }
 
-    const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filePath = path.isAbsolute(params.filePath)
+      ? params.filePath
+      : path.join(Instance.directory, params.filePath)
+
     if (!Filesystem.contains(Instance.directory, filePath)) {
-      throw new Error(`File ${filePath} is not in the current working directory`)
+      const agent = await Agent.get(ctx.agent)
+      const permissions =
+        typeof agent.permission.external_files === "string"
+          ? { "*": agent.permission.external_files }
+          : agent.permission.external_files
+
+      const action = Wildcard.all(filePath, permissions)
+
+      if (action === "deny") {
+        throw new Error(`File ${filePath} is not in the current working directory`)
+      }
+
+      if (action === "ask") {
+        await Permission.ask({
+          type: "external_files",
+          pattern: filePath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: `Edit file outside working directory: ${path.relative(Instance.worktree, filePath)}`,
+          metadata: {
+            filepath: path.relative(Instance.worktree, filePath),
+            operation: "edit",
+          },
+        })
+      }
     }
 
     const agent = await Agent.get(ctx.agent)
@@ -160,7 +194,11 @@ function levenshtein(a: string, b: string): number {
   for (let i = 1; i <= a.length; i++) {
     for (let j = 1; j <= b.length; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1
-      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost,
+      )
     }
   }
   return matrix[a.length][b.length]
@@ -362,7 +400,9 @@ export const WhitespaceNormalizedReplacer: Replacer = function* (content, find) 
         // Find the actual substring in the original line that matches
         const words = find.trim().split(/\s+/)
         if (words.length > 0) {
-          const pattern = words.map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s+")
+          const pattern = words
+            .map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+            .join("\\s+")
           try {
             const regex = new RegExp(pattern)
             const match = line.match(regex)
@@ -600,7 +640,12 @@ export function trimDiff(diff: string): string {
   return trimmedLines.join("\n")
 }
 
-export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
+export function replace(
+  content: string,
+  oldString: string,
+  newString: string,
+  replaceAll = false,
+): string {
   if (oldString === newString) {
     throw new Error("oldString and newString must be different")
   }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -18,6 +18,7 @@ import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 import { Snapshot } from "@/snapshot"
 import { Wildcard } from "../util/wildcard"
+import { expandPermissionPatterns } from "../util/permission"
 
 export const EditTool = Tool.define("edit", {
   description: DESCRIPTION,
@@ -52,7 +53,8 @@ export const EditTool = Tool.define("edit", {
           ? { "*": agent.permission.external_files }
           : agent.permission.external_files
 
-      const action = Wildcard.all(filePath, permissions)
+      const expandedPermissions = expandPermissionPatterns(permissions)
+      const action = Wildcard.all(filePath, expandedPermissions)
 
       if (action === "deny") {
         throw new Error(`File ${filePath} is not in the current working directory`)

--- a/packages/opencode/src/tool/patch.ts
+++ b/packages/opencode/src/tool/patch.ts
@@ -12,6 +12,7 @@ import { Patch } from "../patch"
 import { Filesystem } from "../util/filesystem"
 import { createTwoFilesPatch } from "diff"
 import { Wildcard } from "../util/wildcard"
+import { expandPermissionPatterns } from "../util/permission"
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -60,7 +61,8 @@ export const PatchTool = Tool.define("patch", {
             ? { "*": agent.permission.external_files }
             : agent.permission.external_files
 
-        const action = Wildcard.all(filePath, permissions)
+        const expandedPermissions = expandPermissionPatterns(permissions)
+        const action = Wildcard.all(filePath, expandedPermissions)
 
         if (action === "deny") {
           throw new Error(`File ${filePath} is not in the current working directory`)

--- a/packages/opencode/src/tool/patch.ts
+++ b/packages/opencode/src/tool/patch.ts
@@ -11,6 +11,7 @@ import { Agent } from "../agent/agent"
 import { Patch } from "../patch"
 import { Filesystem } from "../util/filesystem"
 import { createTwoFilesPatch } from "diff"
+import { Wildcard } from "../util/wildcard"
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -54,7 +55,31 @@ export const PatchTool = Tool.define("patch", {
       const filePath = path.resolve(Instance.directory, hunk.path)
 
       if (!Filesystem.contains(Instance.directory, filePath)) {
-        throw new Error(`File ${filePath} is not in the current working directory`)
+        const permissions =
+          typeof agent.permission.external_files === "string"
+            ? { "*": agent.permission.external_files }
+            : agent.permission.external_files
+
+        const action = Wildcard.all(filePath, permissions)
+
+        if (action === "deny") {
+          throw new Error(`File ${filePath} is not in the current working directory`)
+        }
+
+        if (action === "ask") {
+          await Permission.ask({
+            type: "external_files",
+            pattern: filePath,
+            sessionID: ctx.sessionID,
+            messageID: ctx.messageID,
+            callID: ctx.callID,
+            title: `${hunk.type === "add" ? "Create" : hunk.type === "update" ? "Edit" : "Delete"} file outside working directory: ${path.relative(Instance.worktree, filePath)}`,
+            metadata: {
+              filepath: path.relative(Instance.worktree, filePath),
+              operation: hunk.type,
+            },
+          })
+        }
       }
 
       switch (hunk.type) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -9,6 +9,9 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Provider } from "../provider/provider"
 import { Identifier } from "../id/id"
+import { Agent } from "../agent/agent"
+import { Permission } from "../permission"
+import { Wildcard } from "../util/wildcard"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -17,7 +20,10 @@ export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
   parameters: z.object({
     filePath: z.string().describe("The path to the file to read"),
-    offset: z.coerce.number().describe("The line number to start reading from (0-based)").optional(),
+    offset: z.coerce
+      .number()
+      .describe("The line number to start reading from (0-based)")
+      .optional(),
     limit: z.coerce.number().describe("The number of lines to read (defaults to 2000)").optional(),
   }),
   async execute(params, ctx) {
@@ -28,7 +34,32 @@ export const ReadTool = Tool.define("read", {
     const title = path.relative(Instance.worktree, filepath)
 
     if (!ctx.extra?.["bypassCwdCheck"] && !Filesystem.contains(Instance.directory, filepath)) {
-      throw new Error(`File ${filepath} is not in the current working directory`)
+      const agent = await Agent.get(ctx.agent)
+      const permissions =
+        typeof agent.permission.external_files === "string"
+          ? { "*": agent.permission.external_files }
+          : agent.permission.external_files
+
+      const action = Wildcard.all(filepath, permissions)
+
+      if (action === "deny") {
+        throw new Error(`File ${filepath} is not in the current working directory`)
+      }
+
+      if (action === "ask") {
+        await Permission.ask({
+          type: "external_files",
+          pattern: filepath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: `Read file outside working directory: ${path.relative(Instance.worktree, filepath)}`,
+          metadata: {
+            filepath: path.relative(Instance.worktree, filepath),
+            operation: "read",
+          },
+        })
+      }
     }
 
     const file = Bun.file(filepath)
@@ -40,13 +71,16 @@ export const ReadTool = Tool.define("read", {
       const suggestions = dirEntries
         .filter(
           (entry) =>
-            entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
+            entry.toLowerCase().includes(base.toLowerCase()) ||
+            base.toLowerCase().includes(entry.toLowerCase()),
         )
         .map((entry) => path.join(dir, entry))
         .slice(0, 3)
 
       if (suggestions.length > 0) {
-        throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+        throw new Error(
+          `File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`,
+        )
       }
 
       throw new Error(`File not found: ${filepath}`)

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -12,6 +12,7 @@ import { Identifier } from "../id/id"
 import { Agent } from "../agent/agent"
 import { Permission } from "../permission"
 import { Wildcard } from "../util/wildcard"
+import { expandPermissionPatterns } from "../util/permission"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -40,7 +41,8 @@ export const ReadTool = Tool.define("read", {
           ? { "*": agent.permission.external_files }
           : agent.permission.external_files
 
-      const action = Wildcard.all(filepath, permissions)
+      const expandedPermissions = expandPermissionPatterns(permissions)
+      const action = Wildcard.all(filepath, expandedPermissions)
 
       if (action === "deny") {
         throw new Error(`File ${filepath} is not in the current working directory`)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -10,17 +10,50 @@ import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
+import { Wildcard } from "../util/wildcard"
 
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
-    filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
+    filePath: z
+      .string()
+      .describe("The absolute path to the file to write (must be absolute, not relative)"),
     content: z.string().describe("The content to write to the file"),
   }),
   async execute(params, ctx) {
-    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filepath = path.isAbsolute(params.filePath)
+      ? params.filePath
+      : path.join(Instance.directory, params.filePath)
+
     if (!Filesystem.contains(Instance.directory, filepath)) {
-      throw new Error(`File ${filepath} is not in the current working directory`)
+      const agent = await Agent.get(ctx.agent)
+      const permissions =
+        typeof agent.permission.external_files === "string"
+          ? { "*": agent.permission.external_files }
+          : agent.permission.external_files
+
+      const action = Wildcard.all(filepath, permissions)
+
+      if (action === "deny") {
+        throw new Error(`File ${filepath} is not in the current working directory`)
+      }
+
+      if (action === "ask") {
+        const file = Bun.file(filepath)
+        await Permission.ask({
+          type: "external_files",
+          pattern: filepath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: `Write file outside working directory: ${path.relative(Instance.worktree, filepath)}`,
+          metadata: {
+            filepath: path.relative(Instance.worktree, filepath),
+            operation: "write",
+            exists: await file.exists(),
+          },
+        })
+      }
     }
 
     const file = Bun.file(filepath)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -11,6 +11,7 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 import { Wildcard } from "../util/wildcard"
+import { expandPermissionPatterns } from "../util/permission"
 
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
@@ -32,7 +33,8 @@ export const WriteTool = Tool.define("write", {
           ? { "*": agent.permission.external_files }
           : agent.permission.external_files
 
-      const action = Wildcard.all(filepath, permissions)
+      const expandedPermissions = expandPermissionPatterns(permissions)
+      const action = Wildcard.all(filepath, expandedPermissions)
 
       if (action === "deny") {
         throw new Error(`File ${filepath} is not in the current working directory`)

--- a/packages/opencode/src/util/permission.ts
+++ b/packages/opencode/src/util/permission.ts
@@ -1,0 +1,60 @@
+import * as path from "path"
+import * as os from "os"
+import { Instance } from "../project/instance"
+
+/**
+ * Expands path patterns in permission configs to absolute paths.
+ * Supports:
+ * - Tilde expansion: ~/path -> /Users/username/path
+ * - Relative paths: ../path -> resolved from Instance.directory
+ * - Absolute paths: /path -> unchanged
+ * - Wildcard patterns: Preserves wildcards while expanding base path
+ */
+export function expandPermissionPatterns(
+  permissions: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(permissions).map(([pattern, value]) => {
+      // Handle tilde expansion first
+      let expandedPattern = pattern
+      if (pattern.startsWith("~/")) {
+        expandedPattern = path.join(os.homedir(), pattern.slice(2))
+      } else if (pattern.startsWith("~")) {
+        expandedPattern = path.join(os.homedir(), pattern.slice(1))
+      } else if (!path.isAbsolute(pattern)) {
+        // For relative paths, we need to preserve wildcards
+        // Find where wildcards start
+        const parts = pattern.split("/")
+        let wildcardIndex = -1
+
+        for (let i = 0; i < parts.length; i++) {
+          if (parts[i].includes("*")) {
+            wildcardIndex = i
+            break
+          }
+        }
+
+        if (wildcardIndex >= 0) {
+          // Split into base path (before wildcard) and wildcard pattern
+          const baseParts = parts.slice(0, wildcardIndex)
+          const wildcardParts = parts.slice(wildcardIndex)
+
+          // Resolve the base path
+          const basePath =
+            baseParts.length > 0
+              ? path.resolve(Instance.directory, baseParts.join("/"))
+              : Instance.directory
+
+          // Combine resolved base with wildcard parts
+          expandedPattern = `${basePath}/${wildcardParts.join("/")}`
+        } else {
+          // No wildcards - resolve the entire path
+          expandedPattern = path.resolve(Instance.directory, pattern)
+        }
+      }
+      // else: already absolute, leave as-is
+
+      return [expandedPattern, value]
+    }),
+  )
+}

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { EditTool } from "../../src/tool/edit"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+const editTool = await EditTool.init()
+
+describe("tool.edit external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await editTool.execute(
+            { filePath: externalFile, oldString: "line 2", newString: "modified" },
+            ctx,
+          )
+
+          expect(permissionSpy).toHaveBeenCalled()
+          const externalFilesCall = permissionSpy.mock.calls.find(
+            (call) => call[0].type === "external_files",
+          )
+          expect(externalFilesCall).toBeDefined()
+          expect(externalFilesCall[0].metadata.operation).toBe("edit")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await editTool.execute(
+            { filePath: externalFile, oldString: "line 2", newString: "modified" },
+            ctx,
+          )
+
+          const externalFilesCall = permissionSpy.mock.calls.find(
+            (call) => call[0].type === "external_files",
+          )
+          expect(externalFilesCall).toBeUndefined()
+
+          const file = Bun.file(externalFile)
+          const content = await file.text()
+          expect(content).toContain("modified")
+          expect(content).not.toContain("line 2")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "deny",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await expect(
+            editTool.execute(
+              { filePath: externalFile, oldString: "line 2", newString: "modified" },
+              ctx,
+            ),
+          ).rejects.toThrow("is not in the current working directory")
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+})

--- a/packages/opencode/test/tool/patch.test.ts
+++ b/packages/opencode/test/tool/patch.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, test, spyOn } from "bun:test"
 import path from "path"
 import { PatchTool } from "../../src/tool/patch"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import * as fs from "fs/promises"
+import { Permission } from "../../src/permission"
 
 const ctx = {
   sessionID: "test",
@@ -21,7 +22,9 @@ describe("tool.patch", () => {
     await Instance.provide({
       directory: "/tmp",
       fn: async () => {
-        await expect(patchTool.execute({ patchText: "" }, ctx)).rejects.toThrow("patchText is required")
+        await expect(patchTool.execute({ patchText: "" }, ctx)).rejects.toThrow(
+          "patchText is required",
+        )
       },
     })
   })
@@ -30,7 +33,9 @@ describe("tool.patch", () => {
     await Instance.provide({
       directory: "/tmp",
       fn: async () => {
-        await expect(patchTool.execute({ patchText: "invalid patch" }, ctx)).rejects.toThrow("Failed to parse patch")
+        await expect(patchTool.execute({ patchText: "invalid patch" }, ctx)).rejects.toThrow(
+          "Failed to parse patch",
+        )
       },
     })
   })
@@ -113,7 +118,9 @@ describe("tool.patch", () => {
         // Verify file was created with correct content
         const filePath = path.join(fixture.path, "config.js")
         const content = await fs.readFile(filePath, "utf-8")
-        expect(content).toBe('const API_KEY = "test-key"\nconst DEBUG = false\nconst VERSION = "1.0"')
+        expect(content).toBe(
+          'const API_KEY = "test-key"\nconst DEBUG = false\nconst VERSION = "1.0"',
+        )
       },
     })
   })
@@ -256,5 +263,131 @@ describe("tool.patch", () => {
         expect(configContent).toBe('{\n  "version": "1.0",\n  "debug": true\n}')
       },
     })
+  })
+
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Update File: ${externalFile}
+@@ -1,3 +1,3 @@
+ line 1
+-line 2
++modified
+ line 3
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalled()
+          const externalFilesCall = permissionSpy.mock.calls.find(
+            (call) => call[0].type === "external_files",
+          )
+          expect(externalFilesCall).toBeDefined()
+          expect(externalFilesCall[0].metadata.operation).toBe("update")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Update File: ${externalFile}
+@@ -1,3 +1,3 @@
+ line 1
+-line 2
++modified
+ line 3
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          const externalFilesCall = permissionSpy.mock.calls.find(
+            (call) => call[0].type === "external_files",
+          )
+          expect(externalFilesCall).toBeUndefined()
+
+          const content = await Bun.file(externalFile).text()
+          expect(content).toContain("modified")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "deny",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Update File: ${externalFile}
+@@ -1,3 +1,3 @@
+ line 1
+-line 2
++modified
+ line 3
+*** End Patch`
+
+          await expect(patchTool.execute({ patchText }, ctx)).rejects.toThrow(
+            "is not in the current working directory",
+          )
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
   })
 })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { ReadTool } from "../../src/tool/read"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+const readTool = await ReadTool.init()
+
+describe("tool.read external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await readTool.execute({ filePath: externalFile }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("external_files")
+          expect(permissionSpy.mock.calls[0][0].metadata.operation).toBe("read")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          const result = await readTool.execute({ filePath: externalFile }, ctx)
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+          expect(result.output).toContain("external content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "deny",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await expect(readTool.execute({ filePath: externalFile }, ctx)).rejects.toThrow(
+            "is not in the current working directory",
+          )
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should match patterns correctly", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: {
+                "*/docs/*": "allow",
+                "*": "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const docsDir = path.join(path.dirname(tmp.path), "docs")
+    await Bun.write(path.join(docsDir, ".keep"), "")
+    const docsFile = path.join(docsDir, "README.md")
+    await Bun.write(docsFile, "docs content")
+
+    const otherFile = path.join(path.dirname(tmp.path), "other.txt")
+    await Bun.write(otherFile, "other content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          const docsResult = await readTool.execute({ filePath: docsFile }, ctx)
+          expect(docsResult.output).toContain("docs content")
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          await expect(readTool.execute({ filePath: otherFile }, ctx)).rejects.toThrow(
+            "is not in the current working directory",
+          )
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should respect bypassCwdCheck", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+            extra: { bypassCwdCheck: true },
+          }
+
+          await readTool.execute({ filePath: externalFile }, ctx)
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+})

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { WriteTool } from "../../src/tool/write"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+const writeTool = await WriteTool.init()
+
+describe("tool.write external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: externalFile, content: "test content" }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalled()
+          const externalFilesCall = permissionSpy.mock.calls.find(
+            (call) => call[0].type === "external_files",
+          )
+          expect(externalFilesCall).toBeDefined()
+          expect(externalFilesCall[0].metadata.operation).toBe("write")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: externalFile, content: "test content" }, ctx)
+
+          const externalFilesCall = permissionSpy.mock.calls.find(
+            (call) => call[0].type === "external_files",
+          )
+          expect(externalFilesCall).toBeUndefined()
+
+          const file = Bun.file(externalFile)
+          expect(await file.exists()).toBe(true)
+          expect(await file.text()).toBe("test content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: "deny",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await expect(
+            writeTool.execute({ filePath: externalFile, content: "test content" }, ctx),
+          ).rejects.toThrow("is not in the current working directory")
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should match patterns correctly", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              external_files: {
+                "*/output/*": "allow",
+                "*": "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const outputDir = path.join(path.dirname(tmp.path), "output")
+    await Bun.write(path.join(outputDir, ".keep"), "")
+    const outputFile = path.join(outputDir, "result.txt")
+
+    const otherFile = path.join(path.dirname(tmp.path), "other.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: outputFile, content: "output content" }, ctx)
+          const file = Bun.file(outputFile)
+          expect(await file.exists()).toBe(true)
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          await expect(
+            writeTool.execute({ filePath: otherFile, content: "other content" }, ctx),
+          ).rejects.toThrow("is not in the current working directory")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+})

--- a/packages/opencode/test/util/permission.test.ts
+++ b/packages/opencode/test/util/permission.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test"
+import { expandPermissionPatterns } from "../../src/util/permission"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import * as path from "path"
+import * as os from "os"
+
+describe("util.permission.expandPermissionPatterns", () => {
+  test("should expand tilde to home directory", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "~/projects/*": "allow",
+          "~/documents/*/file.txt": "deny",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+        const homedir = os.homedir()
+
+        expect(expanded[`${homedir}/projects/*`]).toBe("allow")
+        expect(expanded[`${homedir}/documents/*/file.txt`]).toBe("deny")
+      },
+    })
+  })
+
+  test("should expand relative paths from Instance.directory", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "../sibling/*": "allow",
+          "./current/*": "deny",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+        const parent = path.dirname(tmp.path)
+
+        expect(expanded[`${parent}/sibling/*`]).toBe("allow")
+        expect(expanded[`${tmp.path}/current/*`]).toBe("deny")
+      },
+    })
+  })
+
+  test("should preserve absolute paths unchanged", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "/absolute/path/*": "allow",
+          "/another/absolute": "deny",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+
+        expect(expanded["/absolute/path/*"]).toBe("allow")
+        expect(expanded["/another/absolute"]).toBe("deny")
+      },
+    })
+  })
+
+  test("should preserve wildcards in patterns", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "~/projects/*/src/*": "allow",
+          "../*/test/*.ts": "deny",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+        const homedir = os.homedir()
+        const parent = path.dirname(tmp.path)
+
+        expect(expanded[`${homedir}/projects/*/src/*`]).toBe("allow")
+        expect(expanded[`${parent}/*/test/*.ts`]).toBe("deny")
+      },
+    })
+  })
+
+  test("should handle complex relative paths with ..", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "../../grandparent/*": "allow",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+        // ../../ resolves two levels up, then /grandparent is a literal directory name
+        const twoLevelsUp = path.dirname(path.dirname(tmp.path))
+        const expected = path.join(twoLevelsUp, "grandparent/*")
+
+        expect(expanded[expected]).toBe("allow")
+      },
+    })
+  })
+
+  test("should handle patterns without wildcards", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "~/specific/file.txt": "allow",
+          "../other.txt": "deny",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+        const homedir = os.homedir()
+        const parent = path.dirname(tmp.path)
+
+        expect(expanded[`${homedir}/specific/file.txt`]).toBe("allow")
+        expect(expanded[`${parent}/other.txt`]).toBe("deny")
+      },
+    })
+  })
+
+  test("should preserve wildcard-only patterns", async () => {
+    await using tmp = await tmpdir()
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const patterns = {
+          "*": "ask",
+        }
+
+        const expanded = expandPermissionPatterns(patterns)
+
+        // Wildcard-only should be treated as relative and resolved
+        expect(expanded[`${tmp.path}/*`]).toBe("ask")
+      },
+    })
+  })
+})

--- a/packages/tui/internal/components/chat/message.go
+++ b/packages/tui/internal/components/chat/message.go
@@ -506,6 +506,16 @@ func renderToolDetails(
 		muted := base.Foreground(t.TextMuted()).Render
 		if permission.Type == "doom-loop" {
 			permissionContent = permission.Title + "\n\n"
+		} else if permission.Type == "external_files" {
+			permissionContent = "Permission required to access file outside working directory:\n\n"
+			if permission.Metadata != nil {
+				if filepath, ok := permission.Metadata["filepath"].(string); ok {
+					permissionContent += fmt.Sprintf("Path: %s\n", filepath)
+				}
+				if operation, ok := permission.Metadata["operation"].(string); ok {
+					permissionContent += fmt.Sprintf("Operation: %s\n\n", operation)
+				}
+			}
 		} else {
 			permissionContent = "Permission required to run this tool:\n\n"
 		}


### PR DESCRIPTION


I've vibed a solution for my issue (#3218). I thought it might be cool to have a more granular control, so added bash-like complex permission for external files.

# Claude overview:

- Implements pattern-based external file access permission system (#3218)
- Adds `external_files` permission with support for `allow`, `ask`, and `deny` modes
- Supports pattern-based control similar to bash permissions (e.g., `*/docs/*: "allow"`)
- Defaults to `ask` for security while enabling flexible configuration for monorepo workflows

## Changes

### Tool Updates
- **Read Tool**: Added permission check for files outside working directory
- **Write Tool**: Added permission check before file creation/modification
- **Edit Tool**: Added permission check for external file edits
- **Patch Tool**: Added permission check for all file operations in patches

## Configuration Examples

### Simple Permission
```json
{
  "permission": {
    "external_files": "ask"
  }
}
```

### Pattern-Based (Monorepo)
```json
{
  "permission": {
    "external_files": {
      "*/docs/*": "allow",
      "*/packages/*/README.md": "allow",
      "*/node_modules/*": "deny",
      "*": "ask"
    }
  }
}
```

### Per-Agent Configuration
```json
{
  "agent": {
    "build": {
      "permission": {
        "external_files": "allow"
      }
    }
  }
}
```


Closes #3218