### PR TITLE
docs: opencode-shell-strategy plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -27,6 +27,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning) | Optimize token usage by pruning obsolete tool outputs                                         |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                | Add native websearch support for supported providers with Google grounded style               |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                      | Enables AI agents to run background processes in a PTY, send interactive input to them.       |
+| [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                    | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                            |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                                     |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible        |


### PR DESCRIPTION
## Summary

Adds [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy) to the Plugins section of the ecosystem page.

## About the Plugin

Instructions file that teaches LLMs how to avoid interactive shell commands that hang in OpenCode's non-TTY environment.

Covers:
- **Package managers**: `npm init -y`, `apt-get install -y`, `pip install --no-input`
- **Git operations**: `git commit -m`, `git merge --no-edit`, avoid `git add -p`
- **System commands**: `rm -f`, `ssh -o BatchMode=yes`, `unzip -o`
- **Banned commands**: editors (`vim`, `nano`), pagers (`less`, `more`, `man`)

This is particularly useful for models less familiar with headless CI/CD environments.

## Checklist

- [x] Entry added alphabetically in the Plugins table
- [x] Link points to valid GitHub repository
- [x] Description is concise and accurate