### PR TITLE
fix: handle missing share files in Session.getShare and ShareNext.get

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -215,7 +215,7 @@ export namespace Session {
   })
 
   export const getShare = fn(Identifier.schema("session"), async (id) => {
-    return Storage.read<ShareInfo>(["share", id])
+    return Storage.read<ShareInfo>(["share", id]).catch(() => undefined)
   })
 
   export const share = fn(Identifier.schema("session"), async (id) => {

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -83,7 +83,7 @@ export namespace ShareNext {
       id: string
       secret: string
       url: string
-    }>(["session_share", sessionID])
+    }>(["session_share", sessionID]).catch(() => undefined)
   }
 
   type Data =


### PR DESCRIPTION
## Summary
- Fix unhandled promise rejections caused by `Storage.read` throwing `NotFoundError` when checking share status for unshared sessions
- The TUI calls these functions during sync, resulting in ~1 error/second in the logs

## Changes
- Add `.catch(() => undefined)` to `Session.getShare()` and `ShareNext.get()` to gracefully handle missing share files
- Consistent with similar patterns elsewhere in the codebase (e.g. `project.ts:95`, `summary.ts:181`)