### PR TITLE
feat: add server_error, rate_limit, and no_kv_space retry logic to accommodate Foundry API issues 

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -71,7 +71,7 @@ export namespace SessionRetry {
         if (json.type === "error" && json.error?.code?.includes("rate_limit")) {
           return "Rate Limited"
         }
-        if (json.error?.message?.includes("no_kv_space") || (json.type === "error" && json.error?.type === "server_error") {
+        if (json.error?.message?.includes("no_kv_space") || (json.type === "error" && json.error?.type === "server_error")) {
           return "Provider Server Error"
         }
       } catch {}

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -71,11 +71,8 @@ export namespace SessionRetry {
         if (json.type === "error" && json.error?.code?.includes("rate_limit")) {
           return "Rate Limited"
         }
-        if (json.error?.message?.includes("no_kv_space")) {
-          return "KV Cache Full"
-        }
-        if (json.type === "error" && json.error?.type === "server_error") {
-          return "Server Error"
+        if (json.error?.message?.includes("no_kv_space") || (json.type === "error" && json.error?.type === "server_error") {
+          return "Provider Server Error"
         }
       } catch {}
     }

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -68,6 +68,15 @@ export namespace SessionRetry {
         if (json.code === "Some resource has been exhausted") {
           return "Provider is overloaded"
         }
+        if (json.type === "error" && json.error?.code?.includes("rate_limit")) {
+          return "Rate Limited"
+        }
+        if (json.error?.message?.includes("no_kv_space")) {
+          return "KV Cache Full"
+        }
+        if (json.type === "error" && json.error?.type === "server_error") {
+          return "Server Error"
+        }
       } catch {}
     }
 


### PR DESCRIPTION
Adds more granular error handling to session retry logic:

* Rate limit errors - returns "Rate Limited"
* KV cache full errors - returns "KV Cache Full"
* Server errors - returns "Server Error"

Not sure if this would have side effects for other providers 

Closes #5526 