### PR TITLE
docs: add MCP OAuth debugging section

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -171,7 +171,7 @@ For most OAuth-enabled MCP servers, no special configuration is needed. Just con
 }
 ```
 
-If the server requires authentication, OpenCode will prompt you to authenticate when you first try to use it.
+If the server requires authentication, OpenCode will prompt you to authenticate when you first try to use it. If not, you can [manually trigger the flow](#authenticating) with `opencode mcp auth <server-name>`.
 
 #### Pre-registered Client
 
@@ -239,6 +239,20 @@ opencode mcp logout my-oauth-server
 ```
 
 The `mcp auth` command will open your browser for authorization. After you authorize, OpenCode will store the tokens securely in `~/.local/share/opencode/mcp-auth.json`.
+
+#### Debugging
+
+If a remote MCP server is failing to authenticate, you can diagnose issues with:
+
+```bash
+# View auth status for all OAuth-capable servers
+opencode mcp auth list
+
+# Debug connection and OAuth flow for a specific server
+opencode mcp debug my-oauth-server
+```
+
+The `mcp debug` command shows the current auth status, tests HTTP connectivity, and attempts the OAuth discovery flow.
 
 ---
 


### PR DESCRIPTION
Documents the new MCP debugging commands from #5980:

- Add note about manually triggering auth with `opencode mcp auth <server-name>` if auto-prompt doesn't work
- Add "Debugging" section covering `opencode mcp auth list` and `opencode mcp debug`