### PR TITLE
fix: change subagent navigation order to newest-to-oldest

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -225,7 +225,7 @@ export function Session() {
     const parentID = session()?.parentID ?? session()?.id
     let children = sync.data.session
       .filter((x) => x.parentID === parentID || x.id === parentID)
-      .toSorted((b, a) => a.id.localeCompare(b.id))
+      .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
     if (children.length === 1) return
     let next = children.findIndex((x) => x.id === session()?.id) + direction
     if (next >= children.length) next = 0


### PR DESCRIPTION
## Summary

When a subagent spawns and you want to navigate to it to view it's progress, the natural intuition is to go to "the next subagent" at least for me - this ends up in me going to the oldest subagent which feels weird

Swaps the ordering so newest is first, and also removes localCompare as it's not needed for the ID comparison