### PR TITLE
fix: process queued messages after session interrupt

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -210,7 +210,7 @@ export namespace SessionPrompt {
   function start(sessionID: string) {
     const s = state()
     if (s[sessionID]) return
-    const loopId = Identifier.ascending("loop")
+    const loopId = ulid()
     const controller = new AbortController()
     s[sessionID] = {
       abort: controller,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -61,6 +61,7 @@ export namespace SessionPrompt {
         string,
         {
           abort: AbortController
+          loopId: string
           callbacks: {
             resolve(input: MessageV2.WithParts): void
             reject(): void
@@ -209,38 +210,56 @@ export namespace SessionPrompt {
   function start(sessionID: string) {
     const s = state()
     if (s[sessionID]) return
+    const loopId = Identifier.ascending("loop")
     const controller = new AbortController()
     s[sessionID] = {
       abort: controller,
+      loopId,
       callbacks: [],
     }
-    return controller.signal
+    return { signal: controller.signal, loopId }
   }
 
-  export function cancel(sessionID: string) {
-    log.info("cancel", { sessionID })
+  export function cancel(sessionID: string, loopId?: string) {
+    log.info("cancel", { sessionID, loopId })
     const s = state()
     const match = s[sessionID]
     if (!match) return
+    // If loopId is provided, only cancel if it matches the current loop
+    // This prevents the old loop's cleanup from aborting a newly started loop
+    if (loopId && match.loopId !== loopId) return
     match.abort.abort()
-    for (const item of match.callbacks) {
-      item.reject()
-    }
+    const pendingCallbacks = [...match.callbacks]
     delete s[sessionID]
     SessionStatus.set(sessionID, { type: "idle" })
-    return
+
+    // If there were queued requests, restart the loop to handle pending messages
+    if (pendingCallbacks.length > 0) {
+      loop(sessionID)
+        .then((result) => {
+          for (const cb of pendingCallbacks) {
+            cb.resolve(result)
+          }
+        })
+        .catch(() => {
+          for (const cb of pendingCallbacks) {
+            cb.reject()
+          }
+        })
+    }
   }
 
   export const loop = fn(Identifier.schema("session"), async (sessionID) => {
-    const abort = start(sessionID)
-    if (!abort) {
+    const startResult = start(sessionID)
+    if (!startResult) {
       return new Promise<MessageV2.WithParts>((resolve, reject) => {
         const callbacks = state()[sessionID].callbacks
         callbacks.push({ resolve, reject })
       })
     }
 
-    using _ = defer(() => cancel(sessionID))
+    const { signal: abort, loopId } = startResult
+    using _ = defer(() => cancel(sessionID, loopId))
 
     let step = 0
     while (true) {


### PR DESCRIPTION
## Issue

related #3543

## Problem

When interrupting a session that has queued messages, the queued messages would appear as "QUEUED" in the UI but never get processed. 

**Root cause:** When `cancel()` is called, it:
1. Aborts the current operation
2. Rejects all pending callbacks
3. Deletes session state
4. Sets status to idle

But user messages queued during the operation were already persisted to storage. After interrupt, no loop runs to process them.

## Solution

1. **Track loop instances with `loopId`** - Each loop gets a unique ID to distinguish it from other loops for the same session

2. **Restart loop after cancel if callbacks exist** - When `cancel()` is called and there are pending callbacks (queued messages), automatically restart the loop to process them

3. **Prevent race condition** - Pass `loopId` to the deferred cleanup so old loop's cleanup doesn't abort the newly started loop

## Changes

- Added `loopId` to session state tracking
- Modified `start()` to return both signal and loopId
- Modified `cancel()` to accept optional loopId and restart loop if pending callbacks exist
- Modified `loop()` to use loopId in deferred cleanup