### PR TITLE
fix(batch): add synthetic flag and cap tool calls gracefully

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -255,6 +255,7 @@ export namespace MessageV2 {
     tool: z.string(),
     state: ToolState,
     metadata: z.record(z.string(), z.any()).optional(),
+    synthetic: z.boolean().optional(),
   }).meta({
     ref: "ToolPart",
   })
@@ -575,6 +576,9 @@ export namespace MessageV2 {
                 },
               ]
             if (part.type === "tool") {
+              // Skip synthetic tool parts (e.g., batch sub-tools) - they're for display only
+              if (part.synthetic) return []
+
               if (part.state.status === "completed") {
                 if (part.state.attachments?.length) {
                   result.push({

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -17,7 +17,6 @@ export const BatchTool = Tool.define("batch", async () => {
           }),
         )
         .min(1, "Provide at least one tool call")
-        .max(10, "Too many tools in batch. Maximum allowed is 10.")
         .describe("Array of tool calls to execute in parallel"),
     }),
     formatValidationError(error) {
@@ -34,14 +33,15 @@ export const BatchTool = Tool.define("batch", async () => {
       const { Session } = await import("../session")
       const { Identifier } = await import("../id/id")
 
-      const toolCalls = params.tool_calls
+      const toolCalls = params.tool_calls.slice(0, 10)
+      const discardedCalls = params.tool_calls.slice(10)
 
       const { ToolRegistry } = await import("./registry")
       const availableTools = await ToolRegistry.tools("", "")
       const toolMap = new Map(availableTools.map((t) => [t.id, t]))
 
       const partIDs = new Map<(typeof toolCalls)[0], string>()
-      for (const call of toolCalls) {
+      for (const call of [...toolCalls, ...discardedCalls]) {
         const partID = Identifier.ascending("part")
         partIDs.set(call, partID)
         Session.updatePart({
@@ -51,6 +51,7 @@ export const BatchTool = Tool.define("batch", async () => {
           type: "tool",
           tool: call.tool,
           callID: partID,
+          synthetic: true,
           state: {
             status: "pending",
             input: call.parameters,
@@ -77,7 +78,24 @@ export const BatchTool = Tool.define("batch", async () => {
           }
           const validatedParams = tool.parameters.parse(call.parameters)
 
-          const result = await tool.execute(validatedParams, { ...ctx, callID: partID })
+          await Session.updatePart({
+            id: partID,
+            messageID: ctx.messageID,
+            sessionID: ctx.sessionID,
+            type: "tool",
+            tool: call.tool,
+            callID: partID,
+            synthetic: true,
+            state: {
+              status: "running",
+              input: call.parameters,
+              time: {
+                start: callStartTime,
+              },
+            },
+          })
+
+          const result = await tool.execute(validatedParams, { ...ctx, callID: ctx.callID })
 
           await Session.updatePart({
             id: partID,
@@ -86,6 +104,7 @@ export const BatchTool = Tool.define("batch", async () => {
             type: "tool",
             tool: call.tool,
             callID: partID,
+            synthetic: true,
             state: {
               status: "completed",
               input: call.parameters,
@@ -109,6 +128,7 @@ export const BatchTool = Tool.define("batch", async () => {
             type: "tool",
             tool: call.tool,
             callID: partID,
+            synthetic: true,
             state: {
               status: "error",
               input: call.parameters,
@@ -126,8 +146,34 @@ export const BatchTool = Tool.define("batch", async () => {
 
       const results = await Promise.all(toolCalls.map((call) => executeCall(call)))
 
+      // Add discarded calls as errors
+      const now = Date.now()
+      for (const call of discardedCalls) {
+        const partID = partIDs.get(call)!
+        await Session.updatePart({
+          id: partID,
+          messageID: ctx.messageID,
+          sessionID: ctx.sessionID,
+          type: "tool",
+          tool: call.tool,
+          callID: partID,
+          synthetic: true,
+          state: {
+            status: "error",
+            input: call.parameters,
+            error: "Maximum of 10 tools allowed in batch",
+            time: { start: now, end: now },
+          },
+        })
+        results.push({
+          success: false as const,
+          tool: call.tool,
+          error: new Error("Maximum of 10 tools allowed in batch"),
+        })
+      }
+
       const successfulCalls = results.filter((r) => r.success).length
-      const failedCalls = toolCalls.length - successfulCalls
+      const failedCalls = results.length - successfulCalls
 
       const outputParts = results.map((r) => {
         if (r.success) {
@@ -139,18 +185,18 @@ export const BatchTool = Tool.define("batch", async () => {
 
       const outputMessage =
         failedCalls > 0
-          ? `Executed ${successfulCalls}/${toolCalls.length} tools successfully. ${failedCalls} failed.\n\n${outputParts.join("\n\n")}`
+          ? `Executed ${successfulCalls}/${results.length} tools successfully. ${failedCalls} failed.\n\n${outputParts.join("\n\n")}`
           : `All ${successfulCalls} tools executed successfully.\n\n${outputParts.join("\n\n")}\n\nKeep using the batch tool for optimal performance in your next response!`
 
       return {
-        title: `Batch execution (${successfulCalls}/${toolCalls.length} successful)`,
+        title: `Batch execution (${successfulCalls}/${results.length} successful)`,
         output: outputMessage,
         attachments: results.filter((result) => result.success).flatMap((r) => r.result.attachments ?? []),
         metadata: {
-          totalCalls: toolCalls.length,
+          totalCalls: results.length,
           successful: successfulCalls,
           failed: failedCalls,
-          tools: toolCalls.map((c) => c.tool),
+          tools: params.tool_calls.map((c) => c.tool),
           details: results.map((r) => ({ tool: r.tool, success: r.success })),
         },
       }


### PR DESCRIPTION
Adding a synthetic flag to the TUI batch tool parts output so they are only returned once instead of twice to the llm. (critical bug)
Throws excess tool calls gracefully instead of discarding the whole batch.