### PR TITLE
docs: add opencode-notificator to ecosystem plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -31,6 +31,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                             |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                                      |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                | 10x faster code editing with Morph Fast Apply API and lazy edit markers                        |
+| [opencode-notificator](https://github.com/panta/opencode-notificator)                             | Desktop notifications and sound alerts for OpenCode sessions                                   |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible         |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                           | AI-powered automatic Zellij session naming based on OpenCode context                           |
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -31,8 +31,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                               | Track OpenCode usage with Wakatime                                                             |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)   | Clean up markdown tables produced by LLMs                                                      |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                | 10x faster code editing with Morph Fast Apply API and lazy edit markers                        |
-| [opencode-notificator](https://github.com/panta/opencode-notificator)                             | Desktop notifications and sound alerts for OpenCode sessions                                   |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible         |
+| [opencode-notificator](https://github.com/panta/opencode-notificator)                             | Desktop notifications and sound alerts for OpenCode sessions                                   |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                           | AI-powered automatic Zellij session naming based on OpenCode context                           |
 
 ---


### PR DESCRIPTION
There's a notification plugin in examples, but it's very simple. This one adds a bit more options and custom sound support, whichever one user prefers.