### PR TITLE
docs: Move tip to correct tool

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -245,7 +245,7 @@ Manage todo lists during coding sessions.
 
 Creates and updates task lists to track progress during complex operations. The LLM uses this to organize multi-step tasks.
 
-:::tip
+:::note
 This tool is disabled for subagents by default, but you can enable it manually. [Learn more](/docs/agents/#tools)
 :::
 
@@ -266,7 +266,7 @@ Read existing todo lists.
 
 Reads the current todo list state. Used by the LLM to track what tasks are pending or completed.
 
-:::tip
+:::note
 This tool is disabled for subagents by default, but you can enable it manually. [Learn more](/docs/agents/#tools)
 :::
 

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -228,10 +228,6 @@ Apply patches to files.
 
 This tool applies patch files to your codebase. Useful for applying diffs and patches from various sources.
 
-:::tip
-This tool is disabled for subagents by default, but you can enable it manually. [Learn more](/docs/agents/#tools)
-:::
-
 ---
 
 ### todowrite
@@ -269,6 +265,10 @@ Read existing todo lists.
 ```
 
 Reads the current todo list state. Used by the LLM to track what tasks are pending or completed.
+
+:::tip
+This tool is disabled for subagents by default, but you can enable it manually. [Learn more](/docs/agents/#tools)
+:::
 
 ---
 


### PR DESCRIPTION
Made a stupid mistake of adding the tip to the path tool in my earlier PR: https://github.com/sst/opencode/pull/4875

Sorry about that. This here is the "fix".