### PR TITLE
core: add built-in Dart LSP server and formatter

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -246,3 +246,12 @@ export const htmlbeautifier: Info = {
     return Bun.which("htmlbeautifier") !== null
   },
 }
+
+export const dart: Info = {
+  name: "dart",
+  command: ["dart", "format", "$FILE"],
+  extensions: [".dart"],
+  async enabled() {
+    return Bun.which("dart") !== null
+  },
+}

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1166,4 +1166,22 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const Dart: Info = {
+    id: "dart",
+    extensions: [".dart"],
+    root: NearestRoot(["pubspec.yaml", "analysis_options.yaml"]),
+    async spawn(root) {
+      const dart = Bun.which("dart")
+      if (!dart) {
+        log.info("dart not found, please install dart first")
+        return
+      }
+      return {
+        process: spawn(dart, ["language-server", "--lsp"], {
+          cwd: root,
+        }),
+      }
+    },
+  }
 }

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -26,6 +26,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | standardrb     | .rb, .rake, .gemspec, .ru                                                                                | `standardrb` command available          |
 | htmlbeautifier | .erb, .html.erb                                                                                          | `htmlbeautifier` command available      |
 | air            | .R                                                                                                       | `air` command available                 |
+| dart           | .dart                                                                                                    | `dart` command available                |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -32,6 +32,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | lua-ls             | .lua                                                 | Auto-installs for Lua projects                               |
 | sourcekit-lsp      | .swift, .objc, .objcpp                               | `swift` installed (`xcode` on macOS)                         |
 | php intelephense   | .php                                                 | Auto-installs for PHP projects                               |
+| dart               | .dart                                                | `dart` command available                                     |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 


### PR DESCRIPTION
I'm working a lot with Flutter / Dart, so when I've noticed that `dart` has a built-in LSP I've tried it.

I have no hard evidence, but subjectively the Models seam to be less lost and perform better with the LSP, so I think this might be useful for others too.

**Benefits:**
Users can now get Dart language support and formatting automatically without manual configuration when dart command is available

---

I haven't opened an Issue for this, because if I understood [contributing guidelines](https://github.com/sst/opencode/blob/dev/CONTRIBUTING.md) correctly, it's not needed for such change.

Let me know if any changes or further clarification is needed :D


