### PR TITLE
docs: fix title for JetBrains ACP config file

### DIFF
--- a/packages/web/src/content/docs/acp.mdx
+++ b/packages/web/src/content/docs/acp.mdx
@@ -71,7 +71,7 @@ You can also bind a keyboard shortcut by editing your `keymap.json`:
 
 Add to your [JetBrains IDE](https://www.jetbrains.com/) acp.json according to the [documentation](https://www.jetbrains.com/help/ai-assistant/acp.html):
 
-```json title="~/.config/zed/settings.json"
+```json title="acp.json"
 {
   "agent_servers": {
     "OpenCode": {


### PR DESCRIPTION
Updated the filename in the JetBrains IDEs section to 'acp.json'.