### PR TITLE
fix(publish): Fetch tags from origin before creating GitHub release

### DIFF
--- a/script/publish.ts
+++ b/script/publish.ts
@@ -103,5 +103,6 @@ if (!Script.preview) {
   await $`git fetch origin`
   await $`git cherry-pick HEAD..origin/dev`.nothrow()
   await $`git push origin HEAD --tags --no-verify --force-with-lease`
+  await $`git fetch --tags origin`
   await $`gh release create v${Script.version} --title "v${Script.version}" --notes ${notes.join("\n") ?? "No notable changes"} ./packages/opencode/dist/*.zip`
 }


### PR DESCRIPTION
A few publishes have failed in cases where "tag exists locally but not on remote", if another fetch is performed it should update local->remote tag references. The push should handle this already but it can't hurt to have it explicitly update right?

I also thought that it could be a timing issue or a problem with the `gh` command itself (if it uses some other method to check remote tags).

If I'm completely wrong, apologies for wasting your time.