### PR TITLE
feat: add simplified permission system for external file access

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -346,10 +346,6 @@ export namespace ACP {
             id: "opencode-login",
           },
         ],
-        agentInfo: {
-          name: "OpenCode",
-          version: Installation.VERSION,
-        },
       }
     }
 

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -17,7 +17,10 @@ export namespace Agent {
       topP: z.number().optional(),
       temperature: z.number().optional(),
       permission: z.object({
-        edit: Config.Permission,
+        edit: z.object({
+          enabled: Config.Permission,
+          external_files: Config.Permission,
+        }),
         bash: z.record(z.string(), Config.Permission),
         webfetch: Config.Permission.optional(),
       }),
@@ -40,7 +43,10 @@ export namespace Agent {
     const cfg = await Config.get()
     const defaultTools = cfg.tools ?? {}
     const defaultPermission: Info["permission"] = {
-      edit: "allow",
+      edit: {
+        enabled: "allow",
+        external_files: "ask",
+      },
       bash: {
         "*": "allow",
       },
@@ -50,7 +56,10 @@ export namespace Agent {
 
     const planPermission = mergeAgentPermissions(
       {
-        edit: "deny",
+        edit: {
+          enabled: "deny",
+          external_files: "ask",
+        },
         bash: {
           "cut*": "allow",
           "diff*": "allow",
@@ -143,7 +152,18 @@ export namespace Agent {
           tools: {},
           builtIn: false,
         }
-      const { name, model, prompt, tools, description, temperature, top_p, mode, permission, ...extra } = value
+      const {
+        name,
+        model,
+        prompt,
+        tools,
+        description,
+        temperature,
+        top_p,
+        mode,
+        permission,
+        ...extra
+      } = value
       item.options = {
         ...item.options,
         ...extra,
@@ -212,7 +232,10 @@ export namespace Agent {
   }
 }
 
-function mergeAgentPermissions(basePermission: any, overridePermission: any): Agent.Info["permission"] {
+function mergeAgentPermissions(
+  basePermission: any,
+  overridePermission: any,
+): Agent.Info["permission"] {
   if (typeof basePermission.bash === "string") {
     basePermission.bash = {
       "*": basePermission.bash,
@@ -223,7 +246,23 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
       "*": overridePermission.bash,
     }
   }
+
+  // Normalize legacy edit permission
+  if (typeof basePermission.edit === "string") {
+    basePermission.edit = {
+      enabled: basePermission.edit,
+      external_files: "ask",
+    }
+  }
+  if (typeof overridePermission.edit === "string") {
+    overridePermission.edit = {
+      enabled: overridePermission.edit,
+      external_files: "ask",
+    }
+  }
+
   const merged = mergeDeep(basePermission ?? {}, overridePermission ?? {}) as any
+
   let mergedBash
   if (merged.bash) {
     if (typeof merged.bash === "string") {
@@ -240,8 +279,26 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
     }
   }
 
+  // Ensure edit is an object
+  let mergedEdit = merged.edit
+  if (typeof mergedEdit === "string") {
+    mergedEdit = {
+      enabled: mergedEdit,
+      external_files: "ask",
+    }
+  }
+  if (!mergedEdit || typeof mergedEdit !== "object") {
+    mergedEdit = {
+      enabled: "allow",
+      external_files: "ask",
+    }
+  }
+
   const result: Agent.Info["permission"] = {
-    edit: merged.edit ?? "allow",
+    edit: {
+      enabled: mergedEdit.enabled ?? "allow",
+      external_files: mergedEdit.external_files ?? "ask",
+    },
     webfetch: merged.webfetch ?? "allow",
     bash: mergedBash ?? { "*": "allow" },
   }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -366,7 +366,15 @@ export namespace Config {
       mode: z.union([z.literal("subagent"), z.literal("primary"), z.literal("all")]).optional(),
       permission: z
         .object({
-          edit: Permission.optional(),
+          edit: z
+            .union([
+              Permission,
+              z.object({
+                enabled: Permission.optional(),
+                external_files: Permission.optional(),
+              }),
+            ])
+            .optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
         })
@@ -652,7 +660,15 @@ export namespace Config {
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: z
         .object({
-          edit: Permission.optional(),
+          edit: z
+            .union([
+              Permission,
+              z.object({
+                enabled: Permission.optional(),
+                external_files: Permission.optional(),
+              }),
+            ])
+            .optional(),
           bash: z.union([Permission, z.record(z.string(), Permission)]).optional(),
           webfetch: Permission.optional(),
         })

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -23,8 +23,13 @@ export const EditTool = Tool.define("edit", {
   parameters: z.object({
     filePath: z.string().describe("The absolute path to the file to modify"),
     oldString: z.string().describe("The text to replace"),
-    newString: z.string().describe("The text to replace it with (must be different from oldString)"),
-    replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
+    newString: z
+      .string()
+      .describe("The text to replace it with (must be different from oldString)"),
+    replaceAll: z
+      .boolean()
+      .optional()
+      .describe("Replace all occurrences of oldString (default false)"),
   }),
   async execute(params, ctx) {
     if (!params.filePath) {
@@ -35,9 +40,32 @@ export const EditTool = Tool.define("edit", {
       throw new Error("oldString and newString must be different")
     }
 
-    const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filePath = path.isAbsolute(params.filePath)
+      ? params.filePath
+      : path.join(Instance.directory, params.filePath)
+
     if (!Filesystem.contains(Instance.directory, filePath)) {
-      throw new Error(`File ${filePath} is not in the current working directory`)
+      const agent = await Agent.get(ctx.agent)
+      const action = agent.permission.edit.external_files
+
+      if (action === "deny") {
+        throw new Error(`File ${filePath} is not in the current working directory`)
+      }
+
+      if (action === "ask") {
+        await Permission.ask({
+          type: "external_files",
+          pattern: filePath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: `Edit file outside working directory: ${path.relative(Instance.worktree, filePath)}`,
+          metadata: {
+            filepath: path.relative(Instance.worktree, filePath),
+            operation: "edit",
+          },
+        })
+      }
     }
 
     const agent = await Agent.get(ctx.agent)
@@ -48,7 +76,7 @@ export const EditTool = Tool.define("edit", {
       if (params.oldString === "") {
         contentNew = params.newString
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
-        if (agent.permission.edit === "ask") {
+        if (agent.permission.edit.enabled === "ask") {
           await Permission.ask({
             type: "edit",
             sessionID: ctx.sessionID,
@@ -77,7 +105,7 @@ export const EditTool = Tool.define("edit", {
       contentNew = replace(contentOld, params.oldString, params.newString, params.replaceAll)
 
       diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
-      if (agent.permission.edit === "ask") {
+      if (agent.permission.edit.enabled === "ask") {
         await Permission.ask({
           type: "edit",
           sessionID: ctx.sessionID,
@@ -160,7 +188,11 @@ function levenshtein(a: string, b: string): number {
   for (let i = 1; i <= a.length; i++) {
     for (let j = 1; j <= b.length; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1
-      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost,
+      )
     }
   }
   return matrix[a.length][b.length]
@@ -362,7 +394,9 @@ export const WhitespaceNormalizedReplacer: Replacer = function* (content, find) 
         // Find the actual substring in the original line that matches
         const words = find.trim().split(/\s+/)
         if (words.length > 0) {
-          const pattern = words.map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("\\s+")
+          const pattern = words
+            .map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+            .join("\\s+")
           try {
             const regex = new RegExp(pattern)
             const match = line.match(regex)
@@ -600,7 +634,12 @@ export function trimDiff(diff: string): string {
   return trimmedLines.join("\n")
 }
 
-export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
+export function replace(
+  content: string,
+  oldString: string,
+  newString: string,
+  replaceAll = false,
+): string {
   if (oldString === newString) {
     throw new Error("oldString and newString must be different")
   }

--- a/packages/opencode/src/tool/patch.ts
+++ b/packages/opencode/src/tool/patch.ts
@@ -38,8 +38,10 @@ export const PatchTool = Tool.define("patch", {
       throw new Error("No file changes found in patch")
     }
 
-    // Validate file paths and check permissions
+    // Fetch agent once before the loop
     const agent = await Agent.get(ctx.agent)
+
+    // Validate file paths and check permissions
     const fileChanges: Array<{
       filePath: string
       oldContent: string
@@ -54,7 +56,26 @@ export const PatchTool = Tool.define("patch", {
       const filePath = path.resolve(Instance.directory, hunk.path)
 
       if (!Filesystem.contains(Instance.directory, filePath)) {
-        throw new Error(`File ${filePath} is not in the current working directory`)
+        const action = agent.permission.edit.external_files
+
+        if (action === "deny") {
+          throw new Error(`File ${filePath} is not in the current working directory`)
+        }
+
+        if (action === "ask") {
+          await Permission.ask({
+            type: "external_files",
+            pattern: filePath,
+            sessionID: ctx.sessionID,
+            messageID: ctx.messageID,
+            callID: ctx.callID,
+            title: `Patch file outside working directory: ${path.relative(Instance.worktree, filePath)}`,
+            metadata: {
+              filepath: path.relative(Instance.worktree, filePath),
+              operation: "patch",
+            },
+          })
+        }
       }
 
       switch (hunk.type) {
@@ -127,7 +148,7 @@ export const PatchTool = Tool.define("patch", {
     }
 
     // Check permissions if needed
-    if (agent.permission.edit === "ask") {
+    if (agent.permission.edit.enabled === "ask") {
       await Permission.ask({
         type: "edit",
         sessionID: ctx.sessionID,

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -9,6 +9,8 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Provider } from "../provider/provider"
 import { Identifier } from "../id/id"
+import { Agent } from "../agent/agent"
+import { Permission } from "../permission"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -17,7 +19,10 @@ export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
   parameters: z.object({
     filePath: z.string().describe("The path to the file to read"),
-    offset: z.coerce.number().describe("The line number to start reading from (0-based)").optional(),
+    offset: z.coerce
+      .number()
+      .describe("The line number to start reading from (0-based)")
+      .optional(),
     limit: z.coerce.number().describe("The number of lines to read (defaults to 2000)").optional(),
   }),
   async execute(params, ctx) {
@@ -28,7 +33,27 @@ export const ReadTool = Tool.define("read", {
     const title = path.relative(Instance.worktree, filepath)
 
     if (!ctx.extra?.["bypassCwdCheck"] && !Filesystem.contains(Instance.directory, filepath)) {
-      throw new Error(`File ${filepath} is not in the current working directory`)
+      const agent = await Agent.get(ctx.agent)
+      const action = agent.permission.edit.external_files
+
+      if (action === "deny") {
+        throw new Error(`File ${filepath} is not in the current working directory`)
+      }
+
+      if (action === "ask") {
+        await Permission.ask({
+          type: "external_files",
+          pattern: filepath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: `Read file outside working directory: ${path.relative(Instance.worktree, filepath)}`,
+          metadata: {
+            filepath: path.relative(Instance.worktree, filepath),
+            operation: "read",
+          },
+        })
+      }
     }
 
     const file = Bun.file(filepath)
@@ -40,13 +65,16 @@ export const ReadTool = Tool.define("read", {
       const suggestions = dirEntries
         .filter(
           (entry) =>
-            entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
+            entry.toLowerCase().includes(base.toLowerCase()) ||
+            base.toLowerCase().includes(entry.toLowerCase()),
         )
         .map((entry) => path.join(dir, entry))
         .slice(0, 3)
 
       if (suggestions.length > 0) {
-        throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+        throw new Error(
+          `File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`,
+        )
       }
 
       throw new Error(`File not found: ${filepath}`)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -25,7 +25,12 @@ export namespace ToolRegistry {
     const glob = new Bun.Glob("tool/*.{js,ts}")
 
     for (const dir of await Config.directories()) {
-      for await (const match of glob.scan({ cwd: dir, absolute: true, followSymlinks: true, dot: true })) {
+      for await (const match of glob.scan({
+        cwd: dir,
+        absolute: true,
+        followSymlinks: true,
+        dot: true,
+      })) {
         const namespace = path.basename(match, path.extname(match))
         const mod = await import(match)
         for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
@@ -115,7 +120,7 @@ export namespace ToolRegistry {
     const result: Record<string, boolean> = {}
     result["patch"] = false
 
-    if (agent.permission.edit === "deny") {
+    if (agent.permission.edit.enabled === "deny") {
       result["edit"] = false
       result["patch"] = false
       result["write"] = false

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -15,20 +15,45 @@ export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
     content: z.string().describe("The content to write to the file"),
-    filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
+    filePath: z
+      .string()
+      .describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
   async execute(params, ctx) {
-    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filepath = path.isAbsolute(params.filePath)
+      ? params.filePath
+      : path.join(Instance.directory, params.filePath)
+
+    const agent = await Agent.get(ctx.agent)
+
     if (!Filesystem.contains(Instance.directory, filepath)) {
-      throw new Error(`File ${filepath} is not in the current working directory`)
+      const action = agent.permission.edit.external_files
+
+      if (action === "deny") {
+        throw new Error(`File ${filepath} is not in the current working directory`)
+      }
+
+      if (action === "ask") {
+        await Permission.ask({
+          type: "external_files",
+          pattern: filepath,
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          callID: ctx.callID,
+          title: `Write file outside working directory: ${path.relative(Instance.worktree, filepath)}`,
+          metadata: {
+            filepath: path.relative(Instance.worktree, filepath),
+            operation: "write",
+          },
+        })
+      }
     }
 
     const file = Bun.file(filepath)
     const exists = await file.exists()
     if (exists) await FileTime.assert(ctx.sessionID, filepath)
 
-    const agent = await Agent.get(ctx.agent)
-    if (agent.permission.edit === "ask")
+    if (agent.permission.edit.enabled === "ask")
       await Permission.ask({
         type: "write",
         sessionID: ctx.sessionID,

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { EditTool } from "../../src/tool/edit"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { FileTime } from "../../src/file/time"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+const editTool = await EditTool.init()
+
+describe("tool.edit external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, externalFile)
+
+          await editTool.execute(
+            {
+              filePath: externalFile,
+              oldString: "old",
+              newString: "new",
+            },
+            ctx,
+          )
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("external_files")
+          expect(permissionSpy.mock.calls[0][0].metadata.operation).toBe("edit")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await expect(
+            editTool.execute(
+              {
+                filePath: externalFile,
+                oldString: "old",
+                newString: "new",
+              },
+              ctx,
+            ),
+          ).rejects.toThrow("is not in the current working directory")
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "allow",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, externalFile)
+
+          await editTool.execute(
+            {
+              filePath: externalFile,
+              oldString: "old",
+              newString: "new",
+            },
+            ctx,
+          )
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const content = await Bun.file(externalFile).text()
+          expect(content).toBe("new content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow internal files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const internalFile = path.join(tmp.path, "internal.txt")
+    await Bun.write(internalFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, internalFile)
+
+          await editTool.execute(
+            {
+              filePath: internalFile,
+              oldString: "old",
+              newString: "new",
+            },
+            ctx,
+          )
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("edit")
+
+          const content = await Bun.file(internalFile).text()
+          expect(content).toBe("new content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should respect permission config for internal files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const internalFile = path.join(tmp.path, "internal.txt")
+    await Bun.write(internalFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, internalFile)
+
+          await editTool.execute(
+            {
+              filePath: internalFile,
+              oldString: "old",
+              newString: "new",
+            },
+            ctx,
+          )
+
+          // With edit.enabled: "allow", should not ask permission
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const content = await Bun.file(internalFile).text()
+          expect(content).toBe("new content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should handle replaceAll parameter", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const internalFile = path.join(tmp.path, "internal.txt")
+    await Bun.write(internalFile, "test test test")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, internalFile)
+
+          await editTool.execute(
+            {
+              filePath: internalFile,
+              oldString: "test",
+              newString: "pass",
+              replaceAll: true,
+            },
+            ctx,
+          )
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+
+          const content = await Bun.file(internalFile).text()
+          expect(content).toBe("pass pass pass")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should throw error when oldString not found", async () => {
+    await using tmp = await tmpdir()
+    const internalFile = path.join(tmp.path, "internal.txt")
+    await Bun.write(internalFile, "test content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, internalFile)
+
+          await expect(
+            editTool.execute(
+              {
+                filePath: internalFile,
+                oldString: "nonexistent",
+                newString: "new",
+              },
+              ctx,
+            ),
+          ).rejects.toThrow("oldString not found in content")
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should handle empty file creation with oldString empty", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const newFile = path.join(tmp.path, "new.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await editTool.execute(
+            {
+              filePath: newFile,
+              oldString: "",
+              newString: "new content",
+            },
+            ctx,
+          )
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+
+          const content = await Bun.file(newFile).text()
+          expect(content).toBe("new content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should backward compatible with legacy config format", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const internalFile = path.join(tmp.path, "internal.txt")
+    await Bun.write(internalFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, internalFile)
+
+          await editTool.execute(
+            {
+              filePath: internalFile,
+              oldString: "old",
+              newString: "new",
+            },
+            ctx,
+          )
+
+          // With legacy config format "allow", should not ask permission
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+})

--- a/packages/opencode/test/tool/patch.test.ts
+++ b/packages/opencode/test/tool/patch.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, test, spyOn } from "bun:test"
 import path from "path"
 import { PatchTool } from "../../src/tool/patch"
 import { Instance } from "../../src/project/instance"
+import { Permission } from "../../src/permission"
+import { FileTime } from "../../src/file/time"
 import { tmpdir } from "../fixture/fixture"
 import * as fs from "fs/promises"
 
@@ -18,8 +20,9 @@ const patchTool = await PatchTool.init()
 
 describe("tool.patch", () => {
   test("should validate required parameters", async () => {
+    await using tmp = await tmpdir()
     await Instance.provide({
-      directory: "/tmp",
+      directory: tmp.path,
       fn: async () => {
         await expect(patchTool.execute({ patchText: "" }, ctx)).rejects.toThrow(
           "patchText is required",
@@ -29,8 +32,9 @@ describe("tool.patch", () => {
   })
 
   test("should validate patch format", async () => {
+    await using tmp = await tmpdir()
     await Instance.provide({
-      directory: "/tmp",
+      directory: tmp.path,
       fn: async () => {
         await expect(patchTool.execute({ patchText: "invalid patch" }, ctx)).rejects.toThrow(
           "Failed to parse patch",
@@ -40,8 +44,9 @@ describe("tool.patch", () => {
   })
 
   test("should handle empty patch", async () => {
+    await using tmp = await tmpdir()
     await Instance.provide({
-      directory: "/tmp",
+      directory: tmp.path,
       fn: async () => {
         const emptyPatch = `*** Begin Patch
 *** End Patch`
@@ -54,8 +59,23 @@ describe("tool.patch", () => {
   })
 
   test("should reject files outside working directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
     await Instance.provide({
-      directory: "/tmp",
+      directory: tmp.path,
       fn: async () => {
         const maliciousPatch = `*** Begin Patch
 *** Add File: /etc/passwd
@@ -262,5 +282,301 @@ describe("tool.patch", () => {
         expect(configContent).toBe('{\n  "version": "1.0",\n  "debug": true\n}')
       },
     })
+  })
+})
+
+describe("tool.patch external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Add File: ../external.txt
++external content
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          // Should ask for external_files permission (edit.enabled is "allow" by default)
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("external_files")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Add File: ../external.txt
++external content
+*** End Patch`
+
+          await expect(patchTool.execute({ patchText }, ctx)).rejects.toThrow(
+            "is not in the current working directory",
+          )
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow internal files with permission check", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Add File: internal.txt
++internal content
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("edit")
+
+          const filePath = path.join(tmp.path, "internal.txt")
+          const content = await fs.readFile(filePath, "utf-8")
+          expect(content).toBe("internal content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should respect permission config", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Add File: internal.txt
++internal content
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          // With edit.enabled: "allow", should not ask permission
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const filePath = path.join(tmp.path, "internal.txt")
+          const content = await fs.readFile(filePath, "utf-8")
+          expect(content).toBe("internal content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should validate all file paths before processing", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          // Mix of valid and invalid paths
+          const patchText = `*** Begin Patch
+*** Add File: valid.txt
++valid content
+*** Add File: ../external.txt
++external content
+*** End Patch`
+
+          await expect(patchTool.execute({ patchText }, ctx)).rejects.toThrow(
+            "is not in the current working directory",
+          )
+
+          // Should not call permission or create any files
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const validPath = path.join(tmp.path, "valid.txt")
+          const exists = await fs
+            .access(validPath)
+            .then(() => true)
+            .catch(() => false)
+          expect(exists).toBe(false)
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should handle update operations on internal files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const testFile = path.join(tmp.path, "test.txt")
+    await fs.writeFile(testFile, "line 1\nline 2\nline 3")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, testFile)
+
+          const patchText = `*** Begin Patch
+*** Update File: test.txt
+@@
+ line 1
+-line 2
++line 2 updated
+ line 3
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("edit")
+
+          const content = await fs.readFile(testFile, "utf-8")
+          // Note: patch may add trailing newline
+          expect(content.trim()).toBe("line 1\nline 2 updated\nline 3")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should backward compatible with legacy config format", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const patchText = `*** Begin Patch
+*** Add File: internal.txt
++internal content
+*** End Patch`
+
+          await patchTool.execute({ patchText }, ctx)
+
+          // With legacy config format "allow", should not ask permission
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const filePath = path.join(tmp.path, "internal.txt")
+          const content = await fs.readFile(filePath, "utf-8")
+          expect(content).toBe("internal content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
   })
 })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { ReadTool } from "../../src/tool/read"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+const readTool = await ReadTool.init()
+
+describe("tool.read external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await readTool.execute({ filePath: externalFile }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("external_files")
+          expect(permissionSpy.mock.calls[0][0].metadata.operation).toBe("read")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "allow",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          const result = await readTool.execute({ filePath: externalFile }, ctx)
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+          expect(result.output).toContain("external content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await expect(readTool.execute({ filePath: externalFile }, ctx)).rejects.toThrow(
+            "is not in the current working directory",
+          )
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should respect bypassCwdCheck", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+            extra: { bypassCwdCheck: true },
+          }
+
+          const result = await readTool.execute({ filePath: externalFile }, ctx)
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+          expect(result.output).toContain("external content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should not ask permission for internal files", async () => {
+    await using tmp = await tmpdir()
+    const internalFile = path.join(tmp.path, "internal.txt")
+    await Bun.write(internalFile, "internal content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          const result = await readTool.execute({ filePath: internalFile }, ctx)
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+          expect(result.output).toContain("internal content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should backward compatible with legacy config format", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "external content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await readTool.execute({ filePath: externalFile }, ctx)
+
+          // With legacy config, should still ask for external files (default behavior)
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("external_files")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+})

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -1,0 +1,375 @@
+import { describe, expect, test, spyOn } from "bun:test"
+import { WriteTool } from "../../src/tool/write"
+import { Permission } from "../../src/permission"
+import { Instance } from "../../src/project/instance"
+import { FileTime } from "../../src/file/time"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+const writeTool = await WriteTool.init()
+
+describe("tool.write external files", () => {
+  test("should ask permission for external files with default config", async () => {
+    await using tmp = await tmpdir()
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "existing")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert (file exists)
+          FileTime.read(ctx.sessionID, externalFile)
+
+          await writeTool.execute({ filePath: externalFile, content: "test" }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("external_files")
+          expect(permissionSpy.mock.calls[0][0].metadata.operation).toBe("write")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should deny external files when configured to deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "deny",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await expect(
+            writeTool.execute({ filePath: externalFile, content: "test" }, ctx),
+          ).rejects.toThrow("is not in the current working directory")
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow external files when configured to allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "allow",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const externalFile = path.join(path.dirname(tmp.path), "external.txt")
+    await Bun.write(externalFile, "existing")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert (file exists)
+          FileTime.read(ctx.sessionID, externalFile)
+
+          await writeTool.execute({ filePath: externalFile, content: "test" }, ctx)
+
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const content = await Bun.file(externalFile).text()
+          expect(content).toBe("test")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should allow internal files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const internalFile = path.join(tmp.path, "internal.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: internalFile, content: "internal content" }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].type).toBe("write")
+
+          const content = await Bun.file(internalFile).text()
+          expect(content).toBe("internal content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should respect permission config for internal files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "allow",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    const internalFile = path.join(tmp.path, "internal.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: internalFile, content: "internal content" }, ctx)
+
+          // With edit.enabled: "allow", should not ask permission
+          expect(permissionSpy).not.toHaveBeenCalled()
+
+          const content = await Bun.file(internalFile).text()
+          expect(content).toBe("internal content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should create new file when it does not exist", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const newFile = path.join(tmp.path, "new-file.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: newFile, content: "new content" }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].metadata.exists).toBe(false)
+
+          const content = await Bun.file(newFile).text()
+          expect(content).toBe("new content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should overwrite existing file", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: {
+                enabled: "ask",
+                external_files: "ask",
+              },
+            },
+          }),
+        )
+      },
+    })
+    const existingFile = path.join(tmp.path, "existing.txt")
+    await Bun.write(existingFile, "old content")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          // Mark file as read to bypass FileTime.assert
+          FileTime.read(ctx.sessionID, existingFile)
+
+          await writeTool.execute({ filePath: existingFile, content: "new content" }, ctx)
+
+          expect(permissionSpy).toHaveBeenCalledTimes(1)
+          expect(permissionSpy.mock.calls[0][0].metadata.exists).toBe(true)
+
+          const content = await Bun.file(existingFile).text()
+          expect(content).toBe("new content")
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+
+  test("should backward compatible with legacy config format", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              edit: "allow",
+            },
+          }),
+        )
+      },
+    })
+
+    const internalFile = path.join(tmp.path, "internal.txt")
+
+    const permissionSpy = spyOn(Permission, "ask").mockImplementation(async () => Promise.resolve())
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ctx = {
+            sessionID: "test",
+            messageID: "msg",
+            callID: "call",
+            agent: "build",
+            abort: AbortSignal.any([]),
+            metadata: () => {},
+          }
+
+          await writeTool.execute({ filePath: internalFile, content: "content" }, ctx)
+
+          // With legacy config format "allow", should not ask permission
+          expect(permissionSpy).not.toHaveBeenCalled()
+        },
+      })
+    } finally {
+      permissionSpy.mockRestore()
+    }
+  })
+})

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -191,7 +191,12 @@ export type AgentConfig = {
   description?: string
   mode?: "subagent" | "primary" | "all"
   permission?: {
-    edit?: "ask" | "allow" | "deny"
+    edit?:
+      | ("ask" | "allow" | "deny")
+      | {
+          enabled?: "ask" | "allow" | "deny"
+          external_files?: "ask" | "allow" | "deny"
+        }
     bash?:
       | ("ask" | "allow" | "deny")
       | {
@@ -456,7 +461,12 @@ export type Config = {
   instructions?: Array<string>
   layout?: LayoutConfig
   permission?: {
-    edit?: "ask" | "allow" | "deny"
+    edit?:
+      | ("ask" | "allow" | "deny")
+      | {
+          enabled?: "ask" | "allow" | "deny"
+          external_files?: "ask" | "allow" | "deny"
+        }
     bash?:
       | ("ask" | "allow" | "deny")
       | {


### PR DESCRIPTION
I've vibed a solution to fix #3218 to let user to read/writes files external to cwd instead of simply denying it


Examples:
1.  Ask for permission (default behavior)
```
{
  $schema: https://opencode.ai/config.json,
  permission: {
    edit: {
      enabled: allow,
      external_files: ask
    }
  }
}
```

2. Allow all external file access 
```
{
  $schema: https://opencode.ai/config.json,
  permission: {
    edit: {
      enabled: allow,
      external_files: allow
    }
  }
}
```

I also asks for permission with option to allow a read for session:

<img width="842" height="372" alt="Screenshot 2025-11-02 at 20 18 46" src="https://github.com/user-attachments/assets/06aa9412-e304-4e74-9eaa-c272709e5fc4" />


Fixes #3218