### PR TITLE
feat(tui): add XML/HTML syntax theme tokens

### DIFF
--- a/packages/opencode/src/cli/cmd/run/theme.ts
+++ b/packages/opencode/src/cli/cmd/run/theme.ts
@@ -72,9 +72,15 @@ type Variant = {
 type ColorValue = HexColor | RefName | Variant | RGBA | number
 type ThemeJson = {
   defs?: Record<string, HexColor | RefName>
-  theme: Omit<Record<ThemeColor, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
+  theme: Omit<
+    Record<ThemeColor, ColorValue>,
+    "selectedListItemText" | "backgroundMenu" | "syntaxTag" | "syntaxAttribute" | "syntaxTagDelimiter"
+  > & {
     selectedListItemText?: ColorValue
     backgroundMenu?: ColorValue
+    syntaxTag?: ColorValue
+    syntaxAttribute?: ColorValue
+    syntaxTagDelimiter?: ColorValue
     thinkingOpacity?: number
   }
 }
@@ -269,7 +275,15 @@ export function resolveTheme(theme: ThemeJson, pick: "dark" | "light"): TuiTheme
 
   const resolved = Object.fromEntries(
     Object.entries(theme.theme)
-      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
+      .filter(
+        ([key]) =>
+          key !== "selectedListItemText" &&
+          key !== "backgroundMenu" &&
+          key !== "thinkingOpacity" &&
+          key !== "syntaxTag" &&
+          key !== "syntaxAttribute" &&
+          key !== "syntaxTagDelimiter",
+      )
       .map(([key, value]) => [key, resolveColor(value as ColorValue)]),
   ) as Partial<Record<ThemeColor, RGBA>>
 
@@ -281,6 +295,13 @@ export function resolveTheme(theme: ThemeJson, pick: "dark" | "light"): TuiTheme
         : resolveColor(theme.theme.selectedListItemText),
     backgroundMenu:
       theme.theme.backgroundMenu === undefined ? resolved.backgroundElement! : resolveColor(theme.theme.backgroundMenu),
+    syntaxTag: theme.theme.syntaxTag === undefined ? resolved.error! : resolveColor(theme.theme.syntaxTag),
+    syntaxAttribute:
+      theme.theme.syntaxAttribute === undefined ? resolved.syntaxKeyword! : resolveColor(theme.theme.syntaxAttribute),
+    syntaxTagDelimiter:
+      theme.theme.syntaxTagDelimiter === undefined
+        ? resolved.syntaxOperator!
+        : resolveColor(theme.theme.syntaxTagDelimiter),
     thinkingOpacity: theme.theme.thinkingOpacity ?? 0.6,
   }
 }
@@ -424,6 +445,9 @@ export function generateSystem(colors: TerminalColors, pick: "dark" | "light"): 
       syntaxType: ansi.cyan,
       syntaxOperator: ansi.cyan,
       syntaxPunctuation: fg,
+      syntaxTag: ansi.red,
+      syntaxAttribute: ansi.magenta,
+      syntaxTagDelimiter: ansi.cyan,
     },
   }
 }

