### PR TITLE
fix: --prompt flag now auto-submits to begin session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -38,6 +38,7 @@ export type PromptRef = {
   reset(): void
   blur(): void
   focus(): void
+  submit(): void
 }
 
 export function Prompt(props: PromptProps) {
@@ -357,33 +358,6 @@ export function Prompt(props: PromptProps) {
     )
   }
 
-  props.ref?.({
-    get focused() {
-      return input.focused
-    },
-    focus() {
-      input.focus()
-    },
-    blur() {
-      input.blur()
-    },
-    set(prompt) {
-      input.setText(prompt.input, { history: false })
-      setStore("prompt", prompt)
-      restoreExtmarksFromParts(prompt.parts)
-      input.gotoBufferEnd()
-    },
-    reset() {
-      input.clear()
-      input.extmarks.clear()
-      setStore("prompt", {
-        input: "",
-        parts: [],
-      })
-      setStore("extmarkToPartIndex", new Map())
-    },
-  })
-
   async function submit() {
     if (props.disabled) return
     if (autocomplete.visible) return
@@ -495,6 +469,37 @@ export function Prompt(props: PromptProps) {
       }, 50)
     input.clear()
   }
+
+  props.ref?.({
+    get focused() {
+      return input.focused
+    },
+    focus() {
+      input.focus()
+    },
+    blur() {
+      input.blur()
+    },
+    set(prompt) {
+      input.setText(prompt.input, { history: false })
+      setStore("prompt", prompt)
+      restoreExtmarksFromParts(prompt.parts)
+      input.gotoBufferEnd()
+    },
+    reset() {
+      input.clear()
+      input.extmarks.clear()
+      setStore("prompt", {
+        input: "",
+        parts: [],
+      })
+      setStore("extmarkToPartIndex", new Map())
+    },
+    submit() {
+      submit()
+    },
+  })
+
   const exit = useExit()
 
   async function pasteImage(file: { filename?: string; content: string; mime: string }) {

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -44,6 +44,10 @@ export function Home() {
     if (once) return
     if (args.prompt) {
       prompt.set({ input: args.prompt, parts: [] })
+      // Auto-submit the prompt after a short delay to ensure it's properly set
+      setTimeout(() => {
+        prompt.submit()
+      }, 100)
       once = true
     }
   })


### PR DESCRIPTION
Fixes #4700

- added submit() method to allow external code to trigger submit
- move submit function before ref assignment to avoid circular reference
- add auto-submit logic in home component with 100ms delay 

output: when --prompt is provided, it now both populates input AND auto-submits