### PR TITLE
docs(ecosystem): add opencode-zellij-namer plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -30,6 +30,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                            |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                                     |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible        |
+| [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                          |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer) to the ecosystem plugins list.

This OpenCode plugin automatically renames Zellij terminal sessions based on your work context (project name, intent like feat/fix/debug, and optional tag).

**Features:**
- AI-powered naming using Gemini Flash (with heuristic fallback)
- Reads AGENTS.md for project-specific naming guidance
- Non-blocking with debounce and cooldown
- Published on npm: `opencode-zellij-namer`