### PR TITLE
feat: add session archive command

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -920,6 +920,14 @@ export namespace ACP {
             { throwOnError: true },
           )
           break
+        case "archive":
+          await this.config.sdk.session.delete(
+            {
+              sessionID,
+            },
+            { throwOnError: true },
+          )
+          break
       }
 
       return done

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -241,6 +241,12 @@ export function Autocomplete(props: {
           onSelect: () => command.trigger("session.compact"),
         },
         {
+          display: "/archive",
+          aliases: ["/delete"],
+          description: "delete session and go home",
+          onSelect: () => command.trigger("session.archive"),
+        },
+        {
           display: "/unshare",
           disabled: !s.share,
           description: "unshare a session",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -318,6 +318,17 @@ export function Session() {
       },
     },
     {
+      title: "Archive session",
+      value: "session.archive",
+      category: "Session",
+      onSelect: (dialog) => {
+        sdk.client.session.delete({
+          sessionID: route.sessionID,
+        })
+        dialog.clear()
+      },
+    },
+    {
       title: "Unshare session",
       value: "session.unshare",
       keybind: "session_unshare",


### PR DESCRIPTION
## Summary
- Adds `/archive` (with `/delete` alias) command to delete sessions from within the TUI
- Accessible via both the autocomplete menu and command palette

It probably shouldn't be called archive actually because it's a destructive action

Would be nice to get archiving of chats