### PR TITLE
fix(tui): Revamp keybinds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -2,7 +2,7 @@ import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentu
 import { Clipboard } from "@tui/util/clipboard"
 import { TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute, type Route } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal } from "solid-js"
+import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount } from "solid-js"
 import { Installation } from "@/installation"
 import { Global } from "@/global"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -16,7 +16,7 @@ import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
-import { KeybindProvider } from "@tui/context/keybind"
+import { KeybindProvider, useKeybind } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
@@ -103,9 +103,9 @@ export function tui(input: {
 
     const routeData: Route | undefined = input.sessionID
       ? {
-          type: "session",
-          sessionID: input.sessionID,
-        }
+        type: "session",
+        sessionID: input.sessionID,
+      }
       : undefined
 
     const onExit = async () => {
@@ -178,18 +178,15 @@ function App() {
   const [sessionExists, setSessionExists] = createSignal(false)
   const { theme, mode, setMode } = useTheme()
   const exit = useExit()
+  const keybind = useKeybind()
 
-  useKeyboard(async (evt) => {
-    if (!Installation.isLocal()) return
-    if (evt.meta && evt.name === "t") {
+  onMount(() => {
+    keybind.keybinds.global.console_toggle.setHandler(() => renderer.console.toggle())
+    keybind.keybinds.global.toggle_debug_ovelay.setHandler(async () => {
+      if (!Installation.isLocal()) return false
       renderer.toggleDebugOverlay()
-      return
-    }
-
-    if (evt.meta && evt.name === "d") {
-      renderer.console.toggle()
-      return
-    }
+      return true
+    })
   })
 
   // Make sure session is valid, otherwise redirect to home

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -4,10 +4,10 @@ import { useRoute } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { createMemo, createSignal, onMount } from "solid-js"
 import { Locale } from "@/util/locale"
-import { Keybind } from "@/util/keybind"
 import { useTheme } from "../context/theme"
 import { useSDK } from "../context/sdk"
 import { DialogSessionRename } from "./dialog-session-rename"
+import { useKeybind } from "../context/keybind"
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -15,10 +15,9 @@ export function DialogSessionList() {
   const { theme } = useTheme()
   const route = useRoute()
   const sdk = useSDK()
+  const keybind = useKeybind()
 
   const [toDelete, setToDelete] = createSignal<string>()
-
-  const deleteKeybind = "ctrl+d"
 
   const options = createMemo(() => {
     const today = new Date().toDateString()
@@ -32,7 +31,7 @@ export function DialogSessionList() {
         }
         const isDeleting = toDelete() === x.id
         return {
-          title: isDeleting ? `Press ${deleteKeybind} again to confirm` : x.title,
+          title: isDeleting ? `Press ${keybind.keybinds.dialog.session.delete} again to confirm` : x.title,
           bg: isDeleting ? theme.error : undefined,
           value: x.id,
           category,
@@ -62,7 +61,7 @@ export function DialogSessionList() {
       }}
       keybind={[
         {
-          keybind: Keybind.parse(deleteKeybind)[0],
+          keybind: keybind.keybinds.dialog.session.delete,
           title: "delete",
           onTrigger: async (option) => {
             if (toDelete() === option.value) {
@@ -79,7 +78,7 @@ export function DialogSessionList() {
           },
         },
         {
-          keybind: Keybind.parse("ctrl+r")[0],
+          keybind: keybind.keybinds.dialog.session.rename,
           title: "rename",
           onTrigger: async (option) => {
             dialog.replace(() => <DialogSessionRename session={option.value} />)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -65,10 +65,8 @@ export function Prompt(props: PromptProps) {
 
   const textareaKeybindings = createMemo(() => {
     const newlineBindings = keybind.all.input_newline || []
-    const submitBindings = keybind.all.input_submit || []
 
     return [
-      { name: "return", action: "submit" },
       { name: "return", meta: true, action: "newline" },
       ...newlineBindings.map((binding) => ({
         name: binding.name,
@@ -76,13 +74,6 @@ export function Prompt(props: PromptProps) {
         meta: binding.meta || undefined,
         shift: binding.shift || undefined,
         action: "newline" as const,
-      })),
-      ...submitBindings.map((binding) => ({
-        name: binding.name,
-        ctrl: binding.ctrl || undefined,
-        meta: binding.meta || undefined,
-        shift: binding.shift || undefined,
-        action: "submit" as const,
       })),
     ]
   })
@@ -540,6 +531,10 @@ export function Prompt(props: PromptProps) {
               keyBindings={textareaKeybindings()}
               onKeyDown={async (e: KeyEvent) => {
                 if (props.disabled) {
+                  e.preventDefault()
+                  return
+                }
+                if (e.name === "return") {
                   e.preventDefault()
                   return
                 }

--- a/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
@@ -7,17 +7,105 @@ import type { ParsedKey, Renderable } from "@opentui/core"
 import { createStore } from "solid-js/store"
 import { useKeyboard, useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
+import { PRIORITY, state } from "./keybind_"
+import { Config } from "@/config/config"
 
 export const { use: useKeybind, provider: KeybindProvider } = createSimpleContext({
   name: "Keybind",
   init: () => {
     const sync = useSync()
-    const keybinds = createMemo(() => {
+    const userKeybinds = createMemo(() => {
       return pipe(
         sync.data.config.keybinds ?? {},
         mapValues((value) => Keybind.parse(value)),
       )
     })
+
+    useKeyboard(async (evt) => {
+      if (!store.leader && result.match("leader", evt)) {
+        leader(true)
+        return
+      }
+
+      if (store.leader && evt.name) {
+        setImmediate(() => {
+          if (focus && renderer.currentFocusedRenderable === focus) {
+            focus.focus()
+          }
+          leader(false)
+        })
+      }
+    })
+
+    function parse(evt: ParsedKey): Keybind.Info {
+      if (evt.name === "\x1F")
+        return {
+          ctrl: true,
+          name: "_",
+          shift: false,
+          leader: false,
+          meta: false,
+        }
+      return {
+        ctrl: evt.ctrl,
+        name: evt.name,
+        shift: evt.shift,
+        leader: store.leader,
+        meta: evt.meta,
+      }
+    }
+
+    // TODO: I will make the contents of state inline later
+    const _KeybindRegistration = state(parse, () => userKeybinds().leader![0]!)
+
+    const keybinds = createMemo(() => ({
+      global: {
+        ...pipe(
+          sync.data.config.keybinds ?? {},
+          mapValues((value) => new _KeybindRegistration(value))
+        ),
+        command_list: new _KeybindRegistration(sync.data.config.keybinds?.command_list ?? Config.Keybinds.parse({}).command_list, PRIORITY.COMMAND_LIST),
+        console_toggle: new _KeybindRegistration("meta+shift+d"),
+        toggle_debug_ovelay: new _KeybindRegistration("meta+t"),
+      },
+      permission: {
+        once: new _KeybindRegistration("return"),
+        always: new _KeybindRegistration("a"),
+        reject: new _KeybindRegistration(["d", "escape"]),
+      },
+      itemSelection: {
+        up: new _KeybindRegistration(["up", "ctrl+p"], PRIORITY.DIALOG),
+        down: new _KeybindRegistration(["down", "ctrl+n"], PRIORITY.DIALOG),
+        pageup: new _KeybindRegistration("pageup", PRIORITY.DIALOG),
+        pagedown: new _KeybindRegistration("pagedown", PRIORITY.DIALOG),
+        return: new _KeybindRegistration("return", PRIORITY.DIALOG),
+        cancel: new _KeybindRegistration("escape", PRIORITY.DIALOG),
+        select: new _KeybindRegistration(["return", "tab"], PRIORITY.DIALOG),
+      },
+      autocomplete: {
+        "@": new _KeybindRegistration("@"),
+        "/": new _KeybindRegistration("/"),
+      },
+      dialog: {
+        close: new _KeybindRegistration("escape", PRIORITY.DIALOG),
+        help: {
+          close: new _KeybindRegistration(["escape", "return"], PRIORITY.DIALOG),
+        },
+        alert: {
+          close: new _KeybindRegistration(["return"], PRIORITY.DIALOG),
+        },
+        confirm: {
+          submit: new _KeybindRegistration("return", PRIORITY.DIALOG),
+          // TODO: feature suggestion: add tab?
+          cycleFocusedButton: new _KeybindRegistration(["left", "right"], PRIORITY.DIALOG),
+        },
+        session: {
+          delete: new _KeybindRegistration("ctrl+d", PRIORITY.DIALOG),
+          rename: new _KeybindRegistration("ctrl+r", PRIORITY.DIALOG)
+        },
+      }
+    } as const))
+
     const [store, setStore] = createStore({
       leader: false,
     })
@@ -49,48 +137,18 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
       }
     }
 
-    useKeyboard(async (evt) => {
-      if (!store.leader && result.match("leader", evt)) {
-        leader(true)
-        return
-      }
-
-      if (store.leader && evt.name) {
-        setImmediate(() => {
-          if (focus && renderer.currentFocusedRenderable === focus) {
-            focus.focus()
-          }
-          leader(false)
-        })
-      }
-    })
-
     const result = {
       get all() {
-        return keybinds()
+        return userKeybinds()
       },
       get leader() {
         return store.leader
       },
       parse(evt: ParsedKey): Keybind.Info {
-        if (evt.name === "\x1F")
-          return {
-            ctrl: true,
-            name: "_",
-            shift: false,
-            leader: false,
-            meta: false,
-          }
-        return {
-          ctrl: evt.ctrl,
-          name: evt.name,
-          shift: evt.shift,
-          leader: store.leader,
-          meta: evt.meta,
-        }
+        return parse(evt)
       },
       match(key: keyof KeybindsConfig, evt: ParsedKey) {
-        const keybind = keybinds()[key]
+        const keybind = userKeybinds()[key]
         if (!keybind) return false
         const parsed: Keybind.Info = result.parse(evt)
         for (const key of keybind) {
@@ -100,12 +158,16 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
         }
       },
       print(key: keyof KeybindsConfig) {
-        const first = keybinds()[key]?.at(0)
+        const first = userKeybinds()[key]?.at(0)
         if (!first) return ""
         const result = Keybind.toString(first)
-        return result.replace("<leader>", Keybind.toString(keybinds().leader![0]!))
+        return result.replace("<leader>", Keybind.toString(userKeybinds().leader![0]!))
+      },
+      get keybinds() {
+        return keybinds()
       },
     }
+
     return result
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/context/keybind_.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind_.ts
@@ -1,0 +1,80 @@
+import { Keybind } from "@/util/keybind"
+import { useKeyboard } from "@opentui/solid"
+import type { KeyEvent } from "@opentui/core"
+import { onCleanup } from "solid-js"
+
+export const PRIORITY = {
+  NORMAL: 0,
+  COMMAND_LIST: 1,
+  DIALOG: 2,
+}
+
+export abstract class KeybindRegistration {
+  combos: string[]
+  constructor(combos: string | string[], public priority: number = PRIORITY.NORMAL) {
+    this.combos = Array.isArray(combos) ? combos : [combos]
+  }
+  abstract print(): string
+  abstract setHandler(cb: KeybindCallback): void
+}
+
+export type KeybindCallback = () => Promise<void | boolean> | void | boolean
+
+export function state(parse: (evt: KeyEvent) => Keybind.Info, leader: () => Keybind.Info) {
+  class _KeybindRegistration extends KeybindRegistration {
+    setHandler(cb: KeybindCallback) {
+      listeners.set(this, cb)
+      onCleanup(() => {
+        listeners.delete(this)
+      })
+    }
+    print() {
+      return this.combos.map(combo =>
+        combo
+          .replace("<leader>", Keybind.toString(leader()))
+          .replace("escape", "esc")
+          .replace("return", "enter")
+        ).join("/")
+    }
+  }
+
+  const listeners = new Map<KeybindRegistration, KeybindCallback>()
+  let partialKeyCombo: Keybind.Info[] = []
+
+  function compareKeyCombos(partialCombo: Keybind.Info[], fullCombo: Keybind.Info[]): "mismatch" | "match" | "prefix" {
+    if (partialCombo.length > fullCombo.length) return "mismatch"
+    for (let i = 0; i < partialCombo.length; i++) {
+      if (!Keybind.match(partialCombo[i], fullCombo[i])) {
+        return i > 0 ? "prefix" : "mismatch"
+      }
+    }
+    return "match"
+  }
+
+  useKeyboard(async (evt) => {
+    if (!evt.name) return
+
+    const parsed = { ...parse(evt) }
+    for (const [keybindRegistration, cb] of [...listeners.entries()].reverse().sort(
+      ([a], [b]) => -(a.priority - b.priority),
+    )) {
+      for (const binding of keybindRegistration.combos) {
+        partialKeyCombo = [...partialKeyCombo, parsed]
+        const listenedForCombo = Keybind.parse(binding)
+        const comparison = compareKeyCombos(partialKeyCombo, listenedForCombo)
+        if (comparison === "match") {
+          partialKeyCombo = []
+          const result = await cb()
+          // if (result === true || result === undefined) {
+            evt.preventDefault()
+            return
+          // }
+        } else if (comparison === "mismatch") {
+          partialKeyCombo = []
+        }
+      }
+    }
+  })
+
+  return _KeybindRegistration
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -5,6 +5,7 @@ import {
   createSignal,
   For,
   Match,
+  onMount,
   Show,
   Switch,
   useContext,
@@ -114,30 +115,24 @@ export function Session() {
   let prompt: PromptRef
   const keybind = useKeybind()
 
-  useKeyboard((evt) => {
-    if (dialog.stack.length > 0) return
-
+  function submitPermission(response: "once" | "always" | "reject") {
     const first = permissions()[0]
-    if (first) {
-      const response = iife(() => {
-        if (evt.name === "return") return "once"
-        if (evt.name === "a") return "always"
-        if (evt.name === "d") return "reject"
-        if (evt.name === "escape") return "reject"
-        return
-      })
-      if (response) {
-        sdk.client.postSessionIdPermissionsPermissionId({
-          path: {
-            permissionID: first.id,
-            id: route.sessionID,
-          },
-          body: {
-            response: response,
-          },
-        })
-      }
-    }
+    if (!first) return
+    sdk.client.postSessionIdPermissionsPermissionId({
+      path: {
+        permissionID: first.id,
+        id: route.sessionID,
+      },
+      body: {
+        response: response,
+      },
+    })
+  }
+
+  onMount(() => {
+    keybind.keybinds.permission.once.setHandler(() => submitPermission("once"))
+    keybind.keybinds.permission.always.setHandler(() => submitPermission("always"))
+    keybind.keybinds.permission.reject.setHandler(() => submitPermission("reject"))
   })
 
   function toBottom() {
@@ -1031,19 +1026,19 @@ function ToolPart(props: { part: ToolPart; message: AssistantMessage }) {
     const style: BoxProps =
       container === "block" || permission
         ? {
-            border: permissionIndex === 0 ? (["left", "right"] as const) : (["left"] as const),
-            paddingTop: 1,
-            paddingBottom: 1,
-            paddingLeft: 2,
-            marginTop: 1,
-            gap: 1,
-            backgroundColor: theme.backgroundPanel,
-            customBorderChars: SplitBorder.customBorderChars,
-            borderColor: permissionIndex === 0 ? theme.warning : theme.background,
-          }
+          border: permissionIndex === 0 ? (["left", "right"] as const) : (["left"] as const),
+          paddingTop: 1,
+          paddingBottom: 1,
+          paddingLeft: 2,
+          marginTop: 1,
+          gap: 1,
+          backgroundColor: theme.backgroundPanel,
+          customBorderChars: SplitBorder.customBorderChars,
+          borderColor: permissionIndex === 0 ? theme.warning : theme.background,
+        }
         : {
-            paddingLeft: 3,
-          }
+          paddingLeft: 3,
+        }
 
     return (
       <box

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-alert.tsx
@@ -2,6 +2,8 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { useKeyboard } from "@opentui/solid"
+import { useKeybind } from "../context/keybind"
+import { onMount } from "solid-js"
 
 export type DialogAlertProps = {
   title: string
@@ -12,13 +14,15 @@ export type DialogAlertProps = {
 export function DialogAlert(props: DialogAlertProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const keybind = useKeybind()
 
-  useKeyboard((evt) => {
-    if (evt.name === "return") {
+  onMount(() => {
+    keybind.keybinds.dialog.alert.close.setHandler(() => {
       props.onConfirm?.()
       dialog.clear()
-    }
+    })
   })
+
   return (
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-confirm.tsx
@@ -2,9 +2,9 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { createStore } from "solid-js/store"
-import { For } from "solid-js"
-import { useKeyboard } from "@opentui/solid"
+import { For, onMount } from "solid-js"
 import { Locale } from "@/util/locale"
+import { useKeybind } from "../context/keybind"
 
 export type DialogConfirmProps = {
   title: string
@@ -16,21 +16,22 @@ export type DialogConfirmProps = {
 export function DialogConfirm(props: DialogConfirmProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const keybind = useKeybind()
   const [store, setStore] = createStore({
     active: "confirm" as "confirm" | "cancel",
   })
 
-  useKeyboard((evt) => {
-    if (evt.name === "return") {
+  onMount(() => {
+    keybind.keybinds.dialog.confirm.submit.setHandler(() => {
       if (store.active === "confirm") props.onConfirm?.()
       if (store.active === "cancel") props.onCancel?.()
       dialog.clear()
-    }
-
-    if (evt.name === "left" || evt.name === "right") {
+    })
+    keybind.keybinds.dialog.confirm.cycleFocusedButton.setHandler(() => {
       setStore("active", store.active === "confirm" ? "cancel" : "confirm")
-    }
+    })
   })
+
   return (
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-help.tsx
@@ -1,25 +1,26 @@
 import { TextAttributes } from "@opentui/core"
 import { useTheme } from "@tui/context/theme"
 import { useDialog } from "./dialog"
-import { useKeyboard } from "@opentui/solid"
+import { onMount } from "solid-js"
+import { useKeybind } from "../context/keybind"
 
 export function DialogHelp() {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const keybind = useKeybind()
 
-  useKeyboard((evt) => {
-    if (evt.name === "return" || evt.name === "escape") {
-      dialog.clear()
-    }
+  onMount(() => {
+    keybind.keybinds.dialog.help.close.setHandler(() => dialog.clear())
   })
 
   return (
     <box paddingLeft={2} paddingRight={2} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD}>Help</text>
-        <text fg={theme.textMuted}>esc/enter</text>
+        <text fg={theme.textMuted}>{keybind.keybinds.dialog.help.close.print()}</text>
       </box>
       <box paddingBottom={1}>
+        {/* Replace Ctrl+P with expression */}
         <text fg={theme.textMuted}>
           Press Ctrl+P to see all available actions and commands in any context.
         </text>

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-prompt.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "../context/theme"
 import { useDialog, type DialogContext } from "./dialog"
 import { onMount } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
+import { useKeybind } from "../context/keybind"
 
 export type DialogPromptProps = {
   title: string
@@ -14,16 +15,15 @@ export type DialogPromptProps = {
 export function DialogPrompt(props: DialogPromptProps) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const keybind = useKeybind()
   let textarea: TextareaRenderable
 
-  useKeyboard((evt) => {
-    if (evt.name === "return") {
+  onMount(() => {
+    keybind.keybinds.dialog.confirm.submit.setHandler(() => {
       props.onConfirm?.(textarea.plainText)
       dialog.clear()
-    }
-  })
+    })
 
-  onMount(() => {
     dialog.setSize("large")
     setTimeout(() => {
       textarea.focus()

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -1,8 +1,9 @@
-import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
+import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { batch, createContext, Show, useContext, type JSX, type ParentProps } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { Renderable, RGBA } from "@opentui/core"
 import { createStore } from "solid-js/store"
+import { useKeybind } from "../context/keybind"
 
 export function Dialog(
   props: ParentProps<{
@@ -43,6 +44,8 @@ export function Dialog(
 }
 
 function init() {
+  const keybind = useKeybind()
+
   const [store, setStore] = createStore({
     stack: [] as {
       element: JSX.Element
@@ -51,14 +54,15 @@ function init() {
     size: "medium" as "medium" | "large",
   })
 
-  useKeyboard((evt) => {
-    if (evt.name === "escape" && store.stack.length > 0) {
+  keybind.keybinds.dialog.close.setHandler(() => {
+    if (store.stack.length > 0) {
       const current = store.stack.at(-1)!
       current.onClose?.()
       setStore("stack", store.stack.slice(0, -1))
-      evt.preventDefault()
       refocus()
+      return true
     }
+    return false
   })
 
   const renderer = useRenderer()

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -10,7 +10,7 @@ export namespace Keybind {
   }
 
   export function match(a: Info, b: Info): boolean {
-    return isDeepEqual(a, b)
+    return isDeepEqual({ ...a, name: a.name.toLowerCase() }, { ...b, name: b.name.toLowerCase() })
   }
 
   export function toString(info: Info): string {


### PR DESCRIPTION
@thdxr I have revamped the keybinds so that (almost) everything is in a central place and it's difficult to reason about the binding precedence and make changes without introducing regressions.

Most notable features:
- Centralized registry of all keybindings, which supports setting priorities to carefully control precedence: https://github.com/sst/opencode/blob/3272c849a5c9a17976cf18144512c8291fb4bf3e/packages/opencode/src/cli/cmd/tui/context/keybind.tsx#L61
- Example usage: https://github.com/sst/opencode/blob/3272c849a5c9a17976cf18144512c8291fb4bf3e/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx#L125

(There are some rough edges, I'll refactor the api a bit more e.g. I think it's unnecessary to have `keybind.keybinds.`, `keybind.` should suffice, things like that)

Exceptions:
- `<Prompt>`'s `onKeyDown` passed to `<textarea>`. I will investigate if this can (or should) be converted to the universal keybind approach
- The `ErrorComponent` in `app.tsx` - `useKeybind` is a potential point of failure, and our catch-all `ErrorBoundary` should have minimal features IMO

A few caveats (will address before merge):
- Please ignore for now the fact that I separated `keybind.tsx` and `keybind_.ts`. I did that because debugging breakpoints don't work in `tsx` files. I will inline all of `keybind_.ts` into `keybind.tsx` before merge.
- I haven't gotten around to fully testing permission keybind handling 
- Haven't tested those dialogs that are a bit tricky to get to display like the openrouter warning and maybe some others
- It seems there is a bug in opentui where an `<input>` inserts `<letter>` upon receiving `ctrl+<letter>`. I'll investigate a bit more