### PR TITLE
fix: handle empty directory query parameter in server middleware

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -193,7 +193,7 @@ export namespace Server {
         },
       )
       .use(async (c, next) => {
-        const directory = c.req.query("directory") ?? c.req.header("x-opencode-directory") ?? process.cwd()
+        const directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
         return Instance.provide({
           directory,
           init: InstanceBootstrap,


### PR DESCRIPTION
Fix for this issue that is impacting both opencode desktop, and opencode web (specifically when the server process is launched inside a git repo):

<img width="1575" height="729" alt="image" src="https://github.com/user-attachments/assets/e8f8286b-b687-4492-9fdd-f4623529ebaa" />
