### PR TITLE
docs: reduce mobile padding

### DIFF
--- a/packages/web/src/styles/custom.css
+++ b/packages/web/src/styles/custom.css
@@ -368,6 +368,10 @@ nav.sidebar ul.top-level > li > details > summary .group-label > span {
 
 .content-panel {
   padding: 2rem 3rem !important;
+
+  @media (max-width: 768px) {
+    padding: 1rem 1.5rem !important;
+  }
 }
 
 .expressive-code {


### PR DESCRIPTION
I often read opencode docs on mobile and the big padding takes a lot of space

## Before
<img width="750" height="1334" alt="localhost_4322_docs(iPhone SE)" src="https://github.com/user-attachments/assets/de16386d-71d9-419a-aca5-a62841d4858e" />

## After
<img width="750" height="1334" alt="localhost_4322_docs(iPhone SE) (1)" src="https://github.com/user-attachments/assets/6ca10e3b-9b38-498d-bdd3-edbea9a53998" />
