### PR TITLE
feat: add `allow_tmpdir` permission for scoped tmpdir access

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -403,6 +403,7 @@ export namespace Config {
       bash: PermissionRule.optional(),
       task: PermissionRule.optional(),
       external_directory: PermissionRule.optional(),
+      tmpdir: PermissionAction.optional(),
       todowrite: PermissionAction.optional(),
       todoread: PermissionAction.optional(),
       webfetch: PermissionAction.optional(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -400,6 +400,10 @@ export namespace SessionPrompt {
               ruleset: PermissionNext.merge(taskAgent.permission, session.permission ?? []),
             })
           },
+          allowed(permission: string, pattern = "*") {
+            const ruleset = PermissionNext.merge(taskAgent.permission, session.permission ?? [])
+            return PermissionNext.evaluate(permission, pattern, ruleset).action === "allow"
+          },
         }
         const result = await taskTool.execute(taskArgs, taskCtx).catch((error) => {
           executionError = error
@@ -673,6 +677,10 @@ export namespace SessionPrompt {
           ruleset: PermissionNext.merge(input.agent.permission, input.session.permission ?? []),
         })
       },
+      allowed(permission: string, pattern = "*") {
+        const ruleset = PermissionNext.merge(input.agent.permission, input.session.permission ?? [])
+        return PermissionNext.evaluate(permission, pattern, ruleset).action === "allow"
+      },
     })
 
     for (const item of await ToolRegistry.tools(input.model.providerID)) {
@@ -911,6 +919,7 @@ export namespace SessionPrompt {
                       extra: { bypassCwdCheck: true, model },
                       metadata: async () => {},
                       ask: async () => {},
+                      allowed: () => true,
                     }
                     const result = await t.execute(args, readCtx)
                     pieces.push({
@@ -972,6 +981,7 @@ export namespace SessionPrompt {
                   extra: { bypassCwdCheck: true },
                   metadata: async () => {},
                   ask: async () => {},
+                  allowed: () => true,
                 }
                 const result = await ListTool.init().then((t) => t.execute(args, listCtx))
                 return [

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -134,12 +134,18 @@ export const BashTool = Tool.define("bash", async () => {
       }
 
       if (directories.size > 0) {
-        await ctx.ask({
-          permission: "external_directory",
-          patterns: Array.from(directories),
-          always: Array.from(directories).map((x) => path.dirname(x) + "*"),
-          metadata: {},
-        })
+        // Filter out tmpdir paths if tmpdir permission is allowed
+        const filtered = ctx.allowed("tmpdir")
+          ? Array.from(directories).filter((dir) => !Filesystem.isInTmpdir(dir))
+          : Array.from(directories)
+        if (filtered.length > 0) {
+          await ctx.ask({
+            permission: "external_directory",
+            patterns: filtered,
+            always: filtered.map((x) => path.dirname(x) + "*"),
+            metadata: {},
+          })
+        }
       }
 
       if (patterns.size > 0) {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -41,16 +41,20 @@ export const EditTool = Tool.define("edit", {
 
     const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
     if (!Filesystem.contains(Instance.directory, filePath)) {
-      const parentDir = path.dirname(filePath)
-      await ctx.ask({
-        permission: "external_directory",
-        patterns: [parentDir, path.join(parentDir, "*")],
-        always: [parentDir + "/*"],
-        metadata: {
-          filepath: filePath,
-          parentDir,
-        },
-      })
+      // Skip external_directory check for tmpdir paths when tmpdir permission is allowed
+      const skipCheck = ctx.allowed("tmpdir") && Filesystem.isInTmpdir(filePath)
+      if (!skipCheck) {
+        const parentDir = path.dirname(filePath)
+        await ctx.ask({
+          permission: "external_directory",
+          patterns: [parentDir, path.join(parentDir, "*")],
+          always: [parentDir + "/*"],
+          metadata: {
+            filepath: filePath,
+            parentDir,
+          },
+        })
+      }
     }
 
     let diff = ""

--- a/packages/opencode/src/tool/patch.ts
+++ b/packages/opencode/src/tool/patch.ts
@@ -51,16 +51,20 @@ export const PatchTool = Tool.define("patch", {
       const filePath = path.resolve(Instance.directory, hunk.path)
 
       if (!Filesystem.contains(Instance.directory, filePath)) {
-        const parentDir = path.dirname(filePath)
-        await ctx.ask({
-          permission: "external_directory",
-          patterns: [parentDir, path.join(parentDir, "*")],
-          always: [parentDir + "/*"],
-          metadata: {
-            filepath: filePath,
-            parentDir,
-          },
-        })
+        // Skip external_directory check for tmpdir paths when tmpdir permission is allowed
+        const skipCheck = ctx.allowed("tmpdir") && Filesystem.isInTmpdir(filePath)
+        if (!skipCheck) {
+          const parentDir = path.dirname(filePath)
+          await ctx.ask({
+            permission: "external_directory",
+            patterns: [parentDir, path.join(parentDir, "*")],
+            always: [parentDir + "/*"],
+            metadata: {
+              filepath: filePath,
+              parentDir,
+            },
+          })
+        }
       }
 
       switch (hunk.type) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -28,16 +28,20 @@ export const ReadTool = Tool.define("read", {
     const title = path.relative(Instance.worktree, filepath)
 
     if (!ctx.extra?.["bypassCwdCheck"] && !Filesystem.contains(Instance.directory, filepath)) {
-      const parentDir = path.dirname(filepath)
-      await ctx.ask({
-        permission: "external_directory",
-        patterns: [parentDir],
-        always: [parentDir + "/*"],
-        metadata: {
-          filepath,
-          parentDir,
-        },
-      })
+      // Skip external_directory check for tmpdir paths when tmpdir permission is allowed
+      const skipCheck = ctx.allowed("tmpdir") && Filesystem.isInTmpdir(filepath)
+      if (!skipCheck) {
+        const parentDir = path.dirname(filepath)
+        await ctx.ask({
+          permission: "external_directory",
+          patterns: [parentDir],
+          always: [parentDir + "/*"],
+          metadata: {
+            filepath,
+            parentDir,
+          },
+        })
+      }
     }
 
     await ctx.ask({

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -21,6 +21,8 @@ export namespace Tool {
     extra?: { [key: string]: any }
     metadata(input: { title?: string; metadata?: M }): void
     ask(input: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">): Promise<void>
+    /** Check if a permission is allowed for the given pattern */
+    allowed(permission: string, pattern?: string): boolean
   }
   export interface Info<Parameters extends z.ZodType = z.ZodType, M extends Metadata = Metadata> {
     id: string

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -22,12 +22,22 @@ export const WriteTool = Tool.define("write", {
   }),
   async execute(params, ctx) {
     const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
-    /* TODO
     if (!Filesystem.contains(Instance.directory, filepath)) {
-      const parentDir = path.dirname(filepath)
-      ...
+      // Skip external_directory check for tmpdir paths when tmpdir permission is allowed
+      const skipCheck = ctx.allowed("tmpdir") && Filesystem.isInTmpdir(filepath)
+      if (!skipCheck) {
+        const parentDir = path.dirname(filepath)
+        await ctx.ask({
+          permission: "external_directory",
+          patterns: [parentDir, path.join(parentDir, "*")],
+          always: [parentDir + "/*"],
+          metadata: {
+            filepath,
+            parentDir,
+          },
+        })
+      }
     }
-    */
 
     const file = Bun.file(filepath)
     const exists = await file.exists()

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -108,18 +108,26 @@ export namespace Filesystem {
       const resolvedChild = realpathSync(child)
       return !relative(resolvedParent, resolvedChild).startsWith("..")
     } catch {
-      // Path doesn't exist yet (e.g., file being created), resolve parent directory
+      // Path doesn't exist yet (e.g., file being created)
+      // Walk up the child path to find the first existing ancestor and resolve from there
       try {
         const resolvedParent = realpathSync(parent)
-        const childDir = dirname(child)
-        try {
-          const resolvedChildDir = realpathSync(childDir)
-          const resolvedChild = join(resolvedChildDir, child.split(/[/\\]/).pop()!)
-          return !relative(resolvedParent, resolvedChild).startsWith("..")
-        } catch {
-          // Parent directory doesn't exist either, use normalized paths
-          return !relative(parent, child).startsWith("..")
+        let current = child
+        let suffix = ""
+        while (current !== dirname(current)) {
+          try {
+            const resolvedCurrent = realpathSync(current)
+            const resolvedChild = suffix ? join(resolvedCurrent, suffix) : resolvedCurrent
+            return !relative(resolvedParent, resolvedChild).startsWith("..")
+          } catch {
+            // This level doesn't exist, move up
+            const base = current.split(/[/\\]/).pop()!
+            suffix = suffix ? join(base, suffix) : base
+            current = dirname(current)
+          }
         }
+        // No ancestor exists, fall back to unresolved comparison
+        return !relative(parent, child).startsWith("..")
       } catch {
         return !relative(parent, child).startsWith("..")
       }

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,6 +1,7 @@
 import { realpathSync } from "fs"
 import { exists } from "fs/promises"
 import { dirname, join, relative } from "path"
+import os from "os"
 
 export namespace Filesystem {
   /**
@@ -79,5 +80,56 @@ export namespace Filesystem {
       current = parent
     }
     return result
+  }
+
+  /**
+   * Get the system's temporary directory with symlink resolution.
+   * Handles platform differences:
+   * - Linux: Usually /tmp
+   * - macOS: /var/folders/.../T/ (symlinked from /tmp -> /private/tmp)
+   * - Windows: C:\Users\<user>\AppData\Local\Temp
+   */
+  export function tmpdir(): string {
+    const tmp = os.tmpdir()
+    try {
+      return realpathSync(tmp)
+    } catch {
+      return tmp
+    }
+  }
+
+  /**
+   * Check if child path is within parent, with symlink resolution.
+   * Prevents symlink traversal attacks.
+   */
+  export function containsResolved(parent: string, child: string): boolean {
+    try {
+      const resolvedParent = realpathSync(parent)
+      const resolvedChild = realpathSync(child)
+      return !relative(resolvedParent, resolvedChild).startsWith("..")
+    } catch {
+      // Path doesn't exist yet (e.g., file being created), resolve parent directory
+      try {
+        const resolvedParent = realpathSync(parent)
+        const childDir = dirname(child)
+        try {
+          const resolvedChildDir = realpathSync(childDir)
+          const resolvedChild = join(resolvedChildDir, child.split(/[/\\]/).pop()!)
+          return !relative(resolvedParent, resolvedChild).startsWith("..")
+        } catch {
+          // Parent directory doesn't exist either, use normalized paths
+          return !relative(parent, child).startsWith("..")
+        }
+      } catch {
+        return !relative(parent, child).startsWith("..")
+      }
+    }
+  }
+
+  /**
+   * Check if path is within the system tmpdir
+   */
+  export function isInTmpdir(filepath: string): boolean {
+    return containsResolved(tmpdir(), filepath)
   }
 }

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -230,4 +230,90 @@ describe("tool.bash permissions", () => {
       },
     })
   })
+
+  test("allows tmpdir access when allow_tmpdir is true", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        // Create context that allows tmpdir
+        const ctxWithTmpdir = {
+          ...ctx,
+          allowed: (permission: string) => permission === "tmpdir",
+        }
+        // Should allow workdir in system tmpdir when allow_tmpdir is true
+        const result = await bash.execute(
+          {
+            command: "pwd",
+            workdir: require("os").tmpdir(),
+            description: "Print working directory in tmpdir",
+          },
+          ctxWithTmpdir,
+        )
+        expect(result.metadata.exit).toBe(0)
+      },
+    })
+  })
+
+  test("denies tmpdir access when allow_tmpdir is false", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        // Create context that denies tmpdir but asks for external_directory
+        const ctxDenyTmpdir = {
+          ...ctx,
+          allowed: () => false,
+          ask: async (req: { permission: string }) => {
+            if (req.permission === "external_directory") {
+              throw new Error("external_directory denied")
+            }
+          },
+        }
+        // Should deny workdir in system tmpdir when allow_tmpdir is false
+        await expect(
+          bash.execute(
+            {
+              command: "pwd",
+              workdir: require("os").tmpdir(),
+              description: "Print working directory in tmpdir",
+            },
+            ctxDenyTmpdir,
+          ),
+        ).rejects.toThrow()
+      },
+    })
+  })
+
+  test("allow_tmpdir does not affect non-tmpdir external paths", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        // Create context that allows tmpdir but denies other external dirs
+        const ctxWithTmpdir = {
+          ...ctx,
+          allowed: (permission: string) => permission === "tmpdir",
+          ask: async (req: { permission: string }) => {
+            if (req.permission === "external_directory") {
+              throw new Error("external_directory denied")
+            }
+          },
+        }
+        // Should still deny access to non-tmpdir external paths
+        await expect(
+          bash.execute(
+            {
+              command: "cd /usr",
+              description: "Change to /usr directory",
+            },
+            ctxWithTmpdir,
+          ),
+        ).rejects.toThrow()
+      },
+    })
+  })
 })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -13,6 +13,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  allowed: () => false,
 }
 
 const projectRoot = path.join(__dirname, "../..")

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -12,6 +12,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  allowed: () => false,
 }
 
 const projectRoot = path.join(__dirname, "../..")

