### PR TITLE
feat: tui: Add /init command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -236,6 +236,11 @@ export function Autocomplete(props: {
         onSelect: () => command.trigger("session.new"),
       },
       {
+        display: "/init",
+        description: "create/update AGENTS.md",
+        onSelect: () => command.trigger("session.init"),
+      },
+      {
         display: "/models",
         description: "list models",
         onSelect: () => command.trigger("model.list"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -474,6 +474,7 @@ export namespace Config {
         .describe("Insert newline in input"),
       history_previous: z.string().optional().default("up").describe("Previous history item"),
       history_next: z.string().optional().default("down").describe("Previous history item"),
+      project_init: z.string().optional().default("none").describe("Create or update AGENTS.md"),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -420,11 +420,11 @@ export namespace Session {
       sessionID: Identifier.schema("session"),
       modelID: z.string(),
       providerID: z.string(),
-      messageID: Identifier.schema("message"),
+      messageID: Identifier.schema("message").optional(),
     }),
     async (input) => {
       await SessionPrompt.prompt({
-        sessionID: input.sessionID,
+        sessionID: input.sessionID ?? Identifier.ascending("message"),
         messageID: input.messageID,
         model: {
           providerID: input.providerID,

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -166,6 +166,10 @@ export type KeybindsConfig = {
    * Previous history item
    */
   history_next?: string
+  /**
+   * Create or update AGENTS.md
+   */
+  project_init?: string
 }
 
 export type AgentConfig = {
@@ -1697,7 +1701,7 @@ export type SessionInitData = {
   body?: {
     modelID: string
     providerID: string
-    messageID: string
+    messageID?: string
   }
   path: {
     /**


### PR DESCRIPTION
Testing:
- Run `/init` in home route (no session active): should create a new session and send the usual init prompt
- Run `/init` in an existing session: should send the usual init prompt
- Bind a keybind to `project_init`: should work

Closes #3637.