### PR TITLE
[FIX]: Refocus prompt after session delete

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -72,6 +72,7 @@ export function DialogSessionList() {
                 },
               })
               setToDelete(undefined)
+              dialog.clear()
               return
             }
             setToDelete(option.value)


### PR DESCRIPTION
closes #3825 

This PR adds the missing dialog.clear() call to the onTrigger handler for the delete keybind.
The dialog component's built-in clear() function already handles restoring focus to the previously active element (the prompt), so this one-line change correctly fixes the focus regression.

https://github.com/user-attachments/assets/e767582e-a7c2-4588-b4db-d471cbf38231

