### PR TITLE
feat: play sound when agent is finished if notificationSound setting …

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -485,6 +485,12 @@ export namespace Config {
         .describe(
           "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",
         ),
+      notificationSound: z
+        .union([z.boolean(), z.string()])
+        .optional()
+        .describe(
+          "Play a sound when the assistant finishes responding. Set to true for system bell, or provide a custom command (e.g., 'afplay ~/sounds/done.wav' on macOS)",
+        ),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
       enabled_providers: z
         .array(z.string())

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -48,6 +48,7 @@ import { fn } from "@/util/fn"
 import { SessionProcessor } from "./processor"
 import { TaskTool } from "@/tool/task"
 import { SessionStatus } from "./status"
+import { Sound } from "@/util/sound"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -600,6 +601,7 @@ export namespace SessionPrompt {
       continue
     }
     SessionCompaction.prune({ sessionID })
+    Sound.playNotification()
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue
       const queued = state()[sessionID]?.callbacks ?? []

--- a/packages/opencode/src/util/sound.ts
+++ b/packages/opencode/src/util/sound.ts
@@ -1,0 +1,34 @@
+import { spawn } from "child_process"
+import { Config } from "../config/config"
+import { Log } from "./log"
+
+export namespace Sound {
+  const log = Log.create({ service: "sound" })
+
+  export async function playNotification() {
+    const config = await Config.get()
+    const setting = config.notificationSound
+
+    if (!setting) return
+
+    if (setting === true) {
+      // Use system bell
+      process.stdout.write("\x07")
+      return
+    }
+
+    if (typeof setting === "string") {
+      // Execute custom command
+      try {
+        const [command, ...args] = setting.split(" ")
+        const proc = spawn(command, args, {
+          detached: true,
+          stdio: "ignore",
+        })
+        proc.unref()
+      } catch (error) {
+        log.error("failed to play notification sound", { error, command: setting })
+      }
+    }
+  }
+}


### PR DESCRIPTION
Per [#2372](https://github.com/sst/opencode/issues/2372) create setting which allows sound to play when agent is finished. 
- This is off by default.
- If enabled via `"notificationSound": true,` will use system bell.
- If `notificationSound` is not a boolean, a system-specific command/sound can be specified for this action, see below:

### Full possible config:

```jsonc
 {
    // System bell (most portable, but often disabled in terminals)
    "notificationSound": true,

    // Or custom command:
    // macOS
    "notificationSound": "afplay /System/Library/Sounds/Glass.aiff",

    // Linux (with PulseAudio)
    "notificationSound": "paplay
  /usr/share/sounds/freedesktop/stereo/complete.oga",

    // Windows
    "notificationSound": "powershell -c (New-Object Media.SoundPlayer
  'C:\\Windows\\Media\\chimes.wav').PlaySync()"
  }
```

### Audio / Visual Demo

https://github.com/user-attachments/assets/a9913165-4414-413b-bbbe-c4c11677c5ff


