### PR TITLE
feat: add mcp.json support for Claude/Cursor compatibility

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -7,8 +7,9 @@ import { MCP } from "../../mcp"
 import { McpAuth } from "../../mcp/auth"
 import { Config } from "../../config/config"
 import { Instance } from "../../project/instance"
+import { McpJson, transformMcpJson } from "../../config/mcp-json"
+import { parse as parseJsonc } from "jsonc-parser"
 import path from "path"
-import os from "os"
 import { Global } from "../../global"
 
 export const McpCommand = cmd({
@@ -19,6 +20,7 @@ export const McpCommand = cmd({
       .command(McpListCommand)
       .command(McpAuthCommand)
       .command(McpLogoutCommand)
+      .command(McpImportCommand)
       .demandCommand(),
   async handler() {},
 })
@@ -398,5 +400,158 @@ export const McpAddCommand = cmd({
     }
 
     prompts.outro("MCP server added successfully")
+  },
+})
+
+export const McpImportCommand = cmd({
+  command: "import <data>",
+  describe: "import MCP servers from a base64-encoded JSON string",
+  builder: (yargs) =>
+    yargs.positional("data", {
+      describe: "base64-encoded mcp.json content",
+      type: "string",
+      demandOption: true,
+    }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Import MCP Servers")
+
+        // Decode base64
+        let decoded: string
+        try {
+          decoded = Buffer.from(args.data, "base64").toString("utf-8")
+        } catch {
+          prompts.log.error("Invalid base64 encoding")
+          prompts.outro("Import failed")
+          return
+        }
+
+        // Parse JSON
+        let data: unknown
+        try {
+          data = parseJsonc(decoded, [], { allowTrailingComma: true })
+        } catch {
+          prompts.log.error("Invalid JSON")
+          prompts.outro("Import failed")
+          return
+        }
+
+        // Validate against mcp.json schema
+        const parsed = McpJson.safeParse(data)
+        if (!parsed.success) {
+          prompts.log.error("Invalid mcp.json format:")
+          for (const issue of parsed.error.issues) {
+            prompts.log.error(`  ${issue.path.join(".")}: ${issue.message}`)
+          }
+          prompts.outro("Import failed")
+          return
+        }
+
+        if (!parsed.data.mcpServers || Object.keys(parsed.data.mcpServers).length === 0) {
+          prompts.log.warn("No MCP servers found in the provided data")
+          prompts.outro("Import cancelled")
+          return
+        }
+
+        // Transform to OpenCode format
+        const servers = transformMcpJson(parsed.data)
+        const serverNames = Object.keys(servers)
+
+        // Show preview
+        prompts.log.info(`Found ${serverNames.length} MCP server(s):`)
+        for (const [name, config] of Object.entries(servers)) {
+          const typeHint = config.type === "remote" ? config.url : config.command.join(" ")
+          prompts.log.info(`  - ${name} (${config.type}): ${typeHint}`)
+        }
+
+        // Confirm import
+        const confirm = await prompts.confirm({
+          message: "Import these servers?",
+        })
+        if (prompts.isCancel(confirm) || !confirm) {
+          prompts.outro("Import cancelled")
+          return
+        }
+
+        // Ask for location
+        const location = await prompts.select({
+          message: "Where do you want to save the configuration?",
+          options: [
+            {
+              label: "Project",
+              value: "project",
+              hint: path.join(Instance.directory, "opencode.json"),
+            },
+            {
+              label: "Global",
+              value: "global",
+              hint: path.join(Global.Path.config, "opencode.json"),
+            },
+          ],
+        })
+        if (prompts.isCancel(location)) {
+          prompts.outro("Import cancelled")
+          return
+        }
+
+        const configPath =
+          location === "project"
+            ? path.join(Instance.directory, "opencode.json")
+            : path.join(Global.Path.config, "opencode.json")
+
+        // Load existing config or create new one
+        let existingConfig: Config.Info = {}
+        const existingText = await Bun.file(configPath)
+          .text()
+          .catch(() => null)
+
+        if (existingText) {
+          try {
+            existingConfig = parseJsonc(existingText, [], { allowTrailingComma: true }) as Config.Info
+          } catch {
+            prompts.log.warn("Could not parse existing config, will create new one")
+          }
+        }
+
+        // Check for conflicts
+        const existingMcp = existingConfig.mcp ?? {}
+        const conflicts = serverNames.filter((name) => name in existingMcp)
+
+        if (conflicts.length > 0) {
+          prompts.log.warn(`The following servers already exist: ${conflicts.join(", ")}`)
+          const overwrite = await prompts.confirm({
+            message: "Overwrite existing servers?",
+            initialValue: false,
+          })
+          if (prompts.isCancel(overwrite)) {
+            prompts.outro("Import cancelled")
+            return
+          }
+          if (!overwrite) {
+            // Remove conflicting servers from import
+            for (const name of conflicts) {
+              delete servers[name]
+            }
+            if (Object.keys(servers).length === 0) {
+              prompts.log.warn("No new servers to import after removing conflicts")
+              prompts.outro("Import cancelled")
+              return
+            }
+          }
+        }
+
+        // Merge and write
+        existingConfig.$schema = existingConfig.$schema ?? "https://opencode.ai/config.json"
+        existingConfig.mcp = { ...existingMcp, ...servers }
+
+        await Bun.write(configPath, JSON.stringify(existingConfig, null, 2))
+
+        prompts.log.success(`Imported ${Object.keys(servers).length} server(s) to ${configPath}`)
+        prompts.outro("Import complete")
+      },
+    })
   },
 })

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -403,9 +403,34 @@ export const McpAddCommand = cmd({
   },
 })
 
