### PR TITLE
Do not include hidden agents in ACP

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -698,7 +698,7 @@ export namespace ACP {
         })
 
       const availableModes = agents
-        .filter((agent) => agent.mode !== "subagent")
+        .filter((agent) => agent.mode !== "subagent" && !agent.hidden)
         .map((agent) => ({
           id: agent.name,
           name: agent.name,


### PR DESCRIPTION
title/summary/compactation were recently added as agents but they should not be listed as modes under ACP.