### PR TITLE
fix(grep): stream ripgrep output to prevent memory exhaustion

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -6,6 +6,7 @@ import DESCRIPTION from "./grep.txt"
 import { Instance } from "../project/instance"
 
 const MAX_LINE_LENGTH = 2000
+const MATCH_LIMIT = 100
 
 export const GrepTool = Tool.define("grep", {
   description: DESCRIPTION,
@@ -33,11 +34,80 @@ export const GrepTool = Tool.define("grep", {
       stderr: "pipe",
     })
 
-    const output = await new Response(proc.stdout).text()
+    const reader = proc.stdout.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+    const matches: Array<{
+      path: string
+      modTime: number
+      lineNum: number
+      lineText: string
+    }> = []
+    let hitCollectLimit = false
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split("\n")
+        buffer = lines.pop() || ""
+
+        for (const line of lines) {
+          if (!line) continue
+          if (matches.length >= MATCH_LIMIT) {
+            hitCollectLimit = true
+            break
+          }
+
+          const [filePath, lineNumStr, ...lineTextParts] = line.split("|")
+          if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
+
+          const lineNum = parseInt(lineNumStr, 10)
+          const lineText = lineTextParts.join("|")
+
+          const file = Bun.file(filePath)
+          const stats = await file.stat().catch(() => null)
+          if (!stats) continue
+
+          matches.push({
+            path: filePath,
+            modTime: stats.mtime.getTime(),
+            lineNum,
+            lineText,
+          })
+        }
+
+        if (hitCollectLimit) break
+      }
+
+      if (!hitCollectLimit && buffer) {
+        const [filePath, lineNumStr, ...lineTextParts] = buffer.split("|")
+        if (filePath && lineNumStr && lineTextParts.length > 0) {
+          const lineNum = parseInt(lineNumStr, 10)
+          const lineText = lineTextParts.join("|")
+          const file = Bun.file(filePath)
+          const stats = await file.stat().catch(() => null)
+          if (stats) {
+            matches.push({
+              path: filePath,
+              modTime: stats.mtime.getTime(),
+              lineNum,
+              lineText,
+            })
+          }
+        }
+      }
+    } finally {
+      if (hitCollectLimit) proc.kill()
+      reader.releaseLock()
+    }
+
     const errorOutput = await new Response(proc.stderr).text()
     const exitCode = await proc.exited
 
