### PR TITLE
fix: add --backend=copyfile flag to bun add command

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -74,7 +74,7 @@ export namespace BunProc {
     if (parsed.dependencies[pkg] === version) return mod
 
     // Build command arguments
-    const args = ["add", "--force", "--exact", "--cwd", Global.Path.cache, pkg + "@" + version]
+    const args = ["add", "--force", "--exact", "--backend=copyfile", "--cwd", Global.Path.cache, pkg + "@" + version]
 
     // Let Bun handle registry resolution:
     // - If .npmrc files exist, Bun will use them automatically


### PR DESCRIPTION
Use copyfile backend for bun add operations to improve compatibility and avoid potential issues with hardlink-based backends.