### PR TITLE
FIX: "the prompt is too long" -- character aware token estimation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764081664,
-        "narHash": "sha256-sUoHmPr/EwXzRMpv1u/kH+dXuvJEyyF2Q7muE+t0EU4=",
+        "lastModified": 1764138170,
+        "narHash": "sha256-2bCmfCUZyi2yj9FFXYKwsDiaZmizN75cLhI/eWmf3tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dc205f7b4fdb04c8b7877b43edb7b73be7730081",
+        "rev": "bb813de6d2241bcb1b5af2d3059f560c66329967",
         "type": "github"
       },
       "original": {

--- a/packages/opencode/src/util/token.ts
+++ b/packages/opencode/src/util/token.ts
@@ -1,7 +1,37 @@
 export namespace Token {
-  const CHARS_PER_TOKEN = 4
+  // Characters per token ratios by category, derived from typical BPE tokenizer behavior on code
 
-  export function estimate(input: string) {
-    return Math.max(0, Math.round((input || "").length / CHARS_PER_TOKEN))
+  // Digits tokenize poorly - often split into individual digits or small groups
+  const DIGITS_RATIO = 1 / 1.9
+
+  // Punctuation and symbols (brackets, operators, etc.) - most are single tokens,
+  // though some pairs merge (e.g., ->, !=, ::)
+  const PUNCTUATION_RATIO = 1 / 1.2
+
+  // Whitespace - leading indentation often merges (4 spaces → 1 token),
+  // but isolated spaces typically don't
+  const WHITESPACE_RATIO = 1 / 2.5
+
+  // Letters and other characters - keywords compress well, identifiers less so
+  const DEFAULT_RATIO = 1 / 3.5
+
+  // Adjustment multiplier for tuning estimates up (>1) or down (<1)
+  // Set via OPENCODE_TOKEN_FACTOR environment variable
+  const FACTOR = parseFloat(process.env.OPENCODE_TOKEN_FACTOR || "1.0") || 1.0
+
+  export function estimate(input: string): number {
+    let count = 0
+    for (const char of input || "") {
+      if (/\p{N}/u.test(char)) {
+        count += DIGITS_RATIO
+      } else if (/\p{P}|\p{S}/u.test(char)) {
+        count += PUNCTUATION_RATIO
+      } else if (/\s/.test(char)) {
+        count += WHITESPACE_RATIO
+      } else {
+        count += DEFAULT_RATIO
+      }
+    }
+    return Math.trunc(count * FACTOR)
   }
 }

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -424,3 +424,18 @@ These are useful for:
 - Keeping sensitive data like API keys in separate files.
 - Including large instruction files without cluttering your config.
 - Sharing common configuration snippets across multiple config files.
+
+### Token Estimation
+
+Opencode estimates token count for tool results using a weighted heuristic,
+which introduces a small margin of error that can vary between different
+languages and different types of content.
+
+You can use the `OPENCODE_TOKEN_FACTOR` environment variable to tune token estimation.
+Set it to a value greater than 1.0 to increase estimates (more conservative)
+or less than 1.0 to decrease estimates (allow more content).
+
+```bash
+export OPENCODE_TOKEN_FACTOR=1.1 # Estimate token counts 10% more conservatively
+opencode run "Hello world"
+```


### PR DESCRIPTION
## Background

I continue to get "the prompt is too long" errors on a variety of Claude models.  It's frequent enough to be noticeable as an issue for my team.

## Findings

1. It happens on requests when I was at ~25% context fill prior to sending the request
2. It still happens despite modifying my opencode.json to have 10% lower context limits across all models.  

Most recently, after changing Opus 4.1 to have 180k instead of 200k context, I still got "226170 > 200000" which is a full 25% higher than the 180k limit that was configured via opencode.

## Hypothesis

Since most token counts are based _actual_ from the LLM response, I judge that we are underestimating tokens when estimating.  I think 1:4 is both very aggressive and not sensitive enough to differences in types of content.  While for English-language text, my earlier estimates of 1:3.5 are roughly in agreement with 1:4, we diverge when it comes to numeric characters and delimiters.

## Changes

I've replaced the original estimate of 4 characters per token, to a weighted estimate that counts different partial token amounts per character, depending on whether the character is a digit, letter, punctuation, or whitespace.  These combine to create a weighted estimate which can then be multiplied by a factor provided in the environment variable, OPENCODE_TOKEN_FACTOR, in order to make the estimate more or less conservative.

## Other approaches considered

* I declined to add tiktoken though I think it would be wise, given that it would add dependencies for a non-functional upgrade.
* Make the weights and overall factor available in the config file.  Decided this would be heavy-handed until if/when different users might have enough data on their workloads, to be able effectively to tune those values.
* I'd also be interested in making token estimation into a pluggable behavior, so that users could provide a function, e.g. `(provider string, model string, text string) => number` in order to be able to choose how these estimations are done.  If one of y'all would give pointers on an acceptable way to do this, I'd be interested to do that.
