### PR TITLE
Make CLI build script Windows-friendly

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "test": "bun test",
-    "build": "./script/build.ts",
+    "build": "bun run script/build.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
     "random": "echo 'Random script updated at $(date)' && echo 'Change queued successfully' && echo 'Another change made' && echo 'Yet another change' && echo 'One more change' && echo 'Final change' && echo 'Another final change' && echo 'Yet another final change'",
     "clean": "echo 'Cleaning up...' && rm -rf node_modules dist",


### PR DESCRIPTION
Fixes #5836

## Problem

**Issue 1: Build script fails on Windows**
The `build` script in `packages/opencode/package.json` invokes `./script/build.ts` directly, relying on the shebang (`#!/usr/bin/env bun`) to execute. Windows doesn't honor shebangs, causing the script to fail.

**Issue 2: `--single` flag downloads flaky baseline artifacts**
When building with `--single` (current platform only), the script still attempts to build the baseline (non-AVX2) target, which requires downloading additional Bun artifacts. These downloads frequently fail on Windows with "Failed to extract executable" errors.

## Reproduction

See issue #5836 for full reproduction steps.

## Changes

1. **packages/opencode/package.json**: Change `build` script from `./script/build.ts` to `bun run script/build.ts` (Windows-compatible)
2. **packages/opencode/script/build.ts**: When `--single` is used, build only the native target by default; pass `--baseline` to also build the baseline (AVX2=false) variant when needed (eg. release parity)

## Testing

Tested on Windows 11 with Bun 1.3.5:
```powershell
bun run --cwd packages/opencode build -- --single --skip-install
# Successfully builds opencode-windows-x64 (native target only)
```
