### PR TITLE
fix: use system prompt field from prompt input

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -492,7 +492,7 @@ export namespace SessionPrompt {
         system: [
           ...(await SystemPrompt.environment()),
           ...(await SystemPrompt.custom()),
-          ...(lastUser.system ? [lastUser.system] : []),
+          ...[lastUser.system].filter(Boolean),
         ],
         messages: [
           ...MessageV2.toModelMessage(sessionMessages),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -489,7 +489,11 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
-        system: [...(await SystemPrompt.environment()), ...(await SystemPrompt.custom())],
+        system: [
+          ...(await SystemPrompt.environment()),
+          ...(await SystemPrompt.custom()),
+          ...(lastUser.system ? [lastUser.system] : []),
+        ],
         messages: [
           ...MessageV2.toModelMessage(sessionMessages),
           ...(isLastStep
@@ -683,6 +687,7 @@ export namespace SessionPrompt {
       tools: input.tools,
       agent: agent.name,
       model: input.model ?? agent.model ?? (await lastModel(input.sessionID)),
+      system: input.system,
     }
 
     const parts = await Promise.all(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -489,11 +489,7 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
-        system: [
-          ...(await SystemPrompt.environment()),
-          ...(await SystemPrompt.custom()),
-          ...(lastUser.system ? [lastUser.system] : []),
-        ],
+        system: [...(await SystemPrompt.environment()), ...(await SystemPrompt.custom())],
         messages: [
           ...MessageV2.toModelMessage(sessionMessages),
           ...(isLastStep

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -492,7 +492,7 @@ export namespace SessionPrompt {
         system: [
           ...(await SystemPrompt.environment()),
           ...(await SystemPrompt.custom()),
-          ...[lastUser.system].filter(Boolean),
+          ...(lastUser.system ? [lastUser.system] : []),
         ],
         messages: [
           ...MessageV2.toModelMessage(sessionMessages),


### PR DESCRIPTION

- Wire up the existing `system` field in `PromptInput` so it actually gets used
- The system prompt is appended to the end of the system prompt array when sending messages via the API


Tested locally - sending a message with `"system": "Always reply with GOGO"` and `"parts": [{"type": "text", "text": "hello"}]` correctly produces a response starting with "GOGO".