### PR TITLE
fix(tui): pass init bootstrap to checkUpgrade

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -2,6 +2,7 @@ import { Installation } from "@/installation"
 import { Server } from "@/server/server"
 import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { Rpc } from "@/util/rpc"
 import { upgrade } from "@/cli/upgrade"
 
@@ -43,6 +44,7 @@ export const rpc = {
   async checkUpgrade(input: { directory: string }) {
     await Instance.provide({
       directory: input.directory,
+      init: InstanceBootstrap,
       fn: async () => {
         await upgrade().catch(() => {})
       },


### PR DESCRIPTION
### Problem
Race condition in TUI mode: `checkUpgrade` triggers `Instance.provide()` without `init`, caching an uninitialized instance. This prevents subsequent requests from running the initialization logic, skipping plugin config hooks.

### Solution
Pass `InstanceBootstrap` to `checkUpgrade` to ensure the instance is correctly initialized upon creation.

### Reproduction
1. Start TUI mode with a plugin configured.
2. Observe that plugin config hooks are not triggered during startup.

Related: #4846