### PR TITLE
feat(tui): minimal scroll wheel config + wiring (accel mode, scale, max cap)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -119,7 +119,7 @@ export function Session() {
   const keybind = useKeybind()
 
   const scrollAcceleration = createMemo(() => {
-    const t = sync.data.config.tui ?? {}
+    const t = (sync.data.config.tui ?? {}) as any
     const mode = t["scroll_wheel_acceleration"] as "linear" | "mac" | undefined
     const scale = (t["scroll_wheel_scale"] as number | undefined) ?? 1
     const maxMul = t["scroll_wheel_max_multiplier"] as number | undefined

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -16,7 +16,13 @@ import { useRoute, useRouteData } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { SplitBorder } from "@tui/component/border"
 import { useTheme } from "@tui/context/theme"
-import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers } from "@opentui/core"
+import {
+  BoxRenderable,
+  ScrollBoxRenderable,
+  addDefaultParsers,
+  LinearScrollAccel,
+  MacOSScrollAccel,
+} from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type {
   AssistantMessage,
@@ -111,6 +117,28 @@ export function Session() {
   let scroll: ScrollBoxRenderable
   let prompt: PromptRef
   const keybind = useKeybind()
+
+  const scrollAcceleration = createMemo(() => {
+    const t = sync.data.config.tui ?? {}
+    const mode = t["scroll_wheel_acceleration"] as "linear" | "mac" | undefined
+    const scale = (t["scroll_wheel_scale"] as number | undefined) ?? 1
+    const maxMul = t["scroll_wheel_max_multiplier"] as number | undefined
+    const base =
+      mode === "linear"
+        ? new LinearScrollAccel()
+        : new MacOSScrollAccel(maxMul ? { maxMultiplier: maxMul } : undefined)
+    if (scale === 1) return base as any
+    const b = base as any
+    return {
+      tick(now?: number) {
+        const v = typeof b.tick === "function" ? b.tick(now) : 1
+        return v * scale
+      },
+      reset() {
+        if (typeof b.reset === "function") b.reset()
+      },
+    } as any
+  })
 
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
@@ -529,6 +557,7 @@ export function Session() {
               stickyScroll={true}
               stickyStart="bottom"
               flexGrow={1}
+              scrollAcceleration={scrollAcceleration()}
             >
               <For each={messages()}>
                 {(message, index) => (

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -1,9 +1,17 @@
-import { InputRenderable, RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import {
+  InputRenderable,
+  RGBA,
+  ScrollBoxRenderable,
+  TextAttributes,
+  LinearScrollAccel,
+  MacOSScrollAccel,
+} from "@opentui/core"
 import { useTheme } from "@tui/context/theme"
 import { entries, filter, flatMap, groupBy, pipe, take } from "remeda"
 import { batch, createEffect, createMemo, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
+import { useSync } from "@tui/context/sync"
 import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
@@ -46,6 +54,7 @@ export type DialogSelectRef<T> = {
 export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const sync = useSync()
   const [store, setStore] = createStore({
     selected: 0,
     filter: "",
@@ -148,6 +157,27 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   })
 
   let scroll: ScrollBoxRenderable
+  const scrollAcceleration = createMemo(() => {
+    const t = sync.data.config.tui ?? {}
+    const mode = t["scroll_wheel_acceleration"] as "linear" | "mac" | undefined
+    const scale = (t["scroll_wheel_scale"] as number | undefined) ?? 1
+    const maxMul = t["scroll_wheel_max_multiplier"] as number | undefined
+    const base =
+      mode === "linear"
+        ? new LinearScrollAccel()
+        : new MacOSScrollAccel(maxMul ? { maxMultiplier: maxMul } : undefined)
+    if (scale === 1) return base as any
+    const b = base as any
+    return {
+      tick(now?: number) {
+        const v = typeof b.tick === "function" ? b.tick(now) : 1
+        return v * scale
+      },
+      reset() {
+        if (typeof b.reset === "function") b.reset()
+      },
+    } as any
+  })
   const ref: DialogSelectRef<T> = {
     get filter() {
       return store.filter
@@ -193,6 +223,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         scrollbarOptions={{ visible: false }}
         ref={(r: ScrollBoxRenderable) => (scroll = r)}
         maxHeight={height()}
+        scrollAcceleration={scrollAcceleration()}
       >
         <For each={grouped()}>
           {([category, options], index) => (

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -158,7 +158,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   let scroll: ScrollBoxRenderable
   const scrollAcceleration = createMemo(() => {
-    const t = sync.data.config.tui ?? {}
+    const t = (sync.data.config.tui ?? {}) as any
     const mode = t["scroll_wheel_acceleration"] as "linear" | "mac" | undefined
     const scale = (t["scroll_wheel_scale"] as number | undefined) ?? 1
     const maxMul = t["scroll_wheel_max_multiplier"] as number | undefined

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -492,6 +492,20 @@ export namespace Config {
 
   export const TUI = z.object({
     scroll_speed: z.number().min(1).optional().default(2).describe("TUI scroll speed"),
+    scroll_wheel_acceleration: z
+      .enum(["linear", "mac"]) // linear disables acceleration; mac uses macOS-style acceleration
+      .optional()
+      .describe("Mouse wheel acceleration mode for TUI scrollboxes"),
+    scroll_wheel_scale: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Scale factor applied to wheel scrolling (e.g. 0.5 to slow down)"),
+    scroll_wheel_max_multiplier: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Cap for mac acceleration multiplier (lower = less sensitive)"),
   })
 
   export const Layout = z.enum(["auto", "stretch"]).meta({


### PR DESCRIPTION
This PR adds a tiny, backwards‑compatible set of TUI scroll wheel settings and wires them into the two ScrollBox usages. Defaults preserve existing behavior.\n\nWhat’s included (minimal diff):\n- Config schema (TUI):\n  - : 'linear' | 'mac' (optional)\n  - : number (optional, global gain)\n  - : number (optional, mac cap)\n- TUI integration (2 places):\n  - routes/session/index.tsx — pass configured  to main scrollbox\n  - ui/dialog-select.tsx — pass configured  to dialog scrollbox\n  - Implementation is a tiny wrapper: choose Linear/Mac from @opentui/core, optionally pass , then return .\n\nNot included (on purpose):\n- No custom shaping/gating/deadzones\n- No changes to OpenTUI libs\n- No docs changes (can follow existing  docs pattern in a follow‑up if preferred)\n\nCompatibility:\n- All fields are optional; when unset, behavior is unchanged (macOS still uses MacOSScrollAccel by default).\n\nRationale:\n- Users on some terminals/machines perceive wheel sensitivity as too high. These three knobs allow per‑user tuning without changing defaults or forking OpenTUI.\n\nFiles touched:\n- packages/opencode/src/config/config.ts\n- packages/opencode/src/cli/cmd/tui/routes/session/index.tsx\n- packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx\n\nHappy to add a short blurb to the config docs if maintainers prefer.