### PR TITLE
fix(tui): prevent keybinds from executing when dialog is open

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -45,6 +45,7 @@ function init() {
 
   useKeyboard((evt) => {
     if (suspended()) return
+    if (dialog.stack.length > 0) return
     for (const option of options()) {
       if (option.keybind && keybind.match(option.keybind, evt)) {
         evt.preventDefault()


### PR DESCRIPTION
## Summary

- Fixes keybinds (like `Tab` for agent cycling) executing in the background when a dialog/picker is open

## Details

Added `dialog.stack.length > 0` guard to the `useKeyboard` handler in `init()` to prevent registered command keybinds from firing when a dialog is open. This follows the same pattern already used in `CommandProvider` (line 102) and `session/index.tsx` (line 254).

Fixes #6016