### PR TITLE
fix: --model flag being ignored in TUI mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -97,6 +97,7 @@ export const TuiThreadCommand = cmd({
         continue: args.continue,
         sessionID: args.session,
         agent: args.agent,
+        model: args.model,
         prompt,
       },
       onExit: async () => {


### PR DESCRIPTION
Hey! Thanks for building opencode - I use it daily and rely on the `--model` flag quite a bit to switch between different models.

I noticed that the flag stopped working in TUI mode and tracked it down to commit 4bb7ea91 where the `model` parameter was accidentally omitted during the startup speed refactoring.

This PR adds back the missing `model: args.model` line to properly pass the model parameter to the TUI.

**Changes:**
- Added `model: args.model` to the args object in `packages/opencode/src/cli/cmd/tui/thread.ts`

Tested locally and confirmed it now works as expected.