### PR TITLE
Support basic auth in opencode sdk

### DIFF
--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -24,6 +24,19 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
     }
   }
 
+  if (config?.baseUrl) {
+    const baseUrl = new URL(config.baseUrl)
+    if (baseUrl.username || baseUrl.password) {
+      config.headers = {
+        ...config.headers,
+        Authorization: `Basic ${btoa(`${baseUrl.username}:${baseUrl.password}`)}`,
+      }
+      baseUrl.username = ""
+      baseUrl.password = ""
+      config.baseUrl = baseUrl.toString()
+    }
+  }
+
   const client = createClient(config)
   return new OpencodeClient({ client })
 }


### PR DESCRIPTION
**Usecase**: I have an opencode server running in a secure environment, and I want to expose it via tunnel. Currently, everything is public by default. With this, I add basic auth to the tunnel, then can connect via `opencode attach "https://user:password@myopencode.ngrok.io"`. 