### PR TITLE
feat: writing filetime reads to disk to persist across process being killed

### DIFF
--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -1,5 +1,6 @@
 import { Instance } from "../project/instance"
 import { Log } from "../util/log"
+import { Storage } from "../storage/storage"
 
 export namespace FileTime {
   const log = Log.create({ service: "file.time" })
@@ -19,14 +20,33 @@ export namespace FileTime {
     const { read } = state()
     read[sessionID] = read[sessionID] || {}
     read[sessionID][file] = new Date()
+
+    Storage.write(["filetime", sessionID, Buffer.from(file).toString("base64url")], {
+      time: read[sessionID][file]!.toISOString(),
+      path: file,
+    }).catch(() => {})
   }
 
-  export function get(sessionID: string, file: string) {
-    return state().read[sessionID]?.[file]
+  export async function get(sessionID: string, file: string) {
+    const memTime = state().read[sessionID]?.[file]
+    if (memTime) return memTime
+    try {
+      const stored = await Storage.read<{ time: string; path: string }>(["filetime", sessionID, Buffer.from(file).toString("base64url")])
+      if (stored?.time) {
+        const date = new Date(stored.time)
+        const { read } = state()
+        read[sessionID] = read[sessionID] || {}
+        read[sessionID][file] = date
+        return date
+      }
+    } catch {
+      // Storage read failed, treat as not read
+    }
+    return undefined
   }
 
   export async function assert(sessionID: string, filepath: string) {
-    const time = get(sessionID, filepath)
+    const time = await get(sessionID, filepath)
     if (!time) throw new Error(`You must read the file ${filepath} before overwriting it. Use the Read tool first`)
     const stats = await Bun.file(filepath).stat()
     if (stats.mtime.getTime() > time.getTime()) {

--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -30,7 +30,22 @@ export namespace FileTime {
   export async function get(sessionID: string, file: string) {
     const memTime = state().read[sessionID]?.[file]
     if (memTime) return memTime
-    try {
+  export async function get(sessionID: string, file: string) {
+    const memTime = state().read[sessionID]?.[file]
+    if (memTime) return memTime
+    
+    const stored = await Storage.read<{ time: string; path: string }>(["filetime", sessionID, Buffer.from(file).toString("base64url")])
+      .catch(() => undefined)
+    
+    if (stored?.time) {
+      const date = new Date(stored.time)
+      const { read } = state()
+      read[sessionID] = read[sessionID] || {}
+      read[sessionID][file] = date
+      return date
+    }
+    return undefined
+  }
       const stored = await Storage.read<{ time: string; path: string }>(["filetime", sessionID, Buffer.from(file).toString("base64url")])
       if (stored?.time) {
         const date = new Date(stored.time)

--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -30,32 +30,19 @@ export namespace FileTime {
   export async function get(sessionID: string, file: string) {
     const memTime = state().read[sessionID]?.[file]
     if (memTime) return memTime
-  export async function get(sessionID: string, file: string) {
-    const memTime = state().read[sessionID]?.[file]
-    if (memTime) return memTime
-    
-    const stored = await Storage.read<{ time: string; path: string }>(["filetime", sessionID, Buffer.from(file).toString("base64url")])
-      .catch(() => undefined)
-    
+
+    const stored = await Storage.read<{ time: string; path: string }>([
+      "filetime",
+      sessionID,
+      Buffer.from(file).toString("base64url"),
+    ]).catch(() => undefined)
+
     if (stored?.time) {
       const date = new Date(stored.time)
       const { read } = state()
       read[sessionID] = read[sessionID] || {}
       read[sessionID][file] = date
       return date
-    }
-    return undefined
-  }
-      const stored = await Storage.read<{ time: string; path: string }>(["filetime", sessionID, Buffer.from(file).toString("base64url")])
-      if (stored?.time) {
-        const date = new Date(stored.time)
-        const { read } = state()
-        read[sessionID] = read[sessionID] || {}
-        read[sessionID][file] = date
-        return date
-      }
-    } catch {
-      // Storage read failed, treat as not read
     }
     return undefined
   }


### PR DESCRIPTION
#### Addressing Issue https://github.com/sst/opencode/issues/4406

File read content saved to disk associated timestamp existed beyond solely in memory. 

It would lead to double reads when you read a chat in a session -> kill it -> revisit the session and try to invoke write tool call

Steps to reproduce bug:
Read a file `read index.ts`
Exit via `ctrl + c`
Reinit your local -> bun dev
Go back to the session -> `bun dev` + `/session` (find session you just read `index.ts` in ) 

Ask it to `write a comment on top of index.ts` -> throws an error saying you didn't read it -> re-reads wastes tokens

Example: 
<img width="1728" height="1022" alt="Screenshot 2025-12-03 at 11 29 02 PM" src="https://github.com/user-attachments/assets/c56c895b-182b-484e-936a-5a98d258cd33" />

#### Solution: 

We are already persisting the read tool call output. However, we didn't have a way to know how when it happened. So,  we write to disk when the read time was. We were already doing the in memory check but added backup to persist across releases. 

<img width="1359" height="869" alt="Screenshot 2025-12-04 at 12 10 52 AM" src="https://github.com/user-attachments/assets/9b100d61-5151-43a3-abf8-a32ab863375a" />

#### Other Conditions I considered:

Changing a file between a save that you want to edit will STILL force a re-read (intended behaviour):
<img width="1358" height="816" alt="Screenshot 2025-12-04 at 12 01 55 AM" src="https://github.com/user-attachments/assets/4e81a830-36a6-4546-a612-0385f79db9d0" />
