### PR TITLE
chore: update `INVALID_DIRS` to include plural 'skills' directory

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -155,7 +155,7 @@ export namespace Config {
     }
   })
 
-  const INVALID_DIRS = new Bun.Glob(`{${["agents", "commands", "plugins", "tools"].join(",")}}/`)
+  const INVALID_DIRS = new Bun.Glob(`{${["agents", "commands", "plugins", "tools", "skills"].join(",")}}/`)
   async function assertValid(dir: string) {
     const invalid = await Array.fromAsync(
       INVALID_DIRS.scan({


### PR DESCRIPTION
Add `skills/` to invalid OpenCode config directories list to prevent common plural naming mistake.

[OpenCode uses singular directory names (skill/, agent/, command/, plugin/, tool/) for now](https://github.com/sst/opencode/pull/6065#issuecomment-3688120990).

Just in case people coming from other coding agents and miss the difference and get frustrated trying to get skills working. This will help them fail fast.

https://opencode.ai/docs/skills/

### Testing

Before: no warning ❌
```
➜ opencode
```

After ✅
```
➜ bun dev 
$ bun run --cwd packages/opencode --conditions=browser src/index.ts
^[[I^[[I^[[IDirectory "skills" in /Users/connorads/git/opencode/packages/opencode/.opencode is not valid. Rename the directory to "skill" or remove it. This is a common typo.
```