### PR TITLE
fix: Remove conflicting "-h" aliases in TUI spawn and thread commands

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -12,7 +12,6 @@ export const ServeCommand = cmd({
         default: 0,
       })
       .option("hostname", {
-        alias: ["h"],
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -65,7 +65,6 @@ export const TuiCommand = cmd({
         default: 0,
       })
       .option("hostname", {
-        alias: ["h"],
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",

--- a/packages/opencode/src/cli/cmd/tui/spawn.ts
+++ b/packages/opencode/src/cli/cmd/tui/spawn.ts
@@ -18,7 +18,6 @@ export const TuiSpawnCommand = cmd({
         default: 0,
       })
       .option("hostname", {
-        alias: ["h"],
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -42,7 +42,6 @@ export const TuiThreadCommand = cmd({
         default: 0,
       })
       .option("hostname", {
-        alias: ["h"],
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -38,6 +38,7 @@ process.on("uncaughtException", (e) => {
 const cli = yargs(hideBin(process.argv))
   .scriptName("opencode")
   .help("help", "show help")
+  .alias("help", "h")
   .version("version", "show version number", Installation.VERSION)
   .alias("version", "v")
   .option("print-logs", {
@@ -140,5 +141,5 @@ try {
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.
   // Explicitly exit to avoid any hanging subprocesses.
-  process.exit();
+  process.exit()
 }

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -19,6 +19,28 @@ opencode run "Explain how closures work in JavaScript"
 
 ---
 
+### tui
+
+Start the OpenCode terminal user interface.
+
+```bash
+opencode [project]
+```
+
+#### Flags
+
+| Flag         | Short | Description                                |
+| ------------ | ----- | ------------------------------------------ |
+| `--continue` | `-c`  | Continue the last session                  |
+| `--session`  | `-s`  | Session ID to continue                     |
+| `--prompt`   | `-p`  | Prompt to use                              |
+| `--model`    | `-m`  | Model to use in the form of provider/model |
+| `--agent`    |       | Agent to use                               |
+| `--port`     |       | Port to listen on                          |
+| `--hostname` |       | Hostname to listen on                      |
+
+---
+
 ## Commands
 
 The OpenCode CLI also has the following commands.
@@ -164,13 +186,17 @@ opencode run Explain the use of context in Go
 
 #### Flags
 
-| Flag         | Short | Description                                |
-| ------------ | ----- | ------------------------------------------ |
-| `--continue` | `-c`  | Continue the last session                  |
-| `--session`  | `-s`  | Session ID to continue                     |
-| `--share`    |       | Share the session                          |
-| `--model`    | `-m`  | Model to use in the form of provider/model |
-| `--agent`    |       | Agent to use                               |
+| Flag         | Short | Description                                                        |
+| ------------ | ----- | ------------------------------------------------------------------ |
+| `--command`  |       | The command to run, use message for args                           |
+| `--continue` | `-c`  | Continue the last session                                          |
+| `--session`  | `-s`  | Session ID to continue                                             |
+| `--share`    |       | Share the session                                                  |
+| `--model`    | `-m`  | Model to use in the form of provider/model                         |
+| `--agent`    |       | Agent to use                                                       |
+| `--file`     | `-f`  | File(s) to attach to message                                       |
+| `--format`   |       | Format: default (formatted) or json (raw JSON events)              |
+| `--title`    |       | Title for the session (uses truncated prompt if no value provided) |
 
 ---
 
@@ -189,7 +215,7 @@ This starts an HTTP server that provides API access to opencode functionality wi
 | Flag         | Short | Description           |
 | ------------ | ----- | --------------------- |
 | `--port`     | `-p`  | Port to listen on     |
-| `--hostname` | `-h`  | Hostname to listen on |
+| `--hostname` |       | Hostname to listen on |
 
 ---
 
@@ -221,18 +247,13 @@ opencode upgrade v0.1.48
 
 ---
 
-## Flags
+## Global Flags
 
 The opencode CLI takes the following global flags.
 
-| Flag           | Short | Description                                |
-| -------------- | ----- | ------------------------------------------ |
-| `--help`       | `-h`  | Display help                               |
-| `--version`    |       | Print version number                       |
-| `--print-logs` |       | Print logs to stderr                       |
-| `--log-level`  |       | Log level (DEBUG, INFO, WARN, ERROR)       |
-| `--prompt`     | `-p`  | Prompt to use                              |
-| `--model`      | `-m`  | Model to use in the form of provider/model |
-| `--agent`      |       | Agent to use                               |
-| `--port`       |       | Port to listen on                          |
-| `--hostname`   |       | Hostname to listen on                      |
+| Flag           | Short | Description                          |
+| -------------- | ----- | ------------------------------------ |
+| `--help`       | `-h`  | Display help                         |
+| `--version`    | `-v`  | Print version number                 |
+| `--print-logs` |       | Print logs to stderr                 |
+| `--log-level`  |       | Log level (DEBUG, INFO, WARN, ERROR) |


### PR DESCRIPTION
The "h" alias for "hostname" in `thread` conflicts with "h" alias for help, making it impossible to run TUI via `opencode [project]`.