### PR TITLE
feat: add options for bash timeout

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -195,6 +195,7 @@ export namespace Agent {
         permission,
         color,
         maxSteps,
+        bash,
         ...extra
       } = value
       item.options = {
@@ -217,6 +218,14 @@ export namespace Agent {
       if (top_p != undefined) item.topP = top_p
       if (mode) item.mode = mode
       if (color) item.color = color
+      if (bash) {
+        if (bash.timeout != undefined) {
+          item.options.bash_timeout = bash.timeout
+        }
+        if (bash.timeout_max != undefined) {
+          item.options.bash_timeout_max = bash.timeout_max
+        }
+      }
       // just here for consistency & to prevent it from being added as an option
       if (name) item.name = name
       if (maxSteps != undefined) item.maxSteps = maxSteps

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -222,9 +222,6 @@ export namespace Agent {
         if (bash.timeout != undefined) {
           item.options.bash_timeout = bash.timeout
         }
-        if (bash.timeout_max != undefined) {
-          item.options.bash_timeout_max = bash.timeout_max
-        }
       }
       // just here for consistency & to prevent it from being added as an option
       if (name) item.name = name

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -392,15 +392,6 @@ export namespace Config {
             .describe(
               "Timeout in milliseconds for bash commands executed by this agent. The actual timeout will be the greater of this value and any timeout specified in the command. Must be between 1 and 600000 (10 minutes). If not specified, defaults to 60000 (1 minute).",
             ),
-          timeout_max: z
-            .number()
-            .int()
-            .positive()
-            .max(600000)
-            .optional()
-            .describe(
-              "Maximum timeout in milliseconds for bash commands executed by this agent. Commands will be capped at this value even if a longer timeout is requested. Must be between 1 and 600000 (10 minutes). If not specified, defaults to 600000 (10 minutes).",
-            ),
         })
         .optional(),
       permission: z

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -381,6 +381,28 @@ export namespace Config {
         .positive()
         .optional()
         .describe("Maximum number of agentic iterations before forcing text-only response"),
+      bash: z
+        .object({
+          timeout: z
+            .number()
+            .int()
+            .positive()
+            .max(600000)
+            .optional()
+            .describe(
+              "Timeout in milliseconds for bash commands executed by this agent. The actual timeout will be the greater of this value and any timeout specified in the command. Must be between 1 and 600000 (10 minutes). If not specified, defaults to 60000 (1 minute).",
+            ),
+          timeout_max: z
+            .number()
+            .int()
+            .positive()
+            .max(600000)
+            .optional()
+            .describe(
+              "Maximum timeout in milliseconds for bash commands executed by this agent. Commands will be capped at this value even if a longer timeout is requested. Must be between 1 and 600000 (10 minutes). If not specified, defaults to 600000 (10 minutes).",
+            ),
+        })
+        .optional(),
       permission: z
         .object({
           edit: Permission.optional(),

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -106,7 +106,6 @@ export const BashTool = Tool.define("bash", async () => {
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
-      const timeout = params.timeout ?? DEFAULT_TIMEOUT
       const tree = await parser().then((p) => p.parse(params.command))
       if (!tree) {
         throw new Error("Failed to parse command")
@@ -144,6 +143,14 @@ export const BashTool = Tool.define("bash", async () => {
       await checkExternalDirectory(cwd)
 
       const permissions = agent.permission.bash
+      const agentBashTimeout = agent.options.bash_timeout as number | undefined
+      const agentBashTimeoutMax = agent.options.bash_timeout_max as number | undefined
+      const defaultTimeout = agentBashTimeout ?? DEFAULT_TIMEOUT
+      const maxTimeout = agentBashTimeoutMax ?? MAX_TIMEOUT
+      // Take the greater of defaultTimeout and params.timeout (if provided)
+      const baseTimeout = params.timeout !== undefined ? Math.max(defaultTimeout, params.timeout) : defaultTimeout
+      // Cap at maxTimeout
+      const timeout = Math.min(baseTimeout, maxTimeout)
 
       const askPatterns = new Set<string>()
       for (const node of tree.rootNode.descendantsOfType("command")) {
@@ -242,6 +249,7 @@ export const BashTool = Tool.define("bash", async () => {
         metadata: {
           output: "",
           description: params.description,
+          timeout,
         },
       })
 
@@ -356,6 +364,7 @@ export const BashTool = Tool.define("bash", async () => {
           output,
           exit: proc.exitCode,
           description: params.description,
+          timeout,
         },
         output,
       }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -144,13 +144,8 @@ export const BashTool = Tool.define("bash", async () => {
 
       const permissions = agent.permission.bash
       const agentBashTimeout = agent.options.bash_timeout as number | undefined
-      const agentBashTimeoutMax = agent.options.bash_timeout_max as number | undefined
       const defaultTimeout = agentBashTimeout ?? DEFAULT_TIMEOUT
-      const maxTimeout = agentBashTimeoutMax ?? MAX_TIMEOUT
-      // Take the greater of defaultTimeout and params.timeout (if provided)
-      const baseTimeout = params.timeout !== undefined ? Math.max(defaultTimeout, params.timeout) : defaultTimeout
-      // Cap at maxTimeout
-      const timeout = Math.min(baseTimeout, maxTimeout)
+      const timeout = params.timeout !== undefined ? Math.max(defaultTimeout, params.timeout) : defaultTimeout
 
       const askPatterns = new Set<string>()
       for (const node of tree.rootNode.descendantsOfType("command")) {

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -18,7 +18,7 @@ Before executing the command, please follow these steps:
 
 Usage notes:
   - The command argument is required.
-  - You can specify an optional timeout in milliseconds. If not specified, commands will timeout after 120000ms (2 minutes). Use the `timeout` parameter to control execution time.
+  - You can specify an optional timeout in milliseconds. If not specified, commands will timeout after 120000ms (2 minutes). Use bash.timeout and bash.timeout_max in agent properties to change.
   - The `workdir` parameter specifies the working directory for the command. Defaults to the current working directory. Prefer setting `workdir` over using `cd` in your commands.
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds 30000 characters, output will be truncated before being returned to you.

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -18,7 +18,7 @@ Before executing the command, please follow these steps:
 
 Usage notes:
   - The command argument is required.
-  - You can specify an optional timeout in milliseconds. If not specified, commands will timeout after 120000ms (2 minutes). Use bash.timeout and bash.timeout_max in agent properties to change.
+  - You can specify an optional timeout in milliseconds. If not specified, commands will timeout after 120000ms (2 minutes). Use setting `bash.timeout` to set the minimum.
   - The `workdir` parameter specifies the working directory for the command. Defaults to the current working directory. Prefer setting `workdir` over using `cd` in your commands.
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds 30000 characters, output will be truncated before being returned to you.

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -40,17 +40,12 @@ describe("tool.bash", () => {
     {
       name: "loads bash.timeout from agent config",
       config: { timeout: 5000 },
-      expected: { bash_timeout: 5000, bash_timeout_max: undefined },
+      expected: { bash_timeout: 5000 },
     },
     {
-      name: "loads bash.timeout_max from agent config",
-      config: { timeout_max: 300000 },
-      expected: { bash_timeout: undefined, bash_timeout_max: 300000 },
-    },
-    {
-      name: "loads both bash.timeout and bash.timeout_max from agent config",
-      config: { timeout: 10000, timeout_max: 200000 },
-      expected: { bash_timeout: 10000, bash_timeout_max: 200000 },
+      name: "loads bash.timeout from agent config with higher value",
+      config: { timeout: 300000 },
+      expected: { bash_timeout: 300000 },
     },
   ])("$name", async ({ config, expected }) => {
     await using tmp = await tmpdir({
@@ -75,9 +70,6 @@ describe("tool.bash", () => {
         if (expected.bash_timeout !== undefined) {
           expect(agent.options.bash_timeout).toBe(expected.bash_timeout)
         }
-        if (expected.bash_timeout_max !== undefined) {
-          expect(agent.options.bash_timeout_max).toBe(expected.bash_timeout_max)
-        }
       },
     })
   })
@@ -85,25 +77,25 @@ describe("tool.bash", () => {
   test.each([
     {
       name: "uses configured bash.timeout when no params.timeout specified",
-      config: { timeout: 5000, timeout_max: 100000 },
+      config: { timeout: 5000 },
       params: {},
       expectedTimeout: 5000,
     },
     {
       name: "uses max of bash.timeout and params.timeout",
-      config: { timeout: 5000, timeout_max: 100000 },
+      config: { timeout: 5000 },
       params: { timeout: 30000 },
       expectedTimeout: 30000,
     },
     {
-      name: "caps timeout at bash.timeout_max",
-      config: { timeout: 5000, timeout_max: 10000 },
-      params: { timeout: 50000 },
-      expectedTimeout: 10000,
+      name: "allows params.timeout to exceed bash.timeout",
+      config: { timeout: 5000 },
+      params: { timeout: 500000 },
+      expectedTimeout: 500000,
     },
     {
       name: "enforces bash.timeout as minimum",
-      config: { timeout: 10000, timeout_max: 100000 },
+      config: { timeout: 10000 },
       params: { timeout: 2000 },
       expectedTimeout: 10000,
     },
@@ -126,6 +118,7 @@ describe("tool.bash", () => {
     await Instance.provide({
       directory: tmp.path,
       fn: async () => {
+        const bash = await BashTool.init()
         const result = await bash.execute(
           {
             command: "echo 'timeout test'",

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -3,6 +3,8 @@ import path from "path"
 import { BashTool } from "../../src/tool/bash"
 import { Instance } from "../../src/project/instance"
 import { Permission } from "../../src/permission"
+import { Agent } from "../../src/agent/agent"
+import { tmpdir } from "../fixture/fixture"
 
 const ctx = {
   sessionID: "test",
@@ -30,6 +32,110 @@ describe("tool.bash", () => {
         )
         expect(result.metadata.exit).toBe(0)
         expect(result.metadata.output).toContain("test")
+      },
+    })
+  })
+
+  test.each([
+    {
+      name: "loads bash.timeout from agent config",
+      config: { timeout: 5000 },
+      expected: { bash_timeout: 5000, bash_timeout_max: undefined },
+    },
+    {
+      name: "loads bash.timeout_max from agent config",
+      config: { timeout_max: 300000 },
+      expected: { bash_timeout: undefined, bash_timeout_max: 300000 },
+    },
+    {
+      name: "loads both bash.timeout and bash.timeout_max from agent config",
+      config: { timeout: 10000, timeout_max: 200000 },
+      expected: { bash_timeout: 10000, bash_timeout_max: 200000 },
+    },
+  ])("$name", async ({ config, expected }) => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            agent: {
+              build: {
+                bash: config,
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const agent = await Agent.get("build")
+        if (expected.bash_timeout !== undefined) {
+          expect(agent.options.bash_timeout).toBe(expected.bash_timeout)
+        }
+        if (expected.bash_timeout_max !== undefined) {
+          expect(agent.options.bash_timeout_max).toBe(expected.bash_timeout_max)
+        }
+      },
+    })
+  })
+
+  test.each([
+    {
+      name: "uses configured bash.timeout when no params.timeout specified",
+      config: { timeout: 5000, timeout_max: 100000 },
+      params: {},
+      expectedTimeout: 5000,
+    },
+    {
+      name: "uses max of bash.timeout and params.timeout",
+      config: { timeout: 5000, timeout_max: 100000 },
+      params: { timeout: 30000 },
+      expectedTimeout: 30000,
+    },
+    {
+      name: "caps timeout at bash.timeout_max",
+      config: { timeout: 5000, timeout_max: 10000 },
+      params: { timeout: 50000 },
+      expectedTimeout: 10000,
+    },
+    {
+      name: "enforces bash.timeout as minimum",
+      config: { timeout: 10000, timeout_max: 100000 },
+      params: { timeout: 2000 },
+      expectedTimeout: 10000,
+    },
+  ])("$name", async ({ config, params, expectedTimeout }) => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            agent: {
+              build: {
+                bash: config,
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const result = await bash.execute(
+          {
+            command: "echo 'timeout test'",
+            description: "Test timeout calculation",
+            ...params,
+          },
+          ctx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.timeout).toBe(expectedTimeout)
       },
     })
   })

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -386,8 +386,7 @@ Control timeout settings for bash commands executed by this agent using the `bas
   "agent": {
     "build": {
       "bash": {
-        "timeout": 120000,
-        "timeout_max": 300000
+        "timeout": 300000
       }
     }
   }
@@ -397,7 +396,6 @@ Control timeout settings for bash commands executed by this agent using the `bas
 **Options:**
 
 - `bash.timeout` - Timeout in milliseconds. Commands requesting shorter timeouts will use this value instead. Defaults to 60000ms (1 minute) if not specified.
-- `bash.timeout_max` - Maximum timeout in milliseconds. All commands are capped at this value, even if a longer timeout is requested. Defaults to 600000ms (10 minutes) if not specified.
 
 ---
 

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -376,6 +376,31 @@ You can also use wildcards to control multiple tools at once. For example, to di
 
 ---
 
+### Bash Timeout
+
+Control timeout settings for bash commands executed by this agent using the `bash` configuration object.
+
+```json title="opencode.json" {3-8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "build": {
+      "bash": {
+        "timeout": 120000,
+        "timeout_max": 300000
+      }
+    }
+  }
+}
+```
+
+**Options:**
+
+- `bash.timeout` - Timeout in milliseconds. Commands requesting shorter timeouts will use this value instead. Defaults to 60000ms (1 minute) if not specified.
+- `bash.timeout_max` - Maximum timeout in milliseconds. All commands are capped at this value, even if a longer timeout is requested. Defaults to 600000ms (10 minutes) if not specified.
+
+---
+
 ### Permissions
 
 You can configure permissions to manage what actions an agent can take. Currently, the permissions for the `edit`, `bash`, and `webfetch` tools can be configured to:


### PR DESCRIPTION
# Summary

**Added per-agent bash timeout configuration to support long-running builds and tests.**

When working on large projects, the default bash timeout was insufficient for compilation and test suites. This change allows configuring minimum and maximum timeouts per agent:

```jsonc
{
  "agent": {
    "build": {
      "bash": {
        "timeout": 120000, // 2 min minimum (default: 60s)
        "timeout_max": 600000, // 10 min maximum (default: 10min)
      },
    },
  },
}
```

The timeout calculation ensures commands get at least the configured minimum while respecting the maximum cap: `timeout = min(max(bash.timeout, params.timeout), bash.timeout_max)`
