### PR TITLE
feat(plugin): ui components api

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -18,6 +18,7 @@ import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
+import { pluginModalRequest, setPluginModalRequest, PluginUIRenderer } from "@tui/plugin-ui"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { KeybindProvider } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
@@ -33,6 +34,7 @@ import { KVProvider, useKV } from "./context/kv"
 import { Provider } from "@/provider/provider"
 import { ArgsProvider, useArgs, type Args } from "./context/args"
 import open from "open"
+import { PluginRegistry } from "./plugin-ui.tsx"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
@@ -99,6 +101,8 @@ export function tui(input: { url: string; args: Args; onExit?: () => Promise<voi
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
     const mode = await getTerminalBackgroundColor()
+    await PluginRegistry.load(input.url)
+
     const onExit = async () => {
       await input.onExit?.()
       resolve()
@@ -205,6 +209,19 @@ function App() {
   })
 
   const args = useArgs()
+
+  createEffect(() => {
+    const request = pluginModalRequest()
+    if (request) {
+      dialog.replace(
+        <box flexDirection="column" paddingLeft={2} paddingRight={2} paddingBottom={1}>
+          <PluginUIRenderer node={request.node} metadata={request.metadata} />
+        </box>,
+      )
+      setPluginModalRequest(null)
+    }
+  })
+
   onMount(() => {
     batch(() => {
       if (args.agent) local.agent.set(args.agent)

--- a/packages/opencode/src/cli/cmd/tui/plugin-ui.tsx
+++ b/packages/opencode/src/cli/cmd/tui/plugin-ui.tsx
@@ -1,0 +1,309 @@
+import { createSignal, ErrorBoundary, For, Show } from "solid-js"
+import { Dynamic } from "solid-js/web"
+import { useTheme } from "@tui/context/theme"
+import { useKeyboard } from "@opentui/solid"
+import type {
+  PluginUINode,
+  PluginUIComponent,
+  TextNode,
+  BoxNode,
+  ChecklistNode,
+  ButtonNode,
+  CollapsibleNode,
+} from "@opencode-ai/plugin"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "plugin-ui" })
+
+// Signal to trigger re-renders when dismissed state changes
+const [dismissed, setDismissed] = createSignal(new Set<string>())
+
+// Global signal for plugin modals (used when DialogProvider context isn't available)
+export const [pluginModalRequest, setPluginModalRequest] = createSignal<{
+  node: PluginUINode
+  metadata: Record<string, any>
+} | null>(null)
+
+// Plugin UI Registry - stores templates fetched from plugins
+export const PluginRegistry = {
+  templates: new Map<string, { node: PluginUINode; replaceInput: boolean }>(),
+  baseUrl: "",
+  register(name: string, template: PluginUINode, replaceInput?: boolean) {
+    this.templates.set(name, { node: template, replaceInput: replaceInput ?? false })
+  },
+  get(name: string) {
+    const entry = this.templates.get(name)
+    if (!entry) log.warn("template not found", { name })
+    return entry?.node
+  },
+  shouldReplaceInput(name: string) {
+    return this.templates.get(name)?.replaceInput ?? false
+  },
+  dismiss(componentKey: string) {
+    setDismissed((prev) => {
+      const next = new Set(prev)
+      next.add(componentKey)
+      return next
+    })
+  },
+  isDismissed(componentKey: string) {
+    return dismissed().has(componentKey)
+  },
+  async emit(component: string, event: string, data: Record<string, any>) {
+    try {
+      await fetch(`${this.baseUrl}/plugins/ui/event`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ component, event, data }),
+      })
+    } catch (e) {
+      log.error("emit failed", { error: e })
+    }
+  },
+
+  async load(baseUrl: string) {
+    this.baseUrl = baseUrl
+    try {
+      const res = await fetch(`${baseUrl}/plugins/ui`)
+      if (!res.ok) throw new Error(`status ${res.status}`)
+      const components: PluginUIComponent[] = await res.json()
+      log.info("loaded", { count: components.length })
+      for (const c of components) this.register(c.name, c.template, c.replaceInput)
+    } catch (e) {
+      log.error("load failed", { error: e })
+    }
+  },
+}
+
+// Interpolate {{key}} placeholders with metadata values
+function interpolate(text: string, metadata: Record<string, any>): string {
+  return text.replace(/\{\{(\w+)\}\}/g, (_, key) => String(metadata[key] ?? ""))
+}
+
+// Helper to resolve theme colors - returns both getColor and theme
+function useColors() {
+  const { theme } = useTheme()
+  const getColor = (color?: string) => {
+    if (!color) return undefined
+    return (theme as any)[color] ?? color
+  }
+  return { getColor, theme }
+}
+
+type RendererProps<T> = { node: T; metadata: Record<string, any> }
+
+function PluginText(props: RendererProps<TextNode>) {
+  const { getColor, theme } = useColors()
+  const content = () => interpolate(props.node.content, props.metadata)
+  return (
+    <text fg={getColor(props.node.fg) ?? theme.text}>{props.node.bold ? <strong>{content()}</strong> : content()}</text>
+  )
+}
+
+function PluginBox(props: RendererProps<BoxNode>) {
+  const { getColor, theme } = useColors()
+  const n = props.node
+  const hasBorder = n.border !== undefined
+  return (
+    <box
+      flexDirection={n.direction ?? "row"}
+      gap={n.gap ?? 0}
+      backgroundColor={getColor(n.bg)}
+      border={n.border}
+      borderStyle={hasBorder ? n.borderStyle : undefined}
+      borderColor={hasBorder ? (getColor(n.borderColor) ?? theme.border) : undefined}
+      marginTop={n.marginTop ?? n.marginY}
+      marginBottom={n.marginBottom ?? n.marginY}
+      marginLeft={n.marginLeft ?? n.marginX}
+      marginRight={n.marginRight ?? n.marginX}
+      paddingTop={n.paddingTop ?? n.paddingY}
+      paddingBottom={n.paddingBottom ?? n.paddingY}
+      paddingLeft={n.paddingLeft ?? n.paddingX}
+      paddingRight={n.paddingRight ?? n.paddingX}
+      justifyContent={n.justifyContent}
+      alignSelf={n.alignSelf}
+      minWidth={n.minWidth}
+    >
+      <For each={n.children}>{(child) => <PluginUIRenderer node={child} metadata={props.metadata} />}</For>
+    </box>
+  )
+}
+
+function PluginChecklist(props: RendererProps<ChecklistNode>) {
+  const { getColor, theme } = useColors()
+
+  const rawItems = () =>
+    typeof props.node.items === "string"
+      ? ((props.metadata[props.node.items] as Array<{ id: string; label: string; checked?: boolean }>) ?? [])
+      : (props.node.items as Array<{ id: string; label: string; checked?: boolean }>)
+
+  const [items, setItems] = createSignal(rawItems().map((i) => ({ ...i, checked: i.checked ?? false })))
+  const [focusedIndex, setFocusedIndex] = createSignal(0)
+
+  const toggleItem = (index: number) => {
+    const item = items()[index]
+    if (!item) return
+    const updatedItems = items().map((i, idx) => (idx === index ? { ...i, checked: !i.checked } : i))
+    setItems(updatedItems)
+    if (props.node.onToggle && props.metadata._component) {
+      PluginRegistry.emit(props.metadata._component, props.node.onToggle, {
+        id: item.id,
+        checked: !item.checked,
+        items: updatedItems,
+      })
+    }
+  }
+
+  useKeyboard((evt) => {
+    if (evt.name === "up" || evt.name === "k") {
+      setFocusedIndex((i) => Math.max(0, i - 1))
+      return true
+    }
+    if (evt.name === "down" || evt.name === "j") {
+      setFocusedIndex((i) => Math.min(items().length - 1, i + 1))
+      return true
+    }
+    if (evt.name === "space") {
+      toggleItem(focusedIndex())
+      return true
+    }
+    return false
+  })
+
+  return (
+    <box flexDirection="column" gap={0}>
+      <For each={items()}>
+        {(item, index) => (
+          <box
+            flexDirection="row"
+            justifyContent="space-between"
+            backgroundColor={item.checked ? (getColor(props.node.bgChecked) ?? theme.backgroundElement) : undefined}
+            paddingLeft={1}
+            paddingRight={1}
+            onMouseOver={() => setFocusedIndex(index())}
+            onMouseDown={() => toggleItem(index())}
+          >
+            <box flexDirection="row">
+              <text
+                content={item.checked ? "● " : "○ "}
+                fg={getColor(props.node.borderColorChecked) ?? theme.warning}
+              />
+              <text
+                content={item.label}
+                fg={
+                  item.checked
+                    ? (getColor(props.node.fgChecked) ?? theme.text)
+                    : (getColor(props.node.fg) ?? theme.textMuted)
+                }
+              />
+            </box>
+            <text content={focusedIndex() === index() ? "◀" : ""} fg={theme.warning} />
+          </box>
+        )}
+      </For>
+    </box>
+  )
+}
+
+function PluginButton(props: RendererProps<ButtonNode>) {
+  const { getColor, theme } = useColors()
+  const [hovered, setHovered] = createSignal(false)
+  const [clicked, setClicked] = createSignal(false)
+
+  const handleActivate = () => {
+    if (clicked()) return
+    setClicked(true)
+    if (props.node.onModal) {
+      setPluginModalRequest({ node: props.node.onModal, metadata: props.metadata })
+    }
+    if (props.node.onPress && props.metadata._component) {
+      PluginRegistry.emit(props.metadata._component, props.node.onPress, {})
+      if (props.metadata._partId) {
+        setTimeout(() => PluginRegistry.dismiss(props.metadata._partId!), 0)
+      }
+    }
+  }
+
+  useKeyboard((evt) => {
+    if (clicked()) return false
+    if (props.node.shortcut && evt.name === props.node.shortcut.toLowerCase()) {
+      handleActivate()
+      return true
+    }
+    return false
+  })
+
+  const isActive = () => clicked() || hovered()
+  const hasBackground = props.node.bg !== undefined
+
+  return (
+    <box flexDirection="row">
+      <Show when={hasBackground}>
+        <box minWidth={1}>
+          <text content={isActive() ? "┃" : " "} fg={getColor(props.node.borderColorHover) ?? theme.warning} />
+        </box>
+      </Show>
+      <box
+        backgroundColor={hasBackground ? (getColor(props.node.bg) ?? theme.accent) : undefined}
+        paddingLeft={hasBackground ? 1 : 0}
+        paddingRight={hasBackground ? 2 : 0}
+        onMouseOver={() => setHovered(true)}
+        onMouseOut={() => setHovered(false)}
+        onMouseDown={handleActivate}
+      >
+        <text
+          content={props.node.label}
+          fg={
+            isActive()
+              ? (getColor(props.node.fgHover) ?? theme.warning)
+              : (getColor(props.node.fg) ?? (hasBackground ? theme.background : theme.text))
+          }
+        />
+      </box>
+    </box>
+  )
+}
+
+function PluginCollapsible(props: RendererProps<CollapsibleNode>) {
+  const { getColor, theme } = useColors()
+  const [expanded, setExpanded] = createSignal(props.node.expanded ?? false)
+  const title = () => interpolate(props.node.title, props.metadata)
+  const fg = () =>
+    expanded() ? (getColor(props.node.fgExpanded) ?? theme.text) : (getColor(props.node.fg) ?? theme.textMuted)
+
+  return (
+    <box flexDirection="column" gap={0}>
+      <box flexDirection="row" gap={1} onMouseDown={() => setExpanded((e) => !e)}>
+        <text content={expanded() ? (props.node.iconExpanded ?? "▼") : (props.node.icon ?? "▶")} fg={fg()} />
+        <text content={title()} fg={fg()} />
+      </box>
+      <Show when={expanded()}>
+        <box flexDirection="column" paddingLeft={2}>
+          <For each={props.node.children}>{(child) => <PluginUIRenderer node={child} metadata={props.metadata} />}</For>
+        </box>
+      </Show>
+    </box>
+  )
+}
+
+// Component map for dynamic rendering
+const RENDERERS: Record<string, (props: RendererProps<any>) => any> = {
+  text: PluginText,
+  box: PluginBox,
+  checklist: PluginChecklist,
+  button: PluginButton,
+  collapsible: PluginCollapsible,
+}
+
+// Render a plugin UI template
+export function PluginUIRenderer(props: { node: PluginUINode; metadata: Record<string, any> }) {
+  const { theme } = useColors()
+  const Renderer = RENDERERS[props.node.type]
+  return (
+    <ErrorBoundary fallback={<text fg={theme.error}>[plugin render error]</text>}>
+      <Show when={Renderer} fallback={<text fg={theme.error}>[unknown: {props.node.type}]</text>}>
+        <Dynamic component={Renderer} node={props.node} metadata={props.metadata} />
+      </Show>
+    </ErrorBoundary>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -68,6 +68,7 @@ import { Footer } from "./footer.tsx"
 import { usePromptRef } from "../../context/prompt"
 import { Filesystem } from "@/util/filesystem"
 import { DialogSubagent } from "./dialog-subagent.tsx"
+import { PluginRegistry, PluginUIRenderer } from "../../plugin-ui"
 
 addDefaultParsers(parsers.parsers)
 
@@ -109,6 +110,22 @@ export function Session() {
   const session = createMemo(() => sync.session.get(route.sessionID)!)
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const permissions = createMemo(() => sync.data.permission[route.sessionID] ?? [])
+
+  // Find plugin component that wants to replace the input (and isn't dismissed)
+  const replaceInputPlugin = createMemo(() => {
+    for (const msg of messages()) {
+      const parts = sync.data.part[msg.id] ?? []
+      for (const part of parts) {
+        if (part.type === "text" && part.plugin) {
+          const componentName = part.text.trim()
+          if (PluginRegistry.shouldReplaceInput(componentName) && !PluginRegistry.isDismissed(part.id)) {
+            return { component: componentName, partId: part.id, metadata: part.metadata }
+          }
+        }
+      }
+    }
+    return null
+  })
 
   const pending = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant" && !x.time.completed)?.id
@@ -670,7 +687,7 @@ export function Session() {
           if (!parts || !Array.isArray(parts)) continue
 
           const hasValidTextPart = parts.some(
-            (part) => part && part.type === "text" && !part.synthetic && !part.ignored,
+            (part) => part && part.type === "text" && !part.synthetic && !part.ignored && !part.plugin,
           )
 
           if (hasValidTextPart) {
@@ -1082,17 +1099,30 @@ export function Session() {
               </For>
             </scrollbox>
             <box flexShrink={0}>
-              <Prompt
-                ref={(r) => {
-                  prompt = r
-                  promptRef.set(r)
+              <Show when={!replaceInputPlugin()}>
+                <Prompt
+                  ref={(r) => {
+                    prompt = r
+                    promptRef.set(r)
+                  }}
+                  disabled={permissions().length > 0}
+                  onSubmit={() => {
+                    toBottom()
+                  }}
+                  sessionID={route.sessionID}
+                />
+              </Show>
+              <Show when={replaceInputPlugin()}>
+                {(plugin) => {
+                  const template = PluginRegistry.get(plugin().component)
+                  return template ? (
+                    <PluginUIRenderer
+                      node={template}
+                      metadata={{ ...plugin().metadata, _component: plugin().component, _partId: plugin().partId }}
+                    />
+                  ) : null
                 }}
-                disabled={permissions().length > 0}
-                onSubmit={() => {
-                  toBottom()
-                }}
-                sessionID={route.sessionID}
-              />
+              </Show>
             </box>
             <Show when={(!sidebarVisible() || sidebarOverlay()) && tall()}>
               <Footer />
@@ -1145,8 +1175,21 @@ function UserMessage(props: {
 }) {
   const ctx = use()
   const local = useLocal()
-  const text = createMemo(() => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic ? [x] : []))[0])
+  const text = createMemo(
+    () => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic && !x.plugin ? [x] : []))[0],
+  )
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
+  const pluginParts = createMemo(() =>
+    props.parts.flatMap((x): TextPart[] => {
+      if (x.type === "text" && x.plugin) {
+        const componentName = x.text.trim()
+        // Never render replaceInput plugin parts in chat history
+        if (PluginRegistry.shouldReplaceInput(componentName)) return []
+        return [x]
+      }
+      return []
+    }),
+  )
   const sync = useSync()
   const { theme, syntax } = useTheme()
   const [hover, setHover] = createSignal(false)
@@ -1243,6 +1286,20 @@ function UserMessage(props: {
           borderColor={theme.borderActive}
         />
       </Show>
+      <For each={pluginParts()}>
+        {(part) => {
+          const componentName = part.text.trim()
+          const metadata = { ...(part.metadata ?? {}), _component: componentName, _partId: part.id }
+          const template = PluginRegistry.get(componentName)
+          return (
+            <Show when={template}>
+              <box id={"plugin-" + part.id} flexShrink={0}>
+                <PluginUIRenderer node={template!} metadata={metadata} />
+              </box>
+            </Show>
+          )
+        }}
+      </For>
     </>
   )
 }

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -53,9 +53,9 @@ export namespace Plugin {
   })
 
   export async function trigger<
-    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool">,
-    Input = Parameters<Required<Hooks>[Name]>[0],
-    Output = Parameters<Required<Hooks>[Name]>[1],
+    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool" | "ui">,
+    Input = Parameters<Extract<Required<Hooks>[Name], (...args: any) => any>>[0],
+    Output = Parameters<Extract<Required<Hooks>[Name], (...args: any) => any>>[1],
   >(name: Name, input: Input, output: Output): Promise<Output> {
     if (!name) return output
     for (const hook of await state().then((x) => x.hooks)) {
@@ -71,6 +71,18 @@ export namespace Plugin {
 
   export async function list() {
     return state().then((x) => x.hooks)
+  }
+
+  export async function listUIComponents() {
+    const hooks = await list()
+    return hooks.flatMap((h) => h.ui ?? [])
+  }
+
+  export async function triggerUIEvent(event: { component: string; event: string; data: Record<string, any> }) {
+    const hooks = await list()
+    for (const hook of hooks) {
+      await hook["ui.event"]?.(event)
+    }
   }
 
   export async function init() {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -39,6 +39,7 @@ import { Todo } from "../session/todo"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { MCP } from "../mcp"
 import { Storage } from "../storage/storage"
+import { Plugin } from "../plugin"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { TuiEvent } from "@/cli/cmd/tui/event"
 import { Snapshot } from "@/snapshot"
@@ -240,6 +241,56 @@ export namespace Server {
       .use(validator("query", z.object({ directory: z.string().optional() })))
 
       .route("/project", ProjectRoute)
+
+      .get(
+        "/plugins/ui",
+        describeRoute({
+          summary: "List plugin UI components",
+          description: "Get a list of all registered plugin UI components with their templates.",
+          operationId: "plugins.ui",
+          responses: {
+            200: {
+              description: "Plugin UI components",
+              content: {
+                "application/json": {
+                  schema: resolver(z.array(z.any())),
+                },
+              },
+            },
+          },
+        }),
+        async () => {
+          const components = await Plugin.listUIComponents()
+          return Response.json(components)
+        },
+      )
+
+      .post(
+        "/plugins/ui/event",
+        describeRoute({
+          summary: "Send UI event to plugin",
+          description: "Send an event from a plugin UI component back to the plugin.",
+          operationId: "plugins.ui.event",
+          responses: {
+            200: {
+              description: "Event received",
+            },
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            component: z.string(),
+            event: z.string(),
+            data: z.record(z.string(), z.any()),
+          }),
+        ),
+        async (c) => {
+          const body = c.req.valid("json")
+          await Plugin.triggerUIEvent(body)
+          return c.json({ ok: true })
+        },
+      )
 
       .get(
         "/pty",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -63,6 +63,7 @@ export namespace MessageV2 {
     text: z.string(),
     synthetic: z.boolean().optional(),
     ignored: z.boolean().optional(),
+    plugin: z.boolean().optional(),
     time: z
       .object({
         start: z.number(),
@@ -431,7 +432,7 @@ export namespace MessageV2 {
         }
         result.push(userMessage)
         for (const part of msg.parts) {
-          if (part.type === "text" && !part.ignored)
+          if (part.type === "text" && !part.ignored && !part.plugin)
             userMessage.parts.push({
               type: "text",
               text: part.text,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -17,6 +17,109 @@ import { type ToolDefinition } from "./tool"
 
 export * from "./tool"
 
+/**
+ * Text node - displays styled text (non-interactive)
+ */
+export type TextNode = {
+  type: "text"
+  content: string
+  fg?: string
+  bold?: boolean
+}
+
+/**
+ * Box node - layout container with flex properties
+ */
+export type BoxNode = {
+  type: "box"
+  direction?: "row" | "column"
+  gap?: number
+  bg?: string
+  border?: ("top" | "bottom" | "left" | "right")[]
+  borderStyle?: "single" | "double" | "heavy" | "rounded"
+  borderColor?: string
+  marginX?: number
+  marginY?: number
+  marginTop?: number
+  marginBottom?: number
+  marginLeft?: number
+  marginRight?: number
+  paddingX?: number
+  paddingY?: number
+  paddingTop?: number
+  paddingBottom?: number
+  paddingLeft?: number
+  paddingRight?: number
+  justifyContent?: "flex-start" | "flex-end" | "center" | "space-between"
+  alignSelf?: "flex-start" | "flex-end" | "center"
+  minWidth?: number
+  children: PluginUINode[]
+}
+
+/**
+ * Checklist node - interactive toggleable list
+ *
+ * Keyboard: ↑/↓/j/k to navigate, Space to toggle
+ * Mouse: Click to toggle
+ */
+export type ChecklistNode = {
+  type: "checklist"
+  items: Array<{ id: string; label: string; checked?: boolean }> | string
+  fg?: string
+  fgChecked?: string
+  bgChecked?: string
+  borderColorChecked?: string
+  onToggle?: string
+}
+
+/**
+ * Button node - clickable button
+ *
+ * Keyboard: Press shortcut key to activate (if defined)
+ * Mouse: Click to activate
+ */
+export type ButtonNode = {
+  type: "button"
+  label: string
+  shortcut?: string
+  fg?: string
+  bg?: string
+  fgHover?: string
+  borderColorHover?: string
+  onPress?: string
+  onModal?: PluginUINode
+}
+
+/**
+ * Collapsible node - expandable/collapsible section
+ *
+ * Mouse: Click to toggle
+ */
+export type CollapsibleNode = {
+  type: "collapsible"
+  title: string
+  expanded?: boolean
+  fg?: string
+  fgExpanded?: string
+  icon?: string
+  iconExpanded?: string
+  children: PluginUINode[]
+}
+
+export type PluginUINode = TextNode | BoxNode | ChecklistNode | ButtonNode | CollapsibleNode
+
+export type PluginUIComponent = {
+  name: string
+  template: PluginUINode
+  replaceInput?: boolean
+}
+
+export type PluginUIEvent = {
+  component: string
+  event: string
+  data: Record<string, any>
+}
+
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"
   info: Provider
@@ -145,6 +248,8 @@ export type AuthOuathResult = { url: string; instructions: string } & (
 export interface Hooks {
   event?: (input: { event: Event }) => Promise<void>
   config?: (input: Config) => Promise<void>
+  ui?: PluginUIComponent[]
+  "ui.event"?: (input: PluginUIEvent) => Promise<void>
   tool?: {
     [key: string]: ToolDefinition
   }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -56,6 +56,8 @@ import type {
   PathGetResponses,
   PermissionRespondErrors,
   PermissionRespondResponses,
+  PluginsUiEventResponses,
+  PluginsUiResponses,
   ProjectCurrentResponses,
   ProjectListResponses,
   ProjectUpdateErrors,
@@ -306,6 +308,72 @@ export class Project extends HeyApiClient {
       },
     })
   }
+}
+
+export class Ui extends HeyApiClient {
+  /**
+   * Send UI event to plugin
+   *
+   * Send an event from a plugin UI component back to the plugin.
+   */
+  public event<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      component?: string
+      event?: string
+      data?: {
+        [key: string]: unknown
+      }
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "component" },
+            { in: "body", key: "event" },
+            { in: "body", key: "data" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PluginsUiEventResponses, unknown, ThrowOnError>({
+      url: "/plugins/ui/event",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Plugins extends HeyApiClient {
+  /**
+   * List plugin UI components
+   *
+   * Get a list of all registered plugin UI components with their templates.
+   */
+  public ui<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<PluginsUiResponses, unknown, ThrowOnError>({
+      url: "/plugins/ui",
+      ...options,
+      ...params,
+    })
+  }
+
+  ui2 = new Ui({ client: this.client })
 }
 
 export class Pty extends HeyApiClient {
@@ -2666,6 +2734,8 @@ export class OpencodeClient extends HeyApiClient {
   global = new Global({ client: this.client })
 
   project = new Project({ client: this.client })
+
+  plugins = new Plugins({ client: this.client })
 
   pty = new Pty({ client: this.client })
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -191,6 +191,7 @@ export type TextPart = {
   text: string
   synthetic?: boolean
   ignored?: boolean
+  plugin?: boolean
   time?: {
     start: number
     end?: number
@@ -1615,6 +1616,7 @@ export type TextPartInput = {
   text: string
   synthetic?: boolean
   ignored?: boolean
+  plugin?: boolean
   time?: {
     start: number
     end?: number
@@ -2022,6 +2024,46 @@ export type ProjectUpdateResponses = {
 }
 
 export type ProjectUpdateResponse = ProjectUpdateResponses[keyof ProjectUpdateResponses]
+
+export type PluginsUiData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/plugins/ui"
+}
+
+export type PluginsUiResponses = {
+  /**
+   * Plugin UI components
+   */
+  200: Array<unknown>
+}
+
+export type PluginsUiResponse = PluginsUiResponses[keyof PluginsUiResponses]
+
+export type PluginsUiEventData = {
+  body?: {
+    component: string
+    event: string
+    data: {
+      [key: string]: unknown
+    }
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/plugins/ui/event"
+}
+
+export type PluginsUiEventResponses = {
+  /**
+   * Event received
+   */
+  200: unknown
+}
 
 export type PtyListData = {
   body?: never

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -260,3 +260,249 @@ Format as a structured prompt that a new agent can use to resume work.
 ```
 
 When `output.prompt` is set, it completely replaces the default compaction prompt. The `output.context` array is ignored in this case.
+
+---
+
+## UI Components
+
+Plugins can render custom UI components in the TUI. Components are declarative templates that opencode renders natively, with full support for keyboard navigation, mouse events, and theming.
+
+---
+
+### Capabilities
+
+Plugin UI components support:
+
+- **Layout**: Flexible boxes with row/column direction, padding, gaps, and alignment
+- **Text**: Styled text with theme colors and bold formatting
+- **Checklist**: Interactive lists with keyboard (↑/↓/Space) and mouse support
+- **Buttons**: Clickable buttons with shortcuts, hover states, and modal triggers
+- **Collapsible**: Expandable/collapsible sections for progressive disclosure
+- **Modals**: Full-screen dialogs triggered by buttons
+- **Input replacement**: Components can temporarily replace the input area
+
+---
+
+### Defining components
+
+Define UI components in the `ui` hook of your plugin:
+
+```ts title=".opencode/plugin/my-plugin.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const MyPlugin: Plugin = async (ctx) => {
+  return {
+    ui: [
+      {
+        name: "my-status",
+        template: {
+          type: "box",
+          direction: "row",
+          gap: 1,
+          children: [
+            { type: "text", content: "●", fg: "success" },
+            { type: "text", content: "{{message}}", fg: "text" },
+          ],
+        },
+      },
+    ],
+  }
+}
+```
+
+Components use `{{placeholder}}` syntax for dynamic values passed via metadata.
+
+---
+
+### Component options
+
+| Option         | Description                                    |
+| -------------- | ---------------------------------------------- |
+| `name`         | Unique identifier for the component            |
+| `template`     | The UI node tree to render                     |
+| `replaceInput` | When `true`, component replaces the input area |
+
+---
+
+### Rendering components
+
+Send a component to the chat by including a plugin part in a message:
+
+```ts
+await client.session.prompt({
+  path: { id: sessionId },
+  body: {
+    noReply: true,
+    parts: [
+      {
+        type: "text",
+        text: "my-status",
+        plugin: true,
+        metadata: {
+          message: "Build complete",
+        },
+      },
+    ],
+  },
+})
+```
+
+---
+
+### Node types
+
+#### Text
+
+Display styled text with theme colors.
+
+```ts
+{
+  type: "text",
+  content: "Hello {{name}}",
+  fg: "text",       // Theme color or hex
+  bold: true
+}
+```
+
+#### Box
+
+Container for layout with flexbox properties.
+
+```ts
+{
+  type: "box",
+  direction: "column",  // "row" | "column"
+  gap: 1,
+  paddingX: 2,
+  paddingY: 1,
+  justifyContent: "space-between",
+  bg: "backgroundPanel",
+  children: [...]
+}
+```
+
+#### Checklist
+
+Interactive list with keyboard and mouse support.
+
+```ts
+{
+  type: "checklist",
+  items: "items",  // Metadata key or inline array
+  fgChecked: "text",
+  fg: "textMuted",
+  bgChecked: "backgroundElement",
+  onToggle: "item-toggled"
+}
+```
+
+Users can navigate with ↑/↓ arrows and toggle with Space.
+
+#### Button
+
+Clickable button with optional keyboard shortcut and modal trigger.
+
+```ts
+{
+  type: "button",
+  label: "Confirm",
+  shortcut: "c",           // Optional keyboard shortcut
+  fg: "textMuted",
+  bg: "backgroundPanel",   // Omit for text-only button
+  fgHover: "warning",
+  borderColorHover: "warning",
+  onPress: "confirm"       // Event to emit on click
+}
+```
+
+Buttons with `bg` render with a background and left border indicator. Without `bg`, they render as clickable text.
+
+#### Collapsible
+
+Expandable section for hiding details.
+
+```ts
+{
+  type: "collapsible",
+  title: "{{count}} items",
+  expanded: false,
+  icon: "▶",
+  iconExpanded: "▼",
+  fg: "textMuted",
+  fgExpanded: "text",
+  children: [...]
+}
+```
+
+---
+
+### Modals
+
+Buttons can trigger modals by providing an inline `onModal` node:
+
+```ts
+{
+  type: "button",
+  label: "⚙",
+  fg: "textMuted",
+  fgHover: "warning",
+  onModal: {
+    type: "box",
+    direction: "column",
+    children: [
+      { type: "text", content: "Settings", bold: true },
+      { type: "text", content: "Configure options here", fg: "textMuted" },
+    ],
+  },
+}
+```
+
+Modals render with a dimmed overlay. Press Escape to close.
+
+---
+
+### Handling events
+
+Listen for component events using the `ui.event` hook:
+
+```ts
+export const MyPlugin: Plugin = async (ctx) => {
+  return {
+    "ui.event": async ({ component, event, data }) => {
+      if (component === "my-component") {
+        if (event === "confirm") {
+          // Handle confirmation
+        }
+        if (event === "item-toggled") {
+          console.log("Toggled:", data.id, data.checked)
+        }
+      }
+    },
+    ui: [...],
+  }
+}
+```
+
+Events include the component name, event name, and any associated data.
+
+---
+
+### Theme colors
+
+Components use theme color aliases that adapt to the user's theme:
+
+| Alias               | Description                    |
+| ------------------- | ------------------------------ |
+| `text`              | Primary text color             |
+| `textMuted`         | Secondary/dimmed text          |
+| `background`        | Main background                |
+| `backgroundPanel`   | Panel background               |
+| `backgroundElement` | Interactive element background |
+| `border`            | Default border color           |
+| `borderActive`      | Active/focused border          |
+| `accent`            | Accent color                   |
+| `warning`           | Warning/highlight color        |
+| `success`           | Success indicator              |
+| `error`             | Error indicator                |
+
+You can also use hex colors directly: `"#ff5500"`.


### PR DESCRIPTION
## Summary
This PR introduces a declarative UI system for plugins, allowing them to render rich, interactive components directly in the TUI.

### Capabilities
**Render custom UI in chat**
Plugins can display styled text, layout containers, and interactive elements inline within the conversation — useful for status indicators, summaries, or custom workflows.

**Interactive checklists**
Users can navigate with ↑/↓/j/k and toggle items with Space, or use the mouse to select list items. Plugins receive events when items are toggled, enabling things like task selection, feature toggles, or multi-select confirmations.

**Buttons with shortcuts and hover states**
Clickable buttons with optional keyboard shortcuts and hover state. Buttons can emit events back to the plugin or trigger modals for additional context.

**Collapsible sections**
Expandable/collapsible regions for progressive disclosure — show a summary by default, expand for details.

**Modals**
foreground dialogs triggered by buttons, useful for settings panels, detailed views, or focused interactions that need more space.

**Input replacement**
Components can temporarily take over the input area for focused interactions like confirmations or selections, then restore normal input when dismissed.

**Theme-aware styling**
All components use semantic color tokens (text, textMuted, warning, success, etc.) that automatically adapt to the user's chosen theme.

## Few examples

**Replace input component with a checklist**
<img width="1147" height="413" alt="image" src="https://github.com/user-attachments/assets/e369f8ab-deb0-4772-83ac-18c97ad44409" />

**Collapsible list (rendered inline for the example)**
<img width="1152" height="299" alt="image" src="https://github.com/user-attachments/assets/f8a4c75e-2038-492e-a67d-208c2e50b561" />

<img width="1144" height="347" alt="image" src="https://github.com/user-attachments/assets/5ace6053-0592-4c77-b9bd-1f160df3b776" />

**Inline component (not replaceInput)**
<img width="1153" height="664" alt="image" src="https://github.com/user-attachments/assets/7d21e604-66e3-4363-b69f-97748c03f7ac" />

**Modal**
<img width="1148" height="409" alt="image" src="https://github.com/user-attachments/assets/ecb7a523-c34e-4b83-af0a-fcf012c49a28" />


---

### Current shortcomings
- Inline components don't get dismissed, they stay in chat - not sure if we should keep them or remove them upon dismissal.
- Missing scrollbox renderable support, but collapsible may be enough for now ?

### Future consideration
A fluent builder API (e.g., ui.box().row().gap(1).children(...)) could make authoring plugin UIs more ergonomic than the current JSON template format. Keeping that out of scope for this PR since it's already substantial, but worth exploring as a follow-up.

