### PR TITLE
[POC] Github integration as normal run / command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -28,6 +28,7 @@ export namespace Command {
       model: z.string().optional(),
       template: z.string(),
       subtask: z.boolean().optional(),
+      tools: z.record(z.string(), z.boolean()).optional(),
     })
     .meta({
       ref: "Command",
@@ -53,6 +54,12 @@ export namespace Command {
         description: "review changes [commit|branch|pr], defaults to uncommitted",
         template: PROMPT_REVIEW.replace("${path}", Instance.worktree),
         subtask: true,
+        tools: {
+          github_pr_comment: true,
+          github_pr_create: true,
+          github_pr_read: true,
+          github_issue_read: true,
+        },
       },
     }
 

--- a/packages/opencode/src/command/template/review.txt
+++ b/packages/opencode/src/command/template/review.txt
@@ -4,6 +4,22 @@ You are a code reviewer. Your job is to review code changes and provide actionab
 
 Input: $ARGUMENTS
 
+Environment: !`[ "$GITHUB_ACTIONS" = "true" ] && echo "github_actions" || echo "local"`
+
+---
+
+## Environment-Specific Behavior
+
+**If Environment is `github_actions`:**
+- You have access to GitHub tools: `github_pr_read`, `github_pr_comment`, `github_issue_read`, `github_pr_create`
+- Use `github_pr_read` to fetch PR details including diff, commits, comments, and reviews
+- Use `github_pr_comment` to leave line-specific review comments with code suggestions
+- Check for PR number in the input, or use environment context
+
+**If Environment is `local`:**
+- Use git commands and `gh` CLI for GitHub operations
+- Output review results as markdown text
+
 ---
 
 ## Determining What to Review
@@ -21,8 +37,8 @@ Based on the input provided, determine which type of review to perform:
    - Run: `git diff $ARGUMENTS...HEAD`
 
 4. **PR URL or number** (contains "github.com" or "pull" or looks like a PR number): Review the pull request
-   - Run: `gh pr view $ARGUMENTS` to get PR context
-   - Run: `gh pr diff $ARGUMENTS` to get the diff
+   - In GitHub Actions: Use `github_pr_read` tool to get PR details and diff
+   - Locally: Run `gh pr view $ARGUMENTS` and `gh pr diff $ARGUMENTS`
 
 Use best judgement when processing input.
 
@@ -83,12 +99,32 @@ Use these to inform your review:
 - **Exa Code Context** - Verify correct usage of libraries/APIs before flagging something as wrong.
 - **Exa Web Search** - Research best practices if you're unsure about a pattern.
 
+**GitHub Actions only:**
+- **github_pr_read** - Fetch PR details, diff, commits, comments, and reviews
+- **github_pr_comment** - Leave line-specific review comments with optional code suggestions using ```suggestion blocks
+- **github_issue_read** - Read issue details and comments
+- **github_pr_create** - Create a new PR (for suggesting changes on a new branch)
+
 If you're uncertain about something and can't verify it with these tools, say "I'm not sure about X" rather than flagging it as a definite issue.
 
 ---
 
 ## Output
 
+**In GitHub Actions context:**
+- Use `github_pr_comment` to leave inline comments on specific lines where you find issues
+- For code suggestions, use the suggestion block syntax in your comment body:
+  ```suggestion
+  // corrected code here
+  ```
+- Provide a summary of your review findings at the end
+
+**In local CLI context:**
+- Output a markdown summary of your review
+- List issues by file and line number
+- Include code suggestions inline
+
+**General guidelines:**
 1. If there is a bug, be direct and clear about why it is a bug.
 2. Clearly communicate severity of issues. Do not overstate severity.
 3. Critiques should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1373,6 +1373,7 @@ export namespace SessionPrompt {
       model,
       agent: agentName,
       parts,
+      tools: command.tools,
     })) as MessageV2.WithParts
 
     Bus.publish(Command.Event.Executed, {

--- a/packages/opencode/src/tool/github/github.ts
+++ b/packages/opencode/src/tool/github/github.ts
@@ -1,0 +1,116 @@
+import { Octokit } from "@octokit/rest"
+import { graphql } from "@octokit/graphql"
+import * as core from "@actions/core"
+import { $ } from "bun"
+
+export namespace GitHub {
+  let client: Octokit | undefined
+  let graphqlClient: typeof graphql | undefined
+  let repoInfo: { owner: string; repo: string } | undefined
+
+  const DEFAULT_OIDC_BASE_URL = "https://api.opencode.ai"
+
+  /**
+   * Initialize the GitHub clients with pre-authenticated instances.
+   * Used when authentication is handled externally.
+   */
+  export function init(octo: Octokit, gql: typeof graphql) {
+    client = octo
+    graphqlClient = gql
+  }
+
+  async function getToken(): Promise<string> {
+    // Try environment variables first
+    const envToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+    if (envToken) return envToken
+
+    // Try OIDC token exchange (GitHub Actions)
+    const oidcToken = await getOidcToken()
+    if (oidcToken) {
+      return exchangeForAppToken(oidcToken)
+    }
+
+    throw new Error(
+      "GitHub token not found. Set GITHUB_TOKEN or GH_TOKEN environment variable, or ensure id-token: write permission in GitHub Actions.",
+    )
+  }
+
+  async function getOidcToken(): Promise<string | undefined> {
+    try {
+      return await core.getIDToken("opencode-github-action")
+    } catch {
+      return undefined
+    }
+  }
+
+  async function exchangeForAppToken(token: string): Promise<string> {
+    const oidcBaseUrl = process.env.OIDC_BASE_URL?.replace(/\/+$/, "") || DEFAULT_OIDC_BASE_URL
+    const { owner, repo } = await getRepoInfo()
+
+    const response = token.startsWith("github_pat_")
+      ? await fetch(`${oidcBaseUrl}/exchange_github_app_token_with_pat`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ owner, repo }),
+        })
+      : await fetch(`${oidcBaseUrl}/exchange_github_app_token`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+
+    if (!response.ok) {
+      const responseJson = (await response.json().catch(() => ({}))) as { error?: string }
+      throw new Error(`App token exchange failed: ${response.status} ${response.statusText} - ${responseJson.error}`)
+    }
+
+    const responseJson = (await response.json()) as { token: string }
+    return responseJson.token
+  }
+
+  export async function getClient() {
+    if (client) return client
+
+    const token = await getToken()
+    client = new Octokit({ auth: token })
+    return client
+  }
+
+  export async function getGraphQL() {
+    if (graphqlClient) return graphqlClient
+
+    const token = await getToken()
+    graphqlClient = graphql.defaults({
+      headers: { authorization: `token ${token}` },
+    })
+    return graphqlClient
+  }
+
+  export async function getRepoInfo() {
+    if (repoInfo) return repoInfo
+
+    const remoteUrl = (await $`git remote get-url origin`.quiet().nothrow().text()).trim()
+    const parsed = parseGitHubRemote(remoteUrl)
+    if (!parsed) {
+      throw new Error("Could not determine GitHub repository from git remote. Make sure you're in a git repository.")
+    }
+
+    repoInfo = parsed
+    return repoInfo
+  }
+
+  export function parseGitHubRemote(url: string): { owner: string; repo: string } | null {
+    const match = url.match(/^(?:(?:https?|ssh):\/\/)?(?:git@)?github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
+    if (!match) return null
+    return { owner: match[1], repo: match[2] }
+  }
+
+  export function reset() {
+    client = undefined
+    graphqlClient = undefined
+    repoInfo = undefined
+  }
+}

--- a/packages/opencode/src/tool/github/index.ts
+++ b/packages/opencode/src/tool/github/index.ts
@@ -1,0 +1,13 @@
+export { GithubPrCommentTool } from "./pr-comment"
+export { GithubPrCreateTool } from "./pr-create"
+export { GithubPrReadTool } from "./pr-read"
+export { GithubIssueReadTool } from "./issue-read"
+export { GitHub } from "./github"
+
+import type { Tool } from "../tool"
+import { GithubPrCommentTool } from "./pr-comment"
+import { GithubPrCreateTool } from "./pr-create"
+import { GithubPrReadTool } from "./pr-read"
+import { GithubIssueReadTool } from "./issue-read"
+
+export const GithubTools: Tool.Info[] = [GithubPrCommentTool, GithubPrCreateTool, GithubPrReadTool, GithubIssueReadTool]

--- a/packages/opencode/src/tool/github/issue-read.ts
+++ b/packages/opencode/src/tool/github/issue-read.ts
@@ -1,0 +1,93 @@
+import z from "zod"
+import { Tool } from "../tool"
+import { GitHub } from "./github"
+
+export const GithubIssueReadTool = Tool.define("github_issue_read", {
+  description: "Read details of a GitHub issue including title, body, labels, and comments",
+  parameters: z.object({
+    issue_number: z.number().describe("The issue number to read"),
+  }),
+  async execute(args) {
+    const gql = await GitHub.getGraphQL()
+    const { owner, repo } = await GitHub.getRepoInfo()
+
+    const result = await gql<{
+      repository: {
+        issue: {
+          title: string
+          body: string
+          state: string
+          author: { login: string }
+          createdAt: string
+          labels: { nodes: Array<{ name: string }> }
+          comments: {
+            nodes: Array<{
+              author: { login: string }
+              body: string
+              createdAt: string
+            }>
+          }
+        }
+      }
+    }>(
+      `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $number) {
+      title
+      body
+      state
+      author { login }
+      createdAt
+      labels(first: 20) {
+        nodes { name }
+      }
+      comments(first: 100) {
+        nodes {
+          author { login }
+          body
+          createdAt
+        }
+      }
+    }
+  }
+}`,
+      { owner, repo, number: args.issue_number },
+    )
+
+    const issue = result.repository.issue
+    if (!issue) {
+      return {
+        title: `Issue #${args.issue_number} not found`,
+        output: `Issue #${args.issue_number} was not found in ${owner}/${repo}`,
+        metadata: {},
+      }
+    }
+
+    const labels = issue.labels.nodes.map((l) => l.name).join(", ")
+    const comments = issue.comments.nodes.map((c) => `- ${c.author.login} (${c.createdAt}):\n  ${c.body}`).join("\n\n")
+
+    const output = [
+      `# Issue #${args.issue_number}: ${issue.title}`,
+      "",
+      `**State:** ${issue.state}`,
+      `**Author:** ${issue.author.login}`,
+      `**Created:** ${issue.createdAt}`,
+      labels ? `**Labels:** ${labels}` : "",
+      "",
+      "## Description",
+      issue.body || "(No description)",
+      "",
+      issue.comments.nodes.length > 0 ? "## Comments" : "",
+      comments,
+    ]
+      .filter(Boolean)
+      .join("\n")
+
+    return {
+      title: `Issue #${args.issue_number}`,
+      output,
+      metadata: {},
+    }
+  },
+})

