### PR TITLE
feat: add native X11 clipboard support for Linux

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -259,6 +259,7 @@
         "clipboardy": "4.0.0",
         "decimal.js": "10.5.0",
         "diff": "catalog:",
+        "ffi-napi": "^4.0.3",
         "fuzzysort": "3.1.0",
         "gray-matter": "4.0.3",
         "hono": "catalog:",
@@ -2387,6 +2388,8 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "ffi-napi": ["ffi-napi@4.0.3", "", { "dependencies": { "debug": "^4.1.1", "get-uv-event-loop-napi-h": "^1.0.5", "node-addon-api": "^3.0.0", "node-gyp-build": "^4.2.1", "ref-napi": "^2.0.1 || ^3.0.2", "ref-struct-di": "^1.1.0" } }, "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg=="],
+
     "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -2469,7 +2472,11 @@
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
+    "get-symbol-from-current-process-h": ["get-symbol-from-current-process-h@1.0.2", "", {}, "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="],
+
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
+
+    "get-uv-event-loop-napi-h": ["get-uv-event-loop-napi-h@1.0.6", "", { "dependencies": { "get-symbol-from-current-process-h": "^1.0.1" } }, "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg=="],
 
     "ghostty-web": ["ghostty-web@0.3.0", "", {}, "sha512-SAdSHWYF20GMZUB0n8kh1N6Z4ljMnuUqT8iTB2n5FAPswEV10MejEpLlhW/769GL5+BQa1NYwEg9y/XCckV5+A=="],
 
@@ -3324,6 +3331,10 @@
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
 
     "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
