### PR TITLE
Add Gleam LSP and formatter

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -284,3 +284,12 @@ export const latexindent: Info = {
     return Bun.which("latexindent") !== null
   },
 }
+
+export const gleam: Info = {
+  name: "gleam",
+  command: ["gleam", "format", "$FILE"],
+  extensions: [".gleam"],
+  async enabled() {
+    return Bun.which("gleam") !== null
+  },
+}

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -34,6 +34,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".gitrebase": "git-rebase",
   ".go": "go",
   ".groovy": "groovy",
+  ".gleam": "gleam",
   ".hbs": "handlebars",
   ".handlebars": "handlebars",
   ".hs": "haskell",

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1509,4 +1509,22 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const Gleam: Info = {
+    id: "gleam",
+    extensions: [".gleam"],
+    root: NearestRoot(["gleam.toml"]),
+    async spawn(root) {
+      const gleam = Bun.which("gleam")
+      if (!gleam) {
+        log.info("gleam not found, please install gleam first")
+        return
+      }
+      return {
+        process: spawn(gleam, ["lsp"], {
+          cwd: root,
+        }),
+      }
+    },
+  }
 }

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -29,6 +29,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | dart           | .dart                                                                                                    | `dart` command available                                       |
 | ocamlformat    | .ml, .mli                                                                                                | `ocamlformat` command available and `.ocamlformat` config file |
 | terraform      | .tf, .tfvars                                                                                             | `terraform` command available                                  |
+| gleam          | .gleam                                                                                                   | `gleam` command available                                      |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -36,6 +36,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | ocaml-lsp          | .ml, .mli                                            | `ocamllsp` command available                                 |
 | terraform          | .tf, .tfvars                                         | Auto-installs from GitHub releases                           |
 | bash               | .sh, .bash, .zsh, .ksh                               | Auto-installs bash-language-server                           |
+| gleam              | .gleam                                               | `gleam` command available                                    |
 
 LSP servers are automatically enabled when one of the above file extensions are detected and the requirements are met.
 


### PR DESCRIPTION
Add support for Gleam with its built-in LSP and code formatter.

- No auto download necessary as LSP and formatter are built-in to the CLI
- Updates documentation for both formatters and LSP servers