### PR TITLE
fix: only show diagnostics block when errors exist

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -142,8 +142,8 @@ export const EditTool = Tool.define("edit", {
     const diagnostics = await LSP.diagnostics()
     const normalizedFilePath = Filesystem.normalizePath(filePath)
     const issues = diagnostics[normalizedFilePath] ?? []
-    if (issues.length > 0) {
-      const errors = issues.filter((item) => item.severity === 1)
+    const errors = issues.filter((item) => item.severity === 1)
+    if (errors.length > 0) {
       const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
       const suffix =
         errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -83,11 +83,11 @@ export const WriteTool = Tool.define("write", {
     const normalizedFilepath = Filesystem.normalizePath(filepath)
     let projectDiagnosticsCount = 0
     for (const [file, issues] of Object.entries(diagnostics)) {
-      if (issues.length === 0) continue
-      const sorted = issues.toSorted((a, b) => (a.severity ?? 4) - (b.severity ?? 4))
-      const limited = sorted.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+      const errors = issues.filter((item) => item.severity === 1)
+      if (errors.length === 0) continue
+      const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
       const suffix =
-        issues.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${issues.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+        errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
       if (file === normalizedFilepath) {
         output += `\nThis file has errors, please fix\n<file_diagnostics>\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</file_diagnostics>\n`
         continue


### PR DESCRIPTION
## Problem
When the LSP returns only warnings (severity 2), the edit/write tools showed "This file has errors" with an empty diagnostics block. This happened because the code checked `issues.length > 0` before filtering for severity 1 errors.

## Fix
Changed to check `errors.length > 0` (after filtering) instead of `issues.length > 0` (before filtering).