### PR TITLE
fix: ensure selected list items are readable with transparent background

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -5,7 +5,7 @@ import { createMemo, createResource, createEffect, onMount, For, Show } from "so
 import { createStore } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
 import { useSync } from "@tui/context/sync"
-import { useTheme } from "@tui/context/theme"
+import { useTheme, selectedForeground } from "@tui/context/theme"
 import { SplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { Locale } from "@/util/locale"
@@ -471,11 +471,11 @@ export function Autocomplete(props: {
               backgroundColor={index() === store.selected ? theme.primary : undefined}
               flexDirection="row"
             >
-              <text fg={index() === store.selected ? theme.background : theme.text} flexShrink={0}>
+              <text fg={index() === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>
                 {option.display}
               </text>
               <Show when={option.description}>
-                <text fg={index() === store.selected ? theme.background : theme.textMuted} wrapMode="none">
+                <text fg={index() === store.selected ? selectedForeground(theme) : theme.textMuted} wrapMode="none">
                   {option.description}
                 </text>
               </Show>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -455,7 +455,7 @@ export function Autocomplete(props: {
       {...SplitBorder}
       borderColor={theme.border}
     >
-      <box backgroundColor={theme.backgroundElement} height={height()}>
+      <box backgroundColor={theme.backgroundMenu} height={height()}>
         <For
           each={options()}
           fallback={

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -791,10 +791,17 @@ export function Prompt(props: PromptProps) {
             height={1}
             border={["bottom"]}
             borderColor={theme.backgroundElement}
-            customBorderChars={{
-              ...EmptyBorder,
-              horizontal: "▀",
-            }}
+            customBorderChars={
+              theme.background.a != 0
+                ? {
+                    ...EmptyBorder,
+                    horizontal: "▀",
+                  }
+                : {
+                    ...EmptyBorder,
+                    horizontal: " ",
+                  }
+            }
           />
         </box>
         <box flexDirection="row" justifyContent="space-between">

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -46,6 +46,7 @@ type Theme = {
   background: RGBA
   backgroundPanel: RGBA
   backgroundElement: RGBA
+  backgroundMenu: RGBA
   border: RGBA
   borderActive: RGBA
   borderSubtle: RGBA
@@ -89,8 +90,8 @@ type Theme = {
 export function selectedForeground(theme: Theme): RGBA {
   if (theme.background.a === 0) {
     const { r, g, b } = theme.primary
-    const luminance  = 0.299 * r + 0.587 * g + 0.114 * b
-    return luminance  > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
+    const luminance = 0.299 * r + 0.587 * g + 0.114 * b
+    return luminance > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
   }
   return theme.background
 }
@@ -154,11 +155,13 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
     }
     return resolveColor(c[mode])
   }
-  return Object.fromEntries(
+  const resolved = Object.fromEntries(
     Object.entries(theme.theme).map(([key, value]) => {
       return [key, resolveColor(value)]
     }),
   ) as Theme
+  if (!theme.theme.backgroundMenu) resolved.backgroundMenu = resolved.backgroundElement
+  return resolved
 }
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
@@ -300,6 +303,7 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
       background: bg,
       backgroundPanel: grays[2],
       backgroundElement: grays[3],
+      backgroundMenu: grays[3],
 
       // Border colors
       borderSubtle: grays[6],

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -86,6 +86,15 @@ type Theme = {
   syntaxPunctuation: RGBA
 }
 
+export function selectedForeground(theme: Theme): RGBA {
+  if (theme.background.a === 0) {
+    const { r, g, b } = theme.primary
+    const luminance  = 0.299 * r + 0.587 * g + 0.114 * b
+    return luminance  > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
+  }
+  return theme.background
+}
+
 type HexColor = `#${string}`
 type RefName = string
 type Variant = {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -1,5 +1,5 @@
 import { InputRenderable, RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
-import { useTheme } from "@tui/context/theme"
+import { useTheme, selectedForeground } from "@tui/context/theme"
 import { entries, filter, flatMap, groupBy, pipe, take } from "remeda"
 import { batch, createEffect, createMemo, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
@@ -259,31 +259,28 @@ function Option(props: {
   onMouseOver?: () => void
 }) {
   const { theme } = useTheme()
+  const fg = selectedForeground(theme)
 
   return (
     <>
       <Show when={props.current}>
-        <text
-          flexShrink={0}
-          fg={props.active ? theme.background : props.current ? theme.primary : theme.text}
-          marginRight={0.5}
-        >
+        <text flexShrink={0} fg={props.active ? fg : props.current ? theme.primary : theme.text} marginRight={0.5}>
           ●
         </text>
       </Show>
       <text
         flexGrow={1}
-        fg={props.active ? theme.background : props.current ? theme.primary : theme.text}
+        fg={props.active ? fg : props.current ? theme.primary : theme.text}
         attributes={props.active ? TextAttributes.BOLD : undefined}
         overflow="hidden"
         wrapMode="none"
       >
         {Locale.truncate(props.title, 62)}
-        <span style={{ fg: props.active ? theme.background : theme.textMuted }}> {props.description}</span>
+        <span style={{ fg: props.active ? fg : theme.textMuted }}> {props.description}</span>
       </text>
       <Show when={props.footer}>
         <box flexShrink={0}>
-          <text fg={props.active ? theme.background : theme.textMuted}>{props.footer}</text>
+          <text fg={props.active ? fg : theme.textMuted}>{props.footer}</text>
         </box>
       </Show>
     </>


### PR DESCRIPTION
Fixes: https://github.com/sst/opencode/issues/4369

## Summary
Fix unreadable text in selected list items when theme uses background: "none"

## Details
When a theme sets "background": "none", the background color resolves to fully transparent. Previously, selected list items used theme.background as the foreground color, making the text invisible. This PR adds a helper that returns a contrasting color (black or white) based on the luminance of theme.

### Before:
<img width="810" height="547" alt="Screenshot 2025-11-21 at 16 33 19" src="https://github.com/user-attachments/assets/77deede7-a0ca-4dc6-826e-036dd8c17eee" />

<img width="804" height="441" alt="Screenshot 2025-11-21 at 16 33 30" src="https://github.com/user-attachments/assets/0a0a2887-8b7d-4155-a617-38f48106523f" />

### After:
<img width="800" height="548" alt="Screenshot 2025-11-21 at 16 36 04" src="https://github.com/user-attachments/assets/364d3f7b-cca4-4a77-938f-705bedb900ae" />

<img width="836" height="472" alt="Screenshot 2025-11-21 at 16 36 11" src="https://github.com/user-attachments/assets/4cdd325e-1e43-4ad7-b7e6-ba54e045dc2a" />

