### PR TITLE
fix(theme): filter out null values from theme palette

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -196,7 +196,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
-  const palette = colors.palette.map((x) => RGBA.fromHex(x!))
+  const palette = colors.palette.filter((x) => x != null).map((x) => RGBA.fromHex(x))
   const isDark = mode == "dark"
 
   // Generate gray scale based on terminal background

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -196,7 +196,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
-  const palette = colors.palette.filter((x) => x != null).map((x) => RGBA.fromHex(x))
+  const palette = colors.palette.filter((x) => x !== null).map((x) => RGBA.fromHex(x))
   const isDark = mode == "dark"
 
   // Generate gray scale based on terminal background


### PR DESCRIPTION
**Issue**

When opening opencode in zellij we see the following error:

```
null is not an object (evaluating 'hex3.replace')
```

This is because opencode requests 16 colors from the terminal but only 10 are returned when requesting those colors from zellij.

This doesn't seem to break much in opencode, but the big red error log is quite annoying.

**Solution**

Because zellij usually returns 10 colors and looking at the implementation here in opencode only 8 colors are required, we can safely filter out the null values.

Fixes #4017