### PR TITLE
Shell: No -l in fallback, for max compatibility

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1284,8 +1284,9 @@ export namespace SessionPrompt {
         args: ["-NoProfile", "-Command", input.command],
       },
       // Fallback: any shell that doesn't match those above
+      //  - No -l, for max compatibility
       "": {
-        args: ["-c", "-l", `${input.command}`],
+        args: ["-c", `${input.command}`],
       },
     }
 


### PR DESCRIPTION
Remove the `-l` flag from the fallback shell, for best compatibility with random shells that are out there, e.g.
- `fish` — supports `-l`, but must be `-l -c <cmd>` not `-c -l <cmd>`
- `nu` — supports `-l`, but must be `-l -c <cmd>` not `-c -l <cmd>`
- `xonsh` — supports `-l`, but must be `-l -c <cmd>` not `-c -l <cmd>`
- `tcsh`/`csh` — doesn't support `-l`
- `ksh` — supports `-l`
