### PR TITLE
fix: replace ruby-lsp with rubocop for better LSP performance

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -250,12 +250,12 @@ export namespace LSPServer {
     },
   }
 
-  export const RubyLsp: Info = {
+  export const Rubocop: Info = {
     id: "ruby-lsp",
     root: NearestRoot(["Gemfile"]),
     extensions: [".rb", ".rake", ".gemspec", ".ru"],
     async spawn(root) {
-      let bin = Bun.which("ruby-lsp", {
+      let bin = Bun.which("rubocop", {
         PATH: process.env["PATH"] + ":" + Global.Path.bin,
       })
       if (!bin) {
@@ -266,25 +266,25 @@ export namespace LSPServer {
           return
         }
         if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
-        log.info("installing ruby-lsp")
+        log.info("installing rubocop")
         const proc = Bun.spawn({
-          cmd: ["gem", "install", "ruby-lsp", "--bindir", Global.Path.bin],
+          cmd: ["gem", "install", "rubocop", "--bindir", Global.Path.bin],
           stdout: "pipe",
           stderr: "pipe",
           stdin: "pipe",
         })
         const exit = await proc.exited
         if (exit !== 0) {
-          log.error("Failed to install ruby-lsp")
+          log.error("Failed to install rubocop")
           return
         }
-        bin = path.join(Global.Path.bin, "ruby-lsp" + (process.platform === "win32" ? ".exe" : ""))
-        log.info(`installed ruby-lsp`, {
+        bin = path.join(Global.Path.bin, "rubocop" + (process.platform === "win32" ? ".exe" : ""))
+        log.info(`installed rubocop`, {
           bin,
         })
       }
       return {
-        process: spawn(bin!, ["--stdio"], {
+        process: spawn(bin!, ["--lsp"], {
           cwd: root,
         }),
       }

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -11,27 +11,27 @@ OpenCode integrates with your Language Server Protocol (LSP) to help the LLM int
 
 OpenCode comes with several built-in LSP servers for popular languages:
 
-| LSP Server       | Extensions                                           | Requirements                                                 |
-| ---------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
-| typescript       | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project                           |
-| deno             | .ts, .tsx, .js, .jsx, .mjs                           | `deno` command available (auto-detects deno.json/deno.jsonc) |
-| eslint           | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project                               |
-| gopls            | .go                                                  | `go` command available                                       |
-| ruby-lsp         | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available                          |
-| pyright          | .py, .pyi                                            | `pyright` dependency installed                               |
-| elixir-ls        | .ex, .exs                                            | `elixir` command available                                   |
-| zls              | .zig, .zon                                           | `zig` command available                                      |
-| csharp           | .cs                                                  | `.NET SDK` installed                                         |
-| vue              | .vue                                                 | Auto-installs for Vue projects                               |
-| rust             | .rs                                                  | `rust-analyzer` command available                            |
-| clangd           | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |
-| svelte           | .svelte                                              | Auto-installs for Svelte projects                            |
-| astro            | .astro                                               | Auto-installs for Astro projects                             |
-| yaml-ls          | .yaml, .yml                                          | Auto-installs Red Hat yaml-language-server                   |
-| jdtls            | .java                                                | `Java SDK (version 21+)` installed                           |
-| lua-ls           | .lua                                                 | Auto-installs for Lua projects                               |
-| sourcekit-lsp    | .swift, .objc, .objcpp                               | `swift` installed (`xcode` on macOS)                         |
-| php intelephense | .php                                                 | Auto-installs for PHP projects                               |
+| LSP Server         | Extensions                                           | Requirements                                                 |
+| ------------------ | ---------------------------------------------------- | ------------------------------------------------------------ |
+| typescript         | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts         | `typescript` dependency in project                           |
+| deno               | .ts, .tsx, .js, .jsx, .mjs                           | `deno` command available (auto-detects deno.json/deno.jsonc) |
+| eslint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue   | `eslint` dependency in project                               |
+| gopls              | .go                                                  | `go` command available                                       |
+| ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                            | `ruby` and `gem` commands available                          |
+| pyright            | .py, .pyi                                            | `pyright` dependency installed                               |
+| elixir-ls          | .ex, .exs                                            | `elixir` command available                                   |
+| zls                | .zig, .zon                                           | `zig` command available                                      |
+| csharp             | .cs                                                  | `.NET SDK` installed                                         |
+| vue                | .vue                                                 | Auto-installs for Vue projects                               |
+| rust               | .rs                                                  | `rust-analyzer` command available                            |
+| clangd             | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |
+| svelte             | .svelte                                              | Auto-installs for Svelte projects                            |
+| astro              | .astro                                               | Auto-installs for Astro projects                             |
+| yaml-ls            | .yaml, .yml                                          | Auto-installs Red Hat yaml-language-server                   |
+| jdtls              | .java                                                | `Java SDK (version 21+)` installed                           |
+| lua-ls             | .lua                                                 | Auto-installs for Lua projects                               |
+| sourcekit-lsp      | .swift, .objc, .objcpp                               | `swift` installed (`xcode` on macOS)                         |
+| php intelephense   | .php                                                 | Auto-installs for PHP projects                               |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 


### PR DESCRIPTION
## Problem

The current ruby-lsp implementation has two critical issues:
1. **Invalid LSP argument**: ruby-lsp is spawned with `["--stdio"]` which is not a valid argument for ruby-lsp. The LSP server should start automatically without this flag.

```
ruby-lsp --stdio
invalid option: --stdio

Usage: ruby-lsp [options]
        --version                    Print ruby-lsp version
        --debug                      Launch the Ruby LSP with a debugger attached
        --time-index                 Measure the time it takes to index the project
        --branch [BRANCH]            Launch the Ruby LSP using the specified branch rather than the release version
        --doctor                     Run troubleshooting steps
        --use-launcher               [EXPERIMENTAL] Use launcher mechanism to handle missing dependencies gracefully
    -h, --help                       Print this help
```
3. **Startup timeout**: ruby-lsp takes ~2.65 seconds to initialize, and sometimes exceeds opencode's 3-second LSP startup timeout, causing Ruby files to never receive LSP diagnostics.

## Solution

Replace ruby-lsp with rubocop's LSP mode:
- **Startup time**: ~0.58s (78% faster, well under the 3-second timeout)
- **Minimalistic approach**: rubocop focuses on what matters for opencode's LLM workflow:
  - Linting errors and warnings
  - Formatting issues
  - Syntax errors
- **No bloat**: Unlike ruby-lsp, rubocop doesn't include unnecessary IDE features:
  - No autocomplete (LLM handles this)
  - No go-to-definition (LLM provides context)
  - No rename refactoring (LLM suggests refactorings)
  - No documentation hovers (LLM provides documentation)
 
## Changes

- Modified `packages/opencode/src/lsp/server.ts`:
  - Replaced ruby-lsp binary with rubocop
  - Changed spawn arguments from `["--stdio"]` to `["--lsp"]`
  - Updated gem installation and logging
  - Kept LSP ID as `"ruby-lsp"` for backward compatibility
- Updated `packages/web/src/content/docs/lsp.mdx`:
  - Changed LSP table entry to `ruby-lsp (rubocop)` to clarify the implementation

## Backward Compatibility

Users with existing `opencode.jsonc` configs will not be affected:
- The LSP ID remains `"ruby-lsp"` internally
- Existing `"ruby-lsp"` overrides in config will continue to work
- Transparent upgrade with no breaking changes