### PR TITLE
feat(install): add standard CLI flags (--help, --version, --no-modify-path)

### DIFF
--- a/install
+++ b/install
@@ -14,27 +14,37 @@ OpenCode Installer
 Usage: install.sh [options]
 
 Options:
-    -h, --help          Display this help message
-
-Environment variables:
-    VERSION             Install a specific version (e.g., VERSION=1.0.180)
+    -h, --help              Display this help message
+    -v, --version <version> Install a specific version (e.g., 1.0.180)
 
 Examples:
     curl -fsSL https://opencode.ai/install | bash
-    VERSION=1.0.180 curl -fsSL https://opencode.ai/install | bash
+    curl -fsSL https://opencode.ai/install | bash -s -- --version 1.0.180
 EOF
 }
 
-for arg in "$@"; do
-    case "$arg" in
+requested_version=${VERSION:-}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         -h|--help)
             usage
             exit 0
             ;;
+        -v|--version)
+            if [[ -n "${2:-}" ]]; then
+                requested_version="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --version requires a version argument${NC}"
+                exit 1
+            fi
+            ;;
+        *)
+            shift
+            ;;
     esac
 done
-
-requested_version=${VERSION:-}
 
 raw_os=$(uname -s)
 os=$(echo "$raw_os" | tr '[:upper:]' '[:lower:]')

--- a/install
+++ b/install
@@ -7,6 +7,33 @@ RED='\033[0;31m'
 ORANGE='\033[38;5;214m'
 NC='\033[0m' # No Color
 
+usage() {
+    cat <<EOF
+OpenCode Installer
+
+Usage: install.sh [options]
+
+Options:
+    -h, --help          Display this help message
+
+Environment variables:
+    VERSION             Install a specific version (e.g., VERSION=1.0.180)
+
+Examples:
+    curl -fsSL https://opencode.ai/install | bash
+    VERSION=1.0.180 curl -fsSL https://opencode.ai/install | bash
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
 requested_version=${VERSION:-}
 
 raw_os=$(uname -s)

--- a/install
+++ b/install
@@ -47,6 +47,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         *)
+            echo -e "${ORANGE}Warning: Unknown option '$1'${NC}" >&2
             shift
             ;;
     esac

--- a/install
+++ b/install
@@ -16,6 +16,7 @@ Usage: install.sh [options]
 Options:
     -h, --help              Display this help message
     -v, --version <version> Install a specific version (e.g., 1.0.180)
+        --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
 
 Examples:
     curl -fsSL https://opencode.ai/install | bash
@@ -24,6 +25,7 @@ EOF
 }
 
 requested_version=${VERSION:-}
+no_modify_path=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -39,6 +41,10 @@ while [[ $# -gt 0 ]]; do
                 echo -e "${RED}Error: --version requires a version argument${NC}"
                 exit 1
             fi
+            ;;
+        --no-modify-path)
+            no_modify_path=true
+            shift
             ;;
         *)
             shift
@@ -341,42 +347,42 @@ case $current_shell in
     ;;
 esac
 
-config_file=""
-for file in $config_files; do
-    if [[ -f $file ]]; then
-        config_file=$file
-        break
+if [[ "$no_modify_path" != "true" ]]; then
+    config_file=""
+    for file in $config_files; do
+        if [[ -f $file ]]; then
+            config_file=$file
+            break
+        fi
+    done
+
+    if [[ -z $config_file ]]; then
+        print_message warning "No config file found for $current_shell. You may need to manually add to PATH:"
+        print_message info "  export PATH=$INSTALL_DIR:\$PATH"
+    elif [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+        case $current_shell in
+            fish)
+                add_to_path "$config_file" "fish_add_path $INSTALL_DIR"
+            ;;
+            zsh)
+                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+            ;;
+            bash)
+                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+            ;;
+            ash)
+                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+            ;;
+            sh)
+                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+            ;;
+            *)
+                export PATH=$INSTALL_DIR:$PATH
+                print_message warning "Manually add the directory to $config_file (or similar):"
+                print_message info "  export PATH=$INSTALL_DIR:\$PATH"
+            ;;
+        esac
     fi
-done
-
-if [[ -z $config_file ]]; then
-    print_message error "No config file found for $current_shell. Checked files: ${config_files[@]}"
-    exit 1
-fi
-
-if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-    case $current_shell in
-        fish)
-            add_to_path "$config_file" "fish_add_path $INSTALL_DIR"
-        ;;
-        zsh)
-            add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-        ;;
-        bash)
-            add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-        ;;
-        ash)
-            add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-        ;;
-        sh)
-            add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-        ;;
-        *)
-            export PATH=$INSTALL_DIR:$PATH
-            print_message warning "Manually add the directory to $config_file (or similar):"
-            print_message info "  export PATH=$INSTALL_DIR:\$PATH"
-        ;;
-    esac
 fi
 
 if [ -n "${GITHUB_ACTIONS-}" ] && [ "${GITHUB_ACTIONS}" == "true" ]; then


### PR DESCRIPTION
## Summary

Adds standard CLI flags to the install script, following conventions from popular installers like Rustup, Homebrew, and Starship.

Closes #5884

## Changes

This PR contains 4 independent, cherry-pickable commits:

| Commit | Description |
|--------|-------------|
| 1 | `feat(install): add --help flag` |
| 2 | `feat(install): add --version flag` |
| 3 | `feat(install): add --no-modify-path flag` |
| 4 | `fix(install): warn on unknown arguments` |

## New Flags

| Flag | Description |
|------|-------------|
| `-h`, `--help` | Display usage information |
| `-v`, `--version <ver>` | Install a specific version (alternative to `VERSION` env var) |
| `--no-modify-path` | Don't modify shell config files (for NixOS, immutable distros, etc.) |

## Example Usage

```bash
curl -fsSL https://opencode.ai/install | bash -s -- --help
curl -fsSL https://opencode.ai/install | bash -s -- --version 1.0.180
curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path
```

## Additional Changes

- Unknown arguments now produce a warning instead of being silently ignored
- "No config file found" changed from error to warning, allowing install to succeed on systems with read-only configs