### PR TITLE
fix(cli): prevent help text wrapping

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -42,6 +42,7 @@ process.on("uncaughtException", (e) => {
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")
+  .wrap(null)
   .help("help", "show help")
   .alias("help", "h")
   .version("version", "show version number", Installation.VERSION)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -42,7 +42,7 @@ process.on("uncaughtException", (e) => {
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")
-  .wrap(null)
+  .wrap(100)
   .help("help", "show help")
   .alias("help", "h")
   .version("version", "show version number", Installation.VERSION)


### PR DESCRIPTION
## Overview

The current `opencode -h` wraps unnecessarily in a few places ( opencode upgrade [target], opencode pr <number>, --log-level) due to yargs default width:

<img width="684" height="634" alt="Screenshot 2025-12-06 at 5 31 00 PM" src="https://github.com/user-attachments/assets/15255f01-93a5-4d8e-8efe-500cbcb548f4" />

This makes it harder to skim the text.

## Proposed fix

Set `.wrap(null)` on yargs to prevent wrapping.

<img width="758" height="590" alt="Screenshot 2025-12-06 at 5 32 38 PM" src="https://github.com/user-attachments/assets/9d65b184-52d0-4b05-80e7-ee5dbbf46303" />

The potential drawback here is that the type/choices don't align neatly on the right, but personally I find it easier to read without that alignment.

An alternate solution is to just hardcode the number of cols to wrap on, eg here is `.wrap(120)`
<img width="973" height="585" alt="Screenshot 2025-12-06 at 5 34 38 PM" src="https://github.com/user-attachments/assets/190d4b1e-e29a-452b-8115-1f1bcc6dbfe0" />

This preserves the right alignment of types/choices but is more brittle.