### PR TITLE
Revert "fix: system theme background to use 'none' for terminal transparency"

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -278,8 +278,8 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
       text: fg,
       textMuted,
 
-      // Background colors - use 'none' to inherit terminal defaults and transparency
-      background: "none",
+      // Background colors
+      background: bg,
       backgroundPanel: grays[2],
       backgroundElement: grays[3],
 


### PR DESCRIPTION
Reverts sst/opencode#4408