### PR TITLE
tweak: delimit consecutive queued user messages

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -565,7 +565,7 @@ export namespace MessageV2 {
         const userMessage: UIMessage = {
           id: msg.info.id,
           role: "user",
-          parts: [],
+          parts: result.at(-1)?.role === "user" ? [{ type: "text", text: "\n" }] : [],
         }
         result.push(userMessage)
         for (const part of msg.parts) {


### PR DESCRIPTION
When user messages queue during busy sessions, consecutive user messages
serialize without separation. This adds a newline delimiter between them.
One-line change in `message-v2.ts`.