### PR TITLE
ref: improve and enable the multiedit tool with visuals and improved prompting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1187,6 +1187,7 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
           metadata={metadata}
           permission={permission?.metadata ?? {}}
           output={props.part.state.status === "completed" ? props.part.state.output : undefined}
+          title={props.part.state.status === "completed" ? props.part.state.title : undefined}
         />
         {props.part.state.status === "error" && (
           <box paddingLeft={2}>
@@ -1225,6 +1226,7 @@ type ToolProps<T extends Tool.Info> = {
   permission: Record<string, any>
   tool: string
   output?: string
+  title?: string
 }
 function GenericTool(props: ToolProps<any>) {
   return (
@@ -1440,6 +1442,18 @@ ToolRegistry.register<typeof WebFetchTool>({
     return (
       <ToolTitle icon="%" fallback="Fetching from the web..." when={(props.input as any).url}>
         WebFetch {(props.input as any).url}
+      </ToolTitle>
+    )
+  },
+})
+
+ToolRegistry.register({
+  name: "multiedit_edit",
+  container: "inline",
+  render(props) {
+    return (
+      <ToolTitle icon="→" fallback="Editing..." when={props.title}>
+        {props.title || "edit"}
       </ToolTitle>
     )
   },

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -2,7 +2,7 @@ import z from "zod"
 import { Tool } from "./tool"
 import DESCRIPTION from "./batch.txt"
 
-const DISALLOWED = new Set(["batch", "edit", "todoread"])
+const DISALLOWED = new Set(["batch", "edit", "multiedit", "todoread"])
 const FILTERED_FROM_SUGGESTIONS = new Set(["invalid", "patch", ...DISALLOWED])
 
 export const BatchTool = Tool.define("batch", async () => {

--- a/packages/opencode/src/tool/multiedit.ts
+++ b/packages/opencode/src/tool/multiedit.ts
@@ -5,6 +5,35 @@ import DESCRIPTION from "./multiedit.txt"
 import path from "path"
 import { Instance } from "../project/instance"
 
+function extractLineRange(diff: string): { start: number; end: number } | undefined {
+  const headerMatch = diff.match(/@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@/)
+  if (!headerMatch) return undefined
+
+  const oldStart = parseInt(headerMatch[1], 10)
+  const lines = diff.split("\n")
+  let minChangedLine = Infinity
+  let maxChangedLine = -Infinity
+  let currentLine = oldStart
+
+  for (const line of lines) {
+    if (line.startsWith("@@") || line.startsWith("---") || line.startsWith("+++")) continue
+
+    if (line.startsWith("-")) {
+      minChangedLine = Math.min(minChangedLine, currentLine)
+      maxChangedLine = Math.max(maxChangedLine, currentLine)
+      currentLine++
+    } else if (line.startsWith("+")) {
+      // Don't track + lines - they don't exist in original file
+    } else if (line.startsWith(" ")) {
+      currentLine++
+    }
+  }
+
+  if (minChangedLine === Infinity) return undefined
+
+  return { start: minChangedLine, end: maxChangedLine }
+}
+
 export const MultiEditTool = Tool.define("multiedit", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -12,7 +41,6 @@ export const MultiEditTool = Tool.define("multiedit", {
     edits: z
       .array(
         z.object({
-          filePath: z.string().describe("The absolute path to the file to modify"),
           oldString: z.string().describe("The text to replace"),
           newString: z.string().describe("The text to replace it with (must be different from oldString)"),
           replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
@@ -21,26 +49,112 @@ export const MultiEditTool = Tool.define("multiedit", {
       .describe("Array of edit operations to perform sequentially on the file"),
   }),
   async execute(params, ctx) {
+    const { Session } = await import("../session")
+    const { Identifier } = await import("../id/id")
+
     const tool = await EditTool.init()
-    const results = []
-    for (const [, edit] of params.edits.entries()) {
-      const result = await tool.execute(
-        {
-          filePath: params.filePath,
-          oldString: edit.oldString,
-          newString: edit.newString,
-          replaceAll: edit.replaceAll,
-        },
-        ctx,
-      )
-      results.push(result)
+    const results: Array<
+      { success: true; result: Awaited<ReturnType<typeof tool.execute>> } | { success: false; error: unknown }
+    > = []
+    const relativeFilePath = path.relative(Instance.worktree, params.filePath)
+
+    for (const [index, edit] of params.edits.entries()) {
+      const partID = Identifier.ascending("part")
+      const editStartTime = Date.now()
+
+      try {
+        await Session.updatePart({
+          id: partID,
+          messageID: ctx.messageID,
+          sessionID: ctx.sessionID,
+          type: "tool",
+          tool: "multiedit_edit",
+          callID: partID,
+          state: {
+            status: "running",
+            input: { filePath: params.filePath },
+            time: {
+              start: editStartTime,
+            },
+          },
+        })
+
+        const result = await tool.execute(
+          {
+            filePath: params.filePath,
+            oldString: edit.oldString,
+            newString: edit.newString,
+            replaceAll: edit.replaceAll,
+          },
+          ctx,
+        )
+
+        const lineRange = extractLineRange(result.metadata?.diff || "")
+        const lineDisplay = lineRange
+          ? lineRange.start === lineRange.end
+            ? `line=${lineRange.start}`
+            : `lines=${lineRange.start}-${lineRange.end}`
+          : ""
+
+        await Session.updatePart({
+          id: partID,
+          messageID: ctx.messageID,
+          sessionID: ctx.sessionID,
+          type: "tool",
+          tool: "multiedit_edit",
+          callID: partID,
+          state: {
+            status: "completed",
+            input: lineRange ? { lines: `${lineRange.start}-${lineRange.end}` } : {},
+            output: "",
+            title: lineDisplay ? `edit [${lineDisplay}]` : "edit",
+            metadata: result.metadata,
+            time: {
+              start: editStartTime,
+              end: Date.now(),
+            },
+          },
+        })
+
+        results.push({ success: true, result })
+      } catch (error) {
+        await Session.updatePart({
+          id: partID,
+          messageID: ctx.messageID,
+          sessionID: ctx.sessionID,
+          type: "tool",
+          tool: "multiedit_edit",
+          callID: partID,
+          state: {
+            status: "error",
+            input: { filePath: params.filePath },
+            error: error instanceof Error ? error.message : String(error),
+            time: {
+              start: editStartTime,
+              end: Date.now(),
+            },
+          },
+        })
+
+        results.push({ success: false, error })
+        throw error
+      }
     }
+
+    const successfulEdits = results.filter((r) => r.success).length
+
     return {
-      title: path.relative(Instance.worktree, params.filePath),
+      title: relativeFilePath,
       metadata: {
-        results: results.map((r) => r.metadata),
+        totalEdits: params.edits.length,
+        successful: successfulEdits,
+        failed: results.length - successfulEdits,
+        results: results.map((r) => {
+          if (r.success) return r.result.metadata
+          return { error: r.error }
+        }),
       },
-      output: results.at(-1)!.output,
+      output: (results.at(-1)! as Extract<(typeof results)[number], { success: true }>).result.output,
     }
   },
 })

--- a/packages/opencode/src/tool/multiedit.txt
+++ b/packages/opencode/src/tool/multiedit.txt
@@ -1,41 +1,60 @@
-This is a tool for making multiple edits to a single file in one operation. It is built on top of the Edit tool and allows you to perform multiple find-and-replace operations efficiently. Prefer this tool over the Edit tool when you need to make multiple edits to the same file.
+SCOPE: Use ONLY for 2+ edits to single file. For single edits, use Edit tool.
 
-Before using this tool:
+PROTOCOL: Built on Edit tool with exact-match requirements. Multiple edit() calls to same file = violation.
 
-1. Use the Read tool to understand the file's contents and context
-2. Verify the directory path is correct
+PROHIBITED:
 
-To make multiple file edits, provide the following:
-1. file_path: The absolute path to the file to modify (must be absolute, not relative)
-2. edits: An array of edit operations to perform, where each edit contains:
-   - oldString: The text to replace (must match the file contents exactly, including all whitespace and indentation)
-   - newString: The edited text to replace the oldString
-   - replaceAll: Replace all occurrences of oldString. This parameter is optional and defaults to false.
+Multiple edit() calls to same file
+   First edit() adds header, second adds footer
+   Result: File read/written multiple times, wasted tokens
 
-IMPORTANT:
-- All edits are applied in sequence, in the order they are provided
-- Each edit operates on the result of the previous edit
-- All edits must be valid for the operation to succeed - if any edit fails, none will be applied
-- This tool is ideal when you need to make several changes to different parts of the same file
+Using multiedit() for single edit
+   Unnecessary complexity
+   Use edit() tool for single changes
 
-CRITICAL REQUIREMENTS:
-1. All edits follow the same requirements as the single Edit tool
-2. The edits are atomic - either all succeed or none are applied
-3. Plan your edits carefully to avoid conflicts between sequential operations
+Using multiedit() in batch tool
+   Batch rejects multiedit operations
+   Call multiedit directly
 
-WARNING:
-- The tool will fail if edits.oldString doesn't match the file contents exactly (including whitespace)
-- The tool will fail if edits.oldString and edits.newString are the same
-- Since edits are applied in sequence, ensure that earlier edits don't affect the text that later edits are trying to find
+CORRECT:
 
-When making edits:
-- Ensure all edits result in idiomatic, correct code
-- Do not leave the code in a broken state
-- Always use absolute file paths (starting with /)
-- Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
-- Use replaceAll for replacing and renaming strings across the file. This parameter is useful if you want to rename a variable for instance.
+Single multiedit() with 2+ changes
+   One call with array of edits
+   Result: File read/written once, optimal tokens
 
-If you want to create a new file, use:
-- A new file path, including dir name if needed
-- First edit: empty oldString and the new file's contents as newString
-- Subsequent edits: normal edit operations on the created content
+Single edit() for one change
+   Simple, direct edit
+   No array structure needed
+
+PREREQUISITES:
+1. Read file to understand contents
+2. Verify directory path
+
+PARAMETERS:
+1. file_path: Absolute path (not relative)
+2. edits: Array of operations:
+   - oldString: Text to replace (exact match including whitespace)
+   - newString: Replacement text
+   - replaceAll: Replace all occurrences (optional, default false)
+
+EXECUTION:
+- Edits applied sequentially in order
+- Each edit operates on previous edit result
+- All edits must be valid - any failure aborts all
+- Atomic operation
+
+FAILURES:
+- oldString doesn't match file exactly
+- oldString equals newString
+- Earlier edits affect later edit targets
+
+CONSTRAINTS:
+- Produce idiomatic, correct code
+- Do not break code state
+- Use absolute paths (start with /)
+- Emojis only if user requests
+- Use replaceAll for variable renaming
+
+FILE CREATION:
+- First edit: empty oldString, file contents as newString
+- Subsequent edits: normal operations

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -9,6 +9,7 @@ import { TaskTool } from "./task"
 import { TodoWriteTool, TodoReadTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
+import { MultiEditTool } from "./multiedit"
 import { InvalidTool } from "./invalid"
 import type { Agent } from "../agent/agent"
 import { Tool } from "./tool"
@@ -93,6 +94,7 @@ export namespace ToolRegistry {
       ListTool,
       EditTool,
       WriteTool,
+      MultiEditTool,
       TaskTool,
       WebFetchTool,
       TodoWriteTool,

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -128,6 +128,23 @@ This tool performs precise edits to files by replacing exact text matches. It's 
 
 ---
 
+### multiedit
+
+Make multiple changes to a file efficiently in a single operation.
+
+```json title="opencode.json" {4}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tools": {
+    "multiedit": true
+  }
+}
+```
+
+When you need to make several changes to the same file, this tool combines them into one operation for efficiency. Use `edit` for single changes, and `multiedit` when you have multiple modifications to make together.
+
+---
+
 ### write
 
 Create new files or overwrite existing ones.


### PR DESCRIPTION
## Summary

- Enforce tool separation by disallowing multiedit calls within batch operations
- Add user-focused documentation for multiedit tool in website docs
- Improve agent understanding of multiedit tool functionality through better prompt instructions

These changes maintain the principle that batch and multiedit are separate concerns: batch handles parallel tool orchestration, while multiedit handles sequential edits to a single file.

## Showcase

This is how it would look like when the agent edits these lines:
- Line 1
- Lines 5 to 9
- Lines 15 and 16
- Last line of the 20 lines file

<img width="734" height="200" alt="image" src="https://github.com/user-attachments/assets/e35364cc-ce9d-4ea6-82bf-6aa2a69300a9" />
