### PR TITLE
fix: improve sidebar working directory colour contrast with modified files (resolves #5184

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -248,7 +248,7 @@ export function Sidebar(props: { sessionID: string }) {
           </box>
         </scrollbox>
 
-        <box flexShrink={0} gap={1}>
+        <box flexShrink={0} gap={1} paddingTop={1}>
           <Show when={!hasProviders()}>
             <box
               backgroundColor={theme.backgroundElement}
@@ -275,7 +275,7 @@ export function Sidebar(props: { sessionID: string }) {
               </box>
             </box>
           </Show>
-          <text fg={theme.textMuted}>{directory()}</text>
+          <text fg={theme.text}>{directory()}</text>
           <text fg={theme.textMuted}>
             <span style={{ fg: theme.success }}>•</span> <b>Open</b>
             <span style={{ fg: theme.text }}>


### PR DESCRIPTION
Changes the colour used to display the current working directory in the sidebar from `mutedText` to `success`, making the working directory more visually distinct from the modified files displayed above it. In most of the stock themes, `text` seems to be a color that has sufficient contrast to be visually distinguished easily from `textMuted`.

## Examples in some of the stock themes

### Cobalt
With this PR:
<img width="296" height="685" alt="cobalt after Screenshot 2025-12-07 at 8 03 25 AM" src="https://github.com/user-attachments/assets/54aa909c-1b7a-4989-a614-36f07ed1bc18" />
Before this PR:
<img width="304" height="689" alt="cobalt before Screenshot 2025-12-07 at 8 03 45 AM" src="https://github.com/user-attachments/assets/cff5afc8-404c-4c2d-b8c4-e5e96b36d1a3" />

### Matrix
With this PR:
<img width="297" height="693" alt="matrix after Screenshot 2025-12-07 at 8 05 18 AM" src="https://github.com/user-attachments/assets/9d209901-3bd4-4ccb-9306-dc90ab4346c2" />
Before this PR:
<img width="296" height="689" alt="matrix before Screenshot 2025-12-07 at 8 05 32 AM" src="https://github.com/user-attachments/assets/fd0c6533-0bf7-4b31-befc-ff60bfb3718b" />

### Catpuccin
With this PR:
<img width="294" height="693" alt="catp after Screenshot 2025-12-07 at 8 01 11 AM" src="https://github.com/user-attachments/assets/1ef77ffb-aaf0-404b-98f9-2e6412a76539" />
Before this PR:
<img width="289" height="689" alt="catp before Screenshot 2025-12-07 at 8 01 57 AM" src="https://github.com/user-attachments/assets/83e6c95a-adaf-4fd2-90fc-acf9ece1a538" />

Resolves #5184.