### PR TITLE
Add YAML language server support

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -168,6 +168,15 @@ export default {
       },
     },
     {
+      filetype: "yaml",
+      wasm: "https://github.com/tree-sitter-grammars/tree-sitter-yaml/releases/download/v0.7.2/tree-sitter-yaml.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/yaml/highlights.scm",
+        ],
+      },
+    },
+    {
       filetype: "haskell",
       wasm: "https://github.com/tree-sitter/tree-sitter-haskell/releases/download/v0.23.1/tree-sitter-haskell.wasm",
       queries: {

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -945,6 +945,54 @@ export namespace LSPServer {
     },
   }
 
+  export const YamlLS: Info = {
+    id: "yaml-ls",
+    extensions: [".yaml", ".yml"],
+    root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
+    async spawn(root) {
+      let binary = Bun.which("yaml-language-server")
+      const args: string[] = []
+      if (!binary) {
+        const js = path.join(
+          Global.Path.bin,
+          "node_modules",
+          "yaml-language-server",
+          "out",
+          "server",
+          "src",
+          "server.js",
+        )
+        const exists = await Bun.file(js).exists()
+        if (!exists) {
+          if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+          await Bun.spawn([BunProc.which(), "install", "yaml-language-server"], {
+            cwd: Global.Path.bin,
+            env: {
+              ...process.env,
+              BUN_BE_BUN: "1",
+            },
+            stdout: "pipe",
+            stderr: "pipe",
+            stdin: "pipe",
+          }).exited
+        }
+        binary = BunProc.which()
+        args.push("run", js)
+      }
+      args.push("--stdio")
+      const proc = spawn(binary, args, {
+        cwd: root,
+        env: {
+          ...process.env,
+          BUN_BE_BUN: "1",
+        },
+      })
+      return {
+        process: proc,
+      }
+    },
+  }
+
   export const LuaLS: Info = {
     id: "lua-ls",
     root: NearestRoot([

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -27,6 +27,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | clangd        | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |
 | svelte        | .svelte                                              | Auto-installs for Svelte projects                            |
 | astro         | .astro                                               | Auto-installs for Astro projects                             |
+| yaml-ls       | .yaml, .yml                                          | Auto-installs Red Hat yaml-language-server                   |
 | jdtls         | .java                                                | `Java SDK (version 21+)` installed                           |
 | lua-ls        | .lua                                                 | Auto-installs for Lua projects                               |
 | sourcekit-lsp | .swift, .objc, .objcpp                               | `swift` installed (`xcode` on macOS)                         |


### PR DESCRIPTION
## Summary
- add Red Hat yaml-language-server wiring via LSP registry
- add tree-sitter yaml parser config to enable highlights

## Testing
- bun run build -- --single

Solves https://github.com/sst/opencode/issues/4507