### PR TITLE
acp: fix internal error on `/compact`

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -914,6 +914,8 @@ export namespace ACP {
             {
               sessionID,
               directory,
+              providerID: model.providerID,
+              modelID: model.modelID,
             },
             { throwOnError: true },
           )


### PR DESCRIPTION
fix internal error on `ACP`'s `/compact`.

Fixes #5304