### PR TITLE
feat(tui): add session_list_limit for session picker

### DIFF
--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -135,6 +135,19 @@ it.instance("loads tui config with the same precedence order as server config pa
   ),
 )
 
+it.instance("loads session list limit from tui config", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const test = yield* TestInstance
+      yield* fs.writeJson(path.join(test.directory, "tui.json"), { session_list_limit: 75 })
+
+      const config = yield* getTuiConfig(test.directory)
+      expect(config.session_list_limit).toBe(75)
+    }),
+  ),
+)
+
 it.instance("resolves attention config defaults and overrides", () =>
   withCleanState(
     Effect.gen(function* () {

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -17,6 +17,8 @@ import { Spinner } from "./spinner"
 import { errorMessage } from "../util/error"
 import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
 import { useCommandShortcut } from "../keymap"
+import { sessionList } from "../util/session-list"
+import { useTuiConfig } from "../config"
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -27,6 +29,7 @@ export function DialogSessionList() {
   const sdk = useSDK()
   const local = useLocal()
   const toast = useToast()
+  const tui = useTuiConfig()
   const [toDelete, setToDelete] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
   const deleteHint = useCommandShortcut("session.delete")
@@ -43,7 +46,13 @@ export function DialogSessionList() {
   )
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
-  const sessions = createMemo(() => searchResults() ?? sync.data.session)
+  const currentRootSessionID = createMemo(() => {
+    const current = currentSessionID()
+    if (!current) return undefined
+    return sync.session.get(current)?.parentID ?? current
+  })
+  const isSearching = createMemo(() => search().length > 0)
+  const sessions = createMemo(() => (isSearching() ? (searchResults() ?? []) : sync.data.session))
 
   function recover(session: NonNullable<ReturnType<typeof sessions>[number]>) {
     const workspace = project.workspace.get(session.workspaceID!)
@@ -153,16 +162,20 @@ export function DialogSessionList() {
 
   const options = createMemo(() => {
     const today = new Date().toDateString()
-    const sessionMap = new Map(
-      sessions()
-        .filter((x) => x.parentID === undefined)
-        .map((x) => [x.id, x]),
+    const pinnedIDs = [...new Set(local.session.pinned())]
+    const limitedSessions = sessionList(
+      sessions(),
+      tui.session_list_limit ?? 150,
+      currentRootSessionID(),
+      isSearching(),
+      pinnedIDs,
     )
+    const sessionMap = new Map(limitedSessions.map((x) => [x.id, x]))
 
     const searchResult = searchResults()
     const displayOrder = searchResult ? orderByRecency(searchResult) : browseOrder()
 
-    const pinned = local.session.pinned().filter((id) => sessionMap.has(id))
+    const pinned = pinnedIDs.filter((id) => sessionMap.has(id))
     const pinnedSet = new Set(pinned)
     const slotByID = new Map<string, number>(local.session.slots().map((id, i) => [id, i + 1]))
 
@@ -218,7 +231,7 @@ export function DialogSessionList() {
       title="Sessions"
       options={options()}
       skipFilter={true}
-      current={currentSessionID()}
+      current={currentRootSessionID()}
       onFilter={setSearch}
       onMove={() => {
         setToDelete(undefined)

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -50,6 +50,13 @@ export const Prompt = Schema.Struct({
   }),
 }).annotate({ description: "Prompt size settings" })
 
+export const SessionListLimit = Schema.Int.check(
+  Schema.isGreaterThanOrEqualTo(1),
+  Schema.isLessThanOrEqualTo(10000),
+).annotate({
+  description: "Maximum number of sessions to display in session list when not searching (default: 150)",
+})
+
 export const Info = Schema.Struct({
   $schema: Schema.optional(Schema.String),
   theme: Schema.optional(Schema.String),
@@ -63,6 +70,7 @@ export const Info = Schema.Struct({
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  session_list_limit: Schema.optional(SessionListLimit),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 

--- a/packages/tui/src/feature-plugins/home/tips-view.tsx
+++ b/packages/tui/src/feature-plugins/home/tips-view.tsx
@@ -215,6 +215,7 @@ const TIPS: Tip[] = [
   "Add {highlight}$schema{/highlight} to your config for autocomplete in your editor",
   "Configure {highlight}model{/highlight} in config to set your default model",
   "Override any keybind in {highlight}tui.json{/highlight} via the {highlight}keybinds{/highlight} section",
+  "Set {highlight}session_list_limit{/highlight} in {highlight}tui.json{/highlight} to cap sessions shown in the picker",
   "Set any keybind to {highlight}none{/highlight} to disable it completely",
   "Configure local or remote MCP servers in the {highlight}mcp{/highlight} config section",
   "Add {highlight}.md{/highlight} files to {highlight}.opencode/commands/{/highlight} to define reusable custom prompts",

--- a/packages/tui/src/util/session-list.ts
+++ b/packages/tui/src/util/session-list.ts
@@ -1,0 +1,28 @@
+import type { Session } from "@opencode-ai/sdk/v2"
+
+function compareSession(a: Session, b: Session) {
+  return b.time.updated - a.time.updated
+}
+
+export function sessionList(
+  input: Session[],
+  limit: number,
+  current: string | undefined,
+  searching: boolean,
+  pinned: string[] = [],
+) {
+  const list = input.filter((x) => x.parentID === undefined).toSorted(compareSession)
+  if (searching) return list
+
+  const currentRoot = current ? (input.find((x) => x.id === current)?.parentID ?? current) : undefined
+  const currentItem = currentRoot ? list.find((x) => x.id === currentRoot) : undefined
+  const pinnedItems = [...new Set(pinned)]
+    .filter((id) => id !== currentRoot)
+    .map((id) => list.find((x) => x.id === id))
+    .filter((x): x is Session => x !== undefined)
+  const preserved = [...(currentItem ? [currentItem] : []), ...pinnedItems].slice(0, limit)
+  const preservedIDs = new Set(preserved.map((x) => x.id))
+  return [...list.filter((x) => !preservedIDs.has(x.id)).slice(0, limit - preserved.length), ...preserved].toSorted(
+    compareSession,
+  )
+}

--- a/packages/tui/test/util/session-list.test.ts
+++ b/packages/tui/test/util/session-list.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2"
+import { sessionList } from "../../src/util/session-list"
+
+function session(id: string, updated: number, parentID?: string): Session {
+  return {
+    id,
+    slug: id,
+    projectID: "proj",
+    directory: "/tmp",
+    parentID,
+    title: id,
+    version: "1",
+    time: {
+      created: updated,
+      updated,
+    },
+  }
+}
+
+describe("sessionList", () => {
+  test("caps root sessions when not searching", () => {
+    const result = sessionList(
+      [session("old", 1), session("child", 3, "parent"), session("new", 2)],
+      1,
+      undefined,
+      false,
+    )
+
+    expect(result.map((x) => x.id)).toEqual(["new"])
+  })
+
+  test("does not cap when searching", () => {
+    const result = sessionList([session("a", 1), session("b", 2), session("c", 3)], 1, undefined, true)
+
+    expect(result.map((x) => x.id)).toEqual(["c", "b", "a"])
+  })
+
+  test("keeps current session when capped", () => {
+    const result = sessionList([session("a", 4), session("b", 3), session("c", 2)], 2, "c", false)
+
+    expect(result.map((x) => x.id)).toEqual(["a", "c"])
+  })
+
+  test("keeps current root session when current session is a child", () => {
+    const result = sessionList([session("a", 4), session("root", 1), session("child", 5, "root")], 1, "child", false)
+
+    expect(result.map((x) => x.id)).toEqual(["root"])
+  })
+
+  test("inserts current using session sort order", () => {
+    const result = sessionList(
+      [session("a", 10), session("b", 9), session("c", 9), session("d", 9), session("e", 8)],
+      3,
+      "d",
+      false,
+    )
+
+    expect(result.map((x) => x.id)).toEqual(["a", "b", "d"])
+  })
+
+  test("keeps pinned sessions when capped", () => {
+    const result = sessionList(
+      [session("a", 4), session("b", 3), session("c", 2), session("d", 1)],
+      2,
+      undefined,
+      false,
+      ["d"],
+    )
+
+    expect(result.map((x) => x.id)).toEqual(["a", "d"])
+  })
+
+  test("deduplicates pinned sessions inside the cap", () => {
+    const result = sessionList(
+      [session("a", 4), session("b", 3), session("c", 2), session("d", 1)],
+      2,
+      undefined,
+      false,
+      ["d", "d"],
+    )
+
+    expect(result.map((x) => x.id)).toEqual(["a", "d"])
+  })
+
+  test("keeps the cap when pinned sessions exceed the limit", () => {
+    const result = sessionList([session("a", 4), session("b", 3), session("c", 2), session("d", 1)], 1, "c", false, [
+      "d",
+    ])
+
+    expect(result.map((x) => x.id)).toEqual(["c"])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20754

Related to #6137, #8535, and #4918.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds optional `session_list_limit` config in `tui.json` for the TUI session picker. The picker uses a default cap of 150 root sessions when not searching, while search keeps the existing server-limited request path.

The current session stays visible when capped. Pinned session-switching entries are preserved within the cap when room exists, and remaining picker entries stay aligned with updated-time recency.

This is intentionally scoped to the picker render list, not broader session loading or pagination.

### How did you verify your code works?

- From `packages/opencode`: `bun run test test/cli/tui/session-list.test.ts`
- From `packages/opencode`: `bun test --timeout 300000 test/cli/tui/session-list.test.ts test/config/tui.test.ts --max-concurrency=1`
- From repo root: `bun turbo typecheck`

### Screenshots / recordings

N/A. This is a TUI config and picker behavior change with no visual layout change.

### Notes

AI Assistance: OpenCode + openai/gpt-5.5; Review: Human operator reviewed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
