### PR TITLE
docs: add name property to model configuration example

### DIFF
--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -117,6 +117,7 @@ You can also define custom models that extend built-in ones and can optionally u
       "models": {
         "gpt-5-high": {
           "id": "gpt-5",
+          "name": "MyGPT5 (High Reasoning)",
           "options": {
             "reasoningEffort": "high",
             "textVerbosity": "low",
@@ -125,6 +126,7 @@ You can also define custom models that extend built-in ones and can optionally u
         },
         "gpt-5-low": {
           "id": "gpt-5",
+          "name": "MyGPT5 (Low Reasoning)",
           "options": {
             "reasoningEffort": "low",
             "textVerbosity": "low",


### PR DESCRIPTION
Fixes #5852

Adds the `name` property to the model configuration example to clarify that you can customize how models appear in the UI.