### PR TITLE
feat(grep): add timeout support with 60s default to prevent hangs when with very big directories

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { spawn } from "child_process"
 import { Tool } from "./tool"
 import { Ripgrep } from "../file/ripgrep"
 
@@ -6,6 +7,9 @@ import DESCRIPTION from "./grep.txt"
 import { Instance } from "../project/instance"
 
 const MAX_LINE_LENGTH = 2000
+const DEFAULT_TIMEOUT = 1 * 60 * 1000
+const MAX_TIMEOUT = 10 * 60 * 1000
+const SIGKILL_TIMEOUT_MS = 200
 
 export const GrepTool = Tool.define("grep", {
   description: DESCRIPTION,
@@ -13,11 +17,16 @@ export const GrepTool = Tool.define("grep", {
     pattern: z.string().describe("The regex pattern to search for in file contents"),
     path: z.string().optional().describe("The directory to search in. Defaults to the current working directory."),
     include: z.string().optional().describe('File pattern to include in the search (e.g. "*.js", "*.{ts,tsx}")'),
+    timeout: z.number().describe("Optional timeout in milliseconds").optional(),
   }),
-  async execute(params) {
+  async execute(params, ctx) {
     if (!params.pattern) {
       throw new Error("pattern is required")
     }
+    if (params.timeout !== undefined && params.timeout < 0) {
+      throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
+    }
+    const timeout = Math.min(params.timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT)
 
     const searchPath = params.path || Instance.directory
 
@@ -28,19 +37,111 @@ export const GrepTool = Tool.define("grep", {
     }
     args.push(searchPath)
 
-    const proc = Bun.spawn([rgPath, ...args], {
-      stdout: "pipe",
-      stderr: "pipe",
+    const proc = spawn(rgPath, args, {
+      cwd: Instance.directory,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
     })
 
-    const output = await new Response(proc.stdout).text()
-    const errorOutput = await new Response(proc.stderr).text()
-    const exitCode = await proc.exited
+    let output = ""
+    let errorOutput = ""
+    let timedOut = false
+    let aborted = false
+    let exited = false
+
+    const killTree = async () => {
+      const pid = proc.pid
+      if (!pid || exited) {
+        return
+      }
+
+      if (process.platform === "win32") {
+        await new Promise<void>((resolve) => {
+          const killer = spawn("taskkill", ["/pid", String(pid), "/f", "/t"], { stdio: "ignore" })
+          killer.once("exit", resolve)
+          killer.once("error", () => resolve())
+        })
+        return
+      }
+
+      try {
+        process.kill(-pid, "SIGTERM")
+        await Bun.sleep(SIGKILL_TIMEOUT_MS)
+        if (!exited) {
+          process.kill(-pid, "SIGKILL")
+        }
+      } catch {
+        proc.kill("SIGTERM")
+        await Bun.sleep(SIGKILL_TIMEOUT_MS)
+        if (!exited) {
+          proc.kill("SIGKILL")
+        }
+      }
+    }
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      output += chunk.toString()
+    })
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      errorOutput += chunk.toString()
+    })
+
+    if (ctx.abort.aborted) {
+      aborted = true
+      await killTree()
+    }
+
+    const abortHandler = () => {
+      aborted = true
+      void killTree()
+    }
+
+    ctx.abort.addEventListener("abort", abortHandler, { once: true })
+
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true
+      void killTree()
+    }, timeout)
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(timeoutTimer)
+        ctx.abort.removeEventListener("abort", abortHandler)
+      }
+
+      proc.once("exit", (code) => {
+        exited = true
+        cleanup()
+        resolve(code)
+      })
+
+      proc.once("error", (error) => {
+        exited = true
+        cleanup()
+        reject(error)
+      })
+    })
+
+    if (aborted) {
+      return {
+        title: params.pattern,
+        metadata: { matches: 0, truncated: false, timedOut: false },
+        output: "<grep_metadata>\nCommand aborted by user\n</grep_metadata>\n\nNo files found",
+      }
+    }
+
+    if (timedOut) {
+      return {
+        title: params.pattern,
+        metadata: { matches: 0, truncated: false, timedOut: true },
+        output: `<grep_metadata>\nCommand terminated after exceeding timeout ${timeout} ms\n</grep_metadata>\n\nNo files found`,
+      }
+    }
 
     if (exitCode === 1) {
       return {
         title: params.pattern,
-        metadata: { matches: 0, truncated: false },
+        metadata: { matches: 0, truncated: false, timedOut: false },
         output: "No files found",
       }
     }
