### PR TITLE
feat: Enhance task display with [subagent type]

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1096,8 +1096,12 @@ ToolRegistry.register<typeof TaskTool>({
     const { theme } = useTheme()
     return (
       <>
-        <ToolTitle icon="%" fallback="Delegating..." when={props.input.description}>
-          Task {props.input.description}
+        <ToolTitle
+          icon="%"
+          fallback="Delegating..."
+          when={props.input.subagent_type ?? props.input.description}
+        >
+          Task [{props.input.subagent_type ?? "unknown"}] {props.input.description}
         </ToolTitle>
         <Show when={props.metadata.summary?.length}>
           <box>


### PR DESCRIPTION
Improve the task display by adding a toggle for prompt visibility and incorporating the subagent type into the task title.

partially improves #3533

props.input.subagent_type - must have

expandable input props - what are you think.


## Whats changed:

### Before

<img width="1136" height="74" alt="image" src="https://github.com/user-attachments/assets/437c5eb8-db17-44c7-8efb-d6d284494b33" />


### After

subagent_type is shown inside square brackets `[subagent_type]`

<img width="1127" height="64" alt="image" src="https://github.com/user-attachments/assets/3d3a0379-0ae1-4432-9070-09a97010e29c" />

