### PR TITLE
docs: fix tables wrapping

### DIFF
--- a/packages/web/src/styles/custom.css
+++ b/packages/web/src/styles/custom.css
@@ -394,3 +394,15 @@ nav.sidebar ul.top-level > li > details > summary .group-label > span {
     text-decoration: var(--shiki-dark-text-decoration) !important;
   }
 }
+
+/* Table responsive styles */
+.sl-markdown-content table th,
+.sl-markdown-content table td {
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .sl-markdown-content table {
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
Fixed both mobile and desktop viewports

## Before
<img width="682" height="1058" alt="CleanShot 2025-11-25 at 20 40 42@2x" src="https://github.com/user-attachments/assets/0c126a7c-d4ee-4f07-a8b5-d51123429714" />

<img width="706" height="1046" alt="CleanShot 2025-11-25 at 20 40 36@2x" src="https://github.com/user-attachments/assets/56ab2639-6801-4d6d-9fa1-6106b46d369e" />

<img width="662" height="906" alt="CleanShot 2025-11-25 at 20 40 30@2x" src="https://github.com/user-attachments/assets/b731f4a7-5332-419b-a0c0-0eb11eb267f5" />

## After 

https://github.com/user-attachments/assets/cfab6960-82ae-4b2a-bb61-d61b00f2d135

