### PR TITLE
feat: add input context to chat.params and chat.message

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -206,6 +206,8 @@ export namespace SessionPrompt {
     const params = await Plugin.trigger(
       "chat.params",
       {
+        sessionID: input.sessionID,
+        agent: agent.name,
         model: model.info,
         provider: await Provider.getProvider(model.providerID),
         message: userMsg,
@@ -882,7 +884,12 @@ export namespace SessionPrompt {
 
     await Plugin.trigger(
       "chat.message",
-      {},
+      {
+        sessionID: input.sessionID,
+        agent: input.agent,
+        model: input.model,
+        messageID: input.messageID,
+      },
       {
         message: info,
         parts,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -143,12 +143,15 @@ export interface Hooks {
   /**
    * Called when a new message is received
    */
-  "chat.message"?: (input: {}, output: { message: UserMessage; parts: Part[] }) => Promise<void>
+  "chat.message"?: (
+    input: { sessionID: string; agent?: string; model?: { providerID: string; modelID: string; messageID?: string } },
+    output: { message: UserMessage; parts: Part[] },
+  ) => Promise<void>
   /**
    * Modify parameters sent to LLM
    */
   "chat.params"?: (
-    input: { model: Model; provider: Provider; message: UserMessage },
+    input: { sessionID: string; agent: string; model: Model; provider: Provider; message: UserMessage },
     output: { temperature: number; topP: number; options: Record<string, any> },
   ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>


### PR DESCRIPTION
## Description

This PR enhances the plugin hook system by adding input context to both `chat.params` and `chat.message` hooks. 

At the moment it's impossible to know which agent is selected for a `UserMessage`. It's only available in `info.mode` inside `AssistantMessage`. 

This allows plugins to be context aware when reacting to chat messages.

## Changes

- Updated `chat.message` hook input signature to include `sessionID`, `agent`, `model`, and `messageID`
- Updated `chat.params` hook input signature to include `sessionID` and `agent`