### PR TITLE
docs: include "limit" example 

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -963,6 +963,40 @@ Here's an example setting the `apiKey` and `headers` options.
 
 We are setting the `apiKey` using the `env` variable syntax, [learn more](/docs/config#env-vars).
 
+Here's an example setting the model limits for `context` and `output` tokens.
+These parameters are used to display the session context pecentage and for
+auto-session compaction (they are pulled in from models.dev for standard providers)
+
+```json title="opencode.json" {9,11}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "myprovider": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "My AI ProviderDisplay Name",
+      "options": {
+        "baseURL": "https://api.myprovider.com/v1",
+        "apiKey": "{env:ANTHROPIC_API_KEY}",
+        "headers": {
+          "Authorization": "Bearer custom-token"
+        }
+      },
+      "models": {
+        "my-model-name": {
+          "name": "My Model Display Name",
+          "limit": {
+            "context": 200000,
+            "output": 65536
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+
+
 ---
 
 ## Troubleshooting

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -934,9 +934,9 @@ You can use any OpenAI-compatible provider with opencode. Most modern AI provide
 
 ##### Example
 
-Here's an example setting the `apiKey` and `headers` options.
+Here's an example setting the `apiKey`, `headers`, and model `limit` options.
 
-```json title="opencode.json" {9,11}
+```json title="opencode.json" {9,11,17-20}
 {
   "$schema": "https://opencode.ai/config.json",
   "provider": {
@@ -952,7 +952,11 @@ Here's an example setting the `apiKey` and `headers` options.
       },
       "models": {
         "my-model-name": {
-          "name": "My Model Display Name"
+          "name": "My Model Display Name",
+          "limit": {
+            "context": 200000,
+            "output": 65536
+          }
         }
       }
     }
@@ -960,28 +964,14 @@ Here's an example setting the `apiKey` and `headers` options.
 }
 ```
 
-We are setting the `apiKey` using the `env` variable syntax, [learn more](/docs/config#env-vars).
+Configuration details:
 
-You can also set model limits to enable context tracking and auto-compaction.
+- **apiKey**: Set using `env` variable syntax, [learn more](/docs/config#env-vars).
+- **headers**: Custom headers sent with each request.
+- **limit.context**: Maximum input tokens the model accepts.
+- **limit.output**: Maximum tokens the model can generate.
 
-```json title="opencode.json" {4-7}
-"models": {
-  "my-model-name": {
-    "name": "My Model Display Name",
-    "limit": {
-      "context": 200000,
-      "output": 65536
-    }
-  }
-}
-```
-
-The `limit` fields control context management:
-
-- **context**: Maximum input tokens the model accepts.
-- **output**: Maximum tokens the model can generate.
-
-These values display session context percentage and trigger auto-compaction. Standard providers pull these from models.dev automatically.
+The `limit` fields display session context percentage and trigger auto-compaction. Standard providers pull these from models.dev automatically.
 
 ---
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -482,7 +482,6 @@ To use Google Vertex AI with OpenCode:
 
 4. Run the `/models` command to select a model like _Kimi-K2-Instruct_ or _GLM-4.6_.
 
-
 ---
 
 ### LM Studio
@@ -963,39 +962,26 @@ Here's an example setting the `apiKey` and `headers` options.
 
 We are setting the `apiKey` using the `env` variable syntax, [learn more](/docs/config#env-vars).
 
-Here's an example setting the model limits for `context` and `output` tokens.
-These parameters are used to display the session context pecentage and for
-auto-session compaction (they are pulled in from models.dev for standard providers)
+You can also set model limits to enable context tracking and auto-compaction.
 
-```json title="opencode.json" {9,11}
-{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "myprovider": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "My AI ProviderDisplay Name",
-      "options": {
-        "baseURL": "https://api.myprovider.com/v1",
-        "apiKey": "{env:ANTHROPIC_API_KEY}",
-        "headers": {
-          "Authorization": "Bearer custom-token"
-        }
-      },
-      "models": {
-        "my-model-name": {
-          "name": "My Model Display Name",
-          "limit": {
-            "context": 200000,
-            "output": 65536
-          }
-        }
-      }
+```json title="opencode.json" {4-7}
+"models": {
+  "my-model-name": {
+    "name": "My Model Display Name",
+    "limit": {
+      "context": 200000,
+      "output": 65536
     }
   }
 }
 ```
 
+The `limit` fields control context management:
 
+- **context**: Maximum input tokens the model accepts.
+- **output**: Maximum tokens the model can generate.
+
+These values display session context percentage and trigger auto-compaction. Standard providers pull these from models.dev automatically.
 
 ---
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -971,7 +971,7 @@ Configuration details:
 - **limit.context**: Maximum input tokens the model accepts.
 - **limit.output**: Maximum tokens the model can generate.
 
-The `limit` fields display session context percentage and trigger auto-compaction. Standard providers pull these from models.dev automatically.
+The `limit` fields allow OpenCode to understand how much context you have left. Standard providers pull these from models.dev automatically.
 
 ---
 


### PR DESCRIPTION
When using a custom provider, the percentage-of-context-used was always showing zero; also auto-compact was not running when it should.  After a bit of digging I found this can be corrected for by configuring the the model limits in the configuration file.   I've added an example with some sample values to illustrate this.