### PR TITLE
docs: add opencode-morph-fast-apply plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -29,6 +29,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                      | Enables AI agents to run background processes in a PTY, send interactive input to them.       |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                            |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                                     |
+| [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                | 10x faster code editing with Morph Fast Apply API and lazy edit markers                       |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible        |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                           | AI-powered automatic Zellij session naming based on OpenCode context                          |
 


### PR DESCRIPTION
## Summary

Adds [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply) to the Plugins section of the ecosystem page.

## About the Plugin

OpenCode plugin that integrates [Morph's Fast Apply API](https://morphllm.com) for faster code editing:

- **10,500+ tokens/sec** code editing speed
- **Lazy edit markers** (`// ... existing code ...`) - no exact string matching needed
- **Unified diff output** with context for easy review
- **Graceful fallback** - suggests native `edit` tool on API failure

This provides an alternative to the Morph MCP server with a lighter-weight inline plugin approach.

## Checklist

- [x] Entry added alphabetically in the Plugins table
- [x] Link points to valid GitHub repository
- [x] Description is concise and accurate