### PR TITLE
docs: add ai-sdk-provider-opencode-sdk to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -35,14 +35,14 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ## Projects
 
-| Name                                                                               | Description                                                     |
-| ---------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| [kimaki](https://github.com/remorses/kimaki)                                       | Discord bot to control OpenCode sessions, built on the SDK      |
-| [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                      | Neovim plugin for editor-aware prompts, built on the API        |
-| [portal](https://github.com/hosenur/portal)                                        | Mobile-first web UI for OpenCode over Tailscale/VPN             |
-| [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/) | Template for building OpenCode plugins                          |
-| [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                         | Neovim frontend for opencode - a terminal-based AI coding agent |
-| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk |
+| Name                                                                                       | Description                                                     |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK      |
+| [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API        |
+| [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN             |
+| [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                          |
+| [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent |
+| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk  |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -42,6 +42,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [portal](https://github.com/hosenur/portal)                                        | Mobile-first web UI for OpenCode over Tailscale/VPN             |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/) | Template for building OpenCode plugins                          |
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                         | Neovim frontend for opencode - a terminal-based AI coding agent |
+| [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds ai-sdk-provider-opencode-sdk to the ecosystem projects list
- This is a Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk

## Test plan
- [ ] Verify the link works: https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk
- [ ] Check markdown table renders correctly