### PR TITLE
feat(tui): add ctrl+r history search

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-history-search.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-history-search.tsx
@@ -1,7 +1,12 @@
-import { createMemo } from "solid-js"
-import { DialogSelect } from "@tui/ui/dialog-select"
+import { createMemo, createSignal, createEffect, For, Show } from "solid-js"
 import { useDialog } from "@tui/ui/dialog"
+import { InputRenderable, RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
+import { createStore } from "solid-js/store"
+import { useTheme, selectedForeground } from "@tui/context/theme"
+import { Locale } from "@/util/locale"
 import type { PromptInfo } from "./prompt/history"
+import * as fuzzysort from "fuzzysort"
 
 export interface DialogHistorySearchProps {
   items: PromptInfo[]
@@ -10,8 +15,13 @@ export interface DialogHistorySearchProps {
 
 export function DialogHistorySearch(props: DialogHistorySearchProps) {
   const dialog = useDialog()
+  const { theme } = useTheme()
+  const [store, setStore] = createStore({
+    selected: 0,
+    filter: "",
+  })
 
-  const options = createMemo(() => {
+  const items = createMemo(() => {
     const seen = new Set<string>()
     return props.items
       .slice()
@@ -22,16 +32,174 @@ export function DialogHistorySearch(props: DialogHistorySearchProps) {
         seen.add(item.input)
         return true
       })
-      .map((item) => ({
-        title: item.input,
-        value: item,
-        description: undefined,
-        onSelect: () => {
-          props.onSelect(item)
-          dialog.clear()
-        },
-      }))
   })
 
-  return <DialogSelect title="Search History" placeholder="Type to search..." options={options()} />
+  const filtered = createMemo(() => {
+    const query = store.filter.toLowerCase()
+    if (!query) return items().map((item) => ({ item, match: undefined as any }))
+
+    const results = fuzzysort.go(query, items(), {
+      keys: ["input"],
+      limit: 200,
+    })
+
+    return results.map((result) => ({
+      item: result.obj,
+      match: result[0],
+    }))
+  })
+
+  const dimensions = useTerminalDimensions()
+  const height = createMemo(() => Math.min(filtered().length, Math.floor(dimensions().height / 2) - 8))
+
+  const selected = createMemo(() => filtered()[store.selected])
+
+  createEffect(() => {
+    if (store.filter.length > 0) setStore("selected", 0)
+    scroll?.scrollTo(0)
+  })
+
+  function move(direction: number) {
+    let next = store.selected + direction
+    if (next < 0) next = filtered().length - 1
+    if (next >= filtered().length) next = 0
+    moveTo(next)
+  }
+
+  function moveTo(next: number) {
+    setStore("selected", next)
+    if (!scroll) return
+    const target = scroll.getChildren().find((child) => {
+      return child.id === JSON.stringify(selected()?.item)
+    })
+    if (!target) return
+    const y = target.y - scroll.y
+    if (y >= scroll.height) {
+      scroll.scrollBy(y - scroll.height + 1)
+    }
+    if (y < 0) {
+      scroll.scrollBy(y)
+      if (filtered()[0].item === selected()?.item) {
+        scroll.scrollTo(0)
+      }
+    }
+  }
+
+  useKeyboard((evt) => {
+    if (evt.name === "up" || (evt.ctrl && evt.name === "p")) move(-1)
+    if (evt.name === "down" || (evt.ctrl && evt.name === "n")) move(1)
+    if (evt.name === "pageup") move(-10)
+    if (evt.name === "pagedown") move(10)
+    if (evt.ctrl && evt.name === "u") {
+      setStore("filter", "")
+      setStore("selected", 0)
+      scroll?.scrollTo(0)
+    }
+    if (evt.name === "return") {
+      const option = selected()
+      if (option) {
+        props.onSelect(option.item)
+        dialog.clear()
+      }
+    }
+  })
+
+  let input: InputRenderable
+  let scroll: ScrollBoxRenderable
+
+  const fg = selectedForeground(theme)
+
+  const matchedText = createMemo(() => {
+    const match = selected()?.match
+    if (!match || !match.indexes || match.indexes.length === 0) return ""
+    const item = selected()?.item
+    if (!item) return ""
+
+    const startIndex = Math.max(0, match.indexes[0] - 50)
+    const endIndex = Math.min(item.input.length, match.indexes[match.indexes.length - 1] + 50)
+    let text = item.input.slice(startIndex, endIndex)
+    if (startIndex > 0) text = "..." + text
+    if (endIndex < item.input.length) text = text + "..."
+    return text
+  })
+
+  return (
+    <box gap={1} paddingBottom={1}>
+      <box paddingLeft={4} paddingRight={4}>
+        <box flexDirection="row" justifyContent="space-between">
+          <text fg={theme.text} attributes={TextAttributes.BOLD}>
+            Search History
+          </text>
+          <text fg={theme.textMuted}>
+            ctrl+u clear
+            {"  "}
+            esc
+          </text>
+        </box>
+        <box paddingTop={1} paddingBottom={1}>
+          <input
+            value={store.filter}
+            onInput={(e) => {
+              setStore("filter", e)
+            }}
+            focusedBackgroundColor={theme.backgroundPanel}
+            cursorColor={theme.primary}
+            focusedTextColor={theme.textMuted}
+            ref={(r) => {
+              input = r
+              setTimeout(() => input.focus(), 1)
+            }}
+            placeholder="Type to search..."
+          />
+        </box>
+      </box>
+      <scrollbox
+        paddingLeft={1}
+        paddingRight={1}
+        scrollbarOptions={{ visible: false }}
+        ref={(r: ScrollBoxRenderable) => (scroll = r)}
+        maxHeight={height()}
+      >
+        <For each={filtered()}>
+          {(option, index) => (
+            <box
+              id={JSON.stringify(option.item)}
+              flexDirection="row"
+              onMouseUp={() => {
+                props.onSelect(option.item)
+                dialog.clear()
+              }}
+              onMouseOver={() => {
+                const idx = index()
+                if (idx === -1) return
+                moveTo(idx)
+              }}
+              backgroundColor={index() === store.selected ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+              paddingLeft={3}
+              paddingRight={3}
+              gap={1}
+            >
+              <text
+                flexGrow={1}
+                fg={index() === store.selected ? fg : theme.text}
+                attributes={index() === store.selected ? TextAttributes.BOLD : undefined}
+                overflow="hidden"
+                paddingLeft={3}
+              >
+                {Locale.truncate(option.item.input, 61)}
+              </text>
+            </box>
+          )}
+        </For>
+      </scrollbox>
+      <Show when={matchedText()}>
+        <box paddingRight={2} paddingLeft={4} flexShrink={0} paddingTop={1}>
+          <text fg={theme.textMuted}>Match: </text>
+          <text fg={theme.accent} attributes={TextAttributes.BOLD}>
+            {matchedText()}
+          </text>
+        </box>
+      </Show>
+    </box>
+  )
 }

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-history-search.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-history-search.tsx
@@ -1,0 +1,37 @@
+import { createMemo } from "solid-js"
+import { DialogSelect } from "@tui/ui/dialog-select"
+import { useDialog } from "@tui/ui/dialog"
+import type { PromptInfo } from "./prompt/history"
+
+export interface DialogHistorySearchProps {
+  items: PromptInfo[]
+  onSelect: (item: PromptInfo) => void
+}
+
+export function DialogHistorySearch(props: DialogHistorySearchProps) {
+  const dialog = useDialog()
+
+  const options = createMemo(() => {
+    const seen = new Set<string>()
+    return props.items
+      .slice()
+      .reverse()
+      .filter((item) => {
+        if (!item.input.trim().length) return false
+        if (seen.has(item.input)) return false
+        seen.add(item.input)
+        return true
+      })
+      .map((item) => ({
+        title: item.input,
+        value: item,
+        description: undefined,
+        onSelect: () => {
+          props.onSelect(item)
+          dialog.clear()
+        },
+      }))
+  })
+
+  return <DialogSelect title="Search History" placeholder="Type to search..." options={options()} />
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -14,18 +14,18 @@ export type PromptInfo = {
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
     | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
-        source?: {
-          text: {
-            start: number
-            end: number
-            value: string
-          }
+      source?: {
+        text: {
+          start: number
+          end: number
+          value: string
         }
-      })
+      }
+    })
   )[]
 }
 
-const MAX_HISTORY_ENTRIES = 50
+const MAX_HISTORY_ENTRIES = 100
 
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
@@ -51,7 +51,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
       // Rewrite file with only valid entries to self-heal corruption
       if (lines.length > 0) {
         const content = lines.map((line) => JSON.stringify(line)).join("\n") + "\n"
-        writeFile(historyFile.name!, content).catch(() => {})
+        writeFile(historyFile.name!, content).catch(() => { })
       }
     })
 
