### PR TITLE
Update nodeModules hash in hashes.json

### DIFF
--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,3 +1,3 @@
 {
-  "nodeModules": "sha256-HILcNy8B0k++ObGwUrD9dM0n9MvASR4AiyxmKSv3LV8="
+  "nodeModules": "sha256-31ZdigHCsZsGt9WSNKxWBNEHU2L3AqirqXEEz2actHQ="
 }


### PR DESCRIPTION
Updated hash after getting an error trying to upgrade from the flake

```bash
unpacking 2 channels...
building the system configuration...
error: hash mismatch in fixed-output derivation '/nix/store/88y9zf42hq3h11lryzbhwipwccib8bdv-opencode-node_modules-1.0.98.drv':
         specified: sha256-HILcNy8B0k++ObGwUrD9dM0n9MvASR4AiyxmKSv3LV8=
            got:    sha256-31ZdigHCsZsGt9WSNKxWBNEHU2L3AqirqXEEz2actHQ=
error: 1 dependencies of derivation '/nix/store/702pn5xvrggqsp862sfjiixgcvkv9m6k-opencode-1.0.98.drv' failed to build
error: 1 dependencies of derivation '/nix/store/wv5543sn1iql7iyzdhq04klj0bkkgvqp-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/xv29k1asd96g0f3zs1gbfy9gwirnlbfq-nixos-system-nixos-25.05.20251120.c58bc7f.drv' failed to build
```