### PR TITLE
feat: add line-by-line scrolling controls for messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -535,6 +535,28 @@ export function Session() {
       },
     },
     {
+      title: "Line up",
+      value: "session.line.up",
+      keybind: "messages_line_up",
+      category: "Session",
+      disabled: true,
+      onSelect: (dialog) => {
+        scroll.scrollBy(-1)
+        dialog.clear()
+      },
+    },
+    {
+      title: "Line down",
+      value: "session.line.down",
+      keybind: "messages_line_down",
+      category: "Session",
+      disabled: true,
+      onSelect: (dialog) => {
+        scroll.scrollBy(1)
+        dialog.clear()
+      },
+    },
+    {
       title: "First message",
       value: "session.first",
       keybind: "messages_first",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -448,6 +448,8 @@ export namespace Config {
       messages_first: z.string().optional().default("ctrl+g,home").describe("Navigate to first message"),
       messages_last: z.string().optional().default("ctrl+alt+g,end").describe("Navigate to last message"),
       messages_last_user: z.string().optional().default("none").describe("Navigate to last user message"),
+      messages_line_up: z.string().optional().describe("Scroll messages up by one line"),
+      messages_line_down: z.string().optional().describe("Scroll messages down by one line"),
       messages_copy: z.string().optional().default("<leader>y").describe("Copy message"),
       messages_undo: z.string().optional().default("<leader>u").describe("Undo message"),
       messages_redo: z.string().optional().default("<leader>r").describe("Redo message"),


### PR DESCRIPTION
This feature adds actions for scrolling messages line-by-line. I didn't set any default keybindings as I figured the maintainers would decide on this if they wanted to add them. I personally use ctrl-j and ctrl-k.