### PR TITLE
fix: minor ui bug for transparent backgrounds

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -809,7 +809,8 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            vertical: "╹",
+            // when the background is transparent, don't draw the vertical line
+            vertical: theme.background.a != 0 ? "╹" : " ",
           }}
         >
           <box


### PR DESCRIPTION
# Motivation

Sorry for the nit pick bug - it just bothered me 😅

When using a transparent background theme (background set to "none"), the vertical separator line to the left of the prompt input extends visibly past the prompt box, creating a visual artifact.

# Changes

Made the vertical separator character conditional on background transparency, matching the existing behavior of the horizontal separator:

- Opaque backgrounds: Display "╹" separator character
- Transparent backgrounds: Use space character to hide the separator

# Screenshots

Before
<img width="3448" height="2168" alt="CleanShot 2025-11-28 at 22 50 34@2x" src="https://github.com/user-attachments/assets/58291c68-c621-49cf-bb24-0d1fa6b5e574" />

After
<img width="3456" height="2172" alt="CleanShot 2025-11-28 at 22 39 07@2x" src="https://github.com/user-attachments/assets/9dee3c1d-fcef-4210-836d-e8ab5f3f8981" />


