### PR TITLE
fix: prioritize session list loading when resuming with -c

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -229,7 +229,8 @@ function App() {
 
   let continued = false
   createEffect(() => {
-    if (continued || sync.status !== "complete" || !args.continue) return
+    // When using -c, session list is loaded in blocking phase, so we can navigate at "partial"
+    if (continued || sync.status === "loading" || !args.continue) return
     const match = sync.data.session
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .find((x) => x.parentID === undefined)?.id

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -255,9 +255,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const exit = useExit()
+    const args = useArgs()
 
     async function bootstrap() {
-      const args = useArgs()
       const sessionListPromise = sdk.client.session.list().then((x) =>
         setStore(
           "session",
@@ -280,11 +280,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }),
         sdk.client.app.agents({}, { throwOnError: true }).then((x) => setStore("agent", x.data ?? [])),
         sdk.client.config.get({}, { throwOnError: true }).then((x) => setStore("config", x.data!)),
+        ...(args.continue ? [sessionListPromise] : []),
       ]
-
-      if (args.continue) {
-        blockingRequests.push(sessionListPromise)
-      }
 
       await Promise.all(blockingRequests)
         .then(() => {

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -22,6 +22,7 @@ import { Binary } from "@opencode-ai/util/binary"
 import { createSimpleContext } from "./helper"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
+import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
@@ -256,8 +257,16 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     const exit = useExit()
 
     async function bootstrap() {
-      // blocking
-      await Promise.all([
+      const args = useArgs()
+      const sessionListPromise = sdk.client.session.list().then((x) =>
+        setStore(
+          "session",
+          (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)),
+        ),
+      )
+
+      // blocking - include session.list when continuing a session
+      const blockingRequests: Promise<unknown>[] = [
         sdk.client.config.providers({}, { throwOnError: true }).then((x) => {
           batch(() => {
             setStore("provider", x.data!.providers)
@@ -271,17 +280,18 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         }),
         sdk.client.app.agents({}, { throwOnError: true }).then((x) => setStore("agent", x.data ?? [])),
         sdk.client.config.get({}, { throwOnError: true }).then((x) => setStore("config", x.data!)),
-      ])
+      ]
+
+      if (args.continue) {
+        blockingRequests.push(sessionListPromise)
+      }
+
+      await Promise.all(blockingRequests)
         .then(() => {
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           Promise.all([
-            sdk.client.session.list().then((x) =>
-              setStore(
-                "session",
-                (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)),
-              ),
-            ),
+            ...(args.continue ? [] : [sessionListPromise]),
             sdk.client.command.list().then((x) => setStore("command", x.data ?? [])),
             sdk.client.lsp.status().then((x) => setStore("lsp", x.data!)),
             sdk.client.mcp.status().then((x) => setStore("mcp", x.data!)),


### PR DESCRIPTION
## Summary

- Fixes #5815
- Eliminates the confusing dashboard flash when using `opencode -c` to resume a session

## Changes

When using `-c` flag:
1. `session.list()` is now loaded in the blocking phase (instead of non-blocking)
2. The continue effect triggers at "partial" status (instead of waiting for "complete")

This ensures the session data is available immediately, so navigation to the resumed session happens before the dashboard ever renders.

## Testing

1. Start opencode, create a session with messages
2. Exit
3. Run `opencode -c`
4. Session should appear directly without dashboard flash