--- a/packages/opencode/src/cli/cmd/tui/context/theme-resolver.ts
+++ b/packages/opencode/src/cli/cmd/tui/context/theme-resolver.ts
@@ -1,0 +1,215 @@
+import { RGBA } from "@opentui/core"
+import type { TuiThemeCurrent } from "@opencode-ai/plugin/tui"
+import aura from "./theme/aura.json" with { type: "json" }
+import ayu from "./theme/ayu.json" with { type: "json" }
+import catppuccin from "./theme/catppuccin.json" with { type: "json" }
+import catppuccinFrappe from "./theme/catppuccin-frappe.json" with { type: "json" }
+import catppuccinMacchiato from "./theme/catppuccin-macchiato.json" with { type: "json" }
+import cobalt2 from "./theme/cobalt2.json" with { type: "json" }
+import cursor from "./theme/cursor.json" with { type: "json" }
+import dracula from "./theme/dracula.json" with { type: "json" }
+import everforest from "./theme/everforest.json" with { type: "json" }
+import flexoki from "./theme/flexoki.json" with { type: "json" }
+import github from "./theme/github.json" with { type: "json" }
+import gruvbox from "./theme/gruvbox.json" with { type: "json" }
+import kanagawa from "./theme/kanagawa.json" with { type: "json" }
+import material from "./theme/material.json" with { type: "json" }
+import matrix from "./theme/matrix.json" with { type: "json" }
+import mercury from "./theme/mercury.json" with { type: "json" }
+import monokai from "./theme/monokai.json" with { type: "json" }
+import nightowl from "./theme/nightowl.json" with { type: "json" }
+import nord from "./theme/nord.json" with { type: "json" }
+import osakaJade from "./theme/osaka-jade.json" with { type: "json" }
+import onedark from "./theme/one-dark.json" with { type: "json" }
+import opencode from "./theme/opencode.json" with { type: "json" }
+import orng from "./theme/orng.json" with { type: "json" }
+import lucentOrng from "./theme/lucent-orng.json" with { type: "json" }
+import palenight from "./theme/palenight.json" with { type: "json" }
+import rosepine from "./theme/rosepine.json" with { type: "json" }
+import solarized from "./theme/solarized.json" with { type: "json" }
+import synthwave84 from "./theme/synthwave84.json" with { type: "json" }
+import tokyonight from "./theme/tokyonight.json" with { type: "json" }
+import vercel from "./theme/vercel.json" with { type: "json" }
+import vesper from "./theme/vesper.json" with { type: "json" }
+import zenburn from "./theme/zenburn.json" with { type: "json" }
+import carbonfox from "./theme/carbonfox.json" with { type: "json" }
+
+export type Theme = TuiThemeCurrent & {
+  _hasSelectedListItemText: boolean
+}
+
+type ThemeColor = Exclude<keyof TuiThemeCurrent, "thinkingOpacity">
+type HexColor = `#${string}`
+type RefName = string
+type Variant = {
+  dark: HexColor | RefName
+  light: HexColor | RefName
+}
+type ColorValue = HexColor | RefName | Variant | RGBA
+
+export type ThemeJson = {
+  $schema?: string
+  defs?: Record<string, HexColor | RefName>
+  theme: Omit<
+    Record<ThemeColor, ColorValue>,
+    "selectedListItemText" | "backgroundMenu" | "syntaxTag" | "syntaxAttribute" | "syntaxTagDelimiter"
+  > & {
+    selectedListItemText?: ColorValue
+    backgroundMenu?: ColorValue
+    syntaxTag?: ColorValue
+    syntaxAttribute?: ColorValue
+    syntaxTagDelimiter?: ColorValue
+    thinkingOpacity?: number
+  }
+}
+
+export const DEFAULT_THEMES: Record<string, ThemeJson> = {
+  aura,
+  ayu,
+  catppuccin,
+  ["catppuccin-frappe"]: catppuccinFrappe,
+  ["catppuccin-macchiato"]: catppuccinMacchiato,
+  cobalt2,
+  cursor,
+  dracula,
+  everforest,
+  flexoki,
+  github,
+  gruvbox,
+  kanagawa,
+  material,
+  matrix,
+  mercury,
+  monokai,
+  nightowl,
+  nord,
+  ["one-dark"]: onedark,
+  ["osaka-jade"]: osakaJade,
+  opencode,
+  orng,
+  ["lucent-orng"]: lucentOrng,
+  palenight,
+  rosepine,
+  solarized,
+  synthwave84,
+  tokyonight,
+  vesper,
+  vercel,
+  zenburn,
+  carbonfox,
+}
+
+export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
+  const defs = theme.defs ?? {}
+  function resolveColor(c: ColorValue, chain: string[] = []): RGBA {
+    if (c instanceof RGBA) return c
+    if (typeof c === "string") {
+      if (c === "transparent" || c === "none") return RGBA.fromInts(0, 0, 0, 0)
+      if (c.startsWith("#")) return RGBA.fromHex(c)
+      if (chain.includes(c)) {
+        throw new Error(`Circular color reference: ${[...chain, c].join(" -> ")}`)
+      }
+
+      const next = defs[c] ?? theme.theme[c as ThemeColor]
+      if (next === undefined) {
+        throw new Error(`Color reference "${c}" not found in defs or theme`)
+      }
+      return resolveColor(next, [...chain, c])
+    }
+    if (typeof c === "number") return ansiToRgba(c)
+    return resolveColor(c[mode], chain)
+  }
+
+  const resolved = Object.fromEntries(
+    Object.entries(theme.theme)
+      .filter(
+        ([key]) =>
+          key !== "selectedListItemText" &&
+          key !== "backgroundMenu" &&
+          key !== "thinkingOpacity" &&
+          key !== "syntaxTag" &&
+          key !== "syntaxAttribute" &&
+          key !== "syntaxTagDelimiter",
+      )
+      .map(([key, value]) => [key, resolveColor(value as ColorValue)]),
+  ) as Partial<Record<ThemeColor, RGBA>>
+
+  const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
+  if (hasSelectedListItemText) {
+    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!)
+  } else {
+    resolved.selectedListItemText = resolved.background
+  }
+
+  if (theme.theme.backgroundMenu !== undefined) {
+    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
+  } else {
+    resolved.backgroundMenu = resolved.backgroundElement
+  }
+
+  if (theme.theme.syntaxTag !== undefined) {
+    resolved.syntaxTag = resolveColor(theme.theme.syntaxTag)
+  } else {
+    resolved.syntaxTag = resolved.error
+  }
+
+  if (theme.theme.syntaxAttribute !== undefined) {
+    resolved.syntaxAttribute = resolveColor(theme.theme.syntaxAttribute)
+  } else {
+    resolved.syntaxAttribute = resolved.syntaxKeyword
+  }
+
+  if (theme.theme.syntaxTagDelimiter !== undefined) {
+    resolved.syntaxTagDelimiter = resolveColor(theme.theme.syntaxTagDelimiter)
+  } else {
+    resolved.syntaxTagDelimiter = resolved.syntaxOperator
+  }
+
+  const thinkingOpacity = theme.theme.thinkingOpacity ?? 0.6
+
+  return {
+    ...resolved,
+    _hasSelectedListItemText: hasSelectedListItemText,
+    thinkingOpacity,
+  } as Theme
+}
+
+export function ansiToRgba(code: number): RGBA {
+  if (code < 16) {
+    const ansiColors = [
+      "#000000",
+      "#800000",
+      "#008000",
+      "#808000",
+      "#000080",
+      "#800080",
+      "#008080",
+      "#c0c0c0",
+      "#808080",
+      "#ff0000",
+      "#00ff00",
+      "#ffff00",
+      "#0000ff",
+      "#ff00ff",
+      "#00ffff",
+      "#ffffff",
+    ]
+    return RGBA.fromHex(ansiColors[code] ?? "#000000")
+  }
+
+  if (code < 232) {
+    const index = code - 16
+    const b = index % 6
+    const g = Math.floor(index / 6) % 6
+    const r = Math.floor(index / 36)
+    const val = (x: number) => (x === 0 ? 0 : x * 40 + 55)
+    return RGBA.fromInts(val(r), val(g), val(b))
+  }
+
+  if (code < 256) {
+    const gray = (code - 232) * 10 + 8
+    return RGBA.fromInts(gray, gray, gray)
+  }
+
+  return RGBA.fromInts(0, 0, 0)
+}

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -3,39 +3,7 @@ import path from "path"
 import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
 import { createSimpleContext } from "./helper"
 import { Glob } from "@opencode-ai/core/util/glob"
