### PR TITLE
fix: enable shell alias expansion in ! command

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1096,7 +1096,7 @@ export namespace SessionPrompt {
           `
             [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
             [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-            ${input.command}
+            eval ${JSON.stringify(input.command)}
           `,
         ],
       },
@@ -1105,8 +1105,9 @@ export namespace SessionPrompt {
           "-c",
           "-l",
           `
+            shopt -s expand_aliases
             [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-            ${input.command}
+            eval ${JSON.stringify(input.command)}
           `,
         ],
       },


### PR DESCRIPTION
## Summary

Fixes shell aliases not working when using the `!` command prefix (e.g., `! g status` where `g` is aliased to `git`).

Closes #4351

## Problem

Shell aliases weren't being expanded because:
1. In non-interactive shells, alias expansion is disabled by default in both zsh and bash
2. Even after enabling alias expansion with `shopt -s expand_aliases` (bash), the command was already parsed before the aliases were loaded

## Solution

- Add `shopt -s expand_aliases` for bash to enable alias expansion (works in ZSH without it)
- Wrap the command in `eval` to defer parsing until after aliases are loaded
- Use `JSON.stringify` to properly escape the command string