### PR TITLE
Add opencode-jsonl-viewer.vercel.app to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -42,6 +42,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [portal](https://github.com/hosenur/portal)                                        | Mobile-first web UI for OpenCode over Tailscale/VPN             |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/) | Template for building OpenCode plugins                          |
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                         | Neovim frontend for opencode - a terminal-based AI coding agent |
+| [opencode-jsonl-viewer.vercel.app](https://opencode-jsonl-viewer.vercel.app/)      | A browser-based JSONL viewer for OpenCode JSONL output          |
 
 ---
 


### PR DESCRIPTION
When OpenCode is run with the `--format json` flag, it output a JSONL file.  This app helps to expore that JSONL file for humans.