### PR TITLE
tweak: gemini retry message to not be explicitly about gemini 3

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -850,7 +850,7 @@ export function Prompt(props: PromptProps) {
                       const r = retry()
                       if (!r) return
                       if (r.message.includes("exceeded your current quota") && r.message.includes("gemini"))
-                        return "gemini 3 way too hot right now"
+                        return "gemini is way too hot right now"
                       if (r.message.length > 50) return r.message.slice(0, 50) + "..."
                       return r.message
                     })


### PR DESCRIPTION
Hi, I love that the project is using automatic retries, really helps me truly make them run in the background while I handle other stuff.

Right now when the model is not available the message always says "gemini 3", but I'm using 2.5 and it was peeving me a bit. I just made it generic gemini.