### PR TITLE
docs: Add tip to tools about subagents re todos

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -227,7 +227,11 @@ Apply patches to files.
 ```
 
 This tool applies patch files to your codebase. Useful for applying diffs and patches from various sources.
-Disabled in subagents by default.
+
+:::tip
+This tool is disabled for subagents by default, but you can enable it manually. [Learn more](/docs/agents/#tools)
+:::
+
 
 ---
 
@@ -245,7 +249,10 @@ Manage todo lists during coding sessions.
 ```
 
 Creates and updates task lists to track progress during complex operations. The LLM uses this to organize multi-step tasks.
-Disabled in subagents by default.
+
+:::tip
+This tool is disabled for subagents by default, but you can enable it manually. [Learn more](/docs/agents/#tools)
+:::
 
 ---
 

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -227,6 +227,7 @@ Apply patches to files.
 ```
 
 This tool applies patch files to your codebase. Useful for applying diffs and patches from various sources.
+Disabled in subagents by default.
 
 ---
 
@@ -244,6 +245,7 @@ Manage todo lists during coding sessions.
 ```
 
 Creates and updates task lists to track progress during complex operations. The LLM uses this to organize multi-step tasks.
+Disabled in subagents by default.
 
 ---
 


### PR DESCRIPTION
Added notes that todo tools are disabled for subagents by default.

For reference: https://discord.com/channels/1391832426048651334/1403873750650323044/1441818302283518044