### PR TITLE
fix(tui): respect model-agent selection in the home screen

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -31,21 +31,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     }
 
-    // Automatically update model when agent changes
+    // Show warning for invalid hardcoded agent models
     createEffect(() => {
       const value = agent.current()
-      if (value.model) {
-        if (isModelValid(value.model))
-          model.set({
-            providerID: value.model.providerID,
-            modelID: value.model.modelID,
-          })
-        else
-          toast.show({
-            variant: "warning",
-            message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
-            duration: 3000,
-          })
+      if (value.model && !isModelValid(value.model)) {
+        toast.show({
+          variant: "warning",
+          message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
+          duration: 3000,
+        })
       }
     })
 
@@ -131,6 +125,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         Bun.write(
           file,
           JSON.stringify({
+            model: modelStore.model,
             recent: modelStore.recent,
             favorite: modelStore.favorite,
           }),
@@ -140,6 +135,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       file
         .json()
         .then((x) => {
+          if (x.model && typeof x.model === "object") setModelStore("model", x.model)
           if (Array.isArray(x.recent)) setModelStore("recent", x.recent)
           if (Array.isArray(x.favorite)) setModelStore("favorite", x.favorite)
         })
@@ -186,8 +182,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const currentModel = createMemo(() => {
         const a = agent.current()
         return getFirstValidModel(
-          () => modelStore.model[a.name],
           () => a.model,
+          () => modelStore.model[a.name],
           fallbackModel,
         )!
       })
@@ -224,6 +220,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const val = recent[next]
           if (!val) return
           setModelStore("model", agent.current().name, { ...val })
+          save()
         },
         cycleFavorite(direction: 1 | -1) {
           const favorites = modelStore.favorite.filter((item) => isModelValid(item))
@@ -267,8 +264,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               const uniq = uniqueBy([model, ...modelStore.recent], (x) => x.providerID + x.modelID)
               if (uniq.length > 10) uniq.pop()
               setModelStore("recent", uniq)
-              save()
             }
+            save()
           })
         },
         toggleFavorite(model: { providerID: string; modelID: string }) {

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -122,10 +122,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const file = Bun.file(path.join(Global.Path.state, "model.json"))
 
       function save() {
+        // Skip models for agents with hardcoded models
+        const filteredModel = Object.fromEntries(
+          Object.entries(modelStore.model).filter(([agentName]) => {
+            const agentDef = sync.data.agent.find((a) => a.name === agentName)
+            return !agentDef?.model
+          }),
+        )
         Bun.write(
           file,
           JSON.stringify({
-            model: modelStore.model,
+            model: filteredModel,
             recent: modelStore.recent,
             favorite: modelStore.favorite,
           }),
@@ -143,6 +150,23 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         .finally(() => {
           setModelStore("ready", true)
         })
+
+      // Handle the upgrade path to ensure hardcoded models were saved by
+      // removing them from the store on load.
+      createEffect(() => {
+        if (!sync.ready) return
+        if (Object.keys(modelStore.model).length === 0) return
+        const filtered = Object.fromEntries(
+          Object.entries(modelStore.model).filter(([agentName]) => {
+            const agentDef = sync.data.agent.find((a) => a.name === agentName)
+            return !agentDef?.model
+          }),
+        )
+        if (Object.keys(filtered).length !== Object.keys(modelStore.model).length) {
+          setModelStore("model", filtered)
+          save()
+        }
+      })
 
       const args = useArgs()
       const fallbackModel = createMemo(() => {
@@ -182,8 +206,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const currentModel = createMemo(() => {
         const a = agent.current()
         return getFirstValidModel(
-          () => a.model,
           () => modelStore.model[a.name],
+          () => a.model,
           fallbackModel,
         )!
       })


### PR DESCRIPTION
This PR restores the agent-model tuple switching behavior of pre-v1.0.

Closes https://github.com/sst/opencode/issues/4344