### PR TITLE
fix: ensure input borders are drawn in transparent themes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -869,8 +869,7 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            // when the background is transparent, don't draw the vertical line
-            vertical: theme.background.a != 0 ? "╹" : " ",
+            vertical: "╹",
           }}
         >
           <box
@@ -878,15 +877,10 @@ export function Prompt(props: PromptProps) {
             border={["bottom"]}
             borderColor={theme.backgroundElement}
             customBorderChars={
-              theme.background.a != 0
-                ? {
-                    ...EmptyBorder,
-                    horizontal: "▀",
-                  }
-                : {
-                    ...EmptyBorder,
-                    horizontal: " ",
-                  }
+              {
+                ...EmptyBorder,
+                horizontal: "▀",
+              }
             }
           />
         </box>


### PR DESCRIPTION
fixes #5496 

https://github.com/user-attachments/assets/9956230a-d4c7-4bca-88d7-e7c39b2006fe