--- a/packages/opencode/src/tool/github/pr-comment.ts
+++ b/packages/opencode/src/tool/github/pr-comment.ts
@@ -1,0 +1,52 @@
+import z from "zod"
+import { Tool } from "../tool"
+import { GitHub } from "./github"
+
+export const GithubPrCommentTool = Tool.define("github_pr_comment", {
+  description: "Create a review comment on a specific line or line range in a pull request",
+  parameters: z.object({
+    pull_number: z.number().describe("Pull request number"),
+    commit_id: z.string().describe("SHA of the commit to comment on"),
+    path: z.string().describe("File path relative to repository root"),
+    line: z.number().describe("Line number in the new version of the file (end line for multi-line comments)"),
+    start_line: z
+      .number()
+      .optional()
+      .describe("Starting line number for multi-line comments. If provided, comment spans from start_line to line"),
+    body: z.string().describe("Comment text. Use ```suggestion blocks for code fixes"),
+    side: z.enum(["LEFT", "RIGHT"]).optional().describe("LEFT for old version, RIGHT for new (default)"),
+    start_side: z
+      .enum(["LEFT", "RIGHT"])
+      .optional()
+      .describe("Side for start_line in multi-line comments. Defaults to RIGHT"),
+  }),
+  async execute(args) {
+    const octo = await GitHub.getClient()
+    const { owner, repo } = await GitHub.getRepoInfo()
+
+    const lineRange = args.start_line ? `${args.start_line}-${args.line}` : `${args.line}`
+
+    await octo.rest.pulls.createReviewComment({
+      owner,
+      repo,
+      pull_number: args.pull_number,
+      commit_id: args.commit_id,
+      path: args.path,
+      line: args.line,
+      body: args.body,
+      side: args.side ?? "RIGHT",
+      ...(args.start_line
+        ? {
+            start_line: args.start_line,
+            start_side: args.start_side ?? "RIGHT",
+          }
+        : {}),
+    })
+
+    return {
+      title: `Comment on ${args.path}:${lineRange}`,
+      output: `Successfully created review comment on ${args.path} at line${args.start_line ? "s" : ""} ${lineRange}`,
+      metadata: {},
+    }
+  },
+})

