### PR TITLE
fix(tui): ensure fatal error UI is readable in light mode

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -107,7 +107,9 @@ export function tui(input: { url: string; args: Args; onExit?: () => Promise<voi
     render(
       () => {
         return (
-          <ErrorBoundary fallback={(error, reset) => <ErrorComponent error={error} reset={reset} onExit={onExit} />}>
+          <ErrorBoundary
+            fallback={(error, reset) => <ErrorComponent error={error} reset={reset} onExit={onExit} mode={mode} />}
+          >
             <ArgsProvider {...input.args}>
               <ExitProvider onExit={onExit}>
                 <KVProvider>
@@ -536,7 +538,12 @@ function App() {
   )
 }
 
-function ErrorComponent(props: { error: Error; reset: () => void; onExit: () => Promise<void> }) {
+function ErrorComponent(props: {
+  error: Error
+  reset: () => void
+  onExit: () => Promise<void>
+  mode?: "dark" | "light"
+}) {
   const term = useTerminalDimensions()
   useKeyboard((evt) => {
     if (evt.ctrl && evt.name === "c") {
@@ -546,6 +553,15 @@ function ErrorComponent(props: { error: Error; reset: () => void; onExit: () => 
   const [copied, setCopied] = createSignal(false)
 
   const issueURL = new URL("https://github.com/sst/opencode/issues/new?template=bug-report.yml")
+
+  // Choose safe fallback colors per mode since theme context may not be available
+  const isLight = props.mode === "light"
+  const colors = {
+    bg: isLight ? "#ffffff" : "#0a0a0a",
+    text: isLight ? "#1a1a1a" : "#eeeeee",
+    muted: isLight ? "#8a8a8a" : "#808080",
+    primary: isLight ? "#3b7dd8" : "#fab283",
+  }
 
   if (props.error.message) {
     issueURL.searchParams.set("title", `opentui: fatal: ${props.error.message}`)
@@ -567,27 +583,31 @@ function ErrorComponent(props: { error: Error; reset: () => void; onExit: () => 
   }
 
   return (
-    <box flexDirection="column" gap={1}>
+    <box flexDirection="column" gap={1} backgroundColor={colors.bg}>
       <box flexDirection="row" gap={1} alignItems="center">
-        <text attributes={TextAttributes.BOLD}>Please report an issue.</text>
-        <box onMouseUp={copyIssueURL} backgroundColor="#565f89" padding={1}>
-          <text attributes={TextAttributes.BOLD}>Copy issue URL (exception info pre-filled)</text>
+        <text attributes={TextAttributes.BOLD} fg={colors.text}>
+          Please report an issue.
+        </text>
+        <box onMouseUp={copyIssueURL} backgroundColor={colors.primary} padding={1}>
+          <text attributes={TextAttributes.BOLD} fg={colors.bg}>
+            Copy issue URL (exception info pre-filled)
+          </text>
         </box>
-        {copied() && <text>Successfully copied</text>}
+        {copied() && <text fg={colors.muted}>Successfully copied</text>}
       </box>
       <box flexDirection="row" gap={2} alignItems="center">
-        <text>A fatal error occurred!</text>
-        <box onMouseUp={props.reset} backgroundColor="#565f89" padding={1}>
-          <text>Reset TUI</text>
+        <text fg={colors.text}>A fatal error occurred!</text>
+        <box onMouseUp={props.reset} backgroundColor={colors.primary} padding={1}>
+          <text fg={colors.bg}>Reset TUI</text>
         </box>
-        <box onMouseUp={props.onExit} backgroundColor="#565f89" padding={1}>
-          <text>Exit</text>
+        <box onMouseUp={props.onExit} backgroundColor={colors.primary} padding={1}>
+          <text fg={colors.bg}>Exit</text>
         </box>
       </box>
       <scrollbox height={Math.floor(term().height * 0.7)}>
-        <text>{props.error.stack}</text>
+        <text fg={colors.muted}>{props.error.stack}</text>
       </scrollbox>
-      <text>{props.error.message}</text>
+      <text fg={colors.text}>{props.error.message}</text>
     </box>
   )
 }


### PR DESCRIPTION
  Fixes invisible text in the fatal error screen on light terminals by making the error fallback mode-aware and applying explicit foreground/background colors. 
  
  Similar to #5352 and #5378, but unlike them, the fatal fallback cannot depend on the theme context, since the ErrorBoundary wraps ThemeProvider. Without explicit fg, the renderer defaults to white text (probably the OpenTUI default), causing white-on-white invisibility in light terminals.
  
  ## Changes
  - Pass precomputed mode into ErrorBoundary fallback
  - Make ErrorComponent accept mode?: "dark" | "light" and use explicit fg/backgroundColor with safe light/dark fallback colors derived from the opencode palette (replaced hardcoded #565f89 button color with it as well)
  - Apply the colors to the fatal error message elements
  
  ## Notes
  There are two main stylistic choices, and I would like the maintainers to modify the code as needed. This PR strictly fixes the visibility bug in light mode.
  
1. Panel background: This PR sets an explicit backgroundColor on the error panel to guarantee contrast. Alternative: remove it to use the terminal's native background (may compromise readability depending on the terminal's background color). The current codebase is using the terminal's background.
2. Color approach: This PR uses dynamic dark/light colors based on terminal mode. Alternative: force a dark background with light text regardless of mode (simpler/more robust, but worse UX for light-terminal users).
  
  ## Examples 
  
  I added a mock throw error to check the fatal error screen. 
  
  Before (light)
  <img width="3360" height="2100" alt="image" src="https://github.com/user-attachments/assets/3072fd67-b761-412b-8b00-15fdd8fb7491" />
  
  After (light)
  <img width="3360" height="2100" alt="image" src="https://github.com/user-attachments/assets/9cdf34c3-9612-4611-9c4b-862cfec3c442" />
  
  Before (dark)
  <img width="3360" height="2100" alt="image" src="https://github.com/user-attachments/assets/e179f7f4-1de5-4f33-a033-b43cfe78c53b" />
  
  After (dark)
  <img width="3360" height="2100" alt="image" src="https://github.com/user-attachments/assets/f48d245c-edbe-48d3-a610-7483ef9b2832" />