### PR TITLE
fix: resolve @file references in slash commands with subagents

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -65,6 +65,7 @@ export const TaskTool = Tool.define("task", async () => {
       ctx.abort.addEventListener("abort", () => {
         SessionLock.abort(session.id)
       })
+      const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
       const result = await SessionPrompt.prompt({
         messageID,
         sessionID: session.id,
@@ -79,13 +80,7 @@ export const TaskTool = Tool.define("task", async () => {
           task: false,
           ...agent.tools,
         },
-        parts: [
-          {
-            id: Identifier.ascending("part"),
-            type: "text",
-            text: params.prompt,
-          },
-        ],
+        parts: promptParts,
       })
       unsub()
       let all


### PR DESCRIPTION
Fixes an issue where `@file` references in custom slash commands were not resolved  
when the command specified `agent: <subagent>`.

### Problem  
When a slash command used both `@file` references and `agent: foo`, the file references  
were passed literally to the subagent instead of being resolved to actual file  
contents. This worked correctly for normal commands but failed for subagent  
dispatch.

### Solution  
Extracted `resolvePromptParts()` function and reused it in the task tool pipeline  
(`packages/opencode/src/tool/task.ts:68`) to ensure `@file` references are resolved  
before subagent execution, matching the behavior of normal command handling.
