### PR TITLE
fix: update branding in TUI update notifications to use shuvcode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -418,7 +418,7 @@ function App() {
     toast.show({
       variant: "success",
       title: "Update Complete",
-      message: `OpenCode updated to v${evt.properties.version}`,
+      message: `shuvcode updated to v${evt.properties.version}`,
       duration: 5000,
     })
   })
@@ -427,7 +427,7 @@ function App() {
     toast.show({
       variant: "info",
       title: "Update Available",
-      message: `OpenCode v${evt.properties.version} is available. Run 'opencode upgrade' to update manually.`,
+      message: `shuvcode v${evt.properties.version} is available. Run 'shuvcode upgrade' to update manually.`,
       duration: 10000,
     })
   })


### PR DESCRIPTION
## Summary

- Fixes #73 - Updates hardcoded "OpenCode" branding in TUI update notification messages to display "shuvcode" instead

## Changes

Updates two toast messages in `packages/opencode/src/cli/cmd/tui/app.tsx`:

| Message | Before | After |
|---------|--------|-------|
| Update Complete | `OpenCode updated to v{version}` | `shuvcode updated to v{version}` |
| Update Available | `OpenCode v{version} is available. Run 'opencode upgrade' to update manually.` | `shuvcode v{version} is available. Run 'shuvcode upgrade' to update manually.` |

## Testing

- [x] TypeScript syntax check passed
- [x] Code changes verified at correct line locations (421, 430)

## Risk Assessment

**Low risk** - String-only UI text changes with no logic modifications. Changes are isolated to a single file.