### PR TITLE
feat(config): deduplicate plugins by name with priority-based resolution

### DIFF
--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, mock, afterEach } from "bun:test"
+import { test, expect, describe, mock } from "bun:test"
 import { Config } from "../../src/config/config"
 import { Instance } from "../../src/project/instance"
 import { Auth } from "../../src/auth"
@@ -1144,4 +1144,92 @@ test("project config overrides remote well-known config", async () => {
     globalThis.fetch = originalFetch
     Auth.all = originalAuthAll
   }
+})
+
+describe("getPluginName", () => {
+  test("extracts name from file:// URL", () => {
+    expect(Config.getPluginName("file:///path/to/plugin/foo.js")).toBe("foo")
+    expect(Config.getPluginName("file:///path/to/plugin/bar.ts")).toBe("bar")
+    expect(Config.getPluginName("file:///some/path/my-plugin.js")).toBe("my-plugin")
+  })
+
+  test("extracts name from npm package with version", () => {
+    expect(Config.getPluginName("oh-my-opencode@2.4.3")).toBe("oh-my-opencode")
+    expect(Config.getPluginName("some-plugin@1.0.0")).toBe("some-plugin")
+    expect(Config.getPluginName("plugin@latest")).toBe("plugin")
+  })
+
+  test("extracts name from scoped npm package", () => {
+    expect(Config.getPluginName("@scope/pkg@1.0.0")).toBe("@scope/pkg")
+    expect(Config.getPluginName("@opencode/plugin@2.0.0")).toBe("@opencode/plugin")
+  })
+
+  test("returns full string for package without version", () => {
+    expect(Config.getPluginName("some-plugin")).toBe("some-plugin")
+    expect(Config.getPluginName("@scope/pkg")).toBe("@scope/pkg")
+  })
+})
+
+describe("deduplicatePlugins", () => {
+  test("removes duplicates keeping higher priority (later entries)", () => {
+    const plugins = ["global-plugin@1.0.0", "shared-plugin@1.0.0", "local-plugin@2.0.0", "shared-plugin@2.0.0"]
+
+    const result = Config.deduplicatePlugins(plugins)
+
+    expect(result).toContain("global-plugin@1.0.0")
+    expect(result).toContain("local-plugin@2.0.0")
+    expect(result).toContain("shared-plugin@2.0.0")
+    expect(result).not.toContain("shared-plugin@1.0.0")
+    expect(result.length).toBe(3)
+  })
+
+  test("prefers local file over npm package with same name", () => {
+    const plugins = ["oh-my-opencode@2.4.3", "file:///project/.opencode/plugin/oh-my-opencode.js"]
+
+    const result = Config.deduplicatePlugins(plugins)
+
+    expect(result.length).toBe(1)
+    expect(result[0]).toBe("file:///project/.opencode/plugin/oh-my-opencode.js")
+  })
+
+  test("preserves order of remaining plugins", () => {
+    const plugins = ["a-plugin@1.0.0", "b-plugin@1.0.0", "c-plugin@1.0.0"]
+
+    const result = Config.deduplicatePlugins(plugins)
+
+    expect(result).toEqual(["a-plugin@1.0.0", "b-plugin@1.0.0", "c-plugin@1.0.0"])
+  })
+
+  test("local plugin directory overrides global opencode.json plugin", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const projectDir = path.join(dir, "project")
+        const opencodeDir = path.join(projectDir, ".opencode")
+        const pluginDir = path.join(opencodeDir, "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            plugin: ["my-plugin@1.0.0"],
+          }),
+        )
+
+        await Bun.write(path.join(pluginDir, "my-plugin.js"), "export default {}")
+      },
+    })
+
+    await Instance.provide({
+      directory: path.join(tmp.path, "project"),
+      fn: async () => {
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+
+        const myPlugins = plugins.filter((p) => Config.getPluginName(p) === "my-plugin")
+        expect(myPlugins.length).toBe(1)
+        expect(myPlugins[0].startsWith("file://")).toBe(true)
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Deduplicate plugins by name so that when the same plugin is loaded from multiple sources, only the highest priority one is used
- Closes https://github.com/anomalyco/opencode/issues/7427

## Problem
Previously, if the same plugin existed in both `opencode.json` and `.opencode/plugin/` directory, both would be loaded.
- Example: `oh-my-opencode@2.4.3` (npm) + `oh-my-opencode.js` (local) → both executed

## Solution
- `getPluginName`: Extract canonical name from plugin specifier (supports file:// URLs, npm packages, scoped packages)
- `deduplicatePlugins`: Deduplicate by name, later entries (higher priority) win

## Priority (highest to lowest)
1. Local `plugin/` directory
2. Local `opencode.json`
3. Global `plugin/` directory
4. Global `opencode.json`

## Tests
- Unit tests for `getPluginName` (file URLs, npm packages, scoped packages)
- Unit tests for `deduplicatePlugins` (priority resolution, order preservation)
- Integration test for local plugin overriding global config