--- a/packages/opencode/src/tool/github/pr-create.ts
+++ b/packages/opencode/src/tool/github/pr-create.ts
@@ -1,0 +1,37 @@
+import z from "zod"
+import { Tool } from "../tool"
+import { GitHub } from "./github"
+
+export const GithubPrCreateTool = Tool.define("github_pr_create", {
+  description: "Create a new pull request on GitHub",
+  parameters: z.object({
+    title: z.string().describe("Title of the pull request"),
+    body: z.string().describe("Description/body of the pull request"),
+    head: z.string().describe("The name of the branch where your changes are implemented"),
+    base: z.string().describe("The name of the branch you want the changes pulled into"),
+    draft: z.boolean().optional().describe("Whether to create the pull request as a draft"),
+  }),
+  async execute(args) {
+    const octo = await GitHub.getClient()
+    const { owner, repo } = await GitHub.getRepoInfo()
+
+    const pr = await octo.rest.pulls.create({
+      owner,
+      repo,
+      title: args.title,
+      body: args.body,
+      head: args.head,
+      base: args.base,
+      draft: args.draft,
+    })
+
+    return {
+      title: `Created PR #${pr.data.number}`,
+      output: `Successfully created pull request #${pr.data.number}: ${pr.data.html_url}`,
+      metadata: {
+        number: pr.data.number,
+        url: pr.data.html_url,
+      },
+    }
+  },
+})

