### PR TITLE
fix: prevent session list selection from jumping to active session when confirming delete

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -63,7 +63,7 @@ export function DialogSessionList() {
     <DialogSelect
       title="Sessions"
       options={options()}
-      current={toDelete() ? undefined : currentSessionID()}
+      current={currentSessionID()}
       onMove={() => {
         setToDelete(undefined)
       }}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -63,7 +63,7 @@ export function DialogSessionList() {
     <DialogSelect
       title="Sessions"
       options={options()}
-      current={currentSessionID()}
+      current={toDelete() ? undefined : currentSessionID()}
       onMove={() => {
         setToDelete(undefined)
       }}


### PR DESCRIPTION
After the fix, I've made changes so that the effect triggers only when the current selection changes

https://github.com/user-attachments/assets/e77ced73-d5d5-4f03-b030-2d77e0c9790e

Closes #5466 



