### PR TITLE
feat: Add OPENCODE_DATA_DIR environment variable

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -13,6 +13,7 @@ export namespace Flag {
   export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
   export const OPENCODE_EXPERIMENTAL_BASH_MAX_OUTPUT_LENGTH =
     process.env["OPENCODE_EXPERIMENTAL_BASH_MAX_OUTPUT_LENGTH"]
+  export const OPENCODE_DATA_DIR = process.env["OPENCODE_DATA_DIR"]
 
   // Experimental
   export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL")

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -2,10 +2,11 @@ import fs from "fs/promises"
 import { xdgData, xdgCache, xdgConfig, xdgState } from "xdg-basedir"
 import path from "path"
 import os from "os"
+import { Flag } from "../flag/flag"
 
 const app = "opencode"
 
-const data = path.join(xdgData!, app)
+const data = Flag.OPENCODE_DATA_DIR || path.join(xdgData!, app)
 const cache = path.join(xdgCache!, app)
 const config = path.join(xdgConfig!, app)
 const state = path.join(xdgState!, app)

--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -28,6 +28,15 @@ opencode stores session data and other application data on disk at:
 - **macOS/Linux**: `~/.local/share/opencode/`
 - **Windows**: `%USERPROFILE%\.local\share\opencode`
 
+You can override this location using the `OPENCODE_DATA_DIR` environment variable:
+
+```bash
+export OPENCODE_DATA_DIR=/path/to/custom/opencode/storage-directory
+opencode
+```
+
+This will store all opencode data (sessions, auth, logs, etc.) in the specified directory.
+
 This directory contains:
 
 - `auth.json` - Authentication data like API keys, OAuth tokens


### PR DESCRIPTION
This allows overriding the default storage directory.