### PR TITLE
fix(tui): --continue selects wrong session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -218,7 +218,9 @@ function App() {
   let continued = false
   createEffect(() => {
     if (continued || sync.status !== "complete" || !args.continue) return
-    const match = sync.data.session.find((x) => x.parentID === undefined)?.id
+    const match = sync.data.session
+      .toSorted((a, b) => b.time.updated - a.time.updated)
+      .find((x) => x.parentID === undefined)?.id
     if (match) {
       continued = true
       route.navigate({ type: "session", sessionID: match })


### PR DESCRIPTION
## Problem
`--continue` selects sessions based on ID order, but IDs reflect creation time, not last activity. 
This causes `--continue` to open an old session instead of the one you were last working on.

## Solution
Sort sessions by `time.updated` (descending) before selecting, so `--continue` opens the most recently used session.

fixes  #5510