### PR TITLE
fix: Perform snapshot in cases finish-step is not reached

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -365,6 +365,20 @@ export namespace SessionProcessor {
               error: input.assistantMessage.error,
             })
           }
+          if (snapshot) {
+            const patch = await Snapshot.patch(snapshot)
+            if (patch.files.length) {
+              await Session.updatePart({
+                id: Identifier.ascending("part"),
+                messageID: input.assistantMessage.id,
+                sessionID: input.sessionID,
+                type: "patch",
+                hash: patch.hash,
+                files: patch.files,
+              })
+            }
+            snapshot = undefined
+          }
           const p = await MessageV2.parts(input.assistantMessage.id)
           for (const part of p) {
             if (part.type === "tool" && part.state.status !== "completed" && part.state.status !== "error") {


### PR DESCRIPTION
Fix for https://github.com/sst/opencode/issues/5911

When snapshots are enabled, we may have untracked files when a snapshot is set at start-step, but finish-step is never reached - for example due to a user cancellation. 

This PR adds an explicit patch and updatePart at the end of the process method, if snapshot is still not undefined.

Tested against the script in https://github.com/sst/opencode/issues/5911