### PR TITLE
fix(tui): Show correct keybind in session delete confirmation message

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -18,6 +18,8 @@ export function DialogSessionList() {
 
   const [toDelete, setToDelete] = createSignal<string>()
 
+  const deleteKeybind = "ctrl+d"
+
   const options = createMemo(() => {
     const today = new Date().toDateString()
     return sync.data.session
@@ -30,7 +32,7 @@ export function DialogSessionList() {
         }
         const isDeleting = toDelete() === x.id
         return {
-          title: isDeleting ? "Press delete again to confirm" : x.title,
+          title: isDeleting ? `Press ${deleteKeybind} again to confirm` : x.title,
           bg: isDeleting ? theme.error : undefined,
           value: x.id,
           category,
@@ -60,7 +62,7 @@ export function DialogSessionList() {
       }}
       keybind={[
         {
-          keybind: Keybind.parse("ctrl+d")[0],
+          keybind: Keybind.parse(deleteKeybind)[0],
           title: "delete",
           onTrigger: async (option) => {
             if (toDelete() === option.value) {


### PR DESCRIPTION
Before:
<img width="932" height="387" alt="image" src="https://github.com/user-attachments/assets/b1945b4f-a774-48a0-ba5a-ba5e575449a9" />

After:
<img width="970" height="426" alt="image" src="https://github.com/user-attachments/assets/90d6c4d0-7ad9-4885-81a1-d92567713da7" />

