### PR TITLE
Add ripgrep to Docker image

### DIFF
--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine
 # On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
 ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
-RUN apk add libgcc libstdc++
+RUN apk add libgcc libstdc++ ripgrep
 ADD ./dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
 RUN opencode --version
 ENTRYPOINT ["opencode"]


### PR DESCRIPTION
Currently the Docker image can't perform most text based tasks because RipgrepExtractionFailedRipgrepExtractionFailedError keeps happening. This PR fixes it.