### PR TITLE
docs: fix math tool example 

### DIFF
--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -108,7 +108,7 @@ export const add = tool({
     b: tool.schema.number().describe("Second number"),
   },
   async execute(args) {
-    return (args.a * args.b).toString()
+    return (args.a + args.b).toString()
   },
 })
 

--- a/packages/web/src/content/docs/custom-tools.mdx
+++ b/packages/web/src/content/docs/custom-tools.mdx
@@ -108,7 +108,7 @@ export const add = tool({
     b: tool.schema.number().describe("Second number"),
   },
   async execute(args) {
-    return args.a + args.b
+    return (args.a * args.b).toString()
   },
 })
 
@@ -119,7 +119,7 @@ export const multiply = tool({
     b: tool.schema.number().describe("Second number"),
   },
   async execute(args) {
-    return args.a * args.b
+    return (args.a * args.b).toString()
   },
 })
 ```


### PR DESCRIPTION
Fixes #4008

## Summary

- Fixes the custom tools documentation example to return strings instead of numbers, resolving validation errors when executing the tools.
- This error is occurred since `tool` allows  only `Promise<string>` for its result.

## Changes

- Updated `add` and `multiply` tool examples to return string results using `.toString()`

## Test

<img width="249" height="88" alt="Screenshot 2025-11-07 at 9 23 32 AM" src="https://github.com/user-attachments/assets/2fe6b5bf-f9c8-4475-972d-92ad92b5c0a9" />
