### PR TITLE
Tag latest on publish

### DIFF
--- a/script/publish.ts
+++ b/script/publish.ts
@@ -154,8 +154,9 @@ if (!Script.preview) {
   await $`git tag -f latest`
   await $`git fetch origin`
   await $`git cherry-pick HEAD..origin/dev`.nothrow()
-  await $`git push origin HEAD --tags --no-verify --force-with-lease`
-  await $`git push origin latest --force`
+  await $`git push origin HEAD --no-verify --force-with-lease`
+  await $`git push origin v${Script.version} --no-verify`
+  await $`git push origin latest --no-verify --force`
   await new Promise((resolve) => setTimeout(resolve, 5_000))
   await $`gh release create v${Script.version} -d --title "v${Script.version}" --notes ${notes.join("\n") || "No notable changes"} ./packages/opencode/dist/*.zip ./packages/opencode/dist/*.tar.gz`
   const release = await $`gh release view v${Script.version} --json id,tagName`.json()

--- a/script/publish.ts
+++ b/script/publish.ts
@@ -151,9 +151,11 @@ process.chdir(dir)
 if (!Script.preview) {
   await $`git commit -am "release: v${Script.version}"`
   await $`git tag v${Script.version}`
+  await $`git tag -f latest`
   await $`git fetch origin`
   await $`git cherry-pick HEAD..origin/dev`.nothrow()
   await $`git push origin HEAD --tags --no-verify --force-with-lease`
+  await $`git push origin latest --force`
   await new Promise((resolve) => setTimeout(resolve, 5_000))
   await $`gh release create v${Script.version} -d --title "v${Script.version}" --notes ${notes.join("\n") || "No notable changes"} ./packages/opencode/dist/*.zip ./packages/opencode/dist/*.tar.gz`
   const release = await $`gh release view v${Script.version} --json id,tagName`.json()


### PR DESCRIPTION
https://github.com/sst/opencode/releases/tag/latest is getting outdated and seems to be requiring manual tagging.

This should tag it automatically on every release.