### PR TITLE
fix: permission rejection no longer stalls queued messages

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -181,6 +181,8 @@ export namespace Permission {
   }
 
   export class RejectedError extends Error {
+    readonly isPermissionRejected = true
+
     constructor(
       public readonly sessionID: string,
       public readonly permissionID: string,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -28,8 +28,8 @@ export namespace SessionProcessor {
   }) {
     const toolcalls: Record<string, MessageV2.ToolPart> = {}
     let snapshot: string | undefined
-    let blocked = false
     let attempt = 0
+    let rejected = false
 
     const result = {
       get message() {
@@ -218,9 +218,7 @@ export namespace SessionProcessor {
                       },
                     })
 
-                    if (value.error instanceof Permission.RejectedError) {
-                      blocked = true
-                    }
+                    if ((value.error as any)?.isPermissionRejected) rejected = true
                     delete toolcalls[value.toolCallId]
                   }
                   break
@@ -369,8 +367,8 @@ export namespace SessionProcessor {
             }
           }
           input.assistantMessage.time.completed = Date.now()
+          if (rejected) input.assistantMessage.finish = "stop"
           await Session.updateMessage(input.assistantMessage)
-          if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"
           return "continue"
         }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -620,7 +620,6 @@ export namespace SessionPrompt {
         }),
       )
       if (result === "stop") break
-      continue
     }
     SessionCompaction.prune({ sessionID })
     for await (const item of MessageV2.stream(sessionID)) {


### PR DESCRIPTION
Permission rejection was indicating decline without actually stopping the model;
queued messages appeared sent but weren't going through.

This should address both. Feedback welcome.
