### PR TITLE
docs: Add portal project to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -30,7 +30,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ------------------------------------------------------------- | ---------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                  | Discord bot to control OpenCode sessions, built on the SDK |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim) | Neovim plugin for editor-aware prompts, built on the API   |
-| [portal](https://github.com/hosenur/portal)                   | Web UI for OpenCode, built on the SDK                      |
+| [portal](https://github.com/hosenur/portal)                   | Mobile-first web UI for OpenCode over Tailscale/VPN        |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -30,6 +30,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ------------------------------------------------------------- | ---------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                  | Discord bot to control OpenCode sessions, built on the SDK |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim) | Neovim plugin for editor-aware prompts, built on the API   |
+| [portal](https://github.com/hosenur/portal)                   | Web UI for Opencode, built on the SDK                      |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -30,7 +30,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ------------------------------------------------------------- | ---------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                  | Discord bot to control OpenCode sessions, built on the SDK |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim) | Neovim plugin for editor-aware prompts, built on the API   |
-| [portal](https://github.com/hosenur/portal)                   | Web UI for Opencode, built on the SDK                      |
+| [portal](https://github.com/hosenur/portal)                   | Web UI for OpenCode, built on the SDK                      |
 
 ---
 


### PR DESCRIPTION
[Portal](https://github.com/hosenur/portal) is a Web UI I am working on, can be primarily used with Tailscale or other VPN services to run opencode on a VPS or Remote machine. 