### PR TITLE
config: add setCacheKey in provider options

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -524,6 +524,10 @@ export namespace Config {
                   apiKey: z.string().optional(),
                   baseURL: z.string().optional(),
                   enterpriseUrl: z.string().optional().describe("GitHub Enterprise URL for copilot authentication"),
+                  setCacheKey: z
+                    .boolean()
+                    .optional()
+                    .describe("Enable promptCacheKey for this provider (default false)"),
                   timeout: z
                     .union([
                       z

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -128,7 +128,13 @@ export namespace ProviderTransform {
     return undefined
   }
 
-  export function options(providerID: string, modelID: string, npm: string, sessionID: string): Record<string, any> {
+  export function options(
+    providerID: string,
+    modelID: string,
+    npm: string,
+    sessionID: string,
+    providerOptions?: Record<string, any>,
+  ): Record<string, any> | undefined {
     const result: Record<string, any> = {}
 
     // switch to providerID later, for now use this
@@ -138,7 +144,7 @@ export namespace ProviderTransform {
       }
     }
 
-    if (providerID === "openai") {
+    if (providerID === "openai" || providerOptions?.setCacheKey) {
       result["promptCacheKey"] = sessionID
     }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -475,13 +475,14 @@ export namespace SessionPrompt {
         tools: lastUser.tools,
         processor,
       })
+      const provider = await Provider.getProvider(model.providerID)
       const params = await Plugin.trigger(
         "chat.params",
         {
           sessionID: sessionID,
           agent: lastUser.agent,
           model: model.info,
-          provider: await Provider.getProvider(model.providerID),
+          provider,
           message: lastUser,
         },
         {
@@ -491,7 +492,7 @@ export namespace SessionPrompt {
           topP: agent.topP ?? ProviderTransform.topP(model.providerID, model.modelID),
           options: pipe(
             {},
-            mergeDeep(ProviderTransform.options(model.providerID, model.modelID, model.npm ?? "", sessionID)),
+            mergeDeep(ProviderTransform.options(model.providerID, model.modelID, model.npm ?? "", sessionID, provider?.options)),
             mergeDeep(model.info.options),
             mergeDeep(agent.options),
           ),
@@ -1411,7 +1412,7 @@ export namespace SessionPrompt {
     const small = await Provider.getSmallModel(input.providerID)
     const options = pipe(
       {},
-      mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", input.session.id)),
+      mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", input.session.id, provider?.options)),
       mergeDeep(ProviderTransform.smallOptions({ providerID: small.providerID, modelID: small.modelID })),
       mergeDeep(small.info.options),
     )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -492,7 +492,9 @@ export namespace SessionPrompt {
           topP: agent.topP ?? ProviderTransform.topP(model.providerID, model.modelID),
           options: pipe(
             {},
-            mergeDeep(ProviderTransform.options(model.providerID, model.modelID, model.npm ?? "", sessionID, provider?.options)),
+            mergeDeep(
+              ProviderTransform.options(model.providerID, model.modelID, model.npm ?? "", sessionID, provider?.options),
+            ),
             mergeDeep(model.info.options),
             mergeDeep(agent.options),
           ),
@@ -1412,7 +1414,15 @@ export namespace SessionPrompt {
     const small = await Provider.getSmallModel(input.providerID)
     const options = pipe(
       {},
-      mergeDeep(ProviderTransform.options(small.providerID, small.modelID, small.npm ?? "", input.session.id, provider?.options)),
+      mergeDeep(
+        ProviderTransform.options(
+          small.providerID,
+          small.modelID,
+          small.npm ?? "",
+          input.session.id,
+          provider?.options,
+        ),
+      ),
       mergeDeep(ProviderTransform.smallOptions({ providerID: small.providerID, modelID: small.modelID })),
       mergeDeep(small.info.options),
     )


### PR DESCRIPTION
By default disabled, when enabled adds promptCacheKey for prompt caching. 

This is needed to enable promptCaching for providers that use @ai-sdk/openai and support prompt caching.