### PR TITLE
docs: add gitlab-opencode to GitLab docs

### DIFF
--- a/packages/web/src/content/docs/gitlab.mdx
+++ b/packages/web/src/content/docs/gitlab.mdx
@@ -43,8 +43,8 @@ See more inputs and use cases in [its documentation](https://gitlab.com/explore/
 
 ## GitLab Duo integration
 
-opencode integrates with your GitLab workflow.
-Mention `@opencode` in a comment, and opencode will execute tasks within your GitLab CI pipeline.
+OpenCode integrates with your GitLab workflow.
+Mention `@opencode` in a comment, and OpenCode will execute tasks within your GitLab CI pipeline.
 
 ---
 
@@ -59,7 +59,7 @@ Mention `@opencode` in a comment, and opencode will execute tasks within your Gi
 
 ### Setup
 
-opencode runs in your GitLab CI/CD pipeline, here's what you'll need to set it up:
+OpenCode runs in your GitLab CI/CD pipeline, here's what you'll need to set it up:
 
 :::tip
 Check out the [**GitLab docs**](https://docs.gitlab.com/user/duo_agent_platform/agent_assistant/) for up to date instructions.
@@ -155,7 +155,7 @@ You can refer to the [GitLab CLI agents docs](https://docs.gitlab.com/user/duo_a
 
 ### Examples
 
-Here are some examples of how you can use opencode in GitLab.
+Here are some examples of how you can use OpenCode in GitLab.
 
 :::tip
 You can configure to use a different trigger phrase than `@opencode`.
@@ -169,7 +169,7 @@ You can configure to use a different trigger phrase than `@opencode`.
   @opencode explain this issue
   ```
 
-  opencode will read the issue and reply with a clear explanation.
+  OpenCode will read the issue and reply with a clear explanation.
 
 - **Fix an issue**
 
@@ -179,7 +179,7 @@ You can configure to use a different trigger phrase than `@opencode`.
   @opencode fix this
   ```
 
-  opencode will create a new branch, implement the changes, and open a merge request with the changes.
+  OpenCode will create a new branch, implement the changes, and open a merge request with the changes.
 
 - **Review merge requests**
 
@@ -189,4 +189,4 @@ You can configure to use a different trigger phrase than `@opencode`.
   @opencode review this merge request
   ```
 
-  opencode will review the merge request and provide feedback.
+  OpenCode will review the merge request and provide feedback.

--- a/packages/web/src/content/docs/gitlab.mdx
+++ b/packages/web/src/content/docs/gitlab.mdx
@@ -3,12 +3,52 @@ title: GitLab
 description: Use opencode in GitLab issues and merge requests.
 ---
 
+## Integration options
+
+There are at least two approaches to run OpenCode in GitLab:
+
+- Run it in GitLab pipelines as a regular pipeline
+- Run it through GitLab Duo
+
+In both cases, OpenCode will run on your GitLab runners.
+
+## GitLab CI integration
+
+opencode works in a regular GitLab pipeline. You build it into a pipeline as a [CI component](https://docs.gitlab.com/ee/ci/components/)
+
+---
+
+### Features
+
+- **Use custom configuration per job**: Configure OpenCode with a [custom configuration directory](./config/#custom-directory) to enable/disable functionality per opencode invocation.
+- **Minimal setup**: The CI component sets up OpenCode in the background, you only need to create the OpenCode configuration and the initial prompt.
+- **Flexible**: The CI component supports several inputs for customizing its behavior
+
+### Setup
+
+1. Store your OpenCode authentication JSON as a File type CI environment variables under **Settings -> CI/CD -> Variables**. Tip: Mark it "Masked and hidden".
+2. Add code blocks like the following to your `.gitlab-ci.yml` file:
+
+```
+include:
+  - component: $CI_SERVER_FQDN/nagyv/gitlab-opencode/opencode@1.0.0
+    inputs:
+      config_dir: ${CI_PROJECT_DIR}/opencode-config
+      auth_json: $OPENCODE_AUTH_JSON  # The variable name for your OpenCode authentication JSON
+      command: optional-custom-command
+      message: "Your prompt here"
+```
+
+See more inputs and use cases in [its documentation](https://gitlab.com/explore/catalog/nagyv/gitlab-opencode).
+
+## GitLab Duo integration
+
 opencode integrates with your GitLab workflow.
 Mention `@opencode` in a comment, and opencode will execute tasks within your GitLab CI pipeline.
 
 ---
 
-## Features
+### Features
 
 - **Triage issues**: Ask opencode to look into an issue and explain it to you.
 - **Fix and implement**: Ask opencode to fix an issue or implement a feature.
@@ -17,7 +57,7 @@ Mention `@opencode` in a comment, and opencode will execute tasks within your Gi
 
 ---
 
-## Setup
+### Setup
 
 opencode runs in your GitLab CI/CD pipeline, here's what you'll need to set it up:
 
@@ -113,7 +153,7 @@ You can refer to the [GitLab CLI agents docs](https://docs.gitlab.com/user/duo_a
 
 ---
 
-## Examples
+### Examples
 
 Here are some examples of how you can use opencode in GitLab.
 


### PR DESCRIPTION
The current GitLab page describes OpenCode integration through GitLab Duo. 

GitLab Duo is a paying functionality and is limited to workflows supported by GitLab. 

GitLab-OpenCode is a community project that offers more flexiblity, better customization and easier setup to use OpenCode in GitLab. On the downside, it does not have the level of integration into GitLab as Duo does.