### PR TITLE
feat: add F# language server support

### DIFF
--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -22,6 +22,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | elixir-ls          | .ex, .exs                                            | `elixir` command available                                   |
 | zls                | .zig, .zon                                           | `zig` command available                                      |
 | csharp             | .cs                                                  | `.NET SDK` installed                                         |
+| fsharp             | .fs, .fsi, .fsx, .fsscript                           | `.NET SDK` installed                                         |
 | vue                | .vue                                                 | Auto-installs for Vue projects                               |
 | rust               | .rs                                                  | `rust-analyzer` command available                            |
 | clangd             | .c, .cpp, .cc, .cxx, .c++, .h, .hpp, .hh, .hxx, .h++ | Auto-installs for C/C++ projects                             |


### PR DESCRIPTION
- Add FSharp LSP server configuration using fsautocomplete
- Support for .fs, .fsi, .fsx, and .fsscript file extensions
- Auto-install fsautocomplete via dotnet tool when .NET SDK is available
- Update documentation to include F# in LSP servers table

Closes #5535 