### PR TITLE
fix(tui): display `ctrl+x left` and `ctrl+x right` shortcuts on the `ctrl+p` commands menu

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -745,7 +745,6 @@ export function Session() {
       value: "session.child.next",
       keybind: "session_child_cycle",
       category: "Session",
-      disabled: true,
       onSelect: (dialog) => {
         moveChild(1)
         dialog.clear()
@@ -756,7 +755,6 @@ export function Session() {
       value: "session.child.previous",
       keybind: "session_child_cycle_reverse",
       category: "Session",
-      disabled: true,
       onSelect: (dialog) => {
         moveChild(-1)
         dialog.clear()


### PR DESCRIPTION
fixes #5706 