### PR TITLE
feat(formatter): restrict formatting to only the changed range of a file. 

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -78,6 +78,16 @@ export const Event = {
     "file.edited",
     z.object({
       file: z.string(),
+      ranges: z
+        .array(
+          z.object({
+            start: z.number(),
+            end: z.number(),
+            byteOffset: z.number().optional(),
+            byteLength: z.number().optional(),
+          }),
+        )
+        .optional(),
     }),
   ),
 }

--- a/packages/opencode/src/format/diff-range.ts
+++ b/packages/opencode/src/format/diff-range.ts
@@ -1,0 +1,108 @@
+import { diffLines } from "diff"
+
+const ADJACENT_THRESHOLD = 6
+const encoder = new TextEncoder()
+
+export type DiffRange = {
+  start: number
+  end: number
+  byteStart?: number
+  byteEnd?: number
+}
+
+export const DiffRange = {
+  create(start: number, len: number, byte: number, blen: number) {
+    return { start, end: start + len, byteStart: byte, byteEnd: byte + blen }
+  },
+
+  toJSON(r: DiffRange) {
+    return {
+      start: r.start,
+      end: r.end,
+      byteOffset: r.byteStart,
+      byteLength: r.byteEnd != null && r.byteStart != null ? r.byteEnd - r.byteStart : undefined,
+    }
+  },
+
+  merge(a: DiffRange, b: DiffRange): DiffRange {
+    const has = a.byteStart != null && a.byteEnd != null && b.byteStart != null && b.byteEnd != null
+    return {
+      start: Math.min(a.start, b.start),
+      end: Math.max(a.end, b.end),
+      byteStart: has ? Math.min(a.byteStart!, b.byteStart!) : undefined,
+      byteEnd: has ? Math.max(a.byteEnd!, b.byteEnd!) : undefined,
+    }
+  },
+
+  adjacent(a: DiffRange, b: DiffRange): boolean {
+    return b.start - a.end <= ADJACENT_THRESHOLD
+  },
+}
+
+function mapping(content: string) {
+  const map: number[] = []
+  const bytes: number[] = []
+  let coff = 0
+  let boff = 0
+  const chars = Array.from(content)
+
+  for (let i = 0; i < chars.length; i++) {
+    const char = chars[i]!
+    map.push(coff)
+    bytes.push(boff)
+    if (char === "\r" && chars[i + 1] === "\n") {
+      boff += 2
+      coff += 2
+      i++
+    } else {
+      boff += encoder.encode(char).length
+      coff += char.length // code units (2 for supplementary chars like emoji)
+    }
+  }
+  map.push(coff)
+  bytes.push(boff)
+
+  return { map, bytes }
+}
+
+export function calculateRanges(oldContent: string, newContent: string): DiffRange[] {
+  const m = mapping(newContent)
+  const changes = diffLines(oldContent.replace(/\r\n/g, "\n"), newContent.replace(/\r\n/g, "\n"))
+  const result: DiffRange[] = []
+  let offset = 0
+
+  for (const change of changes) {
+    if (change.added) {
+      const len = Array.from(change.value).length
+      const start = m.map[offset] ?? newContent.length
+      const idx = offset + len
+      const end = idx < m.map.length ? m.map[idx]! : newContent.length
+      result.push(
+        DiffRange.create(
+          start,
+          end - start,
+          m.bytes[offset]!,
+          (idx < m.bytes.length ? m.bytes[idx]! : m.bytes[m.bytes.length - 1]!) - m.bytes[offset]!,
+        ),
+      )
+      offset += len
+    } else if (change.removed) {
+      const start = m.map[offset] ?? newContent.length
+      result.push(DiffRange.create(start, 0, m.bytes[offset] ?? m.bytes[m.bytes.length - 1] ?? 0, 0))
+    } else {
+      offset += Array.from(change.value).length
+    }
+  }
+
+  return merge(result)
+}
+
+function merge(ranges: DiffRange[]): DiffRange[] {
+  if (!ranges.length) return ranges
+  return ranges.reduce((acc, r) => {
+    const last = acc[acc.length - 1]
+    if (last && DiffRange.adjacent(last, r)) acc[acc.length - 1] = DiffRange.merge(last, r)
+    else acc.push(r)
+    return acc
+  }, [] as DiffRange[])
+}

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -4,6 +4,7 @@ import { Filesystem } from "../util"
 import { Process } from "../util"
 import { which } from "../util/which"
 import { Flag } from "@/flag/flag"
