### PR TITLE
feat: support images in mcp tool responses

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -699,33 +699,6 @@ export namespace SessionPrompt {
         }
       }
       item.toModelOutput = (result) => {
-        const hasNonTextContent = result.content.some((item: any) => item.type !== "text")
-        if (hasNonTextContent) {
-          const contentItems = result.content
-            .map((item: any) => {
-              if (item.type === "text") {
-                return {
-                  type: "text",
-                  text: item.text,
-                }
-              }
-              if (item.type === "image") {
-                return {
-                  type: "media",
-                  data: item.data,
-                  mediaType: item.mimeType,
-                }
-              }
-              // Add support for other types if needed
-              return null
-            })
-            .filter(Boolean)
-          return {
-            type: "content",
-            value: contentItems,
-          }
-        }
-
         return {
           type: "text",
           value: result.output,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -671,18 +671,61 @@ export namespace SessionPrompt {
           result,
         )
 
-        const output = result.content
-          .filter((x: any) => x.type === "text")
-          .map((x: any) => x.text)
-          .join("\n\n")
+        const textParts: string[] = []
+        const attachments: MessageV2.FilePart[] = []
+
+        for (const item of result.content) {
+          if (item.type === "text") {
+            textParts.push(item.text)
+          } else if (item.type === "image") {
+            attachments.push({
+              id: Identifier.ascending("part"),
+              sessionID: input.sessionID,
+              messageID: input.processor.message.id,
+              type: "file",
+              mime: item.mimeType,
+              url: `data:${item.mimeType};base64,${item.data}`,
+            })
+          }
+          // Add support for other types if needed
+        }
 
         return {
           title: "",
           metadata: result.metadata ?? {},
-          output,
+          output: textParts.join("\n\n"),
+          attachments,
+          content: result.content, // directly return content to preserve ordering when outputting to model
         }
       }
       item.toModelOutput = (result) => {
+        const hasNonTextContent = result.content.some((item: any) => item.type !== "text")
+        if (hasNonTextContent) {
+          const contentItems = result.content
+            .map((item: any) => {
+              if (item.type === "text") {
+                return {
+                  type: "text",
+                  text: item.text,
+                }
+              }
+              if (item.type === "image") {
+                return {
+                  type: "media",
+                  data: item.data,
+                  mediaType: item.mimeType,
+                }
+              }
+              // Add support for other types if needed
+              return null
+            })
+            .filter(Boolean)
+          return {
+            type: "content",
+            value: contentItems,
+          }
+        }
+
         return {
           type: "text",
           value: result.output,


### PR DESCRIPTION
Vision-capable models can now consume images from mcp tool responses. 

https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#multi-modal-tool-results

This resolves the merge conflict in the original PR: https://github.com/sst/opencode/pull/1589

Closes: https://github.com/sst/opencode/issues/1563

<img width="2366" height="448" alt="CleanShot 2025-11-09 at 22 12 39" src="https://github.com/user-attachments/assets/c0af717e-7d18-4843-b270-0d12b52a1389" />
