### PR TITLE
feat: add support for `.claude/skills` directory

### DIFF
--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -101,31 +101,31 @@ test("returns empty array when no skills exist", async () => {
   })
 })
 
-// test("discovers skills from .claude/skills/ directory", async () => {
-//   await using tmp = await tmpdir({
-//     git: true,
-//     init: async (dir) => {
-//       const skillDir = path.join(dir, ".claude", "skills", "claude-skill")
-//       await Bun.write(
-//         path.join(skillDir, "SKILL.md"),
-//         `---
-// name: claude-skill
-// description: A skill in the .claude/skills directory.
-// ---
+test("discovers skills from .claude/skills/ directory", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      const skillDir = path.join(dir, ".claude", "skills", "claude-skill")
+      await Bun.write(
+        path.join(skillDir, "SKILL.md"),
+        `---
+name: claude-skill
+description: A skill in the .claude/skills directory.
+---
 
-// # Claude Skill
-// `,
-//       )
-//     },
-//   })
+# Claude Skill
+`,
+      )
+    },
+  })
 
-//   await Instance.provide({
-//     directory: tmp.path,
-//     fn: async () => {
-//       const skills = await Skill.all()
-//       expect(skills.length).toBe(1)
-//       expect(skills[0].name).toBe("claude-skill")
-//       expect(skills[0].location).toContain(".claude/skills/claude-skill/SKILL.md")
-//     },
-//   })
-// })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      expect(skills.length).toBe(1)
+      expect(skills[0].name).toBe("claude-skill")
+      expect(skills[0].location).toContain(".claude/skills/claude-skill/SKILL.md")
+    },
+  })
+})


### PR DESCRIPTION
As per docs, intention was to suppport `.claude/skills`
https://opencode.ai/docs/skills/
<img width="857" height="226" alt="Screen Shot 2025-12-27 at 4 21 43 PM" src="https://github.com/user-attachments/assets/5993bed3-2502-4a4b-8226-cf47e4c20652" />

I can see `.claude/skills` support was removed in 009b0960044257cf2a3213ba49c0a3f64abea202 by @rekram1-node. Seems like this might have been because of another issue https://github.com/sst/opencode/issues/5991#issuecomment-3684530655 which I think has since been fixed here by removing the regex https://github.com/sst/opencode/commit/046e3511409e7830fb24d8943b241d1febb10646#diff-54184cd5893ffa6ad25945157739a92970d03937b46c73ee9e3c3838de3c52fd
<img width="938" height="775" alt="Screen Shot 2025-12-27 at 4 55 46 PM" src="https://github.com/user-attachments/assets/30561c5e-6081-42a1-9d5b-52dd9ff2f69f" />

Fixes #6177

_PS. I'm also happy for you to change this implementation to be more like 009b0960044257cf2a3213ba49c0a3f64abea202, where it walks up from cwd to worktree, I didn't know that existed when I started working on this fix._

### Testing

Before
No `.claude/skills` ❌
```
➜ opencode debug skill
[
  {
    "name": "global-opencode-skill",
    "description": "Global .opencode skill for troubleshooting discovery.",
    "location": "/Users/connorads/.config/opencode/skill/global-opencode-skill/SKILL.md"
  },
  {
    "name": "test-skill",
    "description": "use this when asked to test skill",
    "location": "/Users/connorads/git/opencode/.opencode/skill/test-skill/SKILL.md"
  }
]
```

After
`claude/skills` loaded ✅
```
➜ bun dev debug skill 
$ bun run --cwd packages/opencode --conditions=browser src/index.ts debug skill
[
  {
    "name": "global-opencode-skill",
    "description": "Global .opencode skill for troubleshooting discovery.",
    "location": "/Users/connorads/.config/opencode/skill/global-opencode-skill/SKILL.md"
  },
  {
    "name": "test-skill",
    "description": "use this when asked to test skill",
    "location": "/Users/connorads/git/opencode/.opencode/skill/test-skill/SKILL.md"
  },
  {
    "name": "local-claude-skill",
    "description": "Local test skill for validating skill loading.",
    "location": "/Users/connorads/git/opencode/.claude/skills/local-claude-skill/SKILL.md"
  }
]
```