### PR TITLE
Add promptCacheKey for any provider with npm @ai-sdk/openai

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -136,7 +136,7 @@ export namespace ProviderTransform {
   ): Record<string, any> | undefined {
     const result: Record<string, any> = {}
 
-    if (providerID === "openai") {
+    if (providerID === "openai" || npm === "@ai-sdk/openai") {
       result["promptCacheKey"] = sessionID
     }
 


### PR DESCRIPTION
v2 for openai-caching when npm uses @ai-sdk/openai
Includes fix for #4386