### PR TITLE
docs: add opencode-type-inject to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -18,6 +18,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                                                              | Description                                                   |
 | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
 | [opencode-skills](https://github.com/malhashemi/opencode-skills)                                  | Manage and organize OpenCode skills and capabilities          |
+| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                           | Auto-inject TypeScript/Svelte types into file reads with lookup tools |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)            | Use your ChatGPT Plus/Pro subscription instead of API credits |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing          |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing          |


### PR DESCRIPTION
## Summary

Adds [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject) to the ecosystem plugins list.

**What it does:**
- Auto-injects TypeScript/Svelte type signatures into file reads
- Provides `lookup_type` and `list_types` tools for type discovery
- Resolves imported types up to 4 levels deep
- Supports both TypeScript and Svelte files