### PR TITLE
fix: #5064 ProviderInitError github-copilot-enterprise

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -490,6 +490,10 @@ export namespace Provider {
         ...githubCopilot,
         id: "github-copilot-enterprise",
         name: "GitHub Copilot Enterprise",
+        models: mapValues(githubCopilot.models, (model) => ({
+          ...model,
+          providerID: "github-copilot-enterprise",
+        })),
       }
     }
 


### PR DESCRIPTION
Fixes #5064.

When using GitHub Copilot Enterprise, the error occurred because models inherited from github-copilot had providerID: "github-copilot" instead of "github-copilot-enterprise". This caused `s.providers[model.providerID]` to return `undefined`.

Test:
````
bun dev run "test"
$ bun run --cwd packages/opencode --conditions=browser src/index.ts run test

It looks like you want to run the tests for this project. Based on the instructions in AGENTS.md, the correct command to run all tests is:

```bash
bun test
```

I will run this command now to execute all tests in the project and report the results.
````