### PR TITLE
Fix @ file tagging on new lines in both desktop and TUI

### DIFF
--- a/packages/desktop/src/components/prompt-input.tsx
+++ b/packages/desktop/src/components/prompt-input.tsx
@@ -125,31 +125,71 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const parseFromDOM = (): ContentPart[] => {
     const newParts: ContentPart[] = []
     let position = 0
-    editorRef.childNodes.forEach((node) => {
+
+    const visitNode = (node: Node) => {
       if (node.nodeType === Node.TEXT_NODE) {
         if (node.textContent) {
           const content = node.textContent
-          newParts.push({ type: "text", content, start: position, end: position + content.length })
-          position += content.length
-        }
-      } else if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).dataset.type) {
-        switch ((node as HTMLElement).dataset.type) {
-          case "file":
-            const content = node.textContent!
-            newParts.push({
-              type: "file",
-              path: (node as HTMLElement).dataset.path!,
-              content,
-              start: position,
-              end: position + content.length,
-            })
+          const last = newParts[newParts.length - 1]
+          if (last && last.type === "text") {
+            newParts[newParts.length - 1] = {
+              type: "text",
+              content: last.content + content,
+              start: last.start,
+              end: last.end + content.length,
+            }
             position += content.length
-            break
-          default:
-            break
+          } else {
+            newParts.push({ type: "text", content, start: position, end: position + content.length })
+            position += content.length
+          }
+        }
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as HTMLElement
+        if (element.dataset.type === "file") {
+          const content = node.textContent!
+          newParts.push({
+            type: "file",
+            path: element.dataset.path!,
+            content,
+            start: position,
+            end: position + content.length,
+          })
+          position += content.length
+        } else if (element.tagName === "BR") {
+          const last = newParts[newParts.length - 1]
+          if (last && last.type === "text") {
+            newParts[newParts.length - 1] = {
+              type: "text",
+              content: last.content + "\n",
+              start: last.start,
+              end: last.end + 1,
+            }
+          } else {
+            newParts.push({ type: "text", content: "\n", start: position, end: position + 1 })
+          }
+          position += 1
+        } else {
+          element.childNodes.forEach(visitNode)
+          if (element.tagName === "DIV" && element.nextSibling) {
+            const last = newParts[newParts.length - 1]
+            if (last && last.type === "text") {
+              newParts[newParts.length - 1] = {
+                type: "text",
+                content: last.content + "\n",
+                start: last.start,
+                end: last.end + 1,
+              }
+            } else {
+              newParts.push({ type: "text", content: "\n", start: position, end: position + 1 })
+            }
+            position += 1
+          }
         }
       }
-    })
+    }
+
+    editorRef.childNodes.forEach(visitNode)
     if (newParts.length === 0) newParts.push(...defaultParts)
     return newParts
   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -382,12 +382,14 @@ export function Autocomplete(props: {
         if (!store.visible) {
           if (e.name === "@") {
             const cursorOffset = props.input().visualCursor.offset
+            const atStartOfLine = props.input().logicalCursor.col === 0
             const charBeforeCursor =
               cursorOffset === 0
                 ? undefined
                 : props.input().getTextRange(cursorOffset - 1, cursorOffset)
 
             if (
+              atStartOfLine ||
               charBeforeCursor === " " ||
               charBeforeCursor === "\n" ||
               charBeforeCursor === undefined


### PR DESCRIPTION
Fixes #3860

## Changes

This PR fixes the issue where @ file tagging doesn't work on new lines in both the desktop and TUI components.

### Desktop Component
- Modified `parseFromDOM` in `packages/desktop/src/components/prompt-input.tsx` to recursively traverse nested DOM nodes
- Properly handles BR and DIV elements as newlines
- When you press Enter in the contenteditable div, the browser creates nested DIV elements, and the previous implementation only parsed direct child nodes

### TUI Component  
- Added explicit start-of-line check (`logicalCursor.col === 0`) in `packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx`
- The issue was that `getTextRange(cursorOffset - 1, cursorOffset)` wasn't returning "\n" at the start of a new line
- Now the autocomplete triggers correctly when @ is typed at the beginning of any line

## Demo


https://github.com/user-attachments/assets/70eeba1c-8312-4735-bbe0-41a24d32330c

---

**Link to Devin run:** https://cognition.devinenterprise.com/sessions/c432df81027546de8f1804d2655f6c6c
**Requested by:** Walden Yan (walden@cognition-labs.com) (@walnutwaldo)