### PR TITLE
Add --refresh flag to models command

### DIFF
--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -29,7 +29,6 @@ export const ModelsCommand = cmd({
     if (args.refresh) {
       await ModelsDev.refresh()
       UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache refreshed" + UI.Style.TEXT_NORMAL)
-      return
     }
 
     await Instance.provide({

--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -1,6 +1,7 @@
 import type { Argv } from "yargs"
 import { Instance } from "../../project/instance"
 import { Provider } from "../../provider/provider"
+import { ModelsDev } from "../../provider/models"
 import { cmd } from "./cmd"
 import { UI } from "../ui"
 import { EOL } from "os"
@@ -19,8 +20,18 @@ export const ModelsCommand = cmd({
         describe: "use more verbose model output (includes metadata like costs)",
         type: "boolean",
       })
+      .option("clear", {
+        describe: "clear the models cache by refreshing it",
+        type: "boolean",
+      })
   },
   handler: async (args) => {
+    if (args.clear) {
+      await ModelsDev.refresh()
+      UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache cleared" + UI.Style.TEXT_NORMAL)
+      return
+    }
+
     await Instance.provide({
       directory: process.cwd(),
       async fn() {

--- a/packages/opencode/src/cli/cmd/models.ts
+++ b/packages/opencode/src/cli/cmd/models.ts
@@ -20,15 +20,15 @@ export const ModelsCommand = cmd({
         describe: "use more verbose model output (includes metadata like costs)",
         type: "boolean",
       })
-      .option("clear", {
-        describe: "clear the models cache by refreshing it",
+      .option("refresh", {
+        describe: "refresh the models cache from models.dev",
         type: "boolean",
       })
   },
   handler: async (args) => {
-    if (args.clear) {
+    if (args.refresh) {
       await ModelsDev.refresh()
-      UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache cleared" + UI.Style.TEXT_NORMAL)
+      UI.println(UI.Style.TEXT_SUCCESS_BOLD + "Models cache refreshed" + UI.Style.TEXT_NORMAL)
       return
     }
 


### PR DESCRIPTION
## Summary
- Add `--refresh` flag to the `opencode models` command to refresh the models cache
- When used, calls `ModelsDev.refresh()` to force fetch fresh data from models.dev (an existing function in the codebase)
- Shows a success message after cache refresh
- Allows users to refresh their cached models when needed manually
- Shows models after refreshing

## Usage
```bash
opencode models --refresh
```
or
```bash
opencode models opencode --refresh
```

This is useful when users want to force refresh their models cache to get the latest models from models.dev without waiting for the automatic hourly refresh. Such as an hour ago, when a new Opus was released.

Currently, the advice is to run `rm ~/.cache/opencode/models.json`, which is equally as effective but less cool. 