### PR TITLE
fix: update execArgv configuration in build script to futher disable toml

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -135,7 +135,11 @@ for (const item of targets) {
       autoloadPackageJson: true,
       target: name.replace(pkg.name, "bun") as any,
       outfile: `dist/${name}/bin/opencode`,
-      execArgv: [`--user-agent=opencode/${Script.version}`, "--"],
+      execArgv: [
+        `--user-agent=opencode/${Script.version}`,
+        `--config=${item.os === "win32" ? "NUL" : "/dev/null"}`,
+        "--",
+      ],
       windows: {},
     },
     entrypoints: ["./src/index.ts", parserWorker, workerPath],


### PR DESCRIPTION
Not a real complete fix, as it still doesnt answer why the toml is loaded even when compiled to disable it.

But adding a null config path to the execArgs works

https://bun.com/docs/runtime#param-config

Potential fix to #5349