### PR TITLE
feat(tui): OSC 9 desktop notifications for toasts (#4454)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -107,10 +107,10 @@ export function tui(input: { url: string; args: Args; onExit?: () => Promise<voi
             <ArgsProvider {...input.args}>
               <ExitProvider onExit={onExit}>
                 <KVProvider>
-                  <ToastProvider>
-                    <RouteProvider>
-                      <SDKProvider url={input.url}>
-                        <SyncProvider>
+                  <RouteProvider>
+                    <SDKProvider url={input.url}>
+                      <SyncProvider>
+                        <ToastProvider>
                           <ThemeProvider mode={mode}>
                             <LocalProvider>
                               <KeybindProvider>
@@ -124,10 +124,10 @@ export function tui(input: { url: string; args: Args; onExit?: () => Promise<voi
                               </KeybindProvider>
                             </LocalProvider>
                           </ThemeProvider>
-                        </SyncProvider>
-                      </SDKProvider>
-                    </RouteProvider>
-                  </ToastProvider>
+                        </ToastProvider>
+                      </SyncProvider>
+                    </SDKProvider>
+                  </RouteProvider>
                 </KVProvider>
               </ExitProvider>
             </ArgsProvider>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -144,6 +144,53 @@ export function Session() {
   const toast = useToast()
   const sdk = useSDK()
 
+  const status = createMemo(
+    () =>
+      sync.data.session_status[route.sessionID] ?? {
+        type: "idle" as const,
+      },
+  )
+
+  const [prevStatusType, setPrevStatusType] = createSignal(status().type)
+  const [prevPermissionCount, setPrevPermissionCount] = createSignal(permissions().length)
+
+  createEffect(
+    on(
+      () => route.sessionID,
+      () => {
+        setPrevStatusType(status().type)
+        setPrevPermissionCount(permissions().length)
+      },
+    ),
+  )
+
+  createEffect(() => {
+    const current = status().type
+    const previous = prevStatusType()
+
+    if (previous !== "idle" && current === "idle") {
+      toast.show({
+        title: "Agent finished",
+        message: "Session is now idle",
+        variant: "info",
+      })
+    }
+    setPrevStatusType(current)
+  })
+
+  createEffect(() => {
+    const current = permissions().length
+    const previous = prevPermissionCount()
+    if (previous === 0 && current > 0) {
+      toast.show({
+        title: "Permission required",
+        message: "Review and approve requested actions",
+        variant: "warning",
+      })
+    }
+    setPrevPermissionCount(current)
+  })
+
   // Auto-navigate to whichever session currently needs permission input
   createEffect(() => {
     const currentSession = session()
@@ -665,20 +712,24 @@ export function Session() {
       if (!diffText) return []
 
       try {
-        const patches = parsePatch(diffText)
+        const patches = parsePatch(diffText) as Array<{
+          newFileName?: string
+          oldFileName?: string
+          hunks: Array<{
+            lines: string[]
+          }>
+        }>
         return patches.map((patch) => {
           const filename = patch.newFileName || patch.oldFileName || "unknown"
           const cleanFilename = filename.replace(/^[ab]\//, "")
           return {
             filename: cleanFilename,
-            additions: patch.hunks.reduce(
-              (sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("+")).length,
-              0,
-            ),
-            deletions: patch.hunks.reduce(
-              (sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("-")).length,
-              0,
-            ),
+            additions: patch.hunks.reduce((sum, hunk) => {
+              return sum + hunk.lines.filter((line) => line.startsWith("+")).length
+            }, 0),
+            deletions: patch.hunks.reduce((sum, hunk) => {
+              return sum + hunk.lines.filter((line) => line.startsWith("-")).length
+            }, 0),
           }
         })
       } catch (error) {

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -1,11 +1,13 @@
 import { createContext, useContext, type ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "@tui/context/theme"
+import { useSync } from "@tui/context/sync"
 import { useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "../component/border"
 import { TextAttributes } from "@opentui/core"
 import z from "zod"
 import { TuiEvent } from "../event"
+import { osc9 } from "../util/osc"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
 
@@ -51,14 +53,24 @@ function init() {
   const [store, setStore] = createStore({
     currentToast: null as ToastOptions | null,
   })
+  const sync = useSync()
 
-  let timeoutHandle: NodeJS.Timeout | null = null
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+
+  const sendDesktopNotification = (summary: string) => {
+    const config = sync.data.config as { tui?: { notifications?: { desktop?: boolean } } }
+    const enabled = config.tui?.notifications?.desktop ?? true
+    if (!enabled) return
+
+    osc9(summary)
+  }
 
   const toast = {
     show(options: ToastOptions) {
       const parsedOptions = TuiEvent.ToastShow.properties.parse(options)
       const { duration, ...currentToast } = parsedOptions
       setStore("currentToast", currentToast)
+      sendDesktopNotification(parsedOptions.title ?? "Notification")
       if (timeoutHandle) clearTimeout(timeoutHandle)
       timeoutHandle = setTimeout(() => {
         setStore("currentToast", null)

--- a/packages/opencode/src/cli/cmd/tui/util/osc.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/osc.ts
@@ -1,0 +1,10 @@
+const wrapForTmux = (input: string) => {
+  if (!Bun.env["TMUX"]) return input
+  return `\u001bPtmux;\u001b${input}\u001b\\`
+}
+
+export const osc9 = (text: string) => {
+  const payload = wrapForTmux(`\u001b]9;${text}\u0007`)
+
+  Bun.stdout.write(payload)
+}


### PR DESCRIPTION
## Summary

Implements OSC 9 desktop notifications for important TUI events, as proposed in [#4454](https://github.com/sst/opencode/issues/4454).

- Add a small OSC 9 helper for emitting terminal notifications from the TUI.
- Wire desktop notifications through the existing toast system so any `toast.show(...)` can surface a desktop notification.
- Gate notifications behind `config.tui.notifications.desktop` (defaulting to enabled when unset).

## Implementation Details

**OSC 9 helper**

- New file `packages/opencode/src/cli/cmd/tui/util/osc.ts` exposes:
  - `osc9(text: string)` which writes `ESC ] 9;{text} BEL` to stdout, wrapped for tmux when `$TMUX` is set.
- This keeps OSC 9 usage encapsulated and aligned with how Codex/Claude use terminal notifications.

**Toast integration**

- `packages/opencode/src/cli/cmd/tui/ui/toast.tsx`:
  - `ToastProvider` now reads `sync.data.config.tui.notifications.desktop` via `useSync`.
  - `toast.show(...)` calls `sendDesktopNotification(summary)` once per toast (using the toast `title` or a default `"Notification"`).
  - If `config.tui.notifications.desktop === false`, desktop notifications are suppressed but visual toasts still render.
- This keeps OSC 9 as a purely TUI concern and avoids sprinkling notification calls around the codebase.

**Session toasts as first OSC 9 triggers**

- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`:
  - Track `status` and `permissions` per `route.sessionID` and detect transitions:
    - `non-idle -> idle` → show "Agent finished / Session is now idle" toast.
    - `permissions.length: 0 -> >0` → show "Permission required / Review and approve requested actions" toast.
  - Because these go through `toast.show(...)`, they also trigger OSC 9 notifications (when enabled), matching the behavior described in #4454.

<img width="740" height="196" alt="image" src="https://github.com/user-attachments/assets/cc1ee3ee-dee0-4a1c-a3f5-0f96e2fc4f88" />
