### PR TITLE
prompts: improve built-in /review prompt

### DIFF
--- a/packages/opencode/src/command/template/review.txt
+++ b/packages/opencode/src/command/template/review.txt
@@ -45,7 +45,7 @@ Use best judgement when processing input.
 - If-else guards: missing guards, incorrect branching, unreachable code paths
 - Edge cases: null/empty/undefined inputs, error conditions, race conditions
 - Security issues: injection, auth bypass, data exposure
-- Broken error handling that swallows failures or throws unexpectedly
+- Broken error handling that swallows failures, throws unexpectedly or returns error types that are not caught.
 
 **Structure** - Does the code fit the codebase?
 - Does it follow existing patterns and conventions?
@@ -91,7 +91,7 @@ If you're uncertain about something and can't verify it with these tools, say "I
 
 1. If there is a bug, be direct and clear about why it is a bug.
 2. Clearly communicate severity of issues. Do not overstate severity.
-3. Critiques should explicitly state the scenarios, environments, or inputs where the bug arises. Indicate when severity depends on these factors.
-4. Frame suggestions as suggestions. The human reviewer decides what to act on.
+3. Critiques should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
+4. Your tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
 5. Write so the reader can quickly understand the issue without reading too closely.
-6. Avoid flattery. No "Great job...", "Thanks for...", or other filler.
+6. AVOID flattery, do not give any comments that are not helpful to the reader. Avoid phrasing like "Great job ...", "Thanks for ...".

--- a/packages/opencode/src/command/template/review.txt
+++ b/packages/opencode/src/command/template/review.txt
@@ -28,30 +28,52 @@ Use best judgement when processing input.
 
 ---
 
+## Gathering Context
+
+**Diffs alone are not enough.** After getting the diff, read the entire file(s) being modified to understand the full context. Code that looks wrong in isolation may be correct given surrounding logic—and vice versa.
+
+- Use the diff to identify which files changed
+- Read the full file to understand existing patterns, control flow, and error handling
+- Check for existing style guide or conventions files (CONVENTIONS.md, AGENTS.md, .editorconfig, etc.)
+
+---
+
 ## What to Look For
 
 **Bugs** - Your primary focus.
 - Logic errors, off-by-one mistakes, incorrect conditionals
-- Edge cases: null/empty inputs, error conditions, race conditions
+- If-else guards: missing guards, incorrect branching, unreachable code paths
+- Edge cases: null/empty/undefined inputs, error conditions, race conditions
 - Security issues: injection, auth bypass, data exposure
-- Broken error handling that swallows failures
+- Broken error handling that swallows failures or throws unexpectedly
 
 **Structure** - Does the code fit the codebase?
 - Does it follow existing patterns and conventions?
 - Are there established abstractions it should use but doesn't?
+- Excessive nesting that could be flattened with early returns or extraction
 
 **Performance** - Only flag if obviously problematic.
 - O(n²) on unbounded data, N+1 queries, blocking I/O on hot paths
 
+---
+
 ## Before You Flag Something
 
-Be certain. If you're going to call something a bug, you need to be confident it actually is one.
+**Be certain.** If you're going to call something a bug, you need to be confident it actually is one.
 
 - Only review the changes - do not review pre-existing code that wasn't modified
 - Don't flag something as a bug if you're unsure - investigate first
-- Don't flag style preferences as issues
 - Don't invent hypothetical problems - if an edge case matters, explain the realistic scenario where it breaks
 - If you need more context to be sure, use the tools below to get it
+
+**Don't be a zealot about style.** When checking code against conventions:
+
+- Verify the code is *actually* in violation. Don't complain about else statements if early returns are already being used correctly.
+- Some "violations" are acceptable when they're the simplest option. A `let` statement is fine if the alternative is convoluted.
+- Excessive nesting is a legitimate concern regardless of other style choices.
+- Don't flag style preferences as issues unless they clearly violate established project conventions.
+
+---
 
 ## Tools
 
@@ -63,11 +85,13 @@ Use these to inform your review:
 
 If you're uncertain about something and can't verify it with these tools, say "I'm not sure about X" rather than flagging it as a definite issue.
 
