### PR TITLE
Fix empty tool call ID causing API errors when switching providers

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -129,6 +129,21 @@ export namespace SessionCompaction {
       model: model.info,
       abort: input.abort,
     })
+    const modelMessages = await MessageV2.toModelMessage(
+      input.messages.filter((m) => {
+        if (m.info.role !== "assistant" || m.info.error === undefined) {
+          return true
+        }
+        if (
+          MessageV2.AbortedError.isInstance(m.info.error) &&
+          m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
+        ) {
+          return true
+        }
+
+        return false
+      }),
+    )
     const result = await processor.process(() =>
       streamText({
         onError(error) {
@@ -157,21 +172,7 @@ export namespace SessionCompaction {
               content: x,
             }),
           ),
-          ...MessageV2.toModelMessage(
-            input.messages.filter((m) => {
-              if (m.info.role !== "assistant" || m.info.error === undefined) {
-                return true
-              }
-              if (
-                MessageV2.AbortedError.isInstance(m.info.error) &&
-                m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
-              ) {
-                return true
-              }
-
-              return false
-            }),
-          ),
+          ...modelMessages,
           {
             role: "user",
             content: [

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -9,6 +9,7 @@ import { Snapshot } from "@/snapshot"
 import { fn } from "@/util/fn"
 import { Storage } from "@/storage/storage"
 import { ProviderTransform } from "@/provider/transform"
+import { ulid } from "ulid"
 
 export namespace MessageV2 {
   export const OutputLengthError = NamedError.create("MessageOutputLengthError", z.object({}))
@@ -549,12 +550,12 @@ export namespace MessageV2 {
     throw new Error("unknown message type")
   }
 
-  export function toModelMessage(
+  export async function toModelMessage(
     input: {
       info: Info
       parts: Part[]
     }[],
-  ): ModelMessage[] {
+  ): Promise<ModelMessage[]> {
     const result: UIMessage[] = []
 
     for (const msg of input) {
@@ -616,6 +617,11 @@ export namespace MessageV2 {
               type: "step-start",
             })
           if (part.type === "tool") {
+            // Fix empty callID from providers that don't generate tool call IDs (e.g. Gemini)
+            if (!part.callID) {
+              part.callID = ulid()
+              await Storage.write(["part", part.messageID, part.id], part)
+            }
             if (part.state.status === "completed") {
               if (part.state.attachments?.length) {
                 result.push({

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -3,6 +3,7 @@ import { MessageV2 } from "./message-v2"
 import { type StreamTextResult, type Tool as AITool, APICallError } from "ai"
 import { Log } from "@/util/log"
 import { Identifier } from "@/id/id"
+import { ulid } from "ulid"
 import { Session } from "."
 import { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
@@ -101,7 +102,7 @@ export namespace SessionProcessor {
                     sessionID: input.assistantMessage.sessionID,
                     type: "tool",
                     tool: value.toolName,
-                    callID: value.id,
+                    callID: value.id || ulid(),
                     state: {
                       status: "pending",
                       input: {},

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -505,6 +505,22 @@ export namespace SessionPrompt {
         })
       }
 
+      const modelMessages = await MessageV2.toModelMessage(
+        msgs.filter((m) => {
+          if (m.info.role !== "assistant" || m.info.error === undefined) {
+            return true
+          }
+          if (
+            MessageV2.AbortedError.isInstance(m.info.error) &&
+            m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
+          ) {
+            return true
+          }
+
+          return false
+        }),
+      )
+
       const result = await processor.process(() =>
         streamText({
           onError(error) {
@@ -563,21 +579,7 @@ export namespace SessionPrompt {
                 content: x,
               }),
             ),
-            ...MessageV2.toModelMessage(
-              msgs.filter((m) => {
-                if (m.info.role !== "assistant" || m.info.error === undefined) {
-                  return true
-                }
-                if (
-                  MessageV2.AbortedError.isInstance(m.info.error) &&
-                  m.parts.some((part) => part.type !== "step-start" && part.type !== "reasoning")
-                ) {
-                  return true
-                }
-
-                return false
-              }),
-            ),
+            ...modelMessages,
           ],
           tools: model.info.tool_call === false ? undefined : tools,
           model: wrapLanguageModel({
@@ -1431,7 +1433,7 @@ export namespace SessionPrompt {
           role: "user",
           content: "Generate a title for this conversation:\n",
         },
-        ...MessageV2.toModelMessage([
+        ...(await MessageV2.toModelMessage([
           {
             info: {
               id: Identifier.ascending("message"),
@@ -1448,7 +1450,7 @@ export namespace SessionPrompt {
             },
             parts: input.message.parts,
           },
-        ]),
+        ])),
       ],
       headers: small.info.headers,
       model: small.language,

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -142,7 +142,7 @@ export namespace SessionSummary {
                 content: x,
               }),
             ),
-            ...MessageV2.toModelMessage(messages),
+            ...(await MessageV2.toModelMessage(messages)),
             {
               role: "user",
               content: `Summarize the above conversation according to your system prompts.`,


### PR DESCRIPTION
close #1279

**Problem**

Some providers (e.g. Gemini) don't generate tool call IDs, resulting in empty callID being stored. When switching to providers that require tool call IDs (e.g. Anthropic, OpenAI), this causes API errors with "id": "" in tool_use blocks.

**Solution**

- Generate fallback ulid() when value.id is empty from stream events
- Make toModelMessage async to fix empty callID in existing stored data
- Update storage with generated ID when empty callID is found

**Test plan**

- Use Gemini model to create tool calls in a session
- Switch to Anthropic/OpenAI model and continue the session
- Verify no API errors about empty tool call IDs