### PR TITLE
feat: add cursor theme

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -8,6 +8,7 @@ import ayu from "./theme/ayu.json" with { type: "json" }
 import catppuccin from "./theme/catppuccin.json" with { type: "json" }
 import catppuccinMacchiato from "./theme/catppuccin-macchiato.json" with { type: "json" }
 import cobalt2 from "./theme/cobalt2.json" with { type: "json" }
+import cursor from "./theme/cursor.json" with { type: "json" }
 import dracula from "./theme/dracula.json" with { type: "json" }
 import everforest from "./theme/everforest.json" with { type: "json" }
 import flexoki from "./theme/flexoki.json" with { type: "json" }
@@ -138,6 +139,7 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   catppuccin,
   ["catppuccin-macchiato"]: catppuccinMacchiato,
   cobalt2,
+  cursor,
   dracula,
   everforest,
   flexoki,

--- a/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/cursor.json
@@ -1,0 +1,249 @@
+{
+  "$schema": "https://opencode.ai/theme.json",
+  "defs": {
+    "darkBg": "#181818",
+    "darkPanel": "#141414",
+    "darkElement": "#262626",
+    "darkFg": "#e4e4e4",
+    "darkMuted": "#e4e4e45e",
+    "darkBorder": "#e4e4e413",
+    "darkBorderActive": "#e4e4e426",
+    "darkCyan": "#88c0d0",
+    "darkBlue": "#81a1c1",
+    "darkGreen": "#3fa266",
+    "darkGreenBright": "#70b489",
+    "darkRed": "#e34671",
+    "darkRedBright": "#fc6b83",
+    "darkYellow": "#f1b467",
+    "darkOrange": "#d2943e",
+    "darkPink": "#E394DC",
+    "darkPurple": "#AAA0FA",
+    "darkTeal": "#82D2CE",
+    "darkSyntaxYellow": "#F8C762",
+    "darkSyntaxOrange": "#EFB080",
+    "darkSyntaxGreen": "#A8CC7C",
+    "darkSyntaxBlue": "#87C3FF",
+    "lightBg": "#fcfcfc",
+    "lightPanel": "#f3f3f3",
+    "lightElement": "#ededed",
+    "lightFg": "#141414",
+    "lightMuted": "#141414ad",
+    "lightBorder": "#14141413",
+    "lightBorderActive": "#14141426",
+    "lightTeal": "#6f9ba6",
+    "lightBlue": "#3c7cab",
+    "lightBlueDark": "#206595",
+    "lightGreen": "#1f8a65",
+    "lightGreenBright": "#55a583",
+    "lightRed": "#cf2d56",
+    "lightRedBright": "#e75e78",
+    "lightOrange": "#db704b",
+    "lightYellow": "#c08532",
+    "lightPurple": "#9e94d5",
+    "lightPurpleDark": "#6049b3",
+    "lightPink": "#b8448b",
+    "lightMagenta": "#b3003f"
+  },
+  "theme": {
+    "primary": {
+      "dark": "darkCyan",
+      "light": "lightTeal"
+    },
+    "secondary": {
+      "dark": "darkBlue",
+      "light": "lightBlue"
+    },
+    "accent": {
+      "dark": "darkCyan",
+      "light": "lightTeal"
+    },
+    "error": {
+      "dark": "darkRed",
+      "light": "lightRed"
+    },
+    "warning": {
+      "dark": "darkYellow",
+      "light": "lightOrange"
+    },
+    "success": {
+      "dark": "darkGreen",
+      "light": "lightGreen"
+    },
+    "info": {
+      "dark": "darkBlue",
+      "light": "lightBlue"
+    },
+    "text": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    },
+    "textMuted": {
+      "dark": "darkMuted",
+      "light": "lightMuted"
+    },
+    "background": {
+      "dark": "darkBg",
+      "light": "lightBg"
+    },
+    "backgroundPanel": {
+      "dark": "darkPanel",
+      "light": "lightPanel"
+    },
+    "backgroundElement": {
+      "dark": "darkElement",
+      "light": "lightElement"
+    },
+    "border": {
+      "dark": "darkBorder",
+      "light": "lightBorder"
+    },
+    "borderActive": {
+      "dark": "darkCyan",
+      "light": "lightTeal"
+    },
+    "borderSubtle": {
+      "dark": "#0f0f0f",
+      "light": "#e0e0e0"
+    },
+    "diffAdded": {
+      "dark": "darkGreen",
+      "light": "lightGreen"
+    },
+    "diffRemoved": {
+      "dark": "darkRed",
+      "light": "lightRed"
+    },
+    "diffContext": {
+      "dark": "darkMuted",
+      "light": "lightMuted"
+    },
+    "diffHunkHeader": {
+      "dark": "darkMuted",
+      "light": "lightMuted"
+    },
+    "diffHighlightAdded": {
+      "dark": "darkGreenBright",
+      "light": "lightGreenBright"
+    },
+    "diffHighlightRemoved": {
+      "dark": "darkRedBright",
+      "light": "lightRedBright"
+    },
+    "diffAddedBg": {
+      "dark": "#3fa26633",
+      "light": "#1f8a651f"
+    },
+    "diffRemovedBg": {
+      "dark": "#b8004933",
+      "light": "#cf2d5614"
+    },
+    "diffContextBg": {
+      "dark": "darkPanel",
+      "light": "lightPanel"
+    },
+    "diffLineNumber": {
+      "dark": "#e4e4e442",
+      "light": "#1414147a"
+    },
+    "diffAddedLineNumberBg": {
+      "dark": "#3fa26633",
+      "light": "#1f8a651f"
+    },
+    "diffRemovedLineNumberBg": {
+      "dark": "#b8004933",
+      "light": "#cf2d5614"
+    },
+    "markdownText": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    },
+    "markdownHeading": {
+      "dark": "darkPurple",
+      "light": "lightBlueDark"
+    },
+    "markdownLink": {
+      "dark": "darkTeal",
+      "light": "lightBlueDark"
+    },
+    "markdownLinkText": {
+      "dark": "darkBlue",
+      "light": "lightMuted"
+    },
+    "markdownCode": {
+      "dark": "darkPink",
+      "light": "lightGreen"
+    },
+    "markdownBlockQuote": {
+      "dark": "darkMuted",
+      "light": "lightMuted"
+    },
+    "markdownEmph": {
+      "dark": "darkTeal",
+      "light": "lightFg"
+    },
+    "markdownStrong": {
+      "dark": "darkSyntaxYellow",
+      "light": "lightFg"
+    },
+    "markdownHorizontalRule": {
+      "dark": "darkMuted",
+      "light": "lightMuted"
+    },
+    "markdownListItem": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    },
+    "markdownListEnumeration": {
+      "dark": "darkCyan",
+      "light": "lightMuted"
+    },
+    "markdownImage": {
+      "dark": "darkCyan",
+      "light": "lightBlueDark"
+    },
+    "markdownImageText": {
+      "dark": "darkBlue",
+      "light": "lightMuted"
+    },
+    "markdownCodeBlock": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    },
+    "syntaxComment": {
+      "dark": "darkMuted",
+      "light": "lightMuted"
+    },
+    "syntaxKeyword": {
+      "dark": "darkTeal",
+      "light": "lightMagenta"
+    },
+    "syntaxFunction": {
+      "dark": "darkSyntaxOrange",
+      "light": "lightOrange"
+    },
+    "syntaxVariable": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    },
+    "syntaxString": {
+      "dark": "darkPink",
+      "light": "lightPurple"
+    },
+    "syntaxNumber": {
+      "dark": "darkSyntaxYellow",
+      "light": "lightPink"
+    },
+    "syntaxType": {
+      "dark": "darkSyntaxOrange",
+      "light": "lightBlueDark"
+    },
+    "syntaxOperator": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    },
+    "syntaxPunctuation": {
+      "dark": "darkFg",
+      "light": "lightFg"
+    }
+  }
+}


### PR DESCRIPTION
 **Summary**
 
Adds the Cursor editor theme to OpenCode, combining both Cursor Dark and Cursor Light into a single unified theme with dark/light mode support.

 **Theme Features**
 
- **Dark mode**: Deep charcoal backgrounds (`#181818`, `#141414`) with soft cyan/blue accents (`#88c0d0`, `#81a1c1`)
- **Light mode**: Clean white backgrounds (`#fcfcfc`, `#f3f3f3`) with teal/blue accents (`#6f9ba6`, `#3c7cab`)
- Syntax highlighting colors matched to Cursor's token colors
- Full support for diffs, markdown, and code syntax

 **Screenshots**
 
 **Dark Mode**
 
<img width="2602" height="1636" alt="CleanShot 2025-12-20 at 16 51 37@2x" src="https://github.com/user-attachments/assets/65179b38-95d0-4b20-a46b-48f28175eab4" />

**Light Mode**
 
<img width="2364" height="1556" alt="CleanShot 2025-12-20 at 16 52 15@2x" src="https://github.com/user-attachments/assets/52293c2b-d990-4ff2-b3d4-ef9d6d7f2c38" />

 