### PR TITLE
fix: TUI spawn: reset BUN_OPTIONS

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/spawn.ts
+++ b/packages/opencode/src/cli/cmd/tui/spawn.ts
@@ -48,6 +48,10 @@ export const TuiSpawnCommand = cmd({
       stdout: "inherit",
       stderr: "inherit",
       stdin: "inherit",
+      env: {
+        ...process.env,
+        BUN_OPTIONS: "",
+      }
     })
     await proc.exited
     await Instance.disposeAll()


### PR DESCRIPTION
I often do something like `export BUN_OPTIONS='--inspect-wait=localhost:6499/'` before running `bun dev`.
In the opentui branch, I usually use `bun dev spawn` so I can get working debugger endpoints in `server.ts`. Before this fix, the `attach` subprocess spawned by `bun dev spawn` would inherit `BUN_OPTIONS`, causing a port conflict.

Even as a more general principle, I think we shouldn't blindly pass `BUN_OPTIONS` to subprocesses.