### PR TITLE
fix(tui): exclude reverted assistant reply when copying last message

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -597,7 +597,10 @@ export function Session() {
       keybind: "messages_copy",
       category: "Session",
       onSelect: (dialog) => {
-        const lastAssistantMessage = messages().findLast((msg) => msg.role === "assistant")
+        const revertID = session()?.revert?.messageID
+        const lastAssistantMessage = messages().findLast(
+          (msg) => msg.role === "assistant" && (!revertID || msg.id < revertID),
+        )
         if (!lastAssistantMessage) {
           toast.show({ message: "No assistant messages found", variant: "error" })
           dialog.clear()


### PR DESCRIPTION
previously, the "Copy last assistant message" action would copy the most recent assistant message even if that reply had been reverted, causing users to copy content that was no longer part of the active session state.

fixes: https://github.com/sst/opencode/issues/5707