### PR TITLE
Add Cerebras integration header with opencode identifier

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -318,6 +318,16 @@ export namespace Provider {
         },
       }
     },
+    cerebras: async () => {
+      return {
+        autoload: false,
+        options: {
+          headers: {
+            "X-Cerebras-3rd-Party-Integration": "opencode",
+          },
+        },
+      }
+    },
   }
 
   export const Model = z


### PR DESCRIPTION
## Context

Add the X-Cerebras-3rd-Party-Integration header to all Cerebras API requests to properly identify requests coming from OpenCode. This helps Cerebras track usage and provide better support for different integrations.

## Implementation

- Added cerebras provider configuration to the CUSTOM_LOADERS object
- Set the X-Cerebras-3rd-Party-Integration header to "opencode" in the provider options
- This ensures all Cerebras API requests from OpenCode include the proper integration identifier

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Configure OpenCode with a Cerebras API key
- Select a Cerebras model and make an API request
- Verify the X-Cerebras-3rd-Party-Integration header is present with value "opencode" in the network request

## Get in Touch

