### PR TITLE
fix(providers.opencode): check config for api key in addition to auth

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -67,6 +67,8 @@ export namespace Provider {
         const env = Env.all()
         if (input.env.some((item) => env[item])) return true
         if (await Auth.get(input.id)) return true
+        const config = await Config.get()
+        if (config.provider?.["opencode"]?.options?.apiKey) return true
         return false
       })()
 


### PR DESCRIPTION
Without this, you can't use `~/.config/opencode/opencode.json` to set the `opencode` API key without also having `.opencode.key` in `~/.local/share/opencode/auth.json` set to any string. Notably, this means you can't store your opencode zen api key in an environment variable without also exposing it (or some other string) in `auth.json`.

Note: although I tested this change and I understand what it does (it's two lines), this code _was_ written by an AI and I don't know typescript that well, so feel free to say if there's something I should do differently.