### PR TITLE
fix(tui): resolve session_status TypeError

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -37,7 +37,7 @@ export function DialogSessionList() {
           category = "Today"
         }
         const isDeleting = toDelete() === x.id
-        const status = sync.data.session_status[x.id]
+        const status = sync.data.session_status?.[x.id]
         const isWorking = status?.type === "busy"
         return {
           title: isDeleting ? `Press ${deleteKeybind} again to confirm` : x.title,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -115,7 +115,7 @@ export function Prompt(props: PromptProps) {
   const sync = useSync()
   const dialog = useDialog()
   const toast = useToast()
-  const status = createMemo(() => sync.data.session_status[props.sessionID ?? ""] ?? { type: "idle" })
+  const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
   const history = usePromptHistory()
   const command = useCommandDialog()
   const renderer = useRenderer()

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -336,7 +336,7 @@ export function Session() {
       keybind: "messages_undo",
       category: "Session",
       onSelect: async (dialog) => {
-        const status = sync.data.session_status[route.sessionID]
+        const status = sync.data.session_status?.[route.sessionID]
         if (status?.type !== "idle") await sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
         const revert = session().revert?.messageID
         const message = messages().findLast((x) => (!revert || x.id < revert) && x.role === "user")

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -55,7 +55,7 @@ export namespace SessionStatus {
   }
 
   export function list() {
-    return Object.values(state())
+    return state()
   }
 
   export function set(sessionID: string, status: Info) {


### PR DESCRIPTION
## Problem

TypeError: undefined is not an object (evaluating 'sync.data.session_status[props.sessionID]')

`SessionStatus.list()` was returning an array instead of a Record object, causing session status lookups by ID to fail.

## Solution
- Changed `SessionStatus.list()` to return `state()` instead of `Object.values(state())` to match the API schema
- Added optional chaining for defensive access during initial sync

Fixes : #5487
