### PR TITLE
fix(tui): constrain dialog option height to single line

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -307,8 +307,8 @@ function Option(props: {
         fg={props.active ? fg : props.current ? theme.primary : theme.text}
         attributes={props.active ? TextAttributes.BOLD : undefined}
         overflow="hidden"
-        wrapMode="word"
-        paddingLeft={3}
+        wrapMode="none"
+        maxHeight={1}
       >
         {Locale.truncate(props.title, 62)}
         <Show when={props.description}>


### PR DESCRIPTION
## Summary
- Constrain dialog select options to single line height with `wrapMode="none"` and `maxHeight={1}`
- Prevents text from wrapping to multiple lines in dialog menus

## Why
- `Locale.truncate` already truncates text, but `wrapMode="word"` was still causing text to wrap to multiple lines
- This ensures truncation works as intended and keeps all dialog options uniform height