### PR TITLE
fix: Tool calling on windows

### DIFF
--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -182,8 +182,7 @@ export namespace Storage {
       using _ = await Lock.write(target)
       const content = await Bun.file(target).json()
       fn(content)
-      const jsonContent = JSON.stringify(content, null, 2)
-      await Bun.write(target, jsonContent)
+      await Bun.write(target, JSON.stringify(content, null, 2))
       return content as T
     })
   }
@@ -193,9 +192,7 @@ export namespace Storage {
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
       using _ = await Lock.write(target)
-      const jsonContent = JSON.stringify(content, null, 2)
-      await fs.mkdir(path.dirname(target), { recursive: true })
-      await Bun.write(target, jsonContent)
+      await Bun.write(target, JSON.stringify(content, null, 2))
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -182,13 +182,17 @@ export namespace Storage {
       const content = await Bun.file(target).json()
       fn(content)
       const jsonContent = JSON.stringify(content, null, 2)
-      const handle = await fs.open(target, "w")
+      const tempFile = target + ".tmp"
+      const handle = await fs.open(tempFile, "w")
       try {
         await handle.writeFile(jsonContent, "utf-8")
         await handle.sync()
       } finally {
         await handle.close()
       }
+      // On Windows, must delete target before rename
+      await fs.unlink(target).catch(() => {})
+      await fs.rename(tempFile, target)
       return content as T
     })
   }
@@ -200,13 +204,17 @@ export namespace Storage {
       using _ = await Lock.write(target)
       const jsonContent = JSON.stringify(content, null, 2)
       await fs.mkdir(path.dirname(target), { recursive: true })
-      const handle = await fs.open(target, "w")
+      const tempFile = target + ".tmp"
+      const handle = await fs.open(tempFile, "w")
       try {
         await handle.writeFile(jsonContent, "utf-8")
         await handle.sync()
       } finally {
         await handle.close()
       }
+      // On Windows, must delete target before rename
+      await fs.unlink(target).catch(() => {})
+      await fs.rename(tempFile, target)
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -170,8 +170,7 @@ export namespace Storage {
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
       using _ = await Lock.read(target)
-      const result = await Bun.file(target).json()
-      return result as Promise<T>
+      return Bun.file(target).json() as Promise<T>
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -173,19 +173,8 @@ export namespace Storage {
   }
 
   async function replaceFile(source: string, target: string) {
-    if (process.platform === "win32") {
-      // Windows: must delete before rename (creates brief window where file doesn't exist)
-      // Callers must hold write lock to coordinate with Storage.read()
-      try {
-        await fs.unlink(target)
-      } catch (e) {
-        const code = (e as NodeJS.ErrnoException).code
-        if (code !== "ENOENT") {
-          log.warn("Unexpected unlink error during replace", { target, code })
-        }
-      }
-    }
-    // Unix: rename is atomic and overwrites
+    // Both Unix and Windows: rename should be atomic with overwrite
+    // Node.js uses MoveFileEx with MOVEFILE_REPLACE_EXISTING on Windows
     await fs.rename(source, target)
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -165,6 +165,13 @@ export namespace Storage {
     })
   }
 
+  async function atomicRename(source: string, target: string) {
+    if (process.platform === "win32") {
+      await fs.unlink(target).catch(() => {})
+    }
+    await fs.rename(source, target)
+  }
+
   export async function read<T>(key: string[]) {
     const dir = await state().then((x) => x.dir)
     const target = path.join(dir, ...key) + ".json"
@@ -183,16 +190,8 @@ export namespace Storage {
       fn(content)
       const jsonContent = JSON.stringify(content, null, 2)
       const tempFile = target + ".tmp"
-      const handle = await fs.open(tempFile, "w")
-      try {
-        await handle.writeFile(jsonContent, "utf-8")
-        await handle.sync()
-      } finally {
-        await handle.close()
-      }
-      // On Windows, must delete target before rename
-      await fs.unlink(target).catch(() => {})
-      await fs.rename(tempFile, target)
+      await Bun.write(tempFile, jsonContent)
+      await atomicRename(tempFile, target)
       return content as T
     })
   }
@@ -205,16 +204,8 @@ export namespace Storage {
       const jsonContent = JSON.stringify(content, null, 2)
       await fs.mkdir(path.dirname(target), { recursive: true })
       const tempFile = target + ".tmp"
-      const handle = await fs.open(tempFile, "w")
-      try {
-        await handle.writeFile(jsonContent, "utf-8")
-        await handle.sync()
-      } finally {
-        await handle.close()
-      }
-      // On Windows, must delete target before rename
-      await fs.unlink(target).catch(() => {})
-      await fs.rename(tempFile, target)
+      await Bun.write(tempFile, jsonContent)
+      await atomicRename(tempFile, target)
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -165,13 +165,6 @@ export namespace Storage {
     })
   }
 
