### PR TITLE
feat: allow ctrl+d to exit the app (v0)

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -402,7 +402,7 @@ export namespace Config {
         .default("ctrl+x")
         .describe("Leader key for keybind combinations"),
       app_help: z.string().optional().default("<leader>h").describe("Show help dialog"),
-      app_exit: z.string().optional().default("ctrl+c,<leader>q").describe("Exit the application"),
+      app_exit: z.string().optional().default("ctrl+d,ctrl+c,<leader>q").describe("Exit the application"),
       editor_open: z.string().optional().default("<leader>e").describe("Open external editor"),
       theme_list: z.string().optional().default("<leader>t").describe("List available themes"),
       project_init: z.string().optional().default("<leader>i").describe("Create/update AGENTS.md"),

--- a/packages/sdk/python/src/opencode_ai/models/keybinds_config.py
+++ b/packages/sdk/python/src/opencode_ai/models/keybinds_config.py
@@ -15,7 +15,7 @@ class KeybindsConfig:
     Attributes:
         leader (Union[Unset, str]): Leader key for keybind combinations Default: 'ctrl+x'.
         app_help (Union[Unset, str]): Show help dialog Default: '<leader>h'.
-        app_exit (Union[Unset, str]): Exit the application Default: 'ctrl+c,<leader>q'.
+        app_exit (Union[Unset, str]): Exit the application Default: 'ctrl+d,ctrl+c,<leader>q'.
         editor_open (Union[Unset, str]): Open external editor Default: '<leader>e'.
         theme_list (Union[Unset, str]): List available themes Default: '<leader>t'.
         project_init (Union[Unset, str]): Create/update AGENTS.md Default: '<leader>i'.
@@ -67,7 +67,7 @@ class KeybindsConfig:
 
     leader: Union[Unset, str] = "ctrl+x"
     app_help: Union[Unset, str] = "<leader>h"
-    app_exit: Union[Unset, str] = "ctrl+c,<leader>q"
+    app_exit: Union[Unset, str] = "ctrl+d,ctrl+c,<leader>q"
     editor_open: Union[Unset, str] = "<leader>e"
     theme_list: Union[Unset, str] = "<leader>t"
     project_init: Union[Unset, str] = "<leader>i"

--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -367,7 +367,6 @@ func LoadFromConfig(config *opencode.Config, customCommands []opencode.Command) 
 			Description: "last message",
 			Keybindings: parseBindings("ctrl+alt+g"),
 		},
-
 		{
 			Name:        MessagesCopyCommand,
 			Description: "copy message",
@@ -388,7 +387,8 @@ func LoadFromConfig(config *opencode.Config, customCommands []opencode.Command) 
 		{
 			Name:        AppExitCommand,
 			Description: "exit the app",
-			Keybindings: parseBindings("ctrl+c", "<leader>q"),
+			// NOTE: ctrl+c requires a double press to exit while ctrl+d requires a single press
+			Keybindings: parseBindings("ctrl+c", "ctrl+d", "<leader>q"),
 			Trigger:     []string{"exit", "quit", "q"},
 		},
 	}

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -305,9 +305,14 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// 8. Handle exit key debounce for app exit when using non-leader command
+		// 8. Handle immediate exit command both for empty and non-empty editor
 		exitCommand := a.app.Commands[commands.AppExitCommand]
-		if exitCommand.Matches(msg, a.app.IsLeaderSequence) {
+		if exitCommand.Matches(msg, a.app.IsLeaderSequence) && keyString == "ctrl+d" && a.editor.Length() == 0 {
+			return a, util.CmdHandler(commands.ExecuteCommandMsg(exitCommand))
+		}
+
+		// 9. Handle exit key debounce for app exit when using non-leader command
+		if exitCommand.Matches(msg, a.app.IsLeaderSequence) && keyString != "ctrl+d" {
 			switch a.exitKeyState {
 			case ExitKeyIdle:
 				// First exit key press - start debounce timer
@@ -324,22 +329,26 @@ func (a Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		// 9. Check again for commands that don't require leader (excluding interrupt when busy and exit when in debounce)
+		// 10. Check again for commands that don't require leader (excluding interrupt when busy and exit when in debounce)
 		matches := a.app.Commands.Matches(msg, a.app.IsLeaderSequence)
-		if len(matches) > 0 {
+		if len(matches) > 0 && keyString != "ctrl+d" {
 			// Skip interrupt key if we're in debounce mode and app is busy
 			if interruptCommand.Matches(msg, a.app.IsLeaderSequence) && a.app.IsBusy() && a.interruptKeyState != InterruptKeyIdle {
+				return a, nil
+			}
+			// Skip ctrl+d immediate exit key if the editor has content. Allow editor update commands to handle it as forward delete.
+			if exitCommand.Matches(msg, a.app.IsLeaderSequence) && keyString == "ctrl+d" && a.editor.Length() > 0 {
 				return a, nil
 			}
 			return a, util.CmdHandler(commands.ExecuteCommandsMsg(matches))
 		}
 
-		// Fallback: suspend if ctrl+z is pressed and no user keybind matched
+		// 11. Fallback: suspend if ctrl+z is pressed and no user keybind matched
 		if keyString == "ctrl+z" {
 			return a, tea.Suspend
 		}
 
-		// 10. Fallback to editor. This is for other characters like backspace, tab, etc.
+		// 12. Fallback to editor. This is for other characters like backspace, tab, etc.
 		updatedEditor, cmd := a.editor.Update(msg)
 		a.editor = updatedEditor.(chat.EditorComponent)
 		return a, cmd


### PR DESCRIPTION
> I have another PR for OpenTUI changes pointed at branch `dev`: https://github.com/sst/opencode/pull/3636

## Problem

Pressing `ctrl+d` should terminate OpenCode. Claude Code and Codex support similar behavior (Claude Code with two presses, Codex with one), and Unix tools typically require one press to exit programs as well.

See https://github.com/sst/opencode/issues/3025 for more details of the problem statement.

## Solution

I opted to roll this new functionality into the existing `AppExitCommand` code. I added a separate block to control the new `ctrl+d` app exit (on single press) but also preserved the existing forward delete functionality when the text editor has content in it.

I also updated all locations I could find with the new keybinding information, including where it's displayed for `/help`.

## Testing

Below is videos showing testing on all major platforms.

<table>
  <tr>
    <th>MacOS 15.7.1</th>
    <th>Windows 11 (26120.6982)</th>
    <th>Linux (Ubuntu 24.04)</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/09a31db8-2ba1-44aa-94b1-ad8ff8eea5b2"></td>
    <td><video src="https://github.com/user-attachments/assets/c47654ae-2954-40c6-a9f8-d6468086a53b"></td>
    <td><video src="https://github.com/user-attachments/assets/4fb7c7da-bfea-4807-8918-57e87aa29e7d"></td>
  </tr>
</table>