### PR TITLE
feat: add texlab language server and latexindent formatter

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -275,3 +275,12 @@ export const terraform: Info = {
     return Bun.which("terraform") !== null
   },
 }
+
+export const latexindent: Info = {
+  name: "latexindent",
+  command: ["latexindent", "-w", "-s", "$FILE"],
+  extensions: [".tex"],
+  async enabled() {
+    return Bun.which("latexindent") !== null
+  },
+}

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1307,4 +1307,88 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const TexLab: Info = {
+    id: "texlab",
+    extensions: [".tex", ".bib"],
+    root: NearestRoot([".latexmkrc", "latexmkrc", ".texlabroot", "texlabroot"]),
+    async spawn(root) {
+      let bin = Bun.which("texlab", {
+        PATH: process.env["PATH"] + ":" + Global.Path.bin,
+      })
+
+      if (!bin) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+        log.info("downloading texlab from GitHub releases")
+
+        const response = await fetch("https://api.github.com/repos/latex-lsp/texlab/releases/latest")
+        if (!response.ok) {
+          log.error("Failed to fetch texlab release info")
+          return
+        }
+
+        const release = (await response.json()) as {
+          tag_name?: string
+          assets?: { name?: string; browser_download_url?: string }[]
+        }
+        const version = release.tag_name?.replace("v", "")
+        if (!version) {
+          log.error("texlab release did not include a version tag")
+          return
+        }
+
+        const platform = process.platform
+        const arch = process.arch
+
+        const texArch = arch === "arm64" ? "aarch64" : "x86_64"
+        const texPlatform = platform === "darwin" ? "macos" : platform === "win32" ? "windows" : "linux"
+        const ext = platform === "win32" ? "zip" : "tar.gz"
+        const assetName = `texlab-${texArch}-${texPlatform}.${ext}`
+
+        const assets = release.assets ?? []
+        const asset = assets.find((a) => a.name === assetName)
+        if (!asset?.browser_download_url) {
+          log.error(`Could not find asset ${assetName} in texlab release`)
+          return
+        }
+
+        const downloadResponse = await fetch(asset.browser_download_url)
+        if (!downloadResponse.ok) {
+          log.error("Failed to download texlab")
+          return
+        }
+
+        const tempPath = path.join(Global.Path.bin, assetName)
+        await Bun.file(tempPath).write(downloadResponse)
+
+        if (ext === "zip") {
+          await $`unzip -o -q ${tempPath}`.cwd(Global.Path.bin).nothrow()
+        }
+        if (ext === "tar.gz") {
+          await $`tar -xzf ${tempPath}`.cwd(Global.Path.bin).nothrow()
+        }
+
+        await fs.rm(tempPath, { force: true })
+
+        bin = path.join(Global.Path.bin, "texlab" + (platform === "win32" ? ".exe" : ""))
+
+        if (!(await Bun.file(bin).exists())) {
+          log.error("Failed to extract texlab binary")
+          return
+        }
+
+        if (platform !== "win32") {
+          await $`chmod +x ${bin}`.nothrow()
+        }
+
+        log.info("installed texlab", { bin })
+      }
+
+      return {
+        process: spawn(bin, {
+          cwd: root,
+        }),
+      }
+    },
+  }
 }


### PR DESCRIPTION
## Summary
Add LaTeX LSP support via TexLab language server.

## Changes
- Add TexLab LSP server with auto-download from GitHub releases
- Add latexindent formatter for .tex files

## Features
- Code completion for commands, environments, citations, references
- Hover documentation
- Go-to-definition for labels and citations
- Diagnostics via chktex (when installed)
- BibTeX support (.bib files)

## Files Modified
- `packages/opencode/src/lsp/server.ts` - Added TexLab LSP server
- `packages/opencode/src/format/formatter.ts` - Added latexindent formatter

## Tests Run
- `bun run typecheck` - Passed (opencode package)
- `bun test` - 255 passed, 1 skipped, 0 failed
- `bun dev --help` - Verified code compiles and runs
- Verified asset naming against actual texlab GitHub releases (confirmed correct):
  - `texlab-aarch64-macos.tar.gz`
  - `texlab-x86_64-macos.tar.gz`
  - `texlab-x86_64-linux.tar.gz`
  - `texlab-x86_64-windows.zip`