### PR TITLE
feat: allow ctrl+d to exit the app

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -530,6 +530,17 @@ export function Prompt(props: PromptProps) {
                   setStore("extmarkToPartIndex", new Map())
                   return
                 }
+                if (keybind.match("input_forward_delete", e) && store.prompt.input !== "") {
+                  const cursorOffset = input.cursorOffset
+                  if (cursorOffset < input.plainText.length) {
+                    const text = input.plainText
+                    const newText = text.slice(0, cursorOffset) + text.slice(cursorOffset + 1)
+                    input.setText(newText)
+                    input.cursorOffset = cursorOffset
+                  }
+                  e.preventDefault()
+                  return
+                }
                 if (keybind.match("app_exit", e)) {
                   await exit()
                   return

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -385,7 +385,7 @@ export namespace Config {
         .optional()
         .default("ctrl+x")
         .describe("Leader key for keybind combinations"),
-      app_exit: z.string().optional().default("ctrl+c,<leader>q").describe("Exit the application"),
+      app_exit: z.string().optional().default("ctrl+c,ctrl+d,<leader>q").describe("Exit the application"),
       editor_open: z.string().optional().default("<leader>e").describe("Open external editor"),
       theme_list: z.string().optional().default("<leader>t").describe("List available themes"),
       sidebar_toggle: z.string().optional().default("<leader>b").describe("Toggle sidebar"),
@@ -454,6 +454,7 @@ export namespace Config {
       agent_cycle: z.string().optional().default("tab").describe("Next agent"),
       agent_cycle_reverse: z.string().optional().default("shift+tab").describe("Previous agent"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
+      input_forward_delete: z.string().optional().default("ctrl+d").describe("Forward delete"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("enter").describe("Submit input"),
       input_newline: z

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -135,6 +135,10 @@ export type KeybindsConfig = {
    */
   input_clear?: string
   /**
+   * Forward delete characters in input field
+   */
+  input_forward_delete?: string
+  /**
    * Paste from clipboard
    */
   input_paste?: string

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -11,7 +11,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
   "keybinds": {
     "leader": "ctrl+x",
     "app_help": "<leader>h",
-    "app_exit": "ctrl+c,<leader>q",
+    "app_exit": "ctrl+c,ctrl+d,<leader>q",
     "editor_open": "<leader>e",
     "theme_list": "<leader>t",
     "project_init": "<leader>i",
@@ -42,6 +42,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "agent_cycle": "tab",
     "agent_cycle_reverse": "shift+tab",
     "input_clear": "ctrl+c",
+    "input_forward_delete": "ctrl+d",
     "input_paste": "ctrl+v",
     "input_submit": "enter",
     "input_newline": "shift+enter,ctrl+j"


### PR DESCRIPTION
> I have another PR for v0 changes pointed at branch `v0`: https://github.com/sst/opencode/pull/3594

## Problem

Pressing `ctrl+d` should terminate OpenCode. Claude Code and Codex support similar behavior (Claude Code with two presses, Codex with one), and Unix tools typically require one press to exit programs as well.

See https://github.com/sst/opencode/issues/3025 for more details of the problem statement.

## Solution

I've leveraged existing new OpenTUI keybindings to implementing both `input_forward_delete` (new functionality) and add `ctrl+d` to the existing `app_exit` event.

## Testing

Below is videos showing testing on all major platforms.

<table>
  <tr>
    <th>MacOS 15.7.1</th>
    <th>Windows 11 (26120.6982)</th>
    <th>Linux (Ubuntu 24.04)</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/b3eccdbd-356f-4820-8dc7-978c1ee59df2"></td>
    <td><video src="https://github.com/user-attachments/assets/359e518c-9f68-43f2-a1a4-d2067ac95d2a"></td>
    <td><video src="https://github.com/user-attachments/assets/9ea02f6c-4158-4940-9d21-c1d6ae1ec423"></td>
  </tr>
</table>