### PR TITLE
tui: persist agent/model per session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -1,5 +1,5 @@
-import { createStore } from "solid-js/store"
 import { batch, createEffect, createMemo } from "solid-js"
+import { createStore } from "solid-js/store"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
 import { uniqueBy } from "remeda"
@@ -12,7 +12,13 @@ import { Provider } from "@/provider/provider"
 import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
-import { readPrefs, writePrefs, type SessionPref } from "./session-pref"
+import type { SessionPref } from "./session-pref"
+
+type SessionPrefStore = {
+  get(sessionID: string): SessionPref | undefined
+  setAgent(sessionID: string, agent: string): void
+  setModel(sessionID: string, model: { providerID: string; modelID: string }): void
+}
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -21,33 +27,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sdk = useSDK()
     const toast = useToast()
 
-    const pref = iife(() => {
-      const [store, setStore] = createStore<Record<string, SessionPref>>({})
-
-      readPrefs()
-        .then((data) => {
-          setStore(() => data)
-        })
-        .catch(() => {})
-
-      function setSession(sessionID: string, value: SessionPref) {
-        const next = { ...store, [sessionID]: value }
-        setStore(next)
-        writePrefs(next)
-      }
-
-      return {
-        get(sessionID: string) {
-          return store[sessionID]
-        },
-        setAgent(sessionID: string, agent: string) {
-          setSession(sessionID, { ...(store[sessionID] ?? {}), agent })
-        },
-        setModel(sessionID: string, model: { providerID: string; modelID: string }) {
-          setSession(sessionID, { ...(store[sessionID] ?? {}), model })
-        },
-      }
-    })
+    const pref: SessionPrefStore = {
+      get() {
+        return undefined
+      },
+      setAgent() {},
+      setModel() {},
+    }
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((x) => x.id === model.providerID)

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -12,6 +12,7 @@ import { Provider } from "@/provider/provider"
 import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
+import { readPrefs, writePrefs, type SessionPref } from "./session-pref"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -19,6 +20,37 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const sync = useSync()
     const sdk = useSDK()
     const toast = useToast()
+
+    const pref = iife(() => {
+      const [store, setStore] = createStore<Record<string, SessionPref>>({})
+
+      readPrefs()
+        .then((data) => {
+          setStore(() => data)
+        })
+        .catch(() => {})
+
+      function snapshot() {
+        return JSON.parse(JSON.stringify(store)) as Record<string, SessionPref>
+      }
+
+      function setSession(sessionID: string, value: SessionPref) {
+        setStore(sessionID, value)
+        writePrefs(snapshot())
+      }
+
+      return {
+        get(sessionID: string) {
+          return store[sessionID]
+        },
+        setAgent(sessionID: string, agent: string) {
+          setSession(sessionID, { ...(store[sessionID] ?? {}), agent })
+        },
+        setModel(sessionID: string, model: { providerID: string; modelID: string }) {
+          setSession(sessionID, { ...(store[sessionID] ?? {}), model })
+        },
+      }
+    })
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((x) => x.id === model.providerID)
@@ -333,6 +365,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       model,
       agent,
       mcp,
+      pref,
     }
     return result
   },

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -30,13 +30,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         })
         .catch(() => {})
 
