### PR TITLE
fix: resolve 'latest' to actual version when caching plugins

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -127,7 +127,18 @@ export namespace BunProc {
 
     await runInstall()
 
-    parsed.dependencies[pkg] = version
+    // Resolve actual version from installed package when using "latest"
+    // This ensures subsequent starts use the cached version until explicitly updated
+    let resolvedVersion = version
+    if (version === "latest") {
+      const installedPkgJson = Bun.file(path.join(mod, "package.json"))
+      const installedPkg = await installedPkgJson.json().catch(() => null)
+      if (installedPkg?.version) {
+        resolvedVersion = installedPkg.version
+      }
+    }
+
+    parsed.dependencies[pkg] = resolvedVersion
     await Bun.write(pkgjson.name!, JSON.stringify(parsed, null, 2))
     return mod
   }


### PR DESCRIPTION
## Problem

When a plugin is specified without a version (e.g., `"my-plugin"` or `"my-plugin@latest"`), OpenCode stores the literal string `"latest"` in the cache (`~/.cache/opencode/package.json`).

On subsequent starts, the check `parsed.dependencies[pkg] === version` compares `"latest" === "latest"`, returns the cached module, and never checks npm for updates.

## Fix

After installing a package with `@latest`, read the actual installed version from the package's `package.json` and store that instead.

This means:
- `@latest` now re-fetches on each start (correct behavior - user wants latest)
- Explicit versions like `@1.2.3` still use cache efficiently

## Testing

1. Clear cache: `rm ~/.cache/opencode/package.json`
2. Start OpenCode with a plugin using `@latest`
3. Check cache - now shows actual version (e.g., `"1.2.3"`) instead of `"latest"`