### PR TITLE
feat(openai): promptCacheRetention settings

### DIFF
--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-language-model.ts
@@ -289,6 +289,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       service_tier: openaiOptions?.serviceTier,
       include,
       prompt_cache_key: openaiOptions?.promptCacheKey,
+      prompt_cache_retention: openaiOptions?.promptCacheRetention,
       safety_identifier: openaiOptions?.safetyIdentifier,
       top_logprobs: topLogprobs,
 
@@ -1700,6 +1701,7 @@ const openaiResponsesProviderOptionsSchema = z.object({
   parallelToolCalls: z.boolean().nullish(),
   previousResponseId: z.string().nullish(),
   promptCacheKey: z.string().nullish(),
+  promptCacheRetention: z.enum(["in_memory", "24h"]).nullish(),
   reasoningEffort: z.string().nullish(),
   reasoningSummary: z.string().nullish(),
   safetyIdentifier: z.string().nullish(),

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -81,6 +81,7 @@ You can globally configure a model's options through the config.
             "reasoningEffort": "high",
             "textVerbosity": "low",
             "reasoningSummary": "auto",
+            "promptCacheRetention": "24h",
             "include": ["reasoning.encrypted_content"],
           },
         },


### PR DESCRIPTION
https://platform.openai.com/docs/guides/prompt-caching#extended-prompt-cache-retention

Wanted a way to add the `24h` extended prompt caching when using OpenAI through API key. 

Not sure if should warn the user if they are using a model that doesn't support it. But it is a power user feature so they hopefully know what they are doing.

On the docs it supports only the following models: 
gpt-5.1
gpt-5.1-codex
gpt-5.1-codex-mini
gpt-5.1-chat-latest
gpt-5
gpt-5-codex
gpt-4.1

But these are already outdated (ex: gpt-5.1-codex-max), so I have left any warnings to be up to the user.

Verified via mitmproxy:
<img width="669" height="841" alt="image" src="https://github.com/user-attachments/assets/dc0f9505-a6fc-42c3-a081-de969bba21f7" />
