### PR TITLE
fix: upgrade toast notification

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -22,7 +22,7 @@ import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { PromptHistoryProvider } from "./component/prompt/history"
 import { DialogAlert } from "./ui/dialog-alert"
-import { ToastProvider, useToast } from "./ui/toast"
+import { ToastProvider, useToast, Toast } from "./ui/toast"
 import { ExitProvider, useExit } from "./context/exit"
 import { Session as SessionApi } from "@/session"
 import { TuiEvent } from "./event"
@@ -393,6 +393,15 @@ function App() {
     })
   })
 
+  event.on(Installation.Event.Updated.type, (evt) => {
+    toast.show({
+      variant: "success",
+      title: "Update Complete",
+      message: `OpenCode updated to v${evt.properties.version}`,
+      duration: 5000,
+    })
+  })
+
   return (
     <box
       width={dimensions().width}
@@ -453,6 +462,7 @@ function App() {
           </text>
         </box>
       </box>
+      <Toast />
     </box>
   )
 }


### PR DESCRIPTION
Fixes #4154

Displays a success toast notification when OpenCode automatically upgrades to a new version in the background.

## Changes
  - Subscribe to `Installation.Event.Updated` events
  - Show success toast with upgrade completion message

## Test Plan
  - [x] Verified toast system works by testing with clipboard copy notification
  - [x] Confirmed toast displays with correct styling (green success variant)
  - [x] Toast shows: "Update Complete - OpenCode updated to v{version}"
  - [x] Toast auto-dismisses after 5 seconds

## Before
  - No visual feedback when automatic upgrades completed
  - User unaware of version changes

## After
  - Success toast appears in top-right corner
  - Shows new version number
  - Provides clear user feedback