### PR TITLE
feat: add experimental.continue_loop_on_deny config option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -783,6 +783,7 @@ export namespace Config {
             .array(z.string())
             .optional()
             .describe("Tools that should only be available to primary agents."),
+          continue_loop_on_deny: z.boolean().optional().describe("Continue the agent loop when a tool call is denied"),
         })
         .optional(),
     })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -12,6 +12,7 @@ import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { Plugin } from "@/plugin"
 import type { Provider } from "@/provider/provider"
+import { Config } from "@/config/config"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -39,7 +40,6 @@ export namespace SessionProcessor {
     let snapshot: string | undefined
     let blocked = false
     let attempt = 0
-    const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
 
     const result = {
       get message() {
@@ -50,6 +50,7 @@ export namespace SessionProcessor {
       },
       async process(streamInput: StreamInput) {
         log.info("process")
+        const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
           try {
             let currentText: MessageV2.TextPart | undefined

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -39,6 +39,7 @@ export namespace SessionProcessor {
     let snapshot: string | undefined
     let blocked = false
     let attempt = 0
+    const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
 
     const result = {
       get message() {
@@ -228,7 +229,7 @@ export namespace SessionProcessor {
                     })
 
                     if (value.error instanceof Permission.RejectedError) {
-                      blocked = true
+                      blocked = shouldBreak
                     }
                     delete toolcalls[value.toolCallId]
                   }


### PR DESCRIPTION
Currently the agent loop breaks in the case of a tool deny. It means the error is not automatically sent back to the LLM, and it requires user action to continue.

My preference, and perhaps that of others, is to continue the agent loop and have the error automatically fed back to the LLM.

To support this I added a new configuration option `breakLoopOnToolDeny` which defaults to `true` (current behavior). This allows users to change this behavior through their config.

**Open questions**
- Is this feature desirable?
- Is the naming of this configuration option correct? I see both camel case and snake case for config options. Also this could've move under 'experimental' options, but I don't know what the criteria are for that.
- Does this require a change in the OpenCode `config.json` schema? I had some issues getting that sorted locally