### PR TITLE
OpenAI compatible cache

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -128,10 +128,10 @@ export namespace ProviderTransform {
     return undefined
   }
 
-  export function options(providerID: string, modelID: string, sessionID: string): Record<string, any> | undefined {
+  export function options(providerID: string, modelID: string, npm: string, sessionID: string): Record<string, any> | undefined {
     const result: Record<string, any> = {}
 
-    if (providerID === "openai") {
+    if (providerID === "openai" || npm.includes("openai")) {
       result["promptCacheKey"] = sessionID
     }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -128,7 +128,12 @@ export namespace ProviderTransform {
     return undefined
   }
 
-  export function options(providerID: string, modelID: string, npm: string, sessionID: string): Record<string, any> | undefined {
+  export function options(
+    providerID: string,
+    modelID: string,
+    npm: string,
+    sessionID: string,
+  ): Record<string, any> | undefined {
     const result: Record<string, any> = {}
 
     if (providerID === "openai" || npm.includes("openai")) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -218,7 +218,7 @@ export namespace SessionPrompt {
           : undefined,
         topP: agent.topP ?? ProviderTransform.topP(model.providerID, model.modelID),
         options: {
-          ...ProviderTransform.options(model.providerID, model.modelID, input.sessionID),
+          ...ProviderTransform.options(model.providerID, model.modelID, model.npm ?? "", input.sessionID),
           ...model.info.options,
           ...agent.options,
         },
@@ -1815,7 +1815,7 @@ export namespace SessionPrompt {
     const small =
       (await Provider.getSmallModel(input.providerID)) ?? (await Provider.getModel(input.providerID, input.modelID))
     const options = {
-      ...ProviderTransform.options(small.providerID, small.modelID, input.session.id),
+      ...ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", input.session.id),
       ...small.info.options,
     }
     if (small.providerID === "openai" || small.modelID.includes("gpt-5")) {


### PR DESCRIPTION
Add prompt caching for openai compatible providers configured with npm.
Without this codex is unusable with opencode via CLIProxyAPI