### PR TITLE
fix: support custom agent names for plan/build reminders

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1111,10 +1111,15 @@ export namespace SessionPrompt {
     }
   }
 
+  function hasAgentType(name: string, type: "plan" | "build"): boolean {
+    const pattern = new RegExp(`\\b${type}\\b`, "i")
+    return pattern.test(name)
+  }
+
   function insertReminders(input: { messages: MessageV2.WithParts[]; agent: Agent.Info }) {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
     if (!userMessage) return input.messages
-    if (input.agent.name === "plan") {
+    if (hasAgentType(input.agent.name, "plan")) {
       userMessage.parts.push({
         id: Identifier.ascending("part"),
         messageID: userMessage.info.id,
@@ -1125,8 +1130,8 @@ export namespace SessionPrompt {
         synthetic: true,
       })
     }
-    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.mode === "plan")
-    if (wasPlan && input.agent.name === "build") {
+    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && hasAgentType(msg.info.mode, "plan"))
+    if (wasPlan && hasAgentType(input.agent.name, "build")) {
       userMessage.parts.push({
         id: Identifier.ascending("part"),
         messageID: userMessage.info.id,


### PR DESCRIPTION
## Summary
- Fix plan/build agent reminder triggers to work with custom agent names
- Replace exact string matching with word boundary regex pattern matching
- Ensures users with custom agents containing "plan" or "build" receive proper context reminders

## Issue
The plan/build reminder system used exact string matching (`input.agent.name === "plan"` and `input.agent.name === "build"`), which completely bypassed important context for users with custom agents. Users with agents like "my-plan-agent" or "custom-build-helper" would never see the plan mode reminder or build-switch reminder, reducing the effectiveness of the agent switching system.

## Solution
- Added `hasAgentType()` helper function that uses word boundary regex matching
- Changed triggers from exact string matches to pattern matching for any agent name containing "plan" or "build" as whole words
- Applied the same logic to both current agent detection and previous message mode detection
- Maintains backward compatibility while extending support to custom agent names

## Impact
Users with custom plan/build agents will now correctly receive contextual reminders, improving the agent switching experience and ensuring important context is preserved across agent transitions.