### PR TITLE
docs: Improving Plugin Documentation - Adding Events

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -61,6 +61,73 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 ---
 
+### Events
+
+Plugins can subscribe to events as seen below in the Examples section. Here is a list of the different events available.
+
+#### Command Events
+
+- `command.executed`
+
+#### File Events
+
+- `file.edited`
+- `file.watcher.updated`
+
+#### Installation Events
+
+- `installation.updated`
+
+#### LSP Events
+
+- `lsp.client.diagnostics`
+- `lsp.updated`
+
+#### Message Events
+
+- `message.part.removed`
+- `message.part.updated`
+- `message.removed`
+- `message.updated`
+
+#### Permission Events
+
+- `permission.replied`
+- `permission.updated`
+
+#### Server Events
+
+- `server.connected`
+
+#### Session Events
+
+- `session.created`
+- `session.compacted`
+- `session.deleted`
+- `session.diff`
+- `session.error`
+- `session.idle`
+- `session.status`
+- `session.updated`
+
+#### Todo Events
+
+- `todo.updated`
+
+
+#### Tool Events
+
+- `tool.execute.after`
+- `tool.execute.before`
+
+#### TUI Events
+
+- `tui.prompt.append`
+- `tui.command.execute`
+- `tui.toast.show`
+
+---
+
 ## Examples
 
 Here are some examples of plugins you can use to extend opencode.

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -114,7 +114,6 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 - `todo.updated`
 
-
 #### Tool Events
 
 - `tool.execute.after`


### PR DESCRIPTION
I'm new around here and was looking into plugins, but quickly noticed the events were not published anywhere. Doing my part to expose them. I'm happy to adjust as you see fit, but I've alphabetized the sections and the events under them.