### PR TITLE
docs(bash): clarify description parameter is required

### DIFF
--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -20,8 +20,7 @@ Usage notes:
     - The command argument is required.
     - You can specify an optional timeout in milliseconds (up to 600000ms / 10 minutes).
   If not specified, commands will timeout after 120000ms (2 minutes).
-    - It is very helpful if you write a clear, concise description of what this command
-  does in 5-10 words.
+    - The description argument is required. You must write a clear, concise description of what this command does in 5-10 words.
     - If the output exceeds 30000 characters, output will be truncated before being
   returned to you.
     - You can use the `run_in_background` parameter to run the command in the background,


### PR DESCRIPTION
## Summary

- Bash tool documentation implied description was optional ("very helpful if you write"), but TypeScript schema enforces it as required
- Updated bash.txt line 23 to explicitly state description is required, aligning documentation with actual validation behavior

## Context

- Takes opposite approach from below PR: keep validation strict but fix misleading documentation
  - #1333