### PR TITLE
feat: add configurable prompt history max size (experimental)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -25,12 +25,13 @@ export type PromptInfo = {
   )[]
 }
 
-const MAX_HISTORY_ENTRIES = 50
-
 export const { use: usePromptHistory, provider: PromptHistoryProvider } = createSimpleContext({
   name: "PromptHistory",
   init: () => {
     const historyFile = Bun.file(path.join(Global.Path.state, "prompt-history.jsonl"))
+    // Default to 50, this will be overridden by config if set
+    let maxEntries = 50
+
     onMount(async () => {
       const text = await historyFile.text().catch(() => "")
       const lines = text
@@ -44,7 +45,7 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
           }
         })
         .filter((line): line is PromptInfo => line !== null)
-        .slice(-MAX_HISTORY_ENTRIES)
+        .slice(-maxEntries)
 
       setStore("history", lines)
 
@@ -87,8 +88,8 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
         setStore(
           produce((draft) => {
             draft.history.push(entry)
-            if (draft.history.length > MAX_HISTORY_ENTRIES) {
-              draft.history = draft.history.slice(-MAX_HISTORY_ENTRIES)
+            if (draft.history.length > maxEntries) {
+              draft.history = draft.history.slice(-maxEntries)
               trimmed = true
             }
             draft.index = 0

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -585,6 +585,13 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    prompt_history_max_size: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(50)
+      .describe("Maximum number of prompt history entries to keep in memory"),
   })
 
   export const Layout = z.enum(["auto", "stretch"]).meta({


### PR DESCRIPTION
- Add prompt_history_max_size to TUI config with default value of 50
- Update history provider to use config value instead of hardcoded constant
- Allow users to customize how many prompts are kept in memory
- Config can be set in opencode.json: { "tui": { "prompt_history_max_size": 200 } }