### PR TITLE
fix(build): use correct import path for solid-plugin

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"
@@ -11,6 +10,9 @@ const __dirname = path.dirname(__filename)
 const dir = path.resolve(__dirname, "..")
 
 process.chdir(dir)
+
+// Import solid-plugin using the bun-plugin export
+import solidPlugin from "@opentui/solid/bun-plugin"
 
 import pkg from "../package.json"
 import { Script } from "@opencode-ai/script"


### PR DESCRIPTION
The build script was importing solid-plugin using a relative path to node_modules, which breaks TypeScript resolution. The @opentui/solid package exports a bun-plugin path that we should use instead.

This changes the import to use the package export @opentui/solid/bun-plugin, which properly resolves through the package's exports field. The import is moved after process.chdir to ensure proper resolution.