### PR TITLE
fix: handle `0` in ANSI theme color definitions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -161,7 +161,7 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
 
       if (c.startsWith("#")) return RGBA.fromHex(c)
 
-      if (defs[c]) {
+      if (defs[c] != null) {
         return resolveColor(defs[c])
       } else if (theme.theme[c as keyof ThemeColors] !== undefined) {
         return resolveColor(theme.theme[c as keyof ThemeColors]!)


### PR DESCRIPTION
The theme handling code currently breaks when a color definition uses the ANSI value `0`, like:

```json
{
  "defs": {
    "black": 0
  },
  "theme": {
    "text": "black"
  }
}
```

This PR updates the color definition lookup code to handle 0, which it currently treats as falsey.

Fixes #5010 