### PR TITLE
tui: wrap dialog option descriptions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -294,21 +294,19 @@ function Option(props: {
           ●
         </text>
       </Show>
-      <box flexGrow={1} flexDirection="column" paddingLeft={3}>
-        <text
-          fg={props.active ? fg : props.current ? theme.primary : theme.text}
-          attributes={props.active ? TextAttributes.BOLD : undefined}
-          overflow="hidden"
-          wrapMode="none"
-        >
-          {Locale.truncate(props.title, 62)}
-        </text>
+      <text
+        flexGrow={1}
+        fg={props.active ? fg : props.current ? theme.primary : theme.text}
+        attributes={props.active ? TextAttributes.BOLD : undefined}
+        overflow="hidden"
+        wrapMode="word"
+        paddingLeft={3}
+      >
+        {Locale.truncate(props.title, 62)}
         <Show when={props.description}>
-          <text fg={props.active ? fg : theme.textMuted} wrapMode="word" overflow="hidden">
-            {props.description}
-          </text>
+          <span style={{ fg: props.active ? fg : theme.textMuted }}> {props.description}</span>
         </Show>
-      </box>
+      </text>
       <Show when={props.footer}>
         <box flexShrink={0}>
           <text fg={props.active ? fg : theme.textMuted}>{props.footer}</text>

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -294,17 +294,21 @@ function Option(props: {
           ●
         </text>
       </Show>
-      <text
-        flexGrow={1}
-        fg={props.active ? fg : props.current ? theme.primary : theme.text}
-        attributes={props.active ? TextAttributes.BOLD : undefined}
-        overflow="hidden"
-        wrapMode="none"
-        paddingLeft={3}
-      >
-        {Locale.truncate(props.title, 62)}
-        <span style={{ fg: props.active ? fg : theme.textMuted }}> {props.description}</span>
-      </text>
+      <box flexGrow={1} flexDirection="column" paddingLeft={3}>
+        <text
+          fg={props.active ? fg : props.current ? theme.primary : theme.text}
+          attributes={props.active ? TextAttributes.BOLD : undefined}
+          overflow="hidden"
+          wrapMode="none"
+        >
+          {Locale.truncate(props.title, 62)}
+        </text>
+        <Show when={props.description}>
+          <text fg={props.active ? fg : theme.textMuted} wrapMode="word" overflow="hidden">
+            {props.description}
+          </text>
+        </Show>
+      </box>
       <Show when={props.footer}>
         <box flexShrink={0}>
           <text fg={props.active ? fg : theme.textMuted}>{props.footer}</text>


### PR DESCRIPTION
- Render dialog option descriptions on their own wrapped line; keep titles single-line truncated.
  - Tests: bun run --cwd packages/opencode typecheck; bun test --cwd packages/ opencode
