### PR TITLE
fix(autocomplete): Prioritize exact matches

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -303,7 +303,7 @@ export function Autocomplete(props: {
     const currentFilter = filter()
     if (!currentFilter) return mixed.slice(0, 10)
     const result = fuzzysort.go(currentFilter, mixed, {
-      keys: ["display", "description", (obj) => obj.aliases?.join(" ") ?? ""],
+      keys: [(obj) => obj.display.trimEnd(), "description", (obj) => obj.aliases?.join(" ") ?? ""],
       limit: 10,
     })
     return result.map((arr) => arr.obj)


### PR DESCRIPTION
Before:
<img width="1025" height="517" alt="image" src="https://github.com/user-attachments/assets/972d9bcc-ffdc-41bb-96b2-df73f11c4efc" />
After:
<img width="962" height="417" alt="image" src="https://github.com/user-attachments/assets/511a1317-04cd-478d-810a-50aa24d4f3f0" />

Closes #3771.