### PR TITLE
docs: update skills to use canonical `~/.config/opencode` location

### DIFF
--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -14,7 +14,7 @@ Create one folder per skill name and put a `SKILL.md` inside it.
 OpenCode searches these locations:
 
 - Project config: `.opencode/skill/<name>/SKILL.md`
-- Global config: `~/.opencode/skill/<name>/SKILL.md`
+- Global config: `~/.config/opencode/skill/<name>/SKILL.md`
 - Claude-compatible: `.claude/skills/<name>/SKILL.md`
 
 ---
@@ -24,7 +24,7 @@ OpenCode searches these locations:
 For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
 It loads any matching `skill/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` along the way.
 
-Global definitions are also loaded from `~/.opencode/skill/*/SKILL.md`.
+Global definitions are also loaded from `~/.config/opencode/skill/*/SKILL.md`.
 
 ---
 


### PR DESCRIPTION
Updates the skills documentation to use the canonical `~/.config/opencode/skill/` path for global config instead of `~/.opencode/skill/`.

This is confusing for users getting started with skills and is inconsistent with all other global config locations in the documentation ([agents](https://opencode.ai/docs/agents), [modes](https://opencode.ai/docs/modes), [commands](https://opencode.ai/docs/commands), [themes](https://opencode.ai/docs/themes), etc. all use `~/.config/opencode/`).

For example: https://opencode.ai/docs/agents
<img width="1097" height="443" alt="Screen Shot 2025-12-24 at 10 19 28 PM" src="https://github.com/user-attachments/assets/5f3cc0fd-9f96-4aa5-89e5-e5eec6359bcb" />