### PR TITLE
Fix: Auto-scroll to bottom when selecting session from list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -5,6 +5,7 @@ import {
   createSignal,
   For,
   Match,
+  on,
   Show,
   Switch,
   useContext,
@@ -115,18 +116,6 @@ export function Session() {
     })
   })
 
-  createEffect(() => {
-    route.sessionID
-    const checkAndScroll = () => {
-      if (scroll && messages().length > 0) {
-        toBottom()
-      } else {
-        setTimeout(checkAndScroll, 50)
-      }
-    }
-    checkAndScroll()
-  })
-
   const toast = useToast()
 
   const sdk = useSDK()
@@ -172,6 +161,9 @@ export function Session() {
     if (old !== session()?.revert?.messageID) toBottom()
     return session()?.revert?.messageID
   })
+
+  // snap to bottom when session changes
+  createEffect(on(() => route.sessionID, toBottom))
 
   const local = useLocal()
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -115,6 +115,18 @@ export function Session() {
     })
   })
 
+  createEffect(() => {
+    route.sessionID
+    const checkAndScroll = () => {
+      if (scroll && messages().length > 0) {
+        toBottom()
+      } else {
+        setTimeout(checkAndScroll, 50)
+      }
+    }
+    checkAndScroll()
+  })
+
   const toast = useToast()
 
   const sdk = useSDK()


### PR DESCRIPTION
## Problem
When selecting a session from the /sessions list, the conversation view shows the top instead of the latest messages.

## Fix
Added auto-scroll to bottom when navigating to a session so users see the latest messages immediately.

## Why this fix was needed
Although there was already a `toBottom()` function in the code, it was only being called when the revert position changed. When navigating to a session from the /sessions list, the route.sessionID changes but this doesn't trigger the existing scroll-to-bottom logic. 

The new effect watches for sessionID changes and ensures the scroll happens after both the scroll element is available and messages are loaded.