### PR TITLE
fix(tui): open parent session instead of subagent on continue flag

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -218,7 +218,7 @@ function App() {
   let continued = false
   createEffect(() => {
     if (continued || sync.status !== "complete" || !args.continue) return
-    const match = sync.data.session.at(0)?.id
+    const match = sync.data.session.find((x) => x.parentID === undefined)?.id
     if (match) {
       continued = true
       route.navigate({ type: "session", sessionID: match })


### PR DESCRIPTION
## Summary
- Filter sessions to exclude subagents when using `-c` or `--continue` flag in TUI mode

## Why
- When a session has subagents, `sync.data.session.at(0)` could return a subagent session instead of the parent session
- This is inconsistent with the session list dialog which already filters with `x.parentID === undefined`