### PR TITLE
nix: update flake.lock as part of the github workflow

### DIFF
--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -37,6 +37,11 @@ jobs:
           git config --global user.email "action@github.com"
           git config --global user.name "Github Action"
 
+      - name: Update flake.lock
+        run: |
+          set -euo pipefail
+          nix flake update
+
       - name: Update node_modules hash
         run: |
           set -euo pipefail
@@ -62,7 +67,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
           }
 
-          FILES=(flake.nix nix/node-modules.nix nix/hashes.json)
+          FILES=(flake.lock flake.nix nix/node-modules.nix nix/hashes.json)
           STATUS="$(git status --short -- "${FILES[@]}" || true)"
           if [ -z "$STATUS" ]; then
             summarize "no changes"
@@ -71,7 +76,7 @@ jobs:
           fi
 
           git add "${FILES[@]}"
-          git commit -m "Update Nix hashes"
+          git commit -m "Update Nix flake.lock and hashes"
 
           BRANCH="${TARGET_BRANCH:-${GITHUB_REF_NAME}}"
           git push origin HEAD:"$BRANCH"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762156382,
-        "narHash": "sha256-Yg7Ag7ov5+36jEFC1DaZh/12SEXo6OO3/8rqADRxiqs=",
+        "lastModified": 1763464769,
+        "narHash": "sha256-AJHrsT7VoeQzErpBRlLJM1SODcaayp0joAoEA35yiwM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7241bcbb4f099a66aafca120d37c65e8dda32717",
+        "rev": "6f374686605df381de8541c072038472a5ea2e2d",
         "type": "github"
       },
       "original": {

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,3 +1,3 @@
 {
-  "nodeModules": "sha256-xqiDrKpODha+cfU6UpXLEUcApZ1xEkjRpqzFVJmq1uA="
+  "nodeModules": "sha256-bPiUpHGtgwVxHQHXBprpc6fFeJqW6/x7dwtQZBq29oU="
 }


### PR DESCRIPTION
Make sure the lockfile stays constantly up-to-date like we do with the node_modules build outputs.

Bit of an oversight on my part to forget about this, could potentially be causing the issues some people are reporting but not 100% sure.