### PR TITLE
tweak: createOpencodeServer expose `logLevel`

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -633,6 +633,7 @@ export namespace Config {
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
+      logLevel: z.enum(["DEBUG", "INFO", "WARN", "ERROR"]).optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),
       command: z
         .record(z.string(), Command)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -633,7 +633,7 @@ export namespace Config {
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
-      logLevel: z.enum(["DEBUG", "INFO", "WARN", "ERROR"]).optional().describe("Log level"),
+      logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),
       command: z
         .record(z.string(), Command)

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1175,6 +1175,10 @@ export type Config = {
   theme?: string
   keybinds?: KeybindsConfig
   /**
+   * Log level
+   */
+  logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"
+  /**
    * TUI specific settings
    */
   tui?: {

--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -28,7 +28,10 @@ export async function createOpencodeServer(options?: ServerOptions) {
     options ?? {},
   )
 
-  const proc = spawn(`opencode`, [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`], {
+  const args = [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`]
+  if (options.config?.logLevel) args.push(`--log-level=${options.config.logLevel}`)
+
+  const proc = spawn(`opencode`, args, {
     signal: options.signal,
     env: {
       ...process.env,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1389,6 +1389,10 @@ export type Config = {
   theme?: string
   keybinds?: KeybindsConfig
   /**
+   * Log level
+   */
+  logLevel?: "DEBUG" | "INFO" | "WARN" | "ERROR"
+  /**
    * TUI specific settings
    */
   tui?: {

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -28,7 +28,10 @@ export async function createOpencodeServer(options?: ServerOptions) {
     options ?? {},
   )
 
-  const proc = spawn(`opencode`, [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`], {
+  const args = [`serve`, `--hostname=${options.hostname}`, `--port=${options.port}`]
+  if (options.config?.logLevel) args.push(`--log-level=${options.config.logLevel}`)
+
+  const proc = spawn(`opencode`, args, {
     signal: options.signal,
     env: {
       ...process.env,


### PR DESCRIPTION
To be able to programatically control logLevel of server, when running in dev vs prod mode.