### PR TITLE
fix(tui): show bootstrap errors instead of {} to trace

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763934636,
-        "narHash": "sha256-9glbI7f1uU+yzQCq5LwLgdZqx6svOhZWkd4JRY265fc=",
+        "lastModified": 1764081664,
+        "narHash": "sha256-sUoHmPr/EwXzRMpv1u/kH+dXuvJEyyF2Q7muE+t0EU4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "rev": "dc205f7b4fdb04c8b7877b43edb7b73be7730081",
         "type": "github"
       },
       "original": {

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -1,6 +1,6 @@
 import { useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
-import { FormatError } from "@/cli/error"
+import { FormatError, FormatUnknownError } from "@/cli/error"
 
 export const { use: useExit, provider: ExitProvider } = createSimpleContext({
   name: "Exit",
@@ -10,8 +10,10 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
       renderer.destroy()
       await input.onExit?.()
       if (reason) {
-        const formatted = FormatError(reason) ?? JSON.stringify(reason)
-        process.stderr.write(formatted + "\n")
+        const formatted = FormatError(reason) ?? FormatUnknownError(reason)
+        if (formatted) {
+          process.stderr.write(formatted + "\n")
+        }
       }
       process.exit(0)
     }

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -23,6 +23,7 @@ import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { batch, onMount } from "solid-js"
+import { Log } from "@/util/log"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -290,6 +291,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           })
         })
         .catch(async (e) => {
+          Log.Default.error("tui bootstrap failed", {
+            error: e instanceof Error ? e.message : String(e),
+            name: e instanceof Error ? e.name : undefined,
+            stack: e instanceof Error ? e.stack : undefined,
+          })
           await exit(e)
         })
     }

--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -38,3 +38,18 @@ export function FormatError(input: unknown) {
 
   if (UI.CancelledError.isInstance(input)) return ""
 }
+
+export function FormatUnknownError(input: unknown): string {
+  if (input instanceof Error) {
+    return input.stack ?? `${input.name}: ${input.message}`
+  }
+
+  if (typeof input === "object" && input !== null) {
+    try {
+      const json = JSON.stringify(input, null, 2)
+      if (json && json !== "{}") return json
+    } catch {}
+  }
+
+  return String(input)
+}


### PR DESCRIPTION
- add FormatUnknownError to format non-domain errors (stack or JSON)


add log for  #4650