### PR TITLE
fix: Enable Windows builds and fix bun+pnpm install on Windows

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -115,7 +115,7 @@ for (const item of targets) {
     entrypoints: ["./src/index.ts", parserWorker, workerPath],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
-      OTUI_TREE_SITTER_WORKER_PATH: "/$bunfs/root/" + path.relative(dir, parserWorker).replace(/\\/g, "/"),
+      OTUI_TREE_SITTER_WORKER_PATH: "/$bunfs/root/" + path.relative(dir, parserWorker).replaceAll("\\", "/"),
       OPENCODE_WORKER_PATH: workerPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
     },

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -66,11 +66,11 @@ const allTargets: {
     avx2: false,
   },
   {
-    os: "windows",
+    os: "win32",
     arch: "x64",
   },
   {
-    os: "windows",
+    os: "win32",
     arch: "x64",
     avx2: false,
   },
@@ -115,7 +115,7 @@ for (const item of targets) {
     entrypoints: ["./src/index.ts", parserWorker, workerPath],
     define: {
       OPENCODE_VERSION: `'${Script.version}'`,
-      OTUI_TREE_SITTER_WORKER_PATH: "/$bunfs/root/" + path.relative(dir, parserWorker),
+      OTUI_TREE_SITTER_WORKER_PATH: "/$bunfs/root/" + path.relative(dir, parserWorker).replace(/\\/g, "/"),
       OPENCODE_WORKER_PATH: workerPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
     },
@@ -127,7 +127,7 @@ for (const item of targets) {
       {
         name,
         version: Script.version,
-        os: [item.os === "windows" ? "win32" : item.os],
+        os: [item.os],
         cpu: [item.arch],
       },
       null,

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -143,6 +143,7 @@ async function main() {
     if (os.platform() === "win32") {
       // NPM eg format - npm/11.4.2 node/v24.4.1 win32 x64
       // Bun eg format - bun/1.2.19 npm/? node/v24.3.0 win32 x64
+      // pnpm eg format - pnpm/8.10.0 npm/? node/v20.10.0 win32 x64
       const userAgent = process.env.npm_config_user_agent || ""
 
       if (userAgent.startsWith("npm")) {
@@ -152,6 +153,13 @@ async function main() {
 
       if (userAgent.startsWith("bun")) {
         console.log("Windows + bun detected: Setting up binary")
+        const { binaryPath, binaryName } = findBinary()
+        copyBinary(binaryPath, binaryName)
+        return
+      }
+
+      if (userAgent.startsWith("pnpm")) {
+        console.log("Windows + pnpm detected: Setting up binary")
         const { binaryPath, binaryName } = findBinary()
         copyBinary(binaryPath, binaryName)
         return

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -20,7 +20,7 @@ function detectPlatformAndArch() {
       platform = "linux"
       break
     case "win32":
-      platform = "windows"
+      platform = "win32"
       break
     default:
       platform = os.platform()
@@ -50,7 +50,7 @@ function detectPlatformAndArch() {
 function findBinary() {
   const { platform, arch } = detectPlatformAndArch()
   const packageName = `opencode-${platform}-${arch}`
-  const binary = platform === "windows" ? "opencode.exe" : "opencode"
+  const binary = platform === "win32" ? "opencode.exe" : "opencode"
 
   try {
     // Use require.resolve to find the package
@@ -102,11 +102,38 @@ async function main() {
     if (os.platform() === "win32") {
       // NPM eg format - npm/11.4.2 node/v24.4.1 win32 x64
       // Bun eg format - bun/1.2.19 npm/? node/v24.3.0 win32 x64
-      if (process.env.npm_config_user_agent.startsWith("npm")) {
+      const userAgent = process.env.npm_config_user_agent || ""
+
+      if (userAgent.startsWith("npm")) {
         await regenerateWindowsCmdWrappers()
-      } else {
-        console.log("Windows detected but not npm, skipping postinstall")
+        return
       }
+
+      if (userAgent.startsWith("bun")) {
+        // For bun on Windows, copy the .exe directly
+        console.log("Windows + bun detected: Setting up binary")
+        const binaryPath = findBinary()
+        const binDir = path.join(__dirname, "bin")
+        const binScript = path.join(binDir, "opencode.exe")
+
+        // Ensure bin directory exists
+        if (!fs.existsSync(binDir)) {
+          fs.mkdirSync(binDir, { recursive: true })
+        }
+
+        // Remove existing binary if it exists
+        if (fs.existsSync(binScript)) {
+          fs.unlinkSync(binScript)
+        }
+
+        // Copy the binary
+        fs.copyFileSync(binaryPath, binScript)
+        console.log(`opencode binary installed: ${binScript}`)
+        return
+      }
+
+      // Unknown package manager on Windows
+      console.log("Windows detected but unknown package manager, skipping postinstall")
       return
     }
 

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -50,21 +50,62 @@ function detectPlatformAndArch() {
 function findBinary() {
   const { platform, arch } = detectPlatformAndArch()
   const packageName = `opencode-${platform}-${arch}`
-  const binary = platform === "win32" ? "opencode.exe" : "opencode"
+  const binaryName = platform === "win32" ? "opencode.exe" : "opencode"
 
   try {
     // Use require.resolve to find the package
     const packageJsonPath = require.resolve(`${packageName}/package.json`)
     const packageDir = path.dirname(packageJsonPath)
-    const binaryPath = path.join(packageDir, "bin", binary)
+    const binaryPath = path.join(packageDir, "bin", binaryName)
 
     if (!fs.existsSync(binaryPath)) {
       throw new Error(`Binary not found at ${binaryPath}`)
     }
 
-    return binaryPath
+    return { binaryPath, binaryName }
   } catch (error) {
     throw new Error(`Could not find package ${packageName}: ${error.message}`)
+  }
+}
+
+function prepareBinDirectory(binaryName) {
+  const binDir = path.join(__dirname, "bin")
+  const targetPath = path.join(binDir, binaryName)
+
+  // Ensure bin directory exists
+  if (!fs.existsSync(binDir)) {
+    fs.mkdirSync(binDir, { recursive: true })
+  }
+
+  // Remove existing binary/symlink if it exists
+  if (fs.existsSync(targetPath)) {
+    fs.unlinkSync(targetPath)
+  }
+
+  return { binDir, targetPath }
+}
+
+function copyBinary(sourcePath, binaryName) {
+  const { targetPath } = prepareBinDirectory(binaryName)
+
+  fs.copyFileSync(sourcePath, targetPath)
+  console.log(`opencode binary installed: ${targetPath}`)
+
+  // Verify the file exists after operation
+  if (!fs.existsSync(targetPath)) {
+    throw new Error(`Failed to copy binary to ${targetPath}`)
+  }
+}
+
+function symlinkBinary(sourcePath, binaryName) {
+  const { targetPath } = prepareBinDirectory(binaryName)
+
+  fs.symlinkSync(sourcePath, targetPath)
+  console.log(`opencode binary symlinked: ${targetPath} -> ${sourcePath}`)
+
+  // Verify the file exists after operation
+  if (!fs.existsSync(targetPath)) {
+    throw new Error(`Failed to symlink binary to ${targetPath}`)
   }
 }
 
@@ -110,25 +151,9 @@ async function main() {
       }
 
       if (userAgent.startsWith("bun")) {
-        // For bun on Windows, copy the .exe directly
         console.log("Windows + bun detected: Setting up binary")
-        const binaryPath = findBinary()
-        const binDir = path.join(__dirname, "bin")
-        const binScript = path.join(binDir, "opencode.exe")
-
-        // Ensure bin directory exists
-        if (!fs.existsSync(binDir)) {
-          fs.mkdirSync(binDir, { recursive: true })
-        }
-
-        // Remove existing binary if it exists
-        if (fs.existsSync(binScript)) {
-          fs.unlinkSync(binScript)
-        }
-
-        // Copy the binary
-        fs.copyFileSync(binaryPath, binScript)
-        console.log(`opencode binary installed: ${binScript}`)
+        const { binaryPath, binaryName } = findBinary()
+        copyBinary(binaryPath, binaryName)
         return
       }
 
@@ -137,19 +162,10 @@ async function main() {
       return
     }
 
-    const binaryPath = findBinary()
-    const binScript = path.join(__dirname, "bin", "opencode")
-
-    // Remove existing bin script if it exists
-    if (fs.existsSync(binScript)) {
-      fs.unlinkSync(binScript)
-    }
-
-    // Create symlink to the actual binary
-    fs.symlinkSync(binaryPath, binScript)
-    console.log(`opencode binary symlinked: ${binScript} -> ${binaryPath}`)
+    const { binaryPath, binaryName } = findBinary()
+    symlinkBinary(binaryPath, binaryName)
   } catch (error) {
-    console.error("Failed to create opencode binary symlink:", error.message)
+    console.error("Failed to setup opencode binary:", error.message)
     process.exit(1)
   }
 }


### PR DESCRIPTION
Fixes #3363 - `bun install -g opencode-ai` now works on Windows
Fixes #4195 - `pnpm install -g opencode-ai` now works on Windows


  ### Problem
  OpenCode could not be built or installed on Windows using bun due to three critical issues:

  1. **Build script platform mismatch**: The build script used `"windows"` as the platform identifier, but `process.platform` returns `"win32"` on Windows. This caused:
     - The `--single` flag to fail (built wrong platform or nothing at all)
     - Package names like `opencode-windows-x64` that didn't match the expected `opencode-win32-x64`

  2. **Windows path separator bug**: The build script used `path.relative()` which returns backslashes on Windows (`\`), but the bundled code expected forward slashes (`/`). This
  caused syntax errors and made all Windows builds fail.

  3. **Bun install failure**: The postinstall script skipped all processing when detecting bun on Windows, causing bun to generate a default `#!/bin/sh` wrapper script that failed
  with:
     error: interpreter executable "/bin/sh" not found in %PATH%

  ### Solution

  #### 1. Platform naming consistency
  - Changed platform identifier from `"windows"` to `"win32"` in:
    - `build.ts`: Target definitions and package.json generation
    - `postinstall.mjs`: Platform detection logic
  - This ensures consistency with Node.js's `process.platform` value

> [!WARNING]
> I'm not sure how this would interact with old installs -> upgrade paths 

  #### 2. Path separator normalization
  - Added `.replace(/\\/g, "/")` to normalize Windows backslashes to forward slashes in bundled paths
  - Fixes the `OTUI_TREE_SITTER_WORKER_PATH` define that was causing build failures

  #### 3. Bun support on Windows
  - Added explicit bun detection and handling in `postinstall.mjs`
  - For bun on Windows: copies the `.exe` directly to the bin directory (bun doesn't need wrapper scripts)
  - For npm on Windows: continues to use `npm rebuild` to regenerate CMD/PS1 wrappers
  - For other package managers on Windows: gracefully skips with a clear message

  ### Testing

  Verified the following scenarios work correctly:

  - ✅ `bun run script/build.ts --single` on Windows (now builds `opencode-win32-x64`)
  - ✅ Full build on Windows without errors
  - ✅ `bun install -g opencode-ai` on Windows (no more `/bin/sh` error)
  - ✅ `npm install -g opencode-ai` on Windows (CMD wrappers still generated correctly)
  - ✅ Postinstall script correctly detects and handles npm vs bun on Windows