### PR TITLE
feat: If an `apiKey` is provided, skip Oauth handling.

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -640,6 +640,14 @@ export namespace Provider {
       const providerID = plugin.auth.provider
       if (disabled.has(providerID)) continue
 
+      // Skip OAuth/plugin auth if config explicitly sets an apiKey for this provider
+      const configProvider = config.provider?.[providerID]
+      const hasExplicitApiKey = configProvider?.options?.apiKey !== undefined
+      if (hasExplicitApiKey) {
+        log.debug("skipping plugin auth loader - config has explicit apiKey", { providerID })
+        continue
+      }
+
       // For github-copilot plugin, check if auth exists for either github-copilot or github-copilot-enterprise
       let hasAuth = false
       const auth = await Auth.get(providerID)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1807,3 +1807,35 @@ test("custom model inherits api.url from models.dev provider", async () => {
     },
   })
 })
+
+test("config apiKey takes precedence over OAuth plugin auth loaders", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              options: {
+                apiKey: "explicit-config-api-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["anthropic"]).toBeDefined()
+      // When config has explicit apiKey, it should be used
+      // and plugin auth loaders should be skipped (no OAuth processing)
+      expect(providers["anthropic"].options.apiKey).toBe("explicit-config-api-key")
+      // Source should be "config" since config is merged last
+      expect(providers["anthropic"].source).toBe("config")
+    },
+  })
+})


### PR DESCRIPTION
## Context

My situation is this:

* I have a **personal** Claude Code Pro subscription, which is Oauth-ed (just like Claude Code the agent does).
* My work uses **Anthropic Claude Enterprise**, with multiple API keys (one key for each client). Those are usually set in the config via `provider.anthropic.options.apiKey`.

Using fake "profiles" (individually managed custom config files), I'd like to be able to use `opencode` with either type.

## Expected

When configured to use the `Anthropic Claude` provider, if an (enterprise) `apiKey` is provided, it should take precedence over the stored Oauth (Claude Code Pro) credentials. If not provided, `opencode` should use the Oauth credentials.

## Actual

Because of the way the configurations merging happens, the Oauth credentials (from `~/.local/share/opencode/auth.json`) always "win", and the manually set `apiKey` is ignored.

This means all usage, even when I provide an enterprise API key, always ends up pointed at my **personal** Claude Pro subscription.

## Solution

If an `apiKey` is configured & present, assume the user knows better & skip the loading of the Oauth credentials.

---

## Deeper Explanation of Setup/Situation

* I'm simulating having different "profiles" (one-per-client + a personal) by creating a bunch of custom config files within `~/.config/opencode/my_profiles/<profile-name>.jsonc`.
* In the work-based config files, under the `provider.anthropic.options.apiKey` path, I supply `{file:~/.secrets/<profile-name>.apikey}`, with different key paths for each work config.
* I then launch `opencode` with: `OPENCODE_CONFIG=~/.config/opencode/my_profiles/<profile-name>.jsonc opencode`.
* (Assuming I've renamed/moved the `~/.local/share/opencode/auth.json` away) This works great for all the different clients/keys... but because that file is gone, I can no longer use my personal subscription (e.g. `OPENCODE_CONFIG=~/.config/opencode/my_profiles/personal.jsonc opencode`).
* (Assuming I move the `~/.local/share/opencode/auth.json` back) My personal Claude Pro subscription is back, but now takes over everything, & the client API keys are never used.

---

This adds a small skip (non-specific to Anthropic/Claude) to the provider code, only if an `apiKey` is set/present. It includes a new passing test that demonstrates the behavior.