### PR TITLE
feat: add unread indicator for completed sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -172,6 +172,15 @@ function App() {
     console.log(JSON.stringify(route.data))
   })
 
+  // Track current session for unread indicator
+  createEffect(() => {
+    if (route.data.type === "session") {
+      sync.session.setCurrentSession(route.data.sessionID)
+    } else {
+      sync.session.setCurrentSession(undefined)
+    }
+  })
+
   // Update terminal window title based on current route and session
   createEffect(() => {
     if (route.data.type === "home") {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -39,13 +39,19 @@ export function DialogSessionList() {
         const isDeleting = toDelete() === x.id
         const status = sync.data.session_status[x.id]
         const isWorking = status?.type === "busy"
+        const isUnread = sync.data.session_unread[x.id]
+        const gutter = isWorking ? (
+          <spinner frames={spinnerFrames} interval={80} color={theme.primary} />
+        ) : isUnread ? (
+          <text fg={theme.primary}>○</text>
+        ) : undefined
         return {
           title: isDeleting ? `Press ${deleteKeybind} again to confirm` : x.title,
           bg: isDeleting ? theme.error : undefined,
           value: x.id,
           category,
           footer: Locale.time(x.time.updated),
-          gutter: isWorking ? <spinner frames={spinnerFrames} interval={80} color={theme.primary} /> : undefined,
+          gutter,
         }
       })
       .slice(0, 150)

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -45,6 +45,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       session_status: {
         [sessionID: string]: SessionStatus
       }
+      session_unread: {
+        [sessionID: string]: boolean
+      }
       session_diff: {
         [sessionID: string]: Snapshot.FileDiff[]
       }
@@ -80,6 +83,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       provider_default: {},
       session: [],
       session_status: {},
+      session_unread: {},
       session_diff: {},
       todo: {},
       message: {},
@@ -92,6 +96,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const sdk = useSDK()
+    let currentSessionID: string | undefined = undefined
 
     sdk.event.listen((e) => {
       const event = e.details
@@ -167,7 +172,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }
 
         case "session.status": {
-          setStore("session_status", event.properties.sessionID, event.properties.status)
+          const prev = store.session_status[event.properties.sessionID]
+          const next = event.properties.status
+          // Track if session transitioned from busy to idle while user is not viewing it
+          if (prev?.type === "busy" && next.type === "idle" && currentSessionID !== event.properties.sessionID) {
+            setStore("session_unread", event.properties.sessionID, true)
+          }
+          setStore("session_status", event.properties.sessionID, next)
           break
         }
 
@@ -333,6 +344,18 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           if (!last) return "idle"
           if (last.role === "user") return "working"
           return last.time.completed ? "idle" : "working"
+        },
+        setCurrentSession(sessionID: string | undefined) {
+          currentSessionID = sessionID
+          if (sessionID) {
+            setStore("session_unread", sessionID, false)
+          }
+        },
+        getCurrentSession() {
+          return currentSessionID
+        },
+        markRead(sessionID: string) {
+          setStore("session_unread", sessionID, false)
         },
         async sync(sessionID: string) {
           if (fullSyncedSessions.has(sessionID)) return


### PR DESCRIPTION
## Summary
- Add a hollow circle indicator (○) in the session list for sessions that completed while the user was viewing a different session
- The indicator is automatically cleared when the user navigates to that session

## How it works
1. When a session transitions from `busy` → `idle` and the user is NOT currently viewing that session, it gets marked as "unread"
2. When the user navigates to a session, it automatically gets marked as "read"
3. In the session list dialog, unread sessions show a `○` indicator in the primary color
4. Sessions that are actively working still show the spinner instead of the unread indicator