### PR TITLE
fix: restore session agent and model on subtask return

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -161,6 +161,7 @@ export namespace MessageV2 {
     description: z.string(),
     agent: z.string(),
     command: z.string().optional(),
+    parentAgent: z.string().optional(),
     parentModel: z
       .object({
         providerID: z.string(),

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -161,6 +161,12 @@ export namespace MessageV2 {
     description: z.string(),
     agent: z.string(),
     command: z.string().optional(),
+    parentModel: z
+      .object({
+        providerID: z.string(),
+        modelID: z.string(),
+      })
+      .optional(),
   })
   export type SubtaskPart = z.infer<typeof SubtaskPart>
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -419,15 +419,6 @@ export namespace SessionPrompt {
         // Add synthetic user message to prevent certain reasoning models from erroring
         // If we create assistant messages w/ out user ones following mid loop thinking signatures
         // will be missing and it can cause errors for models like gemini for example
-        const parentAgent = (() => {
-          for (let i = msgs.length - 1; i >= 0; i--) {
-            const msg = msgs[i]
-            if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "subtask")) {
-              return msg.info.agent
-            }
-          }
-          return "build"
-        })()
         const summaryUserMsg: MessageV2.User = {
           id: Identifier.ascending("message"),
           sessionID,
@@ -435,7 +426,7 @@ export namespace SessionPrompt {
           time: {
             created: Date.now(),
           },
-          agent: parentAgent,
+          agent: task.parentAgent ?? lastUser.agent,
           model: task.parentModel ?? lastUser.model,
         }
         await Session.updateMessage(summaryUserMsg)
@@ -1343,6 +1334,7 @@ export namespace SessionPrompt {
       return await lastModel(input.sessionID)
     })()
     const agent = await Agent.get(agentName)
+    const parentAgent = input.agent ?? "build"
     const parentModel = input.model ? Provider.parseModel(input.model) : await lastModel(input.sessionID)
 
     const parts =
@@ -1353,6 +1345,7 @@ export namespace SessionPrompt {
               agent: agent.name,
               description: command.description ?? "",
               command: input.command,
+              parentAgent,
               parentModel,
               // TODO: how can we make task tool accept a more complex input?
               prompt: await resolvePromptParts(template).then((x) => x.find((y) => y.type === "text")?.text ?? ""),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -562,11 +562,16 @@ export namespace SessionPrompt {
     throw new Error("Impossible")
   })
 
+  async function lastUser(sessionID: string) {
+    for await (const item of MessageV2.stream(sessionID)) {
+      if (item.info.role === "user") return item.info as MessageV2.User
+    }
+  }
+
   async function lastModel(sessionID: string) {
     for await (const item of MessageV2.stream(sessionID)) {
-      if (item.info.role === "user" && item.info.model) return item.info.model
+      if (item.info.role === "user") return item.info.model
     }
-    return Provider.defaultModel()
   }
 
   async function resolveTools(input: {
@@ -725,7 +730,7 @@ export namespace SessionPrompt {
       },
       tools: input.tools,
       agent: agent.name,
-      model: input.model ?? agent.model ?? (await lastModel(input.sessionID)),
+      model: input.model ?? (await lastModel(input.sessionID)) ?? agent.model ?? (await Provider.defaultModel()),
       system: input.system,
     }
 
@@ -1053,7 +1058,7 @@ export namespace SessionPrompt {
       SessionRevert.cleanup(session)
     }
     const agent = await Agent.get(input.agent)
-    const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
+    const model = input.model ?? (await lastModel(input.sessionID)) ?? agent.model ?? (await Provider.defaultModel())
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),
       sessionID: input.sessionID,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1325,6 +1325,7 @@ export namespace SessionPrompt {
     }
     template = template.trim()
 
+    const sessionModel = await lastModel(input.sessionID)
     const model = await (async () => {
       if (command.model) {
         return Provider.parseModel(command.model)
@@ -1336,11 +1337,11 @@ export namespace SessionPrompt {
         }
       }
       if (input.model) return Provider.parseModel(input.model)
-      return await lastModel(input.sessionID)
+      return sessionModel
     })()
     const agent = await Agent.get(agentName)
     const parentAgent = input.agent ?? "build"
-    const parentModel = input.model ? Provider.parseModel(input.model) : await lastModel(input.sessionID)
+    const parentModel = input.model ? Provider.parseModel(input.model) : sessionModel
 
     const parts =
       (agent.mode === "subagent" && command.subtask !== false) || command.subtask === true

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -419,6 +419,15 @@ export namespace SessionPrompt {
         // Add synthetic user message to prevent certain reasoning models from erroring
         // If we create assistant messages w/ out user ones following mid loop thinking signatures
         // will be missing and it can cause errors for models like gemini for example
+        const parentAgent = (() => {
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            const msg = msgs[i]
+            if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "subtask")) {
+              return msg.info.agent
+            }
+          }
+          return "build"
+        })()
         const summaryUserMsg: MessageV2.User = {
           id: Identifier.ascending("message"),
           sessionID,
@@ -426,8 +435,8 @@ export namespace SessionPrompt {
           time: {
             created: Date.now(),
           },
-          agent: lastUser.agent,
-          model: lastUser.model,
+          agent: parentAgent,
+          model: task.parentModel ?? lastUser.model,
         }
         await Session.updateMessage(summaryUserMsg)
         await Session.updatePart({
@@ -1334,6 +1343,7 @@ export namespace SessionPrompt {
       return await lastModel(input.sessionID)
     })()
     const agent = await Agent.get(agentName)
+    const parentModel = input.model ? Provider.parseModel(input.model) : await lastModel(input.sessionID)
 
     const parts =
       (agent.mode === "subagent" && command.subtask !== false) || command.subtask === true
@@ -1343,6 +1353,7 @@ export namespace SessionPrompt {
               agent: agent.name,
               description: command.description ?? "",
               command: input.command,
+              parentModel,
               // TODO: how can we make task tool accept a more complex input?
               prompt: await resolvePromptParts(template).then((x) => x.find((y) => y.type === "text")?.text ?? ""),
             },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -418,6 +418,11 @@ export type Part =
       description: string
       agent: string
       command?: string
+      parentAgent?: string
+      parentModel?: {
+        providerID: string
+        modelID: string
+      }
     }
   | ReasoningPart
   | FilePart
@@ -1602,6 +1607,11 @@ export type SubtaskPartInput = {
   description: string
   agent: string
   command?: string
+  parentAgent?: string
+  parentModel?: {
+    providerID: string
+    modelID: string
+  }
 }
 
 export type Command = {


### PR DESCRIPTION
Problem:
When using a subtask command, the session continues with the subtask's agent and model after it completes instead of returning to the original agent and model.

Solution:
Restore the original agent and model when returning from a subtask.