### PR TITLE
fix(server): make time field optional in session update validator

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -791,9 +791,11 @@ export namespace Server {
           "json",
           z.object({
             title: z.string().optional(),
-            time: z.object({
-              archived: z.number().optional(),
-            }),
+            time: z
+              .object({
+                archived: z.number().optional(),
+              })
+              .optional(),
           }),
         ),
         async (c) => {


### PR DESCRIPTION
## Summary
- Make `time` field optional in session.update endpoint validator

## Why
- Previously, the `time` object was required in the request body validation, causing `/rename` command to fail since it only sends `title` without `time`

Closes #5369