### PR TITLE
docs: replace deprecated mise ubi backend with github backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ scoop bucket add extras; scoop install extras/opencode  # Windows
 choco install opencode             # Windows
 brew install opencode              # macOS and Linux
 paru -S opencode-bin               # Arch Linux
-mise use -g ubi:sst/opencode # Any OS
+mise use -g github:sst/opencode # Any OS
 nix run nixpkgs#opencode           # or github:sst/opencode for latest dev branch
 ```
 

--- a/packages/web/src/components/Lander.astro
+++ b/packages/web/src/components/Lander.astro
@@ -133,9 +133,9 @@ if (image) {
       </div>
       <div class="col4">
         <h3>Mise</h3>
-        <button class="command" data-command="mise use -g ubi:sst/opencode">
+        <button class="command" data-command="mise use -g github:sst/opencode">
           <code>
-            <span>mise use -g</span> <span class="highlight">ubi:sst/opencode</span>
+            <span>mise use -g</span> <span class="highlight">github:sst/opencode</span>
           </code>
           <span class="copy">
             <CopyIcon />

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -109,7 +109,7 @@ You can also install it with the following commands:
 - **Using Mise**
 
   ```bash
-  mise use -g ubi:sst/opencode
+  mise use -g github:sst/opencode
   ```
 
 - **Using Docker**


### PR DESCRIPTION
### Summary

Replace deprecated `ubi:` backend with `github:` backend in mise installation commands.

### Problem

Running `mise use -g ubi:sst/opencode` displays a deprecation warning:

```shell
mise WARN deprecated [ubi]: The ubi backend is deprecated. Use the github backend instead (e.g., github:owner/repo)
```

### Changes

Updated installation commands in:
- `README.md`
- `packages/web/src/components/Lander.astro`
- `packages/web/src/content/docs/index.mdx`

`ubi:sst/opencode` → `github:sst/opencode`
