### PR TITLE
fix: tui: Prevent crash when selecting a non-existent theme

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -128,15 +128,17 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     if (evt.name === "pagedown") move(10)
     if (evt.name === "return") {
       const option = selected()
-      if (option.onSelect) option.onSelect(dialog)
-      props.onSelect?.(option)
+      if (option) {
+        option.onSelect?.(dialog)
+        props.onSelect?.(option)
+      }
     }
+    const s = selected()
+    if (!s) return
 
     for (const item of props.keybind ?? []) {
-      if (Keybind.match(item.keybind, keybind.parse(evt))) {
-        const s = selected()
-        if (s) item.onTrigger(s)
-      }
+      if (Keybind.match(item.keybind, keybind.parse(evt)))
+        item.onTrigger(s)
     }
   })
 


### PR DESCRIPTION
Previously, hitting enter with a nonexistent theme selected would crash.

Now it does nothing:

https://github.com/user-attachments/assets/a13e7c0d-9e36-4d6f-a315-d2e3d0080bec

Closes #3614.
Closes #3635.