### PR TITLE
docs: Add opencode-websearch-cited to plugin list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -24,6 +24,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing                                   |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing                                   |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                                  |
+| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                | Add native websearch support for supported providers with Google grounded style        |
 | [opencode-wakatime](https://github.com/angrister/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                     |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                              |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible |


### PR DESCRIPTION
Add [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git) to ecosystem page.