### PR TITLE
fix import path to solid-plugin.

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
+import solidPlugin from "../../../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"


### PR DESCRIPTION
The `bun typecheck` command currently seems to fail due to an incorrect module import. I'm not confident that this fix is appropriate, but it works for me.