### PR TITLE
fix: sort file picker results alphabetically (issue #6187)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -395,7 +395,9 @@ export function Autocomplete(props: {
       },
     })
 
-    return result.map((arr) => arr.obj)
+    return result
+      .map((arr) => arr.obj)
+      .sort((a, b) => a.display.localeCompare(b.display))
   })
 
   createEffect(() => {

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -321,7 +321,11 @@ export namespace File {
     if (!input.query)
       return input.dirs !== false ? result.dirs.toSorted().slice(0, limit) : result.files.slice(0, limit)
     const items = input.dirs !== false ? [...result.files, ...result.dirs] : result.files
-    const sorted = fuzzysort.go(input.query, items, { limit: limit }).map((r) => r.target)
+    const sorted = fuzzysort
+      .go(input.query, items, { limit: limit })
+      .map((r) => r.target)
+      .sort((a, b) => a.localeCompare(b))
+
     log.info("search", { query: input.query, results: sorted.length })
     return sorted
   }


### PR DESCRIPTION
- Apply alphabetical sort to the top results from fuzzy search
- Ensure consistent sorting in both server (index.ts) and client (autocomplete.tsx)
- This fixes the unstable ordering issue where results would jump around