### PR TITLE
docs: fix typo in Google Antigravity github link

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -23,7 +23,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)            | Use your ChatGPT Plus/Pro subscription instead of API credits                                 |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                           | Use your existing Gemini plan instead of API billing                                          |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)               | Use Antigravity's free models instead of API billing                                          |
-| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-goggle-antigravity-auth)  | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling |
+| [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)  | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                                         |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                | Add native websearch support for supported providers with Google grounded style               |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                      | Enables AI agents to run background processes in a PTY, send interactive input to them.       |


### PR DESCRIPTION
Fixes a small typo on the urls