### PR TITLE
docs: Corrected the number of built-in subagents in documentation

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -42,7 +42,7 @@ OpenCode comes with two built-in subagents, **General** and **Explore**. We'll l
 
 ## Built-in
 
-OpenCode comes with two built-in primary agents and one built-in subagent.
+OpenCode comes with two built-in primary agents and two built-in subagents.
 
 ---
 


### PR DESCRIPTION
Corrected the number of built-in subagents (2) in the "Built-in" section of the Agents documentation.