-    if (exitCode === 1) {
+    if (exitCode === 1 && matches.length === 0) {
       return {
         title: params.pattern,
         metadata: { matches: 0, truncated: false },
@@ -45,39 +115,14 @@ export const GrepTool = Tool.define("grep", {
       }
     }
 
-    if (exitCode !== 0) {
+    if (exitCode !== 0 && exitCode !== 1 && !hitCollectLimit) {
       throw new Error(`ripgrep failed: ${errorOutput}`)
-    }
-
-    const lines = output.trim().split("\n")
-    const matches = []
-
-    for (const line of lines) {
-      if (!line) continue
-
-      const [filePath, lineNumStr, ...lineTextParts] = line.split("|")
-      if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
-
-      const lineNum = parseInt(lineNumStr, 10)
-      const lineText = lineTextParts.join("|")
-
-      const file = Bun.file(filePath)
-      const stats = await file.stat().catch(() => null)
-      if (!stats) continue
-
-      matches.push({
-        path: filePath,
-        modTime: stats.mtime.getTime(),
-        lineNum,
-        lineText,
-      })
     }
 
     matches.sort((a, b) => b.modTime - a.modTime)
 
-    const limit = 100
-    const truncated = matches.length > limit
-    const finalMatches = truncated ? matches.slice(0, limit) : matches
+    const truncated = matches.length > MATCH_LIMIT
+    const finalMatches = truncated ? matches.slice(0, MATCH_LIMIT) : matches
 
     if (finalMatches.length === 0) {
       return {
@@ -103,7 +148,7 @@ export const GrepTool = Tool.define("grep", {
       outputLines.push(`  Line ${match.lineNum}: ${truncatedLineText}`)
     }
 
-    if (truncated) {
+    if (truncated || hitCollectLimit) {
       outputLines.push("")
       outputLines.push("(Results are truncated. Consider using a more specific path or pattern.)")
     }
@@ -112,7 +157,7 @@ export const GrepTool = Tool.define("grep", {
       title: params.pattern,
       metadata: {
         matches: finalMatches.length,
-        truncated,
+        truncated: truncated || hitCollectLimit,
       },
       output: outputLines.join("\n"),
     }

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -39,11 +39,10 @@ export const GrepTool = Tool.define("grep", {
     let buffer = ""
     const matches: Array<{
       path: string
-      modTime: number
       lineNum: number
       lineText: string
     }> = []
-    let hitCollectLimit = false
+    let truncated = false
 
     try {
       while (true) {
@@ -57,50 +56,35 @@ export const GrepTool = Tool.define("grep", {
         for (const line of lines) {
           if (!line) continue
           if (matches.length >= MATCH_LIMIT) {
-            hitCollectLimit = true
+            truncated = true
             break
           }
 
           const [filePath, lineNumStr, ...lineTextParts] = line.split("|")
           if (!filePath || !lineNumStr || lineTextParts.length === 0) continue
 
-          const lineNum = parseInt(lineNumStr, 10)
-          const lineText = lineTextParts.join("|")
-
-          const file = Bun.file(filePath)
-          const stats = await file.stat().catch(() => null)
-          if (!stats) continue
-
           matches.push({
             path: filePath,
-            modTime: stats.mtime.getTime(),
-            lineNum,
-            lineText,
+            lineNum: parseInt(lineNumStr, 10),
+            lineText: lineTextParts.join("|"),
           })
         }
 
-        if (hitCollectLimit) break
+        if (truncated) break
       }
 
-      if (!hitCollectLimit && buffer) {
+      if (!truncated && buffer) {
         const [filePath, lineNumStr, ...lineTextParts] = buffer.split("|")
         if (filePath && lineNumStr && lineTextParts.length > 0) {
-          const lineNum = parseInt(lineNumStr, 10)
-          const lineText = lineTextParts.join("|")
-          const file = Bun.file(filePath)
-          const stats = await file.stat().catch(() => null)
-          if (stats) {
-            matches.push({
-              path: filePath,
-              modTime: stats.mtime.getTime(),
-              lineNum,
-              lineText,
-            })
-          }
+          matches.push({
+            path: filePath,
+            lineNum: parseInt(lineNumStr, 10),
+            lineText: lineTextParts.join("|"),
+          })
         }
       }
     } finally {
-      if (hitCollectLimit) proc.kill()
+      if (truncated) proc.kill()
       reader.releaseLock()
     }
 
@@ -115,16 +99,11 @@ export const GrepTool = Tool.define("grep", {
       }
     }
 
-    if (exitCode !== 0 && exitCode !== 1 && !hitCollectLimit) {
+    if (exitCode !== 0 && exitCode !== 1 && !truncated) {
       throw new Error(`ripgrep failed: ${errorOutput}`)
     }
 
-    matches.sort((a, b) => b.modTime - a.modTime)
-
-    const truncated = matches.length > MATCH_LIMIT
-    const finalMatches = truncated ? matches.slice(0, MATCH_LIMIT) : matches
-
-    if (finalMatches.length === 0) {
+    if (matches.length === 0) {
       return {
         title: params.pattern,
         metadata: { matches: 0, truncated: false },
@@ -132,10 +111,10 @@ export const GrepTool = Tool.define("grep", {
       }
     }
 
-    const outputLines = [`Found ${finalMatches.length} matches`]
+    const outputLines = [`Found ${matches.length} matches`]
 
     let currentFile = ""
-    for (const match of finalMatches) {
+    for (const match of matches) {
       if (currentFile !== match.path) {
         if (currentFile !== "") {
           outputLines.push("")
@@ -148,7 +127,7 @@ export const GrepTool = Tool.define("grep", {
       outputLines.push(`  Line ${match.lineNum}: ${truncatedLineText}`)
     }
 
-    if (truncated || hitCollectLimit) {
+    if (truncated) {
       outputLines.push("")
       outputLines.push("(Results are truncated. Consider using a more specific path or pattern.)")
     }
@@ -156,8 +135,8 @@ export const GrepTool = Tool.define("grep", {
     return {
       title: params.pattern,
       metadata: {
-        matches: finalMatches.length,
-        truncated: truncated || hitCollectLimit,
+        matches: matches.length,
+        truncated,
       },
       output: outputLines.join("\n"),
     }


### PR DESCRIPTION
rg runs on some really common string on some large search space e.g. `cd / && rg /`
it waits for ALL the results to finish...
It used to load all the results (imagine 1 GB of text) all into memory.
Then string split, (allocating another 1+ GB of memory).
It would also do stat calls for all results
Then finally only fetch the first 100.

Now when you do sinful rg it returns instantly and saves your memory/disk for better things.

Note: There would be a behavior regression here - it used to load all results and when truncating to 100 it is sorted by recently modified
We could do a hybrid approach here - allow streaming in 2000(?) results and return the most recent 100 out of that (killing rg) to limit worst case, but still provide a good experience for small search results.

<img width="1304" height="947" alt="image" src="https://github.com/user-attachments/assets/4ba70cc9-8eda-4aeb-ac6e-0b6100aca153" />
