### PR TITLE
fix: show reasoning summaries for gemini models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -141,6 +141,12 @@ export namespace ProviderTransform {
       result["promptCacheKey"] = sessionID
     }
 
+    if (providerID === "google") {
+      result["thinkingConfig"] = {
+        includeThoughts: true,
+      }
+    }
+
     if (modelID.includes("gpt-5") && !modelID.includes("gpt-5-chat")) {
       if (modelID.includes("codex")) {
         result["store"] = false
@@ -180,13 +186,7 @@ export namespace ProviderTransform {
         }
       case "@ai-sdk/google":
         return {
-          ["google" as string]: {
-            ...options,
-            thinkingConfig: {
-              ...options?.thinkingConfig,
-              includeThoughts: true,
-            },
-          },
+          ["google" as string]: options,
         }
       case "@ai-sdk/gateway":
         return {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -183,6 +183,7 @@ export namespace ProviderTransform {
           ["google" as string]: {
             ...options,
             thinkingConfig: {
+              ...options.thinkingConfig,
               includeThoughts: true,
             },
           },

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -183,9 +183,8 @@ export namespace ProviderTransform {
           ["google" as string]: {
             ...options,
             thinkingConfig: {
-              ...options.thinkingConfig,
-              includeThoughts: true,
               ...options?.thinkingConfig,
+              includeThoughts: true,
             },
           },
         }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -178,6 +178,15 @@ export namespace ProviderTransform {
         return {
           ["anthropic" as string]: options,
         }
+      case "@ai-sdk/google":
+        return {
+          ["google" as string]: {
+            ...options,
+            thinkingConfig: {
+              includeThoughts: true,
+            },
+          },
+        }
       case "@ai-sdk/gateway":
         return {
           ["gateway" as string]: options,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -185,6 +185,7 @@ export namespace ProviderTransform {
             thinkingConfig: {
               ...options.thinkingConfig,
               includeThoughts: true,
+              ...options?.thinkingConfig,
             },
           },
         }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1405,7 +1405,6 @@ export namespace SessionPrompt {
     }
     if (small.providerID === "google") {
       options["thinkingConfig"] = {
-        includeThoughts: true,
         thinkingBudget: 0,
       }
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1405,7 +1405,7 @@ export namespace SessionPrompt {
     }
     if (small.providerID === "google") {
       options["thinkingConfig"] = {
-        ...options["thinkingConfig"],
+        includeThoughts: true,
         thinkingBudget: 0,
       }
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1405,6 +1405,7 @@ export namespace SessionPrompt {
     }
     if (small.providerID === "google") {
       options["thinkingConfig"] = {
+        ...options["thinkingConfig"],
         thinkingBudget: 0,
       }
     }


### PR DESCRIPTION
Enables the display of reasoning summaries for Gemini models.
<img width="628" height="886" alt="Screenshot 2025-11-19 at 13 25 31" src="https://github.com/user-attachments/assets/90df986d-f663-4222-8eae-4d0cb13ba53e" />

