### PR TITLE
feat: add --tools flag to limit available tools

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,17 +2,24 @@ import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { Wildcard } from "@/util/wildcard"
 
 export const ServeCommand = cmd({
   command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("tools", {
+      type: "string",
+      describe:
+        "comma-separated tool patterns to enable/disable (e.g., '-*,read,write,webfetch' to only enable those three)",
+    }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
-    const server = Server.listen(opts)
+    const tools = Wildcard.parseToolsPattern(args.tools)
+    const server = Server.listen({ ...opts, tools })
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
     await new Promise(() => {})
     await server.stop()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -31,6 +31,8 @@ import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
+import { useArgs } from "../../context/args"
+import { Wildcard } from "@/util/wildcard"
 
 export type PromptProps = {
   sessionID?: string
@@ -66,6 +68,7 @@ export function Prompt(props: PromptProps) {
   const sync = useSync()
   const dialog = useDialog()
   const toast = useToast()
+  const args = useArgs()
   const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
   const history = usePromptHistory()
   const stash = usePromptStash()
@@ -577,6 +580,7 @@ export function Prompt(props: PromptProps) {
           })),
       })
     } else {
+      const tools = Wildcard.parseToolsPattern(args.tools)
       sdk.client.session
         .prompt({
           sessionID,
@@ -585,6 +589,7 @@ export function Prompt(props: PromptProps) {
           agent: local.agent.current().name,
           model: selectedModel,
           variant,
+          ...(tools && { tools }),
           parts: [
             {
               id: Identifier.ascending("part"),

--- a/packages/opencode/src/cli/cmd/tui/context/args.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/args.tsx
@@ -6,6 +6,7 @@ export interface Args {
   prompt?: string
   continue?: boolean
   sessionID?: string
+  tools?: string
 }
 
 export const { use: useArgs, provider: ArgsProvider } = createSimpleContext({

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -71,6 +71,11 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      .option("tools", {
+        type: "string",
+        describe:
+          "comma-separated tool patterns to enable/disable (e.g., '-*,read,write,webfetch' to only enable those three)",
       }),
   handler: async (args) => {
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
@@ -150,6 +155,7 @@ export const TuiThreadCommand = cmd({
         agent: args.agent,
         model: args.model,
         prompt,
+        tools: args.tools,
       },
       onExit: async () => {
         await client.call("shutdown", undefined)

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -5,6 +5,7 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
+import { Wildcard } from "@/util/wildcard"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -30,14 +31,20 @@ function getNetworkIPs() {
 
 export const WebCommand = cmd({
   command: "web",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("tools", {
+      type: "string",
+      describe:
+        "comma-separated tool patterns to enable/disable (e.g., '-*,read,write,webfetch' to only enable those three)",
+    }),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
-    const server = Server.listen(opts)
+    const tools = Wildcard.parseToolsPattern(args.tools)
+    const server = Server.listen({ ...opts, tools })
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -16,6 +16,7 @@ import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Server } from "../server"
 
 const log = Log.create({ service: "server" })
 
@@ -730,7 +731,9 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async (stream) => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
+          const defaults = Server.getDefaultTools()
+          const tools = defaults || body.tools ? { ...defaults, ...body.tools } : undefined
+          const msg = await SessionPrompt.prompt({ ...body, sessionID, tools })
           stream.write(JSON.stringify(msg))
         })
       },
@@ -762,7 +765,9 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async () => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+          const defaults = Server.getDefaultTools()
+          const tools = defaults || body.tools ? { ...defaults, ...body.tools } : undefined
+          SessionPrompt.prompt({ ...body, sessionID, tools })
         })
       },
     )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -54,6 +54,12 @@ export namespace Server {
     return _url ?? new URL("http://localhost:4096")
   }
 
+  let defaultTools: Record<string, boolean> | undefined
+
+  export function getDefaultTools() {
+    return defaultTools
+  }
+
   const app = new Hono()
   export const App: () => Hono = lazy(
     () =>
@@ -560,8 +566,17 @@ export namespace Server {
     return result
   }
 
-  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
+  export function listen(opts: {
+    port: number
+    hostname: string
+    mdns?: boolean
+    cors?: string[]
+    tools?: Record<string, boolean>
+  }) {
     _corsWhitelist = opts.cors ?? []
+    if (opts.tools) {
+      defaultTools = opts.tools
+    }
 
     const args = {
       hostname: opts.hostname,

--- a/packages/opencode/src/util/wildcard.ts
+++ b/packages/opencode/src/util/wildcard.ts
@@ -42,6 +42,20 @@ export namespace Wildcard {
     return result
   }
 
+  export function parseToolsPattern(pattern: string | undefined): Record<string, boolean> | undefined {
+    if (!pattern?.trim()) return undefined
+    const result: Record<string, boolean> = {}
+    const parts = pattern.split(",").map((x) => x.trim())
+    for (const part of parts) {
+      if (part.startsWith("-")) {
+        result[part.slice(1)] = false
+      } else {
+        result[part] = true
+      }
+    }
+    return result
+  }
+
   function matchSequence(items: string[], patterns: string[]): boolean {
     if (patterns.length === 0) return true
     const [pattern, ...rest] = patterns

--- a/packages/opencode/test/util/wildcard.test.ts
+++ b/packages/opencode/test/util/wildcard.test.ts
@@ -73,3 +73,42 @@ test("allStructured handles sed flags", () => {
   expect(Wildcard.allStructured({ head: "sed", tail: ["-n", "1p", "file"] }, rules)).toBe("allow")
   expect(Wildcard.allStructured({ head: "sed", tail: ["-i", "-n", "/./p", "myfile.txt"] }, rules)).toBe("ask")
 })
+
+test("parseToolsPattern handles empty and undefined", () => {
+  expect(Wildcard.parseToolsPattern(undefined)).toBeUndefined()
+  expect(Wildcard.parseToolsPattern("")).toBeUndefined()
+  expect(Wildcard.parseToolsPattern("   ")).toBeUndefined()
+})
+
+test("parseToolsPattern disables all tools", () => {
+  expect(Wildcard.parseToolsPattern("-*")).toEqual({ "*": false })
+})
+
+test("parseToolsPattern enables all tools", () => {
+  expect(Wildcard.parseToolsPattern("*")).toEqual({ "*": true })
+})
+
+test("parseToolsPattern disables all and enables specific tools", () => {
+  expect(Wildcard.parseToolsPattern("-*,read,write,webfetch")).toEqual({
+    "*": false,
+    read: true,
+    write: true,
+    webfetch: true,
+  })
+})
+
+test("parseToolsPattern enables only specific tools", () => {
+  expect(Wildcard.parseToolsPattern("read,write,webfetch")).toEqual({
+    read: true,
+    write: true,
+    webfetch: true,
+  })
+})
+
+test("parseToolsPattern handles whitespace", () => {
+  expect(Wildcard.parseToolsPattern(" -* , read , write ")).toEqual({
+    "*": false,
+    read: true,
+    write: true,
+  })
+})


### PR DESCRIPTION
Add --tools flag to serve, web, and TUI commands to enable selective tool access control. The flag accepts comma-separated patterns to enable/disable tools.

Usage examples:

```
  # Only allow read, write, and webfetch tools
  opencode serve --tools='-*,read,write,webfetch'

  # Disable specific tools
  opencode web --tools='-bash,-edit'

  # Use in TUI mode
  opencode --tools='-*,read,write,webfetch'
```

Changes:
- Add --tools flag to serve, web, and TUI thread commands
- Implement Wildcard.parseToolsPattern() to parse tool enable/disable patterns
- Update Server.listen() to accept tools option
- Pass default tools to SessionPrompt.prompt() in server
- Add tests for parseToolsPattern()

Fixes #9386 