### PR TITLE
Log share link immediately after session creation

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -152,6 +152,9 @@ try {
     return session.id.slice(-8)
   })()
   console.log("opencode session", session.id)
+  if (shareId) {
+    console.log("Share link:", `${useShareUrl()}/s/${shareId}`)
+  }
 
   // Handle 3 cases
   // 1. Issue


### PR DESCRIPTION
Fixes #2721 by logging the Share Link earlier on in the process so we're able to watch the session running with the benefit of the UI on the share website instead of waiting until it's finished to view this

<img width="530" height="154" alt="image" src="https://github.com/user-attachments/assets/53cb10d7-e0a5-4021-82b2-615023f2454c" />
