### PR TITLE
add CPU flag checks to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
 
 ---
 
+### System Requirements
+
+**CPU Requirements:**
+
+- **x64 Linux**: CPU with SSE3 and SSSE3 instruction set support (approximately 2008 or newer)
+
 ### Installation
 
 ```bash

--- a/install
+++ b/install
@@ -159,6 +159,56 @@ unbuffered_sed() {
     fi
 }
 
+# Check CPU capabilities before proceeding (Linux x64 only)
+if [ "$arch" = "x64" ] && [ "$os" = "linux" ]; then
+  cpu_check_failed=false
+  if [ -f /proc/cpuinfo ]; then
+    # Use compatible grep method (works on older systems)
+    cpu_flags_line=$(grep "^flags" /proc/cpuinfo | head -n 1 2>/dev/null || echo "")
+
+    if [ -n "$cpu_flags_line" ]; then
+      # Extract flags after colon (compatible method)
+      cpu_flags=$(echo "$cpu_flags_line" | cut -d: -f2- 2>/dev/null || echo "")
+
+      if [ -n "$cpu_flags" ]; then
+        # Locale-independent case conversion
+        cpu_flags=$(LC_ALL=C echo "$cpu_flags" | tr '[:upper:]' '[:lower:]')
+
+        # Check for required instruction sets
+        missing_flags=""
+        case "$cpu_flags" in
+          *sse3*) ;;
+          *) missing_flags=" sse3" ;;
+        esac
+        case "$cpu_flags" in
+          *ssse3*) ;;
+          *) missing_flags="$missing_flags ssse3" ;;
+        esac
+
+        if [ -n "$missing_flags" ]; then
+          print_message error "CPU not supported"
+          print_message error "Missing required instruction sets:$missing_flags"
+          exit 1
+        fi
+      else
+        print_message warning "Could not parse CPU flags from /proc/cpuinfo. Proceeding with installation..."
+        cpu_check_failed=true
+      fi
+    else
+      print_message warning "No CPU flags found in /proc/cpuinfo. Proceeding with installation..."
+      cpu_check_failed=true
+    fi
+  else
+    print_message warning "Could not read /proc/cpuinfo. Proceeding with installation..."
+    cpu_check_failed=true
+  fi
+
+  # Warning if we couldn't check CPU capabilities
+  if [ "$cpu_check_failed" = true ]; then
+    print_message warning "Note: This may result in compatibility issues on older CPUs"
+  fi
+fi
+
 print_progress() {
     local bytes="$1"
     local length="$2"


### PR DESCRIPTION
Found that opencode installs on an old system that does not have required cpu flags to run.  This patch adds a check in the install check to prevent installation just to find a `Illegal instruction` error message