### PR TITLE
docs: fix typos

### DIFF
--- a/.opencode/agent/triage.md
+++ b/.opencode/agent/triage.md
@@ -15,7 +15,7 @@ Use your github-triage tool to triage issues.
 
 ### windows
 
-Use for any issue that is mentions windows (the OS). Be sure they are saying that they are on windows.
+Use for any issue that mentions Windows (the OS). Be sure they are saying that they are on Windows.
 
 - Use if they mention WSL too
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you're interested in contributing to OpenCode, please read our [contributing 
 
 ### Building on OpenCode
 
-If you are working on a project that's related to OpenCode and is using "opencode" as a part of its name; for example, "opencode-dashboard" or "opencode-mobile", please add a note to your README to clarify that it is not built by the OpenCode team and is not affiliated with us in anyway.
+If you are working on a project that's related to OpenCode and is using "opencode" as a part of its name; for example, "opencode-dashboard" or "opencode-mobile", please add a note to your README to clarify that it is not built by the OpenCode team and is not affiliated with us in any way.
 
 ### FAQ
 

--- a/github/README.md
+++ b/github/README.md
@@ -6,7 +6,7 @@ Mention `/opencode` in your comment, and opencode will execute tasks within your
 
 ## Features
 
-#### Explain an issues
+#### Explain an issue
 
 Leave the following comment on a GitHub issue. `opencode` will read the entire thread, including all comments, and reply with a clear explanation.
 
@@ -14,7 +14,7 @@ Leave the following comment on a GitHub issue. `opencode` will read the entire t
 /opencode explain this issue
 ```
 
-#### Fix an issues
+#### Fix an issue
 
 Leave the following comment on a GitHub issue. opencode will create a new branch, implement the changes, and open a PR with the changes.
 

--- a/packages/console/app/.opencode/agent/css.md
+++ b/packages/console/app/.opencode/agent/css.md
@@ -49,7 +49,7 @@ use data attributes to represent different states of the component
 }
 ```
 
-this will allow jsx to control the syling
+this will allow jsx to control the styling
 
 avoid selectors that just target an element type like `> span` you should assign
 it a slot name. it's ok to do this sometimes where it makes sense semantically


### PR DESCRIPTION
## Summary
- Fixed grammatical errors: "an issues" → "an issue" in GitHub action docs
- Fixed spelling: "syling" → "styling" in CSS agent docs
- Fixed grammar: "is mentions windows" → "mentions Windows" in triage agent docs
- Fixed phrase: "in anyway" → "in any way" in main README