### PR TITLE
fix(enterprise): remove deferStream to fix share page hydration mismatch

### DIFF
--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -138,18 +138,13 @@ const getData = query(async (shareID) => {
 
 export default function () {
   const params = useParams()
-  const data = createAsync(
-    async () => {
-      if (!params.shareID) throw new Error("Missing shareID")
-      const now = Date.now()
-      const data = getData(params.shareID)
-      console.log("getData", Date.now() - now)
-      return data
-    },
-    {
-      deferStream: true,
-    },
-  )
+  const data = createAsync(async () => {
+    if (!params.shareID) throw new Error("Missing shareID")
+    const now = Date.now()
+    const data = getData(params.shareID)
+    console.log("getData", Date.now() - now)
+    return data
+  })
 
   createEffect(() => {
     console.log(data())


### PR DESCRIPTION
## Summary

- Remove `deferStream: true` from share page route to fix blank page issue with large session data

## Problem

Share pages with large data (3.5MB+) render as **completely blank pages**. The `$R` hydration promises never resolve, leaving `#app` with only a Solid marker comment.

**Observed behavior:**
- `#app innerHTML`: `<!--!$e000000010000000020000000010-->` (empty)
- `$R` object: 790 keys loaded, but `R[0], R[3], R[5]` stuck as unresolved promises
- No JavaScript errors in console

## Root Cause

`deferStream: true` was added in commit 95526fb9e (Dec 11, 2025) with the intent to fix share image meta tags. However, this causes **streaming chunk processing failures** with large payloads:

1. Server sends data as streaming chunks (not inline in initial HTML)
2. Large chunks (3.5MB) can fail silently - CDN buffering, truncation, or main thread blocking
3. Client waits indefinitely for chunks that never properly resolve
4. Result: permanent blank page with no error indication

## Solution

Remove `deferStream: true` to ensure data is embedded in initial HTML rather than streamed. This guarantees hydration completes regardless of payload size.

## OG Image Impact: None (No Regression)

Removing `deferStream` does **not** affect OG images because they are **already broken** in production:

```bash
$ curl -sA "facebookexternalhit" "https://opncd.ai/share/vBB6Ttga" | grep og:image
# (no output - OG tags missing)
```

**Why OG tags don't work (regardless of deferStream):**

The `<Meta property="og:image">` tag is inside `<Show when={data()}>`:

```tsx
<Show when={data()}>
  {(data) => (
    <>
      <Meta property="og:image" content={ogImage()} />  // Inside Show
      ...
    </>
  )}
</Show>
```

Since `<head>` is sent before `data()` resolves, OG meta tags are never included in the initial HTML response. This is a separate issue that requires moving meta tags outside of `<Show>`.

| Scenario | OG Image | Page Render |
|----------|----------|-------------|
| Before (deferStream: true) | ❌ Broken | ❌ Blank (large data) |
| After (deferStream removed) | ❌ Broken (unchanged) | ✅ Works |

## Testing

- Tested with production share data (3,522,667 chars / 3.5MB)
- Browser test confirms page renders correctly after fix
- Verified OG tags are absent both before and after change

## Related

- Continues fix from #5509 (Node reference SSR guard)
- Resolves #5493, #5522

---
🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)
