### PR TITLE
Be able to attach to a remote directory

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -83,6 +83,10 @@ export const RunCommand = cmd({
         type: "string",
         describe: "attach to a running opencode server (e.g., http://localhost:4096)",
       })
+      .option("server-dir", {
+        type: "string",
+        describe: "directory to run in on the server (absolute path)",
+      })
       .option("port", {
         type: "number",
         describe: "port for the local server (defaults to random port if no value provided)",
@@ -270,7 +274,14 @@ export const RunCommand = cmd({
     }
 
     if (args.attach) {
-      const sdk = createOpencodeClient({ baseUrl: args.attach })
+      const input = new URL(args.attach)
+      const queryDir = input.searchParams.get("directory") || undefined
+      input.search = ""
+
+      const sdk = createOpencodeClient({
+        baseUrl: input.toString(),
+        directory: args.serverDir || queryDir,
+      })
 
       const sessionID = await (async () => {
         if (args.continue) {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -96,7 +96,7 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   })
 }
 
-export function tui(input: { url: string; args: Args; onExit?: () => Promise<void> }) {
+export function tui(input: { url: string; directory?: string; args: Args; onExit?: () => Promise<void> }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
     const mode = await getTerminalBackgroundColor()
@@ -116,7 +116,7 @@ export function tui(input: { url: string; args: Args; onExit?: () => Promise<voi
                 <KVProvider>
                   <ToastProvider>
                     <RouteProvider>
-                      <SDKProvider url={input.url}>
+                      <SDKProvider url={input.url} directory={input.directory}>
                         <SyncProvider>
                           <ThemeProvider mode={mode}>
                             <LocalProvider>

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -15,6 +15,10 @@ export const AttachCommand = cmd({
         type: "string",
         description: "directory to run in",
       })
+      .option("server-dir", {
+        type: "string",
+        description: "directory to run in on the server (absolute path)",
+      })
       .option("session", {
         alias: ["s"],
         type: "string",
@@ -22,8 +26,14 @@ export const AttachCommand = cmd({
       }),
   handler: async (args) => {
     if (args.dir) process.chdir(args.dir)
+
+    const input = new URL(args.url)
+    const queryDir = input.searchParams.get("directory") || undefined
+    input.search = ""
+
     await tui({
-      url: args.url,
+      url: input.toString(),
+      directory: args.serverDir || queryDir,
       args: { sessionID: args.session },
     })
   },

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -5,11 +5,12 @@ import { batch, onCleanup, onMount } from "solid-js"
 
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
-  init: (props: { url: string }) => {
+  init: (props: { url: string; directory?: string }) => {
     const abort = new AbortController()
     const sdk = createOpencodeClient({
       baseUrl: props.url,
       signal: abort.signal,
+      directory: props.directory,
     })
 
     const emitter = createGlobalEmitter<{

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -303,23 +303,27 @@ opencode serve
 
 # In another terminal, run commands that attach to it
 opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
+
+# Attach with a specific server directory
+opencode run --attach http://localhost:4096 --server-dir /path/to/project "Analyze this codebase"
 ```
 
 #### Flags
 
-| Flag         | Short | Description                                                        |
-| ------------ | ----- | ------------------------------------------------------------------ |
-| `--command`  |       | The command to run, use message for args                           |
-| `--continue` | `-c`  | Continue the last session                                          |
-| `--session`  | `-s`  | Session ID to continue                                             |
-| `--share`    |       | Share the session                                                  |
-| `--model`    | `-m`  | Model to use in the form of provider/model                         |
-| `--agent`    |       | Agent to use                                                       |
-| `--file`     | `-f`  | File(s) to attach to message                                       |
-| `--format`   |       | Format: default (formatted) or json (raw JSON events)              |
-| `--title`    |       | Title for the session (uses truncated prompt if no value provided) |
-| `--attach`   |       | Attach to a running opencode server (e.g., http://localhost:4096)  |
-| `--port`     |       | Port for the local server (defaults to random port)                |
+| Flag           | Short | Description                                                        |
+| -------------- | ----- | ------------------------------------------------------------------ |
+| `--command`    |       | The command to run, use message for args                           |
+| `--continue`   | `-c`  | Continue the last session                                          |
+| `--session`    | `-s`  | Session ID to continue                                             |
+| `--share`      |       | Share the session                                                  |
+| `--model`      | `-m`  | Model to use in the form of provider/model                         |
+| `--agent`      |       | Agent to use                                                       |
+| `--file`       | `-f`  | File(s) to attach to message                                       |
+| `--format`     |       | Format: default (formatted) or json (raw JSON events)              |
+| `--title`      |       | Title for the session (uses truncated prompt if no value provided) |
+| `--attach`     |       | Attach to a running opencode server (e.g., http://localhost:4096)  |
+| `--server-dir` |       | Directory to run in on the server (absolute path)                  |
+| `--port`       |       | Port for the local server (defaults to random port)                |
 
 ---
 
@@ -434,6 +438,46 @@ This starts an HTTP server and opens a web browser to access OpenCode through a 
 | `--port`     | Port to listen on     |
 | `--hostname` | Hostname to listen on |
 | `--mdns`     | Enable mDNS discovery |
+
+---
+
+### attach
+
+Attach the TUI to a running OpenCode server.
+
+```bash
+opencode attach <url>
+```
+
+This command allows you to connect your terminal UI to a running OpenCode server instance, enabling remote usage and avoiding cold boot times.
+
+```bash
+# Attach to a local server
+opencode attach http://localhost:4096
+
+# Attach with a specific server directory
+opencode attach http://localhost:4096 --server-dir /path/to/project
+
+# Attach and continue a specific session
+opencode attach http://localhost:4096 --session abc123
+
+# Attach from a specific local directory
+opencode attach http://localhost:4096 --dir ./my-project
+```
+
+#### Flags
+
+| Flag           | Short | Description                                  |
+| -------------- | ----- | -------------------------------------------- |
+| `--dir`        |       | Directory to run in locally                  |
+| `--server-dir` |       | Directory to run in on the server (absolute) |
+| `--session`    | `-s`  | Session ID to continue                       |
+
+#### Positional Arguments
+
+| Argument | Description                              |
+| -------- | ---------------------------------------- |
+| `url`    | Server URL (e.g., http://localhost:4096) |
 
 ---
 


### PR DESCRIPTION
re: https://github.com/sst/opencode/issues/5380

Be able to specify the remote dir either in the URL (`?directory=/remote/dir`) or via `--server-dir`
Works with both `attach` and `run --attach`