### PR TITLE
fix: ensure Auth.all returns valid providers

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -35,16 +35,19 @@ export namespace Auth {
   const filepath = path.join(Global.Path.data, "auth.json")
 
   export async function get(providerID: string) {
-    const file = Bun.file(filepath)
-    return file
-      .json()
-      .catch(() => ({}))
-      .then((x) => x[providerID] as Info | undefined)
+    const auth = await all()
+    return auth[providerID]
   }
 
   export async function all(): Promise<Record<string, Info>> {
     const file = Bun.file(filepath)
-    return file.json().catch(() => ({}))
+    const data = await file.json().catch(() => ({} as Record<string, unknown>))
+    return Object.entries(data).reduce((acc, [key, value]) => {
+      const parsed = Info.safeParse(value)
+      if (!parsed.success) return acc
+      acc[key] = parsed.data
+      return acc
+    }, {} as Record<string, Info>)
   }
 
   export async function set(key: string, info: Info) {

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -29,13 +29,7 @@ export const AuthListCommand = cmd({
     const homedir = os.homedir()
     const displayPath = authPath.startsWith(homedir) ? authPath.replace(homedir, "~") : authPath
     prompts.intro(`Credentials ${UI.Style.TEXT_DIM}${displayPath}`)
-    const results = await Auth.all().then((all) =>
-      Object.entries(all).flatMap(([key, value]) => {
-        const parsed = Auth.Info.safeParse(value)
-        if (!parsed.success) return []
-        return [[key, parsed.data] as const]
-      }),
-    )
+    const results = Object.entries(await Auth.all())
     const database = await ModelsDev.get()
 
     for (const [providerID, result] of results) {

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -29,7 +29,13 @@ export const AuthListCommand = cmd({
     const homedir = os.homedir()
     const displayPath = authPath.startsWith(homedir) ? authPath.replace(homedir, "~") : authPath
     prompts.intro(`Credentials ${UI.Style.TEXT_DIM}${displayPath}`)
-    const results = await Auth.all().then((x) => Object.entries(x))
+    const results = await Auth.all().then((all) =>
+      Object.entries(all).flatMap(([key, value]) => {
+        const parsed = Auth.Info.safeParse(value)
+        if (!parsed.success) return []
+        return [[key, parsed.data] as const]
+      }),
+    )
     const database = await ModelsDev.get()
 
     for (const [providerID, result] of results) {


### PR DESCRIPTION
Only list credentials that validate against Auth.Info; skip $schema and other metadata keys so no “undefined” rows appear.
