### PR TITLE
File linking on paste

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -691,7 +691,7 @@ export function Prompt(props: PromptProps) {
 
                   const part = {
                     type: "file" as const,
-                    mime: file.type || "text/plain",
+                    mime: file.type,
                     filename: filepath,
                     url: `file://${process.cwd()}/${filepath}`,
                     source: {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -660,6 +660,61 @@ export function Prompt(props: PromptProps) {
                   )
                   return
                 }
+
+                try {
+                  event.preventDefault()
+
+                  const file = Bun.file(filepath)
+                  const stat = await file.stat()
+                  const isReferenceable = stat.isFile() || stat.isSymbolicLink() || stat.isDirectory()
+
+                  if (!isReferenceable) {
+                    input.insertText(pastedContent)
+                    return
+                  }
+
+                  const currentOffset = input.visualCursor.offset
+                  const virtualText = "@" + filepath
+                  const textToInsert = virtualText + " "
+                  const extmarkStart = currentOffset
+                  const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)
+
+                  input.insertText(textToInsert)
+
+                  const extmarkId = input.extmarks.create({
+                    start: extmarkStart,
+                    end: extmarkEnd,
+                    virtual: true,
+                    styleId: fileStyleId,
+                    typeId: promptPartTypeId,
+                  })
+
+                  const part = {
+                    type: "file" as const,
+                    mime: file.type || "text/plain",
+                    filename: filepath,
+                    url: `file://${process.cwd()}/${filepath}`,
+                    source: {
+                      type: "file" as const,
+                      text: {
+                        start: extmarkStart,
+                        end: extmarkEnd,
+                        value: virtualText,
+                      },
+                      path: filepath,
+                    },
+                  }
+
+                  setStore(
+                    produce((draft) => {
+                      const partIndex = draft.prompt.parts.length
+                      draft.prompt.parts.push(part)
+                      draft.extmarkToPartIndex.set(extmarkId, partIndex)
+                    }),
+                  )
+                } catch {
+                  input.insertText(pastedContent)
+                }
               }}
               ref={(r: TextareaRenderable) => (input = r)}
               onMouseDown={(r: MouseEvent) => r.target?.focus()}


### PR DESCRIPTION
1.0.0 removed the feature of auto-file linking when pasting a file path on the input (#3624). I **think** this PR complies with the `CONTRIBUTING.md` guidelines, but feel free to close it if it doesn't (or tell me how to improve it, I will gladly contribute what I can to this project)

The code runs after the image and long text bits and checks if the pasted text is a file/symbolic link/directory. If it isn't, it pastes the plain text as normal and continues, but if it is, it inserts the reference. I had to start with a `preventDefault` because of the async `stat` call, so I manually had to insert the raw text when it didn't match a file.

I didn't find any tests for near code, so I didn't write any, but if you need I can move some stuff around and make it so what I added is easier to test. I also think most of this code is similar to the autocomplete bits in some ways, I just opted to duplicate it to make it less code to review