### PR TITLE
feat: restore experimental.chat.messages.transform and add experimental.chat.system.transform hooks

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -1,7 +1,7 @@
 import { Provider } from "@/provider/provider"
 import { Log } from "@/util/log"
 import { streamText, wrapLanguageModel, type ModelMessage, type StreamTextResult, type Tool, type ToolSet } from "ai"
-import { mergeDeep, pipe } from "remeda"
+import { clone, mergeDeep, pipe } from "remeda"
 import { ProviderTransform } from "@/provider/transform"
 import { Config } from "@/config/config"
 import { Instance } from "@/project/instance"
@@ -59,6 +59,12 @@ export namespace LLM {
         .filter((x) => x)
         .join("\n"),
     )
+
+    const original = clone(system)
+    await Plugin.trigger("experimental.chat.system.transform", {}, { system })
+    if (system.length === 0) {
+      system.push(...original)
+    }
 
     const params = await Plugin.trigger(
       "chat.params",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -20,7 +20,7 @@ import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
 import { defer } from "../util/defer"
-import { mergeDeep, pipe } from "remeda"
+import { clone, mergeDeep, pipe } from "remeda"
 import { ToolRegistry } from "../tool/registry"
 import { Wildcard } from "../util/wildcard"
 import { MCP } from "../mcp"
@@ -480,6 +480,10 @@ export namespace SessionPrompt {
         })
       }
 
+      const sessionMessages = clone(msgs)
+
+      await Plugin.trigger("experimental.chat.messages.transform", {}, { messages: sessionMessages })
+
       const result = await processor.process({
         user: lastUser,
         agent,
@@ -487,7 +491,7 @@ export namespace SessionPrompt {
         sessionID,
         system: [...(await SystemPrompt.environment()), ...(await SystemPrompt.custom())],
         messages: [
-          ...MessageV2.toModelMessage(msgs),
+          ...MessageV2.toModelMessage(sessionMessages),
           ...(isLastStep
             ? [
                 {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -185,6 +185,12 @@ export interface Hooks {
       }[]
     },
   ) => Promise<void>
+  "experimental.chat.system.transform"?: (
+    input: {},
+    output: {
+      system: string[]
+    },
+  ) => Promise<void>
   "experimental.text.complete"?: (
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },


### PR DESCRIPTION
## Summary
- Restores the `experimental.chat.messages.transform` hook
- Adds the `experimental.chat.system.transform` hook

These hooks allow plugins to transform messages and system prompts before they are sent to the LLM.