### PR TITLE
feat(tui): add edit and discard actions for queued messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-command.tsx
@@ -47,7 +47,7 @@ function init() {
     if (suspended()) return
     if (dialog.stack.length > 0) return
     for (const option of options()) {
-      if (option.keybind && keybind.match(option.keybind, evt)) {
+      if (option.keybind && !option.disabled && keybind.match(option.keybind, evt)) {
         evt.preventDefault()
         option.onSelect?.(dialog)
         return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -44,6 +44,7 @@ export type PromptProps = {
 export type PromptRef = {
   focused: boolean
   current: PromptInfo
+  editingQueuedMessageID: string | undefined
   set(prompt: PromptInfo): void
   reset(): void
   blur(): void
@@ -72,6 +73,16 @@ export function Prompt(props: PromptProps) {
   const renderer = useRenderer()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+
+  const queuedMessages = createMemo(() => {
+    if (!props.sessionID) return []
+    const messages = sync.data.message[props.sessionID] ?? []
+    if (status().type !== "busy") return []
+    const sorted = [...messages].sort((a, b) => a.id.localeCompare(b.id))
+    const pending = sorted.findLast((m) => m.role === "assistant" && m.time.completed === undefined)
+    if (!pending) return []
+    return sorted.filter((m) => m.role === "user" && m.id > pending.id)
+  })
 
   function promptModelWarning() {
     toast.show({
@@ -118,6 +129,7 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: Map<number, number>
     interrupt: number
     placeholder: number
+    editingQueuedMessageID: string | undefined
   }>({
     placeholder: Math.floor(Math.random() * PLACEHOLDERS.length),
     prompt: {
@@ -127,6 +139,7 @@ export function Prompt(props: PromptProps) {
     mode: "normal",
     extmarkToPartIndex: new Map(),
     interrupt: 0,
+    editingQueuedMessageID: undefined,
   })
 
   // Initialize agent/model/variant from last user message when session changes
@@ -160,6 +173,7 @@ export function Prompt(props: PromptProps) {
         onSelect: (dialog) => {
           input.extmarks.clear()
           input.clear()
+          setStore("editingQueuedMessageID", undefined)
           dialog.clear()
         },
       },
@@ -307,12 +321,103 @@ export function Prompt(props: PromptProps) {
           input.cursorOffset = Bun.stringWidth(content)
         },
       },
+      {
+        title: "Edit queued message",
+        category: "Queue",
+        keybind: "queue_edit",
+        value: "queue.edit",
+        disabled: queuedMessages().length === 0 || store.editingQueuedMessageID !== undefined,
+        onSelect: async (dialog) => {
+          dialog.clear()
+          if (!props.sessionID) return
+          const queued = queuedMessages()
+          const last = queued.at(-1)
+          if (!last) return
+          const response = await sdk.client.session.getQueue({
+            sessionID: props.sessionID,
+            messageID: last.id,
+          })
+          if (!response.data) return
+          const textParts = response.data.parts.filter((p) => p.type === "text")
+          const fileParts = response.data.parts.filter((p) => p.type === "file")
+          const text = textParts.map((p) => p.text).join("")
+
+          let fullText = text
+          const parts: typeof store.prompt.parts = []
+
+          for (const file of fileParts) {
+            const start = fullText.length + (fullText.length > 0 ? 1 : 0)
+            const virtualText = file.filename ? `[File: ${file.filename}]` : `[Image ${parts.length + 1}]`
+            const end = start + virtualText.length
+            fullText += (fullText.length > 0 ? " " : "") + virtualText
+            parts.push({
+              type: "file",
+              mime: file.mime,
+              filename: file.filename,
+              url: file.url,
+              source: {
+                type: "file",
+                path: file.filename ?? "",
+                text: { start, end, value: virtualText },
+              },
+            })
+          }
+
+          input.setText(fullText)
+          input.cursorOffset = fullText.length
+          setStore("prompt", { input: fullText, parts })
+          restoreExtmarksFromParts(parts)
+          setStore("editingQueuedMessageID", last.id)
+        },
+      },
+      {
+        title: "Discard queued message",
+        category: "Queue",
+        keybind: "queue_discard",
+        value: "queue.discard",
+        disabled: queuedMessages().length === 0,
+        onSelect: async (dialog) => {
+          dialog.clear()
+          if (!props.sessionID) return
+          const messageID = store.editingQueuedMessageID ?? queuedMessages().at(-1)?.id
+          if (!messageID) return
+          await sdk.client.session.cancelQueue({
+            sessionID: props.sessionID,
+            messageID,
+          })
+          if (store.editingQueuedMessageID) {
+            input.clear()
+            input.extmarks.clear()
+            setStore("prompt", { input: "", parts: [] })
+            setStore("extmarkToPartIndex", new Map())
+            setStore("editingQueuedMessageID", undefined)
+          }
+        },
+      },
     ]
   })
 
   createEffect(() => {
     if (props.visible !== false) input?.focus()
     if (props.visible === false) input?.blur()
+  })
+
+  // Clear editing state if the message being edited is no longer in the queue (was processed)
+  createEffect(() => {
+    if (!store.editingQueuedMessageID) return
+    const stillQueued = queuedMessages().some((m) => m.id === store.editingQueuedMessageID)
+    if (!stillQueued) {
+      input.clear()
+      input.extmarks.clear()
+      setStore("prompt", { input: "", parts: [] })
+      setStore("extmarkToPartIndex", new Map())
+      setStore("editingQueuedMessageID", undefined)
+      toast.show({
+        variant: "info",
+        message: "Queued message was processed",
+        duration: 3000,
+      })
+    }
   })
 
   onMount(() => {
@@ -459,6 +564,9 @@ export function Prompt(props: PromptProps) {
     get current() {
       return store.prompt
     },
+    get editingQueuedMessageID() {
+      return store.editingQueuedMessageID
+    },
     focus() {
       input.focus()
     },
@@ -479,6 +587,7 @@ export function Prompt(props: PromptProps) {
         parts: [],
       })
       setStore("extmarkToPartIndex", new Map())
+      setStore("editingQueuedMessageID", undefined)
     },
     submit() {
       submit()
@@ -567,6 +676,12 @@ export function Prompt(props: PromptProps) {
           })),
       })
     } else {
+      if (store.editingQueuedMessageID) {
+        await sdk.client.session.cancelQueue({
+          sessionID,
+          messageID: store.editingQueuedMessageID,
+        })
+      }
       sdk.client.session.prompt({
         sessionID,
         ...selectedModel,
@@ -597,6 +712,7 @@ export function Prompt(props: PromptProps) {
       parts: [],
     })
     setStore("extmarkToPartIndex", new Map())
+    setStore("editingQueuedMessageID", undefined)
     props.onSubmit?.()
 
     // temporary hack to make sure the message is sent
@@ -804,9 +920,19 @@ export function Prompt(props: PromptProps) {
                     parts: [],
                   })
                   setStore("extmarkToPartIndex", new Map())
+                  setStore("editingQueuedMessageID", undefined)
                   return
                 }
                 if (keybind.match("app_exit", e)) {
+                  if (store.editingQueuedMessageID) {
+                    input.clear()
+                    input.extmarks.clear()
+                    setStore("prompt", { input: "", parts: [] })
+                    setStore("extmarkToPartIndex", new Map())
+                    setStore("editingQueuedMessageID", undefined)
+                    e.preventDefault()
+                    return
+                  }
                   if (store.prompt.input === "") {
                     await exit()
                     // Don't preventDefault - let textarea potentially handle the event

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1009,6 +1009,7 @@ export function Session() {
                         message={message as UserMessage}
                         parts={sync.data.part[message.id] ?? []}
                         pending={pending()}
+                        editingMessageID={prompt?.editingQueuedMessageID}
                       />
                     </Match>
                     <Match when={message.role === "assistant"}>
@@ -1076,15 +1077,18 @@ function UserMessage(props: {
   onMouseUp: () => void
   index: number
   pending?: string
+  editingMessageID?: string
 }) {
   const ctx = use()
   const local = useLocal()
+  const keybind = useKeybind()
   const text = createMemo(() => props.parts.flatMap((x) => (x.type === "text" && !x.synthetic ? [x] : []))[0])
   const files = createMemo(() => props.parts.flatMap((x) => (x.type === "file" ? [x] : [])))
   const sync = useSync()
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
+  const editing = createMemo(() => props.editingMessageID === props.message.id)
   const color = createMemo(() => (queued() ? theme.accent : local.agent.color(props.message.agent)))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 
@@ -1148,8 +1152,24 @@ function UserMessage(props: {
             >
               <text fg={theme.textMuted}>
                 <span style={{ bg: theme.accent, fg: theme.backgroundPanel, bold: true }}> QUEUED </span>
-              </text>
-            </Show>
+                <Show
+                  when={editing()}
+                  fallback={
+                    <span style={{ fg: theme.textMuted }}>
+                      {" "}
+                      {keybind.print("queue_edit")} edit · {keybind.print("queue_discard")} discard
+                    </span>
+                  }
+                >
+                  <span> </span>
+                  <span style={{ bg: theme.primary, fg: theme.backgroundPanel, bold: true }}> EDITING </span>
+                  <span style={{ fg: theme.textMuted }}>
+                    {" "}
+                    enter submit · ctrl+c cancel · {keybind.print("queue_discard")} discard
+                  </span>
+                </Show>
+              </Show>
+            </text>
           </box>
         </box>
       </Show>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -692,6 +692,8 @@ export namespace Config {
         .describe("Delete word backward in input"),
       history_previous: z.string().optional().default("up").describe("Previous history item"),
       history_next: z.string().optional().default("down").describe("Next history item"),
+      queue_edit: z.string().optional().default("<leader>i").describe("Edit queued message"),
+      queue_discard: z.string().optional().default("<leader>d").describe("Discard queued message"),
       session_child_cycle: z.string().optional().default("<leader>right").describe("Next child session"),
       session_child_cycle_reverse: z.string().optional().default("<leader>left").describe("Previous child session"),
       session_parent: z.string().optional().default("<leader>up").describe("Go to parent session"),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -72,26 +72,26 @@ export namespace Server {
   }
 
   const app = new Hono()
-  export const App: () => Hono = lazy(
-    () =>
-      app
-        .onError((err, c) => {
-          log.error("failed", {
-            error: err,
-          })
-          if (err instanceof NamedError) {
-            let status: ContentfulStatusCode
-            if (err instanceof Storage.NotFoundError) status = 404
-            else if (err instanceof Provider.ModelNotFoundError) status = 400
-            else if (err.name.startsWith("Worktree")) status = 400
-            else status = 500
-            return c.json(err.toObject(), { status })
-          }
-          const message = err instanceof Error && err.stack ? err.stack : err.toString()
-          return c.json(new NamedError.Unknown({ message }).toObject(), {
-            status: 500,
-          })
+  export const App = lazy(() =>
+    // @ts-expect-error Type instantiation is excessively deep - known TypeScript limitation with Hono
+    app
+      .onError((err, c) => {
+        log.error("failed", {
+          error: err,
         })
+        if (err instanceof NamedError) {
+          let status: ContentfulStatusCode
+          if (err instanceof Storage.NotFoundError) status = 404
+          else if (err instanceof Provider.ModelNotFoundError) status = 400
+          else if (err.name.startsWith("Worktree")) status = 400
+          else status = 500
+          return c.json(err.toObject(), { status })
+        }
+        const message = err instanceof Error && err.stack ? err.stack : err.toString()
+        return c.json(new NamedError.Unknown({ message }).toObject(), {
+          status: 500,
+        })
+      })
         .use(async (c, next) => {
           const skipLogging = c.req.path === "/log"
           if (!skipLogging) {
@@ -2922,8 +2922,8 @@ export namespace Server {
   )
 
   export async function openapi() {
-    // Cast to break excessive type recursion from long route chains
-    const result = await generateSpecs(App() as Hono, {
+    // @ts-expect-error Type instantiation is excessively deep - known TypeScript limitation with Hono
+    const result = await generateSpecs(App(), {
       documentation: {
         info: {
           title: "opencode",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1042,15 +1042,106 @@ export namespace Server {
               sessionID: z.string(),
             }),
           ),
-          async (c) => {
-            SessionPrompt.cancel(c.req.valid("param").sessionID)
-            return c.json(true)
+        async (c) => {
+          SessionPrompt.cancel(c.req.valid("param").sessionID)
+          return c.json(true)
+        },
+      )
+      .get(
+        "/session/:sessionID/queue",
+        describeRoute({
+          summary: "Get queued messages",
+          description: "Get list of message IDs that are queued and waiting to be processed.",
+          operationId: "session.queue",
+          responses: {
+            200: {
+              description: "List of queued message IDs",
+              content: {
+                "application/json": {
+                  schema: resolver(z.array(z.string())),
+                },
+              },
+            },
+            ...errors(400, 404),
           },
-        )
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        async (c) => {
+          const queued = SessionPrompt.queued(c.req.valid("param").sessionID)
+          return c.json(queued)
+        },
+      )
+      .get(
+        "/session/:sessionID/queue/:messageID",
+        describeRoute({
+          summary: "Get queued message",
+          description: "Get a queued message without removing it from the queue.",
+          operationId: "session.getQueue",
+          responses: {
+            200: {
+              description: "Queued message with parts",
+              content: {
+                "application/json": {
+                  schema: resolver(MessageV2.WithParts.nullable()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+            messageID: z.string(),
+          }),
+        ),
+        async (c) => {
+          const { sessionID, messageID } = c.req.valid("param")
+          const message = await SessionPrompt.getQueued(sessionID, messageID)
+          return c.json(message ?? null)
+        },
+      )
+      .delete(
+        "/session/:sessionID/queue/:messageID",
+        describeRoute({
+          summary: "Cancel queued message",
+          description: "Cancel a queued message that has not yet been processed by the agent.",
+          operationId: "session.cancelQueue",
+          responses: {
+            200: {
+              description: "Cancelled message with parts",
+              content: {
+                "application/json": {
+                  schema: resolver(MessageV2.WithParts.nullable()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+            messageID: z.string(),
+          }),
+        ),
+        async (c) => {
+          const { sessionID, messageID } = c.req.valid("param")
+          const message = await SessionPrompt.cancelQueued(sessionID, messageID)
+          return c.json(message ?? null)
+        },
+      )
 
-        .post(
-          "/session/:sessionID/share",
-          describeRoute({
+      .post(
+        "/session/:sessionID/share",
+        describeRoute({
             summary: "Share session",
             description: "Create a shareable link for a session, allowing others to view the conversation.",
             operationId: "session.share",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -59,6 +59,7 @@ export namespace SessionPrompt {
         {
           abort: AbortController
           callbacks: {
+            messageID: string
             resolve(input: MessageV2.WithParts): void
             reject(): void
           }[]
@@ -175,7 +176,7 @@ export namespace SessionPrompt {
       return message
     }
 
-    return loop(input.sessionID)
+    return loop(input.sessionID, message.info.id)
   })
 
   export async function resolvePromptParts(template: string): Promise<PromptInput["parts"]> {
@@ -254,12 +255,51 @@ export namespace SessionPrompt {
     return
   }
 
-  export const loop = fn(Identifier.schema("session"), async (sessionID) => {
+  export function queued(sessionID: string) {
+    const s = state()
+    const match = s[sessionID]
+    if (!match) return []
+    return match.callbacks.map((c) => c.messageID).filter(Boolean)
+  }
+
+  export async function getQueued(sessionID: string, messageID: string) {
+    const s = state()
+    const match = s[sessionID]
+    if (!match) return
+
+    const index = match.callbacks.findIndex((c) => c.messageID === messageID)
+    if (index === -1) return
+
+    const messages = await Session.messages({ sessionID })
+    return messages.find((m) => m.info.id === messageID)
+  }
+
+  export async function cancelQueued(sessionID: string, messageID: string) {
+    log.info("cancelQueued", { sessionID, messageID })
+    const s = state()
+    const match = s[sessionID]
+    if (!match) return
+
+    const index = match.callbacks.findIndex((c) => c.messageID === messageID)
+    if (index === -1) return
+
+    const [removed] = match.callbacks.splice(index, 1)
+    removed.reject()
+
+    const messages = await Session.messages({ sessionID })
+    const message = messages.find((m) => m.info.id === messageID)
+    if (!message) return
+
+    await Session.removeMessage({ sessionID, messageID })
+    return message
+  }
+
+  export async function loop(sessionID: string, messageID?: string) {
     const abort = start(sessionID)
     if (!abort) {
       return new Promise<MessageV2.WithParts>((resolve, reject) => {
         const callbacks = state()[sessionID].callbacks
-        callbacks.push({ resolve, reject })
+        callbacks.push({ messageID: messageID!, resolve, reject })
       })
     }
 
@@ -629,7 +669,7 @@ export namespace SessionPrompt {
       return item
     }
     throw new Error("Impossible")
-  })
+  }
 
   async function lastModel(sessionID: string) {
     for await (const item of MessageV2.stream(sessionID)) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -915,6 +915,74 @@ test("permission config preserves key order", async () => {
   })
 })
 
+test("keybinds queue_edit defaults to <leader>i", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.keybinds?.queue_edit).toBe("<leader>i")
+    },
+  })
+})
+
+test("keybinds queue_discard defaults to <leader>d", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.keybinds?.queue_discard).toBe("<leader>d")
+    },
+  })
+})
+
+test("keybinds queue_edit can be customized", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          keybinds: {
+            queue_edit: "ctrl+e",
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.keybinds?.queue_edit).toBe("ctrl+e")
+    },
+  })
+})
+
+test("keybinds queue_discard can be customized", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          keybinds: {
+            queue_discard: "ctrl+shift+d",
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.keybinds?.queue_discard).toBe("ctrl+shift+d")
+    },
+  })
+})
+
 // MCP config merging tests
 
 test("project config can override MCP server enabled status", async () => {

--- a/packages/opencode/test/session/queue.test.ts
+++ b/packages/opencode/test/session/queue.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Log } from "../../src/util/log"
+import { Instance } from "../../src/project/instance"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("SessionPrompt.queued", () => {
+  test("returns empty array for non-existent session", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = SessionPrompt.queued("non-existent-session-id")
+        expect(result).toEqual([])
+      },
+    })
+  })
+})
+
+describe("SessionPrompt.getQueued", () => {
+  test("returns undefined for non-existent session", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = await SessionPrompt.getQueued("non-existent-session-id", "non-existent-message-id")
+        expect(result).toBeUndefined()
+      },
+    })
+  })
+})
+
+describe("SessionPrompt.cancelQueued", () => {
+  test("returns undefined for non-existent session", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const result = await SessionPrompt.cancelQueued("non-existent-session-id", "non-existent-message-id")
+        expect(result).toBeUndefined()
+      },
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -91,6 +91,8 @@ import type {
   QuestionReplyResponses,
   SessionAbortErrors,
   SessionAbortResponses,
+  SessionCancelQueueErrors,
+  SessionCancelQueueResponses,
   SessionChildrenErrors,
   SessionChildrenResponses,
   SessionCommandErrors,
@@ -103,6 +105,8 @@ import type {
   SessionDiffResponses,
   SessionForkResponses,
   SessionGetErrors,
+  SessionGetQueueErrors,
+  SessionGetQueueResponses,
   SessionGetResponses,
   SessionInitErrors,
   SessionInitResponses,
@@ -115,6 +119,8 @@ import type {
   SessionPromptAsyncResponses,
   SessionPromptErrors,
   SessionPromptResponses,
+  SessionQueueErrors,
+  SessionQueueResponses,
   SessionRevertErrors,
   SessionRevertResponses,
   SessionShareErrors,
@@ -1128,6 +1134,102 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
       url: "/session/{sessionID}/abort",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get queued messages
+   *
+   * Get list of message IDs that are queued and waiting to be processed.
+   */
+  public queue<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionQueueResponses, SessionQueueErrors, ThrowOnError>({
+      url: "/session/{sessionID}/queue",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Cancel queued message
+   *
+   * Cancel a queued message that has not yet been processed by the agent.
+   */
+  public cancelQueue<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<SessionCancelQueueResponses, SessionCancelQueueErrors, ThrowOnError>(
+      {
+        url: "/session/{sessionID}/queue/{messageID}",
+        ...options,
+        ...params,
+      },
+    )
+  }
+
+  /**
+   * Get queued message
+   *
+   * Get a queued message without removing it from the queue.
+   */
+  public getQueue<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      messageID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "messageID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionGetQueueResponses, SessionGetQueueErrors, ThrowOnError>({
+      url: "/session/{sessionID}/queue/{messageID}",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1224,6 +1224,14 @@ export type KeybindsConfig = {
    */
   history_next?: string
   /**
+   * Edit queued message
+   */
+  queue_edit?: string
+  /**
+   * Discard queued message
+   */
+  queue_discard?: string
+  /**
    * Next child session
    */
   session_child_cycle?: string
@@ -2930,6 +2938,113 @@ export type SessionAbortResponses = {
 }
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
+
+export type SessionQueueData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/queue"
+}
+
+export type SessionQueueErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionQueueError = SessionQueueErrors[keyof SessionQueueErrors]
+
+export type SessionQueueResponses = {
+  /**
+   * List of queued message IDs
+   */
+  200: Array<string>
+}
+
+export type SessionQueueResponse = SessionQueueResponses[keyof SessionQueueResponses]
+
+export type SessionCancelQueueData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/queue/{messageID}"
+}
+
+export type SessionCancelQueueErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionCancelQueueError = SessionCancelQueueErrors[keyof SessionCancelQueueErrors]
+
+export type SessionCancelQueueResponses = {
+  /**
+   * Cancelled message with parts
+   */
+  200: {
+    info: Message
+    parts: Array<Part>
+  } | null
+}
+
+export type SessionCancelQueueResponse = SessionCancelQueueResponses[keyof SessionCancelQueueResponses]
+
+export type SessionGetQueueData = {
+  body?: never
+  path: {
+    sessionID: string
+    messageID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/queue/{messageID}"
+}
+
+export type SessionGetQueueErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionGetQueueError = SessionGetQueueErrors[keyof SessionGetQueueErrors]
+
+export type SessionGetQueueResponses = {
+  /**
+   * Queued message with parts
+   */
+  200: {
+    info: Message
+    parts: Array<Part>
+  } | null
+}
+
+export type SessionGetQueueResponse = SessionGetQueueResponses[keyof SessionGetQueueResponses]
 
 export type SessionUnshareData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1691,6 +1691,247 @@
         ]
       }
     },
+    "/session/{sessionID}/queue": {
+      "get": {
+        "operationId": "session.queue",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get queued messages",
+        "description": "Get list of message IDs that are queued and waiting to be processed.",
+        "responses": {
+          "200": {
+            "description": "List of queued message IDs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.queue({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/queue/{messageID}": {
+      "get": {
+        "operationId": "session.getQueue",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "messageID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Get queued message",
+        "description": "Get a queued message without removing it from the queue.",
+        "responses": {
+          "200": {
+            "description": "Queued message with parts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "info": {
+                          "$ref": "#/components/schemas/Message"
+                        },
+                        "parts": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Part"
+                          }
+                        }
+                      },
+                      "required": ["info", "parts"]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.getQueue({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "session.cancelQueue",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "messageID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Cancel queued message",
+        "description": "Cancel a queued message that has not yet been processed by the agent.",
+        "responses": {
+          "200": {
+            "description": "Cancelled message with parts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "info": {
+                          "$ref": "#/components/schemas/Message"
+                        },
+                        "parts": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Part"
+                          }
+                        }
+                      },
+                      "required": ["info", "parts"]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.cancelQueue({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}/share": {
       "post": {
         "operationId": "session.share",
@@ -8477,6 +8718,16 @@
           "history_next": {
             "description": "Next history item",
             "default": "down",
+            "type": "string"
+          },
+          "queue_edit": {
+            "description": "Edit queued message",
+            "default": "<leader>i",
+            "type": "string"
+          },
+          "queue_discard": {
+            "description": "Discard queued message",
+            "default": "<leader>d",
             "type": "string"
           },
           "session_child_cycle": {


### PR DESCRIPTION
## Summary

Add the ability to edit and discard queued messages while the agent is working.
This allows users to fix typos, rephrase, or completely remove messages from
the queue before they are processed.

**New keybinds:**

- `<leader>i` - Edit the last queued message
- `<leader>d` - Discard the last queued message

## Motivation

When iterating quickly with the AI assistant, users often queue multiple messages.
Currently, there's no way to modify or remove these queued messages once sent.
This leads to:

- Wasted tokens on messages with typos
- Duplicate/redundant instructions when user and agent solve the problem simultaneously
- No way to "take back" a queued message

This feature addresses a common workflow need requested by multiple users.

## Related Issues & PRs

### Closes

- #4821 - Add ability to unqueue messages

### Supersedes

- #5415 - feat(tui): cancel queued messages with history_previous
  - Our implementation improves upon this with dedicated keybinds, file preservation, visual feedback, and bug fixes

### Related

- #5333 - Graceful handling of queued messages after session interrupt (partial)
- #5770 - force push message keybind (provides discard capability)
- #3623 - Queued bugging
- #2609 - Compact + Queue interaction

## Screenshots

### Queued message with hints

<img width="1900" height="970" alt="queued-message-with-hints" src="https://github.com/user-attachments/assets/c840250c-27c6-4e97-ac33-ff92bc1e5e25" />

### Editing a queued message

<img width="1907" height="971" alt="editing-queued-message" src="https://github.com/user-attachments/assets/cc043d61-f767-44b7-9b62-cda8a17c9984" />

### Command palette with queue commands

<img width="1903" height="971" alt="command-palette-queue" src="https://github.com/user-attachments/assets/1d189115-f944-4212-ae04-fd77ba5090d9" />

## Demo

https://streamable.com/urjeww

The video demonstrates the complete flow:

1. Sending a message while agent is working (queued)
2. Editing the queued message with `<leader>i`
3. Discarding a queued message with `<leader>d`
4. The toast notification when a message is processed while being edited

## Implementation

<details>
<summary>Why this PR exists (context on #5415)</summary>

This implementation started from PR #5415 which was stale and had several issues:

### Problems with the original PR #5415

1. **Reused `history_previous` keybind** - Hijacked the UP arrow when prompt was empty, conflicting with normal history navigation
2. **Lost file attachments** - When loading a queued message for editing, only text parts were preserved; files and images were silently discarded
3. **No visual feedback** - No indication that a message was being edited vs just queued
4. **No dedicated discard action** - Could only edit, not quickly discard
5. **Missing API endpoint** - Only had cancel endpoint, no way to fetch message without removing it
6. **Bug in dialog-command.tsx** - Disabled commands could still be triggered via keybinds

### What we fixed/improved

| Issue             | Original #5415            | This PR                             |
| ----------------- | ------------------------- | ----------------------------------- |
| Keybinds          | Reuses UP arrow           | Dedicated `<leader>i` / `<leader>d` |
| File preservation | Lost on edit              | Preserved with extmarks             |
| Visual feedback   | None                      | QUEUED + EDITING badges             |
| Discard action    | None                      | Dedicated keybind                   |
| API               | 1 endpoint (cancel)       | 3 endpoints (list, get, cancel)     |
| Disabled commands | Could trigger via keybind | Fixed to respect disabled state     |

</details>

<details>
<summary>Architecture Decisions</summary>

### Why dedicated keybinds instead of UP arrow?

The original PR #5415 proposed reusing `history_previous` (UP arrow) when the prompt
is empty. We chose dedicated keybinds (`<leader>i` and `<leader>d`) because:

1. **No conflict with history navigation** - Users can still navigate history normally
2. **Explicit intent** - Editing a queued message is a distinct action from browsing history
3. **Consistency with OpenCode patterns** - Other specialized actions use leader-prefix keybinds (e.g., `<leader>h` for tips, `<leader>up` for parent session)
4. **Discoverability** - Commands appear in the command palette with clear names
5. **Future-proof** - PR #4268 proposes changing history keybinds, our approach avoids conflicts

### Why separate Edit and Discard?

- **Edit** (`<leader>i`): Loads the message into the prompt for modification
- **Discard** (`<leader>d`): Removes the message entirely without loading it

This separation allows:

- Quick discard without polluting the prompt
- Discard while already editing (removes message, clears prompt)
- Clear mental model: "i" for insert/edit, "d" for delete

### Why only edit the last queued message?

Both OpenAI Codex and our implementation only allow editing the most recent queued message.
Rationale:

- Simplifies UX - no need for message selection UI
- Covers 99% of use cases - users typically want to fix what they just typed
- If you need to edit something deeper in the queue, you probably made a larger mistake and should discard and re-queue

### State Management

We track `editingQueuedMessageID` in the prompt store to:

- Show the `EDITING` badge on the correct message
- Know which message to cancel when submitting the edited version
- Clear state appropriately when the message is processed mid-edit
- Prevent editing multiple messages simultaneously

### File/Image Preservation

When loading a queued message for editing, we preserve non-text parts by reconstructing them with virtual text representations (e.g., `[File: filename]` or `[Image 1]`) and creating extmarks for proper rendering. This ensures images and files aren't silently lost when editing.

</details>

<details>
<summary>Comparison with Other Tools</summary>

We studied how other AI coding assistants handle queued message editing:

### OpenAI Codex (Rust TUI)

**Source:** [`codex-rs/tui/src/chatwidget.rs`](https://github.com/openai/codex/blob/810ebe0/codex-rs/tui/src/chatwidget.rs)

Codex stores queued messages in a `VecDeque<UserMessage>` with text and image paths. It uses `Alt+Up` to pop the most recent queued message back into the composer, preserving image paths separately. A static hint "Alt+Up edit" is shown on queued messages.

**What we learned from Codex:**

- Preserve image paths separately (we preserve all file parts with extmarks)
- Show hint on queued messages (we show contextual hints that change based on state)
- Only edit last message (we follow this pattern)

**How we differ from Codex:**

| Aspect         | Codex                    | OpenCode (this PR)                |
| -------------- | ------------------------ | --------------------------------- |
| Keybind        | `Alt+Up`                 | `<leader>i`                       |
| Discard action | None                     | `<leader>d`                       |
| Visual state   | No badge                 | `EDITING` badge                   |
| Hints          | Static "Alt+Up edit"     | Contextual (changes when editing) |
| On interrupt   | Restores all to composer | N/A (different architecture)      |

### Claude Code

Claude Code allows editing queued messages via UP arrow when prompt is empty.
This is similar to the original #5415 approach, which we improved upon with
dedicated keybinds to avoid conflicts with history navigation.

</details>

<details>
<summary>Flow Diagram</summary>

```
                              QUEUED MESSAGE
    ┌──────────────────────────────────────────────────────────┐
    │                                                          │
    │   You  QUEUED  ctrl+x i edit · ctrl+x d discard          │
    │   > Your queued message text here...                     │
    │                                                          │
    └──────────────────────────────────────────────────────────┘
                    │                           │
                    │ <leader>i                 │ <leader>d
                    ▼                           ▼
    ┌───────────────────────────┐     ┌─────────────────────────┐
    │                           │     │                         │
    │  QUEUED   EDITING         │     │  Message removed from   │
    │                           │     │  queue and storage      │
    │  enter submit             │     │                         │
    │  ctrl+c cancel            │     └─────────────────────────┘
    │  ctrl+x d discard         │
    │                           │
    │  ┌─────────────────────┐  │
    │  │ Prompt: edited text │  │
    │  └─────────────────────┘  │
    └───────────────────────────┘
                    │
                    │ Enter
                    ▼
    ┌───────────────────────────┐
    │                           │
    │  1. Original message      │
    │     cancelled             │
    │                           │
    │  2. New message sent      │
    │     with edited content   │
    │                           │
    └───────────────────────────┘
```

</details>

<details>
<summary>API Endpoints Added</summary>

| Method   | Endpoint                               | Description                           |
| -------- | -------------------------------------- | ------------------------------------- |
| `GET`    | `/session/:sessionID/queue`            | List queued message IDs               |
| `GET`    | `/session/:sessionID/queue/:messageID` | Get queued message (without removing) |
| `DELETE` | `/session/:sessionID/queue/:messageID` | Cancel and remove queued message      |

</details>

## Changes

### Backend (`packages/opencode/src/`)

| File                | Changes                                                                                   |
| ------------------- | ----------------------------------------------------------------------------------------- |
| `session/prompt.ts` | Add `queued()`, `getQueued()`, `cancelQueued()` functions; track `messageID` in callbacks |
| `server/server.ts`  | Add 3 REST endpoints for queue operations                                                 |
| `config/config.ts`  | Add `queue_edit` and `queue_discard` keybind defaults                                     |

### Frontend (`packages/opencode/src/cli/cmd/tui/`)

| File                           | Changes                                                                                                                                                                                         |
| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `component/prompt/index.tsx`   | Add queue edit/discard commands; track `editingQueuedMessageID` state; preserve file parts with extmarks; handle edge cases (message processed mid-edit, cancel with ctrl+c, clear with ctrl+u) |
| `component/dialog-command.tsx` | **Bug fix:** prevent disabled commands from triggering via keybinds                                                                                                                             |
| `routes/session/index.tsx`     | Show QUEUED/EDITING badges with contextual hints                                                                                                                                                |

### SDK (auto-generated)

| File                           | Changes                 |
| ------------------------------ | ----------------------- |
| `packages/sdk/js/src/v2/gen/*` | Types for new endpoints |
| `packages/sdk/openapi.json`    | API schema              |

<details>
<summary>Bug fix: disabled commands triggering via keybinds</summary>

Found and fixed a bug in `dialog-command.tsx` where disabled commands could still be triggered via their keybinds:

```diff
- if (option.keybind && keybind.match(option.keybind, evt)) {
+ if (option.keybind && !option.disabled && keybind.match(option.keybind, evt)) {
```

This affected all commands with a `disabled` property, not just the queue commands.

</details>

## Edge Cases

| Scenario                           | Behavior                                                                  |
| ---------------------------------- | ------------------------------------------------------------------------- |
| Message processed while editing    | Toast "Queued message was processed", prompt cleared, editing state reset |
| Edit message with file attachments | Files preserved as `[File: filename]` with extmarks                       |
| Cancel edit (`ctrl+c`)             | Prompt cleared, returns to normal state, original message stays queued    |
| Clear prompt (`ctrl+u`)            | Editing state also cleared                                                |
| Discard while editing              | Message removed, prompt cleared                                           |
| No queued messages                 | Commands disabled in palette, keybinds have no effect                     |
| Multiple queued messages           | Only last message can be edited (consistent with Codex behavior)          |

## How to Test

```bash
git checkout feat/edit-queued-messages
bun install
cd packages/opencode && bun dev
```

1. Start a conversation with the agent
2. While the agent is working, send another message (it will show `QUEUED` badge)
3. Press `ctrl+x i` to edit the queued message
4. Modify the text and press `Enter` to submit, or `ctrl+c` to cancel
5. Alternatively, press `ctrl+x d` to discard without editing

## Testing

**`test/session/queue.test.ts`** (new file)

- `SessionPrompt.queued()` - returns empty array for non-existent session
- `SessionPrompt.getQueued()` - returns undefined for non-existent session/message
- `SessionPrompt.cancelQueued()` - returns undefined for non-existent session/message

**`test/config/config.test.ts`** (additions)

- `queue_edit` defaults to `<leader>i`
- `queue_discard` defaults to `<leader>d`
- Both keybinds can be customized via config

## Breaking Changes

None. This is an additive feature with new keybinds that don't conflict with existing ones.