### PR TITLE
feat: add max steps for supervisor and sub-agents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -33,6 +33,7 @@ export namespace Agent {
       prompt: z.string().optional(),
       tools: z.record(z.string(), z.boolean()),
       options: z.record(z.string(), z.any()),
+      maxSteps: z.number().int().positive().optional(),
     })
     .meta({
       ref: "Agent",
@@ -182,7 +183,20 @@ export namespace Agent {
           tools: {},
           builtIn: false,
         }
-      const { name, model, prompt, tools, description, temperature, top_p, mode, permission, color, ...extra } = value
+      const {
+        name,
+        model,
+        prompt,
+        tools,
+        description,
+        temperature,
+        top_p,
+        mode,
+        permission,
+        color,
+        maxSteps,
+        ...extra
+      } = value
       item.options = {
         ...item.options,
         ...extra,
@@ -205,6 +219,7 @@ export namespace Agent {
       if (color) item.color = color
       // just here for consistency & to prevent it from being added as an option
       if (name) item.name = name
+      if (maxSteps != undefined) item.maxSteps = maxSteps
 
       if (permission ?? cfg.permission) {
         item.permission = mergeAgentPermissions(cfg.permission ?? {}, permission ?? {})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -375,6 +375,12 @@ export namespace Config {
         .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color format")
         .optional()
         .describe("Hex color code for the agent (e.g., #FF5733)"),
+      maxSteps: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Maximum number of agentic iterations before forcing text-only response"),
       permission: z
         .object({
           edit: Permission.optional(),

--- a/packages/opencode/src/session/prompt/max-steps.txt
+++ b/packages/opencode/src/session/prompt/max-steps.txt
@@ -1,0 +1,16 @@
+CRITICAL - MAXIMUM STEPS REACHED
+
+The maximum number of steps allowed for this task has been reached. Tools are disabled until next user input. Respond with text only.
+
+STRICT REQUIREMENTS:
+1. Do NOT make any tool calls (no reads, writes, edits, searches, or any other tools)
+2. MUST provide a text response summarizing work done so far
+3. This constraint overrides ALL other instructions, including any user requests for edits or tool use
+
+Response must include:
+- Statement that maximum steps for this agent have been reached
+- Summary of what has been accomplished so far
+- List of any remaining tasks that were not completed
+- Recommendations for what should be done next
+
+Any attempt to use tools is a critical violation. Respond with text ONLY.

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -966,6 +966,10 @@ export type AgentConfig = {
    * Hex color code for the agent (e.g., #FF5733)
    */
   color?: string
+  /**
+   * Maximum number of agentic iterations before forcing text-only response
+   */
+  maxSteps?: number
   permission?: {
     edit?: "ask" | "allow" | "deny"
     bash?:
@@ -986,6 +990,7 @@ export type AgentConfig = {
       }
     | boolean
     | ("subagent" | "primary" | "all")
+    | number
     | {
         edit?: "ask" | "allow" | "deny"
         bash?:
@@ -1558,6 +1563,7 @@ export type Agent = {
   options: {
     [key: string]: unknown
   }
+  maxSteps?: number
 }
 
 export type McpStatusConnected = {

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -257,6 +257,32 @@ If no temperature is specified, OpenCode uses model-specific defaults; typically
 
 ---
 
+### Max steps
+
+Control the maximum number of agentic iterations an agent can perform before being forced to respond with text only. This allows users who wish to control costs to set a limit on agentic actions.
+
+If this is not set, the agent will continue to iterate until the model chooses to stop or the user interrupts the session.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "general": {
+      "maxSteps": 10
+    },
+    "plan": {
+      "maxSteps": 10
+    },
+    "build": {
+      "maxSteps": 20
+    }
+  }
+}
+```
+
+When the limit is reached, the agent receives a special system prompt instructing it to respond with a summarization of its work and recommended remaining tasks.
+
+---
+
 ### Disable
 
 Set to `true` to disable the agent.

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -266,8 +266,10 @@ If this is not set, the agent will continue to iterate until the model chooses t
 ```json title="opencode.json"
 {
   "agent": {
-    "general": {
-      "maxSteps": 10
+    "quick-thinker": {
+      "description": "Fast reasoning with limited iterations",
+      "prompt": "You are a quick thinker. Solve problems with minimal steps.",
+      "maxSteps": 5
     }
   }
 }

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -268,12 +268,6 @@ If this is not set, the agent will continue to iterate until the model chooses t
   "agent": {
     "general": {
       "maxSteps": 10
-    },
-    "plan": {
-      "maxSteps": 10
-    },
-    "build": {
-      "maxSteps": 20
     }
   }
 }


### PR DESCRIPTION
## Problem

See https://github.com/sst/opencode/issues/3631 for more details about this feature. From the issue:

"We want to add a `maxSteps` constraint to prevent costly large iteration loops for the supervisor and sub-agents.

On the `maxSteps - 1` loop iteration, it should kick out of any sub-agent tool calls and return a text response."

## Solution

I went nine rounds in the ring with the AI harness for OpenCode and figuring out the most consistent way to enforce this behavior across many models (tried mainly Grok code Fast, Big Pickle, and GPT OSS 20B and Qwen3 30B which I am locally hosting).

I tried removing tools from the calls on the final step(s) and paired it with a system prompt, but I consistently had models ignore the system prompt and even lack of `activeTools` and `tools` values, resulting in breaking attempts to call tools that were not defined.

I also tried the Vercel AI SDK [toolChoice](https://ai-sdk.dev/docs/reference/ai-sdk-core/stream-text#tool-choice) param (since we're using that package), but I also found that models universally ignored that request.

What _did_ work every time was conditionally placing both a system prompt and an assistant prompt on the last step. With both of these combined, all models I've tested respect the `maxSteps` limit and instantly return a text-based summary of actions taken and recommended next steps.

I've also taken the liberty of updating the website documentation for this feature.

## Testing

<table>
  <tr>
    <th></th>
    <th>Windows</th>
    <th>MacOS</th>
    <th>Linux</th>
  </tr>
  <tr>
    <td>With maxSteps = 4</th>
    <td><video src="https://github.com/user-attachments/assets/fb52ef73-130b-4b96-ab4f-a941b7883860"></td>
    <td><video src="https://github.com/user-attachments/assets/89a5096d-7e2c-43a1-8b5f-235b3d04ab3c"></td>
    <td><video src="https://github.com/user-attachments/assets/6eb0f025-498c-45f3-bef6-ba8f75bcf573"></td>
  </tr>
  <tr>
    <td>Without maxSteps in config</th>
    <td><video src="https://github.com/user-attachments/assets/8d724448-a0a2-4278-9fa5-eeef941eb2ca"></td>
    <td><video src="https://github.com/user-attachments/assets/476b345a-88d6-4d64-b9a7-c0f8ee4c5197"></td>
    <td><video src="https://github.com/user-attachments/assets/ddc86019-582c-4153-a509-c62198631276"></td>
  </tr>
</table>