### PR TITLE
fix: light mode visibility for filepath in /undo diff files

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -894,7 +894,7 @@ export function Session() {
                                 <box marginTop={1}>
                                   <For each={revert()!.diffFiles}>
                                     {(file) => (
-                                      <text>
+                                      <text fg={theme.text}>
                                         {file.filename}
                                         <Show when={file.additions > 0}>
                                           <span style={{ fg: theme.diffAdded }}> +{file.additions}</span>


### PR DESCRIPTION
Fixes filepath text being invisible in light mode when using /undo. Added `fg={theme.text}` to the text element displaying filenames in the revert diff files list, matching the pattern used in recent light mode fixes #4928 and I think the actual fixes were made in https://github.com/sst/opencode/commit/db0e1ebb8053a7f4e3a8b913b191e39ac5b7ec48
https://github.com/sst/opencode/commit/e83a47debe81a85dc4ddb2b075fe6f5ade169bd2