### PR TITLE
feat(desktop): arm64 build for linux

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,8 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: blacksmith-4vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
+          - host: blacksmith-4vcpu-ubuntu-2404-arm
+            target: aarch64-unknown-linux-gnu
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3

--- a/packages/tauri/scripts/utils.ts
+++ b/packages/tauri/scripts/utils.ts
@@ -21,6 +21,11 @@ export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; ass
     ocBinary: "opencode-linux-x64",
     assetExt: "tar.gz",
   },
+  {
+    rustTarget: "aarch64-unknown-linux-gnu",
+    ocBinary: "opencode-linux-arm64",
+    assetExt: "tar.gz",
+  },
 ]
 
 export const RUST_TARGET = Bun.env.RUST_TARGET


### PR DESCRIPTION
This PR adds ARM64 architecture support to the publish workflow for OpenCode Desktop.

Resolves #5851.