### PR TITLE
feat(tui): add agent descriptions to autocomplete options

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -238,6 +238,7 @@ export function Autocomplete(props: {
       .map(
         (agent): AutocompleteOption => ({
           display: "@" + agent.name,
+          description: agent.description,
           onSelect: () => {
             insertPart(agent.name, {
               type: "agent",
@@ -608,6 +609,7 @@ export function Autocomplete(props: {
               </text>
               <Show when={option.description}>
                 <text fg={index() === store.selected ? selectedForeground(theme) : theme.textMuted} wrapMode="none">
+                  {" - "}
                   {option.description}
                 </text>
               </Show>


### PR DESCRIPTION
Enhance the agent selection autocomplete by displaying agent descriptions alongside the agent names.

This helps users:
  - understand what each agent does before picking one,
  - differentiate agents from local files

Feature request: https://github.com/sst/opencode/issues/5805