### PR TITLE
fix(tui): add missing fg color to permission keybind hints

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764290847,
-        "narHash": "sha256-VwPgoDgnd628GdE3KyLqTyPF1WWh0VwT5UoKygoi8sg=",
+        "lastModified": 1764384123,
+        "narHash": "sha256-UoliURDJFaOolycBZYrjzd9Cc66zULEyHqGFH3QHEq0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd5fedfc384cb98d9fd3827b55f4522f49efda42",
+        "rev": "59b6c96beacc898566c9be1052ae806f3835f87d",
         "type": "github"
       },
       "original": {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1201,15 +1201,15 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
           <box gap={1}>
             <text fg={theme.text}>Permission required to run this tool:</text>
             <box flexDirection="row" gap={2}>
-              <text>
+              <text fg={theme.text}>
                 <b>enter</b>
                 <span style={{ fg: theme.textMuted }}> accept</span>
               </text>
-              <text>
+              <text fg={theme.text}>
                 <b>a</b>
                 <span style={{ fg: theme.textMuted }}> accept always</span>
               </text>
-              <text>
+              <text fg={theme.text}>
                 <b>d</b>
                 <span style={{ fg: theme.textMuted }}> deny</span>
               </text>


### PR DESCRIPTION
the permission keybind hints (enter/a/d) were missing explicit fg color, causing them to blend into the background on some terminals/themes

# changes

added `fg={theme.text}` to the three `<text>` elements containing the permission keybind hints, matching the existing pattern used elsewhere (e.g. prompt/index.tsx lines 892-901)

# before
keybind letters nearly invisible against backgroundPanel

# after  
keybind letters use theme.text for proper contrast

relates to #4461