### PR TITLE
nix: set dontFixup = true

### DIFF
--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -113,6 +113,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     done
   '';
 
+  dontFixup = true;
+
   meta = {
     description = "AI coding agent built for the terminal";
     longDescription = ''


### PR DESCRIPTION
Very minor tweak to skip the fixup phase which did nothing anyway, but could show a concerning message like:

`building opencode-1.0.110 (fixupPhase): _: line 2: patchelf: command not found`

Better to skip this altogether, ELF patching is not needed for opencode. 