### PR TITLE
fix: update sidebar context size after /compact

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -171,6 +171,21 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           break
         }
 
+        case "session.compacted": {
+          sdk.client.session.messages({ sessionID: event.properties.sessionID, limit: 100 }).then((res) => {
+            if (!res.data) return
+            setStore(
+              produce((draft) => {
+                draft.message[event.properties.sessionID] = res.data!.map((x) => x.info)
+                for (const message of res.data!) {
+                  draft.part[message.info.id] = message.parts
+                }
+              }),
+            )
+          })
+          break
+        }
+
         case "message.updated": {
           const messages = store.message[event.properties.info.sessionID]
           if (!messages) {


### PR DESCRIPTION
## Summary

- Re-fetches session messages when `session.compacted` event is received, ensuring sidebar context size reflects post-compaction state

## Root Cause

The TUI's `sync.tsx` event handler was missing a case for `session.compacted` event. After `/compact` completed, the new compaction message (with reduced token count) wasn't being fetched, leaving the sidebar showing stale pre-compaction context size.

## Fix

Added a handler for `session.compacted` that calls `sdk.client.session.messages()` to refresh the message list, which the sidebar uses to calculate context size.

Closes #5760

---

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)