### PR TITLE
fix: handle uppercase image extensions when pasting file paths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -49,6 +49,22 @@ export type PromptRef = {
 
 const PLACEHOLDERS = ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"]
 
+// Bun.file() only recognizes lowercase extensions, so uppercase extensions like .PNG, .JPG
+// return "application/octet-stream". This function returns the correct MIME type.
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+}
+
+function getImageMime(filepath: string): string | undefined {
+  const ext = filepath.slice(filepath.lastIndexOf(".")).toLowerCase()
+  return IMAGE_EXTENSIONS[ext]
+}
+
 const TEXTAREA_ACTIONS = [
   "submit",
   "newline",
@@ -836,8 +852,11 @@ export function Prompt(props: PromptProps) {
                 if (!isUrl) {
                   try {
                     const file = Bun.file(filepath)
+                    // Bun.file() only recognizes lowercase extensions, so use our helper
+                    // to get the correct MIME type for uppercase extensions like .PNG, .JPG
+                    const mime = getImageMime(filepath) ?? file.type
                     // Handle SVG as raw text content, not as base64 image
-                    if (file.type === "image/svg+xml") {
+                    if (mime === "image/svg+xml") {
                       event.preventDefault()
                       const content = await file.text().catch(() => {})
                       if (content) {
@@ -845,7 +864,7 @@ export function Prompt(props: PromptProps) {
                         return
                       }
                     }
-                    if (file.type.startsWith("image/")) {
+                    if (mime.startsWith("image/")) {
                       event.preventDefault()
                       const content = await file
                         .arrayBuffer()
@@ -854,7 +873,7 @@ export function Prompt(props: PromptProps) {
                       if (content) {
                         await pasteImage({
                           filename: file.name,
-                          mime: file.type,
+                          mime,
                           content,
                         })
                         return


### PR DESCRIPTION
## Summary

Fixes image detection when dragging/pasting file paths with uppercase extensions (e.g., `.PNG`, `.JPG`) from Finder on macOS.

I airdropped these screenshots from my phone and dragging the to OpenCode doesn't work:

<img width="178" height="433" alt="Screenshot 2025-12-22 at 10 04 46 PM" src="https://github.com/user-attachments/assets/a032ac98-273d-4795-940d-6f3c6eb5d826" />

## Problem

`Bun.file()` only recognizes lowercase file extensions for MIME type detection. When you drag an image from Finder that has an uppercase extension like `/Users/nem035/Downloads/IMG_8048.PNG`, Bun returns `application/octet-stream` instead of `image/png`:

```ts
Bun.file('/test.png').type  // "image/png" ✓
Bun.file('/test.PNG').type  // "application/octet-stream" ✗
```

This caused pasted image paths to not be recognized as images, so they would be treated as plain text instead of showing the `[Image 1]` yellow UI indicator.

## Solution

Added a helper function that extracts the file extension, normalizes it to lowercase, and looks up the correct MIME type from a known list of image extensions. This is used as the primary source for MIME type detection, with `Bun.file().type` as a fallback for other file types.

| Before | After |
|---|---|
| <img width="1464" height="875" alt="Screenshot 2025-12-22 at 10 24 09 PM" src="https://github.com/user-attachments/assets/524145ea-0bea-45f2-9d34-44bfac44f4c1" /> |<img width="1463" height="878" alt="Screenshot 2025-12-22 at 10 24 18 PM" src="https://github.com/user-attachments/assets/1c82eec6-9aa6-47fe-af04-aab3e9a30f12" /> |
