### PR TITLE
feat(telemetry): Add userId and sessionId metadata to experimental_telemetry

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -245,7 +245,12 @@ export namespace Agent {
     system.push(PROMPT_GENERATE)
     const existing = await list()
     const result = await generateObject({
-      experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+      experimental_telemetry: {
+        isEnabled: cfg.experimental?.openTelemetry,
+        metadata: {
+          userId: cfg.username ?? "unknown",
+        },
+      },
       temperature: 0.3,
       prompt: [
         ...system.map(

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -192,7 +192,13 @@ export namespace SessionCompaction {
           },
         ],
       }),
-      experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+      experimental_telemetry: {
+        isEnabled: cfg.experimental?.openTelemetry,
+        metadata: {
+          userId: cfg.username ?? "unknown",
+          sessionId: input.sessionID,
+        },
+      },
     })
     if (result === "continue" && input.auto) {
       const continueMsg = await Session.updateMessage({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -628,7 +628,13 @@ export namespace SessionPrompt {
             },
           ],
         }),
-        experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+        experimental_telemetry: {
+          isEnabled: cfg.experimental?.openTelemetry,
+          metadata: {
+            userId: cfg.username ?? "unknown",
+            sessionId: sessionID,
+          },
+        },
       })
       if (result === "stop") break
       continue
@@ -1491,7 +1497,13 @@ export namespace SessionPrompt {
       ],
       headers: small.headers,
       model: language,
-      experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+      experimental_telemetry: {
+        isEnabled: cfg.experimental?.openTelemetry,
+        metadata: {
+          userId: cfg.username ?? "unknown",
+          sessionId: input.session.id,
+        },
+      },
     })
       .then((result) => {
         if (result.text)

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -111,7 +111,13 @@ export namespace SessionSummary {
         ],
         headers: small.headers,
         model: language,
-        experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+        experimental_telemetry: {
+          isEnabled: cfg.experimental?.openTelemetry,
+          metadata: {
+            userId: cfg.username ?? "unknown",
+            sessionId: assistantMsg.sessionID,
+          },
+        },
       })
       log.info("title", { title: result.text })
       userMsg.summary.title = result.text
@@ -153,7 +159,13 @@ export namespace SessionSummary {
             },
           ],
           headers: small.headers,
-          experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+          experimental_telemetry: {
+            isEnabled: cfg.experimental?.openTelemetry,
+            metadata: {
+              userId: cfg.username ?? "unknown",
+              sessionId: assistantMsg.sessionID,
+            },
+          },
         }).catch(() => {})
         if (result) summary = result.text
       }


### PR DESCRIPTION
## Summary

Adds `userId` and `sessionId` to `experimental_telemetry.metadata` across all AI SDK calls, enabling session-level trace grouping in observability platforms.

## Motivation

Currently, OpenCode emits OTEL traces for cost and token usage tracking, but lacks user/session context. This makes it difficult to:
- Group traces by user sessions
- Track conversation flows end-to-end
- Correlate multiple LLM calls within a single session

## Testing

- Tested with Langfuse ✅ - traces correctly group by session and display user attribution
- No impact on existing functionality when OTEL is disabled