### PR TITLE
fix: input lip visibility for transparent themes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -873,17 +873,24 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            vertical: "╹",
+            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
           }}
         >
           <box
             height={1}
             border={["bottom"]}
             borderColor={theme.backgroundElement}
-            customBorderChars={{
-              ...EmptyBorder,
-              horizontal: "▀",
-            }}
+            customBorderChars={
+              theme.backgroundElement.a !== 0
+                ? {
+                    ...EmptyBorder,
+                    horizontal: "▀",
+                  }
+                : {
+                    ...EmptyBorder,
+                    horizontal: " ",
+                  }
+            }
           />
         </box>
         <box flexDirection="row" justifyContent="space-between">


### PR DESCRIPTION
Check backgroundElement.a instead of background.a to determine whether to draw the input box bottom lip. This fixes both:

- nightowl-transparent theme: lip visible with solid backgroundElement
- transparent theme: lip invisible with transparent backgroundElement

Previously PR #5524 removed the condition entirely, causing black bars in fully transparent themes. This restores the conditional logic with the correct property check.

The conditional is being restored, although on a different variable `theme.backgroundElement`, because that also acts as the background of the input box

<img width="1802" height="972" alt="image" src="https://github.com/user-attachments/assets/9bc4739f-fd57-4cc5-a483-e2bdd2df15f0" />

Why we require the conditional rendering ?

<img width="1450" height="752" alt="image" src="https://github.com/user-attachments/assets/637ec8df-d6c7-47d8-b82d-3d77fa5761f4" />

Above change works well with the nightowl-transparent theme from #5496 and transparent theme from https://github.com/sst/opencode/pull/4572#issuecomment-3567640711


https://github.com/user-attachments/assets/23714909-f629-4a8c-bcad-96e9d08cc3ef

Closes #5496 https://github.com/sst/opencode/pull/4572#issuecomment-3567640711