-import aura from "./theme/aura.json" with { type: "json" }
-import ayu from "./theme/ayu.json" with { type: "json" }
-import catppuccin from "./theme/catppuccin.json" with { type: "json" }
-import catppuccinFrappe from "./theme/catppuccin-frappe.json" with { type: "json" }
-import catppuccinMacchiato from "./theme/catppuccin-macchiato.json" with { type: "json" }
-import cobalt2 from "./theme/cobalt2.json" with { type: "json" }
-import cursor from "./theme/cursor.json" with { type: "json" }
-import dracula from "./theme/dracula.json" with { type: "json" }
-import everforest from "./theme/everforest.json" with { type: "json" }
-import flexoki from "./theme/flexoki.json" with { type: "json" }
-import github from "./theme/github.json" with { type: "json" }
-import gruvbox from "./theme/gruvbox.json" with { type: "json" }
-import kanagawa from "./theme/kanagawa.json" with { type: "json" }
-import material from "./theme/material.json" with { type: "json" }
-import matrix from "./theme/matrix.json" with { type: "json" }
-import mercury from "./theme/mercury.json" with { type: "json" }
-import monokai from "./theme/monokai.json" with { type: "json" }
-import nightowl from "./theme/nightowl.json" with { type: "json" }
-import nord from "./theme/nord.json" with { type: "json" }
-import osakaJade from "./theme/osaka-jade.json" with { type: "json" }
-import onedark from "./theme/one-dark.json" with { type: "json" }
-import opencode from "./theme/opencode.json" with { type: "json" }
-import orng from "./theme/orng.json" with { type: "json" }
-import lucentOrng from "./theme/lucent-orng.json" with { type: "json" }
-import palenight from "./theme/palenight.json" with { type: "json" }
-import rosepine from "./theme/rosepine.json" with { type: "json" }
-import solarized from "./theme/solarized.json" with { type: "json" }
-import synthwave84 from "./theme/synthwave84.json" with { type: "json" }
-import tokyonight from "./theme/tokyonight.json" with { type: "json" }
-import vercel from "./theme/vercel.json" with { type: "json" }
-import vesper from "./theme/vesper.json" with { type: "json" }
-import zenburn from "./theme/zenburn.json" with { type: "json" }
-import carbonfox from "./theme/carbonfox.json" with { type: "json" }
+import { DEFAULT_THEMES, ansiToRgba, resolveTheme, type Theme, type ThemeJson } from "./theme-resolver"
 import { useKV } from "./kv"
 import { useRenderer } from "@opentui/solid"
 import { createStore, produce } from "solid-js/store"
