### PR TITLE
Feature/OpenAI compatible reasoning

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -24,7 +24,7 @@ import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import { createOpenRouter, type LanguageModelV2 } from "@openrouter/ai-sdk-provider"
-import { createOpenaiCompatible as createGitHubCopilotOpenAICompatible } from "./sdk/openai-compatible/src"
+import { createOpenaiCompatible as createCustomOpenAICompatible } from "./sdk/openai-compatible/src"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -37,10 +37,13 @@ export namespace Provider {
     "@ai-sdk/google-vertex": createVertex,
     "@ai-sdk/google-vertex/anthropic": createVertexAnthropic,
     "@ai-sdk/openai": createOpenAI,
+    // Official OpenAI-compatible provider for standard models
     "@ai-sdk/openai-compatible": createOpenAICompatible,
+    // Custom provider with reasoning_content support for DeepSeek, Qwen, etc.
+    "@ai-sdk/openai-compatible-reasoning": createCustomOpenAICompatible,
     "@openrouter/ai-sdk-provider": createOpenRouter,
     // @ts-ignore (TODO: kill this code so we dont have to maintain it)
-    "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
+    "@ai-sdk/github-copilot": createCustomOpenAICompatible,
   }
 
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
@@ -1,61 +1,29 @@
 # OpenAI-Compatible Provider SDK
 
-This package provides custom OpenAI-compatible provider implementations for OpenCode.
+Custom OpenAI-compatible provider implementations for OpenCode.
 
 ## Purpose
 
-This package serves two main purposes:
+1. **GitHub Copilot** - Provider for GitHub Copilot models
+2. **Reasoning Models** - Wrapper that handles `reasoning_content` field from OpenAI-compatible APIs
 
-1. **GitHub Copilot Compatibility** - Custom provider implementation for GitHub Copilot models
-2. **Reasoning Model Support** - Extended provider wrapper that handles `reasoning_content` field for thinking/reasoning models
+## Reasoning Provider (`@ai-sdk/openai-compatible-reasoning`)
 
-## Provider Types
+### What It Does
 
-### Standard Provider (`@ai-sdk/openai-compatible`)
+Detects and transforms `reasoning_content` fields from OpenAI-compatible API responses into proper reasoning events that OpenCode displays as collapsible thinking blocks.
 
-Used for:
-- GitHub Copilot models
-- Standard OpenAI-compatible APIs that don't use reasoning
+**Important**: This only works with **OpenAI-compatible API endpoints**. Some models offer OpenAI-compatible endpoints even if they have their own native API.
 
-### Reasoning Provider (`@ai-sdk/openai-compatible-reasoning`)
+### Supported Models
 