+    "ref-napi": ["ref-napi@3.0.3", "", { "dependencies": { "debug": "^4.1.1", "get-symbol-from-current-process-h": "^1.0.2", "node-addon-api": "^3.0.0", "node-gyp-build": "^4.2.1" } }, "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA=="],
+
+    "ref-struct-di": ["ref-struct-di@1.1.1", "", { "dependencies": { "debug": "^3.1.0" } }, "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -4243,6 +4254,8 @@
 
     "express/qs": ["qs@6.13.0", "", { "dependencies": { "side-channel": "^1.0.6" } }, "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg=="],
 
+    "ffi-napi/node-addon-api": ["node-addon-api@3.2.1", "", {}, "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="],
+
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -4334,6 +4347,10 @@
     "readable-stream/events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "readdir-glob/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
+
+    "ref-napi/node-addon-api": ["node-addon-api@3.2.1", "", {}, "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="],
+
+    "ref-struct-di/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -82,6 +82,7 @@
     "bun-pty": "0.4.2",
     "chokidar": "4.0.3",
     "clipboardy": "4.0.0",
+    "ffi-napi": "^4.0.3",
     "decimal.js": "10.5.0",
     "diff": "catalog:",
     "fuzzysort": "3.1.0",

--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -4,6 +4,7 @@ import clipboardy from "clipboardy"
 import { lazy } from "../../../../util/lazy.js"
 import { tmpdir } from "os"
 import path from "path"
+import { X11Clipboard } from "./x11-clipboard.js"
 
 export namespace Clipboard {
   export interface Content {
@@ -52,6 +53,13 @@ export namespace Clipboard {
       }
     }
 
+    if (os === "linux") {
+      const nativeText = await X11Clipboard.read()
+      if (nativeText) {
+        return { data: nativeText, mime: "text/plain" }
+      }
+    }
+
     const text = await clipboardy.read().catch(() => {})
     if (text) {
       return { data: text, mime: "text/plain" }
@@ -79,6 +87,16 @@ export namespace Clipboard {
           await proc.exited.catch(() => {})
         }
       }
+
+      console.log("clipboard: using native X11")
+      return async (text: string) => {
+        const success = await X11Clipboard.copy(text)
+        if (!success) {
+          console.log("X11 clipboard failed, falling back to clipboardy")
+          await clipboardy.write(text).catch(() => {})
+        }
+      }
+
       if (Bun.which("xclip")) {
         console.log("clipboard: using xclip")
         return async (text: string) => {

--- a/packages/opencode/src/cli/cmd/tui/util/x11-clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/x11-clipboard.ts
@@ -1,0 +1,148 @@
+import { lazy } from "./lazy.js"
+
+declare module "ffi-napi" {
+  export class Library {
+    constructor(path: string, functions: Record<string, any>)
+    [key: string]: any
+  }
+}
+
+export namespace X11Clipboard {
+  let libX11: any = null
+  let libXtst: any = null
+
+  const initializeX11 = lazy(() => {
+    try {
+      const ffi = require("ffi-napi")
+
+      libX11 = new ffi.Library("libX11", {
+        XOpenDisplay: ["pointer", ["string"]],
+        XCloseDisplay: ["int", ["pointer"]],
+        XDefaultRootWindow: ["ulong", ["pointer"]],
+        XGetSelectionOwner: ["ulong", ["pointer", "ulong"]],
+        XSetSelectionOwner: ["int", ["pointer", "ulong", "ulong", "uint"]],
+        XCreateSimpleWindow: ["ulong", ["pointer", "ulong", "int", "int", "uint", "uint", "uint", "ulong"]],
+        XSelectInput: ["int", ["pointer", "ulong", "long"]],
+        XNextEvent: ["int", ["pointer", "pointer"]],
+        XChangeProperty: ["int", ["pointer", "ulong", "ulong", "int", "int", "int", "pointer", "int"]],
+        XGetWindowProperty: [
+          "int",
+          ["pointer", "ulong", "ulong", "long", "int", "ulong", "int", "pointer", "pointer", "pointer", "pointer"],
+        ],
+        XDeleteProperty: ["int", ["pointer", "ulong", "ulong"]],
+        XConvertSelection: ["int", ["pointer", "ulong", "ulong", "ulong", "ulong", "uint"]],
+        XFlush: ["int", ["pointer"]],
+        XInternAtom: ["ulong", ["pointer", "string", "int"]],
+      })
+
+      libXtst = new ffi.Library("libXtst", {
+        XTestFakeKeyEvent: ["void", ["pointer", "uint", "int", "ulong"]],
+      })
+
+      return true
+    } catch (error) {
+      console.log("X11 FFI initialization failed:", error)
+      return false
+    }
+  })
+
+  const getDisplay = lazy(() => {
+    if (!initializeX11()) return null
+    return libX11.XOpenDisplay(null)
+  })
+
+  export async function copy(text: string): Promise<boolean> {
+    try {
+      const display = getDisplay()
+      if (!display) return false
+
+      const clipboardAtom = libX11.XInternAtom(display, "CLIPBOARD", 0)
+      const utf8Atom = libX11.XInternAtom(display, "UTF8_STRING", 0)
+      const textAtom = libX11.XInternAtom(display, "TEXT", 0)
+      const targetsAtom = libX11.XInternAtom(display, "TARGETS", 0)
+
+      const window = libX11.XCreateSimpleWindow(display, libX11.XDefaultRootWindow(display), 0, 0, 1, 1, 0, 0, 0)
+
+      libX11.XSetSelectionOwner(display, clipboardAtom, window, 0)
+      libX11.XFlush(display)
+
+      const buffer = Buffer.from(text, "utf8")
+      libX11.XChangeProperty(display, window, clipboardAtom, utf8Atom, 8, 0, buffer, buffer.length)
+      libX11.XFlush(display)
+
+      return true
+    } catch (error) {
+      console.log("X11 copy failed:", error)
+      return false
+    }
+  }
+
+  export async function read(): Promise<string | null> {
+    try {
+      const display = getDisplay()
+      if (!display) return null
+
+      const clipboardAtom = libX11.XInternAtom(display, "CLIPBOARD", 0)
+      const utf8Atom = libX11.XInternAtom(display, "UTF8_STRING", 0)
+      const textAtom = libX11.XInternAtom(display, "TEXT", 0)
+
+      const window = libX11.XCreateSimpleWindow(display, libX11.XDefaultRootWindow(display), 0, 0, 1, 1, 0, 0, 0)
+
+      const owner = libX11.XGetSelectionOwner(display, clipboardAtom)
+      if (owner === 0) return null
+
+      libX11.XConvertSelection(display, clipboardAtom, utf8Atom, clipboardAtom, window, 0)
+      libX11.XFlush(display)
+
+      const ref = Buffer.alloc(8)
+      const actualType = Buffer.alloc(8)
+      const actualFormat = Buffer.alloc(4)
+      const nitems = Buffer.alloc(8)
+      const bytesAfter = Buffer.alloc(8)
+
+      const result = libX11.XGetWindowProperty(
+        display,
+        window,
+        clipboardAtom,
+        0,
+        0,
+        0,
+        0,
+        0,
+        ref,
+        actualType,
+        actualFormat,
+        nitems,
+        bytesAfter,
+      )
+
+      if (result === 0) {
+        const length = nitems.readUInt32LE(0)
+        if (length > 0) {
+          const data = Buffer.alloc(length)
+          libX11.XGetWindowProperty(
+            display,
+            window,
+            clipboardAtom,
+            0,
+            length,
+            0,
+            0,
+            0,
+            ref,
+            actualType,
+            actualFormat,
+            nitems,
+            bytesAfter,
+          )
+          return data.toString("utf8")
+        }
+      }
+
+      return null
+    } catch (error) {
+      console.log("X11 read failed:", error)
+      return null
+    }
+  }
+}


### PR DESCRIPTION
- Add ffi-napi dependency for native X11 integration
- Implement X11Clipboard class for direct X11 clipboard access
- Update clipboard utility to use native X11 on Linux with fallback
- Add x11-clipboard.ts with native copy/read functionality

#5640 