### PR TITLE
Desktop file encoding issue

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -87,27 +87,6 @@ export namespace File {
     const tops = ["image", "audio", "video", "font", "model", "multipart"]
     if (tops.includes(top)) return true
 
-    if (type === "application/octet-stream") {
-      const ext = file.name?.split(".").pop()?.toLowerCase()
-      const textExtensions = [
-        "py",
-        "go",
-        "rb",
-        "swift",
-        "kt",
-        "rs",
-        "scala",
-        "r",
-        "lua",
-        "pl",
-        "sh",
-        "bash",
-        "zsh",
-        "fish",
-      ]
-      if (ext && textExtensions.includes(ext)) return false
-    }
-
     const bins = [
       "zip",
       "gzip",

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -87,7 +87,26 @@ export namespace File {
     const tops = ["image", "audio", "video", "font", "model", "multipart"]
     if (tops.includes(top)) return true
 
-    if (type === "application/octet-stream") return true
+    if (type === "application/octet-stream") {
+      const ext = file.name?.split(".").pop()?.toLowerCase()
+      const textExtensions = [
+        "py",
+        "go",
+        "rb",
+        "swift",
+        "kt",
+        "rs",
+        "scala",
+        "r",
+        "lua",
+        "pl",
+        "sh",
+        "bash",
+        "zsh",
+        "fish",
+      ]
+      if (ext && textExtensions.includes(ext)) return false
+    }
 
     const bins = [
       "zip",


### PR DESCRIPTION
Issue with the display of some file types in the desktop app. 
 
The shouldEncode() function treated all files with MIME type application/octet-stream as binary. Bun's MIME detection returns this type for many text-based programming languages, causing them to be unnecessarily encoded.

Added extension-based fallback checking before encoding application/octet-stream files. The function now checks if the file extension indicates a text file (.py, .go, .rb, .swift, .kt, etc.) and skips base64 encoding for these files.