+import { DiffRange } from "./diff-range"
 
 export interface Context extends Pick<InstanceContext, "directory" | "worktree"> {}
 
@@ -12,6 +13,7 @@ export interface Info {
   environment?: Record<string, string>
   extensions: string[]
   enabled(context: Context): Promise<string[] | false>
+  buildRangeCommand?(file: string, cmd: string[], ranges: DiffRange[]): string[][]
 }
 
 export const gofmt: Info = {
@@ -80,6 +82,14 @@ export const prettier: Info = {
       }
     }
     return false
+  },
+  // Note: only cmd[0] (the binary) is forwarded; extra flags in cmd are not
+  // forwarded because prettier's range flags replace the write invocation entirely.
+  buildRangeCommand(file: string, cmd: string[], ranges: DiffRange[]) {
+    const bin = cmd[0]!
+    return [...ranges]
+      .sort((a, b) => b.start - a.start)
+      .map((r) => [bin, "--write", `--range-start=${r.start}`, `--range-end=${r.end}`, file])
   },
 }
 
@@ -172,6 +182,15 @@ export const clang: Info = {
       if (match) return [match, "-i", "$FILE"]
     }
     return false
+  },
+  // Note: only cmd[0] (the binary) is forwarded; extra flags in cmd are not
+  // forwarded because clang-format's --offset/--length flags replace the -i invocation.
+  buildRangeCommand(file: string, cmd: string[], ranges: DiffRange[]) {
+    const bin = cmd[0]!
+    if (!ranges.every((r) => r.byteStart != null && r.byteEnd != null)) return [[bin, "-i", file]]
+    return [
+      [bin, "-i", ...ranges.flatMap((r) => [`--offset=${r.byteStart}`, `--length=${r.byteEnd! - r.byteStart!}`]), file],
+    ]
   },
 }
 

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -8,6 +8,7 @@ import z from "zod"
 import { Config } from "../config"
 import { Log } from "../util"
 import * as Formatter from "./formatter"
+import { DiffRange } from "./diff-range"
 
 const log = Log.create({ service: "format" })
 
@@ -25,7 +26,7 @@ export type Status = z.infer<typeof Status>
 export interface Interface {
   readonly init: () => Effect.Effect<void>
   readonly status: () => Effect.Effect<Status[]>
-  readonly file: (filepath: string) => Effect.Effect<void>
+  readonly file: (filepath: string, ranges?: DiffRange[]) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Format") {}
@@ -70,47 +71,53 @@ export const layer = Layer.effect(
               }
             }),
           )
-          return checks.filter((x) => x.cmd).map((x) => ({ item: x.item, cmd: x.cmd! }))
+          return checks
+            .filter((x): x is { item: Formatter.Info; cmd: string[] } => Array.isArray(x.cmd))
+            .map((x) => ({ item: x.item, cmd: x.cmd }))
         }
 
