### PR TITLE
feat(tui): add mouse support to menus

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/hoverable-label.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/hoverable-label.tsx
@@ -1,0 +1,51 @@
+import { RGBA } from "@opentui/core"
+import { createSignal, createUniqueId, onCleanup, type JSX } from "solid-js"
+import { useTheme, selectedForeground } from "@tui/context/theme"
+
+const [activeId, setActiveId] = createSignal<string | null>(null)
+
+type HoverableLabelProps = {
+  children: (hover: boolean, hoverFg: () => RGBA) => JSX.Element
+  onClick?: () => void
+  disabled?: boolean
+}
+
+export function HoverableLabel(props: HoverableLabelProps) {
+  const id = createUniqueId()
+  const { theme } = useTheme()
+  const hoverFg = () => selectedForeground(theme)
+
+  const isHovered = () => activeId() === id && !props.disabled
+
+  onCleanup(() => {
+    if (activeId() !== id) return
+    setActiveId(null)
+  })
+
+  const handleMouseOver = () => {
+    if (props.disabled) return
+    setActiveId(id)
+  }
+
+  const handleMouseOut = () => {
+    if (activeId() !== id) return
+    setActiveId(null)
+  }
+
+  const handleClick = () => {
+    if (props.disabled) return
+    setActiveId(null)
+    props.onClick?.()
+  }
+
+  return (
+    <box
+      backgroundColor={isHovered() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
+      onMouseUp={handleClick}
+    >
+      {props.children(isHovered(), hoverFg)}
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,18 +1,8 @@
-import {
-  BoxRenderable,
-  TextareaRenderable,
-  MouseEvent,
-  PasteEvent,
-  t,
-  dim,
-  fg,
-  type KeyBinding,
-  RGBA,
-} from "@opentui/core"
+import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, type KeyBinding } from "@opentui/core"
 import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import { useLocal } from "@tui/context/local"
-import { useTheme, selectedForeground } from "@tui/context/theme"
+import { useTheme } from "@tui/context/theme"
 import { EmptyBorder } from "@tui/component/border"
 import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
@@ -42,6 +32,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { DialogAgent } from "../dialog-agent"
 import { DialogModel } from "../dialog-model"
+import { HoverableLabel } from "../hoverable-label"
 
 export type PromptProps = {
   sessionID?: string
@@ -141,7 +132,6 @@ export function Prompt(props: PromptProps) {
   const wide = createMemo(() => dimensions().width > 120)
   const { theme, syntax } = useTheme()
   const kv = useKV()
-  const hoverFg = createMemo(() => selectedForeground(theme))
 
   function promptModelWarning() {
     toast.show({
@@ -199,11 +189,6 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: new Map(),
     interrupt: 0,
   })
-
-  const [agentHover, setAgentHover] = createSignal(false)
-  const [modelNameHover, setModelNameHover] = createSignal(false)
-  const [agentCycleHover, setAgentCycleHover] = createSignal(false)
-  const [commandListHover, setCommandListHover] = createSignal(false)
 
   command.register(() => {
     return [
@@ -971,38 +956,24 @@ export function Prompt(props: PromptProps) {
             />
             <Show when={tall()}>
               <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
-                <box
-                  backgroundColor={agentHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
-                  onMouseOver={() => setAgentHover(true)}
-                  onMouseOut={() => setAgentHover(false)}
-                  onMouseUp={() => {
-                    if (store.mode === "shell") return
-                    dialog.replace(() => <DialogAgent />)
-                  }}
-                >
-                  <text fg={agentHover() ? hoverFg() : highlight()}>
-                    {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
-                  </text>
-                </box>
-                <Show when={store.mode === "normal"}>
-                  <box
-                    flexDirection="row"
-                    gap={1}
-                    backgroundColor={modelNameHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
-                    onMouseOver={() => setModelNameHover(true)}
-                    onMouseOut={() => setModelNameHover(false)}
-                    onMouseUp={() => {
-                      dialog.replace(() => <DialogModel />)
-                    }}
-                  >
-                    <text
-                      flexShrink={0}
-                      fg={modelNameHover() ? hoverFg() : keybind.leader ? theme.textMuted : theme.text}
-                    >
-                      {local.model.parsed().model}
+                <HoverableLabel disabled={store.mode === "shell"} onClick={() => dialog.replace(() => <DialogAgent />)}>
+                  {(hover, hoverFg) => (
+                    <text fg={hover ? hoverFg() : highlight()}>
+                      {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
                     </text>
-                    <text fg={modelNameHover() ? hoverFg() : theme.textMuted}>{local.model.parsed().provider}</text>
-                  </box>
+                  )}
+                </HoverableLabel>
+                <Show when={store.mode === "normal"}>
+                  <HoverableLabel onClick={() => dialog.replace(() => <DialogModel />)}>
+                    {(hover, hoverFg) => (
+                      <box flexDirection="row" gap={1}>
+                        <text flexShrink={0} fg={hover ? hoverFg() : keybind.leader ? theme.textMuted : theme.text}>
+                          {local.model.parsed().model}
+                        </text>
+                        <text fg={hover ? hoverFg() : theme.textMuted}>{local.model.parsed().provider}</text>
+                      </box>
+                    )}
+                  </HoverableLabel>
                 </Show>
               </box>
             </Show>
@@ -1117,38 +1088,24 @@ export function Prompt(props: PromptProps) {
           <Switch>
             <Match when={status().type !== "retry" && !tall()}>
               <box flexDirection="row" gap={1}>
-                <box
-                  backgroundColor={agentHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
-                  onMouseOver={() => setAgentHover(true)}
-                  onMouseOut={() => setAgentHover(false)}
-                  onMouseUp={() => {
-                    if (store.mode === "shell") return
-                    dialog.replace(() => <DialogAgent />)
-                  }}
-                >
-                  <text fg={agentHover() ? hoverFg() : highlight()}>
-                    {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
-                  </text>
-                </box>
-                <Show when={store.mode === "normal"}>
-                  <box
-                    flexDirection="row"
-                    gap={1}
-                    backgroundColor={modelNameHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
-                    onMouseOver={() => setModelNameHover(true)}
-                    onMouseOut={() => setModelNameHover(false)}
-                    onMouseUp={() => {
-                      dialog.replace(() => <DialogModel />)
-                    }}
-                  >
-                    <text
-                      flexShrink={0}
-                      fg={modelNameHover() ? hoverFg() : keybind.leader ? theme.textMuted : theme.text}
-                    >
-                      {local.model.parsed().model}
+                <HoverableLabel disabled={store.mode === "shell"} onClick={() => dialog.replace(() => <DialogAgent />)}>
+                  {(hover, hoverFg) => (
+                    <text fg={hover ? hoverFg() : highlight()}>
+                      {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
                     </text>
-                    <text fg={modelNameHover() ? hoverFg() : theme.textMuted}>{local.model.parsed().provider}</text>
-                  </box>
+                  )}
+                </HoverableLabel>
+                <Show when={store.mode === "normal"}>
+                  <HoverableLabel onClick={() => dialog.replace(() => <DialogModel />)}>
+                    {(hover, hoverFg) => (
+                      <box flexDirection="row" gap={1}>
+                        <text flexShrink={0} fg={hover ? hoverFg() : keybind.leader ? theme.textMuted : theme.text}>
+                          {local.model.parsed().model}
+                        </text>
+                        <text fg={hover ? hoverFg() : theme.textMuted}>{local.model.parsed().provider}</text>
+                      </box>
+                    )}
+                  </HoverableLabel>
                 </Show>
               </box>
             </Match>
@@ -1157,34 +1114,28 @@ export function Prompt(props: PromptProps) {
             <Switch>
               <Match when={store.mode === "normal"}>
                 <Show when={wide()}>
-                  <box
-                    backgroundColor={agentCycleHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
-                    onMouseOver={() => setAgentCycleHover(true)}
-                    onMouseOut={() => setAgentCycleHover(false)}
-                    onMouseUp={() => dialog.replace(() => <DialogAgent />)}
-                  >
-                    <text fg={agentCycleHover() ? hoverFg() : theme.text}>
-                      {keybind.print("agent_cycle")}{" "}
-                      <span style={{ fg: agentCycleHover() ? hoverFg() : theme.textMuted }}>switch agent</span>
-                    </text>
-                  </box>
+                  <HoverableLabel onClick={() => dialog.replace(() => <DialogAgent />)}>
+                    {(hover, hoverFg) => (
+                      <text fg={hover ? hoverFg() : theme.text}>
+                        {keybind.print("agent_cycle")}{" "}
+                        <span style={{ fg: hover ? hoverFg() : theme.textMuted }}>switch agent</span>
+                      </text>
+                    )}
+                  </HoverableLabel>
                 </Show>
                 <Show when={!wide()}>
                   <text fg={theme.text}>
-                    {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
+                    {keybind.print("sidebar_toggle")} <span style={{ fg: theme.textMuted }}>sidebar</span>
                   </text>
                 </Show>
-                <box
-                  backgroundColor={commandListHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
-                  onMouseOver={() => setCommandListHover(true)}
-                  onMouseOut={() => setCommandListHover(false)}
-                  onMouseUp={() => command.show()}
-                >
-                  <text fg={commandListHover() ? hoverFg() : theme.text}>
-                    {keybind.print("command_list")}{" "}
-                    <span style={{ fg: commandListHover() ? hoverFg() : theme.textMuted }}>commands</span>
-                  </text>
-                </box>
+                <HoverableLabel onClick={() => command.show()}>
+                  {(hover, hoverFg) => (
+                    <text fg={hover ? hoverFg() : theme.text}>
+                      {keybind.print("command_list")}{" "}
+                      <span style={{ fg: hover ? hoverFg() : theme.textMuted }}>commands</span>
+                    </text>
+                  )}
+                </HoverableLabel>
               </Match>
               <Match when={store.mode === "shell"}>
                 <text fg={theme.text}>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,8 +1,18 @@
-import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, t, dim, fg, type KeyBinding } from "@opentui/core"
+import {
+  BoxRenderable,
+  TextareaRenderable,
+  MouseEvent,
+  PasteEvent,
+  t,
+  dim,
+  fg,
+  type KeyBinding,
+  RGBA,
+} from "@opentui/core"
 import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import { useLocal } from "@tui/context/local"
-import { useTheme } from "@tui/context/theme"
+import { useTheme, selectedForeground } from "@tui/context/theme"
 import { EmptyBorder } from "@tui/component/border"
 import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
@@ -16,7 +26,7 @@ import { usePromptStash } from "./stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
 import { useCommandDialog } from "../dialog-command"
-import { useRenderer } from "@opentui/solid"
+import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
@@ -30,6 +40,8 @@ import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
+import { DialogAgent } from "../dialog-agent"
+import { DialogModel } from "../dialog-model"
 
 export type PromptProps = {
   sessionID?: string
@@ -124,8 +136,12 @@ export function Prompt(props: PromptProps) {
   const stash = usePromptStash()
   const command = useCommandDialog()
   const renderer = useRenderer()
+  const dimensions = useTerminalDimensions()
+  const tall = createMemo(() => dimensions().height > 40)
+  const wide = createMemo(() => dimensions().width > 120)
   const { theme, syntax } = useTheme()
   const kv = useKV()
+  const hoverFg = createMemo(() => selectedForeground(theme))
 
   function promptModelWarning() {
     toast.show({
@@ -183,6 +199,11 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: new Map(),
     interrupt: 0,
   })
+
+  const [agentHover, setAgentHover] = createSignal(false)
+  const [modelNameHover, setModelNameHover] = createSignal(false)
+  const [agentCycleHover, setAgentCycleHover] = createSignal(false)
+  const [commandListHover, setCommandListHover] = createSignal(false)
 
   command.register(() => {
     return [
@@ -948,19 +969,43 @@ export function Prompt(props: PromptProps) {
               cursorColor={theme.text}
               syntaxStyle={syntax()}
             />
-            <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
-              <text fg={highlight()}>
-                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
-              </text>
-              <Show when={store.mode === "normal"}>
-                <box flexDirection="row" gap={1}>
-                  <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
-                    {local.model.parsed().model}
+            <Show when={tall()}>
+              <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
+                <box
+                  backgroundColor={agentHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+                  onMouseOver={() => setAgentHover(true)}
+                  onMouseOut={() => setAgentHover(false)}
+                  onMouseUp={() => {
+                    if (store.mode === "shell") return
+                    dialog.replace(() => <DialogAgent />)
+                  }}
+                >
+                  <text fg={agentHover() ? hoverFg() : highlight()}>
+                    {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
                   </text>
-                  <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
                 </box>
-              </Show>
-            </box>
+                <Show when={store.mode === "normal"}>
+                  <box
+                    flexDirection="row"
+                    gap={1}
+                    backgroundColor={modelNameHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+                    onMouseOver={() => setModelNameHover(true)}
+                    onMouseOut={() => setModelNameHover(false)}
+                    onMouseUp={() => {
+                      dialog.replace(() => <DialogModel />)
+                    }}
+                  >
+                    <text
+                      flexShrink={0}
+                      fg={modelNameHover() ? hoverFg() : keybind.leader ? theme.textMuted : theme.text}
+                    >
+                      {local.model.parsed().model}
+                    </text>
+                    <text fg={modelNameHover() ? hoverFg() : theme.textMuted}>{local.model.parsed().provider}</text>
+                  </box>
+                </Show>
+              </box>
+            </Show>
           </box>
         </box>
         <box
@@ -1069,25 +1114,85 @@ export function Prompt(props: PromptProps) {
               </text>
             </box>
           </Show>
-          <Show when={status().type !== "retry"}>
-            <box gap={2} flexDirection="row">
-              <Switch>
-                <Match when={store.mode === "normal"}>
-                  <text fg={theme.text}>
-                    {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>switch agent</span>
+          <Switch>
+            <Match when={status().type !== "retry" && !tall()}>
+              <box flexDirection="row" gap={1}>
+                <box
+                  backgroundColor={agentHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+                  onMouseOver={() => setAgentHover(true)}
+                  onMouseOut={() => setAgentHover(false)}
+                  onMouseUp={() => {
+                    if (store.mode === "shell") return
+                    dialog.replace(() => <DialogAgent />)
+                  }}
+                >
+                  <text fg={agentHover() ? hoverFg() : highlight()}>
+                    {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
                   </text>
+                </box>
+                <Show when={store.mode === "normal"}>
+                  <box
+                    flexDirection="row"
+                    gap={1}
+                    backgroundColor={modelNameHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+                    onMouseOver={() => setModelNameHover(true)}
+                    onMouseOut={() => setModelNameHover(false)}
+                    onMouseUp={() => {
+                      dialog.replace(() => <DialogModel />)
+                    }}
+                  >
+                    <text
+                      flexShrink={0}
+                      fg={modelNameHover() ? hoverFg() : keybind.leader ? theme.textMuted : theme.text}
+                    >
+                      {local.model.parsed().model}
+                    </text>
+                    <text fg={modelNameHover() ? hoverFg() : theme.textMuted}>{local.model.parsed().provider}</text>
+                  </box>
+                </Show>
+              </box>
+            </Match>
+          </Switch>
+          <box gap={2} flexDirection="row" marginLeft="auto">
+            <Switch>
+              <Match when={store.mode === "normal"}>
+                <Show when={wide()}>
+                  <box
+                    backgroundColor={agentCycleHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+                    onMouseOver={() => setAgentCycleHover(true)}
+                    onMouseOut={() => setAgentCycleHover(false)}
+                    onMouseUp={() => dialog.replace(() => <DialogAgent />)}
+                  >
+                    <text fg={agentCycleHover() ? hoverFg() : theme.text}>
+                      {keybind.print("agent_cycle")}{" "}
+                      <span style={{ fg: agentCycleHover() ? hoverFg() : theme.textMuted }}>switch agent</span>
+                    </text>
+                  </box>
+                </Show>
+                <Show when={!wide()}>
                   <text fg={theme.text}>
                     {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
                   </text>
-                </Match>
-                <Match when={store.mode === "shell"}>
-                  <text fg={theme.text}>
-                    esc <span style={{ fg: theme.textMuted }}>exit shell mode</span>
+                </Show>
+                <box
+                  backgroundColor={commandListHover() ? theme.primary : RGBA.fromInts(0, 0, 0, 0)}
+                  onMouseOver={() => setCommandListHover(true)}
+                  onMouseOut={() => setCommandListHover(false)}
+                  onMouseUp={() => command.show()}
+                >
+                  <text fg={commandListHover() ? hoverFg() : theme.text}>
+                    {keybind.print("command_list")}{" "}
+                    <span style={{ fg: commandListHover() ? hoverFg() : theme.textMuted }}>commands</span>
                   </text>
-                </Match>
-              </Switch>
-            </box>
-          </Show>
+                </box>
+              </Match>
+              <Match when={store.mode === "shell"}>
+                <text fg={theme.text}>
+                  esc <span style={{ fg: theme.textMuted }}>exit shell mode</span>
+                </text>
+              </Match>
+            </Switch>
+          </box>
         </box>
       </box>
     </>


### PR DESCRIPTION

https://github.com/user-attachments/assets/1c62c96f-be45-4ded-b156-edbab6248d35

<img width="817" height="399" alt="image" src="https://github.com/user-attachments/assets/a6c4898e-217a-4d4e-9912-215e1501b279" />

makes agent/model/context menu work with mouse controls.