### PR TITLE
fix(edit): add per-file lock to prevent read-before-write race

### DIFF
--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -3,14 +3,20 @@ import { Log } from "../util/log"
 
 export namespace FileTime {
   const log = Log.create({ service: "file.time" })
+  // Per-session read times plus per-file write locks.
+  // All tools that overwrite existing files should run their
+  // assert/read/write/update sequence inside withLock(filepath, ...)
+  // so concurrent writes to the same file are serialized.
   export const state = Instance.state(() => {
     const read: {
       [sessionID: string]: {
         [path: string]: Date | undefined
       }
     } = {}
+    const locks = new Map<string, Promise<void>>()
     return {
       read,
+      locks,
     }
   })
 
@@ -23,6 +29,29 @@ export namespace FileTime {
 
   export function get(sessionID: string, file: string) {
     return state().read[sessionID]?.[file]
+  }
+
+  export async function withLock<T>(filepath: string, fn: () => Promise<T>): Promise<T> {
+    const current = state()
+    const currentLock = current.locks.get(filepath) ?? Promise.resolve()
+    let release: () => void = () => {}
+    const nextLock = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    current.locks.set(
+      filepath,
+      currentLock.then(() => nextLock),
+    )
+    await currentLock
+    try {
+      const result = await fn()
+      return result
+    } finally {
+      release()
+      if (current.locks.get(filepath) === nextLock) {
+        current.locks.delete(filepath)
+      }
+    }
   }
 
   export async function assert(sessionID: string, filepath: string) {

--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -38,17 +38,15 @@ export namespace FileTime {
     const nextLock = new Promise<void>((resolve) => {
       release = resolve
     })
-    current.locks.set(
-      filepath,
-      currentLock.then(() => nextLock),
-    )
+    const chained = currentLock.then(() => nextLock)
+    current.locks.set(filepath, chained)
     await currentLock
     try {
       const result = await fn()
       return result
     } finally {
       release()
-      if (current.locks.get(filepath) === nextLock) {
+      if (current.locks.get(filepath) === chained) {
         current.locks.delete(filepath)
       }
     }

--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -42,8 +42,7 @@ export namespace FileTime {
     current.locks.set(filepath, chained)
     await currentLock
     try {
-      const result = await fn()
-      return result
+      return await fn()
     } finally {
       release()
       if (current.locks.get(filepath) === chained) {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -74,7 +74,7 @@ export const EditTool = Tool.define("edit", {
     let diff = ""
     let contentOld = ""
     let contentNew = ""
-    await (async () => {
+    await FileTime.withLock(filePath, async () => {
       if (params.oldString === "") {
         contentNew = params.newString
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
@@ -95,6 +95,7 @@ export const EditTool = Tool.define("edit", {
         await Bus.publish(File.Event.Edited, {
           file: filePath,
         })
+        FileTime.read(ctx.sessionID, filePath)
         return
       }
 
@@ -131,9 +132,8 @@ export const EditTool = Tool.define("edit", {
       diff = trimDiff(
         createTwoFilesPatch(filePath, filePath, normalizeLineEndings(contentOld), normalizeLineEndings(contentNew)),
       )
-    })()
-
-    FileTime.read(ctx.sessionID, filePath)
+      FileTime.read(ctx.sessionID, filePath)
+    })
 
     let output = ""
     await LSP.touchFile(filePath, true)


### PR DESCRIPTION
what the title says.
didn't wrap write.ts and patch.ts with withLock because it doesn't really make sense, but... should I for consistency?

This fixes the read before edit error we got when doing parallel edit calls (reliably?)

Resolves https://github.com/sst/opencode/issues/2882