### PR TITLE
fix: correct history_next keybinding description

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -473,7 +473,7 @@ export namespace Config {
         .default("shift+return,ctrl+j")
         .describe("Insert newline in input"),
       history_previous: z.string().optional().default("up").describe("Previous history item"),
-      history_next: z.string().optional().default("down").describe("Previous history item"),
+      history_next: z.string().optional().default("down").describe("Next history item"),
       session_child_cycle: z
         .string()
         .optional()


### PR DESCRIPTION
Found this typo while filing https://github.com/sst/opencode/pull/3888.

The `history_next` keybinding description incorrectly said "Previous history item" when it should say "Next history item".

The keybinding uses down arrow (default) and moves forward through history to newer items, so "Next" is the correct description.