### PR TITLE
feat: Add "system.prompt.append" hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -256,6 +256,11 @@ export namespace SessionPrompt {
       await using _ = defer(async () => {
         await processor.end()
       })
+
+      // Dynamically append plugin prompts for this turn
+      const dynamicPrompts = await appendPluginPrompts(input.sessionID, agent, msgs)
+      const turnSystem = [...system, ...dynamicPrompts]
+
       const doStream = () =>
         streamText({
           onError(error) {
@@ -308,7 +313,7 @@ export namespace SessionPrompt {
           temperature: params.temperature,
           topP: params.topP,
           messages: [
-            ...system.map(
+            ...turnSystem.map(
               (x): ModelMessage => ({
                 role: "system",
                 content: x,
@@ -481,6 +486,38 @@ export namespace SessionPrompt {
       return input.agent.model
     }
     return Provider.defaultModel()
+  }
+
+  async function appendPluginPrompts(
+    sessionID: string,
+    agent: Agent.Info,
+    history: MessageV2.WithParts[],
+  ): Promise<string[]> {
+    const appendedPrompts: string[] = []
+    try {
+      const output = { prompt: [] as string[] }
+      await Plugin.trigger(
+        "system.prompt.append",
+        {
+          sessionID,
+          agent,
+          // Convert internal MessageV2 types to SDK types for plugin boundary
+          history: history.map((m) => ({
+            info: m.info as any, // Cast to SDK message types
+            parts: m.parts,
+          })),
+        },
+        output,
+      )
+      // Basic validation
+      if (Array.isArray(output.prompt)) {
+        appendedPrompts.push(...output.prompt.filter((p) => typeof p === "string"))
+      }
+    } catch (error) {
+      console.error(`Error triggering 'system.prompt.append' hook:`, error)
+      // Gracefully continue without plugin content
+    }
+    return appendedPrompts
   }
 
   async function resolveSystemPrompt(input: {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -6,15 +6,19 @@ import type {
   Provider,
   Permission,
   UserMessage,
+  AssistantMessage,
   Part,
   Auth,
   Config,
+  Agent,
 } from "@opencode-ai/sdk"
 
 import type { BunShell } from "./shell"
 import { type ToolDefinition } from "./tool"
 
 export * from "./tool"
+
+export type MessageWithParts = { info: UserMessage | AssistantMessage; parts: Part[] }
 
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
@@ -165,6 +169,21 @@ export interface Hooks {
       title: string
       output: string
       metadata: any
+    },
+  ) => Promise<void>
+  /**
+   * Append text to the system prompt.
+   * This hook is called at the beginning of each step in a turn, allowing plugins
+   * to dynamically add context to the system prompt based on the latest history.
+   */
+  "system.prompt.append"?: (
+    context: {
+      sessionID: string
+      agent: Agent
+      history: MessageWithParts[]
+    },
+    output: {
+      prompt: string[]
     },
   ) => Promise<void>
 }


### PR DESCRIPTION
This PR adds a new hook for the plugin system, "system.prompt.append", to allow appending instructions to the system prompt between messages. The primarily use case for this is to allow plugins to add system instructions dynamically, based on context.

I attempted to write a plugin to implement cursor-style rules, that can always be inserted or inserted when certain glob patterns are matched. With the plugin system as it is currently, the best way to insert these rules was through user messages with noReply set. Thus, rules can only be added, not removed, and are lost when the conversation is compacted. With this hook, rules can be added dynamically as needed, without polluting the chat history with messages.

This is just a first pass of something that works, and I'm looking for feedback on how this can be improved, or if it is even wanted by the team.