### PR TITLE
docs: add opencode-notifier plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -33,6 +33,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                | 10x faster code editing with Morph Fast Apply API and lazy edit markers                        |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                  | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible         |
 | [opencode-notificator](https://github.com/panta/opencode-notificator)                             | Desktop notifications and sound alerts for OpenCode sessions                                   |
+| [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                 | Desktop notifications and sound alerts for permission, completion, and error events            |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                           | AI-powered automatic Zellij session naming based on OpenCode context                           |
 
 ---


### PR DESCRIPTION
Adds the [opencode-notifier](https://github.com/mohak34/opencode-notifier) plugin to the ecosystem page.
This plugin provides:
- Desktop notifications for permission requests, session completion, and errors
- Configurable sound alerts for each event type
- Cross-platform support (macOS, Linux, Windows)
- Per-event toggles for notifications and sounds

### Note
I noticed that `opencode-notificator` (line 35) returns a 404 - the repository appears to be unavailable.