### PR TITLE
fix: make time optional in session update endpoint

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -791,9 +791,11 @@ export namespace Server {
           "json",
           z.object({
             title: z.string().optional(),
-            time: z.object({
-              archived: z.number().optional(),
-            }),
+            time: z
+              .object({
+                archived: z.number().optional(),
+              })
+              .optional(),
           }),
         ),
         async (c) => {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2407,7 +2407,7 @@ export type SessionGetResponse = SessionGetResponses[keyof SessionGetResponses]
 export type SessionUpdateData = {
   body?: {
     title?: string
-    time: {
+    time?: {
       archived?: number
     }
   }


### PR DESCRIPTION
## Summary

The `time` field in the PATCH `/session/:sessionID` endpoint was required, but callers like `DialogSessionRename` only send `title` when renaming a session. This caused validation failures.

Fixes #5369

## Changes

- Made `time` optional in the session update request body schema
- Regenerated SDK to reflect the change

## Why this fix

This is a PATCH endpoint for partial updates - both `title` and `time.archived` are independent optional fields. The handler already used optional chaining (`updates.time?.archived`) expecting `time` to be undefined.

---

*This PR was written with AI assistance (Claude Opus 4.5 via OpenCode).*