### PR TITLE
fix: correct Content-Type headers for static assets on app.opencode.ai

### DIFF
--- a/packages/app/public/_headers
+++ b/packages/app/public/_headers
@@ -1,0 +1,17 @@
+/assets/*.js
+  Content-Type: application/javascript
+
+/assets/*.mjs
+  Content-Type: application/javascript
+
+/assets/*.css
+  Content-Type: text/css
+
+/*.js
+  Content-Type: application/javascript
+
+/*.mjs
+  Content-Type: application/javascript
+
+/*.css
+  Content-Type: text/css


### PR DESCRIPTION
## Problem

When running `opencode web` and opening the URL (e.g., http://127.0.0.1:63308/), users see the message:

> You need to enable JavaScript to run this app.

This occurs even when JavaScript is enabled in the browser. The root cause is that the Cloudflare Pages deployment serving `app.opencode.ai` returns JavaScript and CSS files with incorrect `Content-Type: text/html` headers instead of the correct MIME types (`application/javascript` and `text/css`).

Browsers refuse to execute JavaScript files served with incorrect Content-Type headers as a security measure, causing the `<noscript>` fallback message to display.

## Solution

Add a `_headers` file in `packages/app/public/` to instruct Cloudflare Pages to serve static assets with correct MIME types. Cloudflare Pages reads this configuration file during deployment and applies the specified Content-Type headers to matching file patterns.

## Testing

After deployment, verify that:
1. `https://app.opencode.ai/assets/*.js` returns `Content-Type: application/javascript`
2. `https://app.opencode.ai/assets/*.css` returns `Content-Type: text/css`
3. Running `opencode web` and opening the browser shows the UI instead of the noscript message

## Related

This is a bug fix for the web interface deployment configuration.