### PR TITLE
feat(ephemeral): add ephemeral message - hidden stateless single turn inference

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -939,7 +939,45 @@ export namespace Server {
         },
       )
       .post(
+        "/session/:id/ephemeral",
+        describeRoute({
+          description: "Run an ephemeral model request using session context",
+          operationId: "session.ephemeral",
+          responses: {
+            200: {
+              description: "Ephemeral response",
+              content: {
+                "application/json": {
+                  schema: resolver(
+                    z
+                      .object({
+                        text: z.string(),
+                      })
+                      .meta({ ref: "EphemeralResponse" }),
+                  ),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            id: z.string().meta({ description: "Session ID" }),
+          }),
+        ),
+        validator("json", SessionPrompt.EphemeralInput.omit({ sessionID: true })),
+        async (c) => {
+          const sessionID = c.req.valid("param").id
+          const body = c.req.valid("json")
+          const result = await SessionPrompt.ephemeral({ ...body, sessionID })
+          return c.json(result)
+        },
+      )
+      .post(
         "/session/:id/message",
+
         describeRoute({
           description: "Create and send a new message to a session",
           operationId: "session.prompt",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -142,6 +142,34 @@ export namespace SessionPrompt {
   })
   export type PromptInput = z.infer<typeof PromptInput>
 
+  export const EphemeralInput = z.object({
+    sessionID: Identifier.schema("session"),
+    model: z
+      .object({
+        providerID: z.string(),
+        modelID: z.string(),
+      })
+      .optional(),
+    agent: z.string().optional(),
+    system: z.string().optional(),
+    tools: z.record(z.string(), z.boolean()).optional(),
+    message: z
+      .array(
+        MessageV2.TextPart.omit({
+          messageID: true,
+          sessionID: true,
+        })
+          .partial({
+            id: true,
+          })
+          .meta({
+            ref: "EphemeralTextPartInput",
+          }),
+      )
+      .optional(),
+  })
+  export type EphemeralInput = z.infer<typeof EphemeralInput>
+
   export async function resolvePromptParts(template: string): Promise<PromptInput["parts"]> {
     const parts: PromptInput["parts"] = [
       {
@@ -202,6 +230,82 @@ export namespace SessionPrompt {
     }
 
     return loop(input.sessionID)
+  })
+
+  export const ephemeral = fn(EphemeralInput, async (input) => {
+    const session = await Session.get(input.sessionID)
+    await SessionRevert.cleanup(session)
+
+    const msgs = await MessageV2.filterCompacted(MessageV2.stream(input.sessionID))
+
+    let lastUser: MessageV2.User | undefined
+    for (let index = msgs.length - 1; index >= 0; index--) {
+      const item = msgs[index]
+      if (item.info.role === "user") {
+        lastUser = item.info as MessageV2.User
+        break
+      }
+    }
+
+    if (!lastUser) {
+      throw new Error("No user message found in stream.")
+    }
+
+    const agent = await Agent.get(input.agent ?? lastUser.agent)
+    const baseModel = input.model ?? lastUser.model
+    const model = await Provider.getModel(baseModel.providerID, baseModel.modelID)
+
+    const system = await resolveSystemPrompt({
+      providerID: model.providerID,
+      modelID: model.info.id,
+      agent,
+      system: input.system ?? lastUser.system,
+    })
+
+    const historyMessages = MessageV2.toModelMessage(msgs)
+
+    const messageParts = (input.message ?? []).filter((part) => part.type === "text")
+    const messageMessages: ModelMessage[] = []
+    if (messageParts.length > 0) {
+      const content = messageParts.map((part) => part.text).join("\n\n")
+      messageMessages.push({
+        role: "user",
+        content,
+      })
+    }
+
+    const options = ProviderTransform.options(model.providerID, model.modelID, model.npm ?? "", input.sessionID) ?? {}
+    const maxOutputTokens = ProviderTransform.maxOutputTokens(
+      model.providerID,
+      options,
+      model.info.limit.output,
+      OUTPUT_TOKEN_MAX,
+    )
+
+    const result = await generateText({
+      model: model.language,
+      messages: [
+        ...system.map(
+          (x): ModelMessage => ({
+            role: "system",
+            content: x,
+          }),
+        ),
+        ...historyMessages,
+        ...messageMessages,
+      ],
+      headers: model.info.headers,
+      providerOptions: ProviderTransform.providerOptions(
+        model.npm,
+        model.providerID,
+        options as Record<string, unknown>,
+      ),
+      maxOutputTokens,
+    })
+
+    return {
+      text: result.text,
+    }
   })
 
   function start(sessionID: string) {

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -75,6 +75,9 @@ import type {
   SessionMessageData,
   SessionMessageResponses,
   SessionMessageErrors,
+  SessionEphemeralData,
+  SessionEphemeralResponses,
+  SessionEphemeralErrors,
   SessionCommandData,
   SessionCommandResponses,
   SessionCommandErrors,
@@ -510,6 +513,20 @@ class Session extends _HeyApiClient {
     return (options.client ?? this._client).get<SessionMessageResponses, SessionMessageErrors, ThrowOnError>({
       url: "/session/{id}/message/{messageID}",
       ...options,
+    })
+  }
+
+  /**
+   * Run an ephemeral model request using session context
+   */
+  public ephemeral<ThrowOnError extends boolean = false>(options: Options<SessionEphemeralData, ThrowOnError>) {
+    return (options.client ?? this._client).post<SessionEphemeralResponses, SessionEphemeralErrors, ThrowOnError>({
+      url: "/session/{id}/ephemeral",
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1235,6 +1235,25 @@ export type NotFoundError = {
   }
 }
 
+export type EphemeralResponse = {
+  text: string
+}
+
+export type EphemeralTextPartInput = {
+  id?: string
+  type: "text"
+  text: string
+  synthetic?: boolean
+  ignored?: boolean
+  time?: {
+    start: number
+    end?: number
+  }
+  metadata?: {
+    [key: string]: unknown
+  }
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -2282,6 +2301,53 @@ export type SessionMessageResponses = {
 }
 
 export type SessionMessageResponse = SessionMessageResponses[keyof SessionMessageResponses]
+
+export type SessionEphemeralData = {
+  body?: {
+    model?: {
+      providerID: string
+      modelID: string
+    }
+    agent?: string
+    system?: string
+    tools?: {
+      [key: string]: boolean
+    }
+    message?: Array<EphemeralTextPartInput>
+  }
+  path: {
+    /**
+     * Session ID
+     */
+    id: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{id}/ephemeral"
+}
+
+export type SessionEphemeralErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionEphemeralError = SessionEphemeralErrors[keyof SessionEphemeralErrors]
+
+export type SessionEphemeralResponses = {
+  /**
+   * Ephemeral response
+   */
+  200: EphemeralResponse
+}
+
+export type SessionEphemeralResponse = SessionEphemeralResponses[keyof SessionEphemeralResponses]
 
 export type SessionCommandData = {
   body?: {


### PR DESCRIPTION
As the title says - basically allow plugins to do inference using session's context without mutating anything.

Use cases:
- LLM as a judge plugins (evaluate llm outputs and do something with it - many different applications here)
- A/B testing of different models on the same query under the hood (let plugins handle results as they like)
- Allows for more creative use cases I'm sure