-## Tone and Approach
+---
+
+## Output
 
 1. If there is a bug, be direct and clear about why it is a bug.
-2. You should clearly communicate severity of issues, do not claim issues are more severe than they actually are.
-3. Critiques should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
-4. Your tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
-5. Write in a manner that allows reader to quickly understand issue without reading too closely.
-6. AVOID flattery, do not give any comments that are not helpful to the reader. Avoid phrasing like "Great job ...", "Thanks for ...".
+2. Clearly communicate severity of issues. Do not overstate severity.
+3. Critiques should explicitly state the scenarios, environments, or inputs where the bug arises. Indicate when severity depends on these factors.
+4. Frame suggestions as suggestions. The human reviewer decides what to act on.
+5. Write so the reader can quickly understand the issue without reading too closely.
+6. Avoid flattery. No "Great job...", "Thanks for...", or other filler.


### PR DESCRIPTION
This PR pulls in elements of the `review.yml` prompt into the `/review` command shipped to all OpenCode users.

why:

* I've found the built-in `/review` command to be good, but seems to miss things that this repo's own `/review` workflow (https://github.com/sst/opencode/blob/dev/.github/workflows/review.yml#L64-L71) catches when @rekram1-node tells me my code sucks.
* As with all prompts + no evals, this is somewhat anecdotal, but I've seen good results from just copying in the `review.yml` prompt myself.
* I used OpenCode to combine them with the below prompt + response + and a manual review to pull back some of its brevity.

This is not intended to be a huge change.


### my prompt

```
the sst/opencode repo has two "review" type prompts:

- the built in `/review` command - this prompt: https://github.com/sst/opencode/blob/3456f4ed8053f7718865d2d03dc261e983fed9aa/packages/opencode/src/command/template/review.txt - feeds the command: https://github.com/sst/opencode/blob/3456f4ed8053f7718865d2d03dc261e983fed9aa/packages/opencode/src/command/index.ts#L51-L56
- the `review.yml` workflow that invokes opencode via a GitHub Action: https://github.com/sst/opencode/blob/dev/.github/workflows/review.yml#L64-L71

the latter seems to be shorter but more robust, catching more issues in a code review flow based on observed experience (anecdotal over several PRs). specifically, it does a better job of catching:

- if-else guards around branching control flow
- empty/null/undefined arguments leading to exceptions or unintended behavior
- following existing instructions and style guide conventions.

can you analyze both prompts and provide an updated, single review prompt that we can use for the review.txt template. the workflow one should be inspiration to improve this template.
```

### rationale / response

```
## Summary of Changes

I've updated `review.txt` incorporating insights from the `review.yml` workflow. Here's what changed and why:

### Added: "Gathering Context" section
The workflow prompt explicitly states: *"Diffs are important but make sure you read the entire file to get proper context."* This is critical for catching bugs that only manifest when you understand surrounding code. The original template only looked at diffs.

### Added: If-else guards and branching to the Bugs checklist
Your feedback noted the workflow catches *"if-else guards around branching control flow"* better. I made this explicit under the Bugs section.

### Added: "Don't be a zealot about style" guidance
The workflow has pragmatic advice like:
- *"don't complain about else statements if they already use early returns"*
- *"we don't like let statements but sometimes they are the simplest option"*

This prevents false positives on style issues. The original template had no such nuance.

### Added: Excessive nesting as a legitimate concern
The workflow says *"You may complain about excessive nesting though, regardless of else statement usage"*—this is a real code quality issue worth flagging even when other style rules are bent.

### Added: "Frame suggestions as suggestions"
The workflow states *"Make it clear the suggestions are merely suggestions and the human can decide what to do."* This sets the right tone for reviewer/author collaboration.

### Restructured: Tone section → Output section
Renamed and tightened the guidance. Kept the key points (be direct, accurate severity, matter-of-fact tone, no flattery) but integrated the "suggestions are suggestions" framing.

### Not incorporated:
- The workflow's specific GitHub API comment syntax—that's workflow-specific, not relevant to the general review template
- IIFE pattern mention—too specific to one codebase's conventions
```