### PR TITLE
Remove top-level awaits to enable bytecode compilation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -5,7 +5,7 @@ import { Instance } from "@/project/instance"
 import { Rpc } from "@/util/rpc"
 import { upgrade } from "@/cli/upgrade"
 
-await Log.init({
+Log.init({
   print: process.argv.includes("--print-logs"),
   dev: Installation.isLocal(),
   level: (() => {

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -22,31 +22,33 @@ export namespace Global {
   } as const
 }
 
-await Promise.all([
-  fs.mkdir(Global.Path.data, { recursive: true }),
-  fs.mkdir(Global.Path.config, { recursive: true }),
-  fs.mkdir(Global.Path.state, { recursive: true }),
-  fs.mkdir(Global.Path.log, { recursive: true }),
-  fs.mkdir(Global.Path.bin, { recursive: true }),
-])
+;(async () => {
+  const CACHE_VERSION = "11"
 
-const CACHE_VERSION = "11"
+  await Promise.all([
+    fs.mkdir(Global.Path.data, { recursive: true }),
+    fs.mkdir(Global.Path.config, { recursive: true }),
+    fs.mkdir(Global.Path.state, { recursive: true }),
+    fs.mkdir(Global.Path.log, { recursive: true }),
+    fs.mkdir(Global.Path.bin, { recursive: true }),
+  ])
 
-const version = await Bun.file(path.join(Global.Path.cache, "version"))
-  .text()
-  .catch(() => "0")
+  const version = await Bun.file(path.join(Global.Path.cache, "version"))
+    .text()
+    .catch(() => "0")
 
-if (version !== CACHE_VERSION) {
-  try {
-    const contents = await fs.readdir(Global.Path.cache)
-    await Promise.all(
-      contents.map((item) =>
-        fs.rm(path.join(Global.Path.cache, item), {
-          recursive: true,
-          force: true,
-        }),
-      ),
-    )
-  } catch (e) {}
-  await Bun.file(path.join(Global.Path.cache, "version")).write(CACHE_VERSION)
-}
+  if (version !== CACHE_VERSION) {
+    try {
+      const contents = await fs.readdir(Global.Path.cache)
+      await Promise.all(
+        contents.map((item) =>
+          fs.rm(path.join(Global.Path.cache, item), {
+            recursive: true,
+            force: true,
+          }),
+        ),
+      )
+    } catch (e) {}
+    await Bun.file(path.join(Global.Path.cache, "version")).write(CACHE_VERSION)
+  }
+})()

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -104,49 +104,49 @@ const cli = yargs(hideBin(process.argv))
   })
   .strict()
 
-try {
-  await cli.parse()
-} catch (e) {
-  let data: Record<string, any> = {}
-  if (e instanceof NamedError) {
-    const obj = e.toObject()
-    Object.assign(data, {
-      ...obj.data,
-    })
-  }
+Promise.resolve(cli.parse())
+  .catch((e: unknown) => {
+    let data: Record<string, any> = {}
+    if (e instanceof NamedError) {
+      const obj = e.toObject()
+      Object.assign(data, {
+        ...obj.data,
+      })
+    }
 
-  if (e instanceof Error) {
-    Object.assign(data, {
-      name: e.name,
-      message: e.message,
-      cause: e.cause?.toString(),
-      stack: e.stack,
-    })
-  }
+    if (e instanceof Error) {
+      Object.assign(data, {
+        name: e.name,
+        message: e.message,
+        cause: e.cause?.toString(),
+        stack: e.stack,
+      })
+    }
 
-  if (e instanceof ResolveMessage) {
-    Object.assign(data, {
-      name: e.name,
-      message: e.message,
-      code: e.code,
-      specifier: e.specifier,
-      referrer: e.referrer,
-      position: e.position,
-      importKind: e.importKind,
-    })
-  }
-  Log.Default.error("fatal", data)
-  const formatted = FormatError(e)
-  if (formatted) UI.error(formatted)
-  if (formatted === undefined) {
-    UI.error("Unexpected error, check log file at " + Log.file() + " for more details" + EOL)
-    console.error(e)
-  }
-  process.exitCode = 1
-} finally {
-  // Some subprocesses don't react properly to SIGTERM and similar signals.
-  // Most notably, some docker-container-based MCP servers don't handle such signals unless
-  // run using `docker run --init`.
-  // Explicitly exit to avoid any hanging subprocesses.
-  process.exit()
-}
+    if (e instanceof ResolveMessage) {
+      Object.assign(data, {
+        name: e.name,
+        message: e.message,
+        code: e.code,
+        specifier: e.specifier,
+        referrer: e.referrer,
+        position: e.position,
+        importKind: e.importKind,
+      })
+    }
+    Log.Default.error("fatal", data)
+    const formatted = FormatError(e)
+    if (formatted) UI.error(formatted)
+    if (formatted === undefined) {
+      UI.error("Unexpected error, check log file at " + Log.file() + " for more details" + EOL)
+      console.error(e)
+    }
+    process.exitCode = 1
+  })
+  .finally(() => {
+    // Some subprocesses don't react properly to SIGTERM and similar signals.
+    // Most notably, some docker-container-based MCP servers don't handle such signals unless
+    // run using `docker run --init`.
+    // Explicitly exit to avoid any hanging subprocesses.
+    process.exit()
+  })


### PR DESCRIPTION
Currently this PR is not enough to enable bytecode compiliation
- opentui also needs to remove top level awaits
- bun --bytecode works by compiling to commonjs. some dependencies have bugs that do not allow it. Throwing the error `Expected CommonJS module to have a function wrapper`. This us often caused by the use of `import.meta.url` or other ESM only code. This needs more investigation

Preparation for enabling bytecode compilation (faster startup times).

Related to #4843 and https://github.com/sst/opentui/pull/356

- **global/index.ts**: Wrapped async initialization code in an IIFE instead of top-level await
- **index.ts**: Changed `await cli.parse()` to `Promise.resolve(cli.parse()).catch().finally()` pattern
- **worker.ts**: Removed `await` from `Log.init()` call (fire-and-forget)

Once opentui PR lands and Bun types are updated, bytecode can be enabled in `build.ts` with `bytecode: true`.