### PR TITLE
Use latest Vue LSP and integrate with TypeScript LSP

### DIFF
--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -7,6 +7,7 @@ import { Config } from "../config/config"
 import { spawn } from "child_process"
 import { Instance } from "../project/instance"
 import { Bus } from "../bus"
+import { setupVueTypeScriptBridge } from "./integrations/vue-typescript"
 
 export namespace LSP {
   const log = Log.create({ service: "lsp" })
@@ -225,6 +226,7 @@ export namespace LSP {
       Bus.publish(Event.Updated, {})
     }
 
+    setupVueTypeScriptBridge(s.clients, result, path.parse(file).ext)
     return result
   }
 

--- a/packages/opencode/src/lsp/integrations/vue-typescript.ts
+++ b/packages/opencode/src/lsp/integrations/vue-typescript.ts
@@ -1,0 +1,66 @@
+import path from "path"
+import { LSPClient } from "@/lsp/client"
+import { Log } from "@/util/log"
+import { Global } from "@/global"
+import { Instance } from "@/project/instance"
+
+const log = Log.create({ service: "lsp.vue.bridge" })
+const vueClientsBridged = new Set<string>()
+
+export const setupVueTypeScriptBridge = (
+  allClients: LSPClient.Info[],
+  currentClients: LSPClient.Info[],
+  fileExtension: string,
+) => {
+  if (fileExtension !== ".vue") return
+
+  const vueClient = currentClients.find((client) => client.serverID === "vue")
+  if (!vueClient) return
+
+  const tsClient = allClients.find((client) => client.serverID === "typescript" && client.root === vueClient.root)
+  if (!tsClient) return
+
+  if (vueClientsBridged.has(vueClient.root)) return
+  vueClientsBridged.add(vueClient.root)
+
+  log.info("wiring vue↔ts bridge", { root: path.relative(process.cwd(), vueClient.root) })
+
+  vueClient.connection.onNotification("tsserver/request", async ([id, command, payload]: [number, string, unknown]) => {
+    try {
+      log.info("tsserver/request", { id, command })
+      const result = await tsClient.connection.sendRequest("workspace/executeCommand", {
+        command: "typescript.tsserverRequest",
+        arguments: [command, payload],
+      })
+      const body = typeof result === "object" && result !== null && "body" in result ? result.body : result
+      await vueClient.connection.sendNotification("tsserver/response", [id, body])
+    } catch (error) {
+      log.error("tsserver/request bridge error", { id, command, error })
+      await vueClient.connection.sendNotification("tsserver/response", [id, { error: error?.toString() }])
+    }
+  })
+}
+
+export const extendTypeScriptInitializationWithVueIntegration = async (initialization: Record<string, any>) => {
+  const workspacePluginPkg = await Bun.resolve("@vue/language-server/package.json", Instance.directory).catch(
+    () => undefined,
+  )
+  const globalPluginPkg = await Bun.resolve("@vue/language-server/package.json", Global.Path.bin).catch(() => undefined)
+  const pluginPkg = workspacePluginPkg ?? globalPluginPkg
+
+  if (!pluginPkg) {
+    return initialization
+  }
+
+  return {
+    ...initialization,
+    plugins: [
+      ...(initialization?.plugins ?? []),
+      {
+        name: "@vue/typescript-plugin",
+        location: path.dirname(pluginPkg),
+        languages: ["vue"],
+      },
+    ],
+  }
+}

--- a/packages/opencode/src/lsp/integrations/vue-typescript.ts
+++ b/packages/opencode/src/lsp/integrations/vue-typescript.ts
@@ -23,7 +23,7 @@ export const setupVueTypeScriptBridge = (
   if (vueClientsBridged.has(vueClient.root)) return
   vueClientsBridged.add(vueClient.root)
 
-  log.info("wiring vue↔ts bridge", { root: path.relative(process.cwd(), vueClient.root) })
+  log.info("wiring vue-typescript bridge", { root: path.relative(process.cwd(), vueClient.root) })
 
   vueClient.connection.onNotification("tsserver/request", async ([id, command, payload]: [number, string, unknown]) => {
     try {

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -9,6 +9,7 @@ import fs from "fs/promises"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
+import { extendTypeScriptInitializationWithVueIntegration } from "./integrations/vue-typescript"
 
 export namespace LSPServer {
   const log = Log.create({ service: "lsp.server" })
@@ -86,7 +87,7 @@ export namespace LSPServer {
       ["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"],
       ["deno.json", "deno.jsonc"],
     ),
-    extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
+    extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts", ".vue"],
     async spawn(root) {
       const tsserver = await Bun.resolve("typescript/lib/tsserver.js", Instance.directory).catch(() => {})
       if (!tsserver) return
@@ -99,11 +100,11 @@ export namespace LSPServer {
       })
       return {
         process: proc,
-        initialization: {
+        initialization: await extendTypeScriptInitializationWithVueIntegration({
           tsserver: {
             path: tsserver,
           },
-        },
+        }),
       }
     },
   }


### PR DESCRIPTION
Rewrite of #4065, but simpler.

This PR:

1. Integrates changes from the v3 `@vue/language-tools`
2. Correctly wires Vue and TypeScript so LSP will report TS errors on `.vue` files (tested it before/after locally)
3. Still wraps most of the logic into a separate file as I didn't know where to put the `setupVueTypeScriptBridge` function. I am open to suggestions though, as this implementation introduces the idea of integrations that might be undesired.

Strongly based on [this PR](https://github.com/sst/opencode/pull/2097), solves #2756.