### PR TITLE
feat: add field to allow user only messages

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -58,6 +58,7 @@ export namespace MessageV2 {
     type: z.literal("text"),
     text: z.string(),
     synthetic: z.boolean().optional(),
+    userSynthetic: z.boolean().optional(),
     time: z
       .object({
         start: z.number(),
@@ -566,7 +567,7 @@ export namespace MessageV2 {
         }
         result.push(userMessage)
         for (const part of msg.parts) {
-          if (part.type === "text")
+          if (part.type === "text"  && !part.userSynthetic)
             userMessage.parts.push({
               type: "text",
               text: part.text,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -567,7 +567,7 @@ export namespace MessageV2 {
         }
         result.push(userMessage)
         for (const part of msg.parts) {
-          if (part.type === "text"  && !part.userSynthetic)
+          if (part.type === "text" && !part.userSynthetic)
             userMessage.parts.push({
               type: "text",
               text: part.text,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -58,7 +58,7 @@ export namespace MessageV2 {
     type: z.literal("text"),
     text: z.string(),
     synthetic: z.boolean().optional(),
-    userSynthetic: z.boolean().optional(),
+    ignored: z.boolean().optional(),
     time: z
       .object({
         start: z.number(),
@@ -567,7 +567,7 @@ export namespace MessageV2 {
         }
         result.push(userMessage)
         for (const part of msg.parts) {
-          if (part.type === "text" && !part.userSynthetic)
+          if (part.type === "text" && !part.ignored)
             userMessage.parts.push({
               type: "text",
               text: part.text,

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -150,6 +150,7 @@ export type TextPart = {
   type: "text"
   text: string
   synthetic?: boolean
+  userSynthetic?: boolean
   time?: {
     start: number
     end?: number
@@ -1233,6 +1234,7 @@ export type TextPartInput = {
   type: "text"
   text: string
   synthetic?: boolean
+  userSynthetic?: boolean
   time?: {
     start: number
     end?: number

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -150,7 +150,7 @@ export type TextPart = {
   type: "text"
   text: string
   synthetic?: boolean
-  userSynthetic?: boolean
+  ignored?: boolean
   time?: {
     start: number
     end?: number
@@ -1234,7 +1234,7 @@ export type TextPartInput = {
   type: "text"
   text: string
   synthetic?: boolean
-  userSynthetic?: boolean
+  ignored?: boolean
   time?: {
     start: number
     end?: number


### PR DESCRIPTION
Complements the already present synthetic messages, with the inverse concept.

Perfect for plugins that want to show infos to the user with a message without adding said message to the context being sent out.