@@ -82,7 +183,7 @@ export const GrepTool = Tool.define("grep", {
     if (finalMatches.length === 0) {
       return {
         title: params.pattern,
-        metadata: { matches: 0, truncated: false },
+        metadata: { matches: 0, truncated: false, timedOut: false },
         output: "No files found",
       }
     }
@@ -113,6 +214,7 @@ export const GrepTool = Tool.define("grep", {
       metadata: {
         matches: finalMatches.length,
         truncated,
+        timedOut: false,
       },
       output: outputLines.join("\n"),
     }

--- a/packages/opencode/src/tool/grep.txt
+++ b/packages/opencode/src/tool/grep.txt
@@ -6,3 +6,4 @@
 - Use this tool when you need to find files containing specific patterns
 - If you need to identify/count the number of matches within files, use the Bash tool with `rg` (ripgrep) directly. Do NOT use `grep`.
 - When you are doing an open ended search that may require multiple rounds of globbing and grepping, use the Task tool instead
+- You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes). If not specified, searches will timeout after 60000ms (1 minute).

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { GrepTool } from "../../src/tool/grep"
+import { Instance } from "../../src/project/instance"
+
+const ctx = {
+  sessionID: "test",
+  messageID: "",
+  toolCallID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+}
+
+const grep = await GrepTool.init()
+const projectRoot = path.join(__dirname, "../..")
+
+describe("tool.grep", () => {
+  test("basic", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = await grep.execute(
+          {
+            pattern: "GrepTool",
+            path: path.join(projectRoot, "src/tool"),
+            include: "*.ts",
+          },
+          ctx,
+        )
+        expect(result.metadata.matches).toBeGreaterThan(0)
+        expect(result.output).toContain("GrepTool")
+      },
+    })
+  })
+
+  test("negative timeout throws error", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        await expect(
+          grep.execute(
+            {
+              pattern: "test",
+              timeout: -1,
+            },
+            ctx,
+          ),
+        ).rejects.toThrow("Invalid timeout value: -1. Timeout must be a positive number.")
+      },
+    })
+  })
+
+  test("timeout parameter", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = await grep.execute(
+          {
+            pattern: "GrepTool",
+            path: path.join(projectRoot, "src/tool"),
+            include: "*.ts",
+            timeout: 30000,
+          },
+          ctx,
+        )
+        expect(result.metadata.matches).toBeGreaterThan(0)
+      },
+    })
+  })
+
+  test("no matches", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = await grep.execute(
+          {
+            pattern: "thisPatternShouldNeverMatchAnything12345",
+            path: path.join(projectRoot, "src/tool"),
+          },
+          ctx,
+        )
+        expect(result.metadata.matches).toBe(0)
+        expect(result.output).toBe("No files found")
+      },
+    })
+  })
+})


### PR DESCRIPTION
Grep tool hangs indefinitely when searching large directories like node_modules because there's no timeout.

I've been using a custom made tool called 'SafeGrep' in my personal plugin ([oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)) that has hard-limit timeout thing, but figured this would be more useful in core.

Followed Bash tool's implementation and style:
- Add 60s default timeout (max 10min)
- Add abort signal handling

---

I assumed there would be related issues, but couldn't find any. This was quite annoying in my environment so I thought it was worth fixing—but if this is just my setup or if this PR is heading in the wrong direction, I'd appreciate any feedback!