### PR TITLE
feat: add markdown table formatting in TUI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -266,6 +266,7 @@
         "hono-openapi": "catalog:",
         "ignore": "7.0.5",
         "jsonc-parser": "3.3.1",
+        "marked": "16.2.0",
         "minimatch": "10.0.3",
         "open": "10.1.2",
         "opentui-spinner": "0.0.6",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -90,6 +90,7 @@
     "hono-openapi": "catalog:",
     "ignore": "7.0.5",
     "jsonc-parser": "3.3.1",
+    "marked": "16.2.0",
     "minimatch": "10.0.3",
     "open": "10.1.2",
     "opentui-spinner": "0.0.6",

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -28,6 +28,7 @@ import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
 import { Locale } from "@/util/locale"
+import { formatMarkdownTables } from "@tui/util/markdown-table"
 import type { Tool } from "@/tool/tool"
 import type { ReadTool } from "@/tool/read"
 import type { WriteTool } from "@/tool/write"
@@ -1256,6 +1257,12 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+
+  const formattedContent = createMemo(() => {
+    const text = props.part.text.trim()
+    return formatMarkdownTables(text)
+  })
+
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1264,7 +1271,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           drawUnstyledText={false}
           streaming={true}
           syntaxStyle={syntax()}
-          content={props.part.text.trim()}
+          content={formattedContent()}
           conceal={ctx.conceal()}
           fg={theme.text}
         />

--- a/packages/opencode/src/cli/cmd/tui/util/markdown-table.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/markdown-table.ts
@@ -1,0 +1,96 @@
+import { marked } from "marked"
+
+interface TableToken {
+  type: "table"
+  header: Array<{ text: string }>
+  rows: Array<Array<{ text: string }>>
+  raw: string
+}
+
+export function formatMarkdownTables(markdown: string): string {
+  // Quick heuristic: tables must have pipes and a separator row like |---|
+  // Skip expensive parsing if no table-like patterns exist
+  if (!markdown.includes("|") || !/\|[\s-:]+\|/.test(markdown)) {
+    return markdown
+  }
+
+  const tokens = marked.lexer(markdown)
+
+  // Collect all table tokens with their positions
+  const tables: Array<{ token: TableToken; start: number; end: number }> = []
+  let searchStart = 0
+
+  for (const token of tokens) {
+    if (token.type === "table" && "header" in token && "rows" in token) {
+      const start = markdown.indexOf(token.raw, searchStart)
+      if (start !== -1) {
+        tables.push({
+          token: token as TableToken,
+          start,
+          end: start + token.raw.length,
+        })
+        searchStart = start + token.raw.length
+      }
+    }
+  }
+
+  // Process tables in reverse order so replacements don't affect earlier positions
+  let result = markdown
+  for (let i = tables.length - 1; i >= 0; i--) {
+    const { token, start, end } = tables[i]
+    const formattedTable = renderTerminalTable(token)
+    result = result.substring(0, start) + formattedTable + result.substring(end)
+  }
+
+  return result
+}
+
+function renderTerminalTable(token: TableToken): string {
+  const headers = token.header.map((cell) => stripMarkdown(cell.text))
+  const rows = token.rows.map((row) => row.map((cell) => stripMarkdown(cell.text)))
+
+  const colWidths: number[] = headers.map((h) => h.length)
+  rows.forEach((row) => {
+    row.forEach((cell, i) => {
+      colWidths[i] = Math.max(colWidths[i] || 0, cell.length)
+    })
+  })
+
+  const lines: string[] = []
+
+  lines.push("┌" + colWidths.map((w) => "─".repeat(w + 2)).join("┬") + "┐")
+
+  lines.push(
+    "│ " +
+      headers.map((h, i) => h.padEnd(colWidths[i])).join(" │ ") +
+      " │",
+  )
+
+  lines.push("├" + colWidths.map((w) => "─".repeat(w + 2)).join("┼") + "┤")
+
+  rows.forEach((row) => {
+    lines.push(
+      "│ " +
+        row.map((cell, i) => cell.padEnd(colWidths[i])).join(" │ ") +
+        " │",
+    )
+  })
+
+  lines.push("└" + colWidths.map((w) => "─".repeat(w + 2)).join("┴") + "┘")
+
+  return "\n" + lines.join("\n") + "\n"
+}
+
+function stripMarkdown(text: string): string {
+  return (
+    text
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .replace(/\*\*([^*]+)\*\*/g, "$1")
+      .replace(/__([^_]+)__/g, "$1")
+      .replace(/\*([^*]+)\*/g, "$1")
+      .replace(/_([^_]+)_/g, "$1")
+      .replace(/`([^`]+)`/g, "$1")
+      .replace(/~~([^~]+)~~/g, "$1")
+      .trim()
+  )
+}


### PR DESCRIPTION
### Summary
  - Created `markdown-table.ts` util to parse and format tables
  - Added `marked` dependency for markdown parsing in root repo (not sure about this decision as I've seen marked in used in both desktop and web version but not in TUI)
 - I believe there are multiple ways to properly render tables see below
 
 ### Purpose 
 Other markdown formats are properly rendered in TUI but tables are rendered in raw markdown format 
 I am not sure if this should be done in opentui core package or not but I have thought of doing it within this repo only 

```
opencode --version
1.0.185
```
### Sceenshots
Before 
<img width="1470" height="814" alt="image" src="https://github.com/user-attachments/assets/b11dfa36-2099-4567-9815-6c3138abb627" />
<img width="1470" height="761" alt="image" src="https://github.com/user-attachments/assets/5530d560-0d18-44fa-bb2a-cfcda350ed62" />

After 
<img width="1470" height="820" alt="image" src="https://github.com/user-attachments/assets/b4bd8893-1155-43b7-a1c5-16bfef9f3d61" />
<img width="1470" height="761" alt="image" src="https://github.com/user-attachments/assets/8ed0ce92-a917-4233-987a-0a1f7cea06cf" />
 
 