@@ -43,12 +11,8 @@ import { Global } from "@opencode-ai/core/global"
 import { Filesystem } from "@/util/filesystem"
 import { useTuiConfig } from "./tui-config"
 import { isRecord } from "@/util/record"
-import type { TuiThemeCurrent } from "@opencode-ai/plugin/tui"
 
-type Theme = TuiThemeCurrent & {
-  _hasSelectedListItemText: boolean
-}
-type ThemeColor = Exclude<keyof TuiThemeCurrent, "thinkingOpacity">
+export { DEFAULT_THEMES, resolveTheme }
 
 export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
   // If theme explicitly defines selectedListItemText, use it
@@ -68,59 +32,6 @@ export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
   return theme.background
 }
 
-type HexColor = `#${string}`
-type RefName = string
-type Variant = {
-  dark: HexColor | RefName
-  light: HexColor | RefName
-}
-type ColorValue = HexColor | RefName | Variant | RGBA
-export type ThemeJson = {
-  $schema?: string
-  defs?: Record<string, HexColor | RefName>
-  theme: Omit<Record<ThemeColor, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
-    selectedListItemText?: ColorValue
-    backgroundMenu?: ColorValue
-    thinkingOpacity?: number
-  }
-}
-
-export const DEFAULT_THEMES: Record<string, ThemeJson> = {
-  aura,
-  ayu,
-  catppuccin,
-  ["catppuccin-frappe"]: catppuccinFrappe,
-  ["catppuccin-macchiato"]: catppuccinMacchiato,
-  cobalt2,
-  cursor,
-  dracula,
-  everforest,
-  flexoki,
-  github,
-  gruvbox,
-  kanagawa,
-  material,
-  matrix,
-  mercury,
-  monokai,
-  nightowl,
-  nord,
-  ["one-dark"]: onedark,
-  ["osaka-jade"]: osakaJade,
-  opencode,
-  orng,
-  ["lucent-orng"]: lucentOrng,
-  palenight,
-  rosepine,
-  solarized,
-  synthwave84,
-  tokyonight,
-  vesper,
-  vercel,
-  zenburn,
-  carbonfox,
-}
-
 type State = {
   themes: Record<string, ThemeJson>
   mode: "dark" | "light"
@@ -134,7 +45,6 @@ let customThemes: Record<string, ThemeJson> = {}
 let systemTheme: ThemeJson | undefined
 
 function listThemes() {
-  // Priority: defaults < plugin installs < custom files < generated system.
   const themes = {
     ...DEFAULT_THEMES,
     ...pluginThemes,
@@ -193,111 +103,6 @@ export function upsertTheme(name: string, theme: unknown) {
   }
   syncThemes()
   return true
-}
-
-export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
-  const defs = theme.defs ?? {}
-  function resolveColor(c: ColorValue, chain: string[] = []): RGBA {
-    if (c instanceof RGBA) return c
-    if (typeof c === "string") {
-      if (c === "transparent" || c === "none") return RGBA.fromInts(0, 0, 0, 0)
-
-      if (c.startsWith("#")) return RGBA.fromHex(c)
-
-      if (chain.includes(c)) {
-        throw new Error(`Circular color reference: ${[...chain, c].join(" -> ")}`)
-      }
-
-      const next = defs[c] ?? theme.theme[c as ThemeColor]
-      if (next === undefined) {
-        throw new Error(`Color reference "${c}" not found in defs or theme`)
-      }
-      return resolveColor(next, [...chain, c])
-    }
-    if (typeof c === "number") {
-      return ansiToRgba(c)
-    }
-    return resolveColor(c[mode], chain)
-  }
-
-  const resolved = Object.fromEntries(
-    Object.entries(theme.theme)
-      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
-      .map(([key, value]) => {
-        return [key, resolveColor(value as ColorValue)]
-      }),
-  ) as Partial<Record<ThemeColor, RGBA>>
-
-  // Handle selectedListItemText separately since it's optional
-  const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
-  if (hasSelectedListItemText) {
-    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!)
-  } else {
-    // Backward compatibility: if selectedListItemText is not defined, use background color
-    // This preserves the current behavior for all existing themes
-    resolved.selectedListItemText = resolved.background
-  }
-
-  // Handle backgroundMenu - optional with fallback to backgroundElement
-  if (theme.theme.backgroundMenu !== undefined) {
-    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
-  } else {
-    resolved.backgroundMenu = resolved.backgroundElement
-  }
-
-  // Handle thinkingOpacity - optional with default of 0.6
-  const thinkingOpacity = theme.theme.thinkingOpacity ?? 0.6
-
-  return {
-    ...resolved,
-    _hasSelectedListItemText: hasSelectedListItemText,
-    thinkingOpacity,
-  } as Theme
-}
-
-function ansiToRgba(code: number): RGBA {
-  // Standard ANSI colors (0-15)
-  if (code < 16) {
-    const ansiColors = [
-      "#000000", // Black
-      "#800000", // Red
-      "#008000", // Green
-      "#808000", // Yellow
-      "#000080", // Blue
-      "#800080", // Magenta
-      "#008080", // Cyan
-      "#c0c0c0", // White
-      "#808080", // Bright Black
-      "#ff0000", // Bright Red
-      "#00ff00", // Bright Green
-      "#ffff00", // Bright Yellow
-      "#0000ff", // Bright Blue
-      "#ff00ff", // Bright Magenta
-      "#00ffff", // Bright Cyan
-      "#ffffff", // Bright White
-    ]
-    return RGBA.fromHex(ansiColors[code] ?? "#000000")
-  }
-
-  // 6x6x6 Color Cube (16-231)
-  if (code < 232) {
-    const index = code - 16
-    const b = index % 6
-    const g = Math.floor(index / 6) % 6
-    const r = Math.floor(index / 36)
-
-    const val = (x: number) => (x === 0 ? 0 : x * 40 + 55)
-    return RGBA.fromInts(val(r), val(g), val(b))
-  }
-
-  // Grayscale Ramp (232-255)
-  if (code < 256) {
-    const gray = (code - 232) * 10 + 8
-    return RGBA.fromInts(gray, gray, gray)
-  }
-
-  // Fallback for invalid codes
-  return RGBA.fromInts(0, 0, 0)
 }
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
@@ -625,6 +430,9 @@ export function generateSystem(colors: TerminalColors, mode: "dark" | "light"): 
       syntaxType: ansiColors.cyan,
       syntaxOperator: ansiColors.cyan,
       syntaxPunctuation: fg,
