### PR TITLE
feat: implement double Ctrl+C to exit functionality with warning toast

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -17,6 +17,7 @@ import { useRenderer } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
+import { useToast } from "../../ui/toast"
 import type { FilePart } from "@opencode-ai/sdk"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
@@ -496,6 +497,22 @@ export function Prompt(props: PromptProps) {
     input.clear()
   }
   const exit = useExit()
+  const toast = useToast()
+  let lastExitAttempt = 0
+
+  async function tryExit() {
+    const now = Date.now()
+    if (now - lastExitAttempt < 2000) {
+      await exit()
+      return
+    }
+    lastExitAttempt = now
+    toast.show({
+      variant: "warning",
+      message: "Press again to exit",
+      duration: 2000,
+    })
+  }
 
   function pasteText(text: string, virtualText: string) {
     const currentOffset = input.visualCursor.offset
@@ -676,7 +693,7 @@ export function Prompt(props: PromptProps) {
                   return
                 }
                 if (keybind.match("app_exit", e)) {
-                  await exit()
+                  await tryExit()
                   return
                 }
                 if (e.name === "!" && input.visualCursor.offset === 0) {


### PR DESCRIPTION
**Problem**: It's easy to accidentally exit opencode by pressing Ctrl+C once.

**Proposed Solution**: Require pressing Ctrl+C twice within 2 seconds to exit. 
On first press, show a toast warning "Press again to exit".

**Implementation**: I have a working implementation ready if this is approved.