### PR TITLE
Fix: Display Claude Code rate limit errors in UI

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -259,6 +259,7 @@ export namespace SessionPrompt {
             log.error("stream error", {
               error,
             })
+            throw error
           },
           async experimental_repairToolCall(input) {
             const lower = input.toolCall.toolName.toLowerCase()


### PR DESCRIPTION
## Problem
When Claude Code returns rate limit errors, OpenCode shows endless loading instead of displaying the error message.

## Root Cause
The `onError` handler in `streamText` was only logging errors but not re-throwing them, preventing errors from being caught and displayed in the UI.

## Fix
Added `throw error` in the `onError` handler to properly propagate errors to the UI error handling.