@@ -61,6 +61,9 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
     })
 
     return {
+      get items() {
+        return store.history
+      },
       move(direction: 1 | -1, input: string) {
         if (!store.history.length) return undefined
         const current = store.history.at(store.index)
@@ -97,11 +100,14 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
 
         if (trimmed) {
           const content = store.history.map((line) => JSON.stringify(line)).join("\n") + "\n"
-          writeFile(historyFile.name!, content).catch(() => {})
+          writeFile(historyFile.name!, content).catch(() => { })
           return
         }
 
-        appendFile(historyFile.name!, JSON.stringify(entry) + "\n").catch(() => {})
+        appendFile(historyFile.name!, JSON.stringify(entry) + "\n").catch(() => { })
+      },
+      reset() {
+        setStore("index", 0)
       },
     }
   },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -14,14 +14,14 @@ export type PromptInfo = {
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
     | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
-      source?: {
-        text: {
-          start: number
-          end: number
-          value: string
+        source?: {
+          text: {
+            start: number
+            end: number
+            value: string
+          }
         }
-      }
-    })
+      })
   )[]
 }
 
@@ -51,7 +51,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
       // Rewrite file with only valid entries to self-heal corruption
       if (lines.length > 0) {
         const content = lines.map((line) => JSON.stringify(line)).join("\n") + "\n"
-        writeFile(historyFile.name!, content).catch(() => { })
+        writeFile(historyFile.name!, content).catch(() => {})
       }
     })
 
