### PR TITLE
fix(windows): opencode github install

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -278,7 +278,7 @@ export const GithubInstallCommand = cmd({
               process.platform === "darwin"
                 ? `open "${url}"`
                 : process.platform === "win32"
-                  ? `start "${url}"`
+                  ? `start "" "${url}"`
                   : `xdg-open "${url}"`
 
             exec(command, (error) => {


### PR DESCRIPTION
first string is actually window title, so I was getting a blank cmd with url as the tab name 