### PR TITLE
feat(server): expose auto param in session.summarize for plugins

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1054,6 +1054,7 @@ export namespace Server {
           z.object({
             providerID: z.string(),
             modelID: z.string(),
+            auto: z.boolean().optional().default(false),
           }),
         ),
         async (c) => {
@@ -1075,7 +1076,7 @@ export namespace Server {
               providerID: body.providerID,
               modelID: body.modelID,
             },
-            auto: false,
+            auto: body.auto,
           })
           await SessionPrompt.loop(sessionID)
           return c.json(true)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1132,6 +1132,7 @@ export class Session extends HeyApiClient {
       directory?: string
       providerID?: string
       modelID?: string
+      auto?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1144,6 +1145,7 @@ export class Session extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "body", key: "providerID" },
             { in: "body", key: "modelID" },
+            { in: "body", key: "auto" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2750,6 +2750,7 @@ export type SessionSummarizeData = {
   body?: {
     providerID: string
     modelID: string
+    auto?: boolean
   }
   path: {
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1804,6 +1804,10 @@
                   },
                   "modelID": {
                     "type": "string"
+                  },
+                  "auto": {
+                    "default": false,
+                    "type": "boolean"
                   }
                 },
                 "required": ["providerID", "modelID"]


### PR DESCRIPTION
## Summary

- Exposes `auto` parameter in `/session/:sessionID/summarize` API endpoint, allowing plugins to trigger auto-continuation after compaction

## Motivation

Previously, the `auto` parameter was hardcoded to `false` in the summarize endpoint. Plugins calling `client.session.summarize()` couldn't enable auto-continuation behavior after compaction.

With this change, plugins can now call:
```typescript
await client.session.summarize({
  sessionID,
  providerID,
  modelID,
  auto: true  // enables "Continue if you have next steps" after compaction
})
```

## Changes

- Added `auto: z.boolean().optional().default(false)` to request schema
- Changed `auto: false` to `auto: body.auto` in `SessionCompaction.create()` call

---

🤖 GENERATED WITH ASSISTANCE OF [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)