### PR TITLE
fix: duplicate words in dialog options

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -54,7 +54,7 @@ export function DialogMessage(props: {
         {
           title: "Copy",
           value: "message.copy",
-          description: "copy message text to clipboard",
+          description: "message text to clipboard",
           onSelect: async (dialog) => {
             const msg = message()
             if (!msg) return

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-subagent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-subagent.tsx
@@ -11,7 +11,7 @@ export function DialogSubagent(props: { sessionID: string }) {
         {
           title: "Open",
           value: "subagent.view",
-          description: "open the subagent's session",
+          description: "the subagent's session",
           onSelect: (dialog) => {
             route.navigate({
               type: "session",


### PR DESCRIPTION
Fixes double words in the `message actions` (Copy copy) & `subagent actions` (Open open) dialogs.

<img width="652" height="180" alt="image" src="https://github.com/user-attachments/assets/e16c7480-7cef-4278-8a8d-491ff32f3728" />

<img width="660" height="237" alt="image" src="https://github.com/user-attachments/assets/f9c435cf-0014-472f-a352-5c9a74c46a72" />
