### PR TITLE
github: add configurable mentions input

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -22,6 +22,10 @@ inputs:
     required: false
     default: "false"
 
+  mentions:
+    description: "Comma-separated list of trigger phrases (case-insensitive). Defaults to '/opencode,/oc'"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -57,3 +61,4 @@ runs:
         SHARE: ${{ inputs.share }}
         PROMPT: ${{ inputs.prompt }}
         USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}
+        MENTIONS: ${{ inputs.mentions }}


### PR DESCRIPTION
Adds a new `mentions` input to the GitHub Action that allows customizing the trigger phrases instead of hardcoded `/opencode` and `/oc`. Defaults do not change.

This allows users to wrap `sst/opencode/github` with their own tooling without having to write + publish an entirely new action.

Follows the work in #5459.