### PR TITLE
fix: remove SVG favicon to improve SEO

### DIFF
--- a/packages/ui/src/components/favicon.tsx
+++ b/packages/ui/src/components/favicon.tsx
@@ -4,7 +4,6 @@ export const Favicon = () => {
   return (
     <>
       <Link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-      <Link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <Link rel="shortcut icon" href="/favicon.ico" />
       <Link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
       <Link rel="manifest" href="/site.webmanifest" />


### PR DESCRIPTION
## Summary
- Remove SVG favicon link to fix Google Search not displaying the favicon
- Google's crawler can have issues with SVG favicons, preferring PNG/ICO formats for search result display