### PR TITLE
Add keybindable commands to navigate between user messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -215,19 +215,21 @@ export function Session() {
       return visibleMessages.find((c) => c.y > scrollTop + 10)?.id ?? null
     }
     // Find last message above current position
-    return visibleMessages.reverse().find((c) => c.y < scrollTop - 10)?.id ?? null
+    return [...visibleMessages].reverse().find((c) => c.y < scrollTop - 10)?.id ?? null
   }
 
   // Helper: Scroll to message in direction or fallback to page scroll
-  const scrollToMessage = (direction: "next" | "prev", dialog: any) => {
+  const scrollToMessage = (direction: "next" | "prev", dialog: ReturnType<typeof useDialog>) => {
     const targetID = findNextVisibleMessage(direction)
-    if (targetID) {
-      const child = scroll.getChildren().find((c) => c.id === targetID)
-      if (child) scroll.scrollBy(child.y - scroll.y - 1)
+
+    if (!targetID) {
+      scroll.scrollBy(direction === "next" ? scroll.height : -scroll.height)
       dialog.clear()
       return
     }
-    scroll.scrollBy(direction === "next" ? scroll.height : -scroll.height)
+
+    const child = scroll.getChildren().find((c) => c.id === targetID)
+    if (child) scroll.scrollBy(child.y - scroll.y - 1)
     dialog.clear()
   }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -208,6 +208,19 @@ export function Session() {
     return visibleMessages.reverse().find((c) => c.y < scrollTop - 10)?.id ?? null
   }
 
+  // Helper: Scroll to message in direction or fallback to page scroll
+  const scrollToMessage = (direction: "next" | "prev", dialog: any) => {
+    const targetID = findNextVisibleMessage(direction)
+    if (targetID) {
+      const child = scroll.getChildren().find((c) => c.id === targetID)
+      if (child) scroll.scrollBy(child.y - scroll.y - 1)
+      dialog.clear()
+      return
+    }
+    scroll.scrollBy(direction === "next" ? scroll.height : -scroll.height)
+    dialog.clear()
+  }
+
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
 
@@ -618,17 +631,7 @@ export function Session() {
       keybind: "messages_next",
       category: "Session",
       disabled: true,
-      onSelect: (dialog) => {
-        const targetID = findNextVisibleMessage("next")
-        if (targetID) {
-          const child = scroll.getChildren().find((c) => c.id === targetID)
-          if (child) scroll.scrollBy(child.y - scroll.y - 1)
-          dialog.clear()
-          return
-        }
-        scroll.scrollBy(scroll.height)
-        dialog.clear()
-      },
+      onSelect: (dialog) => scrollToMessage("next", dialog),
     },
     {
       title: "Previous message",
@@ -636,17 +639,7 @@ export function Session() {
       keybind: "messages_previous",
       category: "Session",
       disabled: true,
-      onSelect: (dialog) => {
-        const targetID = findNextVisibleMessage("prev")
-        if (targetID) {
-          const child = scroll.getChildren().find((c) => c.id === targetID)
-          if (child) scroll.scrollBy(child.y - scroll.y - 1)
-          dialog.clear()
-          return
-        }
-        scroll.scrollBy(-scroll.height)
-        dialog.clear()
-      },
+      onSelect: (dialog) => scrollToMessage("prev", dialog),
     },
     {
       title: "Copy last assistant message",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -187,6 +187,27 @@ export function Session() {
   let prompt: PromptRef
   const keybind = useKeybind()
 
+  // Helper: Find next visible message boundary in direction
+  const findNextVisibleMessage = (direction: "next" | "prev"): string | null => {
+    const children = scroll.getChildren()
+    const messagesList = messages()
+    const scrollTop = scroll.y
+
+    // Get visible messages sorted by position
+    const visibleMessages = children
+      .filter((c) => c.id && messagesList.some((m) => m.id === c.id))
+      .sort((a, b) => a.y - b.y)
+
+    if (visibleMessages.length === 0) return null
+
+    if (direction === "next") {
+      // Find first message below current position
+      return visibleMessages.find((c) => c.y > scrollTop + 10)?.id ?? null
+    }
+    // Find last message above current position
+    return visibleMessages.reverse().find((c) => c.y < scrollTop - 10)?.id ?? null
+  }
+
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
 
@@ -589,6 +610,42 @@ export function Session() {
             break
           }
         }
+      },
+    },
+    {
+      title: "Next message",
+      value: "session.message.next",
+      keybind: "messages_next",
+      category: "Session",
+      disabled: true,
+      onSelect: (dialog) => {
+        const targetID = findNextVisibleMessage("next")
+        if (targetID) {
+          const child = scroll.getChildren().find((c) => c.id === targetID)
+          if (child) scroll.scrollBy(child.y - scroll.y - 1)
+          dialog.clear()
+          return
+        }
+        scroll.scrollBy(scroll.height)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous message",
+      value: "session.message.previous",
+      keybind: "messages_previous",
+      category: "Session",
+      disabled: true,
+      onSelect: (dialog) => {
+        const targetID = findNextVisibleMessage("prev")
+        if (targetID) {
+          const child = scroll.getChildren().find((c) => c.id === targetID)
+          if (child) scroll.scrollBy(child.y - scroll.y - 1)
+          dialog.clear()
+          return
+        }
+        scroll.scrollBy(-scroll.height)
+        dialog.clear()
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -193,9 +193,19 @@ export function Session() {
     const messagesList = messages()
     const scrollTop = scroll.y
 
-    // Get visible messages sorted by position
+    // Get visible messages sorted by position, filtering for valid non-synthetic, non-ignored content
     const visibleMessages = children
-      .filter((c) => c.id && messagesList.some((m) => m.id === c.id))
+      .filter((c) => {
+        if (!c.id) return false
+        const message = messagesList.find((m) => m.id === c.id)
+        if (!message) return false
+
+        // Check if message has valid non-synthetic, non-ignored text parts
+        const parts = sync.data.part[message.id]
+        if (!parts || !Array.isArray(parts)) return false
+
+        return parts.some((part) => part && part.type === "text" && !part.synthetic && !part.ignored)
+      })
       .sort((a, b) => a.y - b.y)
 
     if (visibleMessages.length === 0) return null

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -418,6 +418,8 @@ export namespace Config {
         .describe("Scroll messages down by half page"),
       messages_first: z.string().optional().default("ctrl+g,home").describe("Navigate to first message"),
       messages_last: z.string().optional().default("ctrl+alt+g,end").describe("Navigate to last message"),
+      messages_next: z.string().optional().default("none").describe("Navigate to next message"),
+      messages_previous: z.string().optional().default("none").describe("Navigate to previous message"),
       messages_last_user: z.string().optional().default("none").describe("Navigate to last user message"),
       messages_copy: z.string().optional().default("<leader>y").describe("Copy message"),
       messages_undo: z.string().optional().default("<leader>u").describe("Undo message"),

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -855,6 +855,14 @@ export type KeybindsConfig = {
    */
   messages_last?: string
   /**
+   * Navigate to next message
+   */
+  messages_next?: string
+  /**
+   * Navigate to previous message
+   */
+  messages_previous?: string
+  /**
    * Navigate to last user message
    */
   messages_last_user?: string

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -32,6 +32,8 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "messages_half_page_down": "ctrl+alt+d",
     "messages_first": "ctrl+g,home",
     "messages_last": "ctrl+alt+g,end",
+    "messages_next": "none",
+    "messages_previous": "none",
     "messages_copy": "<leader>y",
     "messages_undo": "<leader>u",
     "messages_redo": "<leader>r",


### PR DESCRIPTION
Closes #5077

Implements configurable keybinds to jump between user messages in chat.

- Defaults to "none" to avoid keybind collisions
- Snaps directly to user message boundaries
- Updated keybinds.mdx documentation