### PR TITLE
fix(tui): add linear search fallback for session update/delete sync

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -148,6 +148,17 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
                 draft.splice(result.index, 1)
               }),
             )
+            break
+          }
+          // Linear search fallback for sort order edge cases
+          const linearIndex = store.session.findIndex((s) => s.id === event.properties.info.id)
+          if (linearIndex !== -1) {
+            setStore(
+              "session",
+              produce((draft) => {
+                draft.splice(linearIndex, 1)
+              }),
+            )
           }
           break
         }
@@ -157,6 +168,13 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             setStore("session", result.index, reconcile(event.properties.info))
             break
           }
+          // Linear search fallback for sort order edge cases
+          const linearIndex = store.session.findIndex((s) => s.id === event.properties.info.id)
+          if (linearIndex !== -1) {
+            setStore("session", linearIndex, reconcile(event.properties.info))
+            break
+          }
+          // Not found, insert at binary search position
           setStore(
             "session",
             produce((draft) => {


### PR DESCRIPTION
## Summary

- Adds linear search fallback when `Binary.search` fails to find a session in the store
- Fixes session rename not reflecting in the UI immediately
- Fixes session delete potentially not syncing to UI

## Problem

The `session.updated` and `session.deleted` event handlers use `Binary.search` to find sessions in the store array. However, the binary search can fail to find sessions when the store array order differs from the expected sort order (e.g., due to timing issues or string comparison edge cases).

This causes:
- Session renames to appear to not work (the JSON file IS updated, but the UI doesn't reflect it)
- Session deletes to potentially not sync

## Solution

Add a linear search fallback (`Array.findIndex`) when `Binary.search` returns `found: false`. This ensures the session is found and updated in the UI regardless of array ordering.

The fix is minimal and defensive - it only runs the linear search if binary search fails, so there's no performance impact in the normal case.

## Testing

1. Open OpenCode TUI
2. Create a session and send a message
3. Open session list (`Ctrl+X L`)
4. Rename session (`Ctrl+R`)
5. Submit new name
6. ✅ Session title should update immediately in the list

Fixes #5494
Fixes #3779