### PR TITLE
add experimental.chat.system.transform hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -694,6 +694,14 @@ export namespace SessionPrompt {
       system.push(MAX_STEPS)
     }
 
+    const original = [...system]
+    await Plugin.trigger("experimental.chat.system.transform", {}, { system })
+
+    if (system.length === 0) {
+      log.error("system prompt is empty after plugin transform, using original")
+      system.push(...original)
+    }
+
     // max 2 system prompt messages for caching purposes
     const [first, ...rest] = system
     system = [first, rest.join("\n")]

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -185,6 +185,12 @@ export interface Hooks {
       }[]
     },
   ) => Promise<void>
+  "experimental.chat.system.transform"?: (
+    input: {},
+    output: {
+      system: string[]
+    },
+  ) => Promise<void>
   "experimental.text.complete"?: (
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },


### PR DESCRIPTION
Add a system prompt transform hook to allow plugins to alter system messages.

Plugins receive a mutable `string[]` containing the system prompt parts and can modify, add, or remove entries.

If a plugin empties the array, the original is restored and an error is logged to prevent downstream issues with empty system prompts.