### PR TITLE
Fix keybind documentation: use return instead of enter

### DIFF
--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -47,8 +47,8 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "input_clear": "ctrl+c",
     "input_forward_delete": "ctrl+d",
     "input_paste": "ctrl+v",
-    "input_submit": "enter",
-    "input_newline": "shift+enter,ctrl+j",
+    "input_submit": "return",
+    "input_newline": "shift+return,ctrl+j",
     "history_previous": "up",
     "history_next": "down"
   }


### PR DESCRIPTION
Fix keybind documentation: use return instead of enter

The keybind parser doesn't normalize enter to return, but the terminal sends key events as return. This causes keybinds using enter (like input_submit: "enter" and input_newline: "shift+enter") to silently fail.

Updated all instances of enter to return to match what the terminal actually sends and what the code expects internally.