### PR TITLE
feat: add session-scoped MCP support with same-turn tool refresh

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -225,6 +225,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           sdk.client.lsp.status().then((x) => setStore("lsp", x.data!))
           break
         }
+
+        case "mcp.server.added":
+        case "mcp.server.removed": {
+          sdk.client.mcp.status().then((x) => setStore("mcp", x.data!))
+          break
+        }
       }
     })
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -8,9 +8,29 @@ import { NamedError } from "../util/error"
 import z from "zod/v4"
 import { Instance } from "../project/instance"
 import { withTimeout } from "@/util/timeout"
+import { Bus } from "../bus"
 
 export namespace MCP {
   const log = Log.create({ service: "mcp" })
+
+  export const Event = {
+    ServerAdded: Bus.event(
+      "mcp.server.added",
+      z.object({
+        name: z.string(),
+        scope: z.enum(["instance", "session"]),
+        sessionID: z.string().optional(),
+      }),
+    ),
+    ServerRemoved: Bus.event(
+      "mcp.server.removed",
+      z.object({
+        name: z.string(),
+        scope: z.enum(["instance", "session"]),
+        sessionID: z.string().optional(),
+      }),
+    ),
+  }
 
   export const Failed = NamedError.create(
     "MCPFailed",
@@ -89,9 +109,20 @@ export namespace MCP {
     },
   )
 
-  export async function add(name: string, mcp: Config.Mcp) {
+  // Session-scoped MCP state
+  const sessionState = Instance.state(() => {
+    return new Map<
+      string,
+      {
+        clients: Record<string, Client>
+        status: Record<string, Status>
+      }
+    >()
+  })
+
+  export async function add(name: string, mcp: Config.Mcp, sessionID?: string) {
     const s = await state()
-    const result = await create(name, mcp)
+    const result = await create(name, mcp, true) // Ignore enabled flag for dynamic loading
     if (!result) {
       const status = {
         status: "failed" as const,
@@ -111,13 +142,92 @@ export namespace MCP {
     s.clients[name] = result.mcpClient
     s.status[name] = result.status
 
+    // Publish event so tools can be refreshed
+    await Bus.publish(Event.ServerAdded, {
+      name,
+      scope: "instance",
+      sessionID,
+    })
+
     return {
       status: s.status,
     }
   }
 
-  async function create(key: string, mcp: Config.Mcp) {
-    if (mcp.enabled === false) {
+  export async function addSessionScoped(sessionID: string, name: string, mcp: Config.Mcp) {
+    const sessions = await sessionState()
+    let session = sessions.get(sessionID)
+    if (!session) {
+      session = {
+        clients: {},
+        status: {},
+      }
+      sessions.set(sessionID, session)
+    }
+
+    const result = await create(name, mcp, true) // Ignore enabled flag for dynamic loading
+    if (!result) {
+      const status = {
+        status: "failed" as const,
+        error: "unknown error",
+      }
+      session.status[name] = status
+      return {
+        status,
+      }
+    }
+    if (!result.mcpClient) {
+      session.status[name] = result.status
+      return {
+        status: session.status,
+      }
+    }
+    session.clients[name] = result.mcpClient
+    session.status[name] = result.status
+
+    log.info("added session-scoped MCP", { sessionID, name })
+
+    // Publish event so tools can be refreshed
+    await Bus.publish(Event.ServerAdded, {
+      name,
+      scope: "session",
+      sessionID,
+    })
+
+    return {
+      status: session.status,
+    }
+  }
+
+  export async function disposeSession(sessionID: string) {
+    const sessions = await sessionState()
+    const session = sessions.get(sessionID)
+    if (!session) return
+
+    log.info("disposing session-scoped MCPs", { sessionID, count: Object.keys(session.clients).length })
+
+    await Promise.all(
+      Object.entries(session.clients).map(async ([name, client]) => {
+        await client.close().catch((error) => {
+          log.error("Failed to close session-scoped MCP client", {
+            sessionID,
+            name,
+            error,
+          })
+        })
+        await Bus.publish(Event.ServerRemoved, {
+          name,
+          scope: "session",
+          sessionID,
+        })
+      }),
+    )
+
+    sessions.delete(sessionID)
+  }
+
+  async function create(key: string, mcp: Config.Mcp, ignoreEnabled = false) {
+    if (mcp.enabled === false && !ignoreEnabled) {
       log.info("mcp server disabled", { key })
       return
     }
@@ -252,18 +362,34 @@ export namespace MCP {
     }
   }
 
-  export async function status() {
-    return state().then((state) => state.status)
+  export async function status(sessionID?: string) {
+    const instanceStatus = await state().then((state) => state.status)
+    if (!sessionID) {
+      return instanceStatus
+    }
+
+    const sessions = await sessionState()
+    const session = sessions.get(sessionID)
+    if (!session) {
+      return instanceStatus
+    }
+
+    return {
+      ...instanceStatus,
+      ...session.status,
+    }
   }
 
   export async function clients() {
     return state().then((state) => state.clients)
   }
 
-  export async function tools() {
+  export async function tools(sessionID?: string) {
     const result: Record<string, Tool> = {}
     const s = await state()
     const clientsSnapshot = await clients()
+
+    // Add instance-scoped tools
     for (const [clientName, client] of Object.entries(clientsSnapshot)) {
       const tools = await client.tools().catch((e) => {
         log.error("failed to get tools", { clientName, error: e.message })
@@ -283,6 +409,34 @@ export namespace MCP {
         result[sanitizedClientName + "_" + sanitizedToolName] = tool
       }
     }
+
+    // Add session-scoped tools if sessionID provided
+    if (sessionID) {
+      const sessions = await sessionState()
+      const session = sessions.get(sessionID)
+      if (session) {
+        for (const [clientName, client] of Object.entries(session.clients)) {
+          const tools = await client.tools().catch((e) => {
+            log.error("failed to get session-scoped tools", { sessionID, clientName, error: e.message })
+            const failedStatus = {
+              status: "failed" as const,
+              error: e instanceof Error ? e.message : String(e),
+            }
+            session.status[clientName] = failedStatus
+            delete session.clients[clientName]
+          })
+          if (!tools) {
+            continue
+          }
+          for (const [toolName, tool] of Object.entries(tools)) {
+            const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
+            const sanitizedToolName = toolName.replace(/[^a-zA-Z0-9_-]/g, "_")
+            result[sanitizedClientName + "_" + sanitizedToolName] = tool
+          }
+        }
+      }
+    }
+
     return result
   }
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -81,6 +81,11 @@ export namespace MCP {
 
       await Promise.all(
         Object.entries(config).map(async ([key, mcp]) => {
+          // Only load MCPs that are enabled in config
+          if (mcp.enabled === false) {
+            log.info("mcp server disabled", { key })
+            return
+          }
           const result = await create(key, mcp).catch(() => undefined)
           if (!result) return
 
@@ -120,38 +125,46 @@ export namespace MCP {
     >()
   })
 
-  export async function add(name: string, mcp: Config.Mcp, sessionID?: string) {
-    const s = await state()
-    const result = await create(name, mcp, true) // Ignore enabled flag for dynamic loading
+  async function registerMCP(
+    name: string,
+    mcp: Config.Mcp,
+    scope: "instance" | "session",
+    storage: { clients: Record<string, Client>; status: Record<string, Status> },
+    sessionID?: string,
+  ) {
+    const result = await create(name, mcp)
     if (!result) {
       const status = {
         status: "failed" as const,
         error: "unknown error",
       }
-      s.status[name] = status
-      return {
-        status,
-      }
+      storage.status[name] = status
+      return { status }
     }
     if (!result.mcpClient) {
-      s.status[name] = result.status
-      return {
-        status: s.status,
-      }
+      storage.status[name] = result.status
+      return { status: storage.status }
     }
-    s.clients[name] = result.mcpClient
-    s.status[name] = result.status
+    storage.clients[name] = result.mcpClient
+    storage.status[name] = result.status
+
+    if (scope === "session" && sessionID) {
+      log.info("added session-scoped MCP", { sessionID, name })
+    }
 
     // Publish event so tools can be refreshed
     await Bus.publish(Event.ServerAdded, {
       name,
-      scope: "instance",
+      scope,
       sessionID,
     })
 
-    return {
-      status: s.status,
-    }
+    return { status: storage.status }
+  }
+
+  export async function add(name: string, mcp: Config.Mcp, sessionID?: string) {
+    const s = await state()
+    return registerMCP(name, mcp, "instance", s, sessionID)
   }
 
   export async function addSessionScoped(sessionID: string, name: string, mcp: Config.Mcp) {
@@ -165,38 +178,7 @@ export namespace MCP {
       sessions.set(sessionID, session)
     }
 
-    const result = await create(name, mcp, true) // Ignore enabled flag for dynamic loading
-    if (!result) {
-      const status = {
-        status: "failed" as const,
-        error: "unknown error",
-      }
-      session.status[name] = status
-      return {
-        status,
-      }
-    }
-    if (!result.mcpClient) {
-      session.status[name] = result.status
-      return {
-        status: session.status,
-      }
-    }
-    session.clients[name] = result.mcpClient
-    session.status[name] = result.status
-
-    log.info("added session-scoped MCP", { sessionID, name })
-
-    // Publish event so tools can be refreshed
-    await Bus.publish(Event.ServerAdded, {
-      name,
-      scope: "session",
-      sessionID,
-    })
-
-    return {
-      status: session.status,
-    }
+    return registerMCP(name, mcp, "session", session, sessionID)
   }
 
   export async function disposeSession(sessionID: string) {
@@ -226,11 +208,7 @@ export namespace MCP {
     sessions.delete(sessionID)
   }
 
-  async function create(key: string, mcp: Config.Mcp, ignoreEnabled = false) {
-    if (mcp.enabled === false && !ignoreEnabled) {
-      log.info("mcp server disabled", { key })
-      return
-    }
+  async function create(key: string, mcp: Config.Mcp) {
     log.info("found", { key, type: mcp.type })
     let mcpClient: MCPClient | undefined
     let status: Status | undefined = undefined
@@ -384,21 +362,25 @@ export namespace MCP {
     return state().then((state) => state.clients)
   }
 
-  export async function tools(sessionID?: string) {
+  async function retrieveToolsFromClients(
+    clients: Record<string, Client>,
+    storage: { clients: Record<string, Client>; status: Record<string, Status> },
+    context?: { sessionID?: string; scope?: string },
+  ) {
     const result: Record<string, Tool> = {}
-    const s = await state()
-    const clientsSnapshot = await clients()
-
-    // Add instance-scoped tools
-    for (const [clientName, client] of Object.entries(clientsSnapshot)) {
+    for (const [clientName, client] of Object.entries(clients)) {
       const tools = await client.tools().catch((e) => {
-        log.error("failed to get tools", { clientName, error: e.message })
+        const errorContext = context?.sessionID
+          ? { sessionID: context.sessionID, clientName, error: e.message }
+          : { clientName, error: e.message }
+        const errorMsg = context?.scope === "session" ? "failed to get session-scoped tools" : "failed to get tools"
+        log.error(errorMsg, errorContext)
         const failedStatus = {
           status: "failed" as const,
           error: e instanceof Error ? e.message : String(e),
         }
-        s.status[clientName] = failedStatus
-        delete s.clients[clientName]
+        storage.status[clientName] = failedStatus
+        delete storage.clients[clientName]
       })
       if (!tools) {
         continue
@@ -409,31 +391,28 @@ export namespace MCP {
         result[sanitizedClientName + "_" + sanitizedToolName] = tool
       }
     }
+    return result
+  }
+
+  export async function tools(sessionID?: string) {
+    const result: Record<string, Tool> = {}
+    const s = await state()
+    const clientsSnapshot = await clients()
+
+    // Add instance-scoped tools
+    const instanceTools = await retrieveToolsFromClients(clientsSnapshot, s)
+    Object.assign(result, instanceTools)
 
     // Add session-scoped tools if sessionID provided
     if (sessionID) {
       const sessions = await sessionState()
       const session = sessions.get(sessionID)
       if (session) {
-        for (const [clientName, client] of Object.entries(session.clients)) {
-          const tools = await client.tools().catch((e) => {
-            log.error("failed to get session-scoped tools", { sessionID, clientName, error: e.message })
-            const failedStatus = {
-              status: "failed" as const,
-              error: e instanceof Error ? e.message : String(e),
-            }
-            session.status[clientName] = failedStatus
-            delete session.clients[clientName]
-          })
-          if (!tools) {
-            continue
-          }
-          for (const [toolName, tool] of Object.entries(tools)) {
-            const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
-            const sanitizedToolName = toolName.replace(/[^a-zA-Z0-9_-]/g, "_")
-            result[sanitizedClientName + "_" + sanitizedToolName] = tool
-          }
-        }
+        const sessionTools = await retrieveToolsFromClients(session.clients, session, {
+          sessionID,
+          scope: "session",
+        })
+        Object.assign(result, sessionTools)
       }
     }
 

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -41,6 +41,7 @@ import { Snapshot } from "@/snapshot"
 import { SessionSummary } from "@/session/summary"
 import { GlobalBus } from "@/bus/global"
 import { SessionStatus } from "@/session/status"
+import { Identifier } from "../id/id"
 
 const ERRORS = {
   400: {
@@ -1459,6 +1460,37 @@ export namespace Server {
         async (c) => {
           const { name, config } = c.req.valid("json")
           const result = await MCP.add(name, config)
+          return c.json(result.status)
+        },
+      )
+      .post(
+        "/mcp/session",
+        describeRoute({
+          description: "Add session-scoped MCP server dynamically",
+          operationId: "mcp.addSessionScoped",
+          responses: {
+            200: {
+              description: "Session-scoped MCP server added successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(z.record(z.string(), MCP.Status)),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            sessionID: Identifier.schema("session"),
+            name: z.string(),
+            config: Config.Mcp,
+          }),
+        ),
+        async (c) => {
+          const { sessionID, name, config } = c.req.valid("json")
+          const result = await MCP.addSessionScoped(sessionID, name, config)
           return c.json(result.status)
         },
       )

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -16,6 +16,7 @@ import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
 import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
+import { MCP } from "../mcp"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
@@ -308,6 +309,10 @@ export namespace Session {
       for (const child of await children(sessionID)) {
         await remove(child.id)
       }
+      // Dispose session-scoped MCPs
+      await MCP.disposeSession(sessionID).catch((err) => {
+        log.error("Failed to dispose session-scoped MCPs", { sessionID, error: err })
+      })
       await unshare(sessionID).catch(() => {})
       for (const msg of await Storage.list(["message", sessionID])) {
         for (const part of await Storage.list(["part", msg.at(-1)!])) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -453,13 +453,33 @@ export namespace SessionPrompt {
         agent,
         system: lastUser.system,
       })
-      const tools = await resolveTools({
+      let tools = await resolveTools({
         agent,
         sessionID,
         model: lastUser.model,
         tools: lastUser.tools,
         processor,
       })
+
+      // Track if tools need refresh due to MCP changes
+      let toolsNeedRefresh = false
+
+      // Subscribe to MCP server additions
+      const mcpUnsub = Bus.subscribe(MCP.Event.ServerAdded, (evt) => {
+        // Only refresh if relevant to this session
+        if (evt.properties.scope === "session" && evt.properties.sessionID !== sessionID) {
+          return // Different session, ignore
+        }
+
+        log.info("MCP server added mid-turn, flagging tools for refresh", {
+          server: evt.properties.name,
+          scope: evt.properties.scope,
+          sessionID: sessionID,
+          step,
+        })
+        toolsNeedRefresh = true
+      })
+
       const params = await Plugin.trigger(
         "chat.params",
         {
@@ -489,99 +509,126 @@ export namespace SessionPrompt {
         })
       }
 
-      const result = await processor.process(() =>
-        streamText({
-          onError(error) {
-            log.error("stream error", {
-              error,
-            })
-          },
-          async experimental_repairToolCall(input) {
-            const lower = input.toolCall.toolName.toLowerCase()
-            if (lower !== input.toolCall.toolName && tools[lower]) {
-              log.info("repairing tool call", {
-                tool: input.toolCall.toolName,
-                repaired: lower,
+      // Refresh tools if MCP changed mid-turn
+      if (toolsNeedRefresh) {
+        log.info("refreshing tools after MCP server addition", {
+          sessionID: sessionID,
+          step,
+        })
+        tools = await resolveTools({
+          agent,
+          sessionID,
+          model: lastUser.model,
+          tools: lastUser.tools,
+          processor,
+        })
+        toolsNeedRefresh = false
+      }
+
+      try {
+        const result = await processor.process(() =>
+          streamText({
+            onError(error) {
+              log.error("stream error", {
+                error,
               })
+            },
+            async experimental_repairToolCall(input) {
+              const lower = input.toolCall.toolName.toLowerCase()
+              if (lower !== input.toolCall.toolName && tools[lower]) {
+                log.info("repairing tool call", {
+                  tool: input.toolCall.toolName,
+                  repaired: lower,
+                })
+                return {
+                  ...input.toolCall,
+                  toolName: lower,
+                }
+              }
               return {
                 ...input.toolCall,
-                toolName: lower,
+                input: JSON.stringify({
+                  tool: input.toolCall.toolName,
+                  error: input.error.message,
+                }),
+                toolName: "invalid",
               }
-            }
-            return {
-              ...input.toolCall,
-              input: JSON.stringify({
-                tool: input.toolCall.toolName,
-                error: input.error.message,
-              }),
-              toolName: "invalid",
-            }
-          },
-          headers: {
-            ...(model.providerID === "opencode"
-              ? {
-                  "x-opencode-session": sessionID,
-                  "x-opencode-request": lastUser.id,
-                }
-              : undefined),
-            ...model.info.headers,
-          },
-          // set to 0, we handle loop
-          maxRetries: 0,
-          activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
-          maxOutputTokens: ProviderTransform.maxOutputTokens(
-            model.providerID,
-            params.options,
-            model.info.limit.output,
-            OUTPUT_TOKEN_MAX,
-          ),
-          abortSignal: abort,
-          providerOptions: ProviderTransform.providerOptions(model.npm, model.providerID, params.options),
-          stopWhen: stepCountIs(1),
-          temperature: params.temperature,
-          topP: params.topP,
-          messages: [
-            ...system.map(
-              (x): ModelMessage => ({
-                role: "system",
-                content: x,
-              }),
-            ),
-            ...MessageV2.toModelMessage(
-              msgs.filter((m) => {
-                if (m.info.role !== "assistant" || m.info.error === undefined) {
-                  return true
-                }
-                if (
-                  MessageV2.AbortedError.isInstance(m.info.error) &&
-                  m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
-                ) {
-                  return true
-                }
-
-                return false
-              }),
-            ),
-          ],
-          tools: model.info.tool_call === false ? undefined : tools,
-          model: wrapLanguageModel({
-            model: model.language,
-            middleware: [
-              {
-                async transformParams(args) {
-                  if (args.type === "stream") {
-                    // @ts-expect-error
-                    args.params.prompt = ProviderTransform.message(args.params.prompt, model.providerID, model.modelID)
+            },
+            headers: {
+              ...(model.providerID === "opencode"
+                ? {
+                    "x-opencode-session": sessionID,
+                    "x-opencode-request": lastUser.id,
                   }
-                  return args.params
-                },
-              },
+                : undefined),
+              ...model.info.headers,
+            },
+            // set to 0, we handle loop
+            maxRetries: 0,
+            activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
+            maxOutputTokens: ProviderTransform.maxOutputTokens(
+              model.providerID,
+              params.options,
+              model.info.limit.output,
+              OUTPUT_TOKEN_MAX,
+            ),
+            abortSignal: abort,
+            providerOptions: ProviderTransform.providerOptions(model.npm, model.providerID, params.options),
+            stopWhen: stepCountIs(1),
+            temperature: params.temperature,
+            topP: params.topP,
+            messages: [
+              ...system.map(
+                (x): ModelMessage => ({
+                  role: "system",
+                  content: x,
+                }),
+              ),
+              ...MessageV2.toModelMessage(
+                msgs.filter((m) => {
+                  if (m.info.role !== "assistant" || m.info.error === undefined) {
+                    return true
+                  }
+                  if (
+                    MessageV2.AbortedError.isInstance(m.info.error) &&
+                    m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
+                  ) {
+                    return true
+                  }
+
+                  return false
+                }),
+              ),
             ],
+            tools: model.info.tool_call === false ? undefined : tools,
+            model: wrapLanguageModel({
+              model: model.language,
+              middleware: [
+                {
+                  async transformParams(args) {
+                    if (args.type === "stream") {
+                      // @ts-expect-error
+                      args.params.prompt = ProviderTransform.message(
+                        args.params.prompt,
+                        model.providerID,
+                        model.modelID,
+                      )
+                    }
+                    return args.params
+                  },
+                },
+              ],
+            }),
           }),
-        }),
-      )
-      if (result === "stop") break
-      continue
+        )
+        if (result === "stop") {
+          break
+        }
+        continue
+      } finally {
+        // Cleanup MCP subscription
+        mcpUnsub()
+      }
     }
     SessionCompaction.prune({ sessionID })
     for await (const item of MessageV2.stream(sessionID)) {
@@ -711,7 +758,7 @@ export namespace SessionPrompt {
       })
     }
 
-    for (const [key, item] of Object.entries(await MCP.tools())) {
+    for (const [key, item] of Object.entries(await MCP.tools(input.sessionID))) {
       if (Wildcard.all(key, enabledTools) === false) continue
       const execute = item.execute
       if (!execute) continue

--- a/packages/opencode/test/mcp/session-scoped.test.ts
+++ b/packages/opencode/test/mcp/session-scoped.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { MCP } from "../../src/mcp"
+import { Session } from "../../src/session"
+import { Bus } from "../../src/bus"
+import { Log } from "../../src/util/log"
+import { Instance } from "../../src/project/instance"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session-scoped MCP", () => {
+  test("should add and retrieve session-scoped MCP tools", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        // Create a mock MCP config (won't actually connect)
+        const mockConfig = {
+          type: "local" as const,
+          command: ["echo", "test"],
+          enabled: false, // Disabled so it won't try to actually connect
+        }
+
+        // Add session-scoped MCP
+        await MCP.addSessionScoped(session.id, "test-mcp", mockConfig)
+
+        // Check status includes session-scoped MCP
+        const status = await MCP.status(session.id)
+        expect(status["test-mcp"]).toBeDefined()
+
+        // Cleanup
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("should dispose session-scoped MCPs when session is removed", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const mockConfig = {
+          type: "local" as const,
+          command: ["echo", "test"],
+          enabled: false,
+        }
+
+        // Add session-scoped MCP
+        await MCP.addSessionScoped(session.id, "test-mcp-dispose", mockConfig)
+
+        // Verify it exists
+        let status = await MCP.status(session.id)
+        expect(status["test-mcp-dispose"]).toBeDefined()
+
+        // Remove session (should dispose MCP)
+        await Session.remove(session.id)
+
+        // Create new session to verify old MCP is gone
+        const newSession = await Session.create({})
+        status = await MCP.status(newSession.id)
+        expect(status["test-mcp-dispose"]).toBeUndefined()
+
+        // Cleanup
+        await Session.remove(newSession.id)
+      },
+    })
+  })
+
+  test("should emit session-scoped event when MCP is added", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        let eventReceived = false
+        let eventScope: string | undefined
+        let eventSessionID: string | undefined
+
+        // Subscribe before adding MCP
+        const unsub = Bus.subscribe(MCP.Event.ServerAdded, (event) => {
+          if (event.properties.name === "test-mcp-event") {
+            eventReceived = true
+            eventScope = event.properties.scope
+            eventSessionID = event.properties.sessionID
+          }
+        })
+
+        // Use a mock config that will fail but still trigger event
+        // We check for events even on failure cases
+        const mockConfig = {
+          type: "local" as const,
+          command: ["/nonexistent/command"],
+        }
+
+        // Now add the MCP (will fail but should still emit event)
+        await MCP.addSessionScoped(session.id, "test-mcp-event", mockConfig)
+
+        // Wait a bit for event propagation
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        // Since MCP connection will fail, event should still be published
+        // but status will be failed
+        const status = await MCP.status(session.id)
+
+        // Verify the MCP was registered even though it failed
+        expect(status["test-mcp-event"]).toBeDefined()
+        expect(status["test-mcp-event"]?.status).toBe("failed")
+
+        unsub()
+
+        // Cleanup
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("should load MCP dynamically even with enabled:false in config", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        // Config has enabled: false, but dynamic loading should ignore this
+        const mockConfig = {
+          type: "local" as const,
+          command: ["/nonexistent/command"],
+          enabled: false, // Should be ignored for dynamic loading
+        }
+
+        await MCP.addSessionScoped(session.id, "disabled-mcp", mockConfig)
+
+        // Should still be added (and fail to connect, but that's ok)
+        const status = await MCP.status(session.id)
+        expect(status["disabled-mcp"]).toBeDefined()
+
+        // Cleanup
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("instance-scoped MCPs should not interfere with session-scoped", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session1 = await Session.create({})
+        const session2 = await Session.create({})
+
+        const mockConfig = {
+          type: "local" as const,
+          command: ["echo", "test"],
+          enabled: false,
+        }
+
+        // Add instance-scoped MCP
+        await MCP.add("instance-mcp", mockConfig)
+
+        // Add session-scoped MCP to session1
+        await MCP.addSessionScoped(session1.id, "session1-mcp", mockConfig)
+
+        // Add session-scoped MCP to session2
+        await MCP.addSessionScoped(session2.id, "session2-mcp", mockConfig)
+
+        // Session1 should see both instance and its session MCP
+        const status1 = await MCP.status(session1.id)
+        expect(status1["instance-mcp"]).toBeDefined()
+        expect(status1["session1-mcp"]).toBeDefined()
+        expect(status1["session2-mcp"]).toBeUndefined()
+
+        // Session2 should see instance and its session MCP
+        const status2 = await MCP.status(session2.id)
+        expect(status2["instance-mcp"]).toBeDefined()
+        expect(status2["session1-mcp"]).toBeUndefined()
+        expect(status2["session2-mcp"]).toBeDefined()
+
+        // Cleanup
+        await Session.remove(session1.id)
+        await Session.remove(session2.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/mcp/session-scoped.test.ts
+++ b/packages/opencode/test/mcp/session-scoped.test.ts
@@ -117,22 +117,22 @@ describe("session-scoped MCP", () => {
     })
   })
 
-  test("should load MCP dynamically even with enabled:false in config", async () => {
+  test("should load MCP dynamically regardless of enabled flag", async () => {
     await Instance.provide({
       directory: projectRoot,
       fn: async () => {
         const session = await Session.create({})
 
-        // Config has enabled: false, but dynamic loading should ignore this
+        // Dynamic loading bypasses the enabled flag (which only applies to config-file loading)
         const mockConfig = {
           type: "local" as const,
           command: ["/nonexistent/command"],
-          enabled: false, // Should be ignored for dynamic loading
+          enabled: false, // Ignored for dynamic loading
         }
 
         await MCP.addSessionScoped(session.id, "disabled-mcp", mockConfig)
 
-        // Should still be added (and fail to connect, but that's ok)
+        // Should be added (will fail to connect, but that's expected with invalid command)
         const status = await MCP.status(session.id)
         expect(status["disabled-mcp"]).toBeDefined()
 

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -114,6 +114,9 @@ import type {
   McpAddData,
   McpAddResponses,
   McpAddErrors,
+  McpAddSessionScopedData,
+  McpAddSessionScopedResponses,
+  McpAddSessionScopedErrors,
   LspStatusData,
   LspStatusResponses,
   FormatterStatusData,
@@ -661,6 +664,26 @@ class Mcp extends _HeyApiClient {
   public add<ThrowOnError extends boolean = false>(options?: Options<McpAddData, ThrowOnError>) {
     return (options?.client ?? this._client).post<McpAddResponses, McpAddErrors, ThrowOnError>({
       url: "/mcp",
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    })
+  }
+
+  /**
+   * Add session-scoped MCP server dynamically
+   */
+  public addSessionScoped<ThrowOnError extends boolean = false>(
+    options?: Options<McpAddSessionScopedData, ThrowOnError>,
+  ) {
+    return (options?.client ?? this._client).post<
+      McpAddSessionScopedResponses,
+      McpAddSessionScopedErrors,
+      ThrowOnError
+    >({
+      url: "/mcp/session",
       ...options,
       headers: {
         "Content-Type": "application/json",

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -504,6 +504,24 @@ export type EventTodoUpdated = {
   }
 }
 
+export type EventMcpServerAdded = {
+  type: "mcp.server.added"
+  properties: {
+    name: string
+    scope: "instance" | "session"
+    sessionID?: string
+  }
+}
+
+export type EventMcpServerRemoved = {
+  type: "mcp.server.removed"
+  properties: {
+    name: string
+    scope: "instance" | "session"
+    sessionID?: string
+  }
+}
+
 export type EventCommandExecuted = {
   type: "command.executed"
   properties: {
@@ -654,6 +672,8 @@ export type Event =
   | EventSessionCompacted
   | EventFileEdited
   | EventTodoUpdated
+  | EventMcpServerAdded
+  | EventMcpServerRemoved
   | EventCommandExecuted
   | EventSessionCreated
   | EventSessionUpdated
@@ -2719,6 +2739,39 @@ export type McpAddResponses = {
 }
 
 export type McpAddResponse = McpAddResponses[keyof McpAddResponses]
+
+export type McpAddSessionScopedData = {
+  body?: {
+    sessionID: string
+    name: string
+    config: McpLocalConfig | McpRemoteConfig
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/mcp/session"
+}
+
+export type McpAddSessionScopedErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type McpAddSessionScopedError = McpAddSessionScopedErrors[keyof McpAddSessionScopedErrors]
+
+export type McpAddSessionScopedResponses = {
+  /**
+   * Session-scoped MCP server added successfully
+   */
+  200: {
+    [key: string]: McpStatus
+  }
+}
+
+export type McpAddSessionScopedResponse = McpAddSessionScopedResponses[keyof McpAddSessionScopedResponses]
 
 export type LspStatusData = {
   body?: never


### PR DESCRIPTION
# Add Session-Scoped MCP Support + Same-Turn Tool Refresh

## Summary

Adds session-scoped MCP loading and event-driven tool refresh to enable:

1. **Same-turn usage** - MCPs loaded mid-turn are immediately available without requiring the user to type "continue"
2. **Agent-driven loading** - Agent can decide when to load MCPs based on user requests, not explicit mentions
3. **Session isolation** - Subagents load temporary MCPs that auto-dispose without polluting parent context

## Implementation

MCP state is now split between instance-scoped (shared, persistent) and session-scoped (isolated, ephemeral). When a session-scoped MCP loads, it publishes an event that triggers tool refresh mid-turn, allowing immediate use. Session disposal automatically cleans up associated MCPs.

The API surface adds `addSessionScoped()` and `disposeSession()` to the MCP module, with a new REST endpoint for session-scoped loading. Event-driven tool refresh replaces the previous turn-boundary limitation.