### PR TITLE
add ARM64 Docker image support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: actions/setup-node@v4
         with:
           node-version: "24"

--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -1,10 +1,18 @@
-FROM alpine
+FROM alpine AS base
 
 # Disable the runtime transpiler cache by default inside Docker containers.
 # On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
 ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
 RUN apk add libgcc libstdc++ ripgrep
-ADD ./dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
+
+FROM base AS build-amd64
+COPY dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode
+
+FROM base AS build-arm64
+COPY dist/opencode-linux-arm64-musl/bin/opencode /usr/local/bin/opencode
+
+ARG TARGETARCH
+FROM build-${TARGETARCH}
 RUN opencode --version
 ENTRYPOINT ["opencode"]

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -244,8 +244,8 @@ if (!Script.preview) {
   await $`cd ./dist/homebrew-tap && git push`
 
   const image = "ghcr.io/sst/opencode"
-  await $`docker build -t ${image}:${Script.version} .`
-  await $`docker push ${image}:${Script.version}`
-  await $`docker tag ${image}:${Script.version} ${image}:latest`
-  await $`docker push ${image}:latest`
+  const platforms = "linux/amd64,linux/arm64"
+  const tags = [`${image}:${Script.version}`, `${image}:latest`]
+  const tagFlags = tags.flatMap((t) => ["-t", t])
+  await $`docker buildx build --platform ${platforms} ${tagFlags} --push .`
 }


### PR DESCRIPTION
This is my attempt at adding the arm64 arch to the Docker image manifest. 

## Summary
- Publish multi-arch Docker images (amd64 + arm64)
- Uses buildx with QEMU for cross-platform builds

## Tested locally:
- ARM64 build works
- AMD64 build works (via QEMU)
  
  Closes #5436