### PR TITLE
fix: `opencode web` baseURL error

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -38,7 +38,7 @@ const url = iife(() => {
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
-  return "http://localhost:4096"
+  return window.location.origin
 })
 
 export function App() {


### PR DESCRIPTION
When you run `opencode web` and try to access it over a tailscale network, for example, on a url like `nixos:4096`, we try to connect to the opencode client on `localhost:4096` which isn't accessible.

This fixes that by defaulting to the current URL.