### PR TITLE
[FEATURE]: Show context usage in OpenCode Desktop  Context usage

### DIFF
--- a/packages/desktop/src/components/prompt-input.tsx
+++ b/packages/desktop/src/components/prompt-input.tsx
@@ -22,6 +22,7 @@ import { useProviders } from "@/hooks/use-providers"
 import { useCommand, formatKeybind } from "@/context/command"
 import { persisted } from "@/utils/persist"
 import { Identifier } from "@/utils/id"
+import { SessionContextUsage } from "@/components/session-context"
 
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
 const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]
@@ -1012,6 +1013,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 </Button>
               </Match>
             </Switch>
+            <SessionContextUsage />
           </div>
           <div class="flex items-center gap-1 absolute right-2 bottom-2">
             <input

--- a/packages/desktop/src/components/prompt-input.tsx
+++ b/packages/desktop/src/components/prompt-input.tsx
@@ -22,7 +22,7 @@ import { useProviders } from "@/hooks/use-providers"
 import { useCommand, formatKeybind } from "@/context/command"
 import { persisted } from "@/utils/persist"
 import { Identifier } from "@/utils/id"
-import { SessionContextUsage } from "@/components/session-context"
+import { SessionContextUsage } from "@/components/session-context-usage"
 
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
 const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]

--- a/packages/desktop/src/components/session-context-usage.tsx
+++ b/packages/desktop/src/components/session-context-usage.tsx
@@ -1,0 +1,68 @@
+import { createMemo, Show } from "solid-js"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { ProgressCircle } from "@opencode-ai/ui/progress-circle"
+import { useSync } from "@/context/sync"
+import { useParams } from "@solidjs/router"
+import { AssistantMessage } from "@opencode-ai/sdk/v2"
+
+export function SessionContextUsage() {
+  const sync = useSync()
+  const params = useParams()
+  const messages = createMemo(() => (params.id ? (sync.data.message[params.id] ?? []) : []))
+
+  const cost = createMemo(() => {
+    const total = messages().reduce((sum, x) => sum + (x.role === "assistant" ? x.cost : 0), 0)
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(total)
+  })
+
+  const context = createMemo(() => {
+    const last = messages().findLast((x) => x.role === "assistant" && x.tokens.output > 0) as AssistantMessage
+    if (!last) return
+    const total =
+      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    const model = sync.data.provider.all.find((x) => x.id === last.providerID)?.models[last.modelID]
+    return {
+      tokens: total.toLocaleString(),
+      percentage: model?.limit.context ? Math.round((total / model.limit.context) * 100) : null,
+    }
+  })
+
+  return (
+    <div class="flex items-center justify-between gap-3">
+      <Show when={context ? context() : undefined}>
+        {(ctx) => (
+          <Tooltip
+            openDelay={300}
+            value={
+              <div class="flex flex-col gap-1 p-2">
+                <div class="flex justify-between gap-4">
+                  <span class="text-text-weaker">Tokens</span>
+                  <span class="text-text-strong">{ctx().tokens}</span>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <span class="text-text-weaker">Usage</span>
+                  <span class="text-text-strong">{ctx().percentage ?? 0}%</span>
+                </div>
+                <div class="flex justify-between gap-4">
+                  <span class="text-text-weaker">Cost</span>
+                  <span class="text-text-strong">{cost()}</span>
+                </div>
+              </div>
+            }
+            placement="top"
+          >
+            <div class="flex items-center gap-1 cursor-default">
+              <span class="text-12-medium text-text-weak">{`${ctx().percentage ?? 0}%`}</span>
+              <div class="relative size-4">
+                <ProgressCircle size={16} strokeWidth={2} percentage={ctx().percentage ?? 0} />
+              </div>
+            </div>
+          </Tooltip>
+        )}
+      </Show>
+    </div>
+  )
+}

--- a/packages/desktop/src/components/session-context-usage.tsx
+++ b/packages/desktop/src/components/session-context-usage.tsx
@@ -31,38 +31,34 @@ export function SessionContextUsage() {
   })
 
   return (
-    <div class="flex items-center justify-between gap-3">
-      <Show when={context ? context() : undefined}>
-        {(ctx) => (
-          <Tooltip
-            openDelay={300}
-            value={
-              <div class="flex flex-col gap-1 p-2">
-                <div class="flex justify-between gap-4">
-                  <span class="text-text-weaker">Tokens</span>
-                  <span class="text-text-strong">{ctx().tokens}</span>
-                </div>
-                <div class="flex justify-between gap-4">
-                  <span class="text-text-weaker">Usage</span>
-                  <span class="text-text-strong">{ctx().percentage ?? 0}%</span>
-                </div>
-                <div class="flex justify-between gap-4">
-                  <span class="text-text-weaker">Cost</span>
-                  <span class="text-text-strong">{cost()}</span>
-                </div>
+    <Show when={context?.()}>
+      {(ctx) => (
+        <Tooltip
+          openDelay={300}
+          value={
+            <div class="flex flex-col gap-1 p-2">
+              <div class="flex justify-between gap-4">
+                <span class="text-text-weaker">Tokens</span>
+                <span class="text-text-strong">{ctx().tokens}</span>
               </div>
-            }
-            placement="top"
-          >
-            <div class="flex items-center gap-1 cursor-default">
-              <span class="text-12-medium text-text-weak">{`${ctx().percentage ?? 0}%`}</span>
-              <div class="relative size-4">
-                <ProgressCircle size={16} strokeWidth={2} percentage={ctx().percentage ?? 0} />
+              <div class="flex justify-between gap-4">
+                <span class="text-text-weaker">Usage</span>
+                <span class="text-text-strong">{ctx().percentage ?? 0}%</span>
+              </div>
+              <div class="flex justify-between gap-4">
+                <span class="text-text-weaker">Cost</span>
+                <span class="text-text-strong">{cost()}</span>
               </div>
             </div>
-          </Tooltip>
-        )}
-      </Show>
-    </div>
+          }
+          placement="top"
+        >
+          <div class="flex items-center gap-1">
+            <span class="text-12-medium text-text-weak">{`${ctx().percentage ?? 0}%`}</span>
+            <ProgressCircle size={16} strokeWidth={2} percentage={ctx().percentage ?? 0} />
+          </div>
+        </Tooltip>
+      )}
+    </Show>
   )
 }


### PR DESCRIPTION
As described in #5892. Added a context usage component for current session.

<img width="835" height="353" alt="Screenshot 2025-12-22 at 7 18 23 PM" src="https://github.com/user-attachments/assets/095b30b6-201f-47f4-afa4-b50a59062862" />

For the logic of the session usage reused existing code that shows the information on opencode tui sidebar.
