### PR TITLE
feat(ide): IDE integration with Cursor/VSCode and improved UX

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -346,44 +346,7 @@ export function Prompt(props: PromptProps) {
     promptPartTypeId = input.extmarks.registerType("prompt-part")
   })
 
-  // Track IDE selection extmark so we can update/remove it
-  let ideSelectionExtmarkId: number | null = null
-
-  function removeExtmark(extmarkId: number) {
-    const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
-    const extmark = allExtmarks.find((e) => e.id === extmarkId)
-    const partIndex = store.extmarkToPartIndex.get(extmarkId)
-
-    if (partIndex !== undefined) {
-      setStore(
-        produce((draft) => {
-          draft.prompt.parts.splice(partIndex, 1)
-          draft.extmarkToPartIndex.delete(extmarkId)
-          const newMap = new Map<number, number>()
-          for (const [id, idx] of draft.extmarkToPartIndex) {
-            newMap.set(id, idx > partIndex ? idx - 1 : idx)
-          }
-          draft.extmarkToPartIndex = newMap
-        }),
-      )
-    }
-
-    if (extmark) {
-      const savedOffset = input.cursorOffset
-      input.cursorOffset = extmark.start
-      const start = { ...input.logicalCursor }
-      input.cursorOffset = extmark.end + 1
-      input.deleteRange(start.row, start.col, input.logicalCursor.row, input.logicalCursor.col)
-      input.cursorOffset =
-        savedOffset > extmark.start
-          ? Math.max(extmark.start, savedOffset - (extmark.end + 1 - extmark.start))
-          : savedOffset
-    }
-
-    input.extmarks.delete(extmarkId)
-  }
-
-  function updateIdeSelection(selection: Ide.Selection | null) {
+  function updateIdeSelection(_selection: Ide.Selection | null) {
     // Selection is now displayed in footer via local.selection
     // No visual insertion in the input needed
     // Content will be included at submit time from local.selection
@@ -585,7 +548,7 @@ export function Prompt(props: PromptProps) {
           ...(local.selection.current()?.text ? [{
             id: Identifier.ascending("part"),
             type: "text" as const,
-            text: `\n\n[IDE Selection: ${local.selection.current()!.filePath.split("/").pop() || local.selection.current()!.filePath}:${local.selection.current()!.selection.start.line + 1}-${local.selection.current()!.selection.end.line + 1}]\n\`\`\`\n${local.selection.current()!.text}\n\`\`\``,
+            text: `\n\n[IDE Selection: ${local.selection.current()!.filePath.split(/[\/\\]/).pop() || local.selection.current()!.filePath}:${local.selection.current()!.selection.start.line + 1}-${local.selection.current()!.selection.end.line + 1}]\n\`\`\`\n${local.selection.current()!.text}\n\`\`\``,
             synthetic: true,
           }] : []),
           ...nonTextParts.map((x) => ({
@@ -602,7 +565,6 @@ export function Prompt(props: PromptProps) {
       parts: [],
     })
     setStore("extmarkToPartIndex", new Map())
-    ideSelectionExtmarkId = null
     props.onSubmit?.()
 
     // temporary hack to make sure the message is sent

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -20,6 +20,7 @@ import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
 import type { FilePart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
+import { Ide } from "@/ide"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
 import { createColors, createFrames } from "../../ui/spinner.ts"
@@ -44,7 +45,6 @@ export type PromptRef = {
   reset(): void
   blur(): void
   focus(): void
-  submit(): void
 }
 
 const PLACEHOLDERS = ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"]
@@ -116,7 +116,7 @@ export function Prompt(props: PromptProps) {
   const sync = useSync()
   const dialog = useDialog()
   const toast = useToast()
-  const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
+  const status = createMemo(() => sync.data.session_status[props.sessionID ?? ""] ?? { type: "idle" })
   const history = usePromptHistory()
   const command = useCommandDialog()
   const renderer = useRenderer()
@@ -312,6 +312,10 @@ export function Prompt(props: PromptProps) {
     input.insertText(evt.properties.text)
   })
 
+  sdk.event.on(Ide.Event.SelectionChanged.type, (evt) => {
+    updateIdeSelection(evt.properties.selection)
+  })
+
   createEffect(() => {
     if (props.disabled) input.cursorColor = theme.backgroundElement
     if (!props.disabled) input.cursorColor = theme.text
@@ -341,6 +345,49 @@ export function Prompt(props: PromptProps) {
   onMount(() => {
     promptPartTypeId = input.extmarks.registerType("prompt-part")
   })
+
+  // Track IDE selection extmark so we can update/remove it
+  let ideSelectionExtmarkId: number | null = null
+
+  function removeExtmark(extmarkId: number) {
+    const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
+    const extmark = allExtmarks.find((e) => e.id === extmarkId)
+    const partIndex = store.extmarkToPartIndex.get(extmarkId)
+
+    if (partIndex !== undefined) {
+      setStore(
+        produce((draft) => {
+          draft.prompt.parts.splice(partIndex, 1)
+          draft.extmarkToPartIndex.delete(extmarkId)
+          const newMap = new Map<number, number>()
+          for (const [id, idx] of draft.extmarkToPartIndex) {
+            newMap.set(id, idx > partIndex ? idx - 1 : idx)
+          }
+          draft.extmarkToPartIndex = newMap
+        }),
+      )
+    }
+
+    if (extmark) {
+      const savedOffset = input.cursorOffset
+      input.cursorOffset = extmark.start
+      const start = { ...input.logicalCursor }
+      input.cursorOffset = extmark.end + 1
+      input.deleteRange(start.row, start.col, input.logicalCursor.row, input.logicalCursor.col)
+      input.cursorOffset =
+        savedOffset > extmark.start
+          ? Math.max(extmark.start, savedOffset - (extmark.end + 1 - extmark.start))
+          : savedOffset
+    }
+
+    input.extmarks.delete(extmarkId)
+  }
+
+  function updateIdeSelection(selection: Ide.Selection | null) {
+    // Selection is now displayed in footer via local.selection
+    // No visual insertion in the input needed
+    // Content will be included at submit time from local.selection
+  }
 
   function restoreExtmarksFromParts(parts: PromptInfo["parts"]) {
     input.extmarks.clear()
@@ -448,14 +495,11 @@ export function Prompt(props: PromptProps) {
       })
       setStore("extmarkToPartIndex", new Map())
     },
-    submit() {
-      submit()
-    },
   })
 
   async function submit() {
     if (props.disabled) return
-    if (autocomplete?.visible) return
+    if (autocomplete.visible) return
     if (!store.prompt.input) return
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
@@ -476,6 +520,8 @@ export function Prompt(props: PromptProps) {
     const messageID = Identifier.ascending("message")
     let inputText = store.prompt.input
 
+    // IDE selection is displayed in footer only - not injected into message
+
     // Expand pasted text inline before submitting
     const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
     const sortedExtmarks = allExtmarks.sort((a: { start: number }, b: { start: number }) => b.start - a.start)
@@ -494,9 +540,6 @@ export function Prompt(props: PromptProps) {
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
-
-    // Capture mode before it gets reset
-    const currentMode = store.mode
 
     if (store.mode === "shell") {
       sdk.client.session.shell({
@@ -539,6 +582,12 @@ export function Prompt(props: PromptProps) {
             type: "text",
             text: inputText,
           },
+          ...(local.selection.current()?.text ? [{
+            id: Identifier.ascending("part"),
+            type: "text" as const,
+            text: `\n\n[IDE Selection: ${local.selection.current()!.filePath.split("/").pop() || local.selection.current()!.filePath}:${local.selection.current()!.selection.start.line + 1}-${local.selection.current()!.selection.end.line + 1}]\n\`\`\`\n${local.selection.current()!.text}\n\`\`\``,
+            synthetic: true,
+          }] : []),
           ...nonTextParts.map((x) => ({
             id: Identifier.ascending("part"),
             ...x,
@@ -546,16 +595,14 @@ export function Prompt(props: PromptProps) {
         ],
       })
     }
-    history.append({
-      ...store.prompt,
-      mode: currentMode,
-    })
+    history.append(store.prompt)
     input.extmarks.clear()
     setStore("prompt", {
       input: "",
       parts: [],
     })
     setStore("extmarkToPartIndex", new Map())
+    ideSelectionExtmarkId = null
     props.onSubmit?.()
 
     // temporary hack to make sure the message is sent
@@ -715,8 +762,8 @@ export function Prompt(props: PromptProps) {
           >
             <textarea
               placeholder={props.sessionID ? undefined : `Ask anything... "${PLACEHOLDERS[store.placeholder]}"`}
-              textColor={keybind.leader ? theme.textMuted : theme.text}
-              focusedTextColor={keybind.leader ? theme.textMuted : theme.text}
+              textColor={theme.text}
+              focusedTextColor={theme.text}
               minHeight={1}
               maxHeight={6}
               onContentChange={() => {
@@ -742,12 +789,8 @@ export function Prompt(props: PromptProps) {
                   return
                 }
                 if (keybind.match("app_exit", e)) {
-                  if (store.prompt.input === "") {
-                    await exit()
-                    // Don't preventDefault - let textarea potentially handle the event
-                    e.preventDefault()
-                    return
-                  }
+                  await exit()
+                  return
                 }
                 if (e.name === "!" && input.visualCursor.offset === 0) {
                   setStore("mode", "shell")
@@ -773,7 +816,6 @@ export function Prompt(props: PromptProps) {
                     if (item) {
                       input.setText(item.input)
                       setStore("prompt", item)
-                      setStore("mode", item.mode ?? "normal")
                       restoreExtmarksFromParts(item.parts)
                       e.preventDefault()
                       if (direction === -1) input.cursorOffset = 0
@@ -865,7 +907,7 @@ export function Prompt(props: PromptProps) {
               </text>
               <Show when={store.mode === "normal"}>
                 <box flexDirection="row" gap={1}>
-                  <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
+                  <text flexShrink={0} fg={theme.text}>
                     {local.model.parsed().model}
                   </text>
                   <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
@@ -880,7 +922,8 @@ export function Prompt(props: PromptProps) {
           borderColor={highlight()}
           customBorderChars={{
             ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
+            // when the background is transparent, don't draw the vertical line
+            vertical: theme.background.a != 0 ? "╹" : " ",
           }}
         >
           <box
@@ -888,7 +931,7 @@ export function Prompt(props: PromptProps) {
             border={["bottom"]}
             borderColor={theme.backgroundElement}
             customBorderChars={
-              theme.backgroundElement.a !== 0
+              theme.background.a != 0
                 ? {
                     ...EmptyBorder,
                     horizontal: "▀",

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -1,4 +1,4 @@
-import { createStore } from "solid-js/store"
+import { createStore, reconcile } from "solid-js/store"
 import { batch, createEffect, createMemo } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
@@ -12,6 +12,7 @@ import { Provider } from "@/provider/provider"
 import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
+import { Ide } from "@/ide"
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
@@ -52,11 +53,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     })
 
     const agent = iife(() => {
-      const agents = createMemo(() => sync.data.agent.filter((x) => x.mode !== "subagent" && !x.hidden))
+      const agents = createMemo(() => sync.data.agent.filter((x) => x.mode !== "subagent"))
       const [agentStore, setAgentStore] = createStore<{
         current: string
       }>({
-        current: agents().find((x) => x.default)?.name ?? agents()[0].name,
+        current: agents()[0].name,
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -329,10 +330,61 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       },
     }
 
+    const ide = {
+      isConnected(name: string) {
+        const status = sync.data.ide[name]
+        return status?.status === "connected"
+      },
+      getWorkspaceFolders(name: string) {
+        const status = sync.data.ide[name]
+        if (status && "workspaceFolders" in status && status.workspaceFolders) {
+          return status.workspaceFolders
+        }
+        return []
+      },
+      async toggle(name: string) {
+        const current = sync.data.ide[name]
+        if (current?.status === "connected") {
+          await sdk.client.ide.disconnect({ name })
+        } else {
+          await sdk.client.ide.connect({ name })
+        }
+        const status = await sdk.client.ide.status()
+        if (status.data) sync.set("ide", reconcile(status.data))
+      },
+    }
+
+
+    const selection = iife(() => {
+      const [selStore, setSelStore] = createStore<{
+        current: Ide.Selection | null
+      }>({ current: null })
+
+      sdk.event.on(Ide.Event.SelectionChanged.type, async (evt) => {
+        setSelStore("current", evt.properties.selection)
+        // Refresh IDE status when we receive a selection
+        const status = await sdk.client.ide.status()
+        if (status.data) sync.set("ide", reconcile(status.data))
+      })
+
+      return {
+        current: () => selStore.current,
+        clear: () => setSelStore("current", null),
+        formatted: () => {
+          const sel = selStore.current
+          if (!sel || !sel.text) return null
+          const lines = sel.text.split("\n").length
+          return `${lines} lines`
+        },
+      }
+    })
+
     const result = {
       model,
       agent,
       mcp,
+      ide,
+      selection,
     }
     return result
   },

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -7,6 +7,7 @@ import { useSync } from "../context/sync"
 import { Toast } from "../ui/toast"
 import { useArgs } from "../context/args"
 import { useDirectory } from "../context/directory"
+import { useLocal } from "../context/local"
 import { useRoute, useRouteData } from "@tui/context/route"
 import { usePromptRef } from "../context/prompt"
 import { Installation } from "@/installation"
@@ -57,10 +58,11 @@ export function Home() {
     } else if (args.prompt) {
       prompt.set({ input: args.prompt, parts: [] })
       once = true
-      prompt.submit()
     }
   })
   const directory = useDirectory()
+  const local = useLocal()
+  const ide = createMemo(() => Object.values(sync.data.ide).find((x) => x.status === "connected"))
 
   return (
     <>
@@ -92,8 +94,20 @@ export function Home() {
               </Switch>
               {connectedMcpCount()} MCP
             </text>
-            <text fg={theme.textMuted}>/status</text>
           </Show>
+          <Show when={ide()}>
+            <text fg={theme.text}>
+              <span style={{ fg: theme.success }}>◆ </span>
+              {ide()!.name}
+            </text>
+          </Show>
+          <Show when={local.selection.formatted()}>
+            <text fg={theme.text}>
+              <span style={{ fg: theme.accent }}>[] </span>
+              {local.selection.formatted()}
+            </text>
+          </Show>
+          <text fg={theme.textMuted}>/status</text>
         </box>
         <box flexGrow={1} />
         <box flexShrink={0}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -5,6 +5,7 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/dialog-model"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { useLocal } from "../../context/local"
 
 export function Footer() {
   const { theme } = useTheme()
@@ -13,12 +14,14 @@ export function Footer() {
   const mcp = createMemo(() => Object.values(sync.data.mcp).filter((x) => x.status === "connected").length)
   const mcpError = createMemo(() => Object.values(sync.data.mcp).some((x) => x.status === "failed"))
   const lsp = createMemo(() => Object.keys(sync.data.lsp))
+  const ide = createMemo(() => Object.values(sync.data.ide).find((x) => x.status === "connected"))
   const permissions = createMemo(() => {
     if (route.data.type !== "session") return []
     return sync.data.permission[route.data.sessionID] ?? []
   })
   const directory = useDirectory()
   const connected = useConnected()
+  const local = useLocal()
 
   const [store, setStore] = createStore({
     welcome: false,
@@ -77,6 +80,18 @@ export function Footer() {
                   </Match>
                 </Switch>
                 {mcp()} MCP
+              </text>
+            </Show>
+            <Show when={ide()}>
+              <text fg={theme.text}>
+                <span style={{ fg: theme.success }}>◆ </span>
+                {ide()!.name}
+              </text>
+            </Show>
+            <Show when={local.selection.formatted()}>
+              <text fg={theme.text}>
+                <span style={{ fg: theme.accent }}>[] </span>
+                {local.selection.formatted()}
               </text>
             </Show>
             <text fg={theme.textMuted}>/status</text>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -5,7 +5,7 @@ import os from "os"
 import z from "zod"
 import { Filesystem } from "../util/filesystem"
 import { ModelsDev } from "../provider/models"
-import { mergeDeep, pipe, unique } from "remeda"
+import { mergeDeep, pipe } from "remeda"
 import { Global } from "../global"
 import fs from "fs/promises"
 import { lazy } from "../util/lazy"
@@ -76,13 +76,6 @@ export namespace Config {
           stop: Instance.worktree,
         }),
       )),
-      ...(await Array.fromAsync(
-        Filesystem.up({
-          targets: [".opencode"],
-          start: Global.Path.home,
-          stop: Global.Path.home,
-        }),
-      )),
     ]
 
     if (Flag.OPENCODE_CONFIG_DIR) {
@@ -91,7 +84,7 @@ export namespace Config {
     }
 
     const promises: Promise<void>[] = []
-    for (const dir of unique(directories)) {
+    for (const dir of directories) {
       await assertValid(dir)
 
       if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
@@ -140,17 +133,6 @@ export namespace Config {
     }
 
     if (!result.keybinds) result.keybinds = Info.shape.keybinds.parse({})
-
-    // Only validate if user has configured agents - if none configured, built-in agents will be used
-    if (Object.keys(result.agent).length > 0) {
-      const primaryAgents = Object.values(result.agent).filter((a) => a.mode !== "subagent" && !a.hidden && !a.disable)
-      if (primaryAgents.length === 0) {
-        throw new InvalidError({
-          path: "config",
-          message: "No primary agents are available. Please configure at least one agent with mode 'primary' or 'all'.",
-        })
-      }
-    }
 
     return {
       config: result,
@@ -229,7 +211,7 @@ export namespace Config {
         result[config.name] = parsed.data
         continue
       }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      throw new InvalidError({ path: item }, { cause: parsed.error })
     }
     return result
   }
@@ -272,7 +254,7 @@ export namespace Config {
         result[config.name] = parsed.data
         continue
       }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      throw new InvalidError({ path: item }, { cause: parsed.error })
     }
     return result
   }
@@ -451,8 +433,6 @@ export namespace Config {
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),
       session_list: z.string().optional().default("<leader>l").describe("List all sessions"),
       session_timeline: z.string().optional().default("<leader>g").describe("Show session timeline"),
-      session_fork: z.string().optional().default("none").describe("Fork session from message"),
-      session_rename: z.string().optional().default("none").describe("Rename session"),
       session_share: z.string().optional().default("none").describe("Share current session"),
       session_unshare: z.string().optional().default("none").describe("Unshare current session"),
       session_interrupt: z.string().optional().default("escape").describe("Interrupt current session"),
@@ -480,8 +460,6 @@ export namespace Config {
       model_list: z.string().optional().default("<leader>m").describe("List available models"),
       model_cycle_recent: z.string().optional().default("f2").describe("Next recently used model"),
       model_cycle_recent_reverse: z.string().optional().default("shift+f2").describe("Previous recently used model"),
-      model_cycle_favorite: z.string().optional().default("none").describe("Next favorite model"),
-      model_cycle_favorite_reverse: z.string().optional().default("none").describe("Previous favorite model"),
       command_list: z.string().optional().default("ctrl+p").describe("List available commands"),
       agent_list: z.string().optional().default("<leader>a").describe("List agents"),
       agent_cycle: z.string().optional().default("tab").describe("Next agent"),
@@ -572,7 +550,6 @@ export namespace Config {
       session_child_cycle: z.string().optional().default("<leader>right").describe("Next child session"),
       session_child_cycle_reverse: z.string().optional().default("<leader>left").describe("Previous child session"),
       terminal_suspend: z.string().optional().default("ctrl+z").describe("Suspend terminal"),
-      terminal_title_toggle: z.string().optional().default("none").describe("Toggle terminal title"),
     })
     .strict()
     .meta({
@@ -677,12 +654,6 @@ export namespace Config {
         .string()
         .describe("Small model to use for tasks like title generation in the format of provider/model")
         .optional(),
-      default_agent: z
-        .string()
-        .optional()
-        .describe(
-          "Default agent to use when none is specified. Must be a primary agent. Falls back to 'build' if not set or if the specified agent is invalid.",
-        ),
       username: z
         .string()
         .optional()
@@ -697,16 +668,10 @@ export namespace Config {
         .describe("@deprecated Use `agent` field instead."),
       agent: z
         .object({
-          // primary
           plan: Agent.optional(),
           build: Agent.optional(),
-          // subagent
           general: Agent.optional(),
           explore: Agent.optional(),
-          // specialized
-          title: Agent.optional(),
-          summary: Agent.optional(),
-          compaction: Agent.optional(),
         })
         .catchall(Agent)
         .optional()
@@ -783,6 +748,13 @@ export namespace Config {
           url: z.string().optional().describe("Enterprise URL"),
         })
         .optional(),
+      ide: z
+        .object({
+          lockfile_dir: z.string().optional().describe("Directory containing IDE lock files for WebSocket connections"),
+          auth_header_name: z.string().optional().describe("HTTP header name for IDE WebSocket authentication"),
+        })
+        .optional()
+        .describe("IDE integration settings"),
       experimental: z
         .object({
           hook: z
@@ -818,7 +790,6 @@ export namespace Config {
             .array(z.string())
             .optional()
             .describe("Tools that should only be available to primary agents."),
-          continue_loop_on_deny: z.boolean().optional().describe("Continue the agent loop when a tool call is denied"),
         })
         .optional(),
     })

--- a/packages/opencode/src/ide/connection.ts
+++ b/packages/opencode/src/ide/connection.ts
@@ -1,0 +1,162 @@
+import z from "zod/v4"
+import path from "path"
+import { Glob } from "bun"
+import { Log } from "../util/log"
+import { WebSocketClientTransport, McpError } from "../mcp/ws"
+import { Config } from "../config/config"
+
+const log = Log.create({ service: "ide" })
+
+const WS_PREFIX = "ws://127.0.0.1"
+
+const LockFile = {
+  schema: z.object({
+    port: z.number(),
+    url: z.instanceof(URL),
+    pid: z.number(),
+    workspaceFolders: z.array(z.string()),
+    ideName: z.string(),
+    transport: z.string(),
+    authToken: z.string(),
+  }),
+  async fromFile(file: string) {
+    const port = parseInt(path.basename(file, ".lock"))
+    const url = new URL(`${WS_PREFIX}:${port}`)
+    const content = await Bun.file(file).text()
+    const parsed = this.schema.safeParse({ port, url, ...JSON.parse(content) })
+    if (!parsed.success) {
+      log.warn("invalid lock file", { file, error: parsed.error })
+      return undefined
+    }
+    return parsed.data
+  },
+}
+type LockFile = z.infer<typeof LockFile.schema>
+
+export async function discoverLockFiles(): Promise<Map<string, LockFile>> {
+  const results = new Map<string, LockFile>()
+  const config = await Config.get()
+
+  if (!config.ide?.lockfile_dir) {
+    log.debug("ide.lockfile_dir not configured, skipping IDE discovery")
+    return results
+  }
+
+  const glob = new Glob("*.lock")
+  for await (const file of glob.scan({ cwd: config.ide.lockfile_dir, absolute: true })) {
+    const lockFile = await LockFile.fromFile(file)
+    if (!lockFile) continue
+
+    try {
+      process.kill(lockFile.pid, 0)
+    } catch {
+      log.debug("stale lock file, process not running", { file, pid: lockFile.pid })
+      continue
+    }
+
+    results.set(String(lockFile.port), lockFile)
+  }
+
+  return results
+}
+
+export class Connection {
+  key: string
+  name: string
+  private transport: WebSocketClientTransport
+  private requestId = 0
+  private pendingRequests = new Map<string | number, PromiseWithResolvers<unknown>>()
+  onNotification?: (method: string, params: unknown) => void
+  onClose?: () => void
+
+  private constructor(key: string, name: string, transport: WebSocketClientTransport) {
+    this.key = key
+    this.name = name
+    this.transport = transport
+  }
+
+  static async create(key: string): Promise<Connection> {
+    const config = await Config.get()
+    if (!config.ide?.auth_header_name) {
+      throw new Error("ide.auth_header_name is required in config")
+    }
+
+    const discovered = await discoverLockFiles()
+    const lockFile = discovered.get(key)
+    if (!lockFile) {
+      throw new Error(`IDE instance not found: ${key}`)
+    }
+
+    const transport = new WebSocketClientTransport(lockFile.url, {
+      headers: {
+        [config.ide.auth_header_name]: lockFile.authToken,
+      },
+    })
+
+    const connection = new Connection(key, lockFile.ideName, transport)
+
+    transport.onmessage = (message) => {
+      connection.handleMessage(message as any)
+    }
+
+    transport.onclose = () => {
+      log.info("IDE transport closed", { key })
+      connection.onClose?.()
+    }
+
+    transport.onerror = (err) => {
+      log.error("IDE transport error", { key, error: err })
+    }
+
+    await transport.start()
+
+    return connection
+  }
+
+  private handleMessage(payload: {
+    id?: string | number
+    method?: string
+    params?: unknown
+    result?: unknown
+    error?: { code: number; message: string; data?: unknown }
+  }) {
+    // Handle responses to our requests
+    const pending = payload.id !== undefined ? this.pendingRequests.get(payload.id) : undefined
+    if (pending) {
+      this.pendingRequests.delete(payload.id!)
+      if (payload.error) {
+        const { code, message, data } = payload.error
+        // TODO put code in message on ws server.
+        pending.reject(new McpError(code, `${message} (code: ${code})`, data))
+      } else {
+        pending.resolve(payload.result)
+      }
+      return
+    }
+
+    // Handle notifications
+    if (payload.method) {
+      this.onNotification?.(payload.method, payload.params)
+    }
+  }
+
+  async request<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> {
+    const id = ++this.requestId
+    const pending = Promise.withResolvers<T>()
+    this.pendingRequests.set(id, pending as PromiseWithResolvers<unknown>)
+    this.transport.send({
+      jsonrpc: "2.0" as const,
+      id,
+      method: `tools/call`,
+      params: {
+        name: method,
+        arguments: params ?? {},
+      },
+    })
+    return pending.promise
+  }
+
+  async close() {
+    await this.transport.close()
+  }
+}

--- a/packages/opencode/src/ide/connection.ts
+++ b/packages/opencode/src/ide/connection.ts
@@ -23,9 +23,16 @@ const LockFile = {
     const port = parseInt(path.basename(file, ".lock"))
     const url = new URL(`${WS_PREFIX}:${port}`)
     const content = await Bun.file(file).text()
-    const parsed = this.schema.safeParse({ port, url, ...JSON.parse(content) })
+    let data: unknown
+    try {
+      data = JSON.parse(content)
+    } catch (error) {
+      log.warn("invalid lock file JSON", { file, error })
+      return undefined
+    }
+    const parsed = this.schema.safeParse({ port, url, ...(data as object) })
     if (!parsed.success) {
-      log.warn("invalid lock file", { file, error: parsed.error })
+      log.warn("invalid lock file schema", { file, error: parsed.error })
       return undefined
     }
     return parsed.data

--- a/packages/opencode/src/ide/index.ts
+++ b/packages/opencode/src/ide/index.ts
@@ -2,8 +2,12 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { spawn } from "bun"
 import z from "zod"
+import path from "path"
 import { NamedError } from "@opencode-ai/util/error"
 import { Log } from "../util/log"
+import { Instance } from "../project/instance"
+import { Connection, discoverLockFiles } from "./connection"
+import { Permission } from "../permission"
 
 const SUPPORTED_IDES = [
   { name: "Windsurf" as const, cmd: "windsurf" },
@@ -16,11 +20,41 @@ const SUPPORTED_IDES = [
 export namespace Ide {
   const log = Log.create({ service: "ide" })
 
+  export const Status = z
+    .object({
+      status: z.enum(["connected", "disconnected", "failed"]),
+      name: z.string(),
+      workspaceFolders: z.array(z.string()).optional(),
+      error: z.string().optional(),
+    })
+    .meta({ ref: "IdeStatus" })
+  export type Status = z.infer<typeof Status>
+
+  export const Selection = z
+    .object({
+      text: z.string(),
+      filePath: z.string(),
+      fileUrl: z.string(),
+      selection: z.object({
+        start: z.object({ line: z.number(), character: z.number() }),
+        end: z.object({ line: z.number(), character: z.number() }),
+        isEmpty: z.boolean(),
+      }),
+    })
+    .meta({ ref: "IdeSelection" })
+  export type Selection = z.infer<typeof Selection>
+
   export const Event = {
     Installed: BusEvent.define(
       "ide.installed",
       z.object({
         ide: z.string(),
+      }),
+    ),
+    SelectionChanged: BusEvent.define(
+      "ide.selection.updated",
+      z.object({
+        selection: Selection,
       }),
     ),
   }
@@ -72,5 +106,116 @@ export namespace Ide {
     if (stdout.includes("already installed")) {
       throw new AlreadyInstalledError({})
     }
+  }
+
+  // Connection
+  let activeConnection: Connection | null = null
+
+  function diffTabName(filePath: string) {
+    // TODO this is used for a string match in claudecode.nvim that we could
+    // change if we incorporate a dedicated plugin
+    // (must start with ✻ and end with ⧉))
+    return `✻ [opencode] Edit: ${path.basename(filePath)} ⧉`
+  }
+
+  export async function status(): Promise<Record<string, Status>> {
+    const discovered = await discoverLockFiles()
+    const result: Record<string, Status> = {}
+
+    for (const [key, lockFile] of discovered) {
+      result[key] = {
+        status: activeConnection?.key === key ? "connected" : "disconnected",
+        name: lockFile.ideName,
+        workspaceFolders: lockFile.workspaceFolders,
+      }
+    }
+
+    return result
+  }
+
+  export async function connect(key: string): Promise<void> {
+    if (activeConnection) {
+      await disconnect()
+    }
+
+    const instanceDirectory = Instance.directory
+    const connection = await Connection.create(key)
+
+    connection.onNotification = (method, params) => {
+      handleNotification(method, params, instanceDirectory)
+    }
+
+    connection.onClose = () => {
+      log.info("IDE connection closed callback", { key })
+      if (activeConnection?.key === key) {
+        activeConnection = null
+      }
+    }
+
+    activeConnection = connection
+  }
+
+  function handleNotification(method: string, params: unknown, instanceDirectory: string) {
+    if (method === "selection_changed") {
+      const parsed = Selection.safeParse(params)
+      if (!parsed.success) {
+        log.warn("failed to parse selection_changed params", { error: parsed.error })
+        return
+      }
+      Instance.provide({
+        directory: instanceDirectory,
+        fn: () => {
+          Bus.publish(Event.SelectionChanged, { selection: parsed.data })
+        },
+      })
+    }
+  }
+
+  export async function disconnect(): Promise<void> {
+    if (activeConnection) {
+      log.info("IDE disconnecting", { key: activeConnection.key })
+      await activeConnection.close()
+      activeConnection = null
+    }
+  }
+
+  export function active(): Connection | null {
+    return activeConnection
+  }
+
+  const DiffResponse = {
+    FILE_SAVED: "once",
+    DIFF_REJECTED: "reject",
+  } as const satisfies Record<string, Permission.Response>
+
+  export async function openDiff(filePath: string, newContents: string): Promise<Permission.Response> {
+    const connection = active()
+    if (!connection) {
+      throw new Error("No IDE connected")
+    }
+    const name = diffTabName(filePath)
+    log.info("openDiff", { tabName: name })
+    const result = await connection.request<{ content: Array<{ type: string; text: string }> }>("openDiff", {
+      old_file_path: filePath,
+      new_file_path: filePath,
+      new_file_contents: newContents,
+      tab_name: name,
+    })
+    log.info("openDiff result", { text: result.content?.[0]?.text })
+    const text = result.content?.[0]?.text as keyof typeof DiffResponse | undefined
+    if (text && text in DiffResponse) return DiffResponse[text]
+    throw new Error(`Unexpected openDiff result: ${text}`)
+  }
+
+  async function closeTab(tabName: string): Promise<void> {
+    const connection = active()
+    if (!connection) {
+      throw new Error("No IDE connected")
+    }
+    await connection.request("close_tab", { tab_name: tabName })
+  }
+
+  export async function closeDiff(filePath: string): Promise<void> {
+    await closeTab(diffTabName(filePath))
   }
 }

--- a/packages/opencode/src/mcp/ws.ts
+++ b/packages/opencode/src/mcp/ws.ts
@@ -1,0 +1,64 @@
+import { WebSocketClientTransport as BaseWebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js"
+import { McpError } from "@modelcontextprotocol/sdk/types.js"
+
+export { McpError }
+
+export interface WebSocketTransportOptions {
+  headers?: Record<string, string>
+}
+
+/**
+ * Extended WebSocket transport that supports custom headers.
+ * Bun's WebSocket implementation accepts headers in the constructor options.
+ *
+ * We override start() because the base class inlines WebSocket construction
+ * with no hook to customize it.
+ */
+export class WebSocketClientTransport extends BaseWebSocketClientTransport {
+  private headers: Record<string, string>
+
+  constructor(url: URL, options?: WebSocketTransportOptions) {
+    super(url)
+    this.headers = options?.headers ?? {}
+  }
+
+  override start(): Promise<void> {
+    // @ts-expect-error accessing private field
+    if (this._socket) {
+      throw new Error(
+        "WebSocketClientTransport already started! If using Client class, note that connect() calls start() automatically.",
+      )
+    }
+
+    // Inject our WebSocket with headers before calling super.start()
+    // @ts-expect-error accessing private field
+    this._socket = new WebSocket(this._url, { headers: this.headers } as any)
+
+    // Now delegate to base class - it will see _socket exists and wire up events
+    // Unfortunately base class checks _socket at the start and throws, so we
+    // must duplicate the event wiring logic
+    return new Promise((resolve, reject) => {
+      // @ts-expect-error accessing private field
+      const socket = this._socket as WebSocket
+
+      socket.onerror = (event) => {
+        const error = "error" in event ? (event as any).error : new Error(`WebSocket error: ${JSON.stringify(event)}`)
+        reject(error)
+        this.onerror?.(error)
+      }
+
+      socket.onopen = () => resolve()
+      socket.onclose = () => this.onclose?.()
+      socket.onmessage = (event) => {
+        try {
+          this.onmessage?.(JSON.parse(event.data as string))
+        } catch (error) {
+          this.onerror?.(error as Error)
+        }
+      }
+    })
+  }
+
+  // No-op to match HTTP transport interface (WebSocket doesn't support OAuth)
+  async finishAuth(_authorizationCode: string): Promise<void> {}
+}


### PR DESCRIPTION
## Summary

Complete IDE integration for OpenCode, enabling live text selection from Cursor/VSCode/Windsurf with improved UX.

## Features

- **IDE Connection**: WebSocket-based connection to IDE extensions via lock files
- **Live Selection**: Real-time text selection from editor
- **Footer Display**: Shows IDE status and selection in footer (not cluttering input)
- **Synthetic Context**: Selection sent invisibly to model (doesn't pollute chat history)
- **Home Screen**: IDE/selection visible from launch, not just in sessions

## Changes

### Core IDE Integration
- `src/ide/index.ts` - IDE connection management, status, events
- `src/ide/connection.ts` - WebSocket client with JSON-RPC 2.0
- `src/mcp/ws.ts` - WebSocket transport for MCP

### UX Improvements  
- `local.tsx` - Selection state with `formatted()` helper showing line count
- `home.tsx` - IDE/selection display in home footer
- `footer.tsx` - Selection display in session footer
- `prompt/index.tsx` - Synthetic parts for invisible context

## Configuration

Add to `opencode.json`:
```json
{
  "ide": {
    "lockfile_dir": "~/.claude/ide/",
    "auth_header_name": "x-claude-code-ide-authorization"
  }
}
```

## Testing

1. Install the OpenCode extension in Cursor/VSCode
2. Launch OpenCode in terminal
3. Connect to IDE via `/status`
4. Select text in editor
5. Verify footer shows: `[] 6 lines`
6. Send message - selection content is included invisibly

## Related

Based on initial work from #5447, with additional UX improvements:
- Selection displayed in footer instead of input area
- Synthetic parts so selection doesn't clutter chat history
- Home screen shows IDE connection status