### PR TITLE
fix: pasting in wsl running inside powershell

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -104,6 +104,10 @@ export function Prompt(props: PromptProps) {
   const pasteStyleId = syntax().getStyleId("extmark.paste")!
   let promptPartTypeId: number
 
+  function countLines(text: string): number {
+    return (text.match(/\n/g)?.length ?? 0) + 1
+  }
+
   command.register(() => {
     return [
       {
@@ -143,6 +147,16 @@ export function Prompt(props: PromptProps) {
               mime: content.mime,
               content: content.data,
             })
+          } else if (content?.mime.startsWith("text/")) {
+            const pastedText = content.data
+            const lineCount = countLines(pastedText)
+            if (
+              (lineCount >= 3 || pastedText.length > 150) &&
+              !sync.data.config.experimental?.disable_paste_summary
+            ) {
+              pasteText(pastedText, `[Pasted ~${lineCount} lines]`)
+              return
+            }
           }
         },
       },
@@ -786,7 +800,7 @@ export function Prompt(props: PromptProps) {
                   } catch {}
                 }
 
-                const lineCount = (pastedContent.match(/\n/g)?.length ?? 0) + 1
+                const lineCount = countLines(pastedContent)
                 if (
                   (lineCount >= 3 || pastedContent.length > 150) &&
                   !sync.data.config.experimental?.disable_paste_summary

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -39,6 +39,17 @@ export namespace Clipboard {
           return { data: imageBuffer.toString("base64"), mime: "image/png" }
         }
       }
+      console.log("clipboard read: powershell failed or no image")
+
+      // Try PowerShell for text in WSL
+      console.log("clipboard read: trying powershell for text")
+      const textScript = "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Clipboard]::GetText()"
+      const textResult = await $`powershell.exe -command "${textScript}"`.nothrow().text()
+      if (textResult?.trim()) {
+        console.log("clipboard read: powershell text succeeded")
+        return { data: textResult.trim(), mime: "text/plain" }
+      }
+      console.log("clipboard read: powershell text failed")
     }
 
     if (os === "linux") {


### PR DESCRIPTION
there was some issue when trying to paste text inside wsl running on powershell(it wouldnt work) , this commit fixes that and extracts the line counter into its own function