### PR TITLE
feat: add caching for opencode binary in GitHub Actions

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -20,9 +20,28 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get opencode version
+      id: version
+      shell: bash
+      run: |
+        VERSION=$(curl -sf https://api.github.com/repos/sst/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
+
+    - name: Cache opencode
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.opencode/bin
+        key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
     - name: Install opencode
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: curl -fsSL https://opencode.ai/install | bash
+
+    - name: Add opencode to PATH
+      shell: bash
+      run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
     - name: Run opencode
       shell: bash


### PR DESCRIPTION
## Summary
- Add caching mechanism for opencode binary in GitHub Actions to speed up workflow runs

## Why
- Currently, every workflow run downloads the opencode binary from scratch
- With caching, subsequent runs can skip the download if the same version is already cached

## Comparison
| Scenario   | Time              |
| ---------- | ----------------- |
| Cache miss | 1m 34s            |
| Cache hit  | 24s (~74% faster) |