### PR TITLE
feat: add keybindings reference dialog to TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -15,6 +15,7 @@ import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
+import { DialogKeybindings } from "@tui/component/dialog-keybindings"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
@@ -431,6 +432,15 @@ function App() {
       value: "help.show",
       onSelect: () => {
         dialog.replace(() => <DialogHelp />)
+      },
+      category: "System",
+    },
+    {
+      title: "Show keybindings",
+      value: "help.keybindings",
+      keybind: "keybindings_list",
+      onSelect: () => {
+        dialog.replace(() => <DialogKeybindings />)
       },
       category: "System",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-keybindings.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-keybindings.tsx
@@ -1,0 +1,50 @@
+import { createMemo } from "solid-js"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { useDialog } from "@tui/ui/dialog"
+import { useKeybind } from "@tui/context/keybind"
+import type { KeybindsConfig } from "@opencode-ai/sdk/v2"
+import { zodToJsonSchema } from "zod-to-json-schema"
+import { Config } from "@/config/config"
+
+// Dynamically extract keybinding descriptions from the config schema
+// This ensures descriptions stay in sync with the schema definitions
+function getKeybindDescriptions(): Record<string, string> {
+  const jsonSchema = zodToJsonSchema(Config.Keybinds) as any
+  const descriptions: Record<string, string> = {}
+
+  for (const [key, schema] of Object.entries(jsonSchema.properties || {})) {
+    descriptions[key] = (schema as any).description || key
+  }
+
+  return descriptions
+}
+
+const KEYBIND_DESCRIPTIONS = getKeybindDescriptions()
+
+export function DialogKeybindings() {
+  const keybind = useKeybind()
+  const dialog = useDialog()
+
+  // Get all keybindings and map them to options
+  const options = createMemo(() =>
+    Object.keys(keybind.all)
+      .filter((key) => key !== "leader") // Exclude the leader key itself
+      .map((key) => {
+        const typedKey = key as keyof KeybindsConfig
+        return {
+          title: KEYBIND_DESCRIPTIONS[typedKey] || key,
+          value: key,
+          footer: keybind.print(typedKey),
+        }
+      })
+      .sort((a, b) => a.title.localeCompare(b.title)), // Sort alphabetically by title
+  )
+
+  return (
+    <DialogSelect
+      title="Keybindings"
+      options={options()}
+      onSelect={() => dialog.clear()}
+    />
+  )
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -551,6 +551,7 @@ export namespace Config {
       model_cycle_favorite: z.string().optional().default("none").describe("Next favorite model"),
       model_cycle_favorite_reverse: z.string().optional().default("none").describe("Previous favorite model"),
       command_list: z.string().optional().default("ctrl+p").describe("List available commands"),
+      keybindings_list: z.string().optional().default("<leader>?").describe("Show all keybindings"),
       agent_list: z.string().optional().default("<leader>a").describe("List agents"),
       agent_cycle: z.string().optional().default("tab").describe("Next agent"),
       agent_cycle_reverse: z.string().optional().default("shift+tab").describe("Previous agent"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -981,6 +981,10 @@ export type KeybindsConfig = {
    */
   command_list?: string
   /**
+   * Show all keybindings
+   */
+  keybindings_list?: string
+  /**
    * List agents
    */
   agent_list?: string


### PR DESCRIPTION
## Problem

When using the TUI, there's no easy way to discover what keybindings are available. Users have to check documentation or dig through config files to find out what shortcuts they can use.

## Solution

Added a searchable keybindings dialog accessible via `<leader>?` that displays all 88 keybindings with their descriptions.

## What Changed

- Created `dialog-keybindings.tsx` using the existing `DialogSelect` component
- Added `keybindings_list` config option (default: `<leader>?` = ctrl+x + ?)
- Registered in command palette under "System" category
- Descriptions dynamically extracted from config schema using `zodToJsonSchema`

## How to Use

**Via Keybinding:** Press `ctrl+x` then `?`  
**Via Command Palette:** Press `ctrl+p`, type "keybindings"

## Implementation

Follows existing patterns:
- Reuses `DialogSelect` component (same as model/theme lists)
- Fetches keybindings from `useKeybind()` hook
- Alphabetically sorted and searchable by default
- Descriptions stay in sync with schema automatically (single source of truth)

Fixes #3886