### PR TITLE
feat(tui): add dynamic terminal window title

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -169,6 +169,26 @@ function App() {
     console.log(JSON.stringify(route.data))
   })
 
+  // Update terminal window title based on current route and session
+  createEffect(() => {
+    if (route.data.type === "home") {
+      renderer.setTerminalTitle("opencode")
+      return
+    }
+
+    if (route.data.type === "session") {
+      const session = sync.session.get(route.data.sessionID)
+      if (!session || SessionApi.isDefaultTitle(session.title)) {
+        renderer.setTerminalTitle("opencode")
+        return
+      }
+
+      // Truncate title to 40 chars max
+      const title = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
+      renderer.setTerminalTitle(`oc | ${title}`)
+    }
+  })
+
   const args = useArgs()
   onMount(() => {
     batch(() => {

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -7,6 +7,8 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
   init: (input: { onExit?: () => Promise<void> }) => {
     const renderer = useRenderer()
     return async (reason?: any) => {
+      // Reset window title before destroying renderer
+      renderer.setTerminalTitle("")
       renderer.destroy()
       await input.onExit?.()
       if (reason) {


### PR DESCRIPTION
## Summary

- Update terminal window title reactively based on current route and session state
- Show `opencode` on home screen or for sessions with default/new titles  
- Show `oc | {title}` for sessions with generated titles (truncated to 40 chars max)
- Reset window title on exit to restore terminal defaults

Uses the public `renderer.setTerminalTitle()` API from OpenTUI.