### PR TITLE
feat(cli): add option to attach `opencode web` to a running opencode server

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -1,8 +1,10 @@
+import { WebOnlyServer } from "@/server/web-only"
 import { Server } from "../../server/server"
 import { UI } from "../ui"
 import { cmd } from "./cmd"
 import open from "open"
 import { networkInterfaces } from "os"
+import type { BunWebSocketData } from "hono/bun"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -40,32 +42,50 @@ export const WebCommand = cmd({
         type: "string",
         describe: "hostname to listen on",
         default: "127.0.0.1",
+      })
+      .option("attach", {
+        type: "string",
+        describe: "attach to a running opencode server (e.g., http://localhost:4096)",
       }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
     const hostname = args.hostname
     const port = args.port
-    const server = Server.listen({
-      port,
-      hostname,
+    const serverUrl = args.attach
+    let server: Bun.Server<BunWebSocketData>
+
+    if (serverUrl) {
+      server = WebOnlyServer.listen({
+        port,
+        hostname,
+        serverUrl
     })
+    } else {
+      server = Server.listen({
+        port,
+        hostname,
+      })
+    } 
+
+
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
 
     if (hostname === "0.0.0.0") {
       // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
+      const localhostUrl = serverUrl ? `http://localhost:${server.port}?url=${serverUrl}` : `http://localhost:${server.port}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
 
       // Show network IPs for remote access
       const networkIPs = getNetworkIPs()
       if (networkIPs.length > 0) {
         for (const ip of networkIPs) {
+          const networkUrl = serverUrl ? `http://${ip}:${server.port}?url=${serverUrl}` : `http://${ip}:${server.port}`
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            networkUrl,
           )
         }
       }
@@ -73,7 +93,7 @@ export const WebCommand = cmd({
       // Open localhost in browser
       open(localhostUrl.toString()).catch(() => {})
     } else {
-      const displayUrl = server.url.toString()
+      const displayUrl = serverUrl ? `${server.url.toString()}?url=${serverUrl}` : server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
       open(displayUrl).catch(() => {})
     }

--- a/packages/opencode/src/server/web-only.ts
+++ b/packages/opencode/src/server/web-only.ts
@@ -1,0 +1,104 @@
+import { BusEvent } from "@/bus/bus-event"
+import { Log } from "../util/log"
+import { Hono } from "hono"
+import { cors } from "hono/cors"
+import { proxy } from "hono/proxy"
+import z from "zod"
+import { Provider } from "../provider/provider"
+import { NamedError } from "@opencode-ai/util/error"
+import { lazy } from "../util/lazy"
+import type { ContentfulStatusCode } from "hono/utils/http-status"
+import { websocket } from "hono/bun"
+
+// @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
+globalThis.AI_SDK_LOG_WARNINGS = false
+
+export namespace WebOnlyServer {
+  const log = Log.create({ service: "web-only-server" })
+
+  export const Event = {
+    Connected: BusEvent.define("server.connected", z.object({})),
+    Disposed: BusEvent.define("global.disposed", z.object({})),
+  }
+
+  const app = new Hono()
+  export const App = (serverUrl: string) => lazy(() =>
+    app
+      .onError((err, c) => {
+        log.error("failed", {
+          error: err,
+        })
+        if (err instanceof NamedError) {
+          let status: ContentfulStatusCode = 500
+          return c.json(err.toObject(), { status })
+        }
+        const message = err instanceof Error && err.stack ? err.stack : err.toString()
+        return c.json(new NamedError.Unknown({ message }).toObject(), {
+          status: 500,
+        })
+      })
+      .use(async (c, next) => {
+        const skipLogging = c.req.path === "/log"
+        if (!skipLogging) {
+          log.info("request", {
+            method: c.req.method,
+            path: c.req.path,
+          })
+        }
+        const timer = log.time("request", {
+          method: c.req.method,
+          path: c.req.path,
+        })
+        await next()
+        if (!skipLogging) {
+          timer.stop()
+        }
+      })
+      .use(cors())
+      .all("/*", async (c) => {
+        log.info("NEW REQUEST", {
+          path: c.req.path,
+          url: serverUrl,
+        })
+        // Build the target URL properly
+        const path = c.req.path
+        const query = c.req.query()
+        
+        // Create target URL with path
+        const targetUrl = new URL(`https://desktop.opencode.ai${path}`)
+        
+        // Copy existing query parameters
+        for (const [key, value] of Object.entries(query)) {
+          if (value) {
+            targetUrl.searchParams.set(key, value)
+          }
+        }
+        
+        // Only add ?url= if it's not already present (for first render)
+        if (!targetUrl.searchParams.has("url")) {
+          targetUrl.searchParams.set("url", serverUrl)
+        }
+        
+        log.info("PROXY TO", { targetUrl: targetUrl.toString() })
+              
+        return proxy(targetUrl.toString(), {
+          ...c.req,
+          headers: {
+            host: "desktop.opencode.ai",
+          },
+        })
+      }),
+  )
+
+  export function listen(opts: { port: number; hostname: string; serverUrl: string}) {
+    const server = Bun.serve({
+      port: opts.port,
+      hostname: opts.hostname,
+      idleTimeout: 0,
+      fetch: App(opts.serverUrl)().fetch,
+      websocket: websocket,
+    })
+    
+    return server
+  }
+}

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -250,6 +250,27 @@ This starts an HTTP server that provides API access to opencode functionality wi
 
 ---
 
+### web
+
+Start a web interface for OpenCode. Opens the desktop UI in your browser, allowing you to interact with OpenCode through a graphical interface.
+```bash
+opencode web
+```
+
+#### Flags
+
+| Flag         | Short | Description                                                      |
+| ------------ | ----- | ---------------------------------------------------------------- |
+| `--port`     | `-p`  | Port to listen on                                                |
+| `--hostname` |       | Hostname to listen on                                            |
+| `--attach`   |       | Attach to a running opencode server (e.g., `http://localhost:4096`) |
+
+:::note
+When using `--attach`, the web interface will connect to the specified server URL instead of starting a new server instance. This is useful when you already have an OpenCode server running and just want to access it through the web interface.
+:::
+
+---
+
 ### upgrade
 
 Updates opencode to the latest version or a specific version.


### PR DESCRIPTION
Should be for proposed feature #5692 

Might not be needed since users can just plug it in to the `desktop.opencode.ai` url, but could be convenient as well.