### PR TITLE
docs: Update dead Context7 mcp server link

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -256,7 +256,7 @@ Below are examples of some common MCP servers. You can submit a PR if you want t
 
 ### Context7
 
-Add the [Context7 MCP server](https://github.com/context-labs/mcp-server-context7) to search through docs.
+Add the [Context7 MCP server](https://github.com/upstash/context7) to search through docs.
 
 ```json title="opencode.json" {4-7}
 {


### PR DESCRIPTION
# docs: Update dead Context7 mcp server link

The current link to the Context7 mcp server links to a 404.

This PR updates that link to the current Context7 GitHub: https://github.com/upstash/context7