### PR TITLE
fix(run): allow messages to start with dash (-)

### DIFF
--- a/packages/opencode/src/cli/cmd/cmd.ts
+++ b/packages/opencode/src/cli/cmd/cmd.ts
@@ -1,5 +1,7 @@
 import type { CommandModule } from "yargs"
 
-export function cmd<T, U>(input: CommandModule<T, U>) {
+type WithDoubleDash<T> = T & { "--"?: string[] }
+
+export function cmd<T, U>(input: CommandModule<T, WithDoubleDash<U>>) {
   return input
 }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -88,7 +88,7 @@ export const RunCommand = cmd({
       })
   },
   handler: async (args) => {
-    let message = args.message.join(" ")
+    let message = [...args.message, ...(args["--"] || [])].join(" ")
 
     const fileParts: any[] = []
     if (args.file) {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -39,6 +39,7 @@ process.on("uncaughtException", (e) => {
 })
 
 const cli = yargs(hideBin(process.argv))
+  .parserConfiguration({ "populate--": true })
   .scriptName("opencode")
   .help("help", "show help")
   .alias("help", "h")


### PR DESCRIPTION
This PR adds the Unix `--` idiom to allow positional arguments that start with leading dashes.

Examples 
```
opencode run "-hello" # fails because it thinks that hello is flag
opencode run -- "-hello" # now works, but this PR allow the same logic applied by other Unix CLI tools
```

Closes https://github.com/sst/opencode/issues/4903