### PR TITLE
docs: improve notes on mobile

### DIFF
--- a/packages/web/src/styles/custom.css
+++ b/packages/web/src/styles/custom.css
@@ -215,6 +215,11 @@ site-search > button span {
   .starlight-aside__content {
     margin-top: 0;
   }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 6px;
+  }
 }
 
 site-search > button > kbd {


### PR DESCRIPTION
applies to all aside, that on mobile the title takes a lot of space

## before
<img width="710" height="272" alt="CleanShot 2025-11-25 at 19 49 04@2x" src="https://github.com/user-attachments/assets/fcd75904-86d2-4ad7-a00e-9c6ab0db1807" />

<img width="680" height="356" alt="CleanShot 2025-11-25 at 20 03 21@2x" src="https://github.com/user-attachments/assets/eb8618cb-960f-4df9-8c99-57bff0938e9a" />

## after

<img width="658" height="320" alt="CleanShot 2025-11-25 at 20 04 46@2x" src="https://github.com/user-attachments/assets/2d3fc1bf-d6d2-408e-b664-6bf0b75e0c22" />


<img width="668" height="310" alt="CleanShot 2025-11-25 at 20 03 09@2x" src="https://github.com/user-attachments/assets/b0130d9f-972d-4292-abf0-cf165849279a" />
