### PR TITLE
docs: clarify model ID format for OpenCode provider

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -331,6 +331,8 @@ If you don’t specify a model, primary agents use the [model globally configure
 }
 ```
 
+The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
+
 ---
 
 ### Tools

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -60,7 +60,7 @@ OpenCode config.
 }
 ```
 
-Here the full ID is `provider_id/model_id`.
+Here the full ID is `provider_id/model_id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
 
 If you've configured a [custom provider](/docs/providers#custom), the `provider_id` is key from the `provider` part of your config, and the `model_id` is the key from `provider.models`.
 


### PR DESCRIPTION
## Summary
- Adds clarification to the Models and Agents documentation explaining the `provider/model-id` format with a concrete example using OpenCode Zen (`opencode/gpt-5.1-codex`)
- Makes it clearer for users how to configure models, especially when using the OpenCode provider