### PR TITLE
chore: rm empty file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist
 refs
 Session.vim
 opencode.json
+a.out


### PR DESCRIPTION
There is an empty `a.out` file at the root of the repository. Seems like it shouldn't be there.