### PR TITLE
feat: add bash-language-server LSP

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1184,4 +1184,43 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const BashLS: Info = {
+    id: "bash",
+    extensions: [".sh", ".bash", ".zsh", ".ksh"],
+    root: async () => Instance.directory,
+    async spawn(root) {
+      let binary = Bun.which("bash-language-server")
+      const args: string[] = []
+      if (!binary) {
+        const js = path.join(Global.Path.bin, "node_modules", "bash-language-server", "out", "cli.js")
+        if (!(await Bun.file(js).exists())) {
+          if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+          await Bun.spawn([BunProc.which(), "install", "bash-language-server"], {
+            cwd: Global.Path.bin,
+            env: {
+              ...process.env,
+              BUN_BE_BUN: "1",
+            },
+            stdout: "pipe",
+            stderr: "pipe",
+            stdin: "pipe",
+          }).exited
+        }
+        binary = BunProc.which()
+        args.push("run", js)
+      }
+      args.push("start")
+      const proc = spawn(binary, args, {
+        cwd: root,
+        env: {
+          ...process.env,
+          BUN_BE_BUN: "1",
+        },
+      })
+      return {
+        process: proc,
+      }
+    },
+  }
 }


### PR DESCRIPTION
Adds LSP support for shell scripts (.sh, .bash, .zsh, .ksh) using bash-language-server.

The server is auto-downloaded via bun if not found in PATH, following the same pattern as other Node-based language servers in the codebase.