### PR TITLE
fix: do not print ai sdk warnings

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -42,7 +42,7 @@ import { SessionSummary } from "@/session/summary"
 import { GlobalBus } from "@/bus/global"
 import { SessionStatus } from "@/session/status"
 
-// @ts-ignore This global is needed to prevent ai-sdk to log warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
+// @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
 
 const ERRORS = {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -42,7 +42,7 @@ import { SessionSummary } from "@/session/summary"
 import { GlobalBus } from "@/bus/global"
 import { SessionStatus } from "@/session/status"
 
-// @ts-expect-error This global is needed to prevent ai-sdk to log warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
+// @ts-ignore This global is needed to prevent ai-sdk to log warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
 
 const ERRORS = {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -42,6 +42,9 @@ import { SessionSummary } from "@/session/summary"
 import { GlobalBus } from "@/bus/global"
 import { SessionStatus } from "@/session/status"
 
+// @ts-expect-error This global is needed to prevent ai-sdk to log warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
+globalThis.AI_SDK_LOG_WARNINGS = false
+
 const ERRORS = {
   400: {
     description: "Bad request",


### PR DESCRIPTION
## Summary
- Suppress AI SDK warnings by setting `globalThis.AI_SDK_LOG_WARNINGS = false`.
- Use `@ts-ignore` instead of `@ts-expect-error` to avoid build failures when the type error doesn't occur.

Fixes a new warnings shown in stdout because of the includeThoughts param added to gemini models:
<img width="630" height="264" alt="Screenshot 2025-11-20 at 11 44 26" src="https://github.com/user-attachments/assets/653f4097-568d-4a92-aac7-d9d529f3a683" />

