### PR TITLE
fix: send `mcpName` as state if authUrl doesn't have `state`

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -494,11 +494,18 @@ export namespace MCP {
     // Extract state from authorization URL to use as callback key
     // If no state parameter, use mcpName as fallback
     const authUrl = new URL(authorizationUrl)
-    const oauthState = authUrl.searchParams.get("state") ?? mcpName
+    let oauthState = mcpName
+
+    if (authUrl.searchParams.has("state")) {
+      oauthState = authUrl.searchParams.get("state")!
+    } else {
+      log.info("no state parameter in authorization URL, using mcpName as state", { mcpName })
+      authUrl.searchParams.set("state", oauthState)
+    }
 
     // Open browser
-    log.info("opening browser for oauth", { mcpName, url: authorizationUrl, state: oauthState })
-    await open(authorizationUrl)
+    log.info("opening browser for oauth", { mcpName, url: authUrl.toString(), state: oauthState })
+    await open(authUrl.toString())
 
     // Wait for callback using the OAuth state parameter (or mcpName as fallback)
     const code = await McpOAuthCallback.waitForCallback(oauthState)


### PR DESCRIPTION
Right now, if there's no `state` in the authorization URL opencode uses the MCP name as state...however it doesn't actually send the `state` parameter to the authorization server.

This, combined with a bug in better auth (where `state` comes back as the string `undefined`) which I'm gonna open a PR for in a minute, means that authentication will fail.

Now this is probably more of a better auth bug, but I would say that even returning an empty state could be problematic and if we are gonna use that state we might just also send it for real. This PR changes that.