+/**
+ * Import MCP servers from a base64-encoded mcp.json string.
+ *
+ * This command allows importing MCP server configurations that use the
+ * Claude/Cursor mcp.json format. The input should be base64-encoded JSON
+ * with the following structure:
+ *
+ * {
+ *   "mcpServers": {
+ *     "server-name": {
+ *       "command": "npx",           // For local servers
+ *       "args": ["-y", "mcp-server"],
+ *       "env": { "API_KEY": "..." }
+ *     },
+ *     "remote-server": {
+ *       "url": "https://example.com/mcp",  // For remote servers
+ *       "headers": { "Authorization": "Bearer ..." }
+ *     }
+ *   }
+ * }
+ *
+ * Example usage:
+ *   echo '{"mcpServers":{"my-server":{"url":"https://mcp.example.com"}}}' | base64
+ *   opencode mcp import <base64-output>
+ */
 export const McpImportCommand = cmd({
   command: "import <data>",
-  describe: "import MCP servers from a base64-encoded JSON string",
+  describe: "import MCP servers from a base64-encoded mcp.json string",
   builder: (yargs) =>
     yargs.positional("data", {
       describe: "base64-encoded mcp.json content",

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -108,8 +108,10 @@ export const McpAuthCommand = cmd({
         const config = await Config.get()
         const mcpServers = config.mcp ?? {}
 
-        // Get OAuth-enabled servers
-        const oauthServers = Object.entries(mcpServers).filter(([_, cfg]) => cfg.type === "remote" && !!cfg.oauth)
+        // Get OAuth-enabled servers (OAuth is enabled by default for remote servers unless oauth: false)
+        const oauthServers = Object.entries(mcpServers).filter(
+          ([_, cfg]) => cfg.type === "remote" && cfg.oauth !== false,
+        )
 
         if (oauthServers.length === 0) {
           prompts.log.warn("No OAuth-enabled MCP servers configured")

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -18,6 +18,7 @@ import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
+import { loadAllMcpJson } from "./mcp-json"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -133,6 +134,14 @@ export namespace Config {
     }
 
     if (!result.keybinds) result.keybinds = Info.shape.keybinds.parse({})
+
+    // Load mcp.json files from standard locations (Claude/Cursor compatibility)
+    // These have lower priority than opencode.json mcp config
+    const mcpJsonServers = await loadAllMcpJson()
+    if (Object.keys(mcpJsonServers).length > 0) {
+      // Merge mcp.json servers with lower priority (opencode.json mcp config takes precedence)
+      result.mcp = { ...mcpJsonServers, ...result.mcp }
+    }
 
     return {
       config: result,

--- a/packages/opencode/src/config/mcp-json.ts
+++ b/packages/opencode/src/config/mcp-json.ts
@@ -11,39 +11,39 @@ import { parse as parseJsonc, type ParseError as JsoncParseError } from "jsonc-p
 const log = Log.create({ service: "mcp-json" })
 
 // Schema for local/stdio MCP server (Claude/Cursor format)
-const McpJsonLocalServer = z.object({
+export const McpJsonLocalServer = z.object({
   command: z.string(),
   args: z.array(z.string()).optional(),
   env: z.record(z.string(), z.string()).optional(),
 })
 
 // Schema for remote HTTP/SSE MCP server (Claude/Cursor format)
-const McpJsonRemoteServer = z.object({
+export const McpJsonRemoteServer = z.object({
   url: z.string(),
   headers: z.record(z.string(), z.string()).optional(),
 })
 
 // Combined server schema - discriminated by presence of url vs command
-const McpJsonServer = z.union([McpJsonRemoteServer, McpJsonLocalServer])
-type McpJsonServer = z.infer<typeof McpJsonServer>
+export const McpJsonServer = z.union([McpJsonRemoteServer, McpJsonLocalServer])
+export type McpJsonServer = z.infer<typeof McpJsonServer>
 
 // Root mcp.json schema
-const McpJson = z.object({
+export const McpJson = z.object({
   mcpServers: z.record(z.string(), McpJsonServer).optional(),
 })
-type McpJson = z.infer<typeof McpJson>
+export type McpJson = z.infer<typeof McpJson>
 
 /**
  * Normalize environment variable syntax from ${env:VAR} (Claude/Cursor style) to {env:VAR} (OpenCode style)
  */
-function normalizeEnvSyntax(value: string): string {
+export function normalizeEnvSyntax(value: string): string {
   return value.replace(/\$\{env:([^}]+)\}/g, "{env:$1}")
 }
 
 /**
  * Transform mcp.json format to OpenCode's internal MCP config format
  */
-function transform(mcpJson: McpJson): Record<string, Config.Mcp> {
+export function transformMcpJson(mcpJson: McpJson): Record<string, Config.Mcp> {
   const result: Record<string, Config.Mcp> = {}
   if (!mcpJson.mcpServers) return result
 
@@ -104,7 +104,7 @@ async function loadFile(filepath: string): Promise<Record<string, Config.Mcp>> {
     return {}
   }
 
-  return transform(parsed.data)
+  return transformMcpJson(parsed.data)
 }
 
 /**

--- a/packages/opencode/src/config/mcp-json.ts
+++ b/packages/opencode/src/config/mcp-json.ts
@@ -1,0 +1,166 @@
+import z from "zod"
+import type { Config } from "./config"
+import { Log } from "../util/log"
+import path from "path"
+import os from "os"
+import { Global } from "../global"
+import { Filesystem } from "../util/filesystem"
+import { Instance } from "../project/instance"
+import { parse as parseJsonc, type ParseError as JsoncParseError } from "jsonc-parser"
+
+const log = Log.create({ service: "mcp-json" })
+
+// Schema for local/stdio MCP server (Claude/Cursor format)
+const McpJsonLocalServer = z.object({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+})
+
+// Schema for remote HTTP/SSE MCP server (Claude/Cursor format)
+const McpJsonRemoteServer = z.object({
+  url: z.string(),
+  headers: z.record(z.string(), z.string()).optional(),
+})
+
+// Combined server schema - discriminated by presence of url vs command
+const McpJsonServer = z.union([McpJsonRemoteServer, McpJsonLocalServer])
+type McpJsonServer = z.infer<typeof McpJsonServer>
+
+// Root mcp.json schema
+const McpJson = z.object({
+  mcpServers: z.record(z.string(), McpJsonServer).optional(),
+})
+type McpJson = z.infer<typeof McpJson>
+
+/**
+ * Normalize environment variable syntax from ${env:VAR} (Claude/Cursor style) to {env:VAR} (OpenCode style)
+ */
+function normalizeEnvSyntax(value: string): string {
+  return value.replace(/\$\{env:([^}]+)\}/g, "{env:$1}")
+}
+
+/**
+ * Transform mcp.json format to OpenCode's internal MCP config format
+ */
+function transform(mcpJson: McpJson): Record<string, Config.Mcp> {
+  const result: Record<string, Config.Mcp> = {}
+  if (!mcpJson.mcpServers) return result
+
+  for (const [name, server] of Object.entries(mcpJson.mcpServers)) {
+    if ("url" in server) {
+      // Remote server
+      const headers: Record<string, string> | undefined = server.headers
+        ? Object.fromEntries(Object.entries(server.headers).map(([k, v]) => [k, normalizeEnvSyntax(v)]))
+        : undefined
+
+      result[name] = {
+        type: "remote",
+        url: normalizeEnvSyntax(server.url),
+        ...(headers && { headers }),
+      }
+    } else {
+      // Local server
+      const environment: Record<string, string> | undefined = server.env
+        ? Object.fromEntries(Object.entries(server.env).map(([k, v]) => [k, normalizeEnvSyntax(v)]))
+        : undefined
+
+      result[name] = {
+        type: "local",
+        command: [server.command, ...(server.args ?? [])],
+        ...(environment && { environment }),
+      }
+    }
+  }
+  return result
+}
+
+/**
+ * Load and parse an mcp.json file
+ */
+async function loadFile(filepath: string): Promise<Record<string, Config.Mcp>> {
+  log.info("loading mcp.json", { path: filepath })
+  const text = await Bun.file(filepath)
+    .text()
+    .catch((err) => {
+      if (err.code === "ENOENT") return undefined
+      log.error("failed to read mcp.json", { path: filepath, error: err })
+      return undefined
+    })
+
+  if (!text) return {}
+
+  const errors: JsoncParseError[] = []
+  const data = parseJsonc(text, errors, { allowTrailingComma: true })
+
+  if (errors.length) {
+    log.error("failed to parse mcp.json", { path: filepath, errors })
+    return {}
+  }
+
+  const parsed = McpJson.safeParse(data)
+  if (!parsed.success) {
+    log.error("invalid mcp.json schema", { path: filepath, issues: parsed.error.issues })
+    return {}
+  }
+
+  return transform(parsed.data)
+}
+
+/**
+ * Load all mcp.json files from standard locations and merge them.
+ * Priority (lowest to highest):
+ * 1. ~/.cursor/mcp.json
+ * 2. ~/.claude/mcp.json
+ * 3. ~/.config/opencode/mcp.json
+ * 4. ~/.opencode/mcp.json
+ * 5. <project>/.cursor/mcp.json
+ * 6. <project>/.claude/mcp.json
+ * 7. <project>/.opencode/mcp.json
+ * 8. <project>/mcp.json
+ */
+export async function loadAllMcpJson(): Promise<Record<string, Config.Mcp>> {
+  let result: Record<string, Config.Mcp> = {}
+
+  // Global locations (lowest priority first)
+  const globalPaths = [
+    path.join(os.homedir(), ".cursor", "mcp.json"),
+    path.join(os.homedir(), ".claude", "mcp.json"),
+    path.join(os.homedir(), ".config", "opencode", "mcp.json"),
+    path.join(Global.Path.config, "mcp.json"), // ~/.opencode/mcp.json
+  ]
+
+  for (const filepath of globalPaths) {
+    const servers = await loadFile(filepath)
+    result = { ...result, ...servers }
+  }
+
+  // Project locations (higher priority)
+  const projectPaths = [
+    path.join(Instance.directory, ".cursor", "mcp.json"),
+    path.join(Instance.directory, ".claude", "mcp.json"),
+  ]
+
+  // Also search up for .opencode/mcp.json
+  const opencodeDirectories = await Array.fromAsync(
+    Filesystem.up({
+      targets: [".opencode"],
+      start: Instance.directory,
+      stop: Instance.worktree,
+    }),
+  )
+
+  for (const dir of opencodeDirectories.toReversed()) {
+    projectPaths.push(path.join(dir, "mcp.json"))
+  }
+
+  // Root mcp.json has highest priority
+  projectPaths.push(path.join(Instance.directory, "mcp.json"))
+
+  for (const filepath of projectPaths) {
+    const servers = await loadFile(filepath)
+    result = { ...result, ...servers }
+  }
+
+  return result
+}

--- a/packages/opencode/test/config/mcp-json.test.ts
+++ b/packages/opencode/test/config/mcp-json.test.ts
@@ -1,0 +1,279 @@
+import { test, expect, describe } from "bun:test"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+describe("mcp.json support", () => {
+  test("loads local MCP server from mcp.json", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "test-local": {
+                command: "npx",
+                args: ["-y", "test-server"],
+                env: {
+                  API_KEY: "test-key",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp).toBeDefined()
+        expect(config.mcp!["test-local"]).toEqual({
+          type: "local",
+          command: ["npx", "-y", "test-server"],
+          environment: {
+            API_KEY: "test-key",
+          },
+        })
+      },
+    })
+  })
+
+  test("loads remote MCP server from mcp.json", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "test-remote": {
+                url: "https://api.example.com/mcp",
+                headers: {
+                  Authorization: "Bearer token123",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp).toBeDefined()
+        expect(config.mcp!["test-remote"]).toEqual({
+          type: "remote",
+          url: "https://api.example.com/mcp",
+          headers: {
+            Authorization: "Bearer token123",
+          },
+        })
+      },
+    })
+  })
+
+  test("normalizes ${env:VAR} syntax to {env:VAR}", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "test-env": {
+                url: "https://api.example.com/mcp",
+                headers: {
+                  Authorization: "Bearer ${env:MY_TOKEN}",
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp!["test-env"]).toEqual({
+          type: "remote",
+          url: "https://api.example.com/mcp",
+          headers: {
+            Authorization: "Bearer {env:MY_TOKEN}",
+          },
+        })
+      },
+    })
+  })
+
+  test("opencode.json mcp config takes priority over mcp.json", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Create mcp.json with a server
+        await Bun.write(
+          path.join(dir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "same-name": {
+                command: "from-mcp-json",
+                args: [],
+              },
+              "only-in-mcp-json": {
+                command: "unique-server",
+                args: [],
+              },
+            },
+          }),
+        )
+        // Create opencode.json with the same server name
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            mcp: {
+              "same-name": {
+                type: "local",
+                command: ["from-opencode-json"],
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // opencode.json takes priority for same-named server
+        expect(config.mcp!["same-name"]).toEqual({
+          type: "local",
+          command: ["from-opencode-json"],
+        })
+        // mcp.json servers still available if not overridden
+        expect(config.mcp!["only-in-mcp-json"]).toEqual({
+          type: "local",
+          command: ["unique-server"],
+        })
+      },
+    })
+  })
+
+  test("loads mcp.json from .opencode directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await Bun.write(path.join(opencodeDir, "package.json"), "{}")
+        await Bun.write(
+          path.join(opencodeDir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "from-opencode-dir": {
+                command: "test-cmd",
+                args: ["--flag"],
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp!["from-opencode-dir"]).toEqual({
+          type: "local",
+          command: ["test-cmd", "--flag"],
+        })
+      },
+    })
+  })
+
+  test("loads mcp.json from .cursor directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const cursorDir = path.join(dir, ".cursor")
+        await Bun.write(
+          path.join(cursorDir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "from-cursor": {
+                command: "cursor-server",
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp!["from-cursor"]).toEqual({
+          type: "local",
+          command: ["cursor-server"],
+        })
+      },
+    })
+  })
+
+  test("loads mcp.json from .claude directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const claudeDir = path.join(dir, ".claude")
+        await Bun.write(
+          path.join(claudeDir, "mcp.json"),
+          JSON.stringify({
+            mcpServers: {
+              "from-claude": {
+                command: "claude-server",
+              },
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.mcp!["from-claude"]).toEqual({
+          type: "local",
+          command: ["claude-server"],
+        })
+      },
+    })
+  })
+
+  test("handles empty mcp.json gracefully", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "mcp.json"), "{}")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // Should not throw - may have global mcp.json servers loaded
+        expect(true).toBe(true)
+      },
+    })
+  })
+
+  test("handles mcp.json with only mcpServers key but empty", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "mcp.json"), JSON.stringify({ mcpServers: {} }))
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // Should not throw - may have global mcp.json servers loaded
+        expect(true).toBe(true)
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add support for loading MCP servers from standalone `mcp.json` files, enabling compatibility with Claude Code, Cursor, VS Code, and other tools that use the mcp.json format
- Users no longer need to manually transform their existing mcp.json configurations to opencode.json format

