### PR TITLE
fix: make tui session text respect theme fg (#4618)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1110,7 +1110,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
-  const { syntax } = useTheme()
+  const { theme, syntax } = useTheme()
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1121,6 +1121,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           syntaxStyle={syntax()}
           content={props.part.text.trim()}
           conceal={ctx.conceal()}
+          fg={theme.text}
         />
       </box>
     </Show>


### PR DESCRIPTION
Fixes #4618

In TextPart (packages/opencode/src/cli/cmd/tui/routes/session/index.tsx), pass fg={theme.text} to the assistant \<code filetype="markdown"\> block, consistent with other code views.

Tested that this fixes the markdown table cell rendering color to respect the rest of the theme, and did not notice any issues with coloring in light or dark mode with several themes.