### PR TITLE
docs: add session_child_cycle and session_child_cycle_reverse keybinds

### DIFF
--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -23,6 +23,8 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "session_unshare": "none",
     "session_interrupt": "escape",
     "session_compact": "<leader>c",
+    "session_child_cycle": "ctrl+right",
+    "session_child_cycle_reverse": "ctrl+left",
     "messages_page_up": "pageup",
     "messages_page_down": "pagedown",
     "messages_half_page_up": "ctrl+alt+u",


### PR DESCRIPTION
Closes #3804 

**Issue:**
The `session_child_cycle` and `session_child_cycle_reverse` keybinds are functional but are missing from the `/docs/keybinds` documentation page.

**Fix:**
This change adds the two missing keybinds to the documentation, allowing users to discover and configure them.