### PR TITLE
fix: rejoin system prompt after plugin hook to preserve caching

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -72,10 +72,6 @@ export namespace LLM {
       system.length = 0
       system.push(header, rest.join("\n"))
     }
-      const [first, ...rest] = system
-      system.length = 0
-      system.push(first, rest.join("\n"))
-    }
 
     const params = await Plugin.trigger(
       "chat.params",

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -68,6 +68,10 @@ export namespace LLM {
     }
     // rejoin to maintain 2-part structure for caching if header unchanged
     if (system.length > 2 && system[0] === header) {
+      const rest = system.slice(1)
+      system.length = 0
+      system.push(header, rest.join("\n"))
+    }
       const [first, ...rest] = system
       system.length = 0
       system.push(first, rest.join("\n"))

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -60,10 +60,17 @@ export namespace LLM {
         .join("\n"),
     )
 
+    const header = system[0]
     const original = clone(system)
     await Plugin.trigger("experimental.chat.system.transform", {}, { system })
     if (system.length === 0) {
       system.push(...original)
+    }
+    // rejoin to maintain 2-part structure for caching if header unchanged
+    if (system.length > 2 && system[0] === header) {
+      const [first, ...rest] = system
+      system.length = 0
+      system.push(first, rest.join("\n"))
     }
 
     const params = await Plugin.trigger(


### PR DESCRIPTION
## Summary
- Fixes system prompt caching when plugins modify `output.system`

The caching logic in `transform.ts` expects exactly 2 system parts. If a plugin pushes additional parts, they won't be cached. This rejoins the array after the plugin hook to maintain the 2-part structure.