### PR TITLE
github: add OIDC_BASE_URL for custom GitHub App installs

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Comma-separated list of trigger phrases (case-insensitive). Defaults to '/opencode,/oc'"
     required: false
 
+  oidc_base_url:
+    description: "Base URL for OIDC token exchange API. Only required when running a custom GitHub App install. Defaults to https://api.opencode.ai"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -62,3 +66,4 @@ runs:
         PROMPT: ${{ inputs.prompt }}
         USE_GITHUB_TOKEN: ${{ inputs.use_github_token }}
         MENTIONS: ${{ inputs.mentions }}
+        OIDC_BASE_URL: ${{ inputs.oidc_base_url }}

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -395,6 +395,7 @@ export const GithubRunCommand = cmd({
       const { providerID, modelID } = normalizeModel()
       const runId = normalizeRunId()
       const share = normalizeShare()
+      const oidcBaseUrl = normalizeOidcBaseUrl()
       const { owner, repo } = context.repo
       const payload = context.payload as IssueCommentEvent | PullRequestReviewCommentEvent
       const issueEvent = isIssueCommentEvent(payload) ? payload : undefined
@@ -570,6 +571,12 @@ export const GithubRunCommand = cmd({
         if (value === "true") return true
         if (value === "false") return false
         throw new Error(`Invalid use_github_token value: ${value}. Must be a boolean.`)
+      }
+
+      function normalizeOidcBaseUrl(): string {
+        const value = process.env["OIDC_BASE_URL"]
+        if (!value) return "https://api.opencode.ai"
+        return value.replace(/\/+$/, "")
       }
 
       function isIssueCommentEvent(
@@ -809,14 +816,14 @@ export const GithubRunCommand = cmd({
 
       async function exchangeForAppToken(token: string) {
         const response = token.startsWith("github_pat_")
-          ? await fetch("https://api.opencode.ai/exchange_github_app_token_with_pat", {
+          ? await fetch(`${oidcBaseUrl}/exchange_github_app_token_with_pat`, {
               method: "POST",
               headers: {
                 Authorization: `Bearer ${token}`,
               },
               body: JSON.stringify({ owner, repo }),
             })
-          : await fetch("https://api.opencode.ai/exchange_github_app_token", {
+          : await fetch(`${oidcBaseUrl}/exchange_github_app_token`, {
               method: "POST",
               headers: {
                 Authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary

- Adds `oidc_base_url` input to the GitHub Action for custom GitHub App installations
- Updates `github.ts` to use configurable base URL for OIDC token exchange endpoints
- Defaults to `https://api.opencode.ai` when not specified