### PR TITLE
tweak: adjust light/dark theme toggle 

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -313,10 +313,11 @@ function App() {
       category: "System",
     },
     {
-      title: `Switch to ${mode() === "dark" ? "light" : "dark"} mode`,
+      title: "Toggle appearance",
       value: "theme.switch_mode",
-      onSelect: () => {
+      onSelect: (dialog) => {
         setMode(mode() === "dark" ? "light" : "dark")
+        dialog.clear()
       },
       category: "System",
     },


### PR DESCRIPTION
The main change is simply to rename the "Switch to light/dark mode" command to just "Toggle appearance". This more closely matches what the command currently does -- it doesn't let you choose the mode, it just toggles it.

This PR also updates the toggle command to close the palette after auctioning the command, which is consistent with how other commands behave.