## Supported Locations

Loads mcp.json from these locations (in order of priority, lowest to highest):

**Global:**
1. `~/.cursor/mcp.json`
2. `~/.claude/mcp.json`
3. `~/.config/opencode/mcp.json`
4. `~/.opencode/mcp.json`

**Project:**
5. `<project>/.cursor/mcp.json`
6. `<project>/.claude/mcp.json`
7. `<project>/.opencode/mcp.json`
8. `<project>/mcp.json`

## Features

- Automatic transformation from mcp.json format to OpenCode format
- Support for both local (stdio) and remote (HTTP/SSE) servers
- Environment variable syntax normalization (`${env:VAR}` -> `{env:VAR}`)
- `opencode.json` mcp config takes priority over mcp.json for same-named servers

## Example

**mcp.json (Claude/Cursor format):**
```json
{
  "mcpServers": {
    "my-server": {
      "command": "npx",
      "args": ["-y", "mcp-server"],
      "env": {
        "API_KEY": "${env:MY_API_KEY}"
      }
    },
    "remote-server": {
      "url": "https://api.example.com/mcp",
      "headers": {
        "Authorization": "Bearer ${env:MY_TOKEN}"
      }
    }
  }
}
```

This is automatically transformed to OpenCode's internal format and merged with any existing mcp config in opencode.json.

---

OC Session: https://opncd.ai/share/3fw3GKgV