### PR TITLE
tweak: update description to lowercase for ACP command (to be consistent with other commands)

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -17,7 +17,7 @@ process.on("unhandledRejection", (reason, promise) => {
 
 export const AcpCommand = cmd({
   command: "acp",
-  describe: "Start ACP (Agent Client Protocol) server",
+  describe: "start ACP (Agent Client Protocol) server",
   builder: (yargs) => {
     return yargs
       .option("cwd", {


### PR DESCRIPTION
Sorry this was really really irking me and triggering OCD.

Before:
<img width="932" height="1030" alt="Screenshot From 2025-12-05 22-50-48" src="https://github.com/user-attachments/assets/e9948069-da43-44d1-9929-4859d3ef3d59" />
