### PR TITLE
Github: Create new PR for PR Updates

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -30,6 +30,16 @@ Leave the following comment on a GitHub PR. opencode will implement the requeste
 Delete the attachment from S3 when the note is removed /oc
 ```
 
+#### Create a new PR against an existing PR
+
+Use `/oc-new-pr` to create a separate PR with changes instead of committing directly to the PR branch.
+
+```
+fix the failing tests /oc-new-pr
+```
+
+opencode will create a new branch and open a new PR targeting the original PR branch. This is useful when you want to review the suggested changes separately before merging them into the original PR.
+
 #### Review specific code lines
 
 Leave a comment directly on code lines in the PR's "Files" tab. opencode will automatically detect the file, line numbers, and diff context to provide precise responses.

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -418,7 +418,7 @@ export const GithubRunCommand = cmd({
           headers: { authorization: `token ${appToken}` },
         })
 
-        const { userPrompt, promptFiles } = await getUserPrompt()
+        const { userPrompt, promptFiles, createNewPR } = await getUserPrompt()
         await configureGit(appToken)
         await assertPermissions()
 
@@ -452,10 +452,27 @@ export const GithubRunCommand = cmd({
             const { dirty, uncommittedChanges } = await branchIsDirty(head)
             if (dirty) {
               const summary = await summarize(response)
-              await pushToLocalBranch(summary, uncommittedChanges)
+              // Create new PR against the original PR branch
+              if (createNewPR) {
+                const newBranch = generateBranchName("pr-fix")
+                await $`git checkout -b ${newBranch}`
+                await pushToNewBranch(summary, newBranch, uncommittedChanges)
+                const newPr = await createPR(
+                  prData.headRefName,
+                  newBranch,
+                  summary,
+                  `${response}\n\nFixes #${issueId}${footer({ image: true })}`,
+                )
+                await updateComment(`Created PR #${newPr} against \`${prData.headRefName}\`${footer({ image: true })}`)
+              } else {
+                await pushToLocalBranch(summary, uncommittedChanges)
+                const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+                await updateComment(`${response}${footer({ image: !hasShared })}`)
+              }
+            } else {
+              const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+              await updateComment(`${response}${footer({ image: !hasShared })}`)
             }
-            const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
-            await updateComment(`${response}${footer({ image: !hasShared })}`)
           }
           // Fork PR
           else {
@@ -466,10 +483,27 @@ export const GithubRunCommand = cmd({
             const { dirty, uncommittedChanges } = await branchIsDirty(head)
             if (dirty) {
               const summary = await summarize(response)
-              await pushToForkBranch(summary, prData, uncommittedChanges)
+              // Create new PR against the fork PR branch
+              if (createNewPR) {
+                const newBranch = generateBranchName("pr-fix")
+                await $`git checkout -b ${newBranch}`
+                await pushToNewBranch(summary, newBranch, uncommittedChanges)
+                const newPr = await createPR(
+                  prData.headRefName,
+                  newBranch,
+                  summary,
+                  `${response}\n\nFixes #${issueId}${footer({ image: true })}`,
+                )
+                await updateComment(`Created PR #${newPr} against \`${prData.headRefName}\`${footer({ image: true })}`)
+              } else {
+                await pushToForkBranch(summary, prData, uncommittedChanges)
+                const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+                await updateComment(`${response}${footer({ image: !hasShared })}`)
+              }
+            } else {
+              const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+              await updateComment(`${response}${footer({ image: !hasShared })}`)
             }
-            const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
-            await updateComment(`${response}${footer({ image: !hasShared })}`)
           }
         }
         // Issue
@@ -563,15 +597,26 @@ export const GithubRunCommand = cmd({
 
       async function getUserPrompt() {
         const reviewContext = getReviewCommentContext()
+        const body = payload.comment.body.trim()
+
+        // Check if user wants to create a new PR against the current PR branch
+        // Usage: /oc-new-pr fix the tests
+        // This will create a new branch and PR targeting the original PR branch
+        const createNewPR = body.includes("/oc-new-pr") || body.includes("/opencode-new-pr")
+
         let prompt = (() => {
-          const body = payload.comment.body.trim()
-          if (body === "/opencode" || body === "/oc") {
+          if (body === "/opencode" || body === "/oc" || body === "/oc-new-pr" || body === "/opencode-new-pr") {
             if (reviewContext) {
               return `Review this code change and suggest improvements for the commented lines:\n\nFile: ${reviewContext.file}\nLines: ${reviewContext.line}\n\n${reviewContext.diffHunk}`
             }
             return "Summarize this thread"
           }
-          if (body.includes("/opencode") || body.includes("/oc")) {
+          if (
+            body.includes("/opencode") ||
+            body.includes("/oc") ||
+            body.includes("/oc-new-pr") ||
+            body.includes("/opencode-new-pr")
+          ) {
             if (reviewContext) {
               return `${body}\n\nContext: You are reviewing a comment on file "${reviewContext.file}" at line ${reviewContext.line}.\n\nDiff context:\n${reviewContext.diffHunk}`
             }
@@ -633,7 +678,7 @@ export const GithubRunCommand = cmd({
             replacement,
           })
         }
-        return { userPrompt: prompt, promptFiles: imgData }
+        return { userPrompt: prompt, promptFiles: imgData, createNewPR }
       }
 
       function subscribeSessionEvents() {
@@ -842,7 +887,7 @@ export const GithubRunCommand = cmd({
         await $`git checkout -b ${localBranch} fork/${remoteBranch}`
       }
 
-      function generateBranchName(type: "issue" | "pr") {
+      function generateBranchName(type: "issue" | "pr" | "pr-fix") {
         const timestamp = new Date()
           .toISOString()
           .replace(/[:-]/g, "")

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -132,6 +132,16 @@ Here are some examples of how you can use opencode in GitHub.
 
   opencode will implement the requested change and commit it to the same PR.
 
+- **Create a new PR against an existing PR**
+
+  If you want opencode to create a separate PR with changes instead of committing directly to the PR branch, use `/oc-new-pr`.
+
+  ```
+  fix the failing tests /oc-new-pr
+  ```
+
+  opencode will create a new branch, implement the changes, and open a new PR targeting the original PR branch. This is useful when you want to review the suggested changes separately before merging them into the original PR.
+
 - **Review specific code lines**
 
   Leave a comment directly on code lines in the PR's "Files" tab. opencode automatically detects the file, line numbers, and diff context to provide precise responses.


### PR DESCRIPTION
So currently when you ask opencode to make changes to PR, it pushes directly to the PR, but sometimes you don't like the changes, so need to revert / undo, etc.

Introducing `/oc-new-pr` with will create a new PR against that PR branch with the suggested changes... that way to you can review separately and just close if you don't like it...

Great part is this is backward compatible as current triggers should work just fine.