### PR TITLE
docs: Update "model" inheritance for agents

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -291,7 +291,6 @@ Use the `model` config to override the model for this agent. Useful for using di
 If you don’t specify a model, primary agents use the [model globally configured](/docs/config#models) while subagents will use the model of the primary agent that invoked the subagent.
 :::
 
-docs/config.mdx#models
 
 ```json title="opencode.json"
 {

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -285,7 +285,13 @@ This path is relative to where the config file is located. So this works for bot
 
 ### Model
 
-Use the `model` config to override the model for this agent. If you don’t specify one, the subagent inherits the model of the primary agent that invoked it. Useful for using different models optimized for different tasks. For example, a faster model for planning, a more capable model for implementation.
+Use the `model` config to override the model for this agent. Useful for using different models optimized for different tasks. For example, a faster model for planning, a more capable model for implementation.
+
+:::tip
+If you don’t specify a model, primary agents use the [model globally configured](/docs/config#models) while subagents will use the model of the primary agent that invoked the subagent.
+:::
+
+docs/config.mdx#models
 
 ```json title="opencode.json"
 {

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -285,7 +285,7 @@ This path is relative to where the config file is located. So this works for bot
 
 ### Model
 
-Use the `model` config to override the default model for this agent. Useful for using different models optimized for different tasks. For example, a faster model for planning, a more capable model for implementation.
+Use the `model` config to override the model for this agent. If you don’t specify one, the subagent inherits the model of the primary agent that invoked it. Useful for using different models optimized for different tasks. For example, a faster model for planning, a more capable model for implementation.
 
 ```json title="opencode.json"
 {


### PR DESCRIPTION
Clarified the behavior of the default 'model' config for agents. 

This clarifies that `model`is not inherited from the global model config, but from the primary agent that invokes the subagent. 

I came across this when setting big pickle as global default, using sonnet for the build agent and removed the model config from my subagents. This made the subagents use sonnet instead of big pickle.

I think this is important, especially for providers that count per requests like copilot. Making the subagents using a fast and cheaper model like big pickle seems reasonable.