### PR TITLE
 fix: add explicit fallback model and prevent direct opencode provider calls

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -654,7 +654,7 @@ export namespace Provider {
     }
   }
 
-  export async function getSmallModel(providerID: string) {
+  export async function getSmallModel(providerID: string, fallbackModel?: { providerID: string; modelID: string }) {
     const cfg = await Config.get()
 
     if (cfg.small_model) {
@@ -685,7 +685,20 @@ export namespace Provider {
         }
       }
     }
-    return getModel("opencode", "gpt-5-nano")
+
+    // Check if opencode provider is available before using it
+    const opencodeProvider = await state().then((state) => state.providers["opencode"])
+    if (opencodeProvider && opencodeProvider.info.models["gpt-5-nano"]) {
+      return getModel("opencode", "gpt-5-nano")
+    }
+
+    // Use fallback model if provided
+    if (fallbackModel) {
+      return getModel(fallbackModel.providerID, fallbackModel.modelID)
+    }
+
+    // No fallback available
+    throw new Error("No small model available")
   }
 
   const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -654,7 +654,7 @@ export namespace Provider {
     }
   }
 
-  export async function getSmallModel(providerID: string, fallbackModel?: { providerID: string; modelID: string }) {
+  export async function getSmallModel(providerID: string) {
     const cfg = await Config.get()
 
     if (cfg.small_model) {
@@ -692,13 +692,7 @@ export namespace Provider {
       return getModel("opencode", "gpt-5-nano")
     }
 
-    // Use fallback model if provided
-    if (fallbackModel) {
-      return getModel(fallbackModel.providerID, fallbackModel.modelID)
-    }
-
-    // No fallback available
-    throw new Error("No small model available")
+    return undefined
   }
 
   const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1408,10 +1408,8 @@ export namespace SessionPrompt {
       input.history.filter((m) => m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic))
         .length === 1
     if (!isFirst) return
-    const small = await Provider.getSmallModel(input.providerID, {
-      providerID: input.providerID,
-      modelID: input.modelID,
-    })
+    const small =
+      (await Provider.getSmallModel(input.providerID)) ?? (await Provider.getModel(input.providerID, input.modelID))
     const options = pipe(
       {},
       mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", input.session.id)),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1408,7 +1408,10 @@ export namespace SessionPrompt {
       input.history.filter((m) => m.info.role === "user" && !m.parts.every((p) => "synthetic" in p && p.synthetic))
         .length === 1
     if (!isFirst) return
-    const small = await Provider.getSmallModel(input.providerID)
+    const small = await Provider.getSmallModel(input.providerID, {
+      providerID: input.providerID,
+      modelID: input.modelID,
+    })
     const options = pipe(
       {},
       mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", input.session.id)),

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -73,10 +73,10 @@ export namespace SessionSummary {
     await Session.updateMessage(userMsg)
 
     const assistantMsg = messages.find((m) => m.info.role === "assistant")!.info as MessageV2.Assistant
-    const small = await Provider.getSmallModel(assistantMsg.providerID, {
-      providerID: assistantMsg.providerID,
-      modelID: assistantMsg.modelID,
-    })
+    const small =
+      (await Provider.getSmallModel(assistantMsg.providerID)) ??
+      (await Provider.getModel(assistantMsg.providerID, assistantMsg.modelID))
+
     const options = pipe(
       {},
       mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", assistantMsg.sessionID)),

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -73,7 +73,10 @@ export namespace SessionSummary {
     await Session.updateMessage(userMsg)
 
     const assistantMsg = messages.find((m) => m.info.role === "assistant")!.info as MessageV2.Assistant
-    const small = await Provider.getSmallModel(assistantMsg.providerID)
+    const small = await Provider.getSmallModel(assistantMsg.providerID, {
+      providerID: assistantMsg.providerID,
+      modelID: assistantMsg.modelID,
+    })
     const options = pipe(
       {},
       mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", assistantMsg.sessionID)),


### PR DESCRIPTION

- Add fallbackModel parameter to getSmallModel() to provide explicit fallback
- Check opencode provider availability before using gpt-5-nano model
- Update callers in prompt.ts and summary.ts to use current model as fallback
- Prevent errors when opencode provider is disabled