### PR TITLE
opentui: fix: Make worker.ts path independent from cwd

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -6,6 +6,7 @@ import { upgrade } from "@/cli/upgrade"
 import { Session } from "@/session"
 import { bootstrap } from "@/cli/bootstrap"
 import path from "path"
+import { fileURLToPath } from "url"
 import { UI } from "@/cli/ui"
 
 export const TuiThreadCommand = cmd({
@@ -78,7 +79,9 @@ export const TuiThreadCommand = cmd({
         return undefined
       })()
 
-      const worker = new Worker("./src/cli/cmd/tui/worker.ts")
+      const worker = new Worker(
+        path.join(path.dirname(fileURLToPath(import.meta.url)), "worker.ts"),
+      )
       worker.onerror = console.error
       const client = Rpc.client<typeof rpc>(worker)
       process.on("uncaughtException", (e) => {


### PR DESCRIPTION
This change makes development easier by allowing us to run `bun dev /path/to/project` by uncoupling the path of `worker.ts` from the CWD