### PR TITLE
fix(read): narrow .env file blocking to not block .envrc

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -60,10 +60,12 @@ export const ReadTool = Tool.define("read", {
     }
 
     const block = iife(() => {
-      const whitelist = [".env.sample", ".example"]
+      const basename = path.basename(filepath)
+      const whitelist = [".env.sample", ".env.example", ".example", ".env.template"]
 
-      if (whitelist.some((w) => filepath.endsWith(w))) return false
-      if (filepath.includes(".env")) return true
+      if (whitelist.some((w) => basename.endsWith(w))) return false
+      // Block .env, .env.local, .env.production, etc. but not .envrc
+      if (/^\.env(\.|$)/.test(basename)) return true
 
       return false
     })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { ReadTool } from "../../src/tool/read"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+
+const ctx = {
+  sessionID: "test",
+  messageID: "",
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+}
+
+describe("tool.read env file blocking", () => {
+  test.each([
+    [".env", true],
+    [".env.local", true],
+    [".env.production", true],
+    [".env.sample", false],
+    [".env.example", false],
+    [".envrc", false],
+    ["environment.ts", false],
+  ])("%s blocked=%s", async (filename, blocked) => {
+    await using tmp = await tmpdir({
+      init: (dir) => Bun.write(path.join(dir, filename), "content"),
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const promise = read.execute({ filePath: path.join(tmp.path, filename) }, ctx)
+        if (blocked) {
+          await expect(promise).rejects.toThrow("blocked")
+        } else {
+          expect((await promise).output).toContain("content")
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix overly broad `.env` file blocking that was catching `.envrc` (direnv) and other legitimate files
- Changed from `filepath.includes(".env")` to basename-only regex `/^\.env(\.|$)/`
- Added `.env.example` and `.env.template` to whitelist
- Added test coverage for env file blocking behavior

## Test plan

- [x] `bun test test/tool/read.test.ts` passes (7 tests)
- [ ] Manual test: can now read `.envrc` files
- [ ] Verify `.env`, `.env.local`, `.env.production` still blocked

Fixes #4969

🤖 Generated with [Claude Code](https://claude.com/claude-code)