### PR TITLE
feat(provider): add health check infrastructure

### DIFF
--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -19,6 +19,16 @@ export function FormatError(input: unknown) {
   if (Provider.InitError.isInstance(input)) {
     return `Failed to initialize provider "${input.data.providerID}". Check credentials and configuration.`
   }
+  if (Provider.HealthCheckError.isInstance(input)) {
+    const { providerID, baseURL, error } = input.data
+    return [
+      `Health check failed for provider "${providerID}"`,
+      baseURL ? `Endpoint: ${baseURL}` : "",
+      `Error: ${error}`,
+    ]
+      .filter(Boolean)
+      .join("\n")
+  }
   if (Config.JsonError.isInstance(input)) {
     return (
       `Config file at ${input.data.path} is not valid JSON(C)` + (input.data.message ? `: ${input.data.message}` : "")

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -579,6 +579,14 @@ export namespace Config {
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
       models: z.record(z.string(), ModelsDev.Model.partial()).optional(),
+      healthCheck: z
+        .object({
+          url: z.string().optional().describe("Health check endpoint URL. Defaults to baseURL + /models"),
+          timeout: z.number().int().positive().default(2000).describe("Health check timeout in milliseconds"),
+          enabled: z.boolean().default(true).describe("Enable health check for this provider"),
+        })
+        .optional()
+        .describe("Health check configuration for provider connection validation"),
       options: z
         .object({
           apiKey: z.string().optional(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -407,6 +407,13 @@ export namespace Provider {
       key: z.string().optional(),
       options: z.record(z.string(), z.any()),
       models: z.record(z.string(), Model),
+      healthCheck: z
+        .object({
+          url: z.string().optional(),
+          timeout: z.number().int().positive().optional(),
+          enabled: z.boolean().optional(),
+        })
+        .optional(),
     })
     .meta({
       ref: "Provider",
@@ -484,6 +491,27 @@ export namespace Provider {
     }
   }
 
+  async function checkProviderHealth(
+    baseURL: string,
+    healthCheck?: { url?: string; timeout?: number; enabled?: boolean },
+  ): Promise<{ healthy: boolean; error?: string }> {
+    if (healthCheck?.enabled === false) return { healthy: true }
+
+    const url = healthCheck?.url ?? `${baseURL.replace(/\/$/, "")}/models`
+    const timeout = healthCheck?.timeout ?? 2000
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        signal: AbortSignal.timeout(timeout),
+      })
+      return { healthy: response.ok }
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e)
+      return { healthy: false, error }
+    }
+  }
+
   const state = Instance.state(async () => {
     using _ = log.time("state")
     const config = await Config.get()
@@ -505,6 +533,7 @@ export namespace Provider {
       [providerID: string]: CustomModelLoader
     } = {}
     const sdk = new Map<number, SDK>()
+    const healthCheckResults = new Map<string, { healthy: boolean; error?: string }>()
 
     log.info("init")
 
@@ -547,6 +576,7 @@ export namespace Provider {
         options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
         source: "config",
         models: existing?.models ?? {},
+        healthCheck: provider.healthCheck ?? existing?.healthCheck,
       }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
@@ -742,6 +772,7 @@ export namespace Provider {
       providers,
       sdk,
       modelLoaders,
+      healthCheckResults,
     }
   })
 
@@ -769,6 +800,23 @@ export namespace Provider {
           ...options["headers"],
           ...model.headers,
         }
+
+      const baseURL = options["baseURL"] || model.api.url
+      const isLocal = baseURL?.includes("127.0.0.1") || baseURL?.includes("localhost")
+      const healthCheckConfig = provider.healthCheck
+
+      if ((isLocal || healthCheckConfig?.enabled !== false) && !s.healthCheckResults.has(model.providerID)) {
+        const health = await checkProviderHealth(baseURL, healthCheckConfig)
+        s.healthCheckResults.set(model.providerID, health)
+
+        if (!health.healthy) {
+          log.warn("provider health check failed", {
+            providerID: model.providerID,
+            baseURL,
+            error: health.error,
+          })
+        }
+      }
 
       const key = Bun.hash.xxHash32(JSON.stringify({ npm: model.api.npm, options }))
       const existing = s.sdk.get(key)
@@ -988,6 +1036,15 @@ export namespace Provider {
     "ProviderInitError",
     z.object({
       providerID: z.string(),
+    }),
+  )
+
+  export const HealthCheckError = NamedError.create(
+    "ProviderHealthCheckError",
+    z.object({
+      providerID: z.string(),
+      baseURL: z.string().optional(),
+      error: z.string(),
     }),
   )
 }


### PR DESCRIPTION
When using local providers like LM Studio, users often get generic connection errors that don't help diagnose the problem. This adds optional health check infrastructure so providers can validate their connection before SDK initialization.

The health check runs lazily when the SDK is first requested, and results are cached to avoid repeated checks. For local providers (127.0.0.1 or localhost), health checks are automatically enabled. You can also configure them explicitly for any provider.

If a health check fails, it logs a warning but doesn't prevent SDK creation - this keeps things non-blocking. The health check uses a simple HTTP request to a configurable endpoint (defaults to baseURL + /models) with a timeout.

This is the foundation for better error messages and connection validation, especially useful for local providers where the server might not be running.

Related issues: #1555, #2205, #4255, #508