### PR TITLE
feat(plugin commands): allows for code execution on plugin registered slash commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -211,10 +211,14 @@ export function Autocomplete(props: {
   const commands = createMemo((): AutocompleteOption[] => {
     const results: AutocompleteOption[] = []
     const s = session()
+
     for (const command of sync.data.command) {
+      if (command.sessionOnly && !s) continue
+
       results.push({
         display: "/" + command.name,
         description: command.description,
+        aliases: command.aliases?.map((a) => "/" + a),
         onSelect: () => {
           const newText = "/" + command.name + " "
           const cursor = props.input().logicalCursor

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -513,14 +513,15 @@ export function Prompt(props: PromptProps) {
       inputText.startsWith("/") &&
       iife(() => {
         const command = inputText.split(" ")[0].slice(1)
-        console.log(command)
-        return sync.data.command.some((x) => x.name === command)
+        return sync.data.command.some((x) => x.name === command || x.aliases?.includes(command))
       })
     ) {
       let [command, ...args] = inputText.split(" ")
+      const commandName = command.slice(1)
+      const resolved = sync.data.command.find((x) => x.name === commandName || x.aliases?.includes(commandName))
       sdk.client.session.command({
         sessionID,
-        command: command.slice(1),
+        command: resolved?.name ?? commandName,
         arguments: args.join(" "),
         agent: local.agent.current().name,
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -28,6 +28,7 @@ export namespace Command {
       agent: z.string().optional(),
       model: z.string().optional(),
       template: z.string(),
+      type: z.enum(["template", "plugin"]),
       subtask: z.boolean().optional(),
       sessionOnly: z.boolean().optional(),
       aliases: z.array(z.string()).optional(),
@@ -48,11 +49,13 @@ export namespace Command {
     const result: Record<string, Info> = {
       [Default.INIT]: {
         name: Default.INIT,
+        type: "template",
         description: "create/update AGENTS.md",
         template: PROMPT_INITIALIZE.replace("${path}", Instance.worktree),
       },
       [Default.REVIEW]: {
         name: Default.REVIEW,
+        type: "template",
         description: "review changes [commit|branch|pr], defaults to uncommitted",
         template: PROMPT_REVIEW.replace("${path}", Instance.worktree),
         subtask: true,
@@ -62,6 +65,7 @@ export namespace Command {
     for (const [name, command] of Object.entries(cfg.command ?? {})) {
       result[name] = {
         name,
+        type: "template",
         agent: command.agent,
         model: command.model,
         description: command.description,
@@ -78,6 +82,7 @@ export namespace Command {
         if (result[name]) continue
         result[name] = {
           name,
+          type: "plugin",
           description: cmd.description,
           template: "",
           sessionOnly: cmd.sessionOnly,

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -6,6 +6,7 @@ import { Instance } from "../project/instance"
 import { Identifier } from "../id/id"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
+import { Plugin } from "../plugin"
 
 export namespace Command {
   export const Event = {
@@ -28,6 +29,8 @@ export namespace Command {
       model: z.string().optional(),
       template: z.string(),
       subtask: z.boolean().optional(),
+      sessionOnly: z.boolean().optional(),
+      aliases: z.array(z.string()).optional(),
     })
     .meta({
       ref: "Command",
@@ -67,11 +70,33 @@ export namespace Command {
       }
     }
 
+    const plugins = await Plugin.list()
+    for (const plugin of plugins) {
+      const commands = plugin["plugin.command"]
+      if (!commands) continue
+      for (const [name, cmd] of Object.entries(commands)) {
+        if (result[name]) continue
+        result[name] = {
+          name,
+          description: cmd.description,
+          template: "",
+          sessionOnly: cmd.sessionOnly,
+          aliases: cmd.aliases,
+        }
+      }
+    }
+
     return result
   })
 
   export async function get(name: string) {
-    return state().then((x) => x[name])
+    const commands = await state()
+    if (commands[name]) return commands[name]
+    // Check aliases
+    for (const cmd of Object.values(commands)) {
+      if (cmd.aliases?.includes(name)) return cmd
+    }
+    return undefined
   }
 
   export async function list() {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -295,7 +295,7 @@ export namespace Config {
     return result
   }
 
-  const PLUGIN_GLOB = new Bun.Glob("plugin/*.{ts,js}")
+  const PLUGIN_GLOB = new Bun.Glob("{plugin,command}/*.{ts,js}")
   async function loadPlugin(dir: string) {
     const plugins: string[] = []
 

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -41,6 +41,7 @@ export namespace Plugin {
       }
       const mod = await import(plugin)
       for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+        if (typeof fn !== "function") continue
         const init = await fn(input)
         hooks.push(init)
       }
@@ -53,7 +54,7 @@ export namespace Plugin {
   })
 
   export async function trigger<
-    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool">,
+    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool" | "plugin.command">,
     Input = Parameters<Required<Hooks>[Name]>[0],
     Output = Parameters<Required<Hooks>[Name]>[1],
   >(name: Name, input: Input, output: Output): Promise<Output> {
@@ -71,6 +72,10 @@ export namespace Plugin {
 
   export async function list() {
     return state().then((x) => x.hooks)
+  }
+
+  export async function client() {
+    return state().then((x) => x.input.client)
   }
 
   export async function init() {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1285,8 +1285,8 @@ export namespace SessionPrompt {
     const command = await Command.get(input.command)
     if (!command) return
 
-    // Plugin commands have empty templates - execute them directly
-    if (command.template === "") {
+    // Plugin commands execute directly
+    if (command.type === "plugin") {
       const plugins = await Plugin.list()
       for (const plugin of plugins) {
         const pluginCommands = plugin["plugin.command"]
@@ -1295,7 +1295,11 @@ export namespace SessionPrompt {
 
         const client = await Plugin.client()
         try {
-          await pluginCommand.execute({ sessionID: input.sessionID, client })
+          await pluginCommand.execute({
+            sessionID: input.sessionID,
+            arguments: input.arguments,
+            client,
+          })
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error)
           log.error("plugin command failed", {
@@ -1309,7 +1313,10 @@ export namespace SessionPrompt {
           })
           throw error
         }
-        const last = await Session.messages({ sessionID: input.sessionID, limit: 1 })
+        const last = await Session.messages({
+          sessionID: input.sessionID,
+          limit: 1,
+        })
         return last.at(0)
       }
       return

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -43,6 +43,7 @@ import { SessionStatus } from "./status"
 import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
+import { TuiEvent } from "@/cli/cmd/tui/event"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1282,6 +1283,38 @@ export namespace SessionPrompt {
   export async function command(input: CommandInput) {
     log.info("command", input)
     const command = await Command.get(input.command)
+    if (!command) return
+
+    // Plugin commands have empty templates - execute them directly
+    if (command.template === "") {
+      const plugins = await Plugin.list()
+      for (const plugin of plugins) {
+        const pluginCommands = plugin["plugin.command"]
+        const pluginCommand = pluginCommands?.[command.name]
+        if (!pluginCommand) continue
+
+        const client = await Plugin.client()
+        try {
+          await pluginCommand.execute({ sessionID: input.sessionID, client })
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error)
+          log.error("plugin command failed", {
+            command: command.name,
+            error: errorMessage,
+          })
+          await Bus.publish(TuiEvent.ToastShow, {
+            title: `/${command.name} failed`,
+            message: errorMessage,
+            variant: "error",
+          })
+          throw error
+        }
+        const last = await Session.messages({ sessionID: input.sessionID, limit: 1 })
+        return last.at(0)
+      }
+      return
+    }
+
     const agentName = command.agent ?? input.agent ?? "build"
 
     const raw = input.arguments.match(argsRegex) ?? []

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -208,7 +208,11 @@ export interface Hooks {
       description: string
       aliases?: string[]
       sessionOnly?: boolean
-      execute(input: { sessionID?: string; client: ReturnType<typeof createOpencodeClient> }): Promise<void>
+      execute(input: {
+        sessionID?: string
+        arguments: string
+        client: ReturnType<typeof createOpencodeClient>
+      }): Promise<void>
     }
   }
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -200,4 +200,15 @@ export interface Hooks {
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },
   ) => Promise<void>
+  /**
+   * Register custom plugin commands (accessible via /command in TUI)
+   */
+  "plugin.command"?: {
+    [key: string]: {
+      description: string
+      aliases?: string[]
+      sessionOnly?: boolean
+      execute(input: { sessionID?: string; client: ReturnType<typeof createOpencodeClient> }): Promise<void>
+    }
+  }
 }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1427,6 +1427,8 @@ export type Command = {
   model?: string
   template: string
   subtask?: boolean
+  sessionOnly?: boolean
+  aliases?: Array<string>
 }
 
 export type Model = {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1610,6 +1610,7 @@ export type Command = {
   agent?: string
   model?: string
   template: string
+  type: "template" | "plugin"
   subtask?: boolean
   sessionOnly?: boolean
   aliases?: Array<string>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -557,6 +557,48 @@ export type EventCommandExecuted = {
   }
 }
 
+export type EventTuiPromptAppend = {
+  type: "tui.prompt.append"
+  properties: {
+    text: string
+  }
+}
+
+export type EventTuiCommandExecute = {
+  type: "tui.command.execute"
+  properties: {
+    command:
+      | "session.list"
+      | "session.new"
+      | "session.share"
+      | "session.interrupt"
+      | "session.compact"
+      | "session.page.up"
+      | "session.page.down"
+      | "session.half.page.up"
+      | "session.half.page.down"
+      | "session.first"
+      | "session.last"
+      | "prompt.clear"
+      | "prompt.submit"
+      | "agent.cycle"
+      | string
+  }
+}
+
+export type EventTuiToastShow = {
+  type: "tui.toast.show"
+  properties: {
+    title?: string
+    message: string
+    variant: "info" | "success" | "warning" | "error"
+    /**
+     * Duration in milliseconds
+     */
+    duration?: number
+  }
+}
+
 export type Session = {
   id: string
   projectID: string
@@ -639,48 +681,6 @@ export type EventVcsBranchUpdated = {
   }
 }
 
-export type EventTuiPromptAppend = {
-  type: "tui.prompt.append"
-  properties: {
-    text: string
-  }
-}
-
-export type EventTuiCommandExecute = {
-  type: "tui.command.execute"
-  properties: {
-    command:
-      | "session.list"
-      | "session.new"
-      | "session.share"
-      | "session.interrupt"
-      | "session.compact"
-      | "session.page.up"
-      | "session.page.down"
-      | "session.half.page.up"
-      | "session.half.page.down"
-      | "session.first"
-      | "session.last"
-      | "prompt.clear"
-      | "prompt.submit"
-      | "agent.cycle"
-      | string
-  }
-}
-
-export type EventTuiToastShow = {
-  type: "tui.toast.show"
-  properties: {
-    title?: string
-    message: string
-    variant: "info" | "success" | "warning" | "error"
-    /**
-     * Duration in milliseconds
-     */
-    duration?: number
-  }
-}
-
 export type Pty = {
   id: string
   title: string
@@ -753,6 +753,9 @@ export type Event =
   | EventSessionIdle
   | EventSessionCompacted
   | EventCommandExecuted
+  | EventTuiPromptAppend
+  | EventTuiCommandExecute
+  | EventTuiToastShow
   | EventSessionCreated
   | EventSessionUpdated
   | EventSessionDeleted
@@ -760,9 +763,6 @@ export type Event =
   | EventSessionError
   | EventFileWatcherUpdated
   | EventVcsBranchUpdated
-  | EventTuiPromptAppend
-  | EventTuiCommandExecute
-  | EventTuiToastShow
   | EventPtyCreated
   | EventPtyUpdated
   | EventPtyExited

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1611,6 +1611,8 @@ export type Command = {
   model?: string
   template: string
   subtask?: boolean
+  sessionOnly?: boolean
+  aliases?: Array<string>
 }
 
 export type Model = {

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -249,10 +249,10 @@ const HelloCommand: Plugin = async () => ({
       description: "Say hello",
       aliases: ["hi"],
       sessionOnly: true,
-      async execute({ sessionID, client }) {
+      async execute({ sessionID, arguments: args, client }) {
         await client.session.prompt({
           sessionID: sessionID!,
-          parts: [{ type: "text", text: "Hello from command!" }],
+          parts: [{ type: "text", text: `Hello from command! Args: ${args}` }],
         })
       },
     },
@@ -272,13 +272,13 @@ export const CommandsPlugin: Plugin = async (ctx) => {
     "plugin.command": {
       foo: {
         description: "Do foo",
-        async execute({ sessionID, client }) {
+        async execute({ sessionID, arguments: args, client }) {
           // ...
         },
       },
       bar: {
         description: "Do bar",
-        async execute({ sessionID, client }) {
+        async execute({ sessionID, arguments: args, client }) {
           // ...
         },
       },
@@ -292,6 +292,6 @@ The `plugin.command` hook lets you define commands that appear in command listin
 - `description`: Brief description shown in autocomplete
 - `aliases`: Alternative names for the command (optional)
 - `sessionOnly`: Whether command requires an active session (optional)
-- `execute`: Function that runs when the command is invoked
+- `execute`: Function that runs when the command is invoked, receives `{ sessionID, arguments, client }`
 
 Commands are invoked by typing `/command-name` in the TUI.

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -251,8 +251,10 @@ const HelloCommand: Plugin = async () => ({
       sessionOnly: true,
       async execute({ sessionID, arguments: args, client }) {
         await client.session.prompt({
-          sessionID: sessionID!,
-          parts: [{ type: "text", text: `Hello from command! Args: ${args}` }],
+          path: { id: sessionID! },
+          body: {
+            parts: [{ type: "text", text: `Hello from command! Args: ${args}` }],
+          },
         })
       },
     },
@@ -295,3 +297,30 @@ The `plugin.command` hook lets you define commands that appear in command listin
 - `execute`: Function that runs when the command is invoked, receives `{ sessionID, arguments, client }`
 
 Commands are invoked by typing `/command-name` in the TUI.
+
+---
+
+### Show toast notifications
+
+Commands can display toast notifications using the SDK client:
+
+```ts title=".opencode/command/notify.ts"
+export default async () => ({
+  "plugin.command": {
+    notify: {
+      description: "Show a notification",
+      async execute({ arguments: args, client }) {
+        await client.tui.showToast({
+          body: {
+            title: "Notification",
+            message: args || "Hello from plugin!",
+            variant: "success",
+          },
+        })
+      },
+    },
+  },
+})
+```
+
+Available toast variants: `success`, `error`, `warning`.

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -238,7 +238,31 @@ The `experimental.session.compacting` hook fires before the LLM generates a cont
 
 ### Slash commands
 
-Register custom slash commands that users can execute from the TUI:
+Register custom slash commands that users can execute from the TUI. You can place `.ts` files directly in the `command/` folder:
+
+```ts title=".opencode/command/hello.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+const HelloCommand: Plugin = async () => ({
+  "plugin.command": {
+    hello: {
+      description: "Say hello",
+      aliases: ["hi"],
+      sessionOnly: true,
+      async execute({ sessionID, client }) {
+        await client.session.prompt({
+          sessionID: sessionID!,
+          parts: [{ type: "text", text: "Hello from command!" }],
+        })
+      },
+    },
+  },
+})
+
+export default HelloCommand
+```
+
+You can also register multiple commands from a single plugin file in `.opencode/plugin/`:
 
 ```ts title=".opencode/plugin/commands.ts"
 import type { Plugin } from "@opencode-ai/plugin"
@@ -246,15 +270,16 @@ import type { Plugin } from "@opencode-ai/plugin"
 export const CommandsPlugin: Plugin = async (ctx) => {
   return {
     "plugin.command": {
-      hello: {
-        description: "Say hello",
-        aliases: ["hi"],
-        sessionOnly: true,
+      foo: {
+        description: "Do foo",
         async execute({ sessionID, client }) {
-          await client.session.prompt({
-            sessionID: sessionID!,
-            parts: [{ type: "text", text: "Hello from plugin command!" }],
-          })
+          // ...
+        },
+      },
+      bar: {
+        description: "Do bar",
+        async execute({ sessionID, client }) {
+          // ...
         },
       },
     },

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -233,3 +233,40 @@ Include any state that should persist across compaction:
 ```
 
 The `experimental.session.compacting` hook fires before the LLM generates a continuation summary. Use it to inject domain-specific context that the default compaction prompt would miss.
+
+---
+
+### Slash commands
+
+Register custom slash commands that users can execute from the TUI:
+
+```ts title=".opencode/plugin/commands.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CommandsPlugin: Plugin = async (ctx) => {
+  return {
+    "plugin.command": {
+      hello: {
+        description: "Say hello",
+        aliases: ["hi"],
+        sessionOnly: true,
+        async execute({ sessionID, client }) {
+          await client.session.prompt({
+            sessionID: sessionID!,
+            parts: [{ type: "text", text: "Hello from plugin command!" }],
+          })
+        },
+      },
+    },
+  }
+}
+```
+
+The `plugin.command` hook lets you define commands that appear in command listings. Each command has:
+
+- `description`: Brief description shown in autocomplete
+- `aliases`: Alternative names for the command (optional)
+- `sessionOnly`: Whether command requires an active session (optional)
+- `execute`: Function that runs when the command is invoked
+
+Commands are invoked by typing `/command-name` in the TUI.


### PR DESCRIPTION
This PR adds a powerful new plugin hook to opencode making it possible to run plugins through custom /commands registered by the plugin itself allowing for code execution

needs sdk rebuild to test
```bash
cd packages/sdk/js
bun run script/build.ts
```

As a proof of concept, this PR allowed me to create a plugin with a "/prune" command that prunes all tool outputs from the session

This could also allow to turn a plugin on/off, create composable workflows and many more things i'm sure