### PR TITLE
fix - might be critical? : session rename completely not working since v1.0.144

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-rename.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-rename.tsx
@@ -18,8 +18,8 @@ export function DialogSessionRename(props: DialogSessionRenameProps) {
     <DialogPrompt
       title="Rename Session"
       value={session()?.title}
-      onConfirm={(value) => {
-        sdk.client.session.update({
+      onConfirm={async (value) => {
+        await sdk.client.session.update({
           sessionID: props.session,
           title: value,
         })


### PR DESCRIPTION
## Summary

Fix session rename functionality (`/rename` command) that has been broken since v1.0.144.

## Root Cause Analysis

### Issue 1: Missing `await` in API call (since v1.0.10)

Commit 30f9fa12d9 ("tui: add session rename functionality with /rename command", 2025-10-31) introduced `DialogSessionRename` component without `await` on the API call:

```typescript
onConfirm={(value) => {
  sdk.client.session.update({...})  // No await!
  dialog.clear()  // Closes immediately, ignoring API result
}}
```

This meant any API errors were silently ignored.

### Issue 2: `time` field became required (since v1.0.144)

Commit 936a6be5d6 ("stuff adam needs", 2025-12-10) added a `time` field to the session update validator but made it **required**:

```typescript
validator("json", z.object({
  title: z.string().optional(),
  time: z.object({  // Required! But DialogSessionRename only sends title
    archived: z.number().optional(),
  }),
})),
```

Since `DialogSessionRename` only sends `{ sessionID, title }` without `time`, all rename requests started failing with 400 validation error. Combined with Issue 1 (missing await), users saw no error - the dialog just closed and nothing happened.

## Fix

1. **server.ts**: Make `time` field optional in session update validator
2. **dialog-session-rename.tsx**: Add `async/await` to properly handle API response

## Affected Versions

- v1.0.10 ~ v1.0.143: Rename worked but errors were silently ignored
- v1.0.144+: Rename completely broken (validation failure + silent error)

## Related Issues

- Fixes #5369 (The /rename command is invalid in version 1.0.144 and later versions)
- Might fix #3779 (Session rename via /rename or /session + ctrl-r not working) - reported earlier, possibly same underlying issue

## Changes

| File | Change |
|------|--------|
| `server.ts` | Make `time` field `.optional()` in session update validator |
| `dialog-session-rename.tsx` | Add `async/await` to API call |
