### PR TITLE
docs: add oh-my-opencode to plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -15,17 +15,18 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ## Plugins
 
-| Name                                                                                              | Description                                                           |
-| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                 | Automatically inject Helicone session headers for request grouping    |
-| [opencode-skills](https://github.com/malhashemi/opencode-skills)                                  | Manage and organize OpenCode skills and capabilities                  |
-| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                           | Auto-inject TypeScript/Svelte types into file reads with lookup tools |
-| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)            | Use your ChatGPT Plus/Pro subscription instead of API credits         |
-| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing                  |
-| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing                  |
-| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                 |
-| [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                    |
-| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                             |
+| Name                                                                                              | Description                                                                       |
+| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                 | Automatically inject Helicone session headers for request grouping                |
+| [opencode-skills](https://github.com/malhashemi/opencode-skills)                                  | Manage and organize OpenCode skills and capabilities                              |
+| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                           | Auto-inject TypeScript/Svelte types into file reads with lookup tools             |
+| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)            | Use your ChatGPT Plus/Pro subscription instead of API credits                     |
+| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing                              |
+| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing                              |
+| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                             |
+| [opencode-wakatime](https://github.com/angrister/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                |
+| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                         |
+| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds `oh-my-opencode` to the Plugins section of the ecosystem page.

## Details
**oh-my-opencode** is a comprehensive plugin distribution, every good thing is curated, after my personal experimentation

It provides:
- Background agents & multi-model orchestration (Oracle, Librarian, etc.)
- Pre-built tools including LSP clients and AST-Grep
- A compatibility layer for Claude Code extensions

Repository: https://github.com/code-yeongyu/oh-my-opencode