### PR TITLE
fix: replace union type with enum "true"/"false" in /find/file endpoint

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1137,7 +1137,7 @@ export namespace Server {
           "query",
           z.object({
             query: z.string(),
-            dirs: z.union([z.literal("true"), z.literal("false")]).optional(),
+            dirs: z.enum(["true", "false"]).optional(),
           }),
         ),
         async (c) => {


### PR DESCRIPTION
The `dirs` query param on `/find/file` uses a union of ('true' | 'false') instead of a normal boolean type, which Hono and OpenAPI 3.1 both accept.

Problem is that downstream code generators assume that query parameters are primitive types (string/number/boolean), and the use of a union/sum type causes bugs in e.g. `oapi-codegen`.

This change maintains backward compatibility, and tests still pass, while fixing downstream codegen issues.

Essentially I replaced the following openapi snippet:

```yaml
  "/find/file":
    get:
      operationId: "find.files"
      parameters:
        # ... (other params)
        - in: "query"
          name: "dirs"
          schema:
            anyOf:
              - type: "string"
                const: "true"
              - type: "string"
                const: "false"
```

With the following, simpler idiom:

```yaml
  "/find/file":
    get:
      operationId: "find.files"
      parameters:
        # ... (other params)
        - in: "query"
          name: "dirs"
          schema:
            type: "string"
            enum: ["true", "false"]
```

**edit: changed yaml to match revised submission**