### PR TITLE
fix: take snapshot before stream starts to fix diff tracking for some providers

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -40,6 +40,10 @@ export namespace SessionProcessor {
       },
       async process(fn: () => StreamTextResult<Record<string, AITool>, never>) {
         log.info("process")
+        // Take initial snapshot BEFORE stream starts to ensure we capture
+        // the "before" state regardless of when start-step event fires
+        // (some providers emit start-step after tool execution begins)
+        const initialSnapshot = await Snapshot.track()
         while (true) {
           try {
             let currentText: MessageV2.TextPart | undefined
@@ -229,7 +233,9 @@ export namespace SessionProcessor {
                   throw value.error
 
                 case "start-step":
-                  snapshot = await Snapshot.track()
+                  // Use initialSnapshot taken before stream started to ensure
+                  // we have the true "before" state (some providers emit start-step late)
+                  snapshot = initialSnapshot
                   await Session.updatePart({
                     id: Identifier.ascending("part"),
                     messageID: input.assistantMessage.id,


### PR DESCRIPTION
## Summary

- Fix empty "Modified Files" sidebar when using certain LLM providers (e.g., GLM-4.6 via models.dev)

## Problem

The `start-step` event from the AI SDK fires at different times depending on the provider:

- **Anthropic**: fires before tool execution → correct "before" snapshot
- **Some providers (GLM-4.6, etc.)**: fires after tool execution has begun → snapshot captures "after" state
This caused `step-start` and `step-finish` snapshots to have identical hashes, resulting in empty diffs in the Modified Files sidebar.

## Solution

Take the snapshot **before** the stream starts instead of waiting for the `start-step` event. This ensures we always capture the true "before" state regardless of provider timing.

## Testing

Tested with:
- GLM-4.6 via models.dev (zai-coding-plan) - previously broken, now working
- Anthropic Haiku 4.5 - still working correctly

Before the change, 'Modified Files' was not present:

<img width="1469" height="678" alt="image" src="https://github.com/user-attachments/assets/6ca6078d-dc50-402a-92a0-e85a48b9bd8c" />

After the change updates to the file were tracked well coming from GLM and Haiku

<img width="1136" height="1368" alt="image" src="https://github.com/user-attachments/assets/31ab1e38-8380-41b1-b4a9-e190736b5536" />
