### PR TITLE
docs: add `opencode-pty` and `opencode-google-antigravity-auth` plugins to the echosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -15,19 +15,21 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ## Plugins
 
-| Name                                                                                              | Description                                                                            |
-| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                 | Automatically inject Helicone session headers for request grouping                     |
-| [opencode-skills](https://github.com/malhashemi/opencode-skills)                                  | Manage and organize OpenCode skills and capabilities                                   |
-| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                           | Auto-inject TypeScript/Svelte types into file reads with lookup tools                  |
-| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)            | Use your ChatGPT Plus/Pro subscription instead of API credits                          |
-| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing                                   |
-| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing                                   |
-| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                                  |
-| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                | Add native websearch support for supported providers with Google grounded style        |
-| [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                     |
-| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                              |
-| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible |
+| Name                                                                                              | Description                                                                                   |
+| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                 | Automatically inject Helicone session headers for request grouping                            |
+| [opencode-skills](https://github.com/malhashemi/opencode-skills)                                  | Manage and organize OpenCode skills and capabilities                                          |
+| [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                           | Auto-inject TypeScript/Svelte types into file reads with lookup tools                         |
+| [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)            | Use your ChatGPT Plus/Pro subscription instead of API credits                                 |
+| [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing                                          |
+| [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing                                          |
+| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-goggle-antigravity-auth)  | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling |
+| [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                                         |
+| [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                | Add native websearch support for supported providers with Google grounded style               |
+| [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                      | Enables AI agents to run background processes in a PTY, send interactive input to them.       |
+| [opencode-wakatime](https://github.com/angrister/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                            |
+| [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                                     |
+| [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible        |
 
 ---
 


### PR DESCRIPTION
Hello, this PR adds a new two plugins to the https://opencode.ai/docs/ecosystem/ page

### `opencode-pty`

This was a missing feature in opencode that I really wanted, running background process that can take time or requires interactive inputs from the user during the testing, this new simple plugins adds this feature. it provides interactive PTY (cross-platform btw) management, enabling the AI agent to run background processes, send interactive input, and read output on demand.  it evens handles the permissions system similar to the built-in bash tool.

Read more about it here: https://github.com/shekohex/opencode-pty

### `opencode-google-antigravity-auth`

This another plugin that allows the users to login to opencode using their google account to benefit from their google ai subscription  and  use these AI models outside of the antigravity IDE. I know there is an already plugin called `opencode-antigravity-auth`, it is funny because both of us built that plugin at the same time, I originally found out about it when I was publishing my plugin to NPM and to my surprise I've found my package name is taken. my plugin however is a bit different in the implementation as it handles a lot of edge cases that the other plugin does not, it also adds new features and tools like the `google_search` tool that allows any model (not just the google gemini ones) to natively do google search and get results using a simple trick of using internal subagent. 

Read more about it here: https://github.com/shekohex/opencode-google-antigravity-auth

Thanks. 