### PR TITLE
fix: Writing to Bun.stderr causes CPU pinning to 100%.

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -50,7 +50,7 @@ export namespace Log {
   export function file() {
     return logpath
   }
-  let write = (msg: any) => Bun.stderr.write(msg)
+  let write = (msg: any) => process.stderr.write(msg)
 
   export async function init(options: Options) {
     if (options.level) level = options.level


### PR DESCRIPTION
Seen on macOS Sequoia 15.7.2 . Probably bug in Bun. writing directly to process.stderr works around it. Tested with Bun 1.3.4.

The bug is only seen when process stderr is piped to another process such as tee like

bun run dev -- serve --port 0 --print-logs --log-level INFO 2>&1 | tee -a test.log

And then sending api request to trigger error logs