### PR TITLE
feat(auth): add support for multiple profiles per provider

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -2,6 +2,7 @@ import path from "path"
 import { Global } from "../global"
 import fs from "fs/promises"
 import z from "zod"
+import { NamedError } from "@opencode-ai/util/error"
 
 export namespace Auth {
   export const Oauth = z
@@ -34,9 +35,35 @@ export namespace Auth {
 
   const filepath = path.join(Global.Path.data, "auth.json")
 
-  export async function get(providerID: string) {
+  const PROFILE_DELIMITER = ":"
+  const PROFILE_REGEX = /^[a-zA-Z0-9_-]+$/
+
+  /** Parse composite key into provider and profile */
+  export function parseKey(key: string): { providerID: string; profile?: string } {
+    const idx = key.indexOf(PROFILE_DELIMITER)
+    if (idx === -1) return { providerID: key }
+    return {
+      providerID: key.slice(0, idx),
+      profile: key.slice(idx + 1),
+    }
+  }
+
+  /** Build composite key from provider and profile */
+  export function buildKey(providerID: string, profile?: string): string {
+    if (!profile) return providerID
+    return `${providerID}${PROFILE_DELIMITER}${profile}`
+  }
+
+  /** Validate profile name (alphanumeric, hyphen, underscore) */
+  export function validateProfileName(name: string): boolean {
+    return PROFILE_REGEX.test(name)
+  }
+
+  /** Get auth info for a provider, optionally with a specific profile */
+  export async function get(providerID: string, profile?: string) {
     const auth = await all()
-    return auth[providerID]
+    const key = buildKey(providerID, profile)
+    return auth[key]
   }
 
   export async function all(): Promise<Record<string, Info>> {
@@ -53,18 +80,80 @@ export namespace Auth {
     )
   }
 
-  export async function set(key: string, info: Info) {
+  /** Set auth info for a provider, optionally with a profile name */
+  export async function set(providerID: string, info: Info, profile?: string) {
     const file = Bun.file(filepath)
     const data = await all()
+    const key = buildKey(providerID, profile)
     await Bun.write(file, JSON.stringify({ ...data, [key]: info }, null, 2))
     await fs.chmod(file.name!, 0o600)
   }
 
-  export async function remove(key: string) {
+  /** Remove auth info for a provider, optionally with a specific profile */
+  export async function remove(providerID: string, profile?: string) {
     const file = Bun.file(filepath)
     const data = await all()
+    const key = buildKey(providerID, profile)
     delete data[key]
     await Bun.write(file, JSON.stringify(data, null, 2))
     await fs.chmod(file.name!, 0o600)
   }
+
+  /** List all profiles for a provider */
+  export async function profiles(providerID: string): Promise<Array<{ profile?: string; info: Info }>> {
+    const data = await all()
+    const result: Array<{ profile?: string; info: Info }> = []
+    for (const [key, info] of Object.entries(data)) {
+      const parsed = parseKey(key)
+      if (parsed.providerID === providerID) {
+        result.push({ profile: parsed.profile, info })
+      }
+    }
+    return result
+  }
+
+  /** Check if default profile exists for provider */
+  export async function hasDefault(providerID: string): Promise<boolean> {
+    const data = await all()
+    return providerID in data
+  }
+
+  /** Swap default with a named profile */
+  export async function setDefault(providerID: string, profile: string): Promise<void> {
+    const data = await all()
+    const namedKey = buildKey(providerID, profile)
+    const defaultKey = providerID
+
+    const namedInfo = data[namedKey]
+    if (!namedInfo) throw new ProfileNotFoundError({ providerID, profile })
+
+    const defaultInfo = data[defaultKey]
+
+    // Swap: named becomes default, old default becomes named
+    const file = Bun.file(filepath)
+    const newData = { ...data }
+    newData[defaultKey] = namedInfo
+    if (defaultInfo) {
+      newData[namedKey] = defaultInfo
+    } else {
+      delete newData[namedKey]
+    }
+    await Bun.write(file, JSON.stringify(newData, null, 2))
+    await fs.chmod(file.name!, 0o600)
+  }
+
+  export const ProfileNotFoundError = NamedError.create(
+    "AuthProfileNotFoundError",
+    z.object({
+      providerID: z.string(),
+      profile: z.string(),
+    }),
+  )
+
+  export const InvalidProfileNameError = NamedError.create(
+    "AuthInvalidProfileNameError",
+    z.object({
+      profile: z.string(),
+    }),
+  )
 }

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -15,10 +15,35 @@ import type { Hooks } from "@opencode-ai/plugin"
 type PluginAuth = NonNullable<Hooks["auth"]>
 
 /**
+ * Prompt for profile name if provider already has a default profile.
+ * Returns undefined for default profile, or the profile name.
+ */
+async function promptForProfile(provider: string): Promise<string | undefined> {
+  const hasDefault = await Auth.hasDefault(provider)
+  if (!hasDefault) return undefined
+
+  const profiles = await Auth.profiles(provider)
+  const existingNames = profiles.map((p) => p.profile ?? "default").join(", ")
+  prompts.log.info(`Existing profiles: ${existingNames}`)
+
+  const profileName = await prompts.text({
+    message: "Enter profile name (leave empty for default)",
+    placeholder: "e.g. work, personal",
+    validate: (x) => {
+      if (!x || x.length === 0) return undefined
+      if (!Auth.validateProfileName(x)) return "Only letters, numbers, hyphens, and underscores allowed"
+      return undefined
+    },
+  })
+  if (prompts.isCancel(profileName)) throw new UI.CancelledError()
+  return profileName || undefined
+}
+
+/**
  * Handle plugin-based authentication flow.
  * Returns true if auth was handled, false if it should fall through to default handling.
  */
-async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string): Promise<boolean> {
+async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string, profile?: string): Promise<boolean> {
   let index = 0
   if (plugin.auth.methods.length > 1) {
     const method = await prompts.select({
@@ -83,19 +108,27 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
         const saveProvider = result.provider ?? provider
         if ("refresh" in result) {
           const { type: _, provider: __, refresh, access, expires, ...extraFields } = result
-          await Auth.set(saveProvider, {
-            type: "oauth",
-            refresh,
-            access,
-            expires,
-            ...extraFields,
-          })
+          await Auth.set(
+            saveProvider,
+            {
+              type: "oauth",
+              refresh,
+              access,
+              expires,
+              ...extraFields,
+            },
+            profile,
+          )
         }
         if ("key" in result) {
-          await Auth.set(saveProvider, {
-            type: "api",
-            key: result.key,
-          })
+          await Auth.set(
+            saveProvider,
+            {
+              type: "api",
+              key: result.key,
+            },
+            profile,
+          )
         }
         spinner.stop("Login successful")
       }
@@ -115,19 +148,27 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
         const saveProvider = result.provider ?? provider
         if ("refresh" in result) {
           const { type: _, provider: __, refresh, access, expires, ...extraFields } = result
-          await Auth.set(saveProvider, {
-            type: "oauth",
-            refresh,
-            access,
-            expires,
-            ...extraFields,
-          })
+          await Auth.set(
+            saveProvider,
+            {
+              type: "oauth",
+              refresh,
+              access,
+              expires,
+              ...extraFields,
+            },
+            profile,
+          )
         }
         if ("key" in result) {
-          await Auth.set(saveProvider, {
-            type: "api",
-            key: result.key,
-          })
+          await Auth.set(
+            saveProvider,
+            {
+              type: "api",
+              key: result.key,
+            },
+            profile,
+          )
         }
         prompts.log.success("Login successful")
       }
@@ -145,10 +186,14 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
       }
       if (result.type === "success") {
         const saveProvider = result.provider ?? provider
-        await Auth.set(saveProvider, {
-          type: "api",
-          key: result.key,
-        })
+        await Auth.set(
+          saveProvider,
+          {
+            type: "api",
+            key: result.key,
+          },
+          profile,
+        )
         prompts.log.success("Login successful")
       }
       prompts.outro("Done")
@@ -159,11 +204,82 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
   return false
 }
 
+export const AuthSetDefaultCommand = cmd({
+  command: "set-default",
+  describe: "set a profile as the default for a provider",
+  async handler() {
+    UI.empty()
+    prompts.intro("Set default profile")
+    const credentials = await Auth.all().then((x) => Object.entries(x))
+    const database = await ModelsDev.get()
+
+    // Group by provider, only show providers with multiple profiles (including at least one named)
+    const grouped: Record<string, Array<{ profile?: string; key: string }>> = {}
+    for (const [key] of credentials) {
+      const parsed = Auth.parseKey(key)
+      if (!grouped[parsed.providerID]) grouped[parsed.providerID] = []
+      grouped[parsed.providerID].push({ profile: parsed.profile, key })
+    }
+
+    // Filter to providers with named profiles
+    const eligibleProviders = Object.entries(grouped).filter(([, profiles]) =>
+      profiles.some((p) => p.profile !== undefined),
+    )
+
+    if (eligibleProviders.length === 0) {
+      prompts.log.error("No providers with multiple profiles found")
+      prompts.outro("Done")
+      return
+    }
+
+    // Select provider
+    const providerID = await prompts.select({
+      message: "Select provider",
+      options: eligibleProviders.map(([id, profiles]) => {
+        const name = database[id]?.name || id
+        const count = profiles.length
+        return {
+          label: `${name} ${UI.Style.TEXT_DIM}(${count} profiles)`,
+          value: id,
+        }
+      }),
+    })
+    if (prompts.isCancel(providerID)) throw new UI.CancelledError()
+
+    // Get named profiles for this provider
+    const namedProfiles = grouped[providerID].filter((p) => p.profile !== undefined)
+    if (namedProfiles.length === 0) {
+      prompts.log.error("No named profiles found for this provider")
+      prompts.outro("Done")
+      return
+    }
+
+    // Select profile to promote
+    const profile = await prompts.select({
+      message: "Select profile to set as default",
+      options: namedProfiles.map((p) => ({
+        label: p.profile!,
+        value: p.profile!,
+      })),
+    })
+    if (prompts.isCancel(profile)) throw new UI.CancelledError()
+
+    await Auth.setDefault(providerID, profile)
+    prompts.log.success(`Profile "${profile}" is now the default for ${database[providerID]?.name || providerID}`)
+    prompts.outro("Done")
+  },
+})
+
 export const AuthCommand = cmd({
   command: "auth",
   describe: "manage credentials",
   builder: (yargs) =>
-    yargs.command(AuthLoginCommand).command(AuthLogoutCommand).command(AuthListCommand).demandCommand(),
+    yargs
+      .command(AuthLoginCommand)
+      .command(AuthLogoutCommand)
+      .command(AuthListCommand)
+      .command(AuthSetDefaultCommand)
+      .demandCommand(),
   async handler() {},
 })
 
@@ -180,9 +296,20 @@ export const AuthListCommand = cmd({
     const results = Object.entries(await Auth.all())
     const database = await ModelsDev.get()
 
-    for (const [providerID, result] of results) {
+    // Group by provider
+    const grouped: Record<string, Array<{ profile?: string; type: string }>> = {}
+    for (const [key, result] of results) {
+      const parsed = Auth.parseKey(key)
+      if (!grouped[parsed.providerID]) grouped[parsed.providerID] = []
+      grouped[parsed.providerID].push({ profile: parsed.profile, type: result.type })
+    }
+
+    for (const [providerID, profiles] of Object.entries(grouped)) {
       const name = database[providerID]?.name || providerID
-      prompts.log.info(`${name} ${UI.Style.TEXT_DIM}${result.type}`)
+      for (const p of profiles) {
+        const profileLabel = p.profile ? `:${p.profile}` : " (default)"
+        prompts.log.info(`${name}${profileLabel} ${UI.Style.TEXT_DIM}${p.type}`)
+      }
     }
 
     prompts.outro(`${results.length} credentials`)
@@ -306,12 +433,6 @@ export const AuthLoginCommand = cmd({
 
         if (prompts.isCancel(provider)) throw new UI.CancelledError()
 
-        const plugin = await Plugin.list().then((x) => x.find((x) => x.auth?.provider === provider))
-        if (plugin && plugin.auth) {
-          const handled = await handlePluginAuth({ auth: plugin.auth }, provider)
-          if (handled) return
-        }
-
         if (provider === "other") {
           provider = await prompts.text({
             message: "Enter provider id",
@@ -320,17 +441,6 @@ export const AuthLoginCommand = cmd({
           if (prompts.isCancel(provider)) throw new UI.CancelledError()
           provider = provider.replace(/^@ai-sdk\//, "")
           if (prompts.isCancel(provider)) throw new UI.CancelledError()
-
-          // Check if a plugin provides auth for this custom provider
-          const customPlugin = await Plugin.list().then((x) => x.find((x) => x.auth?.provider === provider))
-          if (customPlugin && customPlugin.auth) {
-            const handled = await handlePluginAuth({ auth: customPlugin.auth }, provider)
-            if (handled) return
-          }
-
-          prompts.log.warn(
-            `This only stores a credential for ${provider} - you will need configure it in opencode.json, check the docs for examples.`,
-          )
         }
 
         if (provider === "amazon-bedrock") {
@@ -339,6 +449,15 @@ export const AuthLoginCommand = cmd({
           )
           prompts.outro("Done")
           return
+        }
+
+        // Prompt for profile name if provider already has credentials
+        const profile = await promptForProfile(provider)
+
+        const plugin = await Plugin.list().then((x) => x.find((x) => x.auth?.provider === provider))
+        if (plugin && plugin.auth) {
+          const handled = await handlePluginAuth({ auth: plugin.auth }, provider, profile)
+          if (handled) return
         }
 
         if (provider === "opencode") {
@@ -354,10 +473,14 @@ export const AuthLoginCommand = cmd({
           validate: (x) => (x && x.length > 0 ? undefined : "Required"),
         })
         if (prompts.isCancel(key)) throw new UI.CancelledError()
-        await Auth.set(provider, {
-          type: "api",
-          key,
-        })
+        await Auth.set(
+          provider,
+          {
+            type: "api",
+            key,
+          },
+          profile,
+        )
 
         prompts.outro("Done")
       },
@@ -377,15 +500,21 @@ export const AuthLogoutCommand = cmd({
       return
     }
     const database = await ModelsDev.get()
-    const providerID = await prompts.select({
-      message: "Select provider",
-      options: credentials.map(([key, value]) => ({
-        label: (database[key]?.name || key) + UI.Style.TEXT_DIM + " (" + value.type + ")",
-        value: key,
-      })),
+    const selection = await prompts.select({
+      message: "Select credential",
+      options: credentials.map(([key, value]) => {
+        const parsed = Auth.parseKey(key)
+        const providerName = database[parsed.providerID]?.name || parsed.providerID
+        const profileLabel = parsed.profile ? `:${parsed.profile}` : " (default)"
+        return {
+          label: providerName + profileLabel + UI.Style.TEXT_DIM + " " + value.type,
+          value: key,
+        }
+      }),
     })
-    if (prompts.isCancel(providerID)) throw new UI.CancelledError()
-    await Auth.remove(providerID)
+    if (prompts.isCancel(selection)) throw new UI.CancelledError()
+    const parsed = Auth.parseKey(selection)
+    await Auth.remove(parsed.providerID, parsed.profile)
     prompts.outro("Logout successful")
   },
 })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -580,6 +580,7 @@ export namespace Config {
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
       models: z.record(z.string(), ModelsDev.Model.partial()).optional(),
+      profile: z.string().optional().describe("Default auth profile to use for this provider"),
       options: z
         .object({
           apiKey: z.string().optional(),

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -76,6 +76,7 @@ export namespace ProviderAuth {
       providerID: z.string(),
       method: z.number(),
       code: z.string().optional(),
+      profile: z.string().optional(),
     }),
     async (input) => {
       const match = await state().then((s) => s.pending[input.providerID])
@@ -93,18 +94,26 @@ export namespace ProviderAuth {
 
       if (result?.type === "success") {
         if ("key" in result) {
-          await Auth.set(input.providerID, {
-            type: "api",
-            key: result.key,
-          })
+          await Auth.set(
+            input.providerID,
+            {
+              type: "api",
+              key: result.key,
+            },
+            input.profile,
+          )
         }
         if ("refresh" in result) {
-          await Auth.set(input.providerID, {
-            type: "oauth",
-            access: result.access,
-            refresh: result.refresh,
-            expires: result.expires,
-          })
+          await Auth.set(
+            input.providerID,
+            {
+              type: "oauth",
+              access: result.access,
+              refresh: result.refresh,
+              expires: result.expires,
+            },
+            input.profile,
+          )
         }
         return
       }
@@ -117,12 +126,17 @@ export namespace ProviderAuth {
     z.object({
       providerID: z.string(),
       key: z.string(),
+      profile: z.string().optional(),
     }),
     async (input) => {
-      await Auth.set(input.providerID, {
-        type: "api",
-        key: input.key,
-      })
+      await Auth.set(
+        input.providerID,
+        {
+          type: "api",
+          key: input.key,
+        },
+        input.profile,
+      )
     },
   )
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -620,14 +620,19 @@ export namespace Provider {
       })
     }
 
-    // load apikeys
-    for (const [providerID, provider] of Object.entries(await Auth.all())) {
+    // load apikeys - parse composite keys to extract provider and profile
+    for (const [key, authInfo] of Object.entries(await Auth.all())) {
+      const { providerID, profile } = Auth.parseKey(key)
       if (disabled.has(providerID)) continue
-      if (provider.type === "api") {
-        mergeProvider(providerID, {
-          source: "api",
-          key: provider.key,
-        })
+      if (authInfo.type === "api") {
+        // Only use default profile (no profile suffix) for auto-loading
+        // Named profiles are explicitly selected via model string or config
+        if (!profile) {
+          mergeProvider(providerID, {
+            source: "api",
+            key: authInfo.key,
+          })
+        }
       }
     }
 
@@ -968,9 +973,19 @@ export namespace Provider {
   }
 
   export function parseModel(model: string) {
-    const [providerID, ...rest] = model.split("/")
+    const [first, ...rest] = model.split("/")
+    // Check for profile in format: provider:profile/model
+    const colonIdx = first.indexOf(":")
+    if (colonIdx !== -1) {
+      return {
+        providerID: first.slice(0, colonIdx),
+        profile: first.slice(colonIdx + 1),
+        modelID: rest.join("/"),
+      }
+    }
     return {
-      providerID: providerID,
+      providerID: first,
+      profile: undefined,
       modelID: rest.join("/"),
     }
   }


### PR DESCRIPTION
implements https://github.com/sst/opencode/issues/5391

## Summary

- Allow users to store multiple API keys for the same provider with named profiles (e.g., separate OpenRouter keys for different cost tracking)
- Add `auth set-default` command to swap a named profile to become the default

## Changes

- **Auth module**: Added profile support to get/set/remove, plus `profiles()`, `hasDefault()`, `setDefault()` functions
- **CLI commands**: `login` prompts for profile name when default exists, `logout`/`list` show profile names, new `set-default` command
- **Provider**: `parseModel()` extracts profile from `provider:profile/model` format
- **Config**: Added optional `profile` field to provider schema
- **Errors**: Added `ProfileNotFoundError` and `InvalidProfileNameError`

## Usage

```bash
# First login creates default profile
opencode auth login  # select openrouter, enter key

# Second login prompts for profile name
opencode auth login  # select openrouter, enter "work", enter key

# List shows profiles
opencode auth list
# OpenRouter (default) api
# OpenRouter:work api

# Use profile in model string
opencode --model openrouter:work/claude-sonnet-4

# Swap profiles
opencode auth set-default  # select openrouter, select "work"
```