### PR TITLE
add ocamlformat support

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -255,3 +255,14 @@ export const dart: Info = {
     return Bun.which("dart") !== null
   },
 }
+
+export const ocamlformat: Info = {
+  name: "ocamlformat",
+  command: ["ocamlformat", "-i", "$FILE"],
+  extensions: [".ml", ".mli"],
+  async enabled() {
+    if (!Bun.which("ocamlformat")) return false
+    const items = await Filesystem.findUp(".ocamlformat", Instance.directory, Instance.worktree)
+    return items.length > 0
+  },
+}

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -11,22 +11,23 @@ OpenCode automatically formats files after they are written or edited using lang
 
 OpenCode comes with several built-in formatters for popular languages and frameworks. Below is a list of the formatters, supported file extensions, and commands or config options it needs.
 
-| Formatter      | Extensions                                                                                               | Requirements                            |
-| -------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| gofmt          | .go                                                                                                      | `gofmt` command available               |
-| mix            | .ex, .exs, .eex, .heex, .leex, .neex, .sface                                                             | `mix` command available                 |
-| prettier       | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://prettier.io/docs/en/index.html) | `prettier` dependency in `package.json` |
-| biome          | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://biomejs.dev/)                   | `biome.json(c)` config file             |
-| zig            | .zig, .zon                                                                                               | `zig` command available                 |
-| clang-format   | .c, .cpp, .h, .hpp, .ino, and [more](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config file             |
-| ktlint         | .kt, .kts                                                                                                | `ktlint` command available              |
-| ruff           | .py, .pyi                                                                                                | `ruff` command available with config    |
-| uv             | .py, .pyi                                                                                                | `uv` command available                  |
-| rubocop        | .rb, .rake, .gemspec, .ru                                                                                | `rubocop` command available             |
-| standardrb     | .rb, .rake, .gemspec, .ru                                                                                | `standardrb` command available          |
-| htmlbeautifier | .erb, .html.erb                                                                                          | `htmlbeautifier` command available      |
-| air            | .R                                                                                                       | `air` command available                 |
-| dart           | .dart                                                                                                    | `dart` command available                |
+| Formatter      | Extensions                                                                                               | Requirements                                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| gofmt          | .go                                                                                                      | `gofmt` command available                                      |
+| mix            | .ex, .exs, .eex, .heex, .leex, .neex, .sface                                                             | `mix` command available                                        |
+| prettier       | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://prettier.io/docs/en/index.html) | `prettier` dependency in `package.json`                        |
+| biome          | .js, .jsx, .ts, .tsx, .html, .css, .md, .json, .yaml, and [more](https://biomejs.dev/)                   | `biome.json(c)` config file                                    |
+| zig            | .zig, .zon                                                                                               | `zig` command available                                        |
+| clang-format   | .c, .cpp, .h, .hpp, .ino, and [more](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config file                                    |
+| ktlint         | .kt, .kts                                                                                                | `ktlint` command available                                     |
+| ruff           | .py, .pyi                                                                                                | `ruff` command available with config                           |
+| uv             | .py, .pyi                                                                                                | `uv` command available                                         |
+| rubocop        | .rb, .rake, .gemspec, .ru                                                                                | `rubocop` command available                                    |
+| standardrb     | .rb, .rake, .gemspec, .ru                                                                                | `standardrb` command available                                 |
+| htmlbeautifier | .erb, .html.erb                                                                                          | `htmlbeautifier` command available                             |
+| air            | .R                                                                                                       | `air` command available                                        |
+| dart           | .dart                                                                                                    | `dart` command available                                       |
+| ocamlformat    | .ml, .mli                                                                                                | `ocamlformat` command available and `.ocamlformat` config file |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 


### PR DESCRIPTION
Adds OCamlFormat as a built-in formatter.

Changes:
- Added `ocamlformat` formatter definition in `packages/opencode/src/format/formatter.ts`
- Updated formatter documentation in `packages/web/src/content/docs/formatters.mdx`