### PR TITLE
fix: ensure checkUpgrade sets `init:`

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -2,6 +2,7 @@ import { Installation } from "@/installation"
 import { Server } from "@/server/server"
 import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"
+import { InstanceBootstrap } from "@/project/bootstrap"
 import { Rpc } from "@/util/rpc"
 import { upgrade } from "@/cli/upgrade"
 
@@ -43,6 +44,7 @@ export const rpc = {
   async checkUpgrade(input: { directory: string }) {
     await Instance.provide({
       directory: input.directory,
+      init: InstanceBootstrap,
       fn: async () => {
         await upgrade().catch(() => {})
       },


### PR DESCRIPTION
## Problem
In TUI mode, a race condition occurs in environments where initialization involves significant latency (e.g., SSH, WSL2, remote VSCode).

The `checkUpgrade` function is scheduled to execute after 1 second. If the TUI initialization phase takes longer than 1 second, `checkUpgrade` executes first. Previously, `checkUpgrade` called `Instance.provide()` without passing the `init` (InstanceBootstrap) object.

Found this and fixed this using my personal plugin [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode), but i thought there is no ai slop for this and found the real cause and fixed so I made this PR.

## Root Cause
The `Instance.provide()` method follows a singleton pattern with caching.
1. `checkUpgrade` executes and calls `Instance.provide()` (without `init`).
2. An `Instance` is created using default settings *without* executing configuration or event hooks, and this uninitialized instance is **cached**.
3. When the main TUI logic eventually calls `Instance.provide(init)`, the system detects the cached instance.
4. It returns the existing (poisoned) instance, effectively ignoring the provided `init` object.

**Impact:**
- Config hooks are skipped -> Custom agents defined on plugin are not registered.
- Event hooks are skipped -> Plugins do not receive events.

## Solution
Updated `checkUpgrade` in `packages/opencode/src/cli/cmd/tui/worker.ts` to accept and pass the `init: InstanceBootstrap` object.

Now, regardless of whether `checkUpgrade` or the main TUI loop wins the race to create the `Instance`, the singleton is guaranteed to be initialized with the correct configuration and hooks.

## Reproduction
1. Run OpenCode TUI in a constrained environment (or inject artificial delay in TUI startup > 1s).
2. Observe that `checkUpgrade` runs.
3. Verify that custom agents defined in `config` are missing or event handlers are not triggering.

## Related
Closes #4846