### PR TITLE
Add support for `uv format` in formatters

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -177,6 +177,21 @@ export const ruff: Info = {
   },
 }
 
+export const uvformat: Info = {
+  name: "uv format",
+  command: ["uv", "format", "--", "$FILE"],
+  extensions: [".py", ".pyi"],
+  async enabled() {
+    if (await ruff.enabled()) return false
+    if (Bun.which("uv") !== null) {
+      const proc = Bun.spawn(["uv", "format", "--help"], { stderr: "pipe", stdout: "pipe" })
+      const code = await proc.exited
+      return code === 0
+    }
+    return false
+  },
+}
+
 export const rubocop: Info = {
   name: "rubocop",
   command: ["rubocop", "--autocorrect", "$FILE"],

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -21,6 +21,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | clang-format   | .c, .cpp, .h, .hpp, .ino, and [more](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config file             |
 | ktlint         | .kt, .kts                                                                                                | `ktlint` command available              |
 | ruff           | .py, .pyi                                                                                                | `ruff` command available with config    |
+| uv             | .py, .pyi                                                                                                | `uv` command available                  |
 | rubocop        | .rb, .rake, .gemspec, .ru                                                                                | `rubocop` command available             |
 | standardrb     | .rb, .rake, .gemspec, .ru                                                                                | `standardrb` command available          |
 | htmlbeautifier | .erb, .html.erb                                                                                          | `htmlbeautifier` command available      |


### PR DESCRIPTION
Astral recently added a new command in uv called `uv format`. This command is a proxy for ruff, but does not require ruff to be installed separately.

https://docs.astral.sh/uv/reference/cli/#uv-format

This PR introduces support for uv format in the formatters list.

Because this feature is relatively new (released in 0.8.13) and is still in preview, the `enabled` check tests for the presence of the `format` command.

If ruff is enabled, the uv formatter will automatically be disabled so that double formatting does not occur.

Discord thread: https://discord.com/channels/1391832426048651334/1435373893060923544