-      function snapshot() {
-        return JSON.parse(JSON.stringify(store)) as Record<string, SessionPref>
-      }
-
       function setSession(sessionID: string, value: SessionPref) {
-        setStore(sessionID, value)
-        writePrefs(snapshot())
+        const next = { ...store, [sessionID]: value }
+        setStore(next)
+        writePrefs(next)
       }
 
       return {

--- a/packages/opencode/src/cli/cmd/tui/context/session-pref.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/session-pref.ts
@@ -1,0 +1,24 @@
+import path from "path"
+import { Global } from "@/global"
+
+export type SessionPref = {
+  agent?: string
+  model?: {
+    providerID: string
+    modelID: string
+  }
+}
+
+const prefPath = process.env.OPENCODE_SESSION_PREF_PATH ?? path.join(Global.Path.state, "session-pref.json")
+const file = Bun.file(prefPath)
+
+export async function readPrefs(): Promise<Record<string, SessionPref>> {
+  return file
+    .json()
+    .then((data) => (data && typeof data === "object" ? (data as Record<string, SessionPref>) : {}))
+    .catch(() => ({}))
+}
+
+export async function writePrefs(prefs: Record<string, SessionPref>) {
+  await Bun.write(file, JSON.stringify(prefs, null, 2))
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -99,7 +99,6 @@ export function Session() {
   const { navigate } = useRoute()
   const sync = useSync()
   const local = useLocal()
-  const [lastSessionId, setLastSessionId] = createSignal<string | undefined>(undefined)
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
@@ -169,45 +168,18 @@ export function Session() {
     if (!sync.data.provider.length) return
     if (!sync.data.agent.length) return
     if (!local.model.ready) return
-    const next = route.sessionID
-
-    const lastWithPrefs = messages().findLast((m) => "agent" in m && "model" in m)
-    if (lastWithPrefs) {
-      const pref = lastWithPrefs as unknown as { agent?: string; model?: { providerID: string; modelID: string } }
-      const agent = pref.agent
-      const model = pref.model
-      if (agent && agent !== local.agent.current().name) local.agent.set(agent)
-      if (model && model !== local.model.current()) local.model.set(model)
-    } else {
-      const pref = local.pref.get(next)
-      if (pref?.agent) local.agent.set(pref.agent)
-      if (pref?.model) local.model.set(pref.model)
-      if (!pref?.agent) local.pref.setAgent(next, local.agent.current().name)
-      const currentModel = local.model.current()
-      if (!pref?.model && currentModel) local.pref.setModel(next, currentModel)
+    const last = messages().at(-1)
+    if (!last) return
+    const pref = last as { agent?: string; model?: { providerID: string; modelID: string } }
+    const agent = pref.agent
+    if (agent && agent !== local.agent.current().name) local.agent.set(agent)
+    const model = pref.model
+    if (model) {
+      const current = local.model.current()
+      const same = current && current.providerID === model.providerID && current.modelID === model.modelID
+      if (!same) local.model.set(model)
     }
-
-    setLastSessionId(next)
   })
-
-  createEffect(
-    on(
-      () => [route.sessionID, local.agent.current().name] as const,
-      ([sessionID, agentName]) => {
-        local.pref.setAgent(sessionID, agentName)
-      },
-    ),
-  )
-
-  createEffect(
-    on(
-      () => [route.sessionID, local.model.current()] as const,
-      ([sessionID, model]) => {
-        if (!model) return
-        local.pref.setModel(sessionID, model)
-      },
-    ),
-  )
 
   // Auto-navigate to whichever session currently needs permission input
   createEffect(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -99,7 +99,7 @@ export function Session() {
   const { navigate } = useRoute()
   const sync = useSync()
   const local = useLocal()
-  const lastSession = { id: undefined as string | undefined }
+  const [lastSessionId, setLastSessionId] = createSignal<string | undefined>(undefined)
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
@@ -164,7 +164,6 @@ export function Session() {
 
   const toast = useToast()
   const sdk = useSDK()
-  const [lastSessionId, setLastSessionId] = createSignal<string | undefined>(undefined)
 
   createEffect(() => {
     if (!sync.data.provider.length) return
@@ -172,19 +171,21 @@ export function Session() {
     if (!local.model.ready) return
     const next = route.sessionID
 
-    if (lastSessionId()) {
-      const prevAgent = local.agent.current().name
-      const prevModel = local.model.current()
-      local.pref.setAgent(lastSessionId()!, prevAgent)
-      if (prevModel) local.pref.setModel(lastSessionId()!, prevModel)
+    const lastWithPrefs = messages().findLast((m) => "agent" in m && "model" in m)
+    if (lastWithPrefs) {
+      const pref = lastWithPrefs as unknown as { agent?: string; model?: { providerID: string; modelID: string } }
+      const agent = pref.agent
+      const model = pref.model
+      if (agent && agent !== local.agent.current().name) local.agent.set(agent)
+      if (model && model !== local.model.current()) local.model.set(model)
+    } else {
+      const pref = local.pref.get(next)
+      if (pref?.agent) local.agent.set(pref.agent)
+      if (pref?.model) local.model.set(pref.model)
+      if (!pref?.agent) local.pref.setAgent(next, local.agent.current().name)
+      const currentModel = local.model.current()
+      if (!pref?.model && currentModel) local.pref.setModel(next, currentModel)
     }
-
-    const pref = local.pref.get(next)
-    if (pref?.agent) local.agent.set(pref.agent)
-    if (pref?.model) local.model.set(pref.model)
-    if (!pref?.agent) local.pref.setAgent(next, local.agent.current().name)
-    const currentModel = local.model.current()
-    if (!pref?.model && currentModel) local.pref.setModel(next, currentModel)
 
     setLastSessionId(next)
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -164,6 +164,7 @@ export function Session() {
 
   const toast = useToast()
   const sdk = useSDK()
+  const [lastSessionId, setLastSessionId] = createSignal<string | undefined>(undefined)
 
   createEffect(() => {
     if (!sync.data.provider.length) return
@@ -171,11 +172,11 @@ export function Session() {
     if (!local.model.ready) return
     const next = route.sessionID
 
-    if (lastSession.id) {
+    if (lastSessionId()) {
       const prevAgent = local.agent.current().name
       const prevModel = local.model.current()
-      local.pref.setAgent(lastSession.id, prevAgent)
-      if (prevModel) local.pref.setModel(lastSession.id, prevModel)
+      local.pref.setAgent(lastSessionId()!, prevAgent)
+      if (prevModel) local.pref.setModel(lastSessionId()!, prevModel)
     }
 
     const pref = local.pref.get(next)
@@ -185,7 +186,7 @@ export function Session() {
     const currentModel = local.model.current()
     if (!pref?.model && currentModel) local.pref.setModel(next, currentModel)
 
-    lastSession.id = next
+    setLastSessionId(next)
   })
 
   createEffect(

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -98,6 +98,8 @@ export function Session() {
   const route = useRouteData("session")
   const { navigate } = useRoute()
   const sync = useSync()
+  const local = useLocal()
+  const lastSession = { id: undefined as string | undefined }
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
@@ -163,6 +165,48 @@ export function Session() {
   const toast = useToast()
   const sdk = useSDK()
 
+  createEffect(() => {
+    if (!sync.data.provider.length) return
+    if (!sync.data.agent.length) return
+    if (!local.model.ready) return
+    const next = route.sessionID
+
+    if (lastSession.id) {
+      const prevAgent = local.agent.current().name
+      const prevModel = local.model.current()
+      local.pref.setAgent(lastSession.id, prevAgent)
+      if (prevModel) local.pref.setModel(lastSession.id, prevModel)
+    }
+
+    const pref = local.pref.get(next)
+    if (pref?.agent) local.agent.set(pref.agent)
+    if (pref?.model) local.model.set(pref.model)
+    if (!pref?.agent) local.pref.setAgent(next, local.agent.current().name)
+    const currentModel = local.model.current()
+    if (!pref?.model && currentModel) local.pref.setModel(next, currentModel)
+
+    lastSession.id = next
+  })
+
+  createEffect(
+    on(
+      () => [route.sessionID, local.agent.current().name] as const,
+      ([sessionID, agentName]) => {
+        local.pref.setAgent(sessionID, agentName)
+      },
+    ),
+  )
+
+  createEffect(
+    on(
+      () => [route.sessionID, local.model.current()] as const,
+      ([sessionID, model]) => {
+        if (!model) return
+        local.pref.setModel(sessionID, model)
+      },
+    ),
+  )
+
   // Auto-navigate to whichever session currently needs permission input
   createEffect(() => {
     const currentSession = session()
@@ -217,8 +261,6 @@ export function Session() {
       if (scroll) scroll.scrollTo(scroll.scrollHeight)
     }, 50)
   }
-
-  const local = useLocal()
 
   function moveChild(direction: number) {
     const parentID = session()?.parentID ?? session()?.id

--- a/packages/opencode/test/tui/session-pref.test.ts
+++ b/packages/opencode/test/tui/session-pref.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import fs from "fs/promises"
+
+describe("session pref storage", () => {
+  test("persists and reads per-session selections", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-pref-"))
+    process.env.OPENCODE_SESSION_PREF_PATH = path.join(dir, "prefs.json")
+
+    const pref = await import("../../src/cli/cmd/tui/context/session-pref")
+    const data = {
+      sessionA: {
+        agent: "Agent Alpha",
+        model: { providerID: "p1", modelID: "m1" },
+      },
+      sessionB: {
+        agent: "Agent Beta",
+      },
+    }
+
+    await pref.writePrefs(data)
+    const result = await pref.readPrefs()
+
+    expect(result.sessionA.agent).toBe("Agent Alpha")
+    expect(result.sessionA.model?.providerID).toBe("p1")
+    expect(result.sessionB.agent).toBe("Agent Beta")
+    expect(result.sessionB.model).toBeUndefined()
+
+    delete process.env.OPENCODE_SESSION_PREF_PATH
+    await fs.rm(dir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
- Per-session agent/model prefs are persisted and re-applied on every switch (old and new sessions).
- Prefs are saved when leaving a session and applied (or seeded) when entering the next session.
- New pref store file session-pref.json under state dir; unit test for round-trip.