### PR TITLE
opentui: fix: Deleting current session from TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -25,6 +25,7 @@ import { DialogAlert } from "./ui/dialog-alert"
 import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider } from "./context/exit"
 import type { SessionRoute } from "./context/route"
+import { Session as SessionApi } from "@/session"
 import { TuiEvent } from "./event"
 
 export function tui(input: {
@@ -243,6 +244,16 @@ function App() {
       variant: evt.properties.variant,
       duration: evt.properties.duration,
     })
+  })
+
+  event.on(SessionApi.Event.Deleted.type, (evt) => {
+    if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
+      route.navigate({ type: "home" })
+      toast.show({
+        variant: "info",
+        message: "The current session was deleted",
+      })
+    }
   })
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -19,7 +19,7 @@ export function Home() {
   let promptRef: PromptRef | undefined = undefined
 
   createEffect(() => {
-    dialog.closeEvent.listen(() => {
+    dialog.allClosedEvent.listen(() => {
       promptRef?.focus()
     })
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,5 +1,5 @@
-import { Prompt } from "@tui/component/prompt"
-import { createMemo, Match, Show, Switch, type ParentProps } from "solid-js"
+import { Prompt, type PromptRef } from "@tui/component/prompt"
+import { createEffect, createMemo, Match, Show, Switch, type ParentProps } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { useKeybind } from "../context/keybind"
 import type { KeybindsConfig } from "@opencode-ai/sdk"
@@ -7,12 +7,21 @@ import { Logo } from "../component/logo"
 import { Locale } from "@/util/locale"
 import { useSync } from "../context/sync"
 import { Toast } from "../ui/toast"
+import { useDialog } from "../ui/dialog"
 
 export function Home() {
   const sync = useSync()
   const { theme } = useTheme()
+  const dialog = useDialog()
   const mcpError = createMemo(() => {
     return Object.values(sync.data.mcp).some((x) => x.status === "failed")
+  })
+  let promptRef: PromptRef | undefined = undefined
+
+  createEffect(() => {
+    dialog.closeEvent.listen(() => {
+      promptRef?.focus()
+    })
   })
 
   const Hint = (
@@ -55,7 +64,7 @@ export function Home() {
         <HelpRow keybind="agent_cycle">Switch agent</HelpRow>
       </box>
       <box width="100%" maxWidth={75} zIndex={1000} paddingTop={1}>
-        <Prompt hint={Hint} />
+        <Prompt hint={Hint} ref={(r) => (promptRef = r)} />
       </box>
       <Toast />
     </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -100,7 +100,7 @@ export function Session() {
   const keybind = useKeybind()
 
   createEffect(() => {
-    dialog.closeEvent.listen(() => {
+    dialog.allClosedEvent.listen(() => {
       prompt.focus()
     })
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -99,6 +99,12 @@ export function Session() {
   let prompt: PromptRef
   const keybind = useKeybind()
 
+  createEffect(() => {
+    dialog.closeEvent.listen(() => {
+      prompt.focus()
+    })
+  })
+
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
 

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -3,6 +3,7 @@ import { batch, createContext, Show, useContext, type JSX, type ParentProps } fr
 import { useTheme } from "@tui/context/theme"
 import { Renderable, RGBA } from "@opentui/core"
 import { createStore } from "solid-js/store"
+import { createEventBus } from "@solid-primitives/event-bus"
 
 const Border = {
   topLeft: "┃",
@@ -65,6 +66,7 @@ function init() {
     }[],
     size: "medium" as "medium" | "large",
   })
+  const closeEvent = createEventBus<void>()
 
   useKeyboard((evt) => {
     if (evt.name === "escape" && store.stack.length > 0) {
@@ -73,6 +75,7 @@ function init() {
       setStore("stack", store.stack.slice(0, -1))
       evt.preventDefault()
       refocus()
+      closeEvent.emit()
     }
   })
 
@@ -105,6 +108,7 @@ function init() {
         setStore("stack", [])
       })
       refocus()
+      closeEvent.emit()
     },
     replace(input: any, onClose?: () => void) {
       if (store.stack.length === 0) focus = renderer.currentFocusedRenderable
@@ -128,6 +132,9 @@ function init() {
     setSize(size: "medium" | "large") {
       setStore("size", size)
     },
+    get closeEvent() {
+      return closeEvent
+    }
   }
 }
 

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -1,5 +1,5 @@
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
-import { batch, createContext, Show, useContext, type JSX, type ParentProps } from "solid-js"
+import { batch, createContext, createEffect, Show, useContext, type JSX, type ParentProps } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { Renderable, RGBA } from "@opentui/core"
 import { createStore } from "solid-js/store"
@@ -66,7 +66,7 @@ function init() {
     }[],
     size: "medium" as "medium" | "large",
   })
-  const closeEvent = createEventBus<void>()
+  const allClosedEvent = createEventBus<void>()
 
   useKeyboard((evt) => {
     if (evt.name === "escape" && store.stack.length > 0) {
@@ -75,7 +75,6 @@ function init() {
       setStore("stack", store.stack.slice(0, -1))
       evt.preventDefault()
       refocus()
-      closeEvent.emit()
     }
   })
 
@@ -98,6 +97,12 @@ function init() {
     }, 1)
   }
 
+  createEffect(() => {
+    if (store.stack.length === 0) {
+      allClosedEvent.emit()
+    }
+  })
+
   return {
     clear() {
       for (const item of store.stack) {
@@ -108,7 +113,6 @@ function init() {
         setStore("stack", [])
       })
       refocus()
-      closeEvent.emit()
     },
     replace(input: any, onClose?: () => void) {
       if (store.stack.length === 0) focus = renderer.currentFocusedRenderable
@@ -132,8 +136,8 @@ function init() {
     setSize(size: "medium" | "large") {
       setStore("size", size)
     },
-    get closeEvent() {
-      return closeEvent
+    get allClosedEvent() {
+      return allClosedEvent
     }
   }
 }


### PR DESCRIPTION
Deleting current session from the TUI would show an empty non-interactive screen.

This PR:
- Navigates to home screen when current session is deleted
- Shows an info toast when the current session is deleted (from any source)
- Properly refocuses the prompt area when the dialog is closed
- Adds utility useful for the future: `useDialog().allClosedEvent`, firing when all dialogs are closed - currently used to refocus prompts in home and session routes (the usual refocus() call doesn't work if routes change while the dialog is open)