### PR TITLE
Correct cli command for Windsurf to `surf`

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -324,7 +324,7 @@ Popular editor options include:
 
 - `code` - Visual Studio Code
 - `cursor` - Cursor
-- `windsurf` - Windsurf
+- `surf` - Windsurf
 - `nvim` - Neovim editor
 - `vim` - Vim editor
 - `nano` - Nano editor


### PR DESCRIPTION
Windsurf installs `surf` not `windsurf` to the path