### PR TITLE
fix: detect protocol from request URL for share links

### DIFF
--- a/packages/enterprise/src/routes/api/[...path].ts
+++ b/packages/enterprise/src/routes/api/[...path].ts
@@ -52,7 +52,10 @@ app
     async (c) => {
       const body = c.req.valid("json")
       const share = await Share.create({ sessionID: body.sessionID })
-      const protocol = c.req.header("x-forwarded-proto") ?? c.req.header("x-forwarded-protocol") ?? "https"
+      const protocol =
+        c.req.header("x-forwarded-proto") ??
+        c.req.header("x-forwarded-protocol") ??
+        new URL(c.req.url).protocol.replace(":", "")
       const host = c.req.header("x-forwarded-host") ?? c.req.header("host")
       return c.json({
         id: share.id,


### PR DESCRIPTION
## Summary

- Fix share URL protocol detection for local development - when running without a reverse proxy, the URL now correctly uses `http://` instead of always defaulting to `https://`

Fixes #6205