### PR TITLE
fix: prevent user message box horizontal overflow on mobile viewports

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -18,6 +18,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
+  max-width: 100%;
 
   [data-slot="user-message-attachments"] {
     display: flex;
@@ -74,6 +76,8 @@
   [data-slot="user-message-text"] {
     white-space: pre-wrap;
     overflow: hidden;
+    overflow-wrap: break-word;
+    word-break: break-word;
     background: var(--surface-inset-base);
     padding: 6px 12px;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- Fix user message content overflowing horizontally on mobile viewports in the share page
- Add proper width constraints (`min-width: 0`, `max-width: 100%`) to allow flex children to shrink
- Add word-break properties to handle long unbroken text

Before:
<img width="1624" height="1056" alt="Screenshot 2025-12-26 at 10 45 27 AM" src="https://github.com/user-attachments/assets/bdee4f3e-3584-41df-b2e6-fc735f24b892" />

After:
<img width="1624" height="1056" alt="Screenshot 2025-12-26 at 10 48 48 AM" src="https://github.com/user-attachments/assets/662a49c2-7ead-456e-b680-6864a35850ea" />


Closes #6200