### PR TITLE
tauri: configure display backends more correctly on linux

### DIFF
--- a/packages/tauri/src-tauri/src/main.rs
+++ b/packages/tauri/src-tauri/src/main.rs
@@ -1,6 +1,62 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// borrowed from https://github.com/skyline69/balatro-mod-manager
+#[cfg(target_os = "linux")]
+fn configure_display_backend() -> Option<String> {
+    use std::env;
+
+    let set_env_if_absent = |key: &str, value: &str| {
+        if env::var_os(key).is_none() {
+            // Safety: called during startup before any threads are spawned, so mutating the
+            // process environment is safe.
+            unsafe { env::set_var(key, value) };
+        }
+    };
+
+    let on_wayland = env::var_os("WAYLAND_DISPLAY").is_some()
+        || matches!(
+            env::var("XDG_SESSION_TYPE"),
+            Ok(v) if v.eq_ignore_ascii_case("wayland")
+        );
+    if !on_wayland {
+        return None;
+    }
+
+    // Allow users to explicitly keep Wayland if they know their setup is stable.
+    let allow_wayland = matches!(
+        env::var("BMM_ALLOW_WAYLAND"),
+        Ok(v) if matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+    );
+    if allow_wayland {
+        return Some("Wayland session detected; respecting BMM_ALLOW_WAYLAND=1".into());
+    }
+
+    // Prefer XWayland when available to avoid Wayland protocol errors seen during startup.
+    if env::var_os("DISPLAY").is_some() {
+        set_env_if_absent("WINIT_UNIX_BACKEND", "x11");
+        set_env_if_absent("GDK_BACKEND", "x11");
+        set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        return Some(
+            "Wayland session detected; forcing X11 backend to avoid compositor protocol errors. \
+               Set BMM_ALLOW_WAYLAND=1 to keep native Wayland."
+                .into(),
+        );
+    }
+
+    set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    Some(
+          "Wayland session detected without X11; leaving Wayland enabled (set WINIT_UNIX_BACKEND/GDK_BACKEND manually if needed)."
+              .into(),
+      )
+}
+
 fn main() {
+    #[cfg(target_os = "linux")]
+    {
+        let backend_note = configure_display_backend();
+        eprintln!("{backend_note}");
+    }
+
     opencode_lib::run()
 }

--- a/packages/tauri/src-tauri/src/main.rs
+++ b/packages/tauri/src-tauri/src/main.rs
@@ -25,11 +25,11 @@ fn configure_display_backend() -> Option<String> {
 
     // Allow users to explicitly keep Wayland if they know their setup is stable.
     let allow_wayland = matches!(
-        env::var("BMM_ALLOW_WAYLAND"),
+        env::var("OC_ALLOW_WAYLAND"),
         Ok(v) if matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes")
     );
     if allow_wayland {
-        return Some("Wayland session detected; respecting BMM_ALLOW_WAYLAND=1".into());
+        return Some("Wayland session detected; respecting OC_ALLOW_WAYLAND=1".into());
     }
 
     // Prefer XWayland when available to avoid Wayland protocol errors seen during startup.
@@ -39,7 +39,7 @@ fn configure_display_backend() -> Option<String> {
         set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         return Some(
             "Wayland session detected; forcing X11 backend to avoid compositor protocol errors. \
-               Set BMM_ALLOW_WAYLAND=1 to keep native Wayland."
+               Set OC_ALLOW_WAYLAND=1 to keep native Wayland."
                 .into(),
         );
     }

--- a/packages/tauri/src-tauri/src/main.rs
+++ b/packages/tauri/src-tauri/src/main.rs
@@ -46,16 +46,17 @@ fn configure_display_backend() -> Option<String> {
 
     set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     Some(
-          "Wayland session detected without X11; leaving Wayland enabled (set WINIT_UNIX_BACKEND/GDK_BACKEND manually if needed)."
-              .into(),
-      )
+        "Wayland session detected without X11; leaving Wayland enabled (set WINIT_UNIX_BACKEND/GDK_BACKEND manually if needed)."
+            .into(),
+    )
 }
 
 fn main() {
     #[cfg(target_os = "linux")]
     {
-        let backend_note = configure_display_backend();
-        eprintln!("{backend_note}");
+        if let Some(backend_note) = configure_display_backend() {
+            eprintln!("{backend_note:?}");
+        }
     }
 
     opencode_lib::run()


### PR DESCRIPTION
Borrows code from [Balatro Mod Manager](https://github.com/skyline69/balatro-mod-manager/blob/66a6237725d55e8508a16202a6da6b6f80cb46e7/src-tauri/src/main.rs#L37) to configure webkit, winit, etc. more appropriately before launching. Would be good to get some testing from linux users before merging. 