### PR TITLE
opentui: fix: Implement session delete endpoint

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -447,6 +447,8 @@ export namespace Server {
           }),
         ),
         async (c) => {
+          const sessionID = c.req.valid("param").id
+          await Session.remove(sessionID)
           await Bus.publish(TuiEvent.CommandExecute, {
             command: "session.list",
           })


### PR DESCRIPTION
Fixes a regression introduced in the opentui branch. Now the session.delete endpoint works again, and sessions in the session list dialog can be deleted by pressing `delete` twice.