### PR TITLE
fix(tui): resize textarea if text inserted via `appendPrompt` TUI API

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -310,6 +310,11 @@ export function Prompt(props: PromptProps) {
 
   sdk.event.on(TuiEvent.PromptAppend.type, (evt) => {
     input.insertText(evt.properties.text)
+    setTimeout(() => {
+      input.getLayoutNode().markDirty()
+      input.gotoBufferEnd()
+      renderer.requestRender()
+    }, 0)
   })
 
   createEffect(() => {


### PR DESCRIPTION
Closes #5664

#### Problem

When using `appendPrompt` to insert multi-line text, the textarea doesn't expand to show all lines. Users only see the last line with the cursor, while earlier lines are hidden above the viewport.

#### Use Case

This enables plugins to create new sessions with pre-filled prompts. 

For example, my [opencode-handoff](https://github.com/joshuadavidthomas/opencode-handoff) plugin that emulates Amp's `/handoff` command generates a full handoff prompt to insert into a new session. Before this fix, I could only reliably get the textarea sized correctly by calling `appendPrompt` twice, once before the `"session_new"` command and once after:

```typescript
await client.tui.clearPrompt()
await new Promise(r => setTimeout(r, 100))
await client.tui.appendPrompt({ body: { text: fullPrompt } })
await client.tui.executeCommand({ body: { command: "session_new" } })
await client.tui.clearPrompt()
await new Promise(r => setTimeout(r, 100))
await client.tui.appendPrompt({ body: { text: fullPrompt } })
```
https://github.com/joshuadavidthomas/opencode-handoff/blob/34a76b2f1e2cd4f024b88196c81fba09e6e1714a/src/tools.ts#L35-L45

After this fix, it can be simplified to this and the re-sizing works:

```typescript
await client.tui.executeCommand({ body: { command: "session_new" } })
await client.tui.appendPrompt({ body: { text: fullPrompt } })
```

#### Details

The `insertText()` method in opentui doesn't trigger yoga layout recalculation. Calling `markDirty()` synchronously doesn't work - yoga needs the insert to fully complete first. Deferring via `setTimeout(..., 0)` allows internal state to settle before recalculating layout.

#### Alternatives

TBH, for my specific use-case a cleaner approach would be exposing a way for plugins to create a new session with a pre-filled prompt directly. However, that potentially would require:

- Adding the parameter to `Session.create` API
- Modifying `/tui/execute-command` to accept parameters
- Wiring the prompt population and textarea sizing

Which is a much bigger change than I'm prepared to make, as it would almost certainly require discussion and maintainer buy-in. This PR just fixes an existing bug - `appendPrompt` should resize the textarea but doesn't. The fix happens to enable my plugin use case, but it stands on its own merit: if you call `appendPrompt` with multi-line text, the textarea should expand to show it.

If there's interest in enabling session creation with a pre-filled prompt, I'm happy to open an issue to continue the discussion.