### PR TITLE
fix: permission rejection no longer stalls queued messages

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -370,8 +370,8 @@ export namespace SessionProcessor {
             }
           }
           input.assistantMessage.time.completed = Date.now()
+          if (blocked) input.assistantMessage.finish = "stop"
           await Session.updateMessage(input.assistantMessage)
-          if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"
           return "continue"
         }


### PR DESCRIPTION
Queued messages were not "flushed" pending a new prompt on tool permission rejection, despite UI indication to the contrary.

Discussed on
https://github.com/sst/opencode/pull/4945
