### PR TITLE
tweak: prioritize fuzzysort results that start with user input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -364,6 +364,13 @@ export function Autocomplete(props: {
     const result = fuzzysort.go(currentFilter, mixed, {
       keys: [(obj) => obj.display.trimEnd(), "description", (obj) => obj.aliases?.join(" ") ?? ""],
       limit: 10,
+      scoreFn: (objResults) => {
+        const displayResult = objResults[0]
+        if (displayResult && displayResult.target.startsWith(store.visible + currentFilter)) {
+          return objResults.score * 2
+        }
+        return objResults.score
+      },
     })
     return result.map((arr) => arr.obj)
   })


### PR DESCRIPTION
Fixes #5567

have fuzzysort prioritize results that start with the user's input.

Before:
<img width="808" height="277" alt="image" src="https://github.com/user-attachments/assets/99f9378a-f43c-4fda-9ee3-de951e38ee84" />

After:
<img width="808" height="277" alt="image" src="https://github.com/user-attachments/assets/de8b0f7b-38a3-4e7a-8831-1eebf0f8710a" />