--- a/packages/opencode/src/tool/github/pr-read.ts
+++ b/packages/opencode/src/tool/github/pr-read.ts
@@ -1,0 +1,208 @@
+import z from "zod"
+import { Tool } from "../tool"
+import { GitHub } from "./github"
+
+export const GithubPrReadTool = Tool.define("github_pr_read", {
+  description:
+    "Read details of a GitHub pull request including title, body, diff, commits, comments, and review comments",
+  parameters: z.object({
+    pull_number: z.number().describe("The pull request number to read"),
+    include_diff: z.boolean().optional().describe("Whether to include the full diff (default: true)"),
+  }),
+  async execute(args) {
+    const gql = await GitHub.getGraphQL()
+    const octo = await GitHub.getClient()
+    const { owner, repo } = await GitHub.getRepoInfo()
+
+    const result = await gql<{
+      repository: {
+        pullRequest: {
+          title: string
+          body: string
+          state: string
+          author: { login: string }
+          createdAt: string
+          baseRefName: string
+          headRefName: string
+          headRefOid: string
+          additions: number
+          deletions: number
+          commits: {
+            totalCount: number
+            nodes: Array<{
+              commit: {
+                oid: string
+                message: string
+                author: { name: string; email: string }
+              }
+            }>
+          }
+          files: {
+            nodes: Array<{
+              path: string
+              additions: number
+              deletions: number
+              changeType: string
+            }>
+          }
+          comments: {
+            nodes: Array<{
+              author: { login: string }
+              body: string
+              createdAt: string
+            }>
+          }
+          reviews: {
+            nodes: Array<{
+              author: { login: string }
+              body: string
+              state: string
+              submittedAt: string
+              comments: {
+                nodes: Array<{
+                  path: string
+                  line: number | null
+                  body: string
+                  author: { login: string }
+                }>
+              }
+            }>
+          }
+        }
+      }
+    }>(
+      `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      title
+      body
+      state
+      author { login }
+      createdAt
+      baseRefName
+      headRefName
+      headRefOid
+      additions
+      deletions
+      commits(first: 100) {
+        totalCount
+        nodes {
+          commit {
+            oid
+            message
+            author { name email }
+          }
+        }
+      }
+      files(first: 100) {
+        nodes {
+          path
+          additions
+          deletions
+          changeType
+        }
+      }
+      comments(first: 100) {
+        nodes {
+          author { login }
+          body
+          createdAt
+        }
+      }
+      reviews(first: 100) {
+        nodes {
+          author { login }
+          body
+          state
+          submittedAt
+          comments(first: 100) {
+            nodes {
+              path
+              line
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+      { owner, repo, number: args.pull_number },
+    )
+
+    const pr = result.repository.pullRequest
+    if (!pr) {
+      return {
+        title: `PR #${args.pull_number} not found`,
+        output: `Pull request #${args.pull_number} was not found in ${owner}/${repo}`,
+        metadata: {},
+      }
+    }
+
+    const files = pr.files.nodes.map((f) => `- ${f.path} (${f.changeType}) +${f.additions}/-${f.deletions}`)
+
+    const commits = pr.commits.nodes.map((c) => `- ${c.commit.oid.slice(0, 7)}: ${c.commit.message.split("\n")[0]}`)
+
+    const comments = pr.comments.nodes.map((c) => `- ${c.author.login} (${c.createdAt}):\n  ${c.body}`)
+
+    const reviews = pr.reviews.nodes.flatMap((r) => {
+      const lines = [`- ${r.author.login} (${r.state}, ${r.submittedAt}):`]
+      if (r.body) lines.push(`  ${r.body}`)
+      for (const c of r.comments.nodes) {
+        lines.push(`  - ${c.path}:${c.line ?? "?"}: ${c.body}`)
+      }
+      return lines
+    })
+
+    const sections = [
+      `# PR #${args.pull_number}: ${pr.title}`,
+      "",
+      `**State:** ${pr.state}`,
+      `**Author:** ${pr.author.login}`,
+      `**Created:** ${pr.createdAt}`,
+      `**Base:** ${pr.baseRefName} ← **Head:** ${pr.headRefName}`,
+      `**Head Commit SHA:** ${pr.headRefOid}`,
+      `**Changes:** +${pr.additions}/-${pr.deletions}`,
+      "",
+      "## Description",
+      pr.body || "(No description)",
+      "",
+      "## Changed Files",
+      ...files,
+      "",
+      "## Commits",
+      ...commits,
+    ]
+
+    if (comments.length > 0) {
+      sections.push("", "## Comments", ...comments)
+    }
+
+    if (reviews.length > 0) {
+      sections.push("", "## Reviews", ...reviews)
+    }
+
+    // Include diff if requested (default: true)
+    if (args.include_diff !== false) {
+      try {
+        const diff = await octo.rest.pulls.get({
+          owner,
+          repo,
+          pull_number: args.pull_number,
+          mediaType: { format: "diff" },
+        })
+        sections.push("", "## Diff", "```diff", diff.data as unknown as string, "```")
+      } catch {
+        sections.push("", "## Diff", "(Failed to fetch diff)")
+      }
+    }
+
+    return {
+      title: `PR #${args.pull_number}`,
+      output: sections.join("\n"),
+      metadata: {},
+    }
+  },
+})

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -23,6 +23,7 @@ import { CodeSearchTool } from "./codesearch"
 import { Flag } from "@/flag/flag"
 import { Log } from "@/util/log"
 import { LspTool } from "./lsp"
