### PR TITLE
Add scroll acceleration support to TUI

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -437,7 +437,7 @@ export namespace Config {
     })
 
   export const TUI = z.object({
-    scroll_speed: z.number().min(1).optional().default(2).describe("TUI scroll speed"),
+    scroll_speed: z.number().min(1).optional().default(1).describe("TUI scroll speed"),
     scroll_acceleration: z
       .object({
         enabled: z.boolean().describe("Enable scroll acceleration"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -438,6 +438,12 @@ export namespace Config {
 
   export const TUI = z.object({
     scroll_speed: z.number().min(1).optional().default(2).describe("TUI scroll speed"),
+    scroll_acceleration: z
+      .object({
+        enabled: z.boolean().describe("Enable scroll acceleration"),
+      })
+      .optional()
+      .describe("Scroll acceleration settings"),
   })
 
   export const Layout = z.enum(["auto", "stretch"]).meta({

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -301,6 +301,15 @@ export type Config = {
      * TUI scroll speed
      */
     scroll_speed?: number
+    /**
+     * Scroll acceleration settings
+     */
+    scroll_acceleration?: {
+      /**
+       * Enable scroll acceleration
+       */
+      enabled: boolean
+    }
   }
   /**
    * Command configuration, see https://opencode.ai/docs/commands

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -104,7 +104,7 @@ You can configure TUI-specific settings through the `tui` option.
 Available options:
 
 - `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration. **Takes precedence over `scroll_speed`.**
-- `scroll_speed` - Custom scroll speed multiplier (default: `2`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
+- `scroll_speed` - Custom scroll speed multiplier (default: `1`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
 
 [Learn more about using the TUI here](/docs/tui).
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -93,10 +93,18 @@ You can configure TUI-specific settings through the `tui` option.
 {
   "$schema": "https://opencode.ai/config.json",
   "tui": {
-    "scroll_speed": 3
+    "scroll_speed": 3,
+    "scroll_acceleration": {
+      "enabled": true
+    }
   }
 }
 ```
+
+Available options:
+
+- `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration. **Takes precedence over `scroll_speed`.**
+- `scroll_speed` - Custom scroll speed multiplier (default: `2`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
 
 [Learn more about using the TUI here](/docs/tui).
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -347,4 +347,4 @@ You can customize TUI behavior through your OpenCode config file.
 ### Options
 
 - `scroll_acceleration` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
-- `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (default: `2`, minimum: `1`). **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
+- `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (default: `1`, minimum: `1`). **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -336,11 +336,15 @@ You can customize TUI behavior through your OpenCode config file.
 {
   "$schema": "https://opencode.ai/config.json",
   "tui": {
-    "scroll_speed": 3
+    "scroll_speed": 3,
+    "scroll_acceleration": {
+      "enabled": true
+    }
   }
 }
 ```
 
 ### Options
 
-- `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (default: `2`, minimum: `1`)
+- `scroll_acceleration` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
+- `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (default: `2`, minimum: `1`). **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**


### PR DESCRIPTION
Adds configurable scroll acceleration to the TUI with macOS-style smooth scrolling via `scroll_acceleration.enabled` config option. Falls back to existing `scroll_speed` for custom linear speed. Acceleration takes precedence when both are set.

Now opencode will scroll faster than before because scroll speed is 2 by deafult. Should I change the default to 1?

Fix https://github.com/sst/opencode/issues/3907
