### PR TITLE
fix: use location.host for web browsers without breaking Tauri

### DIFF
--- a/packages/desktop/src/app.tsx
+++ b/packages/desktop/src/app.tsx
@@ -38,6 +38,9 @@ const url = iife(() => {
   if (import.meta.env.VITE_OPENCODE_SERVER)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
+  if (location.hostname === "localhost" || location.hostname === "127.0.0.1")
+    return `${location.protocol}//${location.host}`
+
   return "/"
 })
 


### PR DESCRIPTION
## Summary
- Fixes issue #5928 where `opencode --port=8080` fails due to hardcoded port 4096
- Addresses the revert of PR #5949 which broke Tauri desktop app
- Adds localhost/127.0.0.1 detection as a fallback before "/" 
- Uses `location.host` to dynamically get the correct port for web browsers

## Changes
This implementation carefully preserves the execution order to avoid breaking Tauri:

1. **Preserved Tauri priority**: `window.__OPENCODE__` check remains in its original position
2. **Added web browser fallback**: New localhost/127.0.0.1 check before the "/" fallback
3. **Dynamic port detection**: Uses `location.host` which includes both hostname and port

## Why This Works

### Three Runtime Environments:

| Environment | `window.__OPENCODE__` | `location.host` | Result |
|-------------|----------------------|-----------------|--------|
| **Tauri Desktop** | ✅ Exists | `tauri://localhost` | Uses `http://127.0.0.1:${port}` (line 37) |
| **Web Browser (localhost)** | ❌ Not exists | `localhost:8080` | Uses `http://localhost:8080` (line 41-42) |
| **Production (opencode.ai)** | ❌ Not exists | `opencode.ai` | Uses `http://localhost:4096` (line 36) |

### Why Previous Fix Failed:
The previous PR #5949 changed the condition order, causing Tauri apps (which run on localhost) to use `location.host` instead of `window.__OPENCODE__.port`, breaking desktop functionality.

### Why This Fix Works:
- Tauri check happens **before** localhost check (line 37 vs line 41)
- Web browsers don't have `window.__OPENCODE__`, so they skip to localhost check
- Tauri apps have `window.__OPENCODE__`, so they never reach localhost check

## Testing
- ✅ Type checking passed
- ✅ Build completed successfully
- Ready for manual testing with `opencode --port=8080`

Fixes #5928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>