-  function getTempFile(target: string): string {
-    // Use unique temp filename to avoid collisions
-    const timestamp = Date.now()
-    const random = Math.random().toString(36).substring(2, 9)
-    return `${target}.${timestamp}.${random}.tmp`
-  }
-
   export async function read<T>(key: string[]) {
     const dir = await state().then((x) => x.dir)
     const target = path.join(dir, ...key) + ".json"
@@ -190,7 +183,7 @@ export namespace Storage {
       const content = await Bun.file(target).json()
       fn(content)
       const jsonContent = JSON.stringify(content, null, 2)
-      const tempFile = getTempFile(target)
+      const tempFile = target + ".tmp"
       await Bun.write(tempFile, jsonContent)
       await fs.rename(tempFile, target)
       return content as T
@@ -204,7 +197,7 @@ export namespace Storage {
       using _ = await Lock.write(target)
       const jsonContent = JSON.stringify(content, null, 2)
       await fs.mkdir(path.dirname(target), { recursive: true })
-      const tempFile = getTempFile(target)
+      const tempFile = target + ".tmp"
       await Bun.write(tempFile, jsonContent)
       await fs.rename(tempFile, target)
     })

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -183,9 +183,7 @@ export namespace Storage {
       const content = await Bun.file(target).json()
       fn(content)
       const jsonContent = JSON.stringify(content, null, 2)
-      const tempFile = target + ".tmp"
-      await Bun.write(tempFile, jsonContent)
-      await fs.rename(tempFile, target)
+      await Bun.write(target, jsonContent)
       return content as T
     })
   }
@@ -197,9 +195,7 @@ export namespace Storage {
       using _ = await Lock.write(target)
       const jsonContent = JSON.stringify(content, null, 2)
       await fs.mkdir(path.dirname(target), { recursive: true })
-      const tempFile = target + ".tmp"
-      await Bun.write(tempFile, jsonContent)
-      await fs.rename(tempFile, target)
+      await Bun.write(target, jsonContent)
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -170,7 +170,8 @@ export namespace Storage {
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
       using _ = await Lock.read(target)
-      return Bun.file(target).json() as Promise<T>
+      const result = await Bun.file(target).json()
+      return result as Promise<T>
     })
   }
 
@@ -178,10 +179,17 @@ export namespace Storage {
     const dir = await state().then((x) => x.dir)
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
-      using _ = await Lock.write("storage")
+      using _ = await Lock.write(target)
       const content = await Bun.file(target).json()
       fn(content)
-      await Bun.write(target, JSON.stringify(content, null, 2))
+      const jsonContent = JSON.stringify(content, null, 2)
+      const handle = await fs.open(target, "w")
+      try {
+        await handle.writeFile(jsonContent, "utf-8")
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
       return content as T
     })
   }
@@ -190,8 +198,16 @@ export namespace Storage {
     const dir = await state().then((x) => x.dir)
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
-      using _ = await Lock.write("storage")
-      await Bun.write(target, JSON.stringify(content, null, 2))
+      using _ = await Lock.write(target)
+      const jsonContent = JSON.stringify(content, null, 2)
+      await fs.mkdir(path.dirname(target), { recursive: true })
+      const handle = await fs.open(target, "w")
+      try {
+        await handle.writeFile(jsonContent, "utf-8")
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -172,18 +172,11 @@ export namespace Storage {
     return `${target}.${timestamp}.${random}.tmp`
   }
 
-  async function replaceFile(source: string, target: string) {
-    // Both Unix and Windows: rename should be atomic with overwrite
-    // Node.js uses MoveFileEx with MOVEFILE_REPLACE_EXISTING on Windows
-    await fs.rename(source, target)
-  }
-
   export async function read<T>(key: string[]) {
     const dir = await state().then((x) => x.dir)
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
       using _ = await Lock.read(target)
-      // Must await JSON parsing before lock releases
       const result = await Bun.file(target).json()
       return result as T
     })
@@ -198,14 +191,8 @@ export namespace Storage {
       fn(content)
       const jsonContent = JSON.stringify(content, null, 2)
       const tempFile = getTempFile(target)
-      try {
-        await Bun.write(tempFile, jsonContent)
-        await replaceFile(tempFile, target)
-      } catch (e) {
-        // Clean up temp file on failure
-        await fs.unlink(tempFile).catch(() => {})
-        throw e
-      }
+      await Bun.write(tempFile, jsonContent)
+      await fs.rename(tempFile, target)
       return content as T
     })
   }
