### PR TITLE
feat(plugin): add experimental.session.compacting hook for pre-compaction context injection

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -13,6 +13,7 @@ import { Log } from "../util/log"
 import { SessionProcessor } from "./processor"
 import { fn } from "@/util/fn"
 import { Agent } from "@/agent/agent"
+import { Plugin } from "@/plugin"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
@@ -125,6 +126,8 @@ export namespace SessionCompaction {
       model,
       abort: input.abort,
     })
+    // Allow plugins to inject context for compaction
+    const compacting = await Plugin.trigger("session.compacting", { sessionID: input.sessionID }, { context: [] })
     const result = await processor.process({
       user: userMessage,
       agent,
@@ -139,7 +142,10 @@ export namespace SessionCompaction {
           content: [
             {
               type: "text",
-              text: "Provide a detailed prompt for continuing our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next considering new session will not have access to our conversation.",
+              text: [
+                "Provide a detailed prompt for continuing our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next considering new session will not have access to our conversation.",
+                ...compacting.context,
+              ].join("\n\n"),
             },
           ],
         },

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -127,7 +127,11 @@ export namespace SessionCompaction {
       abort: input.abort,
     })
     // Allow plugins to inject context for compaction
-    const compacting = await Plugin.trigger("session.compacting", { sessionID: input.sessionID }, { context: [] })
+    const compacting = await Plugin.trigger(
+      "experimental.session.compacting",
+      { sessionID: input.sessionID },
+      { context: [] },
+    )
     const result = await processor.process({
       user: userMessage,
       agent,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -195,7 +195,7 @@ export interface Hooks {
    * Called before session compaction starts. Allows plugins to append
    * additional context to the compaction prompt.
    */
-  "session.compacting"?: (input: { sessionID: string }, output: { context: string[] }) => Promise<void>
+  "experimental.session.compacting"?: (input: { sessionID: string }, output: { context: string[] }) => Promise<void>
   "experimental.text.complete"?: (
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -191,6 +191,11 @@ export interface Hooks {
       system: string[]
     },
   ) => Promise<void>
+  /**
+   * Called before session compaction starts. Allows plugins to append
+   * additional context to the compaction prompt.
+   */
+  "session.compacting"?: (input: { sessionID: string }, output: { context: string[] }) => Promise<void>
   "experimental.text.complete"?: (
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -205,3 +205,31 @@ The `tool` helper creates a custom tool that opencode can call. It takes a Zod s
 - `execute`: Function that runs when the tool is called
 
 Your custom tools will be available to opencode alongside built-in tools.
+
+---
+
+### Compaction hooks
+
+Customize the context included when a session is compacted:
+
+```ts title=".opencode/plugin/compaction.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const CompactionPlugin: Plugin = async (ctx) => {
+  return {
+    "session.compacting": async (input, output) => {
+      // Inject additional context into the compaction prompt
+      output.context.push(`
+## Custom Context
+
+Include any state that should persist across compaction:
+- Current task status
+- Important decisions made
+- Files being actively worked on
+`)
+    },
+  }
+}
+```
+
+The `session.compacting` hook fires before the LLM generates a continuation summary. Use it to inject domain-specific context that the default compaction prompt would miss.

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -217,7 +217,7 @@ import type { Plugin } from "@opencode-ai/plugin"
 
 export const CompactionPlugin: Plugin = async (ctx) => {
   return {
-    "session.compacting": async (input, output) => {
+    "experimental.session.compacting": async (input, output) => {
       // Inject additional context into the compaction prompt
       output.context.push(`
 ## Custom Context
@@ -232,4 +232,4 @@ Include any state that should persist across compaction:
 }
 ```
 
-The `session.compacting` hook fires before the LLM generates a continuation summary. Use it to inject domain-specific context that the default compaction prompt would miss.
+The `experimental.session.compacting` hook fires before the LLM generates a continuation summary. Use it to inject domain-specific context that the default compaction prompt would miss.


### PR DESCRIPTION
## Summary

Adds a `session.compacting` plugin hook that fires **before** compaction starts, allowing plugins to append additional context to the compaction prompt.

## Use Case

The [opencode-swarm-plugin](https://github.com/joelhooks/swarm-tools) uses multi-agent coordination with beads (issue tracker), Swarm Mail (agent communication), and semantic memory. When compaction happens, the generic prompt loses all swarm coordination state. This hook lets plugins inject:

- Active bead ID and status
- Agent name and role
- File reservations
- Recent swarm mail context
- Instructions to re-sync state after resuming

## Changes

| File | Change |
|------|--------|
| `packages/plugin/src/index.ts` | Add `session.compacting` hook type |
| `packages/opencode/src/session/compaction.ts` | Call hook before processor.process(), append context to prompt |
| `packages/web/src/content/docs/plugins.mdx` | Add example showing hook usage |

## Hook Signature

```typescript
"session.compacting"?: (
  input: { sessionID: string },
  output: { context: string[] },
) => Promise<void>
```

## Example Usage

```typescript
export const SwarmPlugin: Plugin = async (ctx) => {
  return {
    "session.compacting": async (input, output) => {
      output.context.push(`
## Swarm Coordination State

IMPORTANT: This session is part of a multi-agent swarm. After resuming:
1. Run beads_query to check current task status
2. Run swarmmail_inbox to sync communications
3. Check file reservations before editing
`)
    }
  }
}
```

## Design Decisions

- **Append-only**: Plugins can only add context, not replace the base prompt
- **Minimal input**: Just `sessionID` - plugins fetch their own state
- **Not experimental**: This is a stable hook for a real use case