### PR TITLE
Replace z.union with z.enum for cleaner OpenAPI generation

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -12,7 +12,7 @@ export namespace Agent {
     .object({
       name: z.string(),
       description: z.string().optional(),
-      mode: z.union([z.literal("subagent"), z.literal("primary"), z.literal("all")]),
+      mode: z.enum(["subagent", "primary", "all"]),
       builtIn: z.boolean(),
       topP: z.number().optional(),
       temperature: z.number().optional(),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -337,7 +337,7 @@ export namespace Config {
   export const Mcp = z.discriminatedUnion("type", [McpLocal, McpRemote])
   export type Mcp = z.infer<typeof Mcp>
 
-  export const Permission = z.union([z.literal("ask"), z.literal("allow"), z.literal("deny")])
+  export const Permission = z.enum(["ask", "allow", "deny"])
   export type Permission = z.infer<typeof Permission>
 
   export const Command = z.object({
@@ -358,7 +358,7 @@ export namespace Config {
       tools: z.record(z.string(), z.boolean()).optional(),
       disable: z.boolean().optional(),
       description: z.string().optional().describe("Description of when to use the agent"),
-      mode: z.union([z.literal("subagent"), z.literal("primary"), z.literal("all")]).optional(),
+      mode: z.enum(["subagent", "primary", "all"]).optional(),
       color: z
         .string()
         .regex(/^#[0-9a-fA-F]{6}$/, "Invalid hex color format")

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -50,7 +50,7 @@ const ERRORS = {
         schema: resolver(
           z
             .object({
-              data: z.any().nullable(),
+              data: z.any(),
               errors: z.array(z.record(z.string(), z.any())),
               success: z.literal(false),
             })


### PR DESCRIPTION
Replaces the use of `z.union()` in Zod schemas where `z.enum()` will suffice, and also changes `z.any().nullable()` to `z.any()` which is implicitly nullable (null is a member of any)

This change is expected to produce no functional changes in the application but to render simpler openapi spec.

The benefit is that by using `z.enum()`, code generators can produce named enumerations and simpler deserialization code for these types.

Attached is a snippet of the resulting changes to the generated openapi spec.
