### PR TITLE
fix: Manage raw mode for stdin in editor function

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/editor.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/editor.ts
@@ -15,6 +15,12 @@ export namespace Editor {
     await Bun.write(filepath, opts.value)
     opts.renderer.suspend()
     opts.renderer.currentRenderBuffer.clear()
+    
+    // Explicitly disable raw mode to ensure editor can read input properly
+    if (process.stdin.isTTY && process.stdin.setRawMode) {
+      process.stdin.setRawMode(false)
+    }
+
     const parts = editor.split(" ")
     const proc = Bun.spawn({
       cmd: [...parts, filepath],
@@ -24,6 +30,12 @@ export namespace Editor {
     })
     await proc.exited
     const content = await Bun.file(filepath).text()
+
+    // Re-enable raw mode after editor exits
+    if (process.stdin.isTTY && process.stdin.setRawMode) {
+      process.stdin.setRawMode(true)
+    }
+    
     opts.renderer.currentRenderBuffer.clear()
     opts.renderer.resume()
     opts.renderer.requestRender()


### PR DESCRIPTION
Toggle raw mode for stdin before and after launching the editor, so that input handling does not interfere with functionality of console-based editors like Vim.

I love Bun and love raw input mode, but this seems like a case where we should totally delegate keyboard control to the external editor, correct?

Solves #4209 and #4586