-Used for models that support the `reasoning_content` field, including:
-- DeepSeek (DeepSeek-V3, DeepSeek-R1, etc.)
-- Qwen Thinking models (Qwen3-235B-A22B-Thinking-2507)
-- Kimi K2 Thinking
-- Other OpenAI-compatible models that return reasoning in the `reasoning_content` field
-
-## How Reasoning Support Works
-
-### The Problem
-
-Some OpenAI-compatible models (like DeepSeek and Qwen) return their reasoning/thinking process in a separate `reasoning_content` field in the streaming response, rather than using OpenAI's native reasoning API format.
-
-Example response chunk:
-```json
-{
-  "choices": [{
-    "delta": {
-      "role": "assistant",
-      "content": null,
-      "reasoning_content": "Let me think about this step by step..."
-    }
-  }]
-}
-```
-
-### The Solution
-
-`OpenAICompatibleChatWithReasoningLanguageModel` extends the base OpenAI-compatible provider to:
-
-1. Intercept streaming chunks from the API
-2. Detect `delta.reasoning_content` fields
-3. Transform them into proper reasoning events (`reasoning-start`, `reasoning-delta`, `reasoning-end`)
-4. Allow OpenCode's processor to display reasoning in collapsible UI blocks
+When accessed via OpenAI-compatible APIs:
+- **DeepSeek** models (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
+- **Qwen Thinking** models (via DeepInfra or compatible providers)
+- **Kimi K2 Thinking** (via compatible providers)
+- Any model that returns `reasoning_content` in streaming chunks
 
 ### Configuration
-
-To use reasoning models, configure your provider with the reasoning npm package:
 
 ```json
 {
@@ -64,73 +32,27 @@ To use reasoning models, configure your provider with the reasoning npm package:
       "npm": "@ai-sdk/openai-compatible-reasoning",
       "options": {
         "baseURL": "https://api.deepinfra.com/v1/openai",
-        "reasoning": {
-          "enabled": true
-        }
+        "reasoning": { "enabled": true }
       },
       "models": {
-        "deepseek-ai/DeepSeek-V3.2": {
-          "name": "DeepSeek V3.2"
-        }
+        "deepseek-ai/DeepSeek-V3.2": {}
       }
     }
   }
 }
 ```
 
-### Provider Options
+**Note**: `reasoning.enabled` is required for some models (e.g., DeepSeek) but not others (e.g., Qwen).
 
-#### `reasoning.enabled`
+## How It Works
 
-Some models (like DeepSeek) require an explicit request parameter to enable reasoning output:
-
-```json
-{
-  "options": {
-    "reasoning": {
-      "enabled": true
-    }
-  }
-}
-```
-
-This adds `"reasoning": { "enabled": true }` to the API request body.
-
-## Architecture
-
-```
-Raw API Response (SSE chunks)
-  ↓
-OpenAICompatibleChatWithReasoningLanguageModel.doStream()
-  ↓
-TransformStream intercepts chunks
-  ↓
-Detects delta.reasoning_content field
-  ↓
-Emits: reasoning-start → reasoning-delta(s) → reasoning-end
-  ↓
-OpenCode processor creates MessageV2.ReasoningPart
-  ↓
-UI displays as collapsible thinking blocks
-```
-
-## Compatibility
-
-The reasoning wrapper is designed to be non-invasive:
-
-- ✅ **Standard models**: Unaffected (no `reasoning_content` field)
-- ✅ **OpenAI o1/o3**: Unaffected (use different Responses API)
-- ✅ **`<think>` tag models**: Unaffected (tags in `content`, not `reasoning_content`)
-- ✅ **DeepSeek/Qwen**: Properly handled via `reasoning_content` parsing
+Response chunks with `delta.reasoning_content` are transformed into:
+- `reasoning-start` → `reasoning-delta` → `reasoning-end` events
+- OpenCode's processor displays these as collapsible thinking blocks
+- All request handling (including multimodal input) is delegated to the base model
 
 ## Files
 
-- `openai-compatible-provider.ts` - Provider factory and registration
-- `openai-compatible-chat-reasoning-model.ts` - Reasoning wrapper implementation
-- `index.ts` - Public exports
-
-## When to Modify
-
-- **Copilot-specific changes**: Safe to modify, won't affect other providers
-- **Reasoning support changes**: Will affect all models using `@ai-sdk/openai-compatible-reasoning`
-- **General OpenAI-compatible fixes**: Consider upstreaming to Vercel AI SDK instead
+- `openai-compatible-provider.ts` - Provider factory
+- `openai-compatible-chat-reasoning-model.ts` - Reasoning wrapper
+- `index.ts` - Exports

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
@@ -5,7 +5,7 @@ Custom OpenAI-compatible provider implementations for OpenCode.
 ## Purpose
 
 1. **GitHub Copilot** - Provider for GitHub Copilot models
-2. **Reasoning Models** - Wrapper that handles `reasoning_content` field from OpenAI-compatible APIs
+2. **Reasoning Models** - Wrapper that handles `reasoning_content` field from models served via OpenAI-compatible APIs
 
 ## Reasoning Provider (`@ai-sdk/openai-compatible-reasoning`)
 
@@ -13,15 +13,15 @@ Custom OpenAI-compatible provider implementations for OpenCode.
 
 Detects and transforms `reasoning_content` fields from OpenAI-compatible API responses into proper reasoning events that OpenCode displays as collapsible thinking blocks.
 
-**Important**: This only works with **OpenAI-compatible API endpoints**. Some models offer OpenAI-compatible endpoints even if they have their own native API.
+**Important**: This only works with **OpenAI-compatible API endpoints**. Some providers serve models via OpenAI-compatible APIs even if those models have their own native APIs.
 
 ### Supported Models
 
-When accessed via OpenAI-compatible APIs:
-- **DeepSeek** models (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
-- **Qwen Thinking** models (via DeepInfra or compatible providers)
-- **Kimi K2 Thinking** (via compatible providers)
-- Any model that returns `reasoning_content` in streaming chunks
+When served via OpenAI-compatible APIs:
+- **DeepSeek** (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
+- **Qwen Thinking** (via DeepInfra or other providers)
+- **Kimi K2 Thinking** (via providers offering OpenAI-compatible APIs)
+- Any model served via OpenAI-compatible APIs that returns `reasoning_content`
 
 ### Configuration
 

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
@@ -1,5 +1,136 @@
-This is a temporary package used primarily for github copilot compatibility.
+# OpenAI-Compatible Provider SDK
 
-Avoid making changes to these files unless you want to only affect Copilot provider.
+This package provides custom OpenAI-compatible provider implementations for OpenCode.
 
-Also this should ONLY be used for Copilot provider.
+## Purpose
+
+This package serves two main purposes:
+
+1. **GitHub Copilot Compatibility** - Custom provider implementation for GitHub Copilot models
+2. **Reasoning Model Support** - Extended provider wrapper that handles `reasoning_content` field for thinking/reasoning models
+
+## Provider Types
+
+### Standard Provider (`@ai-sdk/openai-compatible`)
+
+Used for:
+- GitHub Copilot models
+- Standard OpenAI-compatible APIs that don't use reasoning
+
+### Reasoning Provider (`@ai-sdk/openai-compatible-reasoning`)
+
+Used for models that support the `reasoning_content` field, including:
+- DeepSeek (DeepSeek-V3, DeepSeek-R1, etc.)
+- Qwen Thinking models (Qwen3-235B-A22B-Thinking-2507)
+- Kimi K2 Thinking
+- Other OpenAI-compatible models that return reasoning in the `reasoning_content` field
+
+## How Reasoning Support Works
+
+### The Problem
+
+Some OpenAI-compatible models (like DeepSeek and Qwen) return their reasoning/thinking process in a separate `reasoning_content` field in the streaming response, rather than using OpenAI's native reasoning API format.
+
+Example response chunk:
+```json
+{
+  "choices": [{
+    "delta": {
+      "role": "assistant",
+      "content": null,
+      "reasoning_content": "Let me think about this step by step..."
+    }
+  }]
+}
+```
+
+### The Solution
+
+`OpenAICompatibleChatWithReasoningLanguageModel` extends the base OpenAI-compatible provider to:
+
+1. Intercept streaming chunks from the API
+2. Detect `delta.reasoning_content` fields
+3. Transform them into proper reasoning events (`reasoning-start`, `reasoning-delta`, `reasoning-end`)
+4. Allow OpenCode's processor to display reasoning in collapsible UI blocks
+
+### Configuration
+
+To use reasoning models, configure your provider with the reasoning npm package:
+
+```json
+{
+  "provider": {
+    "deepinfra-thinking": {
+      "npm": "@ai-sdk/openai-compatible-reasoning",
+      "options": {
+        "baseURL": "https://api.deepinfra.com/v1/openai",
+        "reasoning": {
+          "enabled": true
+        }
+      },
+      "models": {
+        "deepseek-ai/DeepSeek-V3.2": {
+          "name": "DeepSeek V3.2"
+        }
+      }
+    }
+  }
+}
+```
+
+### Provider Options
+
+#### `reasoning.enabled`
+
+Some models (like DeepSeek) require an explicit request parameter to enable reasoning output:
+
+```json
+{
+  "options": {
+    "reasoning": {
+      "enabled": true
+    }
+  }
+}
+```
+
+This adds `"reasoning": { "enabled": true }` to the API request body.
+
+## Architecture
+
+```
+Raw API Response (SSE chunks)
+  ↓
+OpenAICompatibleChatWithReasoningLanguageModel.doStream()
+  ↓
+TransformStream intercepts chunks
+  ↓
+Detects delta.reasoning_content field
+  ↓
+Emits: reasoning-start → reasoning-delta(s) → reasoning-end
+  ↓
+OpenCode processor creates MessageV2.ReasoningPart
+  ↓
+UI displays as collapsible thinking blocks
+```
+
+## Compatibility
+
+The reasoning wrapper is designed to be non-invasive:
+
+- ✅ **Standard models**: Unaffected (no `reasoning_content` field)
+- ✅ **OpenAI o1/o3**: Unaffected (use different Responses API)
+- ✅ **`<think>` tag models**: Unaffected (tags in `content`, not `reasoning_content`)
+- ✅ **DeepSeek/Qwen**: Properly handled via `reasoning_content` parsing
+
+## Files
+
+- `openai-compatible-provider.ts` - Provider factory and registration
+- `openai-compatible-chat-reasoning-model.ts` - Reasoning wrapper implementation
+- `index.ts` - Public exports
+
+## When to Modify
+
+- **Copilot-specific changes**: Safe to modify, won't affect other providers
+- **Reasoning support changes**: Will affect all models using `@ai-sdk/openai-compatible-reasoning`
+- **General OpenAI-compatible fixes**: Consider upstreaming to Vercel AI SDK instead

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/index.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/index.ts
@@ -1,2 +1,3 @@
 export { createOpenaiCompatible, openaiCompatible } from "./openai-compatible-provider"
 export type { OpenaiCompatibleProvider, OpenaiCompatibleProviderSettings } from "./openai-compatible-provider"
+export { OpenAICompatibleChatWithReasoningLanguageModel } from "./openai-compatible-chat-reasoning-model"

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
@@ -1,0 +1,110 @@
+import type { LanguageModelV2, LanguageModelV2StreamPart } from "@ai-sdk/provider"
+import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible"
+
+/**
+ * Extended OpenAI-compatible chat model that handles reasoning_content field
+ * in streaming responses (used by DeepSeek, Qwen, and other models).
+ *
+ * This wrapper intercepts streaming chunks and transforms chunks with
+ * `delta.reasoning_content` into proper reasoning-start/delta/end events.
+ */
+export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageModelV2 {
+  readonly specificationVersion = "v2"
+  readonly provider: string
+  readonly modelId: string
+  readonly defaultObjectGenerationMode = "json" as const
+
+  private baseModel: OpenAICompatibleChatLanguageModel
+
+  constructor(modelId: string, settings: ConstructorParameters<typeof OpenAICompatibleChatLanguageModel>[1]) {
+    this.baseModel = new OpenAICompatibleChatLanguageModel(modelId, settings)
+    this.provider = this.baseModel.provider
+    this.modelId = this.baseModel.modelId
+  }
+
+  async doGenerate(options: Parameters<LanguageModelV2["doGenerate"]>[0]) {
+    return this.baseModel.doGenerate(options)
+  }
+
+  async doStream(
+    options: Parameters<LanguageModelV2["doStream"]>[0],
+  ): Promise<Awaited<ReturnType<LanguageModelV2["doStream"]>>> {
+    const result = await this.baseModel.doStream(options)
+
+    // Track reasoning state
+    let currentReasoningId: string | null = null
+    let reasoningStartTime: number | null = null
+
+    // Transform the stream to handle reasoning_content
+    const transformedStream = result.stream.pipeThrough(
+      new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
+        transform(chunk, controller) {
+          // Check if this is a raw chunk with reasoning_content
+          if (chunk.type === "raw") {
+            try {
+              const rawValue = chunk.rawValue
+              // Parse the chunk if it's a string (SSE format)
+              const parsed = typeof rawValue === "string" ? JSON.parse(rawValue) : rawValue
+
+              // Check for reasoning_content in delta
+              const reasoningContent = parsed?.choices?.[0]?.delta?.reasoning_content
+              const regularContent = parsed?.choices?.[0]?.delta?.content
+
+              if (reasoningContent !== undefined && reasoningContent !== null) {
+                // We have reasoning content
+                const reasoningId = currentReasoningId || `reasoning-${Date.now()}`
+
+                if (!currentReasoningId) {
+                  // First reasoning chunk - emit reasoning-start
+                  currentReasoningId = reasoningId
+                  reasoningStartTime = Date.now()
+
+                  controller.enqueue({
+                    type: "reasoning-start",
+                    id: reasoningId,
+                  })
+                }
+
+                // Emit reasoning-delta
+                controller.enqueue({
+                  type: "reasoning-delta",
+                  id: reasoningId,
+                  delta: reasoningContent,
+                })
+              } else if (currentReasoningId && regularContent !== undefined && regularContent !== null) {
+                // Reasoning has ended, regular content is starting
+                controller.enqueue({
+                  type: "reasoning-end",
+                  id: currentReasoningId,
+                })
+
+                currentReasoningId = null
+                reasoningStartTime = null
+              }
+            } catch (e) {
+              // Failed to parse or process - just pass through
+            }
+          }
+
+          // Always pass through the original chunk
+          controller.enqueue(chunk)
+        },
+
+        flush(controller) {
+          // If reasoning was still active when stream ends, close it
+          if (currentReasoningId) {
+            controller.enqueue({
+              type: "reasoning-end",
+              id: currentReasoningId,
+            })
+          }
+        },
+      }),
+    )
+
+    return {
+      ...result,
+      stream: transformedStream,
+    }
+  }
+}

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
@@ -1,5 +1,8 @@
 import type { LanguageModelV2, LanguageModelV2StreamPart } from "@ai-sdk/provider"
 import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "reasoning-model" })
 
 /**
  * Extended OpenAI-compatible chat model that handles reasoning_content field
@@ -20,6 +23,12 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
     this.baseModel = new OpenAICompatibleChatLanguageModel(modelId, settings)
     this.provider = this.baseModel.provider
     this.modelId = this.baseModel.modelId
+
+    // INFO level - will always show in logs
+    log.info("wrapper initialized", {
+      modelId: this.modelId,
+      provider: this.provider
+    })
   }
 
   async doGenerate(options: Parameters<LanguageModelV2["doGenerate"]>[0]) {
@@ -29,7 +38,19 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
   async doStream(
     options: Parameters<LanguageModelV2["doStream"]>[0],
   ): Promise<Awaited<ReturnType<LanguageModelV2["doStream"]>>> {
-    const result = await this.baseModel.doStream(options)
+    // Enable raw chunks so we can see reasoning_content
+    const modifiedOptions = {
+      ...options,
+      _internal: {
+        ...(options as any)._internal,
+        generateId: (options as any)._internal?.generateId,
+        now: (options as any)._internal?.now,
+      },
+    }
+
+    // INFO level - will always show in logs
+    log.info("doStream called", { modelId: this.modelId })
+    const result = await this.baseModel.doStream(modifiedOptions)
 
     // Track reasoning state
     let currentReasoningId: string | null = null
@@ -39,6 +60,9 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
     const transformedStream = result.stream.pipeThrough(
       new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
         transform(chunk, controller) {
+          // Log all chunk types for debugging
+          log.debug("chunk received", { type: chunk.type })
+
           // Check if this is a raw chunk with reasoning_content
           if (chunk.type === "raw") {
             try {
@@ -46,11 +70,17 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
               // Parse the chunk if it's a string (SSE format)
               const parsed = typeof rawValue === "string" ? JSON.parse(rawValue) : rawValue
 
+              // Debug logging
+              if (parsed?.choices?.[0]?.delta) {
+                log.debug("delta content", { delta: parsed.choices[0].delta })
+              }
+
               // Check for reasoning_content in delta
               const reasoningContent = parsed?.choices?.[0]?.delta?.reasoning_content
               const regularContent = parsed?.choices?.[0]?.delta?.content
 
               if (reasoningContent !== undefined && reasoningContent !== null) {
+                log.debug("found reasoning_content", { content: reasoningContent })
                 // We have reasoning content
                 const reasoningId = currentReasoningId || `reasoning-${Date.now()}`
 

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
@@ -1,8 +1,5 @@
 import type { LanguageModelV2, LanguageModelV2StreamPart } from "@ai-sdk/provider"
 import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible"
-import { Log } from "@/util/log"
-
-const log = Log.create({ service: "reasoning-model" })
 
 /**
  * Extended OpenAI-compatible chat model that handles reasoning_content field
@@ -23,12 +20,6 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
     this.baseModel = new OpenAICompatibleChatLanguageModel(modelId, settings)
     this.provider = this.baseModel.provider
     this.modelId = this.baseModel.modelId
-
-    // INFO level - will always show in logs
-    log.info("wrapper initialized", {
-      modelId: this.modelId,
-      provider: this.provider
-    })
   }
 
   async doGenerate(options: Parameters<LanguageModelV2["doGenerate"]>[0]) {
@@ -48,21 +39,15 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
       },
     }
 
-    // INFO level - will always show in logs
-    log.info("doStream called", { modelId: this.modelId })
     const result = await this.baseModel.doStream(modifiedOptions)
 
     // Track reasoning state
     let currentReasoningId: string | null = null
-    let reasoningStartTime: number | null = null
 
     // Transform the stream to handle reasoning_content
     const transformedStream = result.stream.pipeThrough(
       new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>({
         transform(chunk, controller) {
-          // Log all chunk types for debugging
-          log.debug("chunk received", { type: chunk.type })
-
           // Check if this is a raw chunk with reasoning_content
           if (chunk.type === "raw") {
             try {
@@ -70,24 +55,17 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
               // Parse the chunk if it's a string (SSE format)
               const parsed = typeof rawValue === "string" ? JSON.parse(rawValue) : rawValue
 
-              // Debug logging
-              if (parsed?.choices?.[0]?.delta) {
-                log.debug("delta content", { delta: parsed.choices[0].delta })
-              }
-
               // Check for reasoning_content in delta
               const reasoningContent = parsed?.choices?.[0]?.delta?.reasoning_content
               const regularContent = parsed?.choices?.[0]?.delta?.content
 
               if (reasoningContent !== undefined && reasoningContent !== null) {
-                log.debug("found reasoning_content", { content: reasoningContent })
                 // We have reasoning content
                 const reasoningId = currentReasoningId || `reasoning-${Date.now()}`
 
                 if (!currentReasoningId) {
                   // First reasoning chunk - emit reasoning-start
                   currentReasoningId = reasoningId
-                  reasoningStartTime = Date.now()
 
                   controller.enqueue({
                     type: "reasoning-start",
@@ -109,7 +87,6 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
                 })
 
                 currentReasoningId = null
-                reasoningStartTime = null
               }
             } catch (e) {
               // Failed to parse or process - just pass through

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts
@@ -22,6 +22,10 @@ export class OpenAICompatibleChatWithReasoningLanguageModel implements LanguageM
     this.modelId = this.baseModel.modelId
   }
 
+  get supportedUrls() {
+    return this.baseModel.supportedUrls
+  }
+
   async doGenerate(options: Parameters<LanguageModelV2["doGenerate"]>[0]) {
     return this.baseModel.doGenerate(options)
   }

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
@@ -1,5 +1,9 @@
-import type { LanguageModelV2 } from "@ai-sdk/provider"
-import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible"
+import type { LanguageModelV2, EmbeddingModelV2, ImageModelV2 } from "@ai-sdk/provider"
+import {
+  OpenAICompatibleChatLanguageModel,
+  OpenAICompatibleEmbeddingModel,
+  OpenAICompatibleImageModel,
+} from "@ai-sdk/openai-compatible"
 import { type FetchFunction, withoutTrailingSlash, withUserAgentSuffix } from "@ai-sdk/provider-utils"
 import { OpenAIResponsesLanguageModel } from "./responses/openai-responses-language-model"
 import { OpenAICompatibleChatWithReasoningLanguageModel } from "./openai-compatible-chat-reasoning-model"
@@ -41,8 +45,8 @@ export interface OpenaiCompatibleProvider {
   chat(modelId: OpenaiCompatibleModelId): LanguageModelV2
   responses(modelId: OpenaiCompatibleModelId): LanguageModelV2
   languageModel(modelId: OpenaiCompatibleModelId): LanguageModelV2
-  textEmbeddingModel(modelId: OpenaiCompatibleModelId): never
-  imageModel(modelId: OpenaiCompatibleModelId): never
+  textEmbeddingModel(modelId: OpenaiCompatibleModelId): EmbeddingModelV2<string>
+  imageModel(modelId: OpenaiCompatibleModelId): ImageModelV2
 }
 
 /**
@@ -64,22 +68,28 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
 
   const getHeaders = () => withUserAgentSuffix(headers, `ai-sdk/openai-compatible/${VERSION}`)
 
+  // Helper to create common model config
+  const getCommonModelConfig = (modelType: string) => ({
+    provider: `${options.name ?? "openai-compatible"}.${modelType}`,
+    headers: getHeaders,
+    url: ({ path }: { path: string }) => `${baseURL}${path}`,
+    fetch: options.fetch,
+  })
+
   const createChatModel = (modelId: OpenaiCompatibleModelId) => {
-    return new OpenAICompatibleChatWithReasoningLanguageModel(modelId, {
-      provider: `${options.name ?? "openai-compatible"}.chat`,
-      headers: getHeaders,
-      url: ({ path }) => `${baseURL}${path}`,
-      fetch: options.fetch,
-    })
+    return new OpenAICompatibleChatWithReasoningLanguageModel(modelId, getCommonModelConfig("chat"))
   }
 
   const createResponsesModel = (modelId: OpenaiCompatibleModelId) => {
-    return new OpenAIResponsesLanguageModel(modelId, {
-      provider: `${options.name ?? "openai-compatible"}.responses`,
-      headers: getHeaders,
-      url: ({ path }) => `${baseURL}${path}`,
-      fetch: options.fetch,
-    })
+    return new OpenAIResponsesLanguageModel(modelId, getCommonModelConfig("responses"))
+  }
+
+  const createEmbeddingModel = (modelId: OpenaiCompatibleModelId) => {
+    return new OpenAICompatibleEmbeddingModel(modelId, getCommonModelConfig("embedding"))
+  }
+
+  const createImageModel = (modelId: OpenaiCompatibleModelId) => {
+    return new OpenAICompatibleImageModel(modelId, getCommonModelConfig("image"))
   }
 
   const createLanguageModel = (modelId: OpenaiCompatibleModelId) => createChatModel(modelId)
@@ -91,12 +101,8 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
   provider.languageModel = createLanguageModel
   provider.chat = createChatModel
   provider.responses = createResponsesModel
-  provider.textEmbeddingModel = () => {
-    throw new Error("Text embedding models are not supported by this provider")
-  }
-  provider.imageModel = () => {
-    throw new Error("Image models are not supported by this provider")
-  }
+  provider.textEmbeddingModel = createEmbeddingModel
+  provider.imageModel = createImageModel
 
   return provider as OpenaiCompatibleProvider
 }

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV2 } from "@ai-sdk/provider"
 import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible"
 import { type FetchFunction, withoutTrailingSlash, withUserAgentSuffix } from "@ai-sdk/provider-utils"
 import { OpenAIResponsesLanguageModel } from "./responses/openai-responses-language-model"
+import { OpenAICompatibleChatWithReasoningLanguageModel } from "./openai-compatible-chat-reasoning-model"
 
 // Import the version or define it
 const VERSION = "0.1.0"
@@ -66,7 +67,7 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
   const getHeaders = () => withUserAgentSuffix(headers, `ai-sdk/openai-compatible/${VERSION}`)
 
   const createChatModel = (modelId: OpenaiCompatibleModelId) => {
-    return new OpenAICompatibleChatLanguageModel(modelId, {
+    return new OpenAICompatibleChatWithReasoningLanguageModel(modelId, {
       provider: `${options.name ?? "openai-compatible"}.chat`,
       headers: getHeaders,
       url: ({ path }) => `${baseURL}${path}`,

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
@@ -41,10 +41,8 @@ export interface OpenaiCompatibleProvider {
   chat(modelId: OpenaiCompatibleModelId): LanguageModelV2
   responses(modelId: OpenaiCompatibleModelId): LanguageModelV2
   languageModel(modelId: OpenaiCompatibleModelId): LanguageModelV2
-
-  // embeddingModel(modelId: any): EmbeddingModelV2
-
-  // imageModel(modelId: any): ImageModelV2
+  textEmbeddingModel(modelId: OpenaiCompatibleModelId): never
+  imageModel(modelId: OpenaiCompatibleModelId): never
 }
 
 /**
@@ -93,6 +91,12 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
   provider.languageModel = createLanguageModel
   provider.chat = createChatModel
   provider.responses = createResponsesModel
+  provider.textEmbeddingModel = () => {
+    throw new Error("Text embedding models are not supported by this provider")
+  }
+  provider.imageModel = () => {
+    throw new Error("Image models are not supported by this provider")
+  }
 
   return provider as OpenaiCompatibleProvider
 }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -232,6 +232,15 @@ export namespace ProviderTransform {
   ): Record<string, any> {
     const result: Record<string, any> = {}
 
+    // Handle reasoning parameter for openai-compatible-reasoning provider
+    if (
+      (model.api.npm === "@ai-sdk/openai-compatible-reasoning" ||
+        model.api.npm === "@ai-sdk/openai-compatible") &&
+      providerOptions?.reasoning
+    ) {
+      result["reasoning"] = providerOptions.reasoning
+    }
+
     if (model.api.npm === "@openrouter/ai-sdk-provider") {
       result["usage"] = {
         include: true,

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -73,13 +73,17 @@ These models work out of the box - just select them and OpenCode will automatica
 
 ### OpenAI-Compatible Reasoning Models
 
-Some OpenAI-compatible providers offer reasoning models that require special configuration:
+Some models return reasoning content when accessed via **OpenAI-compatible API endpoints**:
 
-- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-reasoner
-- **Qwen**: Qwen3-235B-A22B-Thinking-2507
-- **Kimi**: Kimi-K2-Thinking
+- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-reasoner (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
+- **Qwen**: Qwen3-235B-A22B-Thinking-2507 (via DeepInfra or compatible providers)
+- **Kimi**: Kimi-K2-Thinking (via compatible providers)
 
-To use these models, you need to configure them with the `@ai-sdk/openai-compatible-reasoning` provider. [Learn how to configure reasoning models](/docs/providers#reasoning-models).
+To use these models, configure them with the `@ai-sdk/openai-compatible-reasoning` provider. [Learn how to configure reasoning models](/docs/providers#reasoning-models).
+
+:::note[OpenAI-Compatible APIs Only]
+This feature requires **OpenAI-compatible API endpoints**. Many providers offer these even if the model has its own native API.
+:::
 
 ### When to Use Reasoning Models
 

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -48,6 +48,55 @@ Here are several models that work well with OpenCode, in no particular order. (T
 
 ---
 
+## Reasoning Models
+
+Some models support extended reasoning capabilities where they show their thinking process before providing the final answer. These "reasoning models" or "thinking models" can provide better results for complex coding tasks by breaking down problems step by step.
+
+### How Reasoning Models Work
+
+Reasoning models separate their output into two parts:
+
+1. **Reasoning/Thinking**: The model's internal thought process (shown in collapsible blocks in the UI)
+2. **Response**: The final answer or code
+
+This is similar to how humans solve complex problems - thinking through the solution first, then presenting the final result.
+
+### Built-in Reasoning Models
+
+OpenCode natively supports reasoning from these providers:
+
+- **Anthropic**: Claude Sonnet 4.5 with Extended Thinking
+- **OpenAI**: GPT-5, o1, o3 models
+- **Google**: Gemini 3 Pro with thinking mode
+
+These models work out of the box - just select them and OpenCode will automatically display their reasoning.
+
+### OpenAI-Compatible Reasoning Models
+
+Some OpenAI-compatible providers offer reasoning models that require special configuration:
+
+- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-reasoner
+- **Qwen**: Qwen3-235B-A22B-Thinking-2507
+- **Kimi**: Kimi-K2-Thinking
+
+To use these models, you need to configure them with the `@ai-sdk/openai-compatible-reasoning` provider. [Learn how to configure reasoning models](/docs/providers#reasoning-models).
+
+### When to Use Reasoning Models
+
+Reasoning models are particularly useful for:
+
+- Complex architectural decisions
+- Debugging difficult issues
+- Performance optimization
+- Code refactoring with multiple considerations
+- Algorithm design and optimization
+
+:::tip
+Reasoning models may be slower and more expensive than regular models, but can provide higher quality results for complex tasks.
+:::
+
+---
+
 ## Set a default
 
 To set one of these as the default model, you can set the `model` key in your

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -71,18 +71,18 @@ OpenCode natively supports reasoning from these providers:
 
 These models work out of the box - just select them and OpenCode will automatically display their reasoning.
 
-### OpenAI-Compatible Reasoning Models
+### Models Served via OpenAI-Compatible APIs
 
-Some models return reasoning content when accessed via **OpenAI-compatible API endpoints**:
+Some models return reasoning content when served via **OpenAI-compatible API endpoints**:
 
 - **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-reasoner (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
-- **Qwen**: Qwen3-235B-A22B-Thinking-2507 (via DeepInfra or compatible providers)
-- **Kimi**: Kimi-K2-Thinking (via compatible providers)
+- **Qwen**: Qwen3-235B-A22B-Thinking-2507 (via DeepInfra or other providers)
+- **Kimi**: Kimi-K2-Thinking (via providers offering OpenAI-compatible APIs)
 
 To use these models, configure them with the `@ai-sdk/openai-compatible-reasoning` provider. [Learn how to configure reasoning models](/docs/providers#reasoning-models).
 
 :::note[OpenAI-Compatible APIs Only]
-This feature requires **OpenAI-compatible API endpoints**. Many providers offer these even if the model has its own native API.
+This feature requires **OpenAI-compatible API endpoints**. Many providers serve models via OpenAI-compatible APIs even if those models have their own native APIs.
 :::
 
 ### When to Use Reasoning Models

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1401,11 +1401,15 @@ The `limit` fields allow OpenCode to understand how much context you have left. 
 
 ## Reasoning Models
 
-Some OpenAI-compatible models (like DeepSeek, Qwen Thinking, and Kimi K2 Thinking) support extended reasoning capabilities where the model shows its thinking process. These models require special configuration.
+Some models (like DeepSeek, Qwen Thinking, and Kimi K2 Thinking) return reasoning content when accessed via **OpenAI-compatible API endpoints**. These require special configuration to display their thinking process properly.
+
+:::note[OpenAI-Compatible APIs Required]
+This feature only works with **OpenAI-compatible API endpoints**. Many providers (like DeepInfra) and some model vendors (like DeepSeek) offer OpenAI-compatible endpoints even if they also have their own native APIs.
+:::
 
 ### What are Reasoning Models?
 
-Reasoning models return their thought process in a `reasoning_content` field separate from the main response. OpenCode displays this reasoning in collapsible blocks in the UI, similar to Claude's Extended Thinking or OpenAI's o1 models.
+When these models are accessed via OpenAI-compatible APIs, they return their thought process in a `reasoning_content` field separate from the main response. OpenCode displays this reasoning in collapsible blocks in the UI, similar to Claude's Extended Thinking or OpenAI's o1 models.
 
 ### Configuration
 
@@ -1477,12 +1481,12 @@ To use reasoning models, you need to:
 
 ### Supported Models
 
-Models that work with the reasoning provider include:
+Models that work when accessed via OpenAI-compatible API endpoints:
 
-- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-chat, deepseek-reasoner
-- **Qwen**: Qwen3-235B-A22B-Thinking-2507 and other Qwen thinking models
-- **Kimi**: Kimi-K2-Thinking (moonshotai/Kimi-K2-Thinking)
-- Any OpenAI-compatible model that returns `reasoning_content` in the response
+- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-chat, deepseek-reasoner (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
+- **Qwen**: Qwen3-235B-A22B-Thinking-2507 and other Qwen thinking models (via DeepInfra or compatible providers)
+- **Kimi**: Kimi-K2-Thinking (via compatible providers)
+- Any model that returns `reasoning_content` when accessed via OpenAI-compatible APIs
 
 :::note
 Some models (like Qwen) return reasoning by default, while others (like DeepSeek) require `reasoning.enabled: true` in the provider options.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1399,6 +1399,97 @@ The `limit` fields allow OpenCode to understand how much context you have left. 
 
 ---
 
+## Reasoning Models
+
+Some OpenAI-compatible models (like DeepSeek, Qwen Thinking, and Kimi K2 Thinking) support extended reasoning capabilities where the model shows its thinking process. These models require special configuration.
+
+### What are Reasoning Models?
+
+Reasoning models return their thought process in a `reasoning_content` field separate from the main response. OpenCode displays this reasoning in collapsible blocks in the UI, similar to Claude's Extended Thinking or OpenAI's o1 models.
+
+### Configuration
+
+To use reasoning models, you need to:
+
+1. Use the `@ai-sdk/openai-compatible-reasoning` npm package
+2. Optionally enable reasoning in the request with the `reasoning` option
+
+#### Example: DeepSeek V3
+
+```json title="opencode.json" {5,8-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "deepinfra-thinking": {
+      "npm": "@ai-sdk/openai-compatible-reasoning",
+      "name": "DeepInfra Thinking Models",
+      "options": {
+        "baseURL": "https://api.deepinfra.com/v1/openai",
+        "reasoning": {
+          "enabled": true
+        }
+      },
+      "models": {
+        "deepseek-ai/DeepSeek-V3.2": {
+          "name": "DeepSeek V3.2"
+        },
+        "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+          "name": "Qwen3 235B Thinking"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Example: Direct DeepSeek API
+
+```json title="opencode.json" {5,8-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "deepseek": {
+      "npm": "@ai-sdk/openai-compatible-reasoning",
+      "name": "DeepSeek",
+      "options": {
+        "baseURL": "https://api.deepseek.com/v1",
+        "reasoning": {
+          "enabled": true
+        }
+      },
+      "models": {
+        "deepseek-chat": {
+          "name": "DeepSeek Chat"
+        },
+        "deepseek-reasoner": {
+          "name": "DeepSeek Reasoner"
+        }
+      }
+    }
+  }
+}
+```
+
+### Configuration Options
+
+- **npm**: Must be `@ai-sdk/openai-compatible-reasoning` for reasoning support
+- **options.reasoning.enabled**: Set to `true` to enable reasoning output (required for DeepSeek models)
+
+### Supported Models
+
+Models that work with the reasoning provider include:
+
+- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-chat, deepseek-reasoner
+- **Qwen**: Qwen3-235B-A22B-Thinking-2507 and other Qwen thinking models
+- **Kimi**: Kimi-K2-Thinking (moonshotai/Kimi-K2-Thinking)
+- Any OpenAI-compatible model that returns `reasoning_content` in the response
+
+:::note
+Some models (like Qwen) return reasoning by default, while others (like DeepSeek) require `reasoning.enabled: true` in the provider options.
+:::
+
+---
+
 ## Troubleshooting
 
 If you are having trouble with configuring a provider, check the following:

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1401,15 +1401,15 @@ The `limit` fields allow OpenCode to understand how much context you have left. 
 
 ## Reasoning Models
 
-Some models (like DeepSeek, Qwen Thinking, and Kimi K2 Thinking) return reasoning content when accessed via **OpenAI-compatible API endpoints**. These require special configuration to display their thinking process properly.
+Some models (like DeepSeek, Qwen Thinking, and Kimi K2 Thinking) return reasoning content when served via **OpenAI-compatible API endpoints**. These require special configuration to display their thinking process properly.
 
 :::note[OpenAI-Compatible APIs Required]
-This feature only works with **OpenAI-compatible API endpoints**. Many providers (like DeepInfra) and some model vendors (like DeepSeek) offer OpenAI-compatible endpoints even if they also have their own native APIs.
+This feature only works with **OpenAI-compatible API endpoints**. Many providers (like DeepInfra) and some model vendors (like DeepSeek) serve models via OpenAI-compatible APIs even if those models also have their own native APIs.
 :::
 
 ### What are Reasoning Models?
 
-When these models are accessed via OpenAI-compatible APIs, they return their thought process in a `reasoning_content` field separate from the main response. OpenCode displays this reasoning in collapsible blocks in the UI, similar to Claude's Extended Thinking or OpenAI's o1 models.
+When served via OpenAI-compatible APIs, some models return their thought process in a `reasoning_content` field separate from the main response. OpenCode displays this reasoning in collapsible blocks in the UI, similar to Claude's Extended Thinking or OpenAI's o1 models.
 
 ### Configuration
 
@@ -1481,12 +1481,12 @@ To use reasoning models, you need to:
 
 ### Supported Models
 
-Models that work when accessed via OpenAI-compatible API endpoints:
+Models that work when served via OpenAI-compatible API endpoints:
 
 - **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-chat, deepseek-reasoner (via DeepInfra or DeepSeek's OpenAI-compatible endpoint)
-- **Qwen**: Qwen3-235B-A22B-Thinking-2507 and other Qwen thinking models (via DeepInfra or compatible providers)
-- **Kimi**: Kimi-K2-Thinking (via compatible providers)
-- Any model that returns `reasoning_content` when accessed via OpenAI-compatible APIs
+- **Qwen**: Qwen3-235B-A22B-Thinking-2507 and other Qwen thinking models (via DeepInfra or other providers)
+- **Kimi**: Kimi-K2-Thinking (via providers offering OpenAI-compatible APIs)
+- Any model that returns `reasoning_content` when served via OpenAI-compatible APIs
 
 :::note
 Some models (like Qwen) return reasoning by default, while others (like DeepSeek) require `reasoning.enabled: true` in the provider options.


### PR DESCRIPTION
# Add support for reasoning models with `reasoning_content` field - Kimi K2, Qwen3, DeepSeekV3.2 hosted wth OpenAI compatible APIs

## Overview

This PR adds support for OpenAI-compatible reasoning models that return their thinking process via the `reasoning_content` field, including DeepSeek, Qwen Thinking, and Kimi K2 Thinking models. Please note, I need this feature for myself. This is primarily why I wrote it, but I'm pushing it upstream in hope it will be useful. 

## Problem

Several popular reasoning models (DeepSeek-V3, DeepSeek-R1, Qwen3-235B-Thinking, Kimi-K2-Thinking) are served with OpenAI-compatible APIs by some providers but return their reasoning/thinking content in a separate `reasoning_content` field rather than using OpenAI's native reasoning API format.

Currently, OpenCode either:
- Lost this reasoning content entirely
- Mixed it into the regular response text
- Failed to display it in the proper collapsible UI format

## Impact

Especially when the thinking is not displayed it breaks the flow of work by making user sit there and wait a long time for the final response. I found this inconvenient enough as to be unusable with my favourite models.

## Solution

This PR introduces a custom AI SDK wrapper (`@ai-sdk/openai-compatible-reasoning`) that:

1. Intercepts streaming chunks from OpenAI-compatible APIs
2. Detects `delta.reasoning_content` fields in the response
3. Transforms them into proper reasoning events (`reasoning-start`, `reasoning-delta`, `reasoning-end`)
4. Enables OpenCode to display reasoning in collapsible UI blocks, just like Claude Extended Thinking or OpenAI o1 models

<img width="3783" height="2004" alt="Screenshot from 2025-12-14 18-26-46" src="https://github.com/user-attachments/assets/bad7b4d2-de94-4c85-81ab-eed97b21037a" />

## Implementation Details

### New Provider Type

Created a new bundled provider `@ai-sdk/openai-compatible-reasoning` that extends the standard OpenAI-compatible provider with reasoning detection capabilities.

**File:** `packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-chat-reasoning-model.ts`

The chat model wrapper:
- Extends `OpenAICompatibleChatLanguageModel` from `@ai-sdk/openai-compatible`
- Adds a TransformStream to intercept raw chunks
- Parses `choices[0].delta.reasoning_content` from streaming responses
- Emits synthetic reasoning events that OpenCode's processor already handles
- Maintains state to properly emit start/delta/end events
- **Fully delegates request handling** to base model (preserves multimodal support)

**File:** `packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts`

The provider factory:
- **Chat models**: Uses custom `OpenAICompatibleChatWithReasoningLanguageModel` wrapper
- **Embeddings**: Uses official `OpenAICompatibleEmbeddingModel` directly
- **Image generation**: Uses official `OpenAICompatibleImageModel` directly
- Maintains full feature parity with the standard provider

### Provider Options Support

Added support for `reasoning.enabled` provider option to enable reasoning output for models that require explicit request parameters (like DeepSeek).

**File:** `packages/opencode/src/provider/transform.ts`

When configured, the option is passed through to the API request:
```json
{
  "model": "deepseek-ai/DeepSeek-V3.2",
  "messages": [...],
  "reasoning": {
    "enabled": true
  }
}
```

### Architecture

```
Raw API Response (SSE chunks)
  ↓
OpenAICompatibleChatWithReasoningLanguageModel.doStream()
  ↓
TransformStream intercepts "raw" chunks
  ↓
Parses delta.reasoning_content field
  ↓
Emits: reasoning-start → reasoning-delta(s) → reasoning-end
  ↓
SessionProcessor receives events (existing code)
  ↓
Creates MessageV2.ReasoningPart (existing code)
  ↓
UI displays in collapsible thinking blocks (existing code)
```

## Configuration

Users can now configure reasoning models using the new provider:

### Example: DeepSeek V3 via DeepInfra

```json
{
  "provider": {
    "deepinfra-thinking": {
      "npm": "@ai-sdk/openai-compatible-reasoning",
      "options": {
        "baseURL": "https://api.deepinfra.com/v1/openai",
        "reasoning": {
          "enabled": true
        }
      },
      "models": {
        "deepseek-ai/DeepSeek-V3.2": {
          "name": "DeepSeek V3.2"
        },
        "Qwen/Qwen3-235B-A22B-Thinking-2507": {
          "name": "Qwen3 235B Thinking"
        }
      }
    }
  }
}
```

### Example: Direct DeepSeek API

```json
{
  "provider": {
    "deepseek": {
      "npm": "@ai-sdk/openai-compatible-reasoning",
      "options": {
        "baseURL": "https://api.deepseek.com/v1",
        "reasoning": {
          "enabled": true
        }
      },
      "models": {
        "deepseek-chat": {
          "name": "DeepSeek Chat"
        },
        "deepseek-reasoner": {
          "name": "DeepSeek Reasoner"
        }
      }
    }
  }
}
```

## Supported Models

This implementation works with any OpenAI-compatible model that returns `reasoning_content` in the response, including:

- **DeepSeek**: DeepSeek-V3, DeepSeek-R1, deepseek-chat, deepseek-reasoner
- **Qwen**: Qwen3-235B-A22B-Thinking-2507 and other Qwen thinking models
- **Kimi**: Kimi-K2-Thinking (moonshotai/Kimi-K2-Thinking)

## Feature Completeness

The custom provider maintains **full feature parity** with the official `@ai-sdk/openai-compatible` provider:

-  **Chat models**: Custom wrapper with reasoning support + full multimodal input (images, files)
-  **Embedding models**: Delegated to official `OpenAICompatibleEmbeddingModel`
-  **Image generation**: Delegated to official `OpenAICompatibleImageModel`
-  **Multimodal chat**: Images can be dragged into terminal and sent in messages (unchanged behavior)

### How It Works

The reasoning wrapper is a **thin response-only layer**:

**Requests (unchanged):**
- Multimodal messages (text + images) pass through directly to the base model
- The base model handles image encoding, URL resolution, and API formatting
- All request functionality works identically to the official provider

**Responses (enhanced):**
- Intercepts streaming chunks to detect `reasoning_content` fields
- Transforms reasoning into proper UI events
- Passes through all other content unchanged

This means:
-  Users can send images in chat messages (drag & drop in terminal)
-  Models can use text embeddings via `textEmbeddingModel()`
-  Models can generate images via `imageModel()`
-  Reasoning is properly displayed in collapsible UI blocks

## Testing

Tested with:
- DeepSeek-V3 via DeepInfra (requires `reasoning.enabled: true`)
- Qwen3-235B-A22B-Thinking-2507 via DeepInfra (works without explicit enablement)

## Notes

- The `reasoning.enabled` option is only required for some models (DeepSeek). Other models (Qwen) return reasoning by default.
- The implementation uses OpenCode's existing reasoning display logic.
- **Full feature parity**: The provider supports all capabilities of the official OpenAI-compatible provider (chat, embeddings, image generation, multimodal input).
- **Non-breaking**: Only the response stream is intercepted; all request handling is identical to the official provider.
- Documentation is updated as well.