### PR TITLE
feat: add /plugins command

### DIFF
--- a/.opencode/command/plugins.md
+++ b/.opencode/command/plugins.md
@@ -1,0 +1,12 @@
+---
+description: List all enabled OpenCode plugins
+---
+
+List all enabled OpenCode plugins.
+
+This command shows:
+- All plugins configured in your OpenCode config (global and project-specific)
+- Default plugins that are always enabled
+- Plugin locations and versions
+
+Use the list_plugins tool to get the current list of enabled plugins.


### PR DESCRIPTION
Add /plugins command to list enabled OpenCode plugins.

The command uses the list_plugins tool to show all configured plugins.