@@ -218,14 +205,8 @@ export namespace Storage {
       const jsonContent = JSON.stringify(content, null, 2)
       await fs.mkdir(path.dirname(target), { recursive: true })
       const tempFile = getTempFile(target)
-      try {
-        await Bun.write(tempFile, jsonContent)
-        await replaceFile(tempFile, target)
-      } catch (e) {
-        // Clean up temp file on failure
-        await fs.unlink(tempFile).catch(() => {})
-        throw e
-      }
+      await Bun.write(tempFile, jsonContent)
+      await fs.rename(tempFile, target)
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -165,10 +165,12 @@ export namespace Storage {
     })
   }
 
-  async function atomicRename(source: string, target: string) {
+  async function replaceFile(source: string, target: string) {
     if (process.platform === "win32") {
+      // Windows: delete then rename (not atomic, but safe with write lock)
       await fs.unlink(target).catch(() => {})
     }
+    // Unix: rename is atomic and overwrites
     await fs.rename(source, target)
   }
 
@@ -191,7 +193,7 @@ export namespace Storage {
       const jsonContent = JSON.stringify(content, null, 2)
       const tempFile = target + ".tmp"
       await Bun.write(tempFile, jsonContent)
-      await atomicRename(tempFile, target)
+      await replaceFile(tempFile, target)
       return content as T
     })
   }
@@ -205,7 +207,7 @@ export namespace Storage {
       await fs.mkdir(path.dirname(target), { recursive: true })
       const tempFile = target + ".tmp"
       await Bun.write(tempFile, jsonContent)
-      await atomicRename(tempFile, target)
+      await replaceFile(tempFile, target)
     })
   }
 

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -165,10 +165,25 @@ export namespace Storage {
     })
   }
 
+  function getTempFile(target: string): string {
+    // Use unique temp filename to avoid collisions
+    const timestamp = Date.now()
+    const random = Math.random().toString(36).substring(2, 9)
+    return `${target}.${timestamp}.${random}.tmp`
+  }
+
   async function replaceFile(source: string, target: string) {
     if (process.platform === "win32") {
-      // Windows: delete then rename (not atomic, but safe with write lock)
-      await fs.unlink(target).catch(() => {})
+      // Windows: must delete before rename (creates brief window where file doesn't exist)
+      // Callers must hold write lock to coordinate with Storage.read()
+      try {
+        await fs.unlink(target)
+      } catch (e) {
+        const code = (e as NodeJS.ErrnoException).code
+        if (code !== "ENOENT") {
+          log.warn("Unexpected unlink error during replace", { target, code })
+        }
+      }
     }
     // Unix: rename is atomic and overwrites
     await fs.rename(source, target)
@@ -179,7 +194,9 @@ export namespace Storage {
     const target = path.join(dir, ...key) + ".json"
     return withErrorHandling(async () => {
       using _ = await Lock.read(target)
-      return Bun.file(target).json() as Promise<T>
+      // Must await JSON parsing before lock releases
+      const result = await Bun.file(target).json()
+      return result as T
     })
   }
 
@@ -191,9 +208,15 @@ export namespace Storage {
       const content = await Bun.file(target).json()
       fn(content)
       const jsonContent = JSON.stringify(content, null, 2)
-      const tempFile = target + ".tmp"
-      await Bun.write(tempFile, jsonContent)
-      await replaceFile(tempFile, target)
+      const tempFile = getTempFile(target)
+      try {
+        await Bun.write(tempFile, jsonContent)
+        await replaceFile(tempFile, target)
+      } catch (e) {
+        // Clean up temp file on failure
+        await fs.unlink(tempFile).catch(() => {})
+        throw e
+      }
       return content as T
     })
   }
@@ -205,9 +228,15 @@ export namespace Storage {
       using _ = await Lock.write(target)
       const jsonContent = JSON.stringify(content, null, 2)
       await fs.mkdir(path.dirname(target), { recursive: true })
-      const tempFile = target + ".tmp"
-      await Bun.write(tempFile, jsonContent)
-      await replaceFile(tempFile, target)
+      const tempFile = getTempFile(target)
+      try {
+        await Bun.write(tempFile, jsonContent)
+        await replaceFile(tempFile, target)
+      } catch (e) {
+        // Clean up temp file on failure
+        await fs.unlink(tempFile).catch(() => {})
+        throw e
+      }
     })
   }
 


### PR DESCRIPTION
Replaces global storage lock with per-file lock for write operations and fixes a non awaited operation


fixes https://github.com/sst/opencode/issues/4042