### PR TITLE
Consolidate ACP Tool Call Events from 3 to 2

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -150,7 +150,7 @@ export namespace ACP {
                 if (!message || message.info.role !== "assistant") return
 
                 if (part.type === "tool") {
-                  switch (part.state.status) {    
+                  switch (part.state.status) {
                     case "pending":
                       break
                     case "running":
@@ -163,12 +163,12 @@ export namespace ACP {
                             title: part.tool,
                             kind: toToolKind(part.tool),
                             status: "in_progress",
-                            locations: [],
+                            locations: toLocations(part.tool, part.state.input),
                             rawInput: part.state.input,
                           },
                         })
                         .catch((err) => {
-                          log.error("failed to send tool pending to ACP", { error: err })
+                          log.error("failed to send tool in_progress to ACP", { error: err })
                         })
                       break
                     case "completed":

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -150,8 +150,10 @@ export namespace ACP {
                 if (!message || message.info.role !== "assistant") return
 
                 if (part.type === "tool") {
-                  switch (part.state.status) {
+                  switch (part.state.status) {    
                     case "pending":
+                      break
+                    case "running":
                       await this.connection
                         .sessionUpdate({
                           sessionId,
@@ -160,29 +162,13 @@ export namespace ACP {
                             toolCallId: part.callID,
                             title: part.tool,
                             kind: toToolKind(part.tool),
-                            status: "pending",
-                            locations: [],
-                            rawInput: {},
-                          },
-                        })
-                        .catch((err) => {
-                          log.error("failed to send tool pending to ACP", { error: err })
-                        })
-                      break
-                    case "running":
-                      await this.connection
-                        .sessionUpdate({
-                          sessionId,
-                          update: {
-                            sessionUpdate: "tool_call_update",
-                            toolCallId: part.callID,
                             status: "in_progress",
-                            locations: toLocations(part.tool, part.state.input),
+                            locations: [],
                             rawInput: part.state.input,
                           },
                         })
                         .catch((err) => {
-                          log.error("failed to send tool in_progress to ACP", { error: err })
+                          log.error("failed to send tool pending to ACP", { error: err })
                         })
                       break
                     case "completed":

--- a/script/format.ts
+++ b/script/format.ts
@@ -9,5 +9,6 @@ if (process.env["CI"] && (await $`git status --porcelain`.text())) {
   await $`git config --local user.name "GitHub Action"`
   await $`git add -A`
   await $`git commit -m "chore: format code"`
-  await $`git push --no-verify`
+  const branch = process.env["GITHUB_HEAD_REF"] || process.env["GITHUB_REF_NAME"]
+  await $`git push origin HEAD:${branch} --no-verify`
 }


### PR DESCRIPTION
# Consolidate ACP Tool Call Events from 3 to 2

## Summary
Reduce tool call event emissions from 3 events (pending → running → completed) to 2 events (running → completed) by removing the redundant pending event.

## Problem
Currently, we send 3 ACP events per tool call:
- **pending**: `tool_call` event with no input parameters (empty `{}`)
- **running**: `tool_call_update` event with the actual input parameters
- **completed**: `tool_call_update` event with results

The pending event provides no useful information since `part.state.input` is empty by design, creating unnecessary noise in the ACP event stream.

## Root Cause Analysis

The pending event has no input content by design. In `src/session/prompt.ts:1076`, when the "tool-input-start" event occurs, the tool part is created with:

```typescript
state: {
  status: "pending",
  input: {},  // Empty object - no parameters yet
  raw: "",
}
```

The input parameters are only populated when the tool transitions to "running" status. This means:
- **pending state**: Tool is queued, but `part.state.input` is empty (`{}`)
- **running state**: Tool is executing, `part.state.input` contains actual parameters

In `src/acp/agent.ts`, when we receive the pending event via `this.config.sdk.event.subscribe`, the `part.state.input` field is empty.

**Conclusion**: The pending event is inherently empty and provides no useful information beyond the tool ID. The original 2-event approach (skip pending, only send running + completed) is correct.

## Solution
Skip the pending state and only emit 2 events:
- **running**: `tool_call` event with input parameters and `status: "in_progress"`
- **completed**: `tool_call_update` event with results

## Changes
In `src/acp/agent.ts:150-165`:
- Add `break` in pending case (no-op)
- Consolidate tool call emission into running case with actual input parameters
- Send `status: "in_progress"` instead of separate pending/running events

## Testing
Tested with the latest version of Zed and it works.
