### PR TITLE
fix: preserve agent context during compaction

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -791,8 +791,18 @@ export namespace Server {
         async (c) => {
           const id = c.req.valid("param").id
           const body = c.req.valid("json")
+          const msgs = await Session.messages({ sessionID: id })
+          let currentAgent = "build"
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            const info = msgs[i].info
+            if (info.role === "user") {
+              currentAgent = info.agent || "build"
+              break
+            }
+          }
           await SessionCompaction.create({
             sessionID: id,
+            agent: currentAgent,
             model: {
               providerID: body.providerID,
               modelID: body.modelID,

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -92,6 +92,7 @@ export namespace SessionCompaction {
       providerID: string
       modelID: string
     }
+    agent: string
     abort: AbortSignal
   }) {
     const model = await Provider.getModel(input.model.providerID, input.model.modelID)
@@ -101,7 +102,7 @@ export namespace SessionCompaction {
       role: "assistant",
       parentID: input.parentID,
       sessionID: input.sessionID,
-      mode: "build",
+      mode: input.agent,
       summary: true,
       path: {
         cwd: Instance.directory,
@@ -199,7 +200,7 @@ export namespace SessionCompaction {
         time: {
           created: Date.now(),
         },
-        agent: "build",
+        agent: input.agent,
         model: input.model,
       })
       await Session.updatePart({
@@ -222,6 +223,7 @@ export namespace SessionCompaction {
   export const create = fn(
     z.object({
       sessionID: Identifier.schema("session"),
+      agent: z.string(),
       model: z.object({
         providerID: z.string(),
         modelID: z.string(),
@@ -233,7 +235,7 @@ export namespace SessionCompaction {
         role: "user",
         model: input.model,
         sessionID: input.sessionID,
-        agent: "build",
+        agent: input.agent,
         time: {
           created: Date.now(),
         },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -394,6 +394,7 @@ export namespace SessionPrompt {
           messages: msgs,
           parentID: lastUser.id,
           abort,
+          agent: lastUser.agent,
           model: {
             providerID: model.providerID,
             modelID: model.modelID,
@@ -412,6 +413,7 @@ export namespace SessionPrompt {
       ) {
         await SessionCompaction.create({
           sessionID,
+          agent: lastUser.agent,
           model: lastUser.model,
         })
         continue


### PR DESCRIPTION
Fixes #4546, potentially #3099

## Problem
When compaction is triggered (manually via `<leader>c` or automatically when context overflows), the system hardcodes the agent to 'build', causing unwanted agent switching. This breaks workflows using custom agents and can cause tool call failures after compaction.

## Solution
- Pass the current agent through `SessionCompaction.create()` and `SessionCompaction.process()`
- Retrieve the agent from the last user message in the API endpoint
- Default to 'build' if no user message is found (safe fallback)

## Testing
Tested with custom agents by:
1. Starting a session with a custom agent
2. Triggering manual compaction (`<leader>c`)
3. Verifying the agent persists after compaction
4. Confirming tool calls work correctly post-compaction

## Changes
- `compaction.ts`: Add `agent` parameter to `create()` and `process()` functions
- `prompt.ts`: Pass `lastUser.agent` to compaction calls
- `server.ts`: Retrieve current agent from session messages in API endpoint