### PR TITLE
fix: filter empty messages in toModelMessage

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -666,7 +666,7 @@ export namespace MessageV2 {
       }
     }
 
-    return convertToModelMessages(result)
+    return convertToModelMessages(result.filter((msg) => msg.parts.length > 0))
   }
 
   export const stream = fn(Identifier.schema("session"), async function* (sessionID) {


### PR DESCRIPTION
## Summary
- Filter out messages with empty parts arrays before sending to provider API

## Problem
Related to #2655

Messages with only `ignored: true` text parts pass the initial `parts.length === 0` check but end up with empty content after filtering, causing provider API errors:
```
messages.X: all messages must have non-empty content except for the optional final assistant message
```

## Solution
Filter messages with empty parts after processing, before `convertToModelMessages()`.