### PR TITLE
feat(tui): copy console logs to clipboard on click

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,6 +1,6 @@
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
-import { TextAttributes } from "@opentui/core"
+import { MouseParser, TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
 import { Installation } from "@/installation"
@@ -164,6 +164,30 @@ function App() {
   const sync = useSync()
   const exit = useExit()
   const promptRef = usePromptRef()
+
+  const [consoleOpen, setConsoleOpen] = createSignal(!!process.env["SHOW_CONSOLE"])
+
+  onMount(() => {
+    const parser = new MouseParser()
+    renderer.prependInputHandler((sequence: string) => {
+      if (!consoleOpen()) return false
+
+      const mouse = parser.parseMouseEvent(Buffer.from(sequence))
+      if (!mouse || mouse.type !== "up" || mouse.button !== 0) return false
+
+      const height = Math.floor(renderer.terminalHeight * 0.3)
+      if (mouse.y >= renderer.terminalHeight - height) {
+        const logs = renderer.console.getCachedLogs()
+        if (logs) {
+          Clipboard.copy(logs)
+            .then(() => toast.show({ message: "Console logs copied to clipboard", variant: "info" }))
+            .catch(() => toast.show({ message: "Failed to copy console logs", variant: "error" }))
+        }
+        return true
+      }
+      return false
+    })
+  })
 
   createEffect(() => {
     console.log(JSON.stringify(route.data))
@@ -391,9 +415,10 @@ function App() {
     {
       title: "Toggle console",
       category: "System",
-      value: "app.fps",
+      value: "app.console",
       onSelect: (dialog) => {
         renderer.console.toggle()
+        setConsoleOpen((v) => !v)
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -165,12 +165,19 @@ function App() {
   const exit = useExit()
   const promptRef = usePromptRef()
 
-  const [consoleOpen, setConsoleOpen] = createSignal(!!process.env["SHOW_CONSOLE"])
+  // Track console state to match opentui's 3-state toggle behavior:
+  // - hidden → show+focus (visible=true, focused=true)
+  // - visible+focused → hide (visible=false, focused=false)
+  // - visible+unfocused → focus (visible=true, focused=true)
+  const [consoleState, setConsoleState] = createSignal<{ visible: boolean; focused: boolean }>({
+    visible: !!process.env["SHOW_CONSOLE"],
+    focused: !!process.env["SHOW_CONSOLE"], // show() also focuses
+  })
 
   onMount(() => {
     const parser = new MouseParser()
     renderer.prependInputHandler((sequence: string) => {
-      if (!consoleOpen()) return false
+      if (!consoleState().visible) return false
 
       const mouse = parser.parseMouseEvent(Buffer.from(sequence))
       if (!mouse || mouse.type !== "up" || mouse.button !== 0) return false
@@ -418,7 +425,15 @@ function App() {
       value: "app.console",
       onSelect: (dialog) => {
         renderer.console.toggle()
-        setConsoleOpen((v) => !v)
+        // Mirror opentui's 3-state toggle behavior:
+        // visible+focused → hide, visible+unfocused → focus, hidden → show+focus
+        setConsoleState((s) => {
+          if (s.visible) {
+            if (s.focused) return { visible: false, focused: false }
+            return { visible: true, focused: true }
+          }
+          return { visible: true, focused: true }
+        })
         dialog.clear()
       },
     },


### PR DESCRIPTION
Closes #4885

When the debug console is visible, clicking anywhere on it copies all console logs to the clipboard and shows a toast notification.

**Changes:**
- Add mouse click handler for console area
- Track console visibility state
- Fix incorrect command value (`app.fps` → `app.console`)