### PR TITLE
opentui: feat: Implement POST /tui/toast-show

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -25,6 +25,7 @@ import { DialogAlert } from "./ui/dialog-alert"
 import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider } from "./context/exit"
 import type { SessionRoute } from "./context/route"
+import { TuiEvent } from "./event"
 
 export function tui(input: {
   url: string
@@ -231,7 +232,7 @@ function App() {
     }
   })
 
-  event.on("tui.command.execute", (evt) => {
+  event.on(TuiEvent.CommandExecute.type, (evt) => {
     command.trigger(evt.properties.command)
   })
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -241,6 +241,7 @@ function App() {
       title: evt.properties.title,
       message: evt.properties.message,
       variant: evt.properties.variant,
+      duration: evt.properties.duration,
     })
   })
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -120,7 +120,7 @@ function App() {
       await sync.session.sync(data.sessionID).catch(() => {
         toast.show({
           message: `Session not found: ${data.sessionID}`,
-          type: "error",
+          variant: "error",
         })
         return route.navigate({ type: "home" })
       })
@@ -234,6 +234,14 @@ function App() {
 
   event.on(TuiEvent.CommandExecute.type, (evt) => {
     command.trigger(evt.properties.command)
+  })
+
+  event.on(TuiEvent.ToastShow.type, (evt) => {
+    toast.show({
+      title: evt.properties.title,
+      message: evt.properties.message,
+      variant: evt.properties.variant,
+    })
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -27,6 +27,7 @@ import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
 import type { FilePart } from "@opencode-ai/sdk"
+import { TuiEvent } from "../../event"
 
 export type PromptProps = {
   sessionID?: string
@@ -162,7 +163,7 @@ export function Prompt(props: PromptProps) {
     ]
   })
 
-  sdk.event.on("tui.prompt.append", (evt) => {
+  sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     setStore(
       "prompt",
       produce((draft) => {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -8,7 +8,6 @@ import { Global } from "@/global"
 import { iife } from "@/util/iife"
 import { createSimpleContext } from "./helper"
 import { useToast } from "../ui/toast"
-import type { Provider } from "@opencode-ai/sdk"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -40,7 +39,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const [providerID, modelID] = props.initialModel.split("/")
           if (!providerID || !modelID)
             return toast.show({
-              type: "warning",
+              variant: "warning",
               message: `Invalid model format: ${props.initialModel}`,
               duration: 3000,
             })
@@ -60,7 +59,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           })
         else
           toast.show({
-            type: "warning",
+            variant: "warning",
             message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
             duration: 3000,
           })
@@ -93,7 +92,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         set(name: string) {
           if (!agents().some((x) => x.name === name))
             return toast.show({
-              type: "warning",
+              variant: "warning",
               message: `Agent not found: ${name}`,
               duration: 3000,
             })
@@ -211,7 +210,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (!isModelValid(model)) {
               toast.show({
                 message: `Model ${model.providerID}/${model.modelID} is not valid`,
-                type: "warning",
+                variant: "warning",
                 duration: 3000,
               })
               return

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -1,5 +1,6 @@
 import { Bus } from "@/bus"
 import z from "zod"
+import { Schema as ToastSchema } from "./ui/toast"
 
 export const TuiEvent = {
   PromptAppend: Bus.event("tui.prompt.append", z.object({ text: z.string() })),
@@ -29,10 +30,6 @@ export const TuiEvent = {
   ),
   ToastShow: Bus.event(
     "tui.toast.show",
-    z.object({
-      title: z.string().optional(),
-      message: z.string(),
-      variant: z.enum(["info", "success", "warning", "error"]),
-    }),
+    ToastSchema,
   ),
 }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1157,6 +1157,7 @@ export type EventTuiToastShow = {
     title?: string
     message: string
     variant: "info" | "success" | "warning" | "error"
+    duration?: number
   }
 }
 
@@ -2728,6 +2729,7 @@ export type TuiShowToastData = {
     title?: string
     message: string
     variant: "info" | "success" | "warning" | "error"
+    duration?: number
   }
   path?: never
   query?: {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -19,10 +19,6 @@ export type KeybindsConfig = {
    */
   leader?: string
   /**
-   * Show help dialog
-   */
-  app_help?: string
-  /**
    * Exit the application
    */
   app_exit?: string
@@ -34,18 +30,6 @@ export type KeybindsConfig = {
    * List available themes
    */
   theme_list?: string
-  /**
-   * Create/update AGENTS.md
-   */
-  project_init?: string
-  /**
-   * Toggle tool details
-   */
-  tool_details?: string
-  /**
-   * Toggle thinking blocks
-   */
-  thinking_blocks?: string
   /**
    * Toggle sidebar
    */
@@ -86,14 +70,6 @@ export type KeybindsConfig = {
    * Compact the session
    */
   session_compact?: string
-  /**
-   * Cycle to next child session
-   */
-  session_child_cycle?: string
-  /**
-   * Cycle to previous child session
-   */
-  session_child_cycle_reverse?: string
   /**
    * Scroll messages up by one page
    */
@@ -139,14 +115,6 @@ export type KeybindsConfig = {
    */
   command_list?: string
   /**
-   * Next recent model
-   */
-  model_cycle_recent?: string
-  /**
-   * Previous recent model
-   */
-  model_cycle_recent_reverse?: string
-  /**
    * List agents
    */
   agent_list?: string
@@ -174,54 +142,6 @@ export type KeybindsConfig = {
    * Insert newline in input
    */
   input_newline?: string
-  /**
-   * @deprecated use agent_cycle. Next mode
-   */
-  switch_mode?: string
-  /**
-   * @deprecated use agent_cycle_reverse. Previous mode
-   */
-  switch_mode_reverse?: string
-  /**
-   * @deprecated use agent_cycle. Next agent
-   */
-  switch_agent?: string
-  /**
-   * @deprecated use agent_cycle_reverse. Previous agent
-   */
-  switch_agent_reverse?: string
-  /**
-   * @deprecated Currently not available. List files
-   */
-  file_list?: string
-  /**
-   * @deprecated Close file
-   */
-  file_close?: string
-  /**
-   * @deprecated Search file
-   */
-  file_search?: string
-  /**
-   * @deprecated Split/unified diff
-   */
-  file_diff_toggle?: string
-  /**
-   * @deprecated Navigate to previous message
-   */
-  messages_previous?: string
-  /**
-   * @deprecated Navigate to next message
-   */
-  messages_next?: string
-  /**
-   * @deprecated Toggle layout
-   */
-  messages_layout_toggle?: string
-  /**
-   * @deprecated use messages_undo. Revert message
-   */
-  messages_revert?: string
 }
 
 export type AgentConfig = {
@@ -441,6 +361,9 @@ export type Config = {
           status?: "alpha" | "beta"
           options?: {
             [key: string]: unknown
+          }
+          headers?: {
+            [key: string]: string
           }
           provider?: {
             npm: string
@@ -1009,6 +932,9 @@ export type Model = {
   options: {
     [key: string]: unknown
   }
+  headers?: {
+    [key: string]: string
+  }
   provider?: {
     npm: string
   }
@@ -1157,6 +1083,9 @@ export type EventTuiToastShow = {
     title?: string
     message: string
     variant: "info" | "success" | "warning" | "error"
+    /**
+     * Duration in milliseconds
+     */
     duration?: number
   }
 }
@@ -2729,6 +2658,9 @@ export type TuiShowToastData = {
     title?: string
     message: string
     variant: "info" | "success" | "warning" | "error"
+    /**
+     * Duration in milliseconds
+     */
     duration?: number
   }
   path?: never


### PR DESCRIPTION
Bonus: refactor: Instead of using `sdk.event.on("string")`, use `sdk.event.on(TuiEvent.<EventName>.type)` for better type safety and discoverability.

@rekram1-node I manually updated the types in `types.gen.ts` to include `duration`. I think I was exhaustive (I grepped codebase for `variant:`), so I don't think a regen is needed.

## Example:

```
bun dev spawn --port 9090
```

```
curl -X 'POST' \
  'http://localhost:9090/tui/show-toast' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "title": "Test Toast",
  "message": "This is a test toast of type error",
  "variant": "error",
  "duration": 3000
}'
```
**title is optional**
**duration is optional, defaults to 5000, as before**

<img width="968" height="318" alt="image" src="https://github.com/user-attachments/assets/2962f513-3fe0-4d6b-bed1-3ae6ba44626f" />


### Appearance of toast without title is unchanged
<img width="814" height="182" alt="image" src="https://github.com/user-attachments/assets/6866c768-831a-490f-b621-f74a33b7c52e" />
