### PR TITLE
feat: configurable compaction

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -72,11 +72,11 @@ function init() {
   })
 
   const result = {
-    trigger(name: string) {
+    trigger(name: string, source?: "prompt", data?: any) {
       for (const option of entries()) {
         if (option.value === name) {
           if (!isEnabled(option)) return
-          option.onSelect?.(dialog)
+          option.onSelect?.(dialog, source, data)
           return
         }
       }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -76,7 +76,7 @@ export function Autocomplete(props: {
 }) {
   const sdk = useSDK()
   const sync = useSync()
-  const command = useCommandDialog()
+  const dialog = useCommandDialog()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
   const frecency = useFrecency()
@@ -85,7 +85,6 @@ export function Autocomplete(props: {
     index: 0,
     selected: 0,
     visible: false as AutocompleteRef["visible"],
-    input: "keyboard" as "keyboard" | "mouse",
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -129,14 +128,6 @@ export function Autocomplete(props: {
     return props.input().getTextRange(store.index + 1, props.input().cursorOffset)
   })
 
-  // When the filter changes due to how TUI works, the mousemove might still be triggered
-  // via a synthetic event as the layout moves underneath the cursor. This is a workaround to make sure the input mode remains keyboard so
-  // that the mouseover event doesn't trigger when filtering.
-  createEffect(() => {
-    filter()
-    setStore("input", "keyboard")
-  })
-
   function insertPart(text: string, part: PromptInfo["parts"][number]) {
     const input = props.input()
     const currentCursorOffset = input.cursorOffset
@@ -168,26 +159,6 @@ export function Autocomplete(props: {
     })
 
     props.setPrompt((draft) => {
-      if (part.type === "file") {
-        const existingIndex = draft.parts.findIndex((p) => p.type === "file" && "url" in p && p.url === part.url)
-        if (existingIndex !== -1) {
-          const existing = draft.parts[existingIndex]
-          if (
-            part.source?.text &&
-            existing &&
-            "source" in existing &&
-            existing.source &&
-            "text" in existing.source &&
-            existing.source.text
-          ) {
-            existing.source.text.start = extmarkStart
-            existing.source.text.end = extmarkEnd
-            existing.source.text.value = virtualText
-          }
-          return
-        }
-      }
-
       if (part.type === "file" && part.source?.text) {
         part.source.text.start = extmarkStart
         part.source.text.end = extmarkEnd
@@ -341,25 +312,163 @@ export function Autocomplete(props: {
       )
   })
 
+  const session = createMemo(() => (props.sessionID ? sync.session.get(props.sessionID) : undefined))
   const commands = createMemo((): AutocompleteOption[] => {
-    const results: AutocompleteOption[] = [...command.slashes()]
-
-    for (const serverCommand of sync.data.command) {
-      results.push({
-        display: "/" + serverCommand.name + (serverCommand.mcp ? " (MCP)" : ""),
-        description: serverCommand.description,
-        onSelect: () => {
-          const newText = "/" + serverCommand.name + " "
-          const cursor = props.input().logicalCursor
-          props.input().deleteRange(0, 0, cursor.row, cursor.col)
-          props.input().insertText(newText)
-          props.input().cursorOffset = Bun.stringWidth(newText)
+    const results: AutocompleteOption[] = []
+    const s = session()
+    for (const command of sync.data.command) {
+      if (command.compact && s) {
+        results.push({
+          display: "/" + command.name + (command.mcp ? " (MCP)" : ""),
+          description: command.description ?? "compact the session",
+          aliases: command.name === "compact" ? ["/summarize"] : undefined,
+          onSelect: () => {
+            dialog.trigger("session.compact", "prompt", {
+              commandName: command.name,
+              template: command.template,
+            })
+          },
+        })
+      } else if (!command.compact) {
+        results.push({
+          display: "/" + command.name + (command.mcp ? " (MCP)" : ""),
+          description: command.description,
+          onSelect: () => {
+            const newText = "/" + command.name + " "
+            const cursor = props.input().logicalCursor
+            props.input().deleteRange(0, 0, cursor.row, cursor.col)
+            props.input().insertText(newText)
+            props.input().cursorOffset = Bun.stringWidth(newText)
+          },
+        })
+      }
+    }
+    if (s) {
+      results.push(
+        {
+          display: "/undo",
+          description: "undo the last message",
+          onSelect: () => {
+            dialog.trigger("session.undo")
+          },
         },
-      })
+        {
+          display: "/redo",
+          description: "redo the last message",
+          onSelect: () => dialog.trigger("session.redo"),
+        },
+        {
+          display: "/unshare",
+          disabled: !s.share,
+          description: "unshare a session",
+          onSelect: () => dialog.trigger("session.unshare"),
+        },
+        {
+          display: "/rename",
+          description: "rename session",
+          onSelect: () => dialog.trigger("session.rename"),
+        },
+        {
+          display: "/copy",
+          description: "copy session transcript to clipboard",
+          onSelect: () => dialog.trigger("session.copy"),
+        },
+        {
+          display: "/export",
+          description: "export session transcript to file",
+          onSelect: () => dialog.trigger("session.export"),
+        },
+        {
+          display: "/timeline",
+          description: "jump to message",
+          onSelect: () => dialog.trigger("session.timeline"),
+        },
+        {
+          display: "/fork",
+          description: "fork from message",
+          onSelect: () => dialog.trigger("session.fork"),
+        },
+        {
+          display: "/thinking",
+          description: "toggle thinking visibility",
+          onSelect: () => dialog.trigger("session.toggle.thinking"),
+        },
+      )
+      if (sync.data.config.share !== "disabled") {
+        results.push({
+          display: "/share",
+          disabled: !!s.share?.url,
+          description: "share a session",
+          onSelect: () => dialog.trigger("session.share"),
+        })
+      }
     }
 
-    results.sort((a, b) => a.display.localeCompare(b.display))
-
+    results.push(
+      {
+        display: "/new",
+        aliases: ["/clear"],
+        description: "create a new session",
+        onSelect: () => dialog.trigger("session.new"),
+      },
+      {
+        display: "/models",
+        description: "list models",
+        onSelect: () => dialog.trigger("model.list"),
+      },
+      {
+        display: "/agents",
+        description: "list agents",
+        onSelect: () => dialog.trigger("agent.list"),
+      },
+      {
+        display: "/session",
+        aliases: ["/resume", "/continue"],
+        description: "list sessions",
+        onSelect: () => dialog.trigger("session.list"),
+      },
+      {
+        display: "/status",
+        description: "show status",
+        onSelect: () => dialog.trigger("opencode.status"),
+      },
+      {
+        display: "/mcp",
+        description: "toggle MCPs",
+        onSelect: () => dialog.trigger("mcp.list"),
+      },
+      {
+        display: "/theme",
+        description: "toggle theme",
+        onSelect: () => dialog.trigger("theme.switch"),
+      },
+      {
+        display: "/editor",
+        description: "open editor",
+        onSelect: () => dialog.trigger("prompt.editor", "prompt"),
+      },
+      {
+        display: "/connect",
+        description: "connect to a provider",
+        onSelect: () => dialog.trigger("provider.connect"),
+      },
+      {
+        display: "/help",
+        description: "show help",
+        onSelect: () => dialog.trigger("help.show"),
+      },
+      {
+        display: "/commands",
+        description: "show all commands",
+        onSelect: () => dialog.show(),
+      },
+      {
+        display: "/exit",
+        aliases: ["/quit", "/q"],
+        description: "exit the app",
+        onSelect: () => dialog.trigger("app.exit"),
+      },
+    )
     const max = firstBy(results, [(x) => x.display.length, "desc"])?.display.length
     if (!max) return results
     return results.map((item) => ({
@@ -373,8 +482,9 @@ export function Autocomplete(props: {
     const agentsValue = agents()
     const commandsValue = commands()
 
-    const mixed: AutocompleteOption[] =
+    const mixed: AutocompleteOption[] = (
       store.visible === "@" ? [...agentsValue, ...(filesValue || []), ...mcpResources()] : [...commandsValue]
+    ).filter((x) => x.disabled !== true)
 
     const currentFilter = filter()
 
@@ -462,7 +572,7 @@ export function Autocomplete(props: {
   }
 
   function show(mode: "@" | "/") {
-    command.keybinds(false)
+    dialog.keybinds(false)
     setStore({
       visible: mode,
       index: props.input().cursorOffset,
@@ -479,7 +589,7 @@ export function Autocomplete(props: {
         draft.input = props.input().plainText
       })
     }
-    command.keybinds(true)
+    dialog.keybinds(true)
     setStore("visible", false)
   }
 
@@ -534,13 +644,11 @@ export function Autocomplete(props: {
           const isNavDown = name === "down" || (ctrlOnly && name === "n")
 
           if (isNavUp) {
-            setStore("input", "keyboard")
             move(-1)
             e.preventDefault()
             return
           }
           if (isNavDown) {
-            setStore("input", "keyboard")
             move(1)
             e.preventDefault()
             return
@@ -623,17 +731,7 @@ export function Autocomplete(props: {
               paddingRight={1}
               backgroundColor={index === store.selected ? theme.primary : undefined}
               flexDirection="row"
-              onMouseMove={() => {
-                setStore("input", "mouse")
-              }}
-              onMouseOver={() => {
-                if (store.input !== "mouse") return
-                moveTo(index)
-              }}
-              onMouseDown={() => {
-                setStore("input", "mouse")
-                moveTo(index)
-              }}
+              onMouseOver={() => moveTo(index)}
               onMouseUp={() => select()}
             >
               <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -386,7 +386,7 @@ export function Session() {
         name: "compact",
         aliases: ["summarize"],
       },
-      onSelect: (dialog) => {
+      onSelect: async (dialog, trigger, data) => {
         const selectedModel = local.model.current()
         if (!selectedModel) {
           toast.show({
@@ -396,11 +396,29 @@ export function Session() {
           })
           return
         }
-        sdk.client.session.summarize({
+        // If no template provided (e.g., via keybind), use the default /compact command
+        const prompt = data?.template ?? sync.data.command.find((c) => c.name === "compact")?.template
+        if (!prompt) {
+          toast.show({
+            variant: "warning",
+            message: "No compact command configured",
+            duration: 3000,
+          })
+          return
+        }
+        const result = await sdk.client.session.summarize({
           sessionID: route.sessionID,
-          modelID: selectedModel.modelID,
           providerID: selectedModel.providerID,
+          modelID: selectedModel.modelID,
+          prompt,
         })
+        if (result.error) {
+          toast.show({
+            variant: "error",
+            message: "Summarize failed: " + JSON.stringify(result.error),
+            duration: 5000,
+          })
+        }
         dialog.clear()
       },
     },
@@ -988,11 +1006,11 @@ export function Session() {
                       {(function () {
                         const command = useCommandDialog()
                         const [hover, setHover] = createSignal(false)
-                        const dialog = useDialog()
+                        const modal = useDialog()
 
                         const handleUnrevert = async () => {
                           const confirmed = await DialogConfirm.show(
-                            dialog,
+                            modal,
                             "Confirm Redo",
                             "Are you sure you want to restore the reverted messages?",
                           )

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -38,7 +38,7 @@ export interface DialogSelectOption<T = any> {
   disabled?: boolean
   bg?: RGBA
   gutter?: JSX.Element
-  onSelect?: (ctx: DialogContext) => void
+  onSelect?: (ctx: DialogContext, trigger?: "prompt", data?: any) => void
 }
 
 export type DialogSelectRef<T> = {

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -5,6 +5,7 @@ import { Instance } from "../project/instance"
 import { Identifier } from "../id/id"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
+import PROMPT_COMPACT from "./template/compact.txt"
 import { MCP } from "../mcp"
 
 export namespace Command {
@@ -31,6 +32,7 @@ export namespace Command {
       // https://zod.dev/v4/changelog?id=zfunction
       template: z.promise(z.string()).or(z.string()),
       subtask: z.boolean().optional(),
+      compact: z.boolean().optional(),
       hints: z.array(z.string()),
     })
     .meta({
@@ -53,6 +55,7 @@ export namespace Command {
   export const Default = {
     INIT: "init",
     REVIEW: "review",
+    COMPACT: "compact",
   } as const
 
   const state = Instance.state(async () => {
@@ -76,6 +79,13 @@ export namespace Command {
         subtask: true,
         hints: hints(PROMPT_REVIEW),
       },
+      [Default.COMPACT]: {
+        name: Default.COMPACT,
+        description: "summarize session for compaction",
+        template: PROMPT_COMPACT,
+        compact: true,
+        hints: hints(PROMPT_COMPACT),
+      },
     }
 
     for (const [name, command] of Object.entries(cfg.command ?? {})) {
@@ -88,6 +98,7 @@ export namespace Command {
           return command.template
         },
         subtask: command.subtask,
+        compact: command.compact,
         hints: hints(command.template),
       }
     }

--- a/packages/opencode/src/command/template/compact.txt
+++ b/packages/opencode/src/command/template/compact.txt
@@ -1,0 +1,1 @@
+Provide a detailed prompt for continuing our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next considering new session will not have access to our conversation.

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -556,6 +556,7 @@ export namespace Config {
     agent: z.string().optional(),
     model: z.string().optional(),
     subtask: z.boolean().optional(),
+    compact: z.boolean().optional(),
   })
   export type Command = z.infer<typeof Command>
 
@@ -1042,6 +1043,10 @@ export namespace Config {
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),
           prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
+          command: z
+            .string()
+            .optional()
+            .describe("Command to use for automatic compaction when context limit is reached. Defaults to 'compact'"),
         })
         .optional(),
       experimental: z

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -513,6 +513,7 @@ export const SessionRoutes = lazy(() =>
         z.object({
           providerID: z.string(),
           modelID: z.string(),
+          prompt: z.string().describe("Prompt to use for compaction"),
           auto: z.boolean().optional().default(false),
         }),
       ),
@@ -538,6 +539,7 @@ export const SessionRoutes = lazy(() =>
             modelID: body.modelID,
           },
           auto: body.auto,
+          prompt: body.prompt,
         })
         await SessionPrompt.loop(sessionID)
         return c.json(true)

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -12,11 +12,14 @@ import { Log } from "../util/log"
 import { SessionProcessor } from "./processor"
 import { fn } from "@/util/fn"
 import { Agent } from "@/agent/agent"
+import PROMPT_COMPACT from "../command/template/compact.txt"
 import { Plugin } from "@/plugin"
 import { Config } from "@/config/config"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
+
+  export const DEFAULT_PROMPT = PROMPT_COMPACT
 
   export const Event = {
     Compacted: BusEvent.define(
@@ -95,6 +98,7 @@ export namespace SessionCompaction {
     sessionID: string
     abort: AbortSignal
     auto: boolean
+    prompt: string
   }) {
     const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
     const agent = await Agent.get("compaction")
@@ -132,15 +136,12 @@ export namespace SessionCompaction {
       model,
       abort: input.abort,
     })
-    // Allow plugins to inject context or replace compaction prompt
+    // Allow plugins to inject additional context for compaction
     const compacting = await Plugin.trigger(
       "experimental.session.compacting",
       { sessionID: input.sessionID },
-      { context: [], prompt: undefined },
+      { context: [] },
     )
-    const defaultPrompt =
-      "Provide a detailed prompt for continuing our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next considering new session will not have access to our conversation."
-    const promptText = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
     const result = await processor.process({
       user: userMessage,
       agent,
@@ -155,7 +156,7 @@ export namespace SessionCompaction {
           content: [
             {
               type: "text",
-              text: promptText,
+              text: [input.prompt, ...compacting.context].join("\n\n"),
             },
           ],
         },
@@ -201,6 +202,7 @@ export namespace SessionCompaction {
         modelID: z.string(),
       }),
       auto: z.boolean(),
+      prompt: z.string(),
     }),
     async (input) => {
       const msg = await Session.updateMessage({
@@ -219,6 +221,7 @@ export namespace SessionCompaction {
         sessionID: msg.sessionID,
         type: "compaction",
         auto: input.auto,
+        prompt: input.prompt,
       })
     },
   )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -159,6 +159,7 @@ export namespace MessageV2 {
   export const CompactionPart = PartBase.extend({
     type: z.literal("compaction"),
     auto: z.boolean(),
+    prompt: z.string(),
   }).meta({
     ref: "CompactionPart",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -33,6 +33,7 @@ import { spawn } from "child_process"
 import { Command } from "../command"
 import { $, fileURLToPath } from "bun"
 import { ConfigMarkdown } from "../config/markdown"
+import { Config } from "../config/config"
 import { SessionSummary } from "./summary"
 import { NamedError } from "@opencode-ai/util/error"
 import { fn } from "@/util/fn"
@@ -484,12 +485,16 @@ export namespace SessionPrompt {
 
       // pending compaction
       if (task?.type === "compaction") {
+        if (!task.prompt) {
+          throw new Error("Compaction task missing required prompt")
+        }
         const result = await SessionCompaction.process({
           messages: msgs,
           parentID: lastUser.id,
           abort,
           sessionID,
           auto: task.auto,
+          prompt: task.prompt,
         })
         if (result === "stop") break
         continue
@@ -501,11 +506,26 @@ export namespace SessionPrompt {
         lastFinished.summary !== true &&
         (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model }))
       ) {
+        const cfg = await Config.get()
+        const compactCommandName = cfg.compaction?.command ?? "compact"
+        const compactCommand = await Command.get(compactCommandName)
+
+        if (!compactCommand) {
+          const errorMsg =
+            `Auto-compaction command "${compactCommandName}" not found. ` +
+            `Please ensure the command exists or update the "compaction.command" config setting.`
+          log.error("auto-compaction command not found", {
+            compactCommandName,
+          })
+          throw new Error(errorMsg)
+        }
+
         await SessionCompaction.create({
           sessionID,
           agent: lastUser.agent,
           model: lastUser.model,
           auto: true,
+          prompt: await compactCommand.template,
         })
         continue
       }
@@ -615,11 +635,14 @@ export namespace SessionPrompt {
       })
       if (result === "stop") break
       if (result === "compact") {
+        const cfg = await Config.get()
+        const compactCmd = await Command.get(cfg.compaction?.command ?? Command.Default.COMPACT)
         await SessionCompaction.create({
           sessionID,
           agent: lastUser.agent,
           model: lastUser.model,
           auto: true,
+          prompt: await compactCmd.template,
         })
       }
       continue

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1451,6 +1451,7 @@ export type Command = {
   model?: string
   template: string
   subtask?: boolean
+  compact?: boolean
 }
 
 export type Model = {
@@ -2507,6 +2508,7 @@ export type SessionSummarizeData = {
   body?: {
     providerID: string
     modelID: string
+    prompt?: string
   }
   path: {
     /**

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1288,6 +1288,7 @@ export class Session extends HeyApiClient {
       directory?: string
       providerID?: string
       modelID?: string
+      prompt?: string
       auto?: boolean
     },
     options?: Options<never, ThrowOnError>,
@@ -1301,6 +1302,7 @@ export class Session extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "body", key: "providerID" },
             { in: "body", key: "modelID" },
+            { in: "body", key: "prompt" },
             { in: "body", key: "auto" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2105,6 +2105,7 @@ export type Command = {
   mcp?: boolean
   template: string
   subtask?: boolean
+  compact?: boolean
   hints: Array<string>
 }
 

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -312,6 +312,31 @@ This is an **optional** config option.
 
 ---
 
+### Compact
+
+The `/compact` command performs **session compaction** - summarizing conversation history and removing all previous messages from context, replacing them with the summary. This reduces context size while preserving important information about what happened in the session.
+
+This command is called automatically when OpenCode reaches its token limit threshold (see [`compaction.auto`](/docs/config#compaction)). You can also run it manually at any time.
+
+To customize compaction:
+
+1. **Override the built-in command** - Create a custom `/compact` command using the patterns described above
+2. **Create a new compact command** - Mark any command with `compact: true` and configure [`compaction.command`](/docs/config#compaction) to specify which command is used for automatic compaction
+
+The command body will be used as the summary prompt.
+
+```md title=".opencode/command/handover.md"
+---
+description: Hand over session to next developer
+compact: true
+---
+
+Summarize this session for the next developer.
+Include key decisions and next steps.
+```
+
+---
+
 ## Built-in
 
 opencode includes several built-in commands like `/init`, `/undo`, `/redo`, `/share`, `/help`; [learn more](/docs/tui#commands).

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -488,13 +488,17 @@ You can control context compaction behavior through the `compaction` option.
   "$schema": "https://opencode.ai/config.json",
   "compaction": {
     "auto": true,
-    "prune": true
+    "prune": true,
+    "command": "compact"
   }
 }
 ```
 
 - `auto` - Automatically compact the session when context is full (default: `true`).
 - `prune` - Remove old tool outputs to save tokens (default: `true`).
+- `command` - Command to use for automatic compaction when context limit is reached (default: `"compact"`).
+
+[Learn more about compaction](/docs/commands#compact).
 
 ---
 


### PR DESCRIPTION
This will help to address the [many](https://github.com/anomalyco/opencode/issues/6535) [issues](https://github.com/anomalyco/opencode/issues/3031) [about](https://github.com/anomalyco/opencode/issues/4317) [compaction](https://github.com/anomalyco/opencode/issues/2945)

Closes [#3031](https://github.com/anomalyco/opencode/issues/3031)

I have had great success using this version with a custom "handover" compact prompt.

## example: override `/compact` with `compact.md`

This will now affect auto-compaction.

`~/.config/opencode/command/compact.md`
```markdown
---
description: my custom compact
compact: true
---

Provide a detailed summary focusing on ...
```

## example: custom command `/handover`

`~/.config/opencode/command/handover.md`
```markdown
---
description: handover to new agent
compact: true
---

Produce a handoff note from this conversation ...
```

## example: set auto-compact to use `/handover`

`~/.config/opencode/opencode.json`
```json
{
  "compaction": {
    "command": "handover"
  }
}
```

---

I have spent a lot of time making this PR as small and well integrated as possible, as I'm relying on it for my day-to-day work.