### PR TITLE
Fix TUI ASCII rendering in tmux and add regression coverage

### DIFF
--- a/docs/tui-debug.md
+++ b/docs/tui-debug.md
@@ -1,0 +1,25 @@
+# TUI Debugging Notes
+
+Quick reminders for exercising the OpenTUI client while you diagnose rendering quirks or attachment behaviour.
+
+## Launching inside tmux
+- Start a dedicated session (`tmux new-session -s debug`) so you can detach and reattach while iterating.
+- From the repo root, run `bun run packages/opencode/src/index.ts`.
+- If dependencies are missing, run `bun install` once, then retry.
+
+## Handy environment toggles
+- By default, running inside tmux automatically enables ASCII rendering (unless you override it). Disable with `OPENCODE_TUI_ASCII=0` if you prefer the styled renderer.
+- `OPENCODE_TUI_ASCII=1` forces ASCII mode regardless of the terminal; we automatically fall back to the styled renderer when stdout isn’t a TTY.
+- `OPENCODE_TUI_NO_ALT_SCREEN=1` keeps OpenTUI on the primary screen buffer; handy for non-ASCII captures or when you want Bash commands to leave scrollback.
+
+## Reproduction checklist
+- Use `shift+enter` (or `ctrl+j`) to insert literal newlines without submitting.
+- Trigger `@` completions on blank lines and inline text to confirm behaviour is consistent.
+- Submit a test prompt after each change and skim the transcript for unexpected attachments or spacing artefacts.
+
+## Capturing evidence
+- Break down user-supplied videos with `ffmpeg -i demo.mov -vf fps=1 tmp/frames/frame_%03d.png` to reason about individual frames.
+- In ASCII mode, prefer reading the output directly inside tmux (the frame uses shaded block glyphs; raw files look noisy). If you need a log, `tmux pipe-pane -o -t dev 'cat >> ascii.log'` records frames and messages.
+- Always `tmux kill-session -t dev` once you’re finished so stray ASCII loops don’t keep running.
+
+_Last updated: November 4, 2025_

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,8 +1,8 @@
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
-import { TextAttributes } from "@opentui/core"
+import { TextAttributes, clearEnvCache } from "@opentui/core"
 import { RouteProvider, useRoute, type Route } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal } from "solid-js"
+import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onCleanup } from "solid-js"
 import { Installation } from "@/installation"
 import { Global } from "@/global"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -28,6 +28,9 @@ import type { SessionRoute } from "./context/route"
 import { Session as SessionApi } from "@/session"
 import { TuiEvent } from "./event"
 import { KVProvider, useKV } from "./context/kv"
+import { bufferToAscii, type AsciiBuffer } from "./ascii"
+
+let asciiModeGlobal = false
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -100,6 +103,27 @@ export function tui(input: {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
     const mode = await getTerminalBackgroundColor()
+    const asciiEnv = process.env.OPENCODE_TUI_ASCII?.toLowerCase()
+    const asciiExplicit =
+      asciiEnv === "1" || asciiEnv === "true"
+        ? true
+        : asciiEnv === "0" || asciiEnv === "false"
+          ? false
+          : undefined
+    const asciiAuto = asciiExplicit !== false && asciiExplicit !== true && !!process.env.TMUX
+    const asciiRequested = asciiExplicit ?? asciiAuto
+    const asciiSupported = asciiRequested && process.stdout.isTTY === true
+    asciiModeGlobal = !!asciiSupported
+    if (asciiModeGlobal) {
+      process.env.OTUI_NO_NATIVE_RENDER = "1"
+    } else {
+      delete process.env.OTUI_NO_NATIVE_RENDER
+    }
+    const disableAltScreenEnv =
+      process.env.OPENCODE_TUI_NO_ALT_SCREEN?.toLowerCase() === "1" ||
+      process.env.OPENCODE_TUI_NO_ALT_SCREEN?.toLowerCase() === "true"
+    const disableAltScreen = asciiModeGlobal || disableAltScreenEnv
+    clearEnvCache()
 
     const routeData: Route | undefined = input.sessionID
       ? {
@@ -158,6 +182,8 @@ export function tui(input: {
         gatherStats: false,
         exitOnCtrlC: false,
         useKittyKeyboard: true,
+        useAlternateScreen: !disableAltScreen,
+        useConsole: asciiModeGlobal ? false : !disableAltScreen,
       },
     )
   })
@@ -168,6 +194,26 @@ function App() {
   const dimensions = useTerminalDimensions()
   const renderer = useRenderer()
   renderer.disableStdoutInterception()
+  const asciiMode = asciiModeGlobal
+  if (asciiMode) {
+    renderer.useConsole = false
+  }
+  createEffect(() => {
+    if (!asciiMode) return
+    let previous = ""
+    const tick = async (_delta: number) => {
+      if ((renderer as any)._isDestroyed) return
+      const buffer = (renderer as any).currentRenderBuffer as AsciiBuffer | undefined
+      if (!buffer) return
+      const frame = bufferToAscii(buffer)
+      if (frame === previous) return
+      previous = frame
+      process.stdout.write("\x1b[H\x1b[2J\x1b[H")
+      process.stdout.write(frame)
+    }
+    renderer.setFrameCallback(tick)
+    onCleanup(() => renderer.removeFrameCallback(tick))
+  })
   const dialog = useDialog()
   const local = useLocal()
   const kv = useKV()

--- a/packages/opencode/src/cli/cmd/tui/ascii.ts
+++ b/packages/opencode/src/cli/cmd/tui/ascii.ts
@@ -1,0 +1,11 @@
+const asciiDecoder = new TextDecoder()
+
+export type AsciiBuffer = {
+  getRealCharBytes(addLineBreaks: boolean): Uint8Array
+}
+
+export function bufferToAscii(buffer: AsciiBuffer): string {
+  const bytes = buffer.getRealCharBytes(true)
+  if (!bytes || bytes.length === 0) return ""
+  return asciiDecoder.decode(bytes)
+}

--- a/packages/opencode/test/tui/ascii.test.ts
+++ b/packages/opencode/test/tui/ascii.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { bufferToAscii, type AsciiBuffer } from "@/cli/cmd/tui/ascii"
+
+const encoder = new TextEncoder()
+
+describe("bufferToAscii", () => {
+  test("returns decoded frame bytes", () => {
+    const frame = "AB C\n"
+    const stub: AsciiBuffer = {
+      getRealCharBytes: (_addLineBreaks: boolean) => encoder.encode(frame),
+    }
+
+    expect(bufferToAscii(stub)).toBe(frame)
+  })
+})


### PR DESCRIPTION
## Summary
- automatically enable ASCII rendering whenever OpenTUI runs inside tmux (with an override via `OPENCODE_TUI_ASCII`)
- stream frames through a small helper that decodes `getRealCharBytes` output, making tmux captures readable again
- add a regression test around the helper to keep the decoding pathway honest
- refresh `docs/tui-debug.md` with the latest ASCII-mode tips: auto-enable behaviour, capture advice, and cleanup checklist

## Testing
- bun test --filter ascii
- tmux new-session -s ascii 'cd /Users/steipete/Projects/opencode && OPENCODE_TUI_ASCII=1 OPENCODE_TUI_NO_ALT_SCREEN=1 bun dev'
