### PR TITLE
fix: limit LSP diagnostics to prevent context window waste

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -18,6 +18,8 @@ import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 import { Snapshot } from "@/snapshot"
 
+const MAX_DIAGNOSTICS_PER_FILE = 10
+
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
 }
@@ -141,10 +143,11 @@ export const EditTool = Tool.define("edit", {
     for (const [file, issues] of Object.entries(diagnostics)) {
       if (issues.length === 0) continue
       if (file === filePath) {
-        output += `\nThis file has errors, please fix\n<file_diagnostics>\n${issues
-          .filter((item) => item.severity === 1)
-          .map(LSP.Diagnostic.pretty)
-          .join("\n")}\n</file_diagnostics>\n`
+        const sorted = issues.toSorted((a, b) => (a.severity ?? 4) - (b.severity ?? 4))
+        const limited = sorted.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+        const suffix =
+          issues.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${issues.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+        output += `\nThis file has errors, please fix\n<file_diagnostics>\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</file_diagnostics>\n`
         continue
       }
     }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -143,10 +143,10 @@ export const EditTool = Tool.define("edit", {
     for (const [file, issues] of Object.entries(diagnostics)) {
       if (issues.length === 0) continue
       if (file === filePath) {
-        const sorted = issues.toSorted((a, b) => (a.severity ?? 4) - (b.severity ?? 4))
-        const limited = sorted.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+        const errors = issues.filter((item) => item.severity === 1)
+        const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
         const suffix =
-          issues.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${issues.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+          errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
         output += `\nThis file has errors, please fix\n<file_diagnostics>\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</file_diagnostics>\n`
         continue
       }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -18,7 +18,7 @@ import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 import { Snapshot } from "@/snapshot"
 
-const MAX_DIAGNOSTICS_PER_FILE = 10
+const MAX_DIAGNOSTICS_PER_FILE = 20
 
 function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -11,7 +11,7 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 
-const MAX_DIAGNOSTICS_PER_FILE = 10
+const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
 
 export const WriteTool = Tool.define("write", {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -11,6 +11,9 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Agent } from "../agent/agent"
 
+const MAX_DIAGNOSTICS_PER_FILE = 10
+const MAX_PROJECT_DIAGNOSTICS_FILES = 5
+
 export const WriteTool = Tool.define("write", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -77,13 +80,20 @@ export const WriteTool = Tool.define("write", {
     let output = ""
     await LSP.touchFile(filepath, true)
     const diagnostics = await LSP.diagnostics()
+    let projectDiagnosticsCount = 0
     for (const [file, issues] of Object.entries(diagnostics)) {
       if (issues.length === 0) continue
+      const sorted = issues.toSorted((a, b) => (a.severity ?? 4) - (b.severity ?? 4))
+      const limited = sorted.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+      const suffix =
+        issues.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${issues.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
       if (file === filepath) {
-        output += `\nThis file has errors, please fix\n<file_diagnostics>\n${issues.map(LSP.Diagnostic.pretty).join("\n")}\n</file_diagnostics>\n`
+        output += `\nThis file has errors, please fix\n<file_diagnostics>\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</file_diagnostics>\n`
         continue
       }
-      output += `\n<project_diagnostics>\n${file}\n${issues.map(LSP.Diagnostic.pretty).join("\n")}\n</project_diagnostics>\n`
+      if (projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
+      projectDiagnosticsCount++
+      output += `\n<project_diagnostics>\n${file}\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</project_diagnostics>\n`
     }
 
     return {


### PR DESCRIPTION
LSP diagnostics returned after file writes and edits were unbounded, which could easily fill up the context window when a project has many errors.

This adds limits:
- Max 10 diagnostics per file (sorted by severity - errors first)
- Max 5 files for project-wide diagnostics (in write tool)
- Shows "... and N more" suffix when truncated

Fixes #5259

I encountered this issue while working on a big codebase with many broken scripts. All the LSP issues were filling in the context. I even made a cli to investigate why just 1 file write was consuming so much context. The issue is that LSP diagnostics are unbounded. As you can see in the image a single file write was consuming 400k characters of context


<img width="1715" height="936" alt="Screenshot 2025-12-13 at 12 14 38" src="https://github.com/user-attachments/assets/53c7732d-6c23-48cd-ad80-0cc8db5cd74d" />

