### PR TITLE
Track calls made to LLM API within session (and optionally display with setting)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -16,12 +16,12 @@ const Title = (props: { session: Accessor<Session> }) => {
   )
 }
 
-const ContextInfo = (props: { context: Accessor<string | undefined>; cost: Accessor<string> }) => {
+const ContextInfo = (props: { context: Accessor<string | undefined>; cost: Accessor<string>; llmCalls: Accessor<number> }) => {
   const { theme } = useTheme()
   return (
     <Show when={props.context()}>
       <text fg={theme.textMuted} wrapMode="none" flexShrink={0}>
-        {props.context()} ({props.cost()})
+        {props.context()} ({props.cost()}) ({props.llmCalls()} calls)
       </text>
     </Show>
   )
@@ -58,6 +58,22 @@ export function Header() {
     return result
   })
 
+  // Count LLM calls (step-finish parts) across all messages in session
+  const llmCalls = createMemo(() => {
+    let count = 0
+    for (const msg of messages()) {
+      if (msg.role === "assistant") {
+        const parts = sync.data.part[msg.id] ?? []
+        for (const part of parts) {
+          if (part.type === "step-finish") {
+            count++
+          }
+        }
+      }
+    }
+    return count
+  })
+
   const { theme } = useTheme()
 
   return (
@@ -67,7 +83,7 @@ export function Header() {
         fallback={
           <box flexDirection="row" justifyContent="space-between" gap={1}>
             <Title session={session} />
-            <ContextInfo context={context} cost={cost} />
+            <ContextInfo context={context} cost={cost} llmCalls={llmCalls} />
           </box>
         }
       >
@@ -87,7 +103,7 @@ export function Header() {
               </Match>
             </Switch>
           </box>
-          <ContextInfo context={context} cost={cost} />
+          <ContextInfo context={context} cost={cost} llmCalls={llmCalls} />
         </box>
       </Show>
     </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -16,12 +16,17 @@ const Title = (props: { session: Accessor<Session> }) => {
   )
 }
 
-const ContextInfo = (props: { context: Accessor<string | undefined>; cost: Accessor<string>; llmCalls: Accessor<number> }) => {
+const ContextInfo = (props: {
+  context: Accessor<string | undefined>
+  cost: Accessor<string>
+  llmCalls: Accessor<number>
+  showLlmCalls: Accessor<boolean>
+}) => {
   const { theme } = useTheme()
   return (
     <Show when={props.context()}>
       <text fg={theme.textMuted} wrapMode="none" flexShrink={0}>
-        {props.context()} ({props.cost()}) ({props.llmCalls()} calls)
+        {props.context()} ({props.cost()}){props.showLlmCalls() ? ` (${props.llmCalls()} calls)` : ""}
       </text>
     </Show>
   )
@@ -33,6 +38,7 @@ export function Header() {
   const session = createMemo(() => sync.session.get(route.sessionID)!)
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const shareEnabled = createMemo(() => sync.data.config.share !== "disabled")
+  const showLlmCalls = createMemo(() => sync.data.config.llm_counter === true)
 
   const cost = createMemo(() => {
     const total = pipe(
@@ -83,7 +89,7 @@ export function Header() {
         fallback={
           <box flexDirection="row" justifyContent="space-between" gap={1}>
             <Title session={session} />
-            <ContextInfo context={context} cost={cost} llmCalls={llmCalls} />
+            <ContextInfo context={context} cost={cost} llmCalls={llmCalls} showLlmCalls={showLlmCalls} />
           </box>
         }
       >
@@ -103,7 +109,7 @@ export function Header() {
               </Match>
             </Switch>
           </box>
-          <ContextInfo context={context} cost={cost} llmCalls={llmCalls} />
+          <ContextInfo context={context} cost={cost} llmCalls={llmCalls} showLlmCalls={showLlmCalls} />
         </box>
       </Show>
     </box>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -469,6 +469,10 @@ export namespace Config {
         .optional(),
       plugin: z.string().array().optional(),
       snapshot: z.boolean().optional(),
+      llm_counter: z
+        .boolean()
+        .optional()
+        .describe("Display LLM API call counter in the session header. Disabled by default."),
       share: z
         .enum(["manual", "auto", "disabled"])
         .optional()

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1013,6 +1013,10 @@ export type Config = {
   plugin?: Array<string>
   snapshot?: boolean
   /**
+   * Display LLM API call counter in the session header. Disabled by default.
+   */
+  llm_counter?: boolean
+  /**
    * Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing
    */
   share?: "manual" | "auto" | "disabled"


### PR DESCRIPTION
Per #4577, users are sometimes looking to track the number of service calls they are making to the LLM API in their session.

This update enables tracking this by displaying it next to the cost + context in the TUI header. 
- Note: there are usually multiple calls within one assistant response. 
- Note: this counter resets on session reset.

This is only enabled when the new setting in **opencode.jsonc**: ` { "llm_counter": true } `

See video for visual preview of what this looks like:

https://github.com/user-attachments/assets/d483013f-0e33-4cfa-8d5c-669b46adefb4

