### PR TITLE
docs: JetBrains IDEs to ACP config docs page 

### DIFF
--- a/packages/web/src/content/docs/acp.mdx
+++ b/packages/web/src/content/docs/acp.mdx
@@ -67,6 +67,26 @@ You can also bind a keyboard shortcut by editing your `keymap.json`:
 
 ---
 
+### JetBrains IDEs
+
+Add to your [JetBrains IDE](https://www.jetbrains.com/) acp.json according to the [documentation](https://www.jetbrains.com/help/ai-assistant/acp.html):
+
+```json title="~/.config/zed/settings.json"
+{
+    "agent_servers": {
+        "OpenCode": {
+            "command": "/absolute/path/bin/opencode", 
+            "args": ["acp"]
+        }
+    }
+}
+```
+
+To open it, use the new 'OpenCode' agent in the AI Chat agent selector.
+
+---
+
+
 ### Avante.nvim
 
 Add to your [Avante.nvim](https://github.com/yetone/avante.nvim) configuration:


### PR DESCRIPTION
JetBrains added support for ACP in a beta stage in the latest release, therefore opencode works quite nicely in the AI Chat.
(There are a couple UI issues on our end that I will report to the related team, but fundamentally it is working) 

<img width="484" height="703" alt="image" src="https://github.com/user-attachments/assets/34fc2017-4759-4ea5-a459-e81550c107ba" />