+      syntaxTag: ansiColors.red,
+      syntaxAttribute: ansiColors.magenta,
+      syntaxTagDelimiter: ansiColors.cyan,
     },
   }
 }
@@ -1156,19 +964,19 @@ function getSyntaxRules(theme: Theme) {
     {
       scope: ["tag"],
       style: {
-        foreground: theme.error,
+        foreground: theme.syntaxTag,
       },
     },
     {
       scope: ["tag.attribute"],
       style: {
-        foreground: theme.syntaxKeyword,
+        foreground: theme.syntaxAttribute,
       },
     },
     {
       scope: ["tag.delimiter"],
       style: {
-        foreground: theme.syntaxOperator,
+        foreground: theme.syntaxTagDelimiter,
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/context/theme/opencode.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/opencode.json
@@ -240,6 +240,18 @@
     "syntaxPunctuation": {
       "dark": "darkStep12",
       "light": "lightStep12"
+    },
+    "syntaxTag": {
+      "dark": "darkRed",
+      "light": "lightRed"
+    },
+    "syntaxAttribute": {
+      "dark": "darkAccent",
+      "light": "lightAccent"
+    },
+    "syntaxTagDelimiter": {
+      "dark": "darkCyan",
+      "light": "lightCyan"
     }
   }
 }

--- a/packages/opencode/test/cli/tui/theme.test.ts
+++ b/packages/opencode/test/cli/tui/theme.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { DEFAULT_THEMES, resolveTheme } from "../../../src/cli/cmd/tui/context/theme-resolver"
+
+test("resolveTheme falls back to legacy XML/HTML syntax colors", () => {
+  const theme = {
+    ...DEFAULT_THEMES.opencode,
+    theme: {
+      ...DEFAULT_THEMES.opencode.theme,
+    },
+  }
+
+  delete theme.theme.syntaxTag
+  delete theme.theme.syntaxAttribute
+  delete theme.theme.syntaxTagDelimiter
+
+  const resolved = resolveTheme(theme, "dark")
+
+  expect(resolved.syntaxTag).toBe(resolved.error)
+  expect(resolved.syntaxAttribute).toBe(resolved.syntaxKeyword)
+  expect(resolved.syntaxTagDelimiter).toBe(resolved.syntaxOperator)
+})
+
+test("resolveTheme honors explicit XML/HTML syntax tokens", () => {
+  const syntaxTag = RGBA.fromInts(10, 20, 30)
+  const syntaxAttribute = RGBA.fromInts(40, 50, 60)
+  const syntaxTagDelimiter = RGBA.fromInts(70, 80, 90)
+
+  const theme = {
+    ...DEFAULT_THEMES.opencode,
+    theme: {
+      ...DEFAULT_THEMES.opencode.theme,
+      syntaxTag,
+      syntaxAttribute,
+      syntaxTagDelimiter,
+    },
+  }
+
+  const resolved = resolveTheme(theme, "dark")
+
+  expect(resolved.syntaxTag).toBe(syntaxTag)
+  expect(resolved.syntaxAttribute).toBe(syntaxAttribute)
+  expect(resolved.syntaxTagDelimiter).toBe(syntaxTagDelimiter)
+})

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -80,6 +80,9 @@ function themeCurrent(): HostPluginApi["theme"]["current"] {
     syntaxType: a,
     syntaxOperator: a,
     syntaxPunctuation: c,
+    syntaxTag: d,
+    syntaxAttribute: a,
+    syntaxTagDelimiter: g,
     thinkingOpacity: 0.6,
   }
 }

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -349,6 +349,9 @@ export type TuiThemeCurrent = {
   readonly syntaxType: RGBA
   readonly syntaxOperator: RGBA
   readonly syntaxPunctuation: RGBA
+  readonly syntaxTag: RGBA
+  readonly syntaxAttribute: RGBA
+  readonly syntaxTagDelimiter: RGBA
   readonly thinkingOpacity: number
 }
 

