### PR TITLE
tui: align keybinds with standard terminal/readline/screen conventions

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -396,16 +396,16 @@ export namespace Config {
       session_unshare: z.string().optional().default("none").describe("Unshare current session"),
       session_interrupt: z.string().optional().default("escape").describe("Interrupt current session"),
       session_compact: z.string().optional().default("<leader>c").describe("Compact the session"),
-      messages_page_up: z.string().optional().default("pageup").describe("Scroll messages up by one page"),
-      messages_page_down: z.string().optional().default("pagedown").describe("Scroll messages down by one page"),
+      messages_page_up: z.string().optional().default("ctrl+alt+b,pageup").describe("Scroll messages up by one page"),
+      messages_page_down: z.string().optional().default("ctrl+alt+f,pagedown").describe("Scroll messages down by one page"),
       messages_half_page_up: z.string().optional().default("ctrl+alt+u").describe("Scroll messages up by half page"),
       messages_half_page_down: z
         .string()
         .optional()
         .default("ctrl+alt+d")
         .describe("Scroll messages down by half page"),
-      messages_first: z.string().optional().default("ctrl+g,home").describe("Navigate to first message"),
-      messages_last: z.string().optional().default("ctrl+alt+g,end").describe("Navigate to last message"),
+      messages_first: z.string().optional().default("ctrl+g").describe("Navigate to first message"),
+      messages_last: z.string().optional().default("ctrl+alt+g").describe("Navigate to last message"),
       messages_copy: z.string().optional().default("<leader>y").describe("Copy message"),
       messages_undo: z.string().optional().default("<leader>u").describe("Undo message"),
       messages_redo: z.string().optional().default("<leader>r").describe("Redo message"),
@@ -426,10 +426,10 @@ export namespace Config {
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("return").describe("Submit input"),
       input_newline: z.string().optional().default("shift+return,ctrl+j").describe("Insert newline in input"),
-      history_previous: z.string().optional().default("up").describe("Previous history item"),
-      history_next: z.string().optional().default("down").describe("Next history item"),
-      session_child_cycle: z.string().optional().default("ctrl+right").describe("Next child session"),
-      session_child_cycle_reverse: z.string().optional().default("ctrl+left").describe("Previous child session"),
+      history_previous: z.string().optional().default("ctrl+up").describe("Previous history item"),
+      history_next: z.string().optional().default("ctrl+down").describe("Next history item"),
+      session_child_cycle: z.string().optional().default("ctrl+tab").describe("Next child session"),
+      session_child_cycle_reverse: z.string().optional().default("ctrl+shift+tab").describe("Previous child session"),
     })
     .strict()
     .meta({

--- a/packages/sdk/python/src/opencode_ai/models/keybinds_config.py
+++ b/packages/sdk/python/src/opencode_ai/models/keybinds_config.py
@@ -81,10 +81,10 @@ class KeybindsConfig:
     session_unshare: Union[Unset, str] = "none"
     session_interrupt: Union[Unset, str] = "esc"
     session_compact: Union[Unset, str] = "<leader>c"
-    session_child_cycle: Union[Unset, str] = "ctrl+right"
-    session_child_cycle_reverse: Union[Unset, str] = "ctrl+left"
-    messages_page_up: Union[Unset, str] = "pgup"
-    messages_page_down: Union[Unset, str] = "pgdown"
+    session_child_cycle: Union[Unset, str] = "ctrl+tab"
+    session_child_cycle_reverse: Union[Unset, str] = "ctrl+shift+tab"
+    messages_page_up: Union[Unset, str] = "ctrl+alt+b,pgup"
+    messages_page_down: Union[Unset, str] = "ctrl+alt+f,pgdown"
     messages_half_page_up: Union[Unset, str] = "ctrl+alt+u"
     messages_half_page_down: Union[Unset, str] = "ctrl+alt+d"
     messages_first: Union[Unset, str] = "ctrl+g"
@@ -114,6 +114,8 @@ class KeybindsConfig:
     messages_next: Union[Unset, str] = "none"
     messages_layout_toggle: Union[Unset, str] = "none"
     messages_revert: Union[Unset, str] = "none"
+    history_previous: Union[Unset, str] = "ctrl+up"
+    history_next: Union[Unset, str] = "ctrl+down"
 
     def to_dict(self) -> dict[str, Any]:
         leader = self.leader

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -23,10 +23,10 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "session_unshare": "none",
     "session_interrupt": "escape",
     "session_compact": "<leader>c",
-    "session_child_cycle": "ctrl+right",
-    "session_child_cycle_reverse": "ctrl+left",
-    "messages_page_up": "pageup",
-    "messages_page_down": "pagedown",
+    "session_child_cycle": "ctrl+tab",
+    "session_child_cycle_reverse": "ctrl+shift+tab",
+    "messages_page_up": "ctrl+alt+g,pageup",
+    "messages_page_down": "ctrl+alt+f,pagedown",
     "messages_half_page_up": "ctrl+alt+u",
     "messages_half_page_down": "ctrl+alt+d",
     "messages_first": "ctrl+g,home",
@@ -47,8 +47,8 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "input_paste": "ctrl+v",
     "input_submit": "enter",
     "input_newline": "shift+enter,ctrl+j",
-    "history_previous": "up",
-    "history_next": "down"
+    "history_previous": "ctrl+up",
+    "history_next": "ctrl+down"
   }
 }
 ```


### PR DESCRIPTION
Aligned the keybinds with standard terminal/readline/screen conventions.

<br />

```jsonc
"session_child_cycle": "ctrl+tab", // was "ctrl+right"
"session_child_cycle_reverse": "ctrl+shift+tab", // was "ctrl+left"
```
- Changing `ctrl+left`/`ctrl+right` as it conflicts with standard terminal/readline convention to quickly move the cursor word by word (instead of by char).
- Changed to `ctrl+tab`/`ctrl+shift+tab` to make cycling through child agents similar to cycling through primary agents (`tab`/`shift+tab`).
- Result: Unfortunately, the cursor is not moving yet as something is interfering with the readline configuration (`/etc/inputrc`) and also both `ctrl+tab`/`ctrl+shift+tab` are picked up as there was no `ctrl`. :(

<br />

```jsonc
"messages_page_up": "ctrl+alt+b,pageup", // was "pageup"
"messages_page_down": "ctrl+alt+f,pagedown", // was "pagedown"
```
- Adding GNU/screen-like full screen movement keys `ctrl+alt+b`/`ctrl+alt+f` to match half screen movement keys (opencode: `ctrl+alt+u`/`ctrl+alt+d`, screen: `ctrl+u`/`ctrl+d`) (https://www.gnu.org/software/screen/manual/html_node/Movement.html).
- Leaving `pageup`/`pagedown` as it matches some old terminals behavior.

<br />

```jsonc
"messages_first": "ctrl+g", // was "ctrl+g,home"
"messages_last": "ctrl+alt+g", // was "ctrl+alt+g,end"
```
- Removing `home`/`end` as it conflicts with standard terminal/readline convention of moving the cursor to the beginning/end of the current message.
- Result: Moving to beginning/end of message just works.

<br />

```jsonc
"history_previous": "ctrl+up", // was "up"
"history_next": "ctrl+down", // was "down"
```
- Changing `up`/`down` as it conflicts with standard terminal/readline convention to move the cursor up/down across a multi-line message.
- Result: Moving up/down across a multi-line message just works.