### PR TITLE
feat: add thinking variant for Claude Opus 4.5

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -297,6 +297,22 @@ export namespace Provider {
     const config = await Config.get()
     const database = await ModelsDev.get()
 
+    // Add thinking variant for Opus 4.5
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
     const disabled = new Set(config.disabled_providers ?? [])
     const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
 

--- a/packages/opencode/test/provider/thinking-variant.test.ts
+++ b/packages/opencode/test/provider/thinking-variant.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test, beforeAll, mock } from "bun:test"
+import { ModelsDev } from "../../src/provider/models"
+
+// Mock the models.dev API response with a minimal Anthropic provider
+const mockModelsDevData: Record<string, ModelsDev.Provider> = {
+  anthropic: {
+    id: "anthropic",
+    name: "Anthropic",
+    env: ["ANTHROPIC_API_KEY"],
+    npm: "@ai-sdk/anthropic",
+    models: {
+      "claude-opus-4-5-20251101": {
+        id: "claude-opus-4-5-20251101",
+        name: "Claude Opus 4.5",
+        release_date: "2025-11-01",
+        attachment: true,
+        reasoning: true,
+        temperature: true,
+        tool_call: true,
+        cost: {
+          input: 5,
+          output: 25,
+          cache_read: 0.5,
+          cache_write: 6.25,
+        },
+        limit: {
+          context: 200000,
+          output: 64000,
+        },
+        modalities: {
+          input: ["text", "image"],
+          output: ["text"],
+        },
+        options: {},
+      },
+    },
+  },
+}
+
+describe("Anthropic thinking variant", () => {
+  test("thinking variant is created from base opus 4.5 model", () => {
+    // Simulate what the provider.ts code does
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    // Verify the thinking variant exists
+    const thinkingModel = database["anthropic"].models["claude-opus-4-5-20251101-thinking"]
+    expect(thinkingModel).toBeDefined()
+  })
+
+  test("thinking variant has correct name", () => {
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    const thinkingModel = database["anthropic"].models["claude-opus-4-5-20251101-thinking"]
+    expect(thinkingModel.name).toBe("Claude Opus 4.5 Thinking")
+  })
+
+  test("thinking variant preserves original model id for API calls", () => {
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    const thinkingModel = database["anthropic"].models["claude-opus-4-5-20251101-thinking"]
+    // The id should be preserved from the spread, which is the original model id
+    expect(thinkingModel.id).toBe("claude-opus-4-5-20251101")
+  })
+
+  test("thinking variant has thinking options enabled", () => {
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    const thinkingModel = database["anthropic"].models["claude-opus-4-5-20251101-thinking"]
+    expect(thinkingModel.options).toEqual({
+      thinking: {
+        type: "enabled",
+        budgetTokens: 16000,
+      },
+    })
+  })
+
+  test("thinking variant has correct budget tokens", () => {
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    const thinkingModel = database["anthropic"].models["claude-opus-4-5-20251101-thinking"]
+    expect(thinkingModel.options.thinking.budgetTokens).toBe(16000)
+  })
+
+  test("thinking variant preserves all other model properties", () => {
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    const originalModel = anthropic.models["claude-opus-4-5-20251101"]
+
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    const thinkingModel = database["anthropic"].models["claude-opus-4-5-20251101-thinking"]
+
+    // Verify all other properties are preserved
+    expect(thinkingModel.release_date).toBe(originalModel.release_date)
+    expect(thinkingModel.attachment).toBe(originalModel.attachment)
+    expect(thinkingModel.reasoning).toBe(originalModel.reasoning)
+    expect(thinkingModel.temperature).toBe(originalModel.temperature)
+    expect(thinkingModel.tool_call).toBe(originalModel.tool_call)
+    expect(thinkingModel.cost).toEqual(originalModel.cost)
+    expect(thinkingModel.limit).toEqual(originalModel.limit)
+    expect(thinkingModel.modalities).toEqual(originalModel.modalities)
+  })
+
+  test("original model is not modified", () => {
+    const database = structuredClone(mockModelsDevData)
+
+    const anthropic = database["anthropic"]
+    const originalModelBefore = structuredClone(anthropic.models["claude-opus-4-5-20251101"])
+
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    const originalModelAfter = database["anthropic"].models["claude-opus-4-5-20251101"]
+
+    // Original model should be unchanged
+    expect(originalModelAfter.name).toBe(originalModelBefore.name)
+    expect(originalModelAfter.options).toEqual(originalModelBefore.options)
+  })
+
+  test("no thinking variant created if base model does not exist", () => {
+    const database: Record<string, ModelsDev.Provider> = {
+      anthropic: {
+        id: "anthropic",
+        name: "Anthropic",
+        env: ["ANTHROPIC_API_KEY"],
+        npm: "@ai-sdk/anthropic",
+        models: {
+          // Note: claude-opus-4-5-20251101 is NOT present
+          "claude-sonnet-4-5-20250929": {
+            id: "claude-sonnet-4-5-20250929",
+            name: "Claude Sonnet 4.5",
+            release_date: "2025-09-29",
+            attachment: true,
+            reasoning: true,
+            temperature: true,
+            tool_call: true,
+            cost: { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+            limit: { context: 200000, output: 64000 },
+            options: {},
+          },
+        },
+      },
+    }
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    // Thinking variant should NOT be created
+    expect(database["anthropic"].models["claude-opus-4-5-20251101-thinking"]).toBeUndefined()
+  })
+
+  test("no thinking variant created if anthropic provider does not exist", () => {
+    const database: Record<string, ModelsDev.Provider> = {
+      openai: {
+        id: "openai",
+        name: "OpenAI",
+        env: ["OPENAI_API_KEY"],
+        npm: "@ai-sdk/openai",
+        models: {},
+      },
+    }
+
+    const anthropic = database["anthropic"]
+    if (anthropic?.models["claude-opus-4-5-20251101"]) {
+      const opus45 = anthropic.models["claude-opus-4-5-20251101"]
+      anthropic.models["claude-opus-4-5-20251101-thinking"] = {
+        ...opus45,
+        name: "Claude Opus 4.5 Thinking",
+        options: {
+          thinking: {
+            type: "enabled",
+            budgetTokens: 16000,
+          },
+        },
+      }
+    }
+
+    // Should not throw and anthropic should still not exist
+    expect(database["anthropic"]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Opus 4.5 supports extended thinking (`reasoning: true` in models.dev), but it's not enabled out of the box. To use it, you currently need to add config manually:

```json
"provider": {
  "anthropic": {
    "models": {
      "claude-opus-4-5-20251101": {
        "options": {
          "thinking": {
            "type": "enabled",
            "budgetTokens": 16000
          }
        }
      }
    }
  }
}
```

I was looking into this for my own setup and found #1106 and #2875 where others had similar questions. I saw that a proper thinking toggle UI is planned for after the opentui migration, which makes sense.

This PR is just a small idea in the meantime. It adds a `claude-opus-4-5-20251101-thinking` variant that shows up in the model picker with thinking already enabled. That way people can try it without config changes while the real solution is being worked on.

Totally possible there's already something in the works that makes this unnecessary, or a reason this approach doesn't fit. Happy to close this if so.

**What it does:**

Adds one model variant with thinking enabled (16k token budget). Shows up alongside regular Opus 4.5 in the model list.

**What it doesn't do:**

Doesn't modify the base model. Doesn't add UI toggles. Doesn't add multiple budget tiers.

---

**References:**
- #1106
- #2875