### PR TITLE
docs: format installation commands for madkrown code block

### DIFF
--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -42,10 +42,30 @@ You can also install it with the following commands:
 - **Using Node.js**
 
   <Tabs>
-    <TabItem label="npm">```bash npm install -g opencode-ai ```</TabItem>
-    <TabItem label="Bun">```bash bun install -g opencode-ai ```</TabItem>
-    <TabItem label="pnpm">```bash pnpm install -g opencode-ai ```</TabItem>
-    <TabItem label="Yarn">```bash yarn global add opencode-ai ```</TabItem>
+    <TabItem label="npm">
+      ```bash 
+      npm install -g opencode-ai 
+      ```
+
+    </TabItem>
+    <TabItem label="Bun">
+      ```bash 
+      bun install -g opencode-ai 
+      ```
+
+    </TabItem>
+    <TabItem label="pnpm">
+      ```bash 
+      pnpm install -g opencode-ai 
+      ```
+
+    </TabItem>
+    <TabItem label="Yarn">
+      ```bash 
+      yarn global add opencode-ai 
+      ```
+      
+    </TabItem>
   </Tabs>
 
 - **Using Homebrew on macOS and Linux**

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -42,31 +42,31 @@ You can also install it with the following commands:
 - **Using Node.js**
 
   <Tabs>
-    <TabItem label="npm">
-      ```bash 
-      npm install -g opencode-ai 
-      ```
+  <TabItem label="npm">
+    ```bash 
+    npm install -g opencode-ai 
+    ```
 
     </TabItem>
-    <TabItem label="Bun">
-      ```bash 
-      bun install -g opencode-ai 
-      ```
+  <TabItem label="Bun">
+    ```bash 
+    bun install -g opencode-ai 
+    ```
 
     </TabItem>
-    <TabItem label="pnpm">
-      ```bash 
-      pnpm install -g opencode-ai 
-      ```
+  <TabItem label="pnpm">
+    ```bash 
+    pnpm install -g opencode-ai 
+    ```
 
     </TabItem>
-    <TabItem label="Yarn">
-      ```bash 
-      yarn global add opencode-ai 
-      ```
-      
-    </TabItem>
-  </Tabs>
+  <TabItem label="Yarn">
+    ```bash 
+    yarn global add opencode-ai 
+    ```
+    
+  </TabItem>
+</Tabs>
 
 - **Using Homebrew on macOS and Linux**
 


### PR DESCRIPTION
<img width="2560" height="1288" alt="image" src="https://github.com/user-attachments/assets/8d393de0-cf6a-41b5-80fc-d8467f1ed94f" />

fix the docs not render as  a correct code block :)