### PR TITLE
feat: deduplicate @-referenced files in session context

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -800,9 +800,24 @@ export namespace SessionPrompt {
       }),
     }
 
+    const history = await MessageV2.filterCompacted(MessageV2.stream(input.sessionID))
+    const loaded = new Set<string>()
+    for (const msg of history) {
+      for (const part of msg.parts) {
+        if (part.type === "file") {
+          const filepath = fileURLToPath(part.url)
+          loaded.add(filepath)
+        }
+      }
+    }
+
     const parts = await Promise.all(
       input.parts.map(async (part): Promise<MessageV2.Part[]> => {
         if (part.type === "file") {
+          const filepath = fileURLToPath(part.url)
+          if (loaded.has(filepath)) return []
+          loaded.add(filepath)
+
           const url = new URL(part.url)
           switch (url.protocol) {
             case "data:":
@@ -841,6 +856,8 @@ export namespace SessionPrompt {
               const stat = await Bun.file(filepath).stat()
 
               if (stat.isDirectory()) {
+                if (loaded.has(filepath)) return []
+                loaded.add(filepath)
                 part.mime = "application/x-directory"
               }
 
@@ -880,7 +897,7 @@ export namespace SessionPrompt {
                   }
                 }
                 const args = { filePath: filepath, offset, limit }
-
+                
                 const pieces: MessageV2.Part[] = [
                   {
                     id: Identifier.ascending("part"),
@@ -979,6 +996,7 @@ export namespace SessionPrompt {
                 ]
               }
 
+              
               const file = Bun.file(filepath)
               FileTime.read(input.sessionID, filepath)
               return [

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -856,8 +856,6 @@ export namespace SessionPrompt {
               const stat = await Bun.file(filepath).stat()
 
               if (stat.isDirectory()) {
-                if (loaded.has(filepath)) return []
-                loaded.add(filepath)
                 part.mime = "application/x-directory"
               }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -895,7 +895,7 @@ export namespace SessionPrompt {
                   }
                 }
                 const args = { filePath: filepath, offset, limit }
-                
+
                 const pieces: MessageV2.Part[] = [
                   {
                     id: Identifier.ascending("part"),
@@ -994,7 +994,6 @@ export namespace SessionPrompt {
                 ]
               }
 
-              
               const file = Bun.file(filepath)
               FileTime.read(input.sessionID, filepath)
               return [


### PR DESCRIPTION
Prevents files and directories referenced via `@` from being loaded into the context window multiple times if they are already present in the active conversation history.

This implementation:
- Scans the current (non-compacted) message history for existing file parts.
- Uses the absolute file path (derived from the file URL) to identify loaded resources.
- Skips loading any `@` reference that matches an already loaded file or directory path.
- Ensures that if a message containing a file is compacted away, the file can be re-loaded in a new message.