### PR TITLE
feat: Add open task button functionality

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1154,17 +1154,37 @@ ToolRegistry.register<typeof TaskTool>({
   container: "block",
   render(props) {
     const { theme } = useTheme()
+    const { navigate } = useRoute()
+    const [hover, setHover] = createSignal(false)
     const keybind = useKeybind()
 
     return (
       <>
-        <ToolTitle
-          icon="%"
-          fallback="Delegating..."
-          when={props.input.subagent_type ?? props.input.description}
-        >
-          Task [{props.input.subagent_type ?? "unknown"}] {props.input.description}
-        </ToolTitle>
+        <box justifyContent="space-between" flexDirection="row">
+          <ToolTitle
+            icon="%"
+            fallback="Delegating..."
+            when={props.input.subagent_type ?? props.input.description}
+          >
+            Task [{props.input.subagent_type ?? "unknown"}] {props.input.description}
+          </ToolTitle>
+          <box
+            onMouseOver={() => setHover(true)}
+            onMouseOut={() => setHover(false)}
+            onMouseUp={() => {
+              navigate({
+                type: "session",
+                sessionID: props.metadata.sessionId!,
+              })
+            }}
+            paddingLeft={2}
+            paddingRight={2}
+            marginRight={2}
+            backgroundColor={hover() ? theme.accent : theme.backgroundElement}
+          >
+            <text fg={theme.text}>Open task →</text>
+          </box>
+        </box>
         <Show when={props.metadata.summary?.length}>
           <box>
             <For each={props.metadata.summary ?? []}>


### PR DESCRIPTION
Introduce `open task` button that allows users to navigate to the corresponding task session directly from the task display


![Screen Recording 2025-11-03 at 12 22 20](https://github.com/user-attachments/assets/cb2eeced-869e-4fb4-b49c-577d5cd7fe06)


It definitely needs `navigate back` support too. Probably `ctrl - up` or `ctrl - backspace` keybinding. With scroll preservation. If above is ok I can try to do navigation
