### PR TITLE
fix: debug lsp diagnostics cmd for certain lsps

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/lsp.ts
+++ b/packages/opencode/src/cli/cmd/debug/lsp.ts
@@ -17,6 +17,7 @@ const DiagnosticsCommand = cmd({
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
       await LSP.touchFile(args.file, true)
+      await Bun.sleep(1000)
       process.stdout.write(JSON.stringify(await LSP.diagnostics(), null, 2) + EOL)
     })
   },


### PR DESCRIPTION
Some LSPs (e.g., https://github.com/cucumber/language-server) require configuration from the client and re-indexing of the files after the initial handshake has been established before they can produce relevant diagnostics. This results in invalid diagnostics returned for about a fraction of a second after the handshake has been initialized. After the code has been re-indexed the server sends another (correct) diagnostics response, so this is not a problem for a code editor or the coding agent.

 The debug LSP command sends a diagnostic request right after the handshake has been initialized and will exit after the first response (which in this case will not be correct because of lacking configuration). The simple fix is to add a short timeout after the server has been initialized so that it has had time to receive configuration and do any required re-indexing.