### PR TITLE
Refactor/redundant toast comp

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
+import solidPlugin from "../../../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 
-// @ts-expect-error - Plugin file not exported in package types
 import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../../../node_modules/@opentui/solid/scripts/solid-plugin"
+// @ts-expect-error - Plugin file not exported in package types
+import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -22,7 +22,7 @@ import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { PromptHistoryProvider } from "./component/prompt/history"
 import { DialogAlert } from "./ui/dialog-alert"
-import { ToastProvider, useToast, Toast } from "./ui/toast"
+import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider, useExit } from "./context/exit"
 import { Session as SessionApi } from "@/session"
 import { TuiEvent } from "./event"
@@ -462,7 +462,6 @@ function App() {
           </text>
         </box>
       </box>
-      <Toast />
     </box>
   )
 }


### PR DESCRIPTION
- Remove redundant toast component from TopNav (originally added in #4154)
~~- Fix import path related issue for build script~~

## Changes

### Remove redundant toast component
The toast component in `packages/opencode/src/cli/cmd/tui/app.tsx` was unnecessary since both Home and Session components already implemented it.

~~### Fix build script import path~~
~~The file exists and works at runtime, but TypeScript can't verify it during type checking because it's not in the package's exported types. Added a @ts-expect-error directive to suppress the TypeScript error.~~