### PR TITLE
fix: use current page port instead of hardcoded 4096

### DIFF
--- a/packages/desktop/src/app.tsx
+++ b/packages/desktop/src/app.tsx
@@ -29,13 +29,15 @@ declare global {
 }
 
 const host = import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "127.0.0.1"
-const port = window.__OPENCODE__?.port ?? import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"
+const port = window.__OPENCODE__?.port ?? import.meta.env.VITE_OPENCODE_SERVER_PORT ?? location.port ?? "4096"
 
 const url =
   new URLSearchParams(document.location.search).get("url") ||
-  (location.hostname.includes("opencode.ai") || location.hostname.includes("localhost")
+  (location.hostname.includes("opencode.ai")
     ? `http://${host}:${port}`
-    : "/")
+    : location.hostname.includes("localhost") || location.hostname === "127.0.0.1"
+      ? `${location.protocol}//${location.host}`
+      : "/")
 
 export function App() {
   return (


### PR DESCRIPTION
## Summary
- Uses `location.host` for localhost/127.0.0.1 to preserve actual server port
- Allows `opencode --port=8080` to work correctly with web interface

Fixes #5928