### PR TITLE
fix: record shell mode in history (resolves #5454)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -9,6 +9,7 @@ import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
 
 export type PromptInfo = {
   input: string
+  mode?: "normal" | "shell"
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -539,7 +539,10 @@ export function Prompt(props: PromptProps) {
         ],
       })
     }
-    history.append(store.prompt)
+    history.append({
+      ...store.prompt,
+      mode: store.mode,
+    })
     input.extmarks.clear()
     setStore("prompt", {
       input: "",
@@ -763,6 +766,7 @@ export function Prompt(props: PromptProps) {
                     if (item) {
                       input.setText(item.input)
                       setStore("prompt", item)
+                      setStore("mode", item.mode ?? "normal")
                       restoreExtmarksFromParts(item.parts)
                       e.preventDefault()
                       if (direction === -1) input.cursorOffset = 0

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -491,6 +491,9 @@ export function Prompt(props: PromptProps) {
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
 
+    // Capture mode before it gets reset
+    const currentMode = store.mode
+
     if (store.mode === "shell") {
       sdk.client.session.shell({
         sessionID,
@@ -541,7 +544,7 @@ export function Prompt(props: PromptProps) {
     }
     history.append({
       ...store.prompt,
-      mode: store.mode,
+      mode: currentMode,
     })
     input.extmarks.clear()
     setStore("prompt", {


### PR DESCRIPTION
Fixes bug 1 from issue #5454 where shell commands were not properly recalled from message history. Previously, when typing a shell command such as, e.g., `!date`, only the `date` text was stored in history, not the shell mode. When recalling with up arrow, this caused the command to be sent as a text message to the model instead of executed as a shell command. With this PR, the shell mode state is recorded alongside the message so that it is properly restored when cycling through the command history.

Changes:
- Add optional `mode` field to PromptInfo type
- Store current mode when appending to history
- Restore mode (defaulting to 'normal' for backward compatibility) when recalling from history

Resolves #5454 (at least, the 'bug 1' part of it).