### PR TITLE
fix: correct clipboard image encoding and binary handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -30,13 +30,13 @@ export namespace Clipboard {
     }
 
     if (os === "linux") {
-      const wayland = await $`wl-paste -t image/png`.nothrow().text()
-      if (wayland) {
-        return { data: Buffer.from(wayland).toString("base64url"), mime: "image/png" }
+      const wayland = await $`wl-paste -t image/png`.nothrow().arrayBuffer()
+      if (wayland && wayland.byteLength > 0) {
+        return { data: Buffer.from(wayland).toString("base64"), mime: "image/png" }
       }
-      const x11 = await $`xclip -selection clipboard -t image/png -o`.nothrow().text()
-      if (x11) {
-        return { data: Buffer.from(x11).toString("base64url"), mime: "image/png" }
+      const x11 = await $`xclip -selection clipboard -t image/png -o`.nothrow().arrayBuffer()
+      if (x11 && x11.byteLength > 0) {
+        return { data: Buffer.from(x11).toString("base64"), mime: "image/png" }
       }
     }
 
@@ -47,7 +47,7 @@ export namespace Clipboard {
       if (base64) {
         const imageBuffer = Buffer.from(base64.trim(), "base64")
         if (imageBuffer.length > 0) {
-          return { data: imageBuffer.toString("base64url"), mime: "image/png" }
+          return { data: imageBuffer.toString("base64"), mime: "image/png" }
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes clipboard image paste failures on Linux and Windows (#3816) by addressing two critical bugs in clipboard.ts:

### Bug #1: Binary Data Corruption (Linux)
- **Problem:** Wayland and X11 clipboard reads used `.text()` on binary PNG data, corrupting it via UTF-8 decoding
- **Fix:** Changed to `.arrayBuffer()` to preserve binary data integrity
- **Added:** `byteLength > 0` validation for empty buffer checks

### Bug #2: Encoding Mismatch (All platforms)
- **Problem:** Used `base64url` encoding (URL-safe with `-` and `_`) instead of standard `base64` (with `+` and `/`)
- **Fix:** Changed to standard `base64` encoding as required by RFC 2397 data URL specification
- **Platforms affected:** Linux (Wayland, X11) and Windows

## Changes

**File:** `packages/opencode/src/cli/cmd/tui/util/clipboard.ts`

- Lines 33-35: Wayland clipboard - `.text()` → `.arrayBuffer()`, `base64url` → `base64`
- Lines 37-39: X11 clipboard - `.text()` → `.arrayBuffer()`, `base64url` → `base64`
- Line 50: Windows clipboard - `base64url` → `base64`

These changes align Linux/Windows clipboard handling with the correct approach already used in macOS (line 25).

## Test Plan

1. **Environment:** Ubuntu/Linux with Wayland or X11
2. Take a screenshot (saves to clipboard)
3. Open opencode TUI
4. Paste image using Ctrl+V
5. Submit message with image
6. Verify no `AI_DownloadError` occurs
7. Verify AI can read and process the image

## Technical Details

**Before (broken):**
```typescript
const wayland = await $\`wl-paste -t image/png\`.nothrow().text()
return { data: Buffer.from(wayland).toString("base64url"), ... }
```

**After (fixed):**
```typescript
const wayland = await $\`wl-paste -t image/png\`.nothrow().arrayBuffer()
if (wayland && wayland.byteLength > 0) {
  return { data: Buffer.from(wayland).toString("base64"), ... }
}
```

Fixes #3816