### PR TITLE
fix: disable virtual extmarks for file/agent mentions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -81,7 +81,6 @@ export function Autocomplete(props: {
     const extmarkId = input.extmarks.create({
       start: extmarkStart,
       end: extmarkEnd,
-      virtual: true,
       styleId,
       typeId: props.promptPartTypeId(),
     })

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -310,7 +310,6 @@ export function Prompt(props: PromptProps) {
         const extmarkId = input.extmarks.create({
           start,
           end,
-          virtual: true,
           styleId,
           typeId: promptPartTypeId,
         })


### PR DESCRIPTION
Removes `virtual: true` from extmarks for `@file` and `@agent` mentions in the prompt textarea. Virtual extmarks interfere with standard cursor navigation (Option+Right/Alt+F word jumping) since they behave as overlay text rather than real buffer content.

Keeps `virtual: true` for pasted images and text summaries where atomic deletion is desired.

Closes #2600
Closes #4261

https://github.com/user-attachments/assets/947b7570-39bd-479f-8597-00ff47ca78ad