### PR TITLE
feat: add plugin scope support for desktop multi-project lifecycle

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -1,4 +1,4 @@
-import type { Hooks, PluginInput, Plugin as PluginInstance } from "@opencode-ai/plugin"
+import { type Hooks, type PluginInput, type Plugin as PluginFunction, type PluginDefinition, type PluginScope } from "@opencode-ai/plugin"
 import { Config } from "../config/config"
 import { Bus } from "../bus"
 import { Log } from "../util/log"
@@ -8,6 +8,17 @@ import { BunProc } from "../bun"
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 
+// Built-in auth plugins that should always load (global scope)
+// TODO: Remove once these plugins are updated to use definePlugin({ scope: "global" })
+const BUILTIN_GLOBAL_PLUGINS = ["opencode-copilot-auth", "opencode-anthropic-auth"]
+function isPluginDefinition(value: unknown): value is PluginDefinition {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "plugin" in value &&
+    typeof value.plugin === "function"
+  )
+}
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
 
@@ -31,6 +42,9 @@ export namespace Plugin {
       plugins.push("opencode-copilot-auth@0.0.9")
       plugins.push("opencode-anthropic-auth@0.0.5")
     }
+
+    const isNonProjectContext = Instance.worktree === "/"
+
     for (let plugin of plugins) {
       log.info("loading plugin", { path: plugin })
       if (!plugin.startsWith("file://")) {
@@ -39,13 +53,24 @@ export namespace Plugin {
         const version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
         plugin = await BunProc.install(pkg, version)
       }
+
+      const isBuiltinGlobal = BUILTIN_GLOBAL_PLUGINS.some(name => plugin.includes(name))
       const mod = await import(plugin)
-      for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
-        const init = await fn(input)
-        hooks.push(init)
+
+      for (const [_name, exported] of Object.entries(mod)) {
+        if (isPluginDefinition(exported)) {
+          const scope = exported.scope ?? "project"
+          if (scope === "project" && isNonProjectContext) continue
+          hooks.push(await exported.plugin(input))
+          continue
+        }
+        if (typeof exported === "function") {
+          // Built-in auth plugins are global, others default to project
+          if (!isBuiltinGlobal && isNonProjectContext) continue
+          hooks.push(await (exported as PluginFunction)(input))
+        }
       }
     }
-
     return {
       hooks,
       input,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,5 +1,6 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
+import { Flag } from "@/flag/flag"
 import { GlobalBus } from "@/bus/global"
 import { Log } from "../util/log"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
@@ -193,7 +194,8 @@ export namespace Server {
         },
       )
       .use(async (c, next) => {
-        const directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+        const explicitDirectory = c.req.query("directory") || c.req.header("x-opencode-directory")
+        const directory = explicitDirectory || (Flag.OPENCODE_CLIENT === "desktop" ? Global.Path.home : process.cwd())
         return Instance.provide({
           directory,
           init: InstanceBootstrap,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -33,6 +33,45 @@ export type PluginInput = {
 
 export type Plugin = (input: PluginInput) => Promise<Hooks>
 
+export type PluginScope = "global" | "project"
+export type PluginDefinition<T extends Hooks = Hooks> = {
+  readonly scope: PluginScope
+  readonly plugin: (input: PluginInput) => Promise<T>
+}
+
+/**
+ * Define a plugin with explicit scope.
+ * 
+ * @param options.scope - "global" (loads always) or "project" (loads only in project context, default)
+ * @param options.plugin - The plugin function
+ * 
+ * @example
+ * // Auth plugin (global scope)
+ * export default definePlugin({
+ *   scope: "global",
+ *   plugin: async (input) => ({
+ *     auth: { provider: "my-provider", ... }
+ *   })
+ * })
+ * 
+ * @example
+ * // Project plugin (default scope)
+ * export default definePlugin({
+ *   plugin: async (input) => ({
+ *     "chat.message": async (input, output) => { ... }
+ *   })
+ * })
+ */
+export function definePlugin<T extends Hooks>(options: {
+  scope?: PluginScope
+  plugin: (input: PluginInput) => Promise<T>
+}): PluginDefinition<T> {
+  return {
+    scope: options.scope ?? "project",
+    plugin: options.plugin,
+  }
+}
+
 export type AuthHook = {
   provider: string
   loader?: (auth: () => Promise<Auth>, provider: Provider) => Promise<Record<string, any>>


### PR DESCRIPTION
## Problem

The CLI and desktop app have fundamentally different lifecycles:

- **CLI**: Single project, always starts from a project directory (`process.cwd()`)
- **Desktop**: Multi-project, starts without any project context, users select projects later

This difference wasn't accounted for in the plugin system. Plugins load regardless of whether a valid project context exists.

I discovered this while working on a plugin that requires project context (`tsconfig.json`). The CLI crashed when no tsconfig was present, which I initially handled poorly. But then the desktop crashed regardless - there's no project context on startup, so my plugin could never initialize.

This revealed that the plugin system has no way for plugins to declare whether they need project context.

## Solution

**1. Plugin scopes** - Plugins can now declare `"global"` or `"project"` scope (default):

```typescript
import { definePlugin } from "@opencode-ai/plugin"

export default definePlugin({
  scope: "global",
  plugin: async (input) => ({
    auth: { provider: "my-provider", ... }
  })
})
```

**2. Predictable desktop startup** - Desktop clients without explicit directory use home directory, ensuring `worktree === "/"` (no git repo).

**3. Scope-aware loading** - Project-scoped plugins skip loading when `worktree === "/"`.

## Migration for auth plugin authors

Wrap your plugin with `definePlugin` and set `scope: "global"`:

```typescript
// Before
export default async (input) => ({
  auth: { ... }
})

// After
import { definePlugin } from "@opencode-ai/plugin"

export default definePlugin({
  scope: "global",
  plugin: async (input) => ({
    auth: { ... }
  })
})
```

## Backwards compatibility

- Old plugins (plain functions) default to `"project"` scope
- Built-in auth plugins hardcoded as global temporarily
- CLI behavior unchanged

## Follow-up

If accepted, I can update `opencode-copilot-auth` and `opencode-anthropic-auth` to use `definePlugin`, then remove the hardcoded list.