### PR TITLE
feat: add syntax highlighting for .ets files

### DIFF
--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -25,6 +25,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".ex": "elixir",
   ".exs": "elixir",
   ".erl": "erlang",
+  ".ets": "typescript",
   ".hrl": "erlang",
   ".fs": "fsharp",
   ".fsi": "fsharp",


### PR DESCRIPTION
Closes #5880 by mapping `.ets` file extension to `typescript` for syntax highlighting support