--- a/packages/opencode/test/tool/patch.test.ts
+++ b/packages/opencode/test/tool/patch.test.ts
@@ -14,6 +14,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  allowed: () => false,
 }
 
 const patchTool = await PatchTool.init()

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -13,6 +13,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  allowed: () => false,
 }
 
 describe("tool.read external_directory permission", () => {

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs"
+import { Filesystem } from "../../src/util/filesystem"
+
+describe("Filesystem.tmpdir", () => {
+  test("returns a resolved path", () => {
+    const tmp = Filesystem.tmpdir()
+    // Should be an absolute path
+    expect(path.isAbsolute(tmp)).toBe(true)
+    // Should exist
+    expect(fs.existsSync(tmp)).toBe(true)
+  })
+
+  test("resolves symlinks", () => {
+    const tmp = Filesystem.tmpdir()
+    // On macOS, /tmp is a symlink to /private/tmp
+    // The resolved path should not be /tmp if it's a symlink
+    if (process.platform === "darwin") {
+      expect(tmp).not.toBe("/tmp")
+      expect(tmp).toContain("/private")
+    }
+  })
+})
+
+describe("Filesystem.isInTmpdir", () => {
+  test("returns true for paths in tmpdir", () => {
+    const tmp = Filesystem.tmpdir()
+    expect(Filesystem.isInTmpdir(path.join(tmp, "test.txt"))).toBe(true)
+    expect(Filesystem.isInTmpdir(path.join(tmp, "subdir", "test.txt"))).toBe(true)
+  })
+
+  test("returns false for paths outside tmpdir", () => {
+    expect(Filesystem.isInTmpdir("/home/user/file.txt")).toBe(false)
+    expect(Filesystem.isInTmpdir("/etc/passwd")).toBe(false)
+    expect(Filesystem.isInTmpdir("/usr/local/bin")).toBe(false)
+  })
+
+  test("handles symlinked tmpdir paths on macOS", () => {
+    if (process.platform === "darwin") {
+      // os.tmpdir() on macOS returns /var/folders/.../T which resolves to /private/var/folders/.../T
+      // We should be able to use either the resolved or unresolved form
+      const unresolved = require("os").tmpdir()
+      expect(Filesystem.isInTmpdir(path.join(unresolved, "test.txt"))).toBe(true)
+    }
+  })
+
+  test("returns true for nested non-existent paths in tmpdir", () => {
+    const tmp = Filesystem.tmpdir()
+    const deepPath = path.join(tmp, "nonexistent", "deeply", "nested", "file.txt")
+    expect(Filesystem.isInTmpdir(deepPath)).toBe(true)
+  })
+})
+
+describe("Filesystem.containsResolved", () => {
+  test("returns true when child is within parent", () => {
+    const tmp = Filesystem.tmpdir()
+    expect(Filesystem.containsResolved(tmp, path.join(tmp, "child.txt"))).toBe(true)
+    expect(Filesystem.containsResolved(tmp, path.join(tmp, "subdir", "child.txt"))).toBe(true)
+  })
+
+  test("returns false when child is outside parent", () => {
+    const tmp = Filesystem.tmpdir()
+    expect(Filesystem.containsResolved(tmp, "/etc/passwd")).toBe(false)
+    expect(Filesystem.containsResolved(tmp, "/usr/local")).toBe(false)
+  })
+
+  test("handles non-existent child paths", () => {
+    const tmp = Filesystem.tmpdir()
+    const nonExistent = path.join(tmp, "does-not-exist-" + Date.now(), "file.txt")
+    expect(Filesystem.containsResolved(tmp, nonExistent)).toBe(true)
+  })
+
+  test("handles deeply nested non-existent paths", () => {
+    const tmp = Filesystem.tmpdir()
+    const deepPath = path.join(tmp, "a", "b", "c", "d", "e", "file.txt")
+    expect(Filesystem.containsResolved(tmp, deepPath)).toBe(true)
+  })
+
+  test("resolves symlinks in macOS /tmp", () => {
+    if (process.platform === "darwin") {
+      // /tmp -> /private/tmp on macOS
+      const privateTmp = "/private/tmp"
+      expect(Filesystem.containsResolved(privateTmp, "/tmp/test.txt")).toBe(true)
+    }
+  })
+})

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -384,7 +384,7 @@ You can also use wildcards to control multiple tools at once. For example, to di
 
 ### Permissions
 
-You can configure permissions to manage what actions an agent can take. Currently, the permissions for the `edit`, `bash`, and `webfetch` tools can be configured to:
+You can configure permissions to manage what actions an agent can take. Currently, the permissions for the `edit`, `bash`, `webfetch`, `external_directory`, and `tmpdir` can be configured to:
 
 - `"ask"` — Prompt for approval before running the tool
 - `"allow"` — Allow all operations without approval

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -226,6 +226,34 @@ This provides an additional safety layer to prevent unintended modifications to 
 
 ---
 
+### allow_tmpdir
+
+Use the `permission.allow_tmpdir` key to allow file operations in the system's temporary directory without requiring `external_directory` approval.
+
+This is useful for:
+
+- CI/CD environments where permission prompts cause hangs
+- Tools that need to write temporary files
+- Scoped access without allowing all external directories
+
+```json title="opencode.json" {4-5}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "allow_tmpdir": true,
+    "external_directory": "ask"
+  }
+}
+```
+
+When `allow_tmpdir` is `true`, file operations in the OS tmpdir (e.g., `/tmp` on Linux, `/var/folders/.../T/` on macOS, `%TEMP%` on Windows) are permitted without triggering `external_directory` prompts.
+
+:::note
+This only affects the tmpdir. Access to other external directories still follows `external_directory` settings.
+:::
+
+---
+
 ## Agents
 
 You can also configure permissions per agent. Where the agent specific config

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -29,7 +29,7 @@ This lets you configure granular controls for the `edit`, `bash`, `skill`, `webf
 
 ## Tools
 
-Currently, the permissions for the `edit`, `bash`, `skill`, `webfetch`, `doom_loop`, and `external_directory` tools can be configured through the `permission` option.
+Currently, the permissions for the `edit`, `bash`, `skill`, `webfetch`, `doom_loop`, `external_directory`, and `tmpdir` can be configured through the `permission` option.
 
 ---
 


### PR DESCRIPTION
This PR adds an `allow_tmpdir` permission that allows file operations in the system's temporary directory without requiring `external_directory` approval prompts.

The `permission.allow_tmpdir: boolean` (defaults to `false`) and is in both global/merged config and per-agent config/schemas.

specifically:

- `external_directory` defaults to `"ask"`, prompting for permission on any file operation outside the current working directory
- In CI/CD and CLI environments, this prompt causes indefinite hangs (see #5888)
- The existing workaround (`external_directory: "allow"`) permits access to ALL external directories, which is overly broad
- Requiring users to create a custom agent just to allow tmpdir access is high friction

security:

- Symlink resolution prevents traversal attacks (critical on macOS where `/tmp` → `/private/tmp`)
- Default `false` maintains current security model (opt-in)
- Only affects tmpdir; other external directories still follow `external_directory` settings

tests:

- `Filesystem.tmpdir()`, `isInTmpdir()`, `containsResolved()` utilities tested for symlink resolution and non-existent paths
- Bash tool tests verify `allow_tmpdir: true` permits tmpdir workdir while `external_directory: deny` is set
- Bash tool tests verify `allow_tmpdir: true` does not bypass `external_directory` for non-tmpdir paths

usage example:

```json
{
  "$schema": "https://opencode.ai/config.json",
  "permission": {
    "allow_tmpdir": true,
    "external_directory": "ask"
  }
}
```

Or per-agent:

```json
{
  "agent": {
    "build": {
      "permission": {
        "allow_tmpdir": true
      }
    }
  }
}
```

related:

- #4743 - Feature request for tmpdir access
- #5888 - CLI mode hangs due to external_directory prompts
- #5395 - Split external_directory into read vs write