### PR TITLE
Add Google Generative AI (Gemini) provider support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -224,6 +224,7 @@
       },
       "devDependencies": {
         "@ai-sdk/amazon-bedrock": "2.2.10",
+        "@ai-sdk/google": "2.0.11",
         "@ai-sdk/google-vertex": "3.0.16",
         "@babel/core": "7.28.4",
         "@octokit/webhooks-types": "7.6.1",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "2.2.10",
+    "@ai-sdk/google": "2.0.11",
     "@ai-sdk/google-vertex": "3.0.16",
     "@babel/core": "7.28.4",
     "@octokit/webhooks-types": "7.6.1",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -208,6 +208,18 @@ export namespace Provider {
         },
       }
     },
+    google: async () => {
+      const apiKey =
+        process.env["GOOGLE_GENERATIVE_AI_API_KEY"] ??
+        process.env["GOOGLE_AI_API_KEY"] ??
+        process.env["GEMINI_API_KEY"] ??
+        process.env["GOOGLE_API_KEY"]
+
+      return {
+        autoload: Boolean(apiKey),
+        options: apiKey ? { apiKey } : {},
+      }
+    },
   }
 
   const state = Instance.state(async () => {


### PR DESCRIPTION
Implement support for Google's Generative AI models through the @ai-sdk/google package. The provider automatically loads when API keys are detected in the environment.

Changes:
- Add @ai-sdk/google (v2.0.11) package dependency
- Implement google provider configuration in provider.ts
- Support multiple environment variable names for API keys: GOOGLE_GENERATIVE_AI_API_KEY, GOOGLE_AI_API_KEY, GEMINI_API_KEY, and GOOGLE_API_KEY

This allows users to access Gemini models (e.g., gemini-pro, gemini-2.0-flash) by setting any of the supported API key environment variables.