### PR TITLE
docs: configure mise to use latest version instead of pinned version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ scoop bucket add extras; scoop install extras/opencode  # Windows
 choco install opencode             # Windows
 brew install opencode              # macOS and Linux
 paru -S opencode-bin               # Arch Linux
-mise use --pin -g ubi:sst/opencode # Any OS
+mise use -g ubi:sst/opencode # Any OS
 nix run nixpkgs#opencode           # or github:sst/opencode for latest dev branch
 ```
 

--- a/packages/web/src/components/Lander.astro
+++ b/packages/web/src/components/Lander.astro
@@ -133,9 +133,9 @@ if (image) {
       </div>
       <div class="col4">
         <h3>Mise</h3>
-        <button class="command" data-command="mise use --pin -g ubi:sst/opencode">
+        <button class="command" data-command="mise use -g ubi:sst/opencode">
           <code>
-            <span>mise use --pin -g</span> <span class="highlight">ubi:sst/opencode</span>
+            <span>mise use -g</span> <span class="highlight">ubi:sst/opencode</span>
           </code>
           <span class="copy">
             <CopyIcon />

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -109,7 +109,7 @@ You can also install it with the following commands:
 - **Using Mise**
 
   ```bash
-  mise use --pin -g ubi:sst/opencode
+  mise use -g ubi:sst/opencode
   ```
 
 - **Using Docker**


### PR DESCRIPTION
## Summary

Removed the `--pin` flag from all mise installation commands to allow easier upgrades with `mise upgrade`.
This align with other package managers like `brew` that install the latest version by default and upgrade on `brew upgrade`.

## Why

The `--pin` flag locks users to a specific version (e.g., `opencode@1.0.141`) instead of using `@latest`. This means you can run `mise upgrade` to upgrade versions.