### PR TITLE
Adding LSP: PHP Intelephense

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1077,4 +1077,44 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const PHPIntelephense: Info = {
+    id: "php intelephense",
+    extensions: [".php"],
+    root: NearestRoot(["composer.json", "composer.lock", ".php-version"]),
+    async spawn(root) {
+      let binary = Bun.which("intelephense")
+      const args: string[] = []
+      if (!binary) {
+        const js = path.join(Global.Path.bin, "node_modules", "intelephense", "lib", "intelephense.js")
+        if (!(await Bun.file(js).exists())) {
+          if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+          await Bun.spawn([BunProc.which(), "install", "intelephense"], {
+            cwd: Global.Path.bin,
+            env: {
+              ...process.env,
+              BUN_BE_BUN: "1",
+            },
+            stdout: "pipe",
+            stderr: "pipe",
+            stdin: "pipe",
+          }).exited
+        }
+        binary = BunProc.which()
+        args.push("run", js)
+      }
+      args.push("--stdio")
+      const proc = spawn(binary, args, {
+        cwd: root,
+        env: {
+          ...process.env,
+          BUN_BE_BUN: "1",
+        },
+      })
+      return {
+        process: proc,
+        initialization: {},
+      }
+    },
+  }
 }

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -91,30 +91,6 @@ To disable a specific LSP server, set `disabled` to `true`:
 
 ---
 
-### Intelephense Configuration (PHP)
-
-For PHP projects, you can configure Intelephense with a license key if you have a paid subscription:
-
-```json title="opencode.json" {4-8}
-{
-  "$schema": "https://opencode.ai/config.json",
-  "lsp": {
-    "php intelephense": {
-      "initialization": {
-        "licenceKey": "your-license-key-here"
-      }
-    }
-  }
-}
-```
-
-Alternatively, you can place your license key in a file at:
-
-- **macOS/Linux**: `~/.config/intelephense/licence.txt`
-- **Windows**: `%USERPROFILE%\.config\intelephense\licence.txt`
-
----
-
 ### Custom LSP servers
 
 You can add custom LSP servers by specifying the command and file extensions:

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -11,25 +11,26 @@ OpenCode integrates with your Language Server Protocol (LSP) to help the LLM int
 
 OpenCode comes with several built-in LSP servers for popular languages:
 
-| LSP Server    | Extensions                                           | Requirements                                                 |
-| ------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
-| typescript    | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project                           |
-| deno          | .ts, .tsx, .js, .jsx, .mjs                           | `deno` command available (auto-detects deno.json/deno.jsonc) |
-| eslint        | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project                               |
-| gopls         | .go                                                  | `go` command available                                       |
-| ruby-lsp      | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available                          |
-| pyright       | .py, .pyi                                            | `pyright` dependency installed                               |
-| elixir-ls     | .ex, .exs                                            | `elixir` command available                                   |
-| zls           | .zig, .zon                                           | `zig` command available                                      |
-| csharp        | .cs                                                  | `.NET SDK` installed                                         |
-| vue           | .vue                                                 | Auto-installs for Vue projects                               |
-| rust          | .rs                                                  | `rust-analyzer` command available                            |
-| clangd        | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |
-| svelte        | .svelte                                              | Auto-installs for Svelte projects                            |
-| astro         | .astro                                               | Auto-installs for Astro projects                             |
-| jdtls         | .java                                                | `Java SDK (version 21+)` installed                           |
-| lua-ls        | .lua                                                 | Auto-installs for Lua projects                               |
-| sourcekit-lsp | .swift, .objc, .objcpp                               | `swift` installed (`xcode` on macOS)                         |
+| LSP Server       | Extensions                                           | Requirements                                                 |
+| ---------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| typescript       | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project                           |
+| deno             | .ts, .tsx, .js, .jsx, .mjs                           | `deno` command available (auto-detects deno.json/deno.jsonc) |
+| eslint           | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project                               |
+| gopls            | .go                                                  | `go` command available                                       |
+| ruby-lsp         | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available                          |
+| pyright          | .py, .pyi                                            | `pyright` dependency installed                               |
+| elixir-ls        | .ex, .exs                                            | `elixir` command available                                   |
+| zls              | .zig, .zon                                           | `zig` command available                                      |
+| csharp           | .cs                                                  | `.NET SDK` installed                                         |
+| vue              | .vue                                                 | Auto-installs for Vue projects                               |
+| rust             | .rs                                                  | `rust-analyzer` command available                            |
+| clangd           | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |
+| svelte           | .svelte                                              | Auto-installs for Svelte projects                            |
+| astro            | .astro                                               | Auto-installs for Astro projects                             |
+| jdtls            | .java                                                | `Java SDK (version 21+)` installed                           |
+| lua-ls           | .lua                                                 | Auto-installs for Lua projects                               |
+| sourcekit-lsp    | .swift, .objc, .objcpp                               | `swift` installed (`xcode` on macOS)                         |
+| php intelephense | .php                                                 | Auto-installs for PHP projects                               |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 
@@ -87,6 +88,30 @@ To disable a specific LSP server, set `disabled` to `true`:
   }
 }
 ```
+
+---
+
+### Intelephense Configuration (PHP)
+
+For PHP projects, you can configure Intelephense with a license key if you have a paid subscription:
+
+```json title="opencode.json" {4-8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "php intelephense": {
+      "initialization": {
+        "licenceKey": "your-license-key-here"
+      }
+    }
+  }
+}
+```
+
+Alternatively, you can place your license key in a file at:
+
+- **macOS/Linux**: `~/.config/intelephense/licence.txt`
+- **Windows**: `%USERPROFILE%\.config\intelephense\licence.txt`
 
 ---
 

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -113,8 +113,6 @@ You can add custom LSP servers by specifying the command and file extensions:
 
 ### PHP Intelephense
 
-#### Licensing
-
 PHP Intelephense offers premium features through a license key. Uou can provide a license key by placing (only) the key in a text file at:
 
 - On macOS/Linux: `$HOME/intelephense/licence.txt`

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -106,3 +106,18 @@ You can add custom LSP servers by specifying the command and file extensions:
   }
 }
 ```
+
+---
+
+## Additional Information
+
+### PHP Intelephense
+
+#### Licensing
+
+PHP Intelephense offers premium features through a license key. Uou can provide a license key by placing (only) the key in a text file at:
+
+- On macOS/Linux: `$HOME/intelephense/licence.txt`
+- On Windows: `%USERPROFILE%/intelephense/licence.txt`
+
+The file should contain only the license key with no additional content.


### PR DESCRIPTION
Adding LSP: PHP Intelephense

Intelephense is a freemium LSP, which means you can also add a license to enable the some premium features, probably who buys it will know how to setup but in order to make it work with opencode we need some extra config, which you can see at https://intelephense.com/docs:

> If your LSP client does not expose initializationOptions then a licence key can be provided by placing (only) the key in a text file at $HOME/intelephense/licence.txt on *nix or %USERPROFILE%/intelephense/licence.txt on Windows.

Wondering if we should mention that on the docs, or just leave for the user to find out.