### PR TITLE
fix: correct Provider type in chat.params plugin hook

### DIFF
--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -16,6 +16,12 @@ import { type ToolDefinition } from "./tool"
 
 export * from "./tool"
 
+export type ProviderContext = {
+  source: "env" | "config" | "custom" | "api"
+  info: Provider
+  options: Record<string, any>
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -153,7 +159,7 @@ export interface Hooks {
    * Modify parameters sent to LLM
    */
   "chat.params"?: (
-    input: { sessionID: string; agent: string; model: Model; provider: Provider; message: UserMessage },
+    input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { temperature: number; topP: number; options: Record<string, any> },
   ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>


### PR DESCRIPTION
## Summary

Fixes incorrect TypeScript types for the `provider` parameter in the `chat.params` plugin hook.

Closes #2392

## Problem

The `chat.params` hook type uses `Provider` directly, but at runtime the hook receives a wrapper object with the provider info nested under an `info` property.

**Before (incorrect):**
```typescript
provider: Provider  // expects provider.id
```

**Runtime structure:**
```typescript
{
  source: "env" | "config" | "custom" | "api"
  info: Provider
  options: Record<string, any>
}
```

## Solution

Added a new `ProviderContext` type that matches the actual runtime structure and updated the `chat.params` hook signature to use it.

```typescript
export type ProviderContext = {
  source: "env" | "config" | "custom" | "api"
  info: Provider
  options: Record<string, any>
}
```

## Changes

- Added `ProviderContext` type export
- Updated `chat.params` hook to use `ProviderContext` instead of `Provider`

## Notes

- The `auth.loader` callback correctly uses `Provider` (it receives raw provider info from the database, not the wrapper)
- This is a breaking change for any plugins that incorrectly relied on the wrong types, but those plugins wouldn't have worked correctly at runtime anyway

## Alternative Approach

This PR fixes the types to match the current runtime behavior. An alternative would be to change the runtime to pass `provider.info` directly (the raw `Provider`), matching how `auth.loader` works:

```typescript
// Current runtime (wrapper object)
provider: { source, info: Provider, options }

// Alternative runtime (raw Provider, like auth.loader)
provider: Provider
```

The alternative would be a cleaner API but would be a breaking runtime change for existing plugins that have worked around the type mismatch by accessing `provider.info.id` etc.