--- a/packages/web/public/theme.json
+++ b/packages/web/public/theme.json
@@ -87,7 +87,10 @@
         "syntaxNumber": { "$ref": "#/definitions/colorValue" },
         "syntaxType": { "$ref": "#/definitions/colorValue" },
         "syntaxOperator": { "$ref": "#/definitions/colorValue" },
-        "syntaxPunctuation": { "$ref": "#/definitions/colorValue" }
+        "syntaxPunctuation": { "$ref": "#/definitions/colorValue" },
+        "syntaxTag": { "$ref": "#/definitions/colorValue" },
+        "syntaxAttribute": { "$ref": "#/definitions/colorValue" },
+        "syntaxTagDelimiter": { "$ref": "#/definitions/colorValue" }
       },
       "required": ["primary", "secondary", "accent", "text", "textMuted", "background"],
       "additionalProperties": false


### PR DESCRIPTION
### Issue for this PR

Closes #20746
Refs #6128

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds optional TUI theme tokens for XML/HTML tag highlighting:

- `syntaxTag`
- `syntaxAttribute`
- `syntaxTagDelimiter`

The TUI now maps tag scopes to those tokens instead of reusing `error`, `syntaxKeyword`, and `syntaxOperator`. Existing themes keep the previous colors through resolver fallbacks.

The theme resolver/default-theme loading code moves to `theme-resolver.ts` so token resolution can be tested without constructing the full TUI theme provider. This also updates the plugin theme type, default opencode theme, test fixture, and web theme schema.

### How did you verify your code works?

- `bun test --timeout 120000 test/cli/tui/theme.test.ts test/cli/tui/theme-store.test.ts` from `packages/opencode`
- `bun ./script/generate.ts`
- `bun turbo typecheck`
- `git diff --check dev..HEAD`

### Screenshots / recordings

Not included. This changes the theme-token contract and syntax color mapping; resolver behavior and fallback compatibility are covered by tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
