### PR TITLE
fix(app): use window.location.origin for API URL fallback

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -38,7 +38,7 @@ const url = iife(() => {
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
-  return "http://localhost:4096"
+  return window.location.origin
 })
 
 export function App() {


### PR DESCRIPTION
## Summary

- Fix web UI failing when accessed via non-localhost addresses (Tailscale IP, LAN IP, custom hostname)
- Change API URL fallback from hardcoded `http://localhost:4096` to `window.location.origin`

## Problem

When running `opencode serve --hostname=0.0.0.0` and accessing via a network IP (e.g., `http://192.168.1.100:4096`), the frontend was hardcoded to make API requests to `http://localhost:4096`, which doesn't exist on the remote machine.

## Solution

Use `window.location.origin` as the fallback, which dynamically resolves to the actual server address.

Fixes #5844
Fixes #6063