+import { GithubTools } from "./github"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -105,6 +106,7 @@ export namespace ToolRegistry {
       CodeSearchTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
+      ...GithubTools,
       ...custom,
     ]
   }
@@ -135,8 +137,16 @@ export namespace ToolRegistry {
     return result
   }
 
+  // Tools that are disabled by default and must be explicitly enabled
+  const DISABLED_BY_DEFAULT = ["github_pr_comment", "github_pr_create", "github_pr_read", "github_issue_read"]
+
   export async function enabled(agent: Agent.Info): Promise<Record<string, boolean>> {
     const result: Record<string, boolean> = {}
+
+    // Disable review tools by default - they must be explicitly enabled via command.tools
+    for (const tool of DISABLED_BY_DEFAULT) {
+      result[tool] = false
+    }
 
     if (agent.permission.edit === "deny") {
       result["edit"] = false


### PR DESCRIPTION
This PR is just a POC to discuss ideas of improving github integration.

Currently we run the github integration through `opencode github run`, which as lots of code that the agent should be able to manage by itself.

This PR is just showing the direction of trying to re-use `/review` or maybe creating a new command `/github-review`.

The idea is adding additional tools for the `/review` command like, `Create PR, Comment Issue, Comment PR Review`, etc, so the agent can deal with the scenarios.

Thoughts?