### PR TITLE
fix(ui): guard Node reference for SSR compatibility in isTriggerTitle

### DIFF
--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -13,7 +13,9 @@ export type TriggerTitle = {
 }
 
 const isTriggerTitle = (val: any): val is TriggerTitle => {
-  return typeof val === "object" && val !== null && "title" in val && !(val instanceof Node)
+  return (
+    typeof val === "object" && val !== null && "title" in val && (typeof Node === "undefined" || !(val instanceof Node))
+  )
 }
 
 export interface BasicToolProps {


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: Node is not defined` crash on Share pages (SSR)

## Why
- The `isTriggerTitle` utility checks `instanceof Node` which throws in the server environment where `Node` is not defined
- This caused the entire application to fail hydration and render empty on share routes
- Special thanks to @Dragoy for debugging and identifying the root cause via DevTools

Fixes #5493