### PR TITLE
feat: add context arguments to /compact command

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -691,6 +691,11 @@ export namespace ACP {
           await this.config.sdk.session.summarize({
             path: { id: sessionID },
             throwOnError: true,
+            body: {
+              providerID: model.providerID,
+              modelID: model.modelID,
+              context: cmd.args || undefined,
+            },
             query: {
               directory,
             },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -209,7 +209,13 @@ export function Autocomplete(props: {
           display: "/compact",
           aliases: ["/summarize"],
           description: "compact the session",
-          onSelect: () => command.trigger("session.compact"),
+          onSelect: () => {
+            const newText = "/compact "
+            const cursor = props.input().logicalCursor
+            props.input().deleteRange(0, 0, cursor.row, cursor.col)
+            props.input().insertText(newText)
+            props.input().cursorOffset = Bun.stringWidth(newText)
+          },
         },
         {
           display: "/unshare",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -430,6 +430,18 @@ export function Prompt(props: PromptProps) {
         },
       })
       setStore("mode", "normal")
+    } else if (inputText.startsWith("/compact")) {
+      const args = inputText.slice("/compact".length).trim()
+      sdk.client.session.summarize({
+        path: {
+          id: sessionID,
+        },
+        body: {
+          modelID: local.model.current().modelID,
+          providerID: local.model.current().providerID,
+          context: args || undefined,
+        },
+      })
     } else if (
       inputText.startsWith("/") &&
       iife(() => {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -808,6 +808,7 @@ export namespace Server {
           z.object({
             providerID: z.string(),
             modelID: z.string(),
+            context: z.string().optional(),
           }),
         ),
         async (c) => {
@@ -829,6 +830,7 @@ export namespace Server {
               providerID: body.providerID,
               modelID: body.modelID,
             },
+            context: body.context,
           })
           await SessionPrompt.loop(id)
           return c.json(true)

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -94,6 +94,7 @@ export namespace SessionCompaction {
     }
     agent: string
     abort: AbortSignal
+    context?: string
   }) {
     const model = await Provider.getModel(input.model.providerID, input.model.modelID)
     const system = [...SystemPrompt.summarize(model.providerID)]
@@ -171,7 +172,9 @@ export namespace SessionCompaction {
             content: [
               {
                 type: "text",
-                text: "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.",
+                text:
+                  "Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next." +
+                  (input.context ? `\n\nUser guidance: ${input.context}` : ""),
               },
             ],
           },
@@ -228,6 +231,7 @@ export namespace SessionCompaction {
         providerID: z.string(),
         modelID: z.string(),
       }),
+      context: z.string().optional(),
     }),
     async (input) => {
       const msg = await Session.updateMessage({
@@ -245,6 +249,7 @@ export namespace SessionCompaction {
         messageID: msg.id,
         sessionID: msg.sessionID,
         type: "compaction",
+        context: input.context,
       })
     },
   )

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -273,12 +273,8 @@ export namespace Session {
       limit: z.number().optional(),
     }),
     async (input) => {
-      const result = [] as MessageV2.WithParts[]
-      for await (const msg of MessageV2.stream(input.sessionID)) {
-        if (input.limit && result.length >= input.limit) break
-        result.push(msg)
-      }
-      result.reverse()
+      const result = await MessageV2.filterCompacted(MessageV2.stream(input.sessionID))
+      if (input.limit) return result.slice(0, input.limit)
       return result
     },
   )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -145,6 +145,7 @@ export namespace MessageV2 {
 
   export const CompactionPart = PartBase.extend({
     type: z.literal("compaction"),
+    context: z.string().optional(),
   }).meta({
     ref: "CompactionPart",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -400,7 +400,7 @@ export namespace SessionPrompt {
       if (task?.type === "compaction") {
         const result = await SessionCompaction.process({
           messages: msgs,
-          parentID: lastUser.id,
+          parentID: task.messageID,
           abort,
           agent: lastUser.agent,
           model: {
@@ -408,6 +408,7 @@ export namespace SessionPrompt {
             modelID: model.modelID,
           },
           sessionID,
+          context: task.context,
         })
         if (result === "stop") break
         continue

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -364,6 +364,7 @@ export type CompactionPart = {
   sessionID: string
   messageID: string
   type: "compaction"
+  context?: string
 }
 
 export type Part =
@@ -2113,6 +2114,7 @@ export type SessionSummarizeData = {
   body?: {
     providerID: string
     modelID: string
+    context?: string
   }
   path: {
     /**

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -74,7 +74,13 @@ Here are all available slash commands:
 Compact the current session. _Alias_: `/summarize`
 
 ```bash frame="none"
-/compact
+/compact [focus guidance]
+```
+
+Optionally provide guidance to focus the summary on specific aspects:
+
+```bash frame="none"
+/compact focus on the API changes and documentation updates
 ```
 
 **Keybind:** `ctrl+x c`


### PR DESCRIPTION
Changes in this PR:

- Allow `/compact` slash command to accept optional arguments for summary focus
- Fix `parentID` bug where compaction didn't replace session properly
- Update compaction pipeline to pass context through all stages
- Update types and documentation

Possibly related to #2465