### PR TITLE
fix(tui): restore cmd+backspace (delete line backward) functionality

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -565,6 +565,21 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+                if (keybind.match("input_delete_line_backward", e) && store.prompt.input !== "") {
+                  const text = input.plainText
+                  const cursorOffset = input.cursorOffset
+
+                  let lineStart = cursorOffset
+                  while (lineStart > 0 && text[lineStart - 1] !== '\n') {
+                    lineStart--
+                  }
+
+                  const newText = text.slice(0, lineStart) + text.slice(cursorOffset)
+                  input.setText(newText)
+                  input.cursorOffset = lineStart
+                  e.preventDefault()
+                  return
+                }
                 if (keybind.match("app_exit", e)) {
                   await exit()
                   return

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -465,6 +465,7 @@ export namespace Config {
       agent_cycle_reverse: z.string().optional().default("shift+tab").describe("Previous agent"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
       input_forward_delete: z.string().optional().default("ctrl+d").describe("Forward delete"),
+      input_delete_line_backward: z.string().optional().default("ctrl+u,meta+backspace").describe("Delete from cursor to beginning of line"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
       input_newline: z

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -147,6 +147,10 @@ export type KeybindsConfig = {
    */
   input_forward_delete?: string
   /**
+   * Delete from cursor to beginning of line
+   */
+  input_delete_line_backward?: string
+  /**
    * Paste from clipboard
    */
   input_paste?: string


### PR DESCRIPTION
I just updated from v0.15.x to v1.x, and noticed that cmd+backspace functionality no longer works.

This commit restores that functionality.

It appears, during the OpenTUI migration in 96bdeb3c, this functionality was lost.

The old implementation:

- [Keybinding definition](https://github.com/sst/opencode/blob/81c617770d8595978b497a9cf3c0a5316b108352/packages/tui/internal/components/textarea/textarea.go#L240-L243) - bound to `ctrl+u`
- [Function implementation](https://github.com/sst/opencode/blob/81c617770d8595978b497a9cf3c0a5316b108352/packages/tui/internal/components/textarea/textarea.go#L1200-L1204)
- [Handler](https://github.com/sst/opencode/blob/81c617770d8595978b497a9cf3c0a5316b108352/packages/tui/internal/components/textarea/textarea.go#L1594-L1600)


https://github.com/user-attachments/assets/771d5fb0-bacb-43da-a370-6d48ee84c389

