### PR TITLE
feat(cli): auto-submit prompt when using --prompt flag

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -41,6 +41,7 @@ export type PromptRef = {
   reset(): void
   blur(): void
   focus(): void
+  submit(): void
 }
 
 export function Prompt(props: PromptProps) {
@@ -398,11 +399,14 @@ export function Prompt(props: PromptProps) {
       })
       setStore("extmarkToPartIndex", new Map())
     },
+    submit() {
+      submit()
+    },
   })
 
   async function submit() {
     if (props.disabled) return
-    if (autocomplete.visible) return
+    if (autocomplete?.visible) return
     if (!store.prompt.input) return
     const selectedModel = local.model.current()
     if (!selectedModel) {

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -48,6 +48,7 @@ export function Home() {
     if (args.prompt) {
       prompt.set({ input: args.prompt, parts: [] })
       once = true
+      prompt.submit()
     }
   })
   const directory = useDirectory()


### PR DESCRIPTION
Per [#3937](https://github.com/sst/opencode/issues/3937), `--prompt` is intended to auto-submit the prompt, not just populate it.

fixes #3937