### PR TITLE
feat: experimental.primary_tools, allow user to set the tools that should only be available to primary agents

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -635,12 +635,7 @@ export namespace Config {
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
-      primary_tools: z
-        .array(z.string())
-        .optional()
-        .describe(
-          "Tools that should only be available to primary agents.",
-        ),
+      primary_tools: z.array(z.string()).optional().describe("Tools that should only be available to primary agents."),
       enterprise: z
         .object({
           url: z.string().optional().describe("Enterprise URL"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -635,7 +635,6 @@ export namespace Config {
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
-      primary_tools: z.array(z.string()).optional().describe("Tools that should only be available to primary agents."),
       enterprise: z
         .object({
           url: z.string().optional().describe("Enterprise URL"),
@@ -668,6 +667,10 @@ export namespace Config {
           chatMaxRetries: z.number().optional().describe("Number of retries for chat completions on failure"),
           disable_paste_summary: z.boolean().optional(),
           batch_tool: z.boolean().optional().describe("Enable the batch tool"),
+          primary_tools: z
+            .array(z.string())
+            .optional()
+            .describe("Tools that should only be available to primary agents."),
         })
         .optional(),
     })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -635,6 +635,12 @@ export namespace Config {
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
+      primary_tools: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Tools that should only be available to primary agents (not subagents). Defaults to todowrite, todoread, and task.",
+        ),
       enterprise: z
         .object({
           url: z.string().optional().describe("Enterprise URL"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -639,7 +639,7 @@ export namespace Config {
         .array(z.string())
         .optional()
         .describe(
-          "Tools that should only be available to primary agents (not subagents). Defaults to todowrite, todoread, and task.",
+          "Tools that should only be available to primary agents.",
         ),
       enterprise: z
         .object({

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -9,6 +9,9 @@ import { Agent } from "../agent/agent"
 import { SessionPrompt } from "../session/prompt"
 import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
+import { Config } from "../config/config"
+
+const DEFAULT_PRIMARY_TOOLS = ["todowrite", "todoread", "task"]
 
 export const TaskTool = Tool.define("task", async () => {
   const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
@@ -77,6 +80,14 @@ export const TaskTool = Tool.define("task", async () => {
       ctx.abort.addEventListener("abort", cancel)
       using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
+
+      const config = await Config.get()
+      const primaryTools = [...DEFAULT_PRIMARY_TOOLS, ...(config.primary_tools ?? [])]
+      const disabledTools: Record<string, false> = {}
+      for (const tool of primaryTools) {
+        disabledTools[tool] = false
+      }
+
       const result = await SessionPrompt.prompt({
         messageID,
         sessionID: session.id,
@@ -86,9 +97,7 @@ export const TaskTool = Tool.define("task", async () => {
         },
         agent: agent.name,
         tools: {
-          todowrite: false,
-          todoread: false,
-          task: false,
+          ...disabledTools,
           ...agent.tools,
         },
         parts: promptParts,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,8 +11,6 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 
-const DEFAULT_PRIMARY_TOOLS = ["todowrite", "todoread", "task"]
-
 export const TaskTool = Tool.define("task", async () => {
   const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
   const description = DESCRIPTION.replace(
@@ -82,12 +80,6 @@ export const TaskTool = Tool.define("task", async () => {
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
 
       const config = await Config.get()
-      const primaryTools = [...DEFAULT_PRIMARY_TOOLS, ...(config.primary_tools ?? [])]
-      const disabledTools: Record<string, false> = {}
-      for (const tool of primaryTools) {
-        disabledTools[tool] = false
-      }
-
       const result = await SessionPrompt.prompt({
         messageID,
         sessionID: session.id,
@@ -97,7 +89,10 @@ export const TaskTool = Tool.define("task", async () => {
         },
         agent: agent.name,
         tools: {
-          ...disabledTools,
+          todowrite: false,
+          todoread: false,
+          task: false,
+          ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
           ...agent.tools,
         },
         parts: promptParts,

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1245,6 +1245,10 @@ export type Config = {
      * Enable the batch tool
      */
     batch_tool?: boolean
+    /**
+     * Tools that should only be available to primary agents.
+     */
+    primary_tools?: Array<string>
   }
 }
 


### PR DESCRIPTION
add a way to disable tools for subagent through the config, allows for plugins to disable custom tools from task tool.

can't generate the sdk on my laptop for some reason recently :/