### PR TITLE
DEPRECATED: `/prune` command to delete all tool outputs from session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -220,6 +220,11 @@ export function Autocomplete(props: {
           onSelect: () => command.trigger("session.compact"),
         },
         {
+          display: "/prune",
+          description: "prune all tool call outputs",
+          onSelect: () => command.trigger("session.prune"),
+        },
+        {
           display: "/unshare",
           disabled: !s.share,
           description: "unshare a session",

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -13,6 +13,7 @@ export const TuiEvent = {
           "session.share",
           "session.interrupt",
           "session.compact",
+          "session.prune",
           "session.page.up",
           "session.page.down",
           "session.half.page.up",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -217,6 +217,23 @@ export function Session() {
         dialog.clear()
       },
     },
+    {
+      title: "Prune session",
+      value: "session.prune",
+      keybind: "session_prune",
+      category: "Session",
+      onSelect: (dialog) => {
+        sdk.client.session
+          .prune({
+            path: {
+              id: route.sessionID,
+            },
+          })
+          .then(() => toast.show({ message: "Session pruned successfully!", variant: "success" }))
+          .catch(() => toast.show({ message: "Failed to prune session", variant: "error" }))
+        dialog.clear()
+      },
+    },
     ...(sync.data.config.share !== "disabled"
       ? [
           {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -396,6 +396,7 @@ export namespace Config {
       session_unshare: z.string().optional().default("none").describe("Unshare current session"),
       session_interrupt: z.string().optional().default("escape").describe("Interrupt current session"),
       session_compact: z.string().optional().default("<leader>c").describe("Compact the session"),
+      session_prune: z.string().optional().default("none").describe("Prune all tool call outputs from the session"),
       messages_page_up: z.string().optional().default("pageup").describe("Scroll messages up by one page"),
       messages_page_down: z.string().optional().default("pagedown").describe("Scroll messages down by one page"),
       messages_half_page_up: z.string().optional().default("ctrl+alt+u").describe("Scroll messages up by half page"),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -724,6 +724,35 @@ export namespace Server {
           return c.json(true)
         },
       )
+      .post(
+        "/session/:id/prune",
+        describeRoute({
+          description: "Prune all tool call outputs from the session",
+          operationId: "session.prune",
+          responses: {
+            200: {
+              description: "Pruned session",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            id: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        async (c) => {
+          const id = c.req.valid("param").id
+          await SessionCompaction.prune({ sessionID: id, force: true })
+          return c.json(true)
+        },
+      )
       .get(
         "/session/:id/message",
         describeRoute({
@@ -1607,6 +1636,7 @@ export namespace Server {
               session_share: "session.share",
               session_interrupt: "session.interrupt",
               session_compact: "session.compact",
+              session_prune: "session.prune",
               messages_page_up: "session.page.up",
               messages_page_down: "session.page.down",
               messages_half_page_up: "session.half.page.up",

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -47,9 +47,9 @@ export namespace SessionCompaction {
   // goes backwards through parts until there are 40_000 tokens worth of tool
   // calls. then erases output of previous tool calls. idea is to throw away old
   // tool calls that are no longer relevant.
-  export async function prune(input: { sessionID: string }) {
+  export async function prune(input: { sessionID: string; force?: boolean }) {
     if (Flag.OPENCODE_DISABLE_PRUNE) return
-    log.info("pruning")
+    log.info("pruning", { force: input.force })
     const msgs = await Session.messages({ sessionID: input.sessionID })
     let total = 0
     let pruned = 0
@@ -68,7 +68,7 @@ export namespace SessionCompaction {
             if (part.state.time.compacted) break loop
             const estimate = Token.estimate(part.state.output)
             total += estimate
-            if (total > PRUNE_PROTECT) {
+            if (input.force || total > PRUNE_PROTECT) {
               pruned += estimate
               toPrune.push(part)
             }
@@ -76,7 +76,7 @@ export namespace SessionCompaction {
       }
     }
     log.info("found", { pruned, total })
-    if (pruned > PRUNE_MINIMUM) {
+    if (input.force || pruned > PRUNE_MINIMUM) {
       for (const part of toPrune) {
         if (part.state.status === "completed") {
           part.state.time.compacted = Date.now()

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -51,6 +51,29 @@ export namespace SessionCompaction {
     if (Flag.OPENCODE_DISABLE_PRUNE) return
     log.info("pruning", { force: input.force })
     const msgs = await Session.messages({ sessionID: input.sessionID })
+
+    if (input.force) {
+      const toPrune = [] as Array<MessageV2.ToolPart & { state: MessageV2.ToolStateCompleted }>
+      let pruned = 0
+      for (const msg of msgs) {
+        for (const part of msg.parts) {
+          if (part.type !== "tool") continue
+          if (part.state.status !== "completed") continue
+          if (part.state.time.compacted) continue
+          const estimate = Token.estimate(part.state.output)
+          pruned += estimate
+          toPrune.push(part as MessageV2.ToolPart & { state: MessageV2.ToolStateCompleted })
+        }
+      }
+      log.info("found", { pruned, total: pruned })
+      for (const part of toPrune) {
+        part.state.time.compacted = Date.now()
+        await Session.updatePart(part)
+      }
+      log.info("pruned", { count: toPrune.length })
+      return
+    }
+
     let total = 0
     let pruned = 0
     const toPrune = []
@@ -58,9 +81,9 @@ export namespace SessionCompaction {
 
     loop: for (let msgIndex = msgs.length - 1; msgIndex >= 0; msgIndex--) {
       const msg = msgs[msgIndex]
+      if (msg.info.role === "assistant" && msg.info.summary) break loop
       if (msg.info.role === "user") turns++
       if (turns < 2) continue
-      if (msg.info.role === "assistant" && msg.info.summary) break loop
       for (let partIndex = msg.parts.length - 1; partIndex >= 0; partIndex--) {
         const part = msg.parts[partIndex]
         if (part.type === "tool")
@@ -68,7 +91,7 @@ export namespace SessionCompaction {
             if (part.state.time.compacted) break loop
             const estimate = Token.estimate(part.state.output)
             total += estimate
-            if (input.force || total > PRUNE_PROTECT) {
+            if (total > PRUNE_PROTECT) {
               pruned += estimate
               toPrune.push(part)
             }
@@ -76,7 +99,7 @@ export namespace SessionCompaction {
       }
     }
     log.info("found", { pruned, total })
-    if (input.force || pruned > PRUNE_MINIMUM) {
+    if (pruned > PRUNE_MINIMUM) {
       for (const part of toPrune) {
         if (part.state.status === "completed") {
           part.state.time.compacted = Date.now()


### PR DESCRIPTION
adding a /prune command to prune all tool outputs from the session.

made by sonnet

The SDK needs to be regenerated in order to use the /prune command

```bash
cd packages/sdk/js
bun script/build.ts
```