### PR TITLE
fix(tui): use repo root as default dir in dev mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/spawn.ts
+++ b/packages/opencode/src/cli/cmd/tui/spawn.ts
@@ -3,6 +3,7 @@ import { Instance } from "@/project/instance"
 import path from "path"
 import { Server } from "@/server/server"
 import { upgrade } from "@/cli/upgrade"
+import { Installation } from "@/installation"
 
 export const TuiSpawnCommand = cmd({
   command: "spawn [project]",
@@ -41,7 +42,16 @@ export const TuiSpawnCommand = cmd({
       )
       cwd = new URL("../../../../", import.meta.url).pathname
     } else cmd.push(process.execPath)
-    cmd.push("attach", server.url.toString(), "--dir", args.project ? path.resolve(args.project) : process.cwd())
+    cmd.push(
+      "attach",
+      server.url.toString(),
+      "--dir",
+      args.project
+        ? path.resolve(args.project)
+        : Installation.isLocal()
+          ? path.resolve(process.cwd(), "../..")
+          : process.cwd(),
+    )
     const proc = Bun.spawn({
       cmd,
       cwd,

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -7,6 +7,7 @@ import { Session } from "@/session"
 import { bootstrap } from "@/cli/bootstrap"
 import path from "path"
 import { UI } from "@/cli/ui"
+import { Installation } from "@/installation"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -64,7 +65,11 @@ export const TuiThreadCommand = cmd({
 
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
     const baseCwd = process.env.PWD ?? process.cwd()
-    const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
+    const cwd = args.project
+      ? path.resolve(baseCwd, args.project)
+      : Installation.isLocal()
+        ? path.resolve(process.cwd(), "../..")
+        : process.cwd()
     let workerPath: string | URL = new URL("./worker.ts", import.meta.url)
 
     if (typeof OPENCODE_WORKER_PATH !== "undefined") {


### PR DESCRIPTION
This was an unintentional regression with opentui similar to #3777

Before "bun dev" would start with the project dir set to ./

...but now it's ./packages/opencode

This can cause some confusion as there is an AGENTS.md in the repo root.

When `Installation.isLocal()` returns true (dev mode), the default directory is now: ```typescript path.resolve(process.cwd(), "../..") ```

This means when running `bun dev` from the root with `--cwd packages/opencode`, the working directory will be correctly set to the repo root (`./`) instead of `./packages/opencode`, ensuring the root AGENTS.md file is properly accessible.

Fixes: #3922