### PR TITLE
fix: use package export for @opentui/solid to support monorepos

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
+import solidPlugin from "@opentui/solid/bun-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"


### PR DESCRIPTION
## Why

When running typecheck in a bun/npm workspace monorepo, it failed with:

```
error TS2307: Cannot find module '../node_modules/@opentui/solid/scripts/solid-plugin' 
or its corresponding type declarations.
```

## Summary

- Changed `../node_modules/@opentui/solid/scripts/solid-plugin` → `@opentui/solid/bun-plugin`
- Fixes module resolution in monorepo setups where dependencies are hoisted

## Problem

The hardcoded relative path breaks when:
```
# Expected (single repo)
packages/opencode/node_modules/@opentui/solid/  ✓

# Actual (monorepo with hoisting)
packages/opencode/node_modules/@opentui/solid/  ✗ (doesn't exist)
node_modules/@opentui/solid/                     ✓ (hoisted here)
```

## Solution

Use the proper package export which `@opentui/solid` already provides:
```json
"exports": {
  "./bun-plugin": {
    "types": "./scripts/solid-plugin.d.ts",
    "import": "./scripts/solid-plugin.ts"
  }
}
```

## Test Plan

- [x] Verified package exports `./bun-plugin`
- [x] Tested in monorepo environment