### PR TITLE
Fix MCP OAuth auth commands to recognize remote servers by default

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -109,7 +109,7 @@ export const McpAuthCommand = cmd({
         const mcpServers = config.mcp ?? {}
 
         // Get OAuth-enabled servers
-        const oauthServers = []
+        const oauthServers: Array<[string, Config.Mcp]> = []
         for (const [name, cfg] of Object.entries(mcpServers)) {
           if (await MCP.supportsOAuth(name)) {
             oauthServers.push([name, cfg])

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -46,7 +46,7 @@ export const McpListCommand = cmd({
 
         for (const [name, serverConfig] of Object.entries(mcpServers)) {
           const status = statuses[name]
-          const hasOAuth = serverConfig.type === "remote" && !!serverConfig.oauth
+          const hasOAuth = await MCP.supportsOAuth(name)
           const hasStoredTokens = await MCP.hasStoredTokens(name)
 
           let statusIcon: string
@@ -109,7 +109,12 @@ export const McpAuthCommand = cmd({
         const mcpServers = config.mcp ?? {}
 
         // Get OAuth-enabled servers
-        const oauthServers = Object.entries(mcpServers).filter(([_, cfg]) => cfg.type === "remote" && !!cfg.oauth)
+        const oauthServers = []
+        for (const [name, cfg] of Object.entries(mcpServers)) {
+          if (await MCP.supportsOAuth(name)) {
+            oauthServers.push([name, cfg])
+          }
+        }
 
         if (oauthServers.length === 0) {
           prompts.log.warn("No OAuth-enabled MCP servers configured")
@@ -149,7 +154,7 @@ export const McpAuthCommand = cmd({
           return
         }
 
-        if (serverConfig.type !== "remote" || !serverConfig.oauth) {
+        if (!(await MCP.supportsOAuth(serverName))) {
           prompts.log.error(`MCP server ${serverName} does not have OAuth configured`)
           prompts.outro("Done")
           return


### PR DESCRIPTION
Fixes issue where MCP OAuth authentication commands didn't recognize remote MCP servers as OAuth-enabled unless explicitly configured with 'oauth' in the config.

## Changes
- Updated CLI MCP list and auth commands to use `MCP.supportsOAuth()` function
- Remote MCP servers now support OAuth by default (matching server behavior)
- No longer requires explicit 'oauth' config for remote servers to be OAuth-enabled

## Root Cause
The CLI was checking `!!cfg.oauth` but the server enables OAuth for remote servers by default unless `oauth: false`. This created a mismatch where servers would accept OAuth but the CLI wouldn't show them as OAuth-capable.

Closes #5444