### PR TITLE
docs: update keymap.json bindings for OpenCode command

### DIFF
--- a/packages/web/src/content/docs/acp.mdx
+++ b/packages/web/src/content/docs/acp.mdx
@@ -46,7 +46,20 @@ You can also bind a keyboard shortcut by editing your `keymap.json`:
 [
   {
     "bindings": {
-      "cmd-alt-o": ["agent::NewExternalAgentThread", { "agent": "OpenCode" }]
+      "cmd-alt-o": [
+        "agent::NewExternalAgentThread",
+        {
+          "agent": {
+            "custom": {
+              "name": "OpenCode",
+              "command": {
+                "command": "opencode",
+                "args": ["acp"]
+              }
+            }
+          }
+        }
+      ]
     }
   }
 ]


### PR DESCRIPTION
The existing documentation for keymap doesn't seem to work. I opened an issue with Zed and this was the suggested format (https://github.com/zed-industries/zed/issues/42142)