### PR TITLE
fix: Correct workflow trigger syntax in guidelines check

### DIFF
--- a/.github/workflows/guidelines-check.yml
+++ b/.github/workflows/guidelines-check.yml
@@ -1,6 +1,6 @@
 name: Guidelines Check
 
-on:
+on: {}
   # Disabled - uncomment to re-enable
   # pull_request_target:
   #   types: [opened, synchronize]


### PR DESCRIPTION
- Fix empty 'on:' trigger value by setting it to empty object 'on: {}'