### PR TITLE
feat(tui): allow session names to wrap to two lines in dialog (#6165)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -161,9 +161,12 @@ export function DialogSessionList() {
       if (!x) return undefined
       const workspace = x.workspaceID ? project.workspace.get(x.workspaceID) : undefined
 
-      let footer: JSX.Element | string = ""
+      let footer: JSX.Element | string | undefined
+      let reservedWidth: number | undefined
       if (Flag.OPENCODE_EXPERIMENTAL_WORKSPACES) {
         if (x.workspaceID) {
+          const label = workspace ? `${workspace.name} (${workspace.type})` : `${x.workspaceID} (unknown)`
+          reservedWidth = Bun.stringWidth(label) + 1
           footer = workspace ? (
             <WorkspaceLabel
               type={workspace.type}
@@ -193,6 +196,7 @@ export function DialogSessionList() {
         value: x.id,
         category,
         footer,
+        reservedWidth,
         gutter,
       }
     }
@@ -223,6 +227,7 @@ export function DialogSessionList() {
       title="Sessions"
       options={options()}
       skipFilter={true}
+      maxLines={2}
       current={currentSessionID()}
       onFilter={setSearch}
       onMove={() => {

--- a/packages/opencode/src/cli/cmd/tui/component/spinner.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/spinner.tsx
@@ -12,7 +12,14 @@ export function Spinner(props: { children?: JSX.Element; color?: RGBA }) {
   const kv = useKV()
   const color = () => props.color ?? theme.textMuted
   return (
-    <Show when={kv.get("animations_enabled", true)} fallback={<text fg={color()}>⋯ {props.children}</text>}>
+    <Show
+      when={kv.get("animations_enabled", true)}
+      fallback={
+        <text fg={color()}>
+          ⋯<Show when={props.children}> {props.children}</Show>
+        </text>
+      }
+    >
       <box flexDirection="row" gap={1}>
         <spinner frames={SPINNER_FRAMES} interval={80} color={color()} />
         <Show when={props.children}>

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select-budget.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select-budget.ts
@@ -1,0 +1,93 @@
+import { Locale } from "@/util/locale"
+
+// pad (10) reserves dialog chrome: left+right padding + borders.
+// Single-line fallback caps at 61 chars (default DialogSelect title budget).
+// Multi-line total caps at 122 chars to stay readable on 80-col terminals.
+export function budget(width: number, tail: number, lines: number) {
+  const pad = 10
+  const span = Math.max(width - pad, 0)
+  if (lines === 1) return span === 0 ? 1 : 61
+  const perLine = Math.max(span - tail, 1)
+  return Math.min(Math.max(perLine * lines, 1), 122)
+}
+
+type WrapState = {
+  lines: string[]
+  truncated: boolean
+}
+
+const grapheme = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+function measure(text: string) {
+  return Bun.stringWidth(text)
+}
+
+function sliceWidth(text: string, width: number) {
+  if (width <= 0) return ""
+  let result = ""
+  for (const part of grapheme.segment(text)) {
+    if (measure(result + part.segment) > width) break
+    result += part.segment
+  }
+  return result
+}
+
+function splitWidth(text: string, width: number, limit: number) {
+  const result: string[] = []
+  let rest = text
+  while (rest && result.length < limit) {
+    const next = sliceWidth(rest, width)
+    if (!next) break
+    result.push(next)
+    rest = rest.slice(next.length)
+  }
+  return { parts: result, truncated: rest.length > 0 }
+}
+
+export function wrap(text: string, width: number, tail: number, maxLines: number) {
+  const normalized = text.replace(/[^\S ]+/g, " ")
+  const limit = budget(width, 0, 1)
+  if (maxLines === 1) return Locale.truncate(normalized, limit)
+  const perLine = Math.max(width - 10 - tail, 1)
+  const tokens = normalized.match(/\s+|\S+/g) ?? []
+  const state = tokens.reduce<WrapState>(
+    (current, token) => {
+      if (current.truncated) return current
+      const line = current.lines.at(-1) ?? ""
+      const next = `${line}${token}`
+      if (measure(next) <= perLine) {
+        const lines = current.lines.slice(0, -1).concat(next)
+        return { lines, truncated: false }
+      }
+      if (/^\s+$/.test(token)) return current
+      if (line.length === 0) {
+        const available = maxLines - current.lines.length + 1
+        const split = splitWidth(token, perLine, available)
+        const parts = split.parts
+        const lines = current.lines.slice(0, -1).concat(parts)
+        return { lines, truncated: split.truncated }
+      }
+      if (current.lines.length >= maxLines) {
+        return { lines: current.lines, truncated: true }
+      }
+      if (measure(token) > perLine) {
+        const available = maxLines - current.lines.length
+        const split = splitWidth(token, perLine, available)
+        const parts = split.parts
+        const lines = current.lines.slice(0, -1).concat(line.trimEnd(), parts)
+        return { lines, truncated: split.truncated }
+      }
+      const lines = current.lines.slice(0, -1).concat(line.trimEnd(), token)
+      return { lines, truncated: false }
+    },
+    { lines: [""], truncated: false },
+  )
+  const joined = state.lines.join("\n")
+  if (!state.truncated) return joined
+  const ellipsis = perLine <= 3 ? ".".repeat(perLine) : "..."
+  const room = Math.max(perLine - measure(ellipsis), 0)
+  const last = state.lines.at(-1) ?? ""
+  const head = sliceWidth(last, room).trimEnd()
+  const lines = state.lines.slice(0, -1).concat(`${head}${ellipsis}`)
+  return lines.join("\n")
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -15,7 +15,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
-import { Locale } from "@/util/locale"
+import { wrap } from "@tui/ui/dialog-select-budget"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTuiConfig } from "../context/tui-config"
 import { formatKeyBindings, useBindings, useKeymapSelector } from "../keymap"
@@ -31,6 +31,7 @@ export interface DialogSelectProps<T> {
   onSelect?: (option: DialogSelectOption<T>) => void
   skipFilter?: boolean
   renderFilter?: boolean
+  maxLines?: 1 | 2
   actions?: {
     command: string
     title: string
@@ -47,6 +48,7 @@ export interface DialogSelectOption<T = any> {
   value: T
   description?: string
   footer?: JSX.Element | string
+  reservedWidth?: number
   category?: string
   categoryView?: JSX.Element
   disabled?: boolean
@@ -166,7 +168,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   })
 
   const dimensions = useTerminalDimensions()
-  const height = createMemo(() => Math.min(rows(), Math.floor(dimensions().height / 2) - 6))
+  const lines = createMemo(() => props.maxLines ?? 1)
+  const height = createMemo(() =>
+    Math.min(rows() + (lines() - 1) * flat().length, Math.floor(dimensions().height / 2) - 6),
+  )
+  const width = createMemo(() => {
+    const dialogWidth = dialog.size === "large" ? 80 : 60
+    return Math.max(Math.min(dimensions().width - 2, dialogWidth), 1)
+  })
 
   const selected = createMemo(() => flat()[store.selected])
 
@@ -207,8 +216,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       const centerOffset = Math.floor(scroll.height / 2)
       scroll.scrollBy(y - centerOffset)
     } else {
-      if (y >= scroll.height) {
-        scroll.scrollBy(y - scroll.height + 1)
+      if (y + target.height > scroll.height) {
+        scroll.scrollBy(y + target.height - scroll.height)
       }
       if (y < 0) {
         scroll.scrollBy(y)
@@ -457,6 +466,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                           active={active()}
                           current={current()}
                           gutter={option.gutter}
+                          reservedWidth={option.reservedWidth}
+                          width={width()}
+                          maxLines={lines()}
                         />
                       </box>
                     )
@@ -514,9 +526,19 @@ function Option(props: {
   footer?: JSX.Element | string
   gutter?: () => JSX.Element
   onMouseOver?: () => void
+  reservedWidth?: number
+  width: number
+  maxLines: number
 }) {
   const { theme } = useTheme()
   const fg = selectedForeground(theme)
+  const tail =
+    props.maxLines > 1
+      ? (props.reservedWidth ??
+        (typeof props.footer === "string" && props.footer.length > 0 ? props.footer.length + 1 : 0))
+      : 0
+  const mode = props.maxLines > 1 ? "word" : "none"
+  const overflow = props.maxLines === 1 ? "hidden" : undefined
 
   return (
     <>
@@ -534,11 +556,12 @@ function Option(props: {
         flexGrow={1}
         fg={props.active ? fg : props.current ? theme.primary : theme.text}
         attributes={props.active ? TextAttributes.BOLD : undefined}
-        overflow="hidden"
-        wrapMode="none"
-        paddingLeft={3}
+        wrapMode={mode}
+        maxHeight={props.maxLines}
+        overflow={overflow}
+        paddingLeft={props.maxLines > 1 ? undefined : 3}
       >
-        {Locale.truncate(props.title, 61)}
+        {wrap(props.title, props.width, tail, props.maxLines)}
         <Show when={props.description}>
           <span style={{ fg: props.active ? fg : theme.textMuted }}> {props.description}</span>
         </Show>

--- a/packages/opencode/test/cli/tui/dialog-select.test.ts
+++ b/packages/opencode/test/cli/tui/dialog-select.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import { budget, wrap } from "../../../src/cli/cmd/tui/ui/dialog-select-budget"
+
+describe("dialog-select budget", () => {
+  test("caps width to max", () => {
+    expect(budget(200, 0, 2)).toBe(122)
+  })
+
+  test("scales with width", () => {
+    expect(budget(40, 0, 2)).toBe(60)
+    expect(budget(40, 0, 1)).toBe(61)
+  })
+
+  test("clamps to minimum", () => {
+    expect(budget(0, 0, 1)).toBe(1)
+  })
+
+  test("subtracts footer length for strings", () => {
+    const tail = "tail".length + 1
+    expect(budget(40, tail, 2)).toBe(50)
+  })
+
+  test("supports explicit reserved width", () => {
+    expect(budget(40, 10, 2)).toBe(40)
+  })
+
+  test("keeps single-line budget constant", () => {
+    expect(budget(40, 10, 1)).toBe(61)
+  })
+
+  test("wraps to two lines with ellipsis", () => {
+    const text = "one two three four five six seven eight nine ten"
+    const result = wrap(text, 20, 0, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.at(-1) ?? "").toContain("...")
+  })
+
+  test("wrap respects reserved width", () => {
+    const text = "one two three four five six seven"
+    const result = wrap(text, 20, 5, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.every((line) => line.length <= 5)).toBe(true)
+  })
+
+  test("wrap preserves whitespace when text already fits", () => {
+    expect(wrap("Foo  Bar", 20, 0, 2)).toBe("Foo  Bar")
+  })
+
+  test("wrap preserves repeated spaces when wrapping", () => {
+    const result = wrap("Foo    Bar baz qux quux corge", 20, 0, 2)
+    expect(result.startsWith("Foo    Bar")).toBe(true)
+  })
+
+  test("wraps text that only fits across multiple lines", () => {
+    const result = wrap("123456 123456", 20, 0, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.every((line) => Bun.stringWidth(line) <= 10)).toBe(true)
+  })
+
+  test("wrap does not carry whitespace to the next line", () => {
+    const result = wrap("12345 12 34567 x", 15, 0, 3)
+    expect(result.split("\n").every((line) => !line.startsWith(" "))).toBe(true)
+  })
+
+  test("wrap normalizes hard whitespace before enforcing max lines", () => {
+    const result = wrap("a\nb\nc\nd\ne", 15, 0, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.every((line) => Bun.stringWidth(line) <= 5)).toBe(true)
+  })
+
+  test("wrap respects display width for CJK", () => {
+    const result = wrap("你好世界 你好世界 你好世界", 20, 0, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.every((line) => Bun.stringWidth(line) <= 10)).toBe(true)
+  })
+
+  test("wrap chunks wide tokens by display width", () => {
+    const result = wrap("你好你好你好你好你好你好", 20, 0, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.every((line) => Bun.stringWidth(line) <= 10)).toBe(true)
+  })
+
+  test("wrap reserves jsx footer width plus row gap", () => {
+    const reservedWidth = Bun.stringWidth("git: repo") + 3
+    const result = wrap("one two three four five", 24, reservedWidth, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.every((line) => line.length <= 24 - 10 - reservedWidth)).toBe(true)
+  })
+
+  test("wrap chunks long tokens", () => {
+    const text = "supercalifragilisticexpialidocious"
+    const result = wrap(text, 20, 0, 2)
+    const lines = result.split("\n")
+    expect(lines.length).toBe(2)
+    expect(lines.at(-1) ?? "").toContain("...")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #22480
Relates to #6165

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows long titles in the TUI Sessions dialog to wrap to a second line, while keeping other `DialogSelect` users single-line by default.

The implementation adds an opt-in `maxLines` prop, uses display-width-aware wrapping/truncation for Unicode/CJK text, reserves footer width for workspace status metadata, and keeps the current lazy gutter rendering behavior.

### How did you verify your code works?

- `bun test --timeout 20000 test/cli/tui/dialog-select.test.ts`
- `bun turbo typecheck`

Focused tests cover two-line wrapping, truncation, reserved footer width, whitespace preservation, and CJK/wide-token display width.

### Screenshots / recordings

Before:
![before](https://github.com/user-attachments/assets/590e084b-a8cb-4daf-ad63-9c5c68e529f3)

After:
![after](https://github.com/user-attachments/assets/f84fc84c-9971-4261-942f-993cbf0a4600)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR