### PR TITLE
docs: Add OpenChamber to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -44,6 +44,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                          |
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk  |
+| [OpenChamber](https://github.com/btriapitsyn/openchamber)| Web / Desktop App and VS Code Extension for OpenCode|
 
 ---
 


### PR DESCRIPTION
Add OpenChamber to ecosystem documentation under Projects as it has multiple surfaces like web desktop and vscode extension 