### PR TITLE
fix: stop auto execute on sendText vscode extension

### DIFF
--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (terminal.name === TERMINAL_NAME) {
       // @ts-ignore
       const port = terminal.creationOptions.env?.["_EXTENSION_OPENCODE_PORT"]
-      port ? await appendPrompt(parseInt(port), fileRef) : terminal.sendText(fileRef)
+      port ? await appendPrompt(parseInt(port), fileRef) : terminal.sendText(fileRef, false)
       terminal.show()
     }
   })


### PR DESCRIPTION
Fixes #5920
From what i could tell when calling sendText(fileRef, defaults to true) this would press the enter key when the file ref would be @ and it would choose the first option which is the @extension agent.

By setting to false we stop pressing enter on sending text.

Reproduced:

https://github.com/user-attachments/assets/e9acf801-3b85-4e63-8801-aeb527c3ece6

Fixed: 

https://github.com/user-attachments/assets/a00b4d47-474d-4730-a668-b1c4674a7aed

