### PR TITLE
fix: session rename functionality

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -2,6 +2,7 @@ import { TextareaRenderable, TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { onMount } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
 
 export type DialogPromptProps = {
   title: string
@@ -14,6 +15,13 @@ export function DialogPrompt(props: DialogPromptProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
   let textarea: TextareaRenderable
+
+  useKeyboard((evt) => {
+    if (evt.name === "return") {
+      props.onConfirm?.(textarea.plainText)
+      dialog.clear()
+    }
+  })
 
   onMount(() => {
     dialog.setSize("large")


### PR DESCRIPTION
Basically Enter key on the session rename dialog stopped working since v1.0.10.

Add `useKeyboard` hook to handle return key, fixing regression introduced when kitty keyboard was enabled.
Matches pattern used by `DialogAlert` and `DialogConfirm`.

Let me know if this was the right approach because I feel like I might be missing something.