### PR TITLE
fix(tui): worker path resolution in dev mode

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -41,7 +41,9 @@ for (const [os, arch] of targets) {
 
   const opentui = `@opentui/core-${os === "windows" ? "win32" : os}-${arch.replace("-baseline", "")}`
   await $`mkdir -p ../../node_modules/${opentui}`
-  await $`npm pack ${opentui}@${pkg.dependencies["@opentui/core"]}`.cwd(path.join(dir, "../../node_modules"))
+  await $`npm pack ${opentui}@${pkg.dependencies["@opentui/core"]}`.cwd(
+    path.join(dir, "../../node_modules"),
+  )
   await $`tar -xf ../../node_modules/${opentui.replace("@opentui/", "opentui-")}-*.tgz -C ../../node_modules/${opentui} --strip-components=1`
 
   const watcher = `@parcel/watcher-${os === "windows" ? "win32" : os}-${arch.replace("-baseline", "")}${os === "linux" ? "-glibc" : ""}`
@@ -49,7 +51,11 @@ for (const [os, arch] of targets) {
   await $`npm pack ${watcher}`.cwd(path.join(dir, "../../node_modules")).quiet()
   await $`tar -xf ../../node_modules/${watcher.replace("@parcel/", "parcel-")}-*.tgz -C ../../node_modules/${watcher} --strip-components=1`
 
-  const parserWorker = fs.realpathSync(path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"))
+  const parserWorker = fs.realpathSync(
+    path.resolve(dir, "./node_modules/@opentui/core/parser.worker.js"),
+  )
+  const workerPath = "./src/cli/cmd/tui/worker.ts"
+
   await Bun.build({
     conditions: ["browser"],
     tsconfig: "./tsconfig.json",
@@ -61,10 +67,11 @@ for (const [os, arch] of targets) {
       execArgv: [`--user-agent=opencode/${Script.version}`, `--env-file=""`, `--`],
       windows: {},
     },
-    entrypoints: ["./src/index.ts", parserWorker, "./src/cli/cmd/tui/worker.ts"],
+    entrypoints: ["./src/index.ts", parserWorker, workerPath],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
       OTUI_TREE_SITTER_WORKER_PATH: "/$bunfs/root/" + path.relative(dir, parserWorker),
+      OPENCODE_WORKER_PATH: workerPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
     },
   })


### PR DESCRIPTION
Previous versions allowed:

```
bun install
bun dev ../path/to/my/project
```

But now I get:

```
% bun dev ../path/to/my/project
$ bun run --cwd packages/opencode --conditions=browser src/index.ts ../path/to/my/project
Error: Failed to change directory to /Users/cjs/repos/opencode/packages/path/to/my/project
```

If I try to add more ../ I get:

```
% bun dev ../../../path/to/my/project
$ bun run --cwd packages/opencode --conditions=browser src/index.ts ../../../path/to/my/project
ErrorEvent {
  type: "error",
  message: "BuildMessage: ModuleNotFound resolving \"./src/cli/cmd/tui/worker.ts\" (entry point)",
  error: null,
}
```

This commit fixes this by using relative path resolution.

Fixes: #3777