### PR TITLE
fix(write): support array content from Venice.ai models

### DIFF
--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -14,24 +14,25 @@ import { Agent } from "../agent/agent"
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
-    content: z.preprocess(
-      (val) => {
+    content: z
+      .preprocess((val) => {
         if (typeof val === "string") {
           return val
         }
         if (Array.isArray(val)) {
           // Join array elements with newlines
           // Handle edge cases: null/undefined -> "", objects -> JSON.stringify, others -> String
-          return val.map(item => {
-            if (item === null || item === undefined) return "";
-            if (typeof item === "object") return JSON.stringify(item);
-            return String(item);
-          }).join('\n')
+          return val
+            .map((item) => {
+              if (item === null || item === undefined) return ""
+              if (typeof item === "object") return JSON.stringify(item)
+              return String(item)
+            })
+            .join("\n")
         }
         return String(val)
-      },
-      z.string()
-    ).describe("The content to write to the file"),
+      }, z.string())
+      .describe("The content to write to the file"),
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
   async execute(params, ctx) {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -14,7 +14,19 @@ import { Agent } from "../agent/agent"
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
-    content: z.string().describe("The content to write to the file"),
+    content: z.preprocess(
+      (val) => {
+        if (typeof val === 'string') {
+          return val
+        }
+        if (Array.isArray(val)) {
+          // Join array elements with newlines
+          return val.map(item => String(item)).join('\n')
+        }
+        return String(val)
+      },
+      z.string()
+    ).describe("The content to write to the file"),
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
   async execute(params, ctx) {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -16,7 +16,7 @@ export const WriteTool = Tool.define("write", {
   parameters: z.object({
     content: z.preprocess(
       (val) => {
-        if (typeof val === 'string') {
+        if (typeof val === "string") {
           return val
         }
         if (Array.isArray(val)) {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -21,7 +21,12 @@ export const WriteTool = Tool.define("write", {
         }
         if (Array.isArray(val)) {
           // Join array elements with newlines
-          return val.map(item => String(item)).join('\n')
+          // Handle edge cases: null/undefined -> "", objects -> JSON.stringify, others -> String
+          return val.map(item => {
+            if (item === null || item === undefined) return "";
+            if (typeof item === "object") return JSON.stringify(item);
+            return String(item);
+          }).join('\n')
         }
         return String(val)
       },


### PR DESCRIPTION
Some AI models (e.g., GLM 4.6, Qwen 3 Coder 480B) send tool call content as arrays instead of strings. This causes the write tool to fail with: 'Invalid input: expected string, received array'

This fix uses Zod's preprocess function to handle both formats:
- String content: passed through unchanged
- Array content: joined with newlines
- Other types: converted to string

This maintains backward compatibility while enabling support for Venice.ai and similar models that use array-based content formatting.

Related: https://github.com/charmbracelet/crush/pull/1508