### PR TITLE
fix(session): fix unshare command not clearing share state

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -277,8 +277,8 @@ export const RunCommand = cmd({
           }
           return { error }
         })
-        if (!shareResult.error) {
-          UI.println(UI.Style.TEXT_INFO_BOLD + "~  https://opencode.ai/s/" + sessionID.slice(-8))
+        if (!shareResult.error && "data" in shareResult && shareResult.data?.share?.url) {
+          UI.println(UI.Style.TEXT_INFO_BOLD + "~  " + shareResult.data.share.url)
         }
       }
 
@@ -330,8 +330,8 @@ export const RunCommand = cmd({
           }
           return { error }
         })
-        if (!shareResult.error) {
-          UI.println(UI.Style.TEXT_INFO_BOLD + "~  https://opencode.ai/s/" + sessionID.slice(-8))
+        if (!shareResult.error && "data" in shareResult && shareResult.data?.share?.url) {
+          UI.println(UI.Style.TEXT_INFO_BOLD + "~  " + shareResult.data.share.url)
         }
       }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -323,10 +323,13 @@ export function Session() {
       keybind: "session_unshare",
       disabled: !session()?.share?.url,
       category: "Session",
-      onSelect: (dialog) => {
-        sdk.client.session.unshare({
-          sessionID: route.sessionID,
-        })
+      onSelect: async (dialog) => {
+        await sdk.client.session
+          .unshare({
+            sessionID: route.sessionID,
+          })
+          .then(() => toast.show({ message: "Session unshared successfully", variant: "success" }))
+          .catch(() => toast.show({ message: "Failed to unshare session", variant: "error" }))
         dialog.clear()
       },
     },

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -234,22 +234,12 @@ export namespace Session {
   })
 
   export const unshare = fn(Identifier.schema("session"), async (id) => {
-    const cfg = await Config.get()
-    if (cfg.enterprise?.url) {
-      const { ShareNext } = await import("@/share/share-next")
-      await ShareNext.remove(id)
-      await update(id, (draft) => {
-        draft.share = undefined
-      })
-    }
-    const share = await getShare(id)
-    if (!share) return
-    await Storage.remove(["share", id])
+    // Use ShareNext to remove the share (same as share function uses ShareNext to create)
+    const { ShareNext } = await import("@/share/share-next")
+    await ShareNext.remove(id)
     await update(id, (draft) => {
       draft.share = undefined
     })
-    const { Share } = await import("../share/share")
-    await Share.remove(id, share.secret)
   })
 
   export async function update(id: string, editor: (session: Info) => void) {

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -157,7 +157,7 @@ export namespace ShareNext {
         secret: share.secret,
       }),
     })
-    await Storage.remove(["session_share", share.id])
+    await Storage.remove(["session_share", sessionID])
   }
 
   async function fullSync(sessionID: string) {


### PR DESCRIPTION
## Summary
Fix sharing-related issues: unshare command not working and wrong share URL displayed

### Changes

**Commit 1: fix unshare command** (Fixes #5493)
- Fixed code path mismatch: `unshare` now uses `ShareNext.remove()` like `share` does
- Fixed storage key bug in `ShareNext.remove()` (was using wrong key)
- Added toast feedback for unshare command

**Commit 2: fix share URL display** (Fixes #5522)
- `--share` flag was showing hardcoded URL `opencode.ai/s/xxx`
- Now shows actual URL from API response `opncd.ai/share/xxx`