### PR TITLE
github: support GITHUB_TOKEN + skip OIDC

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -17,6 +17,11 @@ inputs:
     description: "Custom prompt to override the default prompt"
     required: false
 
+  use_github_token:
+    description: "Use GITHUB_TOKEN directly instead of OpenCode App token exchange. When true, skips OIDC and uses the GITHUB_TOKEN env var."
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -51,3 +56,4 @@ runs:
         MODEL: ${{ inputs.model }}
         SHARE: ${{ inputs.share }}
         PROMPT: ${{ inputs.prompt }}
+        USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}


### PR DESCRIPTION
This PR adds a new `use_github_token` input to the GitHub Action that allows using `GITHUB_TOKEN` directly instead of exchanging an OIDC token via api.opencode.ai

Removes the dependency on `api.opencode.ai` to use `opencode github run` in CI / headless contexts.