-        function formatFile(filepath: string) {
+        function formatFile(filepath: string, ranges?: DiffRange[]) {
           return Effect.gen(function* () {
-            log.info("formatting", { file: filepath })
+            log.info("formatting", { file: filepath, ranges })
             const ext = path.extname(filepath)
 
+            const dir = yield* InstanceState.directory
             for (const { item, cmd } of yield* Effect.promise(() => getFormatter(ext))) {
-              if (cmd === false) continue
-              log.info("running", { command: cmd })
-              const replaced = cmd.map((x) => x.replace("$FILE", filepath))
-              const dir = yield* InstanceState.directory
-              const code = yield* spawner
-                .spawn(
-                  ChildProcess.make(replaced[0]!, replaced.slice(1), {
-                    cwd: dir,
-                    env: item.environment,
-                    extendEnv: true,
-                  }),
-                )
-                .pipe(
-                  Effect.flatMap((handle) => handle.exitCode),
-                  Effect.scoped,
-                  Effect.catch(() =>
-                    Effect.sync(() => {
-                      log.error("failed to format file", {
-                        error: "spawn failed",
-                        command: cmd,
-                        ...item.environment,
-                        file: filepath,
-                      })
-                      return ChildProcessSpawner.ExitCode(1)
+              const cmds =
+                item.buildRangeCommand && ranges?.length
+                  ? item.buildRangeCommand(filepath, cmd, ranges)
+                  : [cmd.map((x) => x.replace("$FILE", filepath))]
+              for (const replaced of cmds) {
+                log.info("running", { command: replaced })
+                const code = yield* spawner
+                  .spawn(
+                    ChildProcess.make(replaced[0]!, replaced.slice(1), {
+                      cwd: dir,
+                      env: item.environment,
+                      extendEnv: true,
                     }),
-                  ),
-                )
-              if (code !== 0) {
-                log.error("failed", {
-                  command: cmd,
-                  ...item.environment,
-                })
+                  )
+                  .pipe(
+                    Effect.flatMap((handle) => handle.exitCode),
+                    Effect.scoped,
+                    Effect.catch(() =>
+                      Effect.sync(() => {
+                        log.error("failed to format file", {
+                          error: "spawn failed",
+                          command: replaced,
+                          ...item.environment,
+                          file: filepath,
+                        })
+                        return ChildProcessSpawner.ExitCode(1)
+                      }),
+                    ),
+                  )
+                if (code !== 0) {
+                  log.error("failed", {
+                    command: replaced,
+                    ...item.environment,
+                  })
+                }
               }
             }
           })
@@ -186,9 +193,9 @@ export const layer = Layer.effect(
       return result
     })
 
-    const file = Effect.fn("Format.file")(function* (filepath: string) {
+    const file = Effect.fn("Format.file")(function* (filepath: string, ranges?: DiffRange[]) {
       const { formatFile } = yield* InstanceState.get(state)
-      yield* formatFile(filepath)
+      yield* formatFile(filepath, ranges)
     })
 
     return Service.of({ init, status, file })

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -14,6 +14,7 @@ import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
 import { Format } from "../format"
+import { calculateRanges, DiffRange } from "../format/diff-range"
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -234,8 +235,9 @@ export const ApplyPatchTool = Tool.define(
         }
 
         if (edited) {
-          yield* format.file(edited)
-          yield* bus.publish(File.Event.Edited, { file: edited })
+          const ranges = calculateRanges(change.oldContent, change.newContent)
+          yield* format.file(edited, ranges)
+          yield* bus.publish(File.Event.Edited, { file: edited, ranges: ranges.map(DiffRange.toJSON) })
         }
       }
 

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -18,6 +18,7 @@ import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+import { calculateRanges, DiffRange } from "../format/diff-range"
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
@@ -95,9 +96,10 @@ export const EditTool = Tool.define(
                     diff,
                   },
                 })
+                const ranges = calculateRanges(contentOld, params.newString)
                 yield* afs.writeWithDirs(filePath, params.newString)
-                yield* format.file(filePath)
-                yield* bus.publish(File.Event.Edited, { file: filePath })
+                yield* format.file(filePath, ranges)
+                yield* bus.publish(File.Event.Edited, { file: filePath, ranges: ranges.map(DiffRange.toJSON) })
                 yield* bus.publish(FileWatcher.Event.Updated, {
                   file: filePath,
                   event: existed ? "change" : "add",
@@ -134,9 +136,10 @@ export const EditTool = Tool.define(
                 },
               })
 
+              const ranges = calculateRanges(contentOld, contentNew)
               yield* afs.writeWithDirs(filePath, contentNew)
-              yield* format.file(filePath)
-              yield* bus.publish(File.Event.Edited, { file: filePath })
+              yield* format.file(filePath, ranges)
+              yield* bus.publish(File.Event.Edited, { file: filePath, ranges: ranges.map(DiffRange.toJSON) })
               yield* bus.publish(FileWatcher.Event.Updated, {
                 file: filePath,
                 event: "change",

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -13,6 +13,7 @@ import { AppFileSystem } from "@opencode-ai/shared/filesystem"
 import { Instance } from "../project/instance"
 import { trimDiff } from "./edit"
 import { assertExternalDirectoryEffect } from "./external-directory"
+import { calculateRanges, DiffRange } from "../format/diff-range"
 
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
@@ -51,9 +52,10 @@ export const WriteTool = Tool.define(
             },
           })
 
+          const ranges = calculateRanges(contentOld, params.content)
           yield* fs.writeWithDirs(filepath, params.content)
-          yield* format.file(filepath)
-          yield* bus.publish(File.Event.Edited, { file: filepath })
+          yield* format.file(filepath, ranges)
+          yield* bus.publish(File.Event.Edited, { file: filepath, ranges: ranges.map(DiffRange.toJSON) })
           yield* bus.publish(FileWatcher.Event.Updated, {
             file: filepath,
             event: exists ? "change" : "add",

--- a/packages/opencode/test/diff-range.test.ts
+++ b/packages/opencode/test/diff-range.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+import { calculateRanges, DiffRange } from "../src/format/diff-range"
+
+const expectRange = (old: string, next: string, start: number, end: number, byteStart?: number, byteEnd?: number) => {
+  const ranges = calculateRanges(old, next)
+  expect(ranges.length).toBe(1)
+  expect(ranges[0]!.start).toBe(start)
+  expect(ranges[0]!.end).toBe(end)
+  if (byteStart != null) expect(ranges[0]!.byteStart).toBe(byteStart)
+  if (byteEnd != null) expect(ranges[0]!.byteEnd).toBe(byteEnd)
+}
+
+describe("calculateRanges", () => {
+  test("added lines", () => expectRange("line1\nline2\nline3", "line1\nline2\nnewline\nline3", 12, 20, 12, 20))
+
+  test("multiple added lines", () =>
+    expectRange("line1\nline2\nline3", "line1\nline2\nnewline1\nnewline2\nnewline3\nline3", 12, 39, 12, 39))
+
+  test("removed lines", () => expectRange("line1\nline2\nline3\nline4", "line1\nline2\nline4", 12, 12, 12, 12))
+
+  test("removed lines at end", () => expectRange("line1\nline2\nline3", "line1\nline2", 6, 11, 6, 11))
+
+  test("merges adjacent ranges", () =>
+    expectRange("line1\nline2\nline3\nline4\nline5", "line1\nnew2\nline3\nnew4\nline5", 6, 22, 6, 22))
+
+  test("keeps separate ranges", () => {
+    const ranges = calculateRanges("line1\nline2\nline3\nline4\nline5\nline6", "line1\nnew2\nline3\nline4\nline5\nnew6")
+    expect(ranges.length).toBe(2)
+    expect(ranges[0]!.start).toBe(6)
+    expect(ranges[0]!.end).toBe(11)
+    expect(ranges[1]!.start).toBe(29)
+    expect(ranges[1]!.end).toBe(33)
+  })
+
+  test("empty old content", () => expectRange("", "line1\nline2\nline3", 0, 17, 0, 17))
+
+  test("complex edit", () =>
+    expectRange("line1\nline2\nline3\nline4\nline5", "line1\nnewA\nnewB\nline4\nline5", 6, 16, 6, 16))
+
+  test("adding at beginning", () => expectRange("line2\nline3", "line1\nline2\nline3", 0, 6, 0, 6))
+
+  test("adding at end", () => expectRange("line1\nline2\n", "line1\nline2\nline3\n", 12, 18, 12, 18))
+
+  test("identical content returns empty", () => {
+    const content = "line1\nline2\nline3"
+    expect(calculateRanges(content, content)).toEqual([])
+  })
+
+  test("ignores line ending differences", () => {
+    expect(calculateRanges("line1\r\nline2\r\nline3", "line1\nline2\nline3")).toEqual([])
+  })
+
+  test("unicode accuracy", () => {
+    const ranges = calculateRanges("hello\nworld", "hello\n世界")
+    expect(ranges.length).toBe(1)
+    expect(ranges[0]!.start).toBe(6)
+    expect(ranges[0]!.end).toBe(8)
+    expect(ranges[0]!.byteStart).toBe(6)
+    expect(ranges[0]!.byteEnd).toBe(12)
+  })
+
+  test("delete last line", () => expectRange("line1\nline2", "line1\n", 6, 6, 6, 6))
+
+  test("CRLF byte offsets", () => expectRange("a\r\nb\r\nc\r\n", "a\r\nb\r\nX\r\nc\r\n", 6, 9, 6, 9))
+
+  test("mixed CRLF and LF", () =>
+    expectRange("line1\r\nline2\nline3", "line1\r\nline2\nnewLine\nline3", 13, 21, 13, 21))
+
+  test("completely deleted content", () => expectRange("line1\nline2\nline3", "", 0, 0, 0, 0))
+
+  test("delete single char", () => expectRange("a", "", 0, 0, 0, 0))
+
+  test("empty content edge case", () => {
+    const ranges = calculateRanges("", "")
+    expect(ranges).toEqual([])
+  })
+
+  test("unicode surrogate pairs", () => {
+    // 😀 occupies 2 JS code units; start/end must be code-unit offsets so tools
+    // like prettier receive the right --range-start / --range-end values.
+    const ranges = calculateRanges("", "😀a\n")
+    expect(ranges.length).toBe(1)
+    expect(ranges[0]!.start).toBe(0)
+    expect(ranges[0]!.end).toBe(4) // 2 (😀) + 1 (a) + 1 (\n) code units
+    expect(ranges[0]!.byteStart).toBe(0)
+    expect(ranges[0]!.byteEnd).toBe(6) // 4 (😀 UTF-8) + 1 (a) + 1 (\n) bytes
+    expect(Number.isNaN(ranges[0]!.byteEnd)).toBe(false)
+  })
+})
+
+describe("DiffRange", () => {
+  test("adjacent detection", () => {
+    const a = DiffRange.create(0, 5, 0, 5)
+    const b = DiffRange.create(6, 4, 6, 4)
+    expect(DiffRange.adjacent(a, b)).toBe(true)
+    const c = DiffRange.create(15, 5, 15, 5)
+    expect(DiffRange.adjacent(a, c)).toBe(false)
+  })
+
+  test("merge", () => {
+    const a = DiffRange.create(0, 5, 0, 5)
+    const b = DiffRange.create(6, 4, 6, 4)
+    const m = DiffRange.merge(a, b)
+    expect(m.start).toBe(0)
+    expect(m.end).toBe(10)
+    expect(m.byteStart).toBe(0)
+    expect(m.byteEnd).toBe(10)
+  })
+
+  test("toJSON", () => {
+    const r = DiffRange.create(10, 5, 20, 10)
+    const json = DiffRange.toJSON(r)
+    expect(json).toEqual({ start: 10, end: 15, byteOffset: 20, byteLength: 10 })
+  })
+
+  test("toJSON omits undefined byteLength", () => {
+    const r: DiffRange = { start: 10, end: 15 }
+    const json = DiffRange.toJSON(r)
+    expect(json.byteLength).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -5,6 +5,7 @@ import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import * as CrossSpawnSpawner from "../../src/effect/cross-spawn-spawner"
 import { Format } from "../../src/format"
+import type { DiffRange } from "../../src/format/diff-range"
 import * as Formatter from "../../src/format/formatter"
 
 const it = testEffect(Layer.mergeAll(Format.defaultLayer, CrossSpawnSpawner.defaultLayer, NodeFileSystem.layer))
@@ -239,6 +240,100 @@ describe("Format", () => {
           },
         },
       },
+    ),
+  )
+
+  it.live("passes ranges to buildRangeCommand and skips it when no ranges given", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const file = `${dir}/test.ranged`
+        yield* Effect.promise(() => Bun.write(file, ""))
+
+        const captured: DiffRange[][] = []
+        const orig = {
+          extensions: Formatter.gofmt.extensions,
+          enabled: Formatter.gofmt.enabled,
+          build: Formatter.gofmt.buildRangeCommand,
+        }
+
+        yield* Effect.acquireUseRelease(
+          Effect.sync(() => {
+            Formatter.gofmt.extensions = [".ranged"]
+            Formatter.gofmt.enabled = async () => ["sh", "-c", "true"]
+            Formatter.gofmt.buildRangeCommand = (_file, _cmd, ranges) => {
+              captured.push(ranges)
+              return [["sh", "-c", "true"]]
+            }
+          }),
+          () =>
+            Format.Service.use((fmt) =>
+              Effect.gen(function* () {
+                const ranges: DiffRange[] = [
+                  { start: 5, end: 15 },
+                  { start: 30, end: 50 },
+                ]
+
+                yield* fmt.file(file, ranges)
+                expect(captured.length).toBe(1)
+                expect(captured[0]).toEqual(ranges)
+
+                yield* fmt.file(file)
+                // called without ranges — buildRangeCommand must not be invoked
+                expect(captured.length).toBe(1)
+              }),
+            ),
+          () =>
+            Effect.sync(() => {
+              Formatter.gofmt.extensions = orig.extensions
+              Formatter.gofmt.enabled = orig.enabled
+              Formatter.gofmt.buildRangeCommand = orig.build
+            }),
+        )
+      }),
+    ),
+  )
+
+  it.live("executes all commands returned by buildRangeCommand", () =>
+    provideTmpdirInstance((dir) =>
+      Effect.gen(function* () {
+        const file = `${dir}/test.multi`
+        yield* Effect.promise(() => Bun.write(file, ""))
+
+        const orig = {
+          extensions: Formatter.gofmt.extensions,
+          enabled: Formatter.gofmt.enabled,
+          build: Formatter.gofmt.buildRangeCommand,
+        }
+
+        yield* Effect.acquireUseRelease(
+          Effect.sync(() => {
+            Formatter.gofmt.extensions = [".multi"]
+            Formatter.gofmt.enabled = async () => ["sh", "-c", "true"]
+            // Each command appends a marker so we can count actual executions
+            Formatter.gofmt.buildRangeCommand = () => [
+              ["sh", "-c", `printf A >> "${file}"`],
+              ["sh", "-c", `printf B >> "${file}"`],
+              ["sh", "-c", `printf C >> "${file}"`],
+            ]
+          }),
+          () =>
+            Format.Service.use((fmt) =>
+              Effect.gen(function* () {
+                const ranges: DiffRange[] = [{ start: 0, end: 10 }]
+                yield* fmt.file(file, ranges)
+                // All 3 commands must have executed, writing ABC
+                const content = yield* Effect.promise(() => Bun.file(file).text())
+                expect(content).toBe("ABC")
+              }),
+            ),
+          () =>
+            Effect.sync(() => {
+              Formatter.gofmt.extensions = orig.extensions
+              Formatter.gofmt.enabled = orig.enabled
+              Formatter.gofmt.buildRangeCommand = orig.build
+            }),
+        )
+      }),
     ),
   )
 })

--- a/packages/opencode/test/format/formatter.test.ts
+++ b/packages/opencode/test/format/formatter.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test"
+import * as Formatter from "../../src/format/formatter"
+import type { DiffRange } from "../../src/format/diff-range"
+
+describe("prettier.buildRangeCommand", () => {
+  const bin = "/usr/local/bin/prettier"
+  const cmd = [bin, "--write", "$FILE"]
+
+  test("single range returns one command", () => {
+    const ranges: DiffRange[] = [{ start: 10, end: 20 }]
+    expect(Formatter.prettier.buildRangeCommand!("file.ts", cmd, ranges)).toEqual([
+      [bin, "--write", "--range-start=10", "--range-end=20", "file.ts"],
+    ])
+  })
+
+  test("multiple ranges run backwards — highest start offset first", () => {
+    const ranges: DiffRange[] = [
+      { start: 5, end: 15 },
+      { start: 30, end: 50 },
+    ]
+    expect(Formatter.prettier.buildRangeCommand!("file.ts", cmd, ranges)).toEqual([
+      [bin, "--write", "--range-start=30", "--range-end=50", "file.ts"],
+      [bin, "--write", "--range-start=5", "--range-end=15", "file.ts"],
+    ])
+  })
+
+  test("three ranges are sorted strictly backwards", () => {
+    const ranges: DiffRange[] = [
+      { start: 100, end: 110 },
+      { start: 5, end: 15 },
+      { start: 50, end: 60 },
+    ]
+    const result = Formatter.prettier.buildRangeCommand!("file.ts", cmd, ranges)
+    const starts = result.map((c) => Number(c[2]!.replace("--range-start=", "")))
+    expect(starts).toEqual([100, 50, 5])
+  })
+
+  test("uses binary from cmd[0]", () => {
+    const customBin = "/home/user/.npm/prettier"
+    const ranges: DiffRange[] = [{ start: 0, end: 5 }]
+    const result = Formatter.prettier.buildRangeCommand!("file.ts", [customBin, "--write", "$FILE"], ranges)
+    expect(result[0]![0]).toBe(customBin)
+  })
+
+  test("zero-length range (deletion marker)", () => {
+    const ranges: DiffRange[] = [{ start: 42, end: 42 }]
+    expect(Formatter.prettier.buildRangeCommand!("file.ts", cmd, ranges)).toEqual([
+      [bin, "--write", "--range-start=42", "--range-end=42", "file.ts"],
+    ])
+  })
+
+  test("does not mutate input ranges array", () => {
+    const ranges: DiffRange[] = [
+      { start: 5, end: 15 },
+      { start: 30, end: 50 },
+    ]
+    const copy = [...ranges]
+    Formatter.prettier.buildRangeCommand!("file.ts", cmd, ranges)
+    expect(ranges).toEqual(copy)
+  })
+})
+
+describe("clang.buildRangeCommand", () => {
+  const bin = "/usr/bin/clang-format"
+  const cmd = [bin, "-i", "$FILE"]
+
+  test("single range with byte offsets", () => {
+    const ranges: DiffRange[] = [{ start: 0, end: 10, byteStart: 0, byteEnd: 15 }]
+    expect(Formatter.clang.buildRangeCommand!("file.cpp", cmd, ranges)).toEqual([
+      [bin, "-i", "--offset=0", "--length=15", "file.cpp"],
+    ])
+  })
+
+  test("multiple ranges each get their own offset/length pair in one command", () => {
+    const ranges: DiffRange[] = [
+      { start: 0, end: 10, byteStart: 0, byteEnd: 15 },
+      { start: 20, end: 30, byteStart: 20, byteEnd: 38 },
+    ]
+    expect(Formatter.clang.buildRangeCommand!("file.cpp", cmd, ranges)).toEqual([
+      [bin, "-i", "--offset=0", "--length=15", "--offset=20", "--length=18", "file.cpp"],
+    ])
+  })
+
+  test("falls back to full-file when byte offsets are missing", () => {
+    const ranges: DiffRange[] = [{ start: 0, end: 10 }]
+    expect(Formatter.clang.buildRangeCommand!("file.cpp", cmd, ranges)).toEqual([[bin, "-i", "file.cpp"]])
+  })
+
+  test("falls back to full-file when only some ranges have byte offsets", () => {
+    const ranges: DiffRange[] = [
+      { start: 0, end: 10, byteStart: 0, byteEnd: 10 },
+      { start: 20, end: 30 },
+    ]
+    expect(Formatter.clang.buildRangeCommand!("file.cpp", cmd, ranges)).toEqual([[bin, "-i", "file.cpp"]])
+  })
+
+  test("non-zero byteStart produces correct offset and length", () => {
+    const ranges: DiffRange[] = [{ start: 5, end: 10, byteStart: 8, byteEnd: 20 }]
+    expect(Formatter.clang.buildRangeCommand!("file.cpp", cmd, ranges)).toEqual([
+      [bin, "-i", "--offset=8", "--length=12", "file.cpp"],
+    ])
+  })
+
+  test("zero-length range (deletion marker) produces zero length", () => {
+    const ranges: DiffRange[] = [{ start: 10, end: 10, byteStart: 10, byteEnd: 10 }]
+    expect(Formatter.clang.buildRangeCommand!("file.cpp", cmd, ranges)).toEqual([
+      [bin, "-i", "--offset=10", "--length=0", "file.cpp"],
+    ])
+  })
+})

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -557,6 +557,43 @@ EOF`
     })
   })
 
+  test("emits File.Event.Edited with ranges covering only the changed region", async () => {
+    await using fixture = await tmpdir()
+    const { ctx } = makeCtx()
+
+    await Instance.provide({
+      directory: fixture.path,
+      fn: async () => {
+        const target = path.join(fixture.path, "range_test.txt")
+        // "line1\nline2\n" is 12 chars — TARGET starts at position 12
+        await fs.writeFile(target, "line1\nline2\nTARGET\nline4\n", "utf-8")
+
+        const { File } = await import("../../src/file")
+
+        let ranges: { start: number; end: number }[] | undefined
+        const unsub = await runtime.runPromise(
+          Bus.Service.use((bus) =>
+            bus.subscribeCallback(File.Event.Edited, (event: any) => {
+              ranges = event.properties.ranges
+            }),
+          ),
+        )
+
+        try {
+          const patchText = "*** Begin Patch\n*** Update File: range_test.txt\n@@\n-TARGET\n+CHANGED\n*** End Patch"
+          await execute({ patchText }, ctx)
+        } finally {
+          unsub()
+        }
+
+        expect(ranges).toBeDefined()
+        expect(ranges!.length).toBeGreaterThan(0)
+        // unchanged prefix "line1\nline2\n" must not be inside any range
+        expect(ranges![0].start).toBeGreaterThan(0)
+      },
+    })
+  })
+
   test("matches with Unicode punctuation differences", async () => {
     await using fixture = await tmpdir()
     const { ctx } = makeCtx()

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -52,7 +52,7 @@ const resolve = () =>
     }),
   )
 
-const subscribeBus = <D extends BusEvent.Definition>(def: D, callback: () => unknown) =>
+const subscribeBus = <D extends BusEvent.Definition>(def: D, callback: (event: any) => unknown) =>
   runtime.runPromise(Bus.Service.use((bus) => bus.subscribeCallback(def, callback)))
 
 async function onceBus<D extends BusEvent.Definition>(def: D) {
@@ -630,6 +630,41 @@ describe("tool.edit", () => {
       })
       expect(output).toBe(normalize(blockNew + "\n" + blockNew + "\n", "\r\n"))
       expectCrlf(output)
+    })
+  })
+
+  describe("range-based formatting", () => {
+    test("emits File.Event.Edited with ranges covering only the changed region", async () => {
+      await using tmp = await tmpdir()
+      const filepath = path.join(tmp.path, "file.txt")
+      // "line1\nline2\n" is 12 chars — TARGET starts at position 12
+      await fs.writeFile(filepath, "line1\nline2\nTARGET\nline4\n", "utf-8")
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const { File } = await import("../../src/file")
+
+          let ranges: { start: number; end: number }[] | undefined
+          const unsub = await subscribeBus(File.Event.Edited, (event: any) => {
+            ranges = event.properties.ranges
+          })
+
+          try {
+            const edit = await resolve()
+            await runtime.runPromise(
+              edit.execute({ filePath: filepath, oldString: "TARGET", newString: "CHANGED" }, ctx),
+            )
+          } finally {
+            unsub()
+          }
+
+          expect(ranges).toBeDefined()
+          expect(ranges!.length).toBeGreaterThan(0)
+          // unchanged prefix "line1\nline2\n" must not be inside any range
+          expect(ranges![0].start).toBeGreaterThan(0)
+        },
+      })
     })
   })
 

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -227,6 +227,37 @@ describe("tool.write", () => {
     )
   })
 
+  describe("range-based formatting", () => {
+    it.live("emits File.Event.Edited with ranges covering only the changed region", () =>
+      provideTmpdirInstance((dir) =>
+        Effect.gen(function* () {
+          const filepath = path.join(dir, "file.txt")
+          // "line1\nline2\n" is 12 chars — TARGET starts at position 12
+          yield* Effect.promise(() => fs.writeFile(filepath, "line1\nline2\nTARGET\nline4\n", "utf-8"))
+
+          const { File } = yield* Effect.promise(() => import("../../src/file"))
+
+          let ranges: { start: number; end: number }[] | undefined
+          const bus = yield* Bus.Service
+          const unsub = yield* bus.subscribeCallback(File.Event.Edited, (event: any) => {
+            ranges = event.properties.ranges
+          })
+
+          try {
+            yield* run({ filePath: filepath, content: "line1\nline2\nCHANGED\nline4\n" })
+          } finally {
+            unsub()
+          }
+
+          expect(ranges).toBeDefined()
+          expect(ranges!.length).toBeGreaterThan(0)
+          // unchanged prefix "line1\nline2\n" must not be inside any range
+          expect(ranges![0].start).toBeGreaterThan(0)
+        }),
+      ),
+    )
+  })
+
   describe("title generation", () => {
     it.live("returns relative path as title", () =>
       provideTmpdirInstance((dir) =>


### PR DESCRIPTION
Restrict formatting only to the edited line range for clang-format
When using the Edit tool, clang-format now only formats the specific lines
that were changed, rather than reformatting the entire file. This prevents
unrelated formatting changes from cluttering the diff.


Closes #4603