### PR TITLE
fix: resolve typecheck errors

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"
@@ -9,6 +8,11 @@ import { fileURLToPath } from "url"
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const dir = path.resolve(__dirname, "..")
+
+process.chdir(dir)
+
+// Import solid-plugin using the bun-plugin export
+import solidPlugin from "@opentui/solid/bun-plugin"
 
 process.chdir(dir)
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -407,7 +407,9 @@ export namespace MCP {
       for (const [toolName, tool] of Object.entries(tools)) {
         const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
         const sanitizedToolName = toolName.replace(/[^a-zA-Z0-9_-]/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = tool
+        // MCP tools have FlexibleSchema<unknown> but Tool expects FlexibleSchema<any>
+        // This is safe as the schema is validated at runtime
+        result[sanitizedClientName + "_" + sanitizedToolName] = tool as Tool
       }
     }
     return result


### PR DESCRIPTION
## Summary

Fixes two pre-existing TypeScript typecheck errors that were blocking builds.

## Changes

1. **script/build.ts**: Fixed import path for solid-plugin
   - Changed from relative path `../node_modules/@opentui/solid/scripts/solid-plugin`
   - To package export: `@opentui/solid/bun-plugin`
   - The package exports `./bun-plugin` which points to the solid-plugin file

2. **src/mcp/index.ts**: Fixed Tool type mismatch
   - MCP client tools have `FlexibleSchema<unknown>` but `Tool` type expects `FlexibleSchema<any>`
   - Added type assertion `as Tool` with explanatory comment
   - Safe because schema is validated at runtime

## Testing

- ✅ Typecheck passes without errors
- ✅ No runtime behavior changes
- ✅ All existing functionality preserved

## Related

These were pre-existing errors not related to the LM Studio support PRs.