### PR TITLE
fix(mcp): add type assertion for Tool assignment

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -407,7 +407,9 @@ export namespace MCP {
       for (const [toolName, tool] of Object.entries(tools)) {
         const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
         const sanitizedToolName = toolName.replace(/[^a-zA-Z0-9_-]/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = tool
+        // MCP tools have FlexibleSchema<unknown> but Tool expects FlexibleSchema<any>
+        // This is safe as the schema is validated at runtime
+        result[sanitizedClientName + "_" + sanitizedToolName] = tool as Tool
       }
     }
     return result


### PR DESCRIPTION
TypeScript was complaining that MCP client tools have FlexibleSchema<unknown> but the Tool type expects FlexibleSchema<any>. This is a type system limitation - the MCP client validates schemas at runtime before returning tools, so the runtime behavior is correct.

Adding a type assertion here is safe because the schema validation happens in the MCP client layer. The assertion just tells TypeScript what we already know at runtime.