### PR TITLE
fix: apply provider filtering to /connect endpoint

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -143,7 +143,10 @@ export const AuthLoginCommand = cmd({
               map((x) => ({
                 label: x.name,
                 value: x.id,
-                hint: priority[x.id] <= 1 ? "recommended" : undefined,
+                hint: {
+                  opencode: "recommended",
+                  anthropic: "Claude Max or API key",
+                }[x.id],
               })),
             ),
             {


### PR DESCRIPTION
Respect disabled_providers and enabled_providers config when listing providers in /connect command, matching the behavior of auth login.