### PR TITLE
fix(lsp): make JDTLS use the correct config directory on Windows

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1175,7 +1175,7 @@ export namespace LSPServer {
             case "linux":
               return "config_linux"
             case "win32":
-              return "config_windows"
+              return "config_win"
             default:
               return "config_linux"
           }


### PR DESCRIPTION
The correct config directory for JDTLS on Windows is config_win not config_windows.