### PR TITLE
fix: gpt-5* and gpt-5.1* models context overflow

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -28,12 +28,16 @@ export namespace SessionCompaction {
     ),
   }
 
-  export function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: ModelsDev.Model }) {
+  export function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: ModelsDev.Model; modelID: string }) {
     if (Flag.OPENCODE_DISABLE_AUTOCOMPACT) return false
     const context = input.model.limit.context
     if (context === 0) return false
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output
-    const output = Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
+    const isGPT5 = input.modelID.includes("gpt-5")
+    const output = ( isGPT5 ?
+      Math.max(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) :
+      Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) )
+      || SessionPrompt.OUTPUT_TOKEN_MAX
     const usable = context - output
     return count > usable
   }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -28,16 +28,20 @@ export namespace SessionCompaction {
     ),
   }
 
-  export function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: ModelsDev.Model; modelID: string }) {
+  export function isOverflow(input: {
+    tokens: MessageV2.Assistant["tokens"]
+    model: ModelsDev.Model
+    modelID: string
+  }) {
     if (Flag.OPENCODE_DISABLE_AUTOCOMPACT) return false
     const context = input.model.limit.context
     if (context === 0) return false
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output
     const isGPT5 = input.modelID.includes("gpt-5")
-    const output = ( isGPT5 ?
-      Math.max(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) :
-      Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) )
-      || SessionPrompt.OUTPUT_TOKEN_MAX
+    const output =
+      (isGPT5
+        ? Math.max(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX)
+        : Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX)) || SessionPrompt.OUTPUT_TOKEN_MAX
     const usable = context - output
     return count > usable
   }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -408,7 +408,7 @@ export namespace SessionPrompt {
       if (
         lastFinished &&
         lastFinished.summary !== true &&
-        SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model: model.info })
+        SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model: model.info, modelID: model.modelID })
       ) {
         await SessionCompaction.create({
           sessionID,


### PR DESCRIPTION
gpt-5 and gpt-5.1 models are said to have context window of 400k with max output 128k. But there is a max input limit of 272k ( 400k - 128k)

https://models.dev/?search=gpt-5

Current implementation expects available space of 368k ( 400k - 32k ) tokens which leads to context overflow.

Ref: https://openai.com/index/introducing-gpt-5-for-developers/

`In the API, all GPT‑5 models can accept a maximum of 272,000 input tokens and emit a maximum of 128,000 reasoning & output tokens, for a total context length of 400,000 tokens.`

https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?pivots=azure-openai&view=foundry-classic&tabs=global-standard-aoai%2Cstandard-chat-completions%2Cglobal-standard#region-availability

