### PR TITLE
feat: Add websearch tool with Perplexity AI integration

### DIFF
--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -1,16 +1,12 @@
-import { tool } from "@opencode-ai/plugin/tool";
-import { promises as fs } from "fs";
-import { join } from "path";
+import { tool } from "@opencode-ai/plugin/tool"
+import { join } from "path"
 
-// Load Perplexity API key from auth file
-async function getPerplexityKey(): Promise<string | null> {
-  try {
-    const authPath = join(process.env.HOME || ".", ".local/share/opencode/auth.json");
-    const authData = JSON.parse(await fs.readFile(authPath, "utf-8"));
-    return authData.PERPLEXITY_API_KEY || null;
-  } catch (error) {
-    return null;
-  }
+async function getPerplexityKey() {
+  const authPath = join(process.env.HOME || ".", ".local/share/opencode/auth.json")
+  const file = Bun.file(authPath)
+  if (!(await file.exists())) return null
+  const authData = await file.json()
+  return authData.PERPLEXITY_API_KEY || null
 }
 
 export const websearch = tool({
@@ -19,55 +15,46 @@ export const websearch = tool({
     query: tool.schema
       .string()
       .describe("The search query"),
-    region: tool.schema
-      .string()
-      .optional()
-      .default("us-en")
-      .describe("Region for search results"),
   },
   async execute(args) {
-    try {
-      const apiKey = await getPerplexityKey();
-      
-      if (!apiKey) {
-        return "Error: Perplexity API key not found. Please set PERPLEXITY_API_KEY in ~/.local/share/opencode/auth.json";
-      }
-
-      const response = await fetch("https://api.perplexity.ai/chat/completions", {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "llama-3.1-sonar-small-128k-online",
-          messages: [
-            {
-              role: "system",
-              content: "Be precise and concise."
-            },
-            {
-              role: "user",
-              content: args.query
-            }
-          ]
-        }),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        return `Error: Perplexity API request failed with status ${response.status}: ${errorText}`;
-      }
-
-      const data = await response.json();
-      
-      if (data.choices && data.choices[0] && data.choices[0].message) {
-        return data.choices[0].message.content;
-      } else {
-        return "Error: Unexpected response format from Perplexity API";
-      }
-    } catch (error: any) {
-      return `Error: ${error.message}`;
+    const apiKey = await getPerplexityKey()
+    
+    if (!apiKey) {
+      return "Error: Perplexity API key not found. Please set PERPLEXITY_API_KEY in ~/.local/share/opencode/auth.json"
     }
+
+    const response = await fetch("https://api.perplexity.ai/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "llama-3.1-sonar-small-128k-online",
+        messages: [
+          {
+            role: "system",
+            content: "Be precise and concise."
+          },
+          {
+            role: "user",
+            content: args.query
+          }
+        ]
+      }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      return `Error: Perplexity API request failed with status ${response.status}: ${errorText}`
+    }
+
+    const data = await response.json()
+    
+    if (!data.choices?.[0]?.message?.content) {
+      return "Error: Unexpected response format from Perplexity API"
+    }
+
+    return data.choices[0].message.content
   },
-});
+})

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -1,0 +1,73 @@
+import { tool } from "@opencode-ai/plugin/tool";
+import { promises as fs } from "fs";
+import { join } from "path";
+
+// Load Perplexity API key from auth file
+async function getPerplexityKey(): Promise<string | null> {
+  try {
+    const authPath = join(process.env.HOME || ".", ".local/share/opencode/auth.json");
+    const authData = JSON.parse(await fs.readFile(authPath, "utf-8"));
+    return authData.PERPLEXITY_API_KEY || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+export const websearch = tool({
+  description: "Search the web for current information using Perplexity AI",
+  args: {
+    query: tool.schema
+      .string()
+      .describe("The search query"),
+    region: tool.schema
+      .string()
+      .optional()
+      .default("us-en")
+      .describe("Region for search results"),
+  },
+  async execute(args) {
+    try {
+      const apiKey = await getPerplexityKey();
+      
+      if (!apiKey) {
+        return "Error: Perplexity API key not found. Please set PERPLEXITY_API_KEY in ~/.local/share/opencode/auth.json";
+      }
+
+      const response = await fetch("https://api.perplexity.ai/chat/completions", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "llama-3.1-sonar-small-128k-online",
+          messages: [
+            {
+              role: "system",
+              content: "Be precise and concise."
+            },
+            {
+              role: "user",
+              content: args.query
+            }
+          ]
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return `Error: Perplexity API request failed with status ${response.status}: ${errorText}`;
+      }
+
+      const data = await response.json();
+      
+      if (data.choices && data.choices[0] && data.choices[0].message) {
+        return data.choices[0].message.content;
+      } else {
+        return "Error: Unexpected response format from Perplexity API";
+      }
+    } catch (error: any) {
+      return `Error: ${error.message}`;
+    }
+  },
+});

--- a/packages/opencode/src/tool/websearch.txt
+++ b/packages/opencode/src/tool/websearch.txt
@@ -1,11 +1,12 @@
 
-- Allows opencode to search the web and use the results to inform responses
+- Searches the web for current information using Perplexity AI
 - Provides up-to-date information for current events and recent data
-- Returns search result information formatted as search result blocks
-- Use this tool for accessing information beyond Claude's knowledge cutoff
-- Searches are performed automatically within a single API call
+- Returns precise and concise answers based on real-time web search
+- Use this tool when you need information beyond your training data
+- Requires PERPLEXITY_API_KEY to be set in ~/.local/share/opencode/auth.json
 
 Usage notes:
-  - Domain filtering is supported to include or block specific websites
-  - Web search is only available in the US
+  - The query parameter should be specific and detailed for better results
+  - Uses Perplexity's llama-3.1-sonar-small-128k-online model for real-time search
+  - Returns error messages if the API key is missing or the request fails
 


### PR DESCRIPTION
## Summary

- Adds websearch tool powered by Perplexity AI for real-time web search
- Uses llama-3.1-sonar-small-128k-online model for precise, concise answers
- Requires PERPLEXITY_API_KEY in ~/.local/share/opencode/auth.json
- Follows OpenCode coding standards (Bun APIs, no try/catch, optional chaining)

## Changes

- `packages/opencode/src/tool/websearch.ts`: New tool implementation using Bun.file() API
- `packages/opencode/src/tool/websearch.txt`: Tool documentation

## Testing

Tool has been manually tested with custom Perplexity API key.