### PR TITLE
fix: stats command to correctly handle `--days 0` for current day statistics

### DIFF
--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -86,16 +86,15 @@ export async function aggregateSessionStats(days?: number, projectFilter?: strin
   const sessions = await getAllSessions()
   const MS_IN_DAY = 24 * 60 * 60 * 1000
 
-  let cutoffTime = 0
-  if (days !== undefined) {
+  const cutoffTime = (() => {
+    if (days === undefined) return 0
     if (days === 0) {
       const now = new Date()
       now.setHours(0, 0, 0, 0)
-      cutoffTime = now.getTime()
-    } else {
-      cutoffTime = Date.now() - days * MS_IN_DAY
+      return now.getTime()
     }
-  }
+    return Date.now() - days * MS_IN_DAY
+  })()
 
   let filteredSessions = cutoffTime > 0 ? sessions.filter((session) => session.time.updated >= cutoffTime) : sessions
 

--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -82,12 +82,22 @@ async function getAllSessions(): Promise<Session.Info[]> {
   return sessions
 }
 
-async function aggregateSessionStats(days?: number, projectFilter?: string): Promise<SessionStats> {
+export async function aggregateSessionStats(days?: number, projectFilter?: string): Promise<SessionStats> {
   const sessions = await getAllSessions()
-  const DAYS_IN_SECOND = 24 * 60 * 60 * 1000
-  const cutoffTime = days ? Date.now() - days * DAYS_IN_SECOND : 0
+  const MS_IN_DAY = 24 * 60 * 60 * 1000
 
-  let filteredSessions = days ? sessions.filter((session) => session.time.updated >= cutoffTime) : sessions
+  let cutoffTime = 0
+  if (days !== undefined) {
+    if (days === 0) {
+      const now = new Date()
+      now.setHours(0, 0, 0, 0)
+      cutoffTime = now.getTime()
+    } else {
+      cutoffTime = Date.now() - days * MS_IN_DAY
+    }
+  }
+
+  let filteredSessions = cutoffTime > 0 ? sessions.filter((session) => session.time.updated >= cutoffTime) : sessions
 
   if (projectFilter !== undefined) {
     if (projectFilter === "") {
@@ -198,7 +208,7 @@ async function aggregateSessionStats(days?: number, projectFilter?: string): Pro
     }
   }
 
-  const actualDays = Math.max(1, Math.ceil((latestTime - earliestTime) / DAYS_IN_SECOND))
+  const actualDays = Math.max(1, Math.ceil((latestTime - earliestTime) / MS_IN_DAY))
   stats.dateRange = {
     earliest: earliestTime,
     latest: latestTime,


### PR DESCRIPTION
### Summary

This PR fixes an issue where running `opencode stats --days 0` would display "All Time" statistics instead of statistics for the current day. It also refactors the time calculation logic for better readability and testability.

### Changes

- **Fixed `days=0` logic:** Previously, `days=0` was treated as falsy, causing the cutoff time to default to `0` (Unix Epoch), which displayed the entire history. Now, `days=0` explicitly sets the cutoff time to **00:00:00** of the current day.
- **Refactoring:** Renamed `DAYS_IN_SECOND` to `MS_IN_DAY` and exported `aggregateSessionStats` to enable unit testing.
- **New Tests:** Added unit tests to verify time filtering logic for today, specific day ranges, and default behavior.
 Behavior Comparison
 1. Before Fix: `opencode stats --days 0`
**Issue:** `0` is treated as "undefined/all-time".
- **Result:** Displays stats for the entire history of the project.
   
2. Before/After (Unchanged): opencode stats --days 1
Behavior: correctly calculates "Last 24 Hours".
- Result: Displays stats for the rolling 24-hour window.
  
3. After Fix: opencode stats --days 0
Fix: 0 is treated explicitly as "Today".
- Result: Displays stats only for sessions created since midnight today.
  
### Verification

- Ran bun dev stats --days 0 to verify it captures only today's sessions.
- Ran bun dev stats --days 1 to verify it still captures the last 24h.
- Validated via new unit tests covering days=0, days=N, and days=undefined scenarios.