### PR TITLE
vscode: Add VS Code Insiders support

### DIFF
--- a/packages/opencode/src/ide/index.ts
+++ b/packages/opencode/src/ide/index.ts
@@ -6,6 +6,7 @@ import { Bus } from "../bus"
 
 const SUPPORTED_IDES = [
   { name: "Windsurf" as const, cmd: "windsurf" },
+  { name: "Visual Studio Code - Insiders" as const, cmd: "code-insiders" },
   { name: "Visual Studio Code" as const, cmd: "code" },
   { name: "Cursor" as const, cmd: "cursor" },
   { name: "VSCodium" as const, cmd: "codium" },
@@ -43,7 +44,10 @@ export namespace Ide {
   }
 
   export function alreadyInstalled() {
-    return process.env["OPENCODE_CALLER"] === "vscode"
+    return (
+      process.env["OPENCODE_CALLER"] === "vscode" ||
+      process.env["OPENCODE_CALLER"] === "vscode-insiders"
+    )
   }
 
   export async function install(ide: (typeof SUPPORTED_IDES)[number]["name"]) {

--- a/packages/opencode/test/ide/ide.test.ts
+++ b/packages/opencode/test/ide/ide.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { Ide } from "../../src/ide"
+
+describe("ide", () => {
+  const original = structuredClone(process.env)
+
+  afterEach(() => {
+    Object.keys(process.env).forEach((key) => {
+      delete process.env[key]
+    })
+    Object.assign(process.env, original)
+  })
+
+  test("should detect Visual Studio Code", () => {
+    process.env["TERM_PROGRAM"] = "vscode"
+    process.env["GIT_ASKPASS"] =
+      "/path/to/Visual Studio Code.app/Contents/Resources/app/extensions/git/dist/askpass.sh"
+
+    expect(Ide.ide()).toBe("Visual Studio Code")
+  })
+
+  test("should detect Visual Studio Code Insiders", () => {
+    process.env["TERM_PROGRAM"] = "vscode"
+    process.env["GIT_ASKPASS"] =
+      "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/extensions/git/dist/askpass.sh"
+
+    expect(Ide.ide()).toBe("Visual Studio Code - Insiders")
+  })
+
+  test("should detect Cursor", () => {
+    process.env["TERM_PROGRAM"] = "vscode"
+    process.env["GIT_ASKPASS"] =
+      "/path/to/Cursor.app/Contents/Resources/app/extensions/git/dist/askpass.sh"
+
+    expect(Ide.ide()).toBe("Cursor")
+  })
+
+  test("should detect VSCodium", () => {
+    process.env["TERM_PROGRAM"] = "vscode"
+    process.env["GIT_ASKPASS"] =
+      "/path/to/VSCodium.app/Contents/Resources/app/extensions/git/dist/askpass.sh"
+
+    expect(Ide.ide()).toBe("VSCodium")
+  })
+
+  test("should detect Windsurf", () => {
+    process.env["TERM_PROGRAM"] = "vscode"
+    process.env["GIT_ASKPASS"] =
+      "/path/to/Windsurf.app/Contents/Resources/app/extensions/git/dist/askpass.sh"
+
+    expect(Ide.ide()).toBe("Windsurf")
+  })
+
+  test("should return unknown when TERM_PROGRAM is not vscode", () => {
+    process.env["TERM_PROGRAM"] = "iTerm2"
+    process.env["GIT_ASKPASS"] =
+      "/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/extensions/git/dist/askpass.sh"
+
+    expect(Ide.ide()).toBe("unknown")
+  })
+
+  test("should return unknown when GIT_ASKPASS does not contain IDE name", () => {
+    process.env["TERM_PROGRAM"] = "vscode"
+    process.env["GIT_ASKPASS"] = "/path/to/unknown/askpass.sh"
+
+    expect(Ide.ide()).toBe("unknown")
+  })
+
+  test("should recognize vscode-insiders OPENCODE_CALLER", () => {
+    process.env["OPENCODE_CALLER"] = "vscode-insiders"
+
+    expect(Ide.alreadyInstalled()).toBe(true)
+  })
+
+  test("should recognize vscode OPENCODE_CALLER", () => {
+    process.env["OPENCODE_CALLER"] = "vscode"
+
+    expect(Ide.alreadyInstalled()).toBe(true)
+  })
+
+  test("should return false for unknown OPENCODE_CALLER", () => {
+    process.env["OPENCODE_CALLER"] = "unknown"
+
+    expect(Ide.alreadyInstalled()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add Visual Studio Code Insiders to supported IDEs with proper command detection
- Update IDE detection logic to recognize VS Code Insiders environment and prioritize it over standard VS Code in matching
- Include comprehensive test coverage for all IDE detection scenarios

## Changes
- Add "Visual Studio Code - Insiders" IDE with code-insiders command
- Update alreadyInstalled() to recognize vscode-insiders OPENCODE_CALLER
- Reorder SUPPORTED_IDES to check Insiders variant before standard VS Code (prevents false positives)
- Add 10 test cases covering IDE detection for all supported IDEs

## Testing
All IDE detection tests pass, including specific tests for VS Code Insiders path matching