### PR TITLE
docs: typo in PHP Intelephense documentation

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -114,7 +114,7 @@ You can add custom LSP servers by specifying the command and file extensions:
 
 ### PHP Intelephense
 
-PHP Intelephense offers premium features through a license key. Uou can provide a license key by placing (only) the key in a text file at:
+PHP Intelephense offers premium features through a license key. You can provide a license key by placing (only) the key in a text file at:
 
 - On macOS/Linux: `$HOME/intelephense/licence.txt`
 - On Windows: `%USERPROFILE%/intelephense/licence.txt`


### PR DESCRIPTION
Minor typo fix. `Uou` -> `You`. Found while reading the docs :)