### PR TITLE
feat(tui): add header/footer/shortcuts toggle and improve prompt info line

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -169,6 +169,9 @@ function App() {
   const local = useLocal()
   const kv = useKV()
   const command = useCommandDialog()
+  const [shortcutsHidden, setShortcutsHidden] = createSignal(kv.get("shortcuts_hidden", false))
+  const [headerHidden, setHeaderHidden] = createSignal(kv.get("header_hidden", false))
+  const [footerHidden, setFooterHidden] = createSignal(kv.get("footer_hidden", false))
   const sdk = useSDK()
   const toast = useToast()
   const { theme, mode, setMode } = useTheme()
@@ -447,6 +450,45 @@ function App() {
       value: "app.fps",
       onSelect: (dialog) => {
         renderer.console.toggle()
+        dialog.clear()
+      },
+    },
+    {
+      title: shortcutsHidden() ? "Show shortcuts" : "Hide shortcuts",
+      value: "app.shortcuts.toggle",
+      category: "System",
+      onSelect: (dialog) => {
+        setShortcutsHidden((prev) => {
+          const next = !prev
+          kv.set("shortcuts_hidden", next)
+          return next
+        })
+        dialog.clear()
+      },
+    },
+    {
+      title: headerHidden() ? "Show header" : "Hide header",
+      value: "app.header.toggle",
+      category: "System",
+      onSelect: (dialog) => {
+        setHeaderHidden((prev) => {
+          const next = !prev
+          kv.set("header_hidden", next)
+          return next
+        })
+        dialog.clear()
+      },
+    },
+    {
+      title: footerHidden() ? "Show footer" : "Hide footer",
+      value: "app.footer.toggle",
+      category: "System",
+      onSelect: (dialog) => {
+        setFooterHidden((prev) => {
+          const next = !prev
+          kv.set("footer_hidden", next)
+          return next
+        })
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -27,6 +27,7 @@ import { useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
+import { useKV } from "../../context/kv"
 
 export type PromptProps = {
   sessionID?: string
@@ -35,6 +36,7 @@ export type PromptProps = {
   ref?: (ref: PromptRef) => void
   hint?: JSX.Element
   showPlaceholder?: boolean
+  footerVisible?: boolean
 }
 
 export type PromptRef = {
@@ -117,6 +119,12 @@ export function Prompt(props: PromptProps) {
   const dialog = useDialog()
   const toast = useToast()
   const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
+  const kv = useKV()
+  const permissions = createMemo(() => {
+    if (!props.sessionID) return []
+    return sync.data.permission[props.sessionID] ?? []
+  })
+  const shortcutsVisible = createMemo(() => !kv.get("shortcuts_hidden", false))
   const history = usePromptHistory()
   const command = useCommandDialog()
   const renderer = useRenderer()
@@ -881,17 +889,50 @@ export function Prompt(props: PromptProps) {
               cursorColor={theme.text}
               syntaxStyle={syntax()}
             />
-            <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
-              <text fg={highlight()}>
-                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
-              </text>
-              <Show when={store.mode === "normal"}>
-                <box flexDirection="row" gap={1}>
-                  <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
-                    {local.model.parsed().model}
-                  </text>
-                  <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
-                </box>
+            <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
+              <box flexDirection="row" gap={1}>
+                <text fg={highlight()}>
+                  {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
+                </text>
+                <Show when={store.mode === "normal"}>
+                  <box flexDirection="row" gap={1}>
+                    <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
+                      {local.model.parsed().model}
+                    </text>
+                    <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
+                  </box>
+                </Show>
+              </box>
+              <Show when={store.mode === "normal" && props.sessionID && !props.footerVisible}>
+                <Switch>
+                  <Match when={permissions().length > 0}>
+                    <text fg={theme.warning}>
+                      <span style={{ fg: theme.warning }}>◉</span> {permissions().length} Permission
+                      {permissions().length > 1 ? "s" : ""} pending
+                    </text>
+                  </Match>
+                  <Match when={status().type !== "idle"}>
+                    <box flexDirection="row" gap={1} flexShrink={0}>
+                      <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
+                      <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
+                        esc{" "}
+                        <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
+                          {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+                        </span>
+                      </text>
+                    </box>
+                  </Match>
+                  <Match when={shortcutsVisible()}>
+                    <box gap={2} flexDirection="row" flexShrink={0}>
+                      <text fg={theme.text}>
+                        {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>switch agent</span>
+                      </text>
+                      <text fg={theme.text}>
+                        {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
+                      </text>
+                    </box>
+                  </Match>
+                </Switch>
               </Show>
             </box>
           </box>
@@ -922,103 +963,117 @@ export function Prompt(props: PromptProps) {
             }
           />
         </box>
-        <box flexDirection="row" justifyContent="space-between">
-          <Show when={status().type !== "idle"} fallback={<text />}>
-            <box
-              flexDirection="row"
-              gap={1}
-              flexGrow={1}
-              justifyContent={status().type === "retry" ? "space-between" : "flex-start"}
-            >
-              <box flexShrink={0} flexDirection="row" gap={1}>
-                {/* @ts-ignore // SpinnerOptions doesn't support marginLeft */}
-                <spinner marginLeft={1} color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
-                <box flexDirection="row" gap={1} flexShrink={0}>
-                  {(() => {
-                    const retry = createMemo(() => {
-                      const s = status()
-                      if (s.type !== "retry") return
-                      return s
-                    })
-                    const message = createMemo(() => {
-                      const r = retry()
-                      if (!r) return
-                      if (r.message.includes("exceeded your current quota") && r.message.includes("gemini"))
-                        return "gemini is way too hot right now"
-                      if (r.message.length > 80) return r.message.slice(0, 80) + "..."
-                      return r.message
-                    })
-                    const isTruncated = createMemo(() => {
-                      const r = retry()
-                      if (!r) return false
-                      return r.message.length > 120
-                    })
-                    const [seconds, setSeconds] = createSignal(0)
-                    onMount(() => {
-                      const timer = setInterval(() => {
-                        const next = retry()?.next
-                        if (next) setSeconds(Math.round((next - Date.now()) / 1000))
-                      }, 1000)
-
-                      onCleanup(() => {
-                        clearInterval(timer)
+        <Show when={store.mode === "shell"}>
+          <box gap={2} flexDirection="row">
+            <text fg={theme.text}>
+              esc <span style={{ fg: theme.textMuted }}>exit shell mode</span>
+            </text>
+          </box>
+        </Show>
+        <Show when={store.mode !== "shell"}>
+          <box flexDirection="row" justifyContent="space-between">
+            <Show when={props.footerVisible && status().type !== "idle"} fallback={<text />}>
+              <box
+                flexDirection="row"
+                gap={1}
+                flexGrow={1}
+                justifyContent={status().type === "retry" ? "space-between" : "flex-start"}
+              >
+                <box flexShrink={0} flexDirection="row" gap={1}>
+                  {/* @ts-ignore // SpinnerOptions doesn't support marginLeft */}
+                  <spinner marginLeft={1} color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
+                  <box flexDirection="row" gap={1} flexShrink={0}>
+                    {(() => {
+                      const retry = createMemo(() => {
+                        const s = status()
+                        if (s.type !== "retry") return
+                        return s
                       })
-                    })
-                    const handleMessageClick = () => {
-                      const r = retry()
-                      if (!r) return
-                      if (isTruncated()) {
-                        DialogAlert.show(dialog, "Retry Error", r.message)
+                      const message = createMemo(() => {
+                        const r = retry()
+                        if (!r) return
+                        if (r.message.includes("exceeded your current quota") && r.message.includes("gemini"))
+                          return "gemini is way too hot right now"
+                        if (r.message.length > 80) return r.message.slice(0, 80) + "..."
+                        return r.message
+                      })
+                      const isTruncated = createMemo(() => {
+                        const r = retry()
+                        if (!r) return false
+                        return r.message.length > 120
+                      })
+                      const [seconds, setSeconds] = createSignal(0)
+                      onMount(() => {
+                        const timer = setInterval(() => {
+                          const next = retry()?.next
+                          if (next) setSeconds(Math.round((next - Date.now()) / 1000))
+                        }, 1000)
+
+                        onCleanup(() => {
+                          clearInterval(timer)
+                        })
+                      })
+                      const handleMessageClick = () => {
+                        const r = retry()
+                        if (!r) return
+                        if (isTruncated()) {
+                          DialogAlert.show(dialog, "Retry Error", r.message)
+                        }
                       }
-                    }
 
-                    const retryText = () => {
-                      const r = retry()
-                      if (!r) return ""
-                      const baseMessage = message()
-                      const truncatedHint = isTruncated() ? " (click to expand)" : ""
-                      const retryInfo = ` [retrying ${seconds() > 0 ? `in ${seconds()}s ` : ""}attempt #${r.attempt}]`
-                      return baseMessage + truncatedHint + retryInfo
-                    }
+                      const retryText = () => {
+                        const r = retry()
+                        if (!r) return ""
+                        const baseMessage = message()
+                        const truncatedHint = isTruncated() ? " (click to expand)" : ""
+                        const retryInfo = ` [retrying ${seconds() > 0 ? `in ${seconds()}s ` : ""}attempt #${r.attempt}]`
+                        return baseMessage + truncatedHint + retryInfo
+                      }
 
-                    return (
-                      <Show when={retry()}>
-                        <box onMouseUp={handleMessageClick}>
-                          <text fg={theme.error}>{retryText()}</text>
-                        </box>
-                      </Show>
-                    )
-                  })()}
+                      return (
+                        <Show when={retry()}>
+                          <box onMouseUp={handleMessageClick}>
+                            <text fg={theme.error}>{retryText()}</text>
+                          </box>
+                        </Show>
+                      )
+                    })()}
+                  </box>
                 </box>
+                <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
+                  esc{" "}
+                  <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
+                    {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+                  </span>
+                </text>
               </box>
-              <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
-                esc{" "}
-                <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
-                  {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                </span>
-              </text>
-            </box>
-          </Show>
-          <Show when={status().type !== "retry"}>
-            <box gap={2} flexDirection="row">
-              <Switch>
-                <Match when={store.mode === "normal"}>
+            </Show>
+            <Show when={!props.sessionID && status().type === "idle" && shortcutsVisible()}>
+              <box flexDirection="row" justifyContent="flex-end" flexGrow={1}>
+                <box gap={2} flexDirection="row">
                   <text fg={theme.text}>
                     {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>switch agent</span>
                   </text>
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
-                </Match>
-                <Match when={store.mode === "shell"}>
+                </box>
+              </box>
+            </Show>
+            <Show when={props.sessionID && props.footerVisible && status().type === "idle" && shortcutsVisible()}>
+              <box flexDirection="row" justifyContent="flex-end" flexGrow={1}>
+                <box gap={2} flexDirection="row">
                   <text fg={theme.text}>
-                    esc <span style={{ fg: theme.textMuted }}>exit shell mode</span>
+                    {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>switch agent</span>
                   </text>
-                </Match>
-              </Switch>
-            </box>
-          </Show>
-        </box>
+                  <text fg={theme.text}>
+                    {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
+                  </text>
+                </box>
+              </box>
+            </Show>
+          </box>
+        </Show>
       </box>
     </>
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -73,6 +73,7 @@ export function Home() {
               promptRef.set(r)
             }}
             hint={Hint}
+            footerVisible={false}
           />
         </box>
         <Toast />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -136,6 +136,8 @@ export function Session() {
     return false
   })
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const headerVisible = createMemo(() => !sidebarVisible() && !kv.get("header_hidden", false))
+  const footerVisible = createMemo(() => !sidebarVisible() && !kv.get("footer_hidden", false))
 
   const scrollAcceleration = createMemo(() => {
     const tui = sync.data.config.tui
@@ -959,9 +961,16 @@ export function Session() {
       }}
     >
       <box flexDirection="row">
-        <box flexGrow={1} paddingBottom={1} paddingTop={1} paddingLeft={2} paddingRight={2} gap={1}>
+        <box
+          flexGrow={1}
+          paddingBottom={footerVisible() ? 1 : 0}
+          paddingTop={1}
+          paddingLeft={2}
+          paddingRight={2}
+          gap={1}
+        >
           <Show when={session()}>
-            <Show when={!sidebarVisible()}>
+            <Show when={headerVisible()}>
               <Header />
             </Show>
             <scrollbox
@@ -1089,9 +1098,10 @@ export function Session() {
                   toBottom()
                 }}
                 sessionID={route.sessionID}
+                footerVisible={footerVisible()}
               />
             </box>
-            <Show when={!sidebarVisible()}>
+            <Show when={footerVisible()}>
               <Footer />
             </Show>
           </Show>


### PR DESCRIPTION
## Summary

Add System commands to toggle header, footer, and shortcuts visibility for small screen optimization. All preferences persist across restarts.

## Commands Added (System category)

| Command | Description |
|---------|-------------|
| Show/Hide header | Toggle session title bar |
| Show/Hide footer | Toggle directory/LSP/MCP status bar |
| Show/Hide shortcuts | Toggle idle shortcut hints |

All commands available globally (home + session pages) via command palette (ctrl+p).

## Behavior

### When Footer Hidden
- Prompt info line shows: permissions indicator OR compact status (spinner + esc) OR shortcuts
- Bottom section: empty
- Maximizes vertical space for agent responses

### When Footer Visible  
- Prompt info line: empty
- Bottom section: detailed status with retry info
- Footer: permissions, LSP, MCP status

Fixes #5277