### PR TITLE
fix: wait for stdout to flush in generate command

### DIFF
--- a/packages/opencode/src/cli/cmd/generate.ts
+++ b/packages/opencode/src/cli/cmd/generate.ts
@@ -5,6 +5,14 @@ export const GenerateCommand = {
   command: "generate",
   handler: async () => {
     const specs = await Server.openapi()
-    process.stdout.write(JSON.stringify(specs, null, 2))
+    const json = JSON.stringify(specs, null, 2)
+    
+    // Wait for stdout to finish writing before process.exit() is called
+    await new Promise<void>((resolve, reject) => {
+      process.stdout.write(json, (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
   },
 } satisfies CommandModule


### PR DESCRIPTION
## Summary

Fixes truncation of OpenAPI spec output at 64KB when piping to `jq` or `yq`.

## Problem

The `generate` command was writing JSON output to stdout without waiting for the write to complete. When the process exits via `process.exit()` in the finally block, stdout buffers are not fully flushed when writing to a pipe, causing output to be truncated at exactly 65,536 bytes (64KB).

**Before this fix:**
```bash
bun run src/index.ts generate | jq
# jq: parse error: Unfinished JSON term at EOF at line 2605, column 2
```

**After this fix:**
```bash
bun run src/index.ts generate | jq
# Successfully parses full 181KB spec
```

## Solution

Wait for the `process.stdout.write()` callback to complete before allowing the process to exit. This ensures all buffered data is flushed to the pipe.

## Testing

Verified that piping to both `jq` and `yq` now works correctly:
- `bun run src/index.ts generate | jq .` - ✅ parses successfully
- `bun run src/index.ts generate | yq -p json -o yaml` - ✅ converts successfully