### PR TITLE
docs: add OPENCODE_DISABLE_TERMINAL_TITLE to environment variables

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -304,6 +304,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content             |
 | `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks        |
 | `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data            |
+| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates |
 | `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config        |
 | `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                |
 | `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads |

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -295,23 +295,23 @@ The opencode CLI takes the following global flags.
 
 OpenCode can be configured using environment variables.
 
-| Variable                              | Type    | Description                            |
-| ------------------------------------- | ------- | -------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions           |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows |
-| `OPENCODE_CONFIG`                     | string  | Path to config file                    |
-| `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory               |
-| `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content             |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks        |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data            |
+| Variable                              | Type    | Description                              |
+| ------------------------------------- | ------- | ---------------------------------------- |
+| `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions             |
+| `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows   |
+| `OPENCODE_CONFIG`                     | string  | Path to config file                      |
+| `OPENCODE_CONFIG_DIR`                 | string  | Path to config directory                 |
+| `OPENCODE_CONFIG_CONTENT`             | string  | Inline json config content               |
+| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | Disable automatic update checks          |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | Disable pruning of old data              |
 | `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates |
-| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config        |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models             |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction   |
-| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)  |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools            |
+| `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config          |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                  |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads   |
+| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models               |
+| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction     |
+| `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)    |
+| `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools              |
 
 ---
 


### PR DESCRIPTION
## Summary

Add documentation for `OPENCODE_DISABLE_TERMINAL_TITLE` environment variable that was introduced in #5661 but missing from the docs.

## Changes

- Added `OPENCODE_DISABLE_TERMINAL_TITLE` to the environment variables table in CLI docs
- This boolean variable disables automatic terminal title updates, matching Claude Code's `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` functionality

## Related

Closes the documentation gap from #5661