### PR TITLE
feat(skill): change skill path to skills/

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -71,14 +71,14 @@ export namespace Config {
       Global.Path.config,
       ...(await Array.fromAsync(
         Filesystem.up({
-          targets: [".opencode"],
+          targets: [".opencode", ".claude"],
           start: Instance.directory,
           stop: Instance.worktree,
         }),
       )),
       ...(await Array.fromAsync(
         Filesystem.up({
-          targets: [".opencode"],
+          targets: [".opencode", ".claude"],
           start: Global.Path.home,
           stop: Global.Path.home,
         }),
@@ -92,7 +92,9 @@ export namespace Config {
 
     const promises: Promise<void>[] = []
     for (const dir of unique(directories)) {
-      await assertValid(dir)
+      if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
+        await assertValid(dir)
+      }
 
       if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
         for (const file of ["opencode.jsonc", "opencode.json"]) {
@@ -147,7 +149,7 @@ export namespace Config {
     }
   })
 
-  const INVALID_DIRS = new Bun.Glob(`{${["agents", "commands", "plugins", "tools"].join(",")}}/`)
+  const INVALID_DIRS = new Bun.Glob(`{${["agents", "commands", "plugins", "tools", "skill"].join(",")}}/`)
   async function assertValid(dir: string) {
     const invalid = await Array.fromAsync(
       INVALID_DIRS.scan({

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -32,7 +32,7 @@ export namespace Skill {
     }),
   )
 
-  const SKILL_GLOB = new Bun.Glob("skill/**/SKILL.md")
+  const SKILL_GLOB = new Bun.Glob("skills/**/SKILL.md")
 
   export const state = Instance.state(async () => {
     const directories = await Config.directories()

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -5,11 +5,11 @@ import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import path from "path"
 
-test("discovers skills from .opencode/skill/ directory", async () => {
+test("discovers skills from .opencode/skills/ directory", async () => {
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
-      const skillDir = path.join(dir, ".opencode", "skill", "test-skill")
+      const skillDir = path.join(dir, ".opencode", "skills", "test-skill")
       await Bun.write(
         path.join(skillDir, "SKILL.md"),
         `---
@@ -32,16 +32,16 @@ Instructions here.
       expect(skills.length).toBe(1)
       expect(skills[0].name).toBe("test-skill")
       expect(skills[0].description).toBe("A test skill for verification.")
-      expect(skills[0].location).toContain("skill/test-skill/SKILL.md")
+      expect(skills[0].location).toContain("skills/test-skill/SKILL.md")
     },
   })
 })
 
-test("discovers multiple skills from .opencode/skill/ directory", async () => {
+test("discovers multiple skills from .opencode/skills/ directory", async () => {
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
-      const skillDir = path.join(dir, ".opencode", "skill", "my-skill")
+      const skillDir = path.join(dir, ".opencode", "skills", "my-skill")
       await Bun.write(
         path.join(skillDir, "SKILL.md"),
         `---
@@ -69,7 +69,7 @@ test("skips skills with missing frontmatter", async () => {
   await using tmp = await tmpdir({
     git: true,
     init: async (dir) => {
-      const skillDir = path.join(dir, ".opencode", "skill", "no-frontmatter")
+      const skillDir = path.join(dir, ".opencode", "skills", "no-frontmatter")
       await Bun.write(
         path.join(skillDir, "SKILL.md"),
         `# No Frontmatter
@@ -101,31 +101,31 @@ test("returns empty array when no skills exist", async () => {
   })
 })
 
-// test("discovers skills from .claude/skills/ directory", async () => {
-//   await using tmp = await tmpdir({
-//     git: true,
-//     init: async (dir) => {
-//       const skillDir = path.join(dir, ".claude", "skills", "claude-skill")
-//       await Bun.write(
-//         path.join(skillDir, "SKILL.md"),
-//         `---
-// name: claude-skill
-// description: A skill in the .claude/skills directory.
-// ---
+test("discovers skills from .claude/skills/ directory", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const skillDir = path.join(dir, ".claude", "skills", "claude-skill")
+      await Bun.write(
+        path.join(skillDir, "SKILL.md"),
+        `---
+name: claude-skill
+description: A skill in the .claude/skills directory.
+---
 
-// # Claude Skill
-// `,
-//       )
-//     },
-//   })
+# Claude Skill
+`,
+      )
+    },
+  })
 
-//   await Instance.provide({
-//     directory: tmp.path,
-//     fn: async () => {
-//       const skills = await Skill.all()
-//       expect(skills.length).toBe(1)
-//       expect(skills[0].name).toBe("claude-skill")
-//       expect(skills[0].location).toContain(".claude/skills/claude-skill/SKILL.md")
-//     },
-//   })
-// })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      expect(skills.length).toBe(1)
+      expect(skills[0].name).toBe("claude-skill")
+      expect(skills[0].location).toContain(".claude/skills/claude-skill/SKILL.md")
+    },
+  })
+})

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -13,8 +13,8 @@ Skills are loaded on-demand via the native `skill` tool—agents see available s
 Create one folder per skill name and put a `SKILL.md` inside it.
 OpenCode searches these locations:
 
-- Project config: `.opencode/skill/<name>/SKILL.md`
-- Global config: `~/.opencode/skill/<name>/SKILL.md`
+- Project config: `.opencode/skills/<name>/SKILL.md`
+- Global config: `~/.opencode/skills/<name>/SKILL.md`
 - Claude-compatible: `.claude/skills/<name>/SKILL.md`
 
 ---
@@ -22,9 +22,9 @@ OpenCode searches these locations:
 ## Understand discovery
 
 For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
-It loads any matching `skill/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` along the way.
+It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` along the way.
 
-Global definitions are also loaded from `~/.opencode/skill/*/SKILL.md`.
+Global definitions are also loaded from `~/.opencode/skills/*/SKILL.md`.
 
 ---
 
@@ -70,7 +70,7 @@ Keep it specific enough for the agent to choose correctly.
 
 ## Use an example
 
-Create `.opencode/skill/git-release/SKILL.md` like this:
+Create `.opencode/skills/git-release/SKILL.md` like this:
 
 ```markdown
 ---


### PR DESCRIPTION
## Summary
- Changed skill discovery path from `.opencode/skill/` to `.opencode/skills/` (plural).
- Added support for discovering skills from `.claude/skills/` in both project and home directories.
- Added validation to guide users to use the plural `skills/` directory.
- Updated documentation and tests to reflect these changes.

## Context
In version 1.0.192, skills located in `.opencode/skill/` (as previously documented) were **failing** to load for users with large skill libraries (~25 skills). 

Solution: Renaming the parent directory to `skills/` resolved the issue. 

While the [Agent Skills spec](https://agentskills.io/integrate-skills) defines the `SKILL.md` file, it does not strictly define the parent directory name. This PR standardizes on `skills/` to align with Claude-compatible conventions and ensures OpenCode looks in both `.opencode/` and `.claude/` locations. This fixes the documentation mismatch and the loading issue.

## tree

per example, this works as expected as tested in the current version of oc (1.0.192)

```txt
.opencode
├── agent
├── command
└── skills
    ├── changelog
    │   ├── references
    │   │   └── changelog_sop.md
    │   └── SKILL.md
    ├── cli-gh
    │   ├── references
    │   │   └── help.md
    │   └── SKILL.md
    └── cli-chezmoi
        ├── references
        │   └── cli_reference.md
        ├── scripts
        │   └── apply_chezmoi.sh
        ├── assets
        └── SKILL.md
```

## Session

https://opncd.ai/share/1XhiOijp

Crap, this share seems broken 😥