### PR TITLE
fix: use basename for shell detection to support non-standard paths

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -60,7 +60,8 @@ export const BashTool = Tool.define("bash", async () => {
   const shell = iife(() => {
     const s = process.env.SHELL
     if (s) {
-      if (!new Set(["/bin/fish", "/bin/nu", "/usr/bin/fish", "/usr/bin/nu"]).has(s)) {
+      const basename = path.basename(s);
+      if (!new Set(["fish", "nu"]).has(basename)) {
         return s
       }
     }


### PR DESCRIPTION
The shell exclusion check for fish and nu was hardcoded to specific paths (/bin/fish, /usr/bin/fish, etc.), which failed for users with shells installed in non-standard locations (e.g., /opt/homebrew/bin/fish, ~/.nix-profile/bin/nu).

Now uses path.basename() to check just the shell name regardless of install path.

Resolves: #5190