### PR TITLE
feat(docs): adding .md to docs pages shows raw markdown

### DIFF
--- a/packages/web/src/pages/[...slug].md.ts
+++ b/packages/web/src/pages/[...slug].md.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from "astro"
+import { getCollection } from "astro:content"
+
+export const GET: APIRoute = async ({ params }) => {
+  const slug = params.slug || "index"
+  const docs = await getCollection("docs")
+  const doc = docs.find((d) => d.id === slug)
+
+  if (!doc) {
+    return new Response("Not found", { status: 404 })
+  }
+
+  return new Response(doc.body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Adds a new API endpoint that serves raw MDX content when `.md` is appended to any docs URL
- Enables programmatic access to documentation source files

## Examples

- `/docs/config.md` → returns raw MDX for the config page
- `/docs/index.md` → returns raw MDX for the index page  
- `/docs/mcp-servers.md` → returns raw MDX for the MCP servers page

## Implementation

Uses Astro's content collections API to look up docs by slug and returns the raw body content with `text/plain` content type.

Example:

<img width="1057" height="685" alt="image" src="https://github.com/user-attachments/assets/d03c5456-c480-469d-b3b1-1fa74abe32ff" />
