### PR TITLE
fix: make Worker import cwd-independent (use import.meta.url)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -88,13 +88,18 @@ export const TuiThreadCommand = cmd({
         return undefined
       })()
 
-      const worker = new Worker("./src/cli/cmd/tui/worker.ts", {
-        env: Object.fromEntries(
-          Object.entries(process.env).filter(
-            (entry): entry is [string, string] => entry[1] !== undefined,
+      const worker = new Worker(
+        typeof OPENCODE_VERSION !== "undefined"
+          ? "./src/cli/cmd/tui/worker.ts"
+          : new URL("./worker.ts", import.meta.url),
+        {
+          env: Object.fromEntries(
+            Object.entries(process.env).filter(
+              (entry): entry is [string, string] => entry[1] !== undefined,
+            ),
           ),
-        ),
-      })
+        },
+      )
       worker.onerror = console.error
       const client = Rpc.client<typeof rpc>(worker)
       process.on("uncaughtException", (e) => {


### PR DESCRIPTION
Allows to use relative worker path.

Allows to use dev version with different cwd, i.e. test against user own projects.
like excuting this in my project.

```shell
bun run --preload @opentui/solid/preload  {{OPENCODE_DIR}}/packages/opencode/src/index.ts
# or
cd opencode-repo
bun dev ~/my-own-repo
```

Original bun issue https://github.com/oven-sh/bun/issues/15981

Bun doc has example of using worker with URL (href is not needed)
https://bun.com/docs/runtime/workers#%22open%22


Closes #3220