@@ -100,11 +100,11 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
 
         if (trimmed) {
           const content = store.history.map((line) => JSON.stringify(line)).join("\n") + "\n"
-          writeFile(historyFile.name!, content).catch(() => { })
+          writeFile(historyFile.name!, content).catch(() => {})
           return
         }
 
-        appendFile(historyFile.name!, JSON.stringify(entry) + "\n").catch(() => { })
+        appendFile(historyFile.name!, JSON.stringify(entry) + "\n").catch(() => {})
       },
       reset() {
         setStore("index", 0)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -27,6 +27,7 @@ import { useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
+import { DialogHistorySearch } from "../dialog-history-search"
 
 export type PromptProps = {
   sessionID?: string
@@ -763,6 +764,24 @@ export function Prompt(props: PromptProps) {
                 }
                 if (store.mode === "normal") autocomplete.onKeyDown(e)
                 if (!autocomplete.visible) {
+                  if (keybind.match("history_search", e)) {
+                    e.preventDefault()
+                    const historyItems = history.items
+                    dialog.replace(() => (
+                      <DialogHistorySearch
+                        items={historyItems}
+                        onSelect={(item) => {
+                          input.setText(item.input)
+                          setStore("prompt", item)
+                          setStore("mode", item.mode ?? "normal")
+                          restoreExtmarksFromParts(item.parts)
+                          history.reset()
+                        }}
+                      />
+                    ))
+                    return
+                  }
+
                   if (
                     (keybind.match("history_previous", e) && input.cursorOffset === 0) ||
                     (keybind.match("history_next", e) && input.cursorOffset === input.plainText.length)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -775,6 +775,7 @@ export function Prompt(props: PromptProps) {
                           setStore("prompt", item)
                           setStore("mode", item.mode ?? "normal")
                           restoreExtmarksFromParts(item.parts)
+                          input.cursorOffset = input.plainText.length
                           history.reset()
                         }}
                       />

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -558,6 +558,7 @@ export namespace Config {
         .describe("Delete word backward in input"),
       history_previous: z.string().optional().default("up").describe("Previous history item"),
       history_next: z.string().optional().default("down").describe("Next history item"),
+      history_search: z.string().optional().default("ctrl+r").describe("Search history"),
       session_child_cycle: z.string().optional().default("<leader>right").describe("Next child session"),
       session_child_cycle_reverse: z.string().optional().default("<leader>left").describe("Previous child session"),
       terminal_suspend: z.string().optional().default("ctrl+z").describe("Suspend terminal"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1107,6 +1107,10 @@ export type KeybindsConfig = {
    */
   history_next?: string
   /**
+   * Search history
+   */
+  history_search?: string
+  /**
    * Next child session
    */
   session_child_cycle?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -7407,6 +7407,11 @@
             "default": "down",
             "type": "string"
           },
+          "history_search": {
+            "description": "Search history",
+            "default": "ctrl+r",
+            "type": "string"
+          },
           "session_child_cycle": {
             "description": "Next child session",
             "default": "<leader>right",


### PR DESCRIPTION
## Summary

Implements Ctrl+R history search functionality for the TUI prompt, allowing users to fuzzy search through their prompt history.

<img width="2005" height="1227" alt="Image" src="https://github.com/user-attachments/assets/3567d5ab-d388-4137-b20d-3a10bf1fdaa5" />

## Changes

- Added `DialogHistorySearch` component with fuzzy filtering and deduplication
- Increased max history entries from 50 to 100
- Added `items` getter and `reset()` method to `PromptHistory` context
- Added `history_search` keybind (default: `ctrl+r`) to config
- Integrated history search into prompt component

Closes https://github.com/sst/opencode/issues/5062
Related  #6276