### PR TITLE
feat: add Swift syntax highlighting support

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -212,5 +212,19 @@ export default {
         ],
       },
     },
+    {
+      filetype: "swift",
+      wasm: "https://github.com/alex-pinkus/tree-sitter-swift/releases/download/0.7.1/tree-sitter-swift.wasm",
+      queries: {
+        highlights: [
+          // NOTE: Using parser repo queries instead of nvim-treesitter due to incompatible #lua-match? predicates
+          // "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/highlights.scm
+          "https://raw.githubusercontent.com/alex-pinkus/tree-sitter-swift/main/queries/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/swift/locals.scm",
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
Adds Swift syntax highlighting support via tree-sitter parser

##  Changes
- Added Swift parser configuration to `parsers-config.ts`
- Uses tree-sitter-swift v0.7.1 release from alex-pinkus/tree-sitter-swift
- Uses parser repo highlights query (nvim-treesitter version has incompatible `#lua-match?` predicates) and nvim-treesitter locals query

## Testing
- Verified Swift syntax highlighting works correctly in OpenCode
- Parser downloads and caches properly from GitHub releases