### PR TITLE
fix: support non-Latin keyboard layouts (e.g., Korean IME) for keybindings

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -707,7 +707,7 @@ function ErrorComponent(props: {
   }
 
   useKeyboard((evt) => {
-    if (evt.ctrl && evt.name === "c") {
+    if (evt.ctrl && (evt.name === "c" || evt.baseCode === 99)) {
       handleExit()
     }
   })

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -23,7 +23,7 @@ export namespace Keybind {
    */
   export function fromParsedKey(key: ParsedKey, leader = false): Info {
     return {
-      name: key.name,
+      name: key.baseCode ? String.fromCharCode(key.baseCode) : key.name,
       ctrl: key.ctrl,
       meta: key.meta,
       shift: key.shift,


### PR DESCRIPTION
## Summary

- Fix keybindings not working when using non-Latin keyboard layouts (e.g., Korean, Japanese, Chinese IME)

## Problem

When Kitty keyboard protocol is enabled, pressing `Ctrl+C` with Korean IME active sends:
- `\x1b[12618::99;5u` (codepoint=12618 which is 'ㅊ', baseCode=99 which is 'c')

The keybind system was only checking `name` ('ㅊ') and ignoring `baseCode` ('c'), causing keybindings to fail.

## Solution

Use `baseCode` (base layout codepoint) when available in keybind matching. This correctly identifies the physical key regardless of the active keyboard layout.

### Changes

1. **`keybind.ts`**: Use `baseCode` when available for key name resolution
2. **`app.tsx`**: Add `baseCode` check in `ErrorComponent` (renders outside `KeybindProvider`, so needs explicit handling)

## Future Improvement

After [opentui#426](https://github.com/sst/opentui/pull/426) is released, upgrading the `@opentui/core` dependency will provide this fix at the parser level, making the `app.tsx` change unnecessary.

**Related**: https://github.com/sst/opentui/commit/4a8442193e972c7649a195fad5578b511916e5c9