### PR TITLE
chore: update AGENTS.md to ~150 lines

### DIFF
--- a/packages/opencode/src/command/template/initialize.txt
+++ b/packages/opencode/src/command/template/initialize.txt
@@ -2,7 +2,7 @@ Please analyze this codebase and create an AGENTS.md file containing:
 1. Build/lint/test commands - especially for running a single test
 2. Code style guidelines including imports, formatting, types, naming conventions, error handling, etc.
 
-The file you create will be given to agentic coding agents (such as yourself) that operate in this repository. Make it about 20 lines long.
+The file you create will be given to agentic coding agents (such as yourself) that operate in this repository. Make it about 150 lines long.
 If there are Cursor rules (in .cursor/rules/ or .cursorrules) or Copilot rules (in .github/copilot-instructions.md), make sure to include them.
 
 If there's already an AGENTS.md, improve it if it's located in ${path}


### PR DESCRIPTION
Typically 20 lines is too less for an AI agent to have enough context. 100 or 150 lines is closer to what coding agents like Claude Code generate. Updating the initialization prompt to adapt to this standard.