### PR TITLE
feat(tui): add double-click to copy word

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -575,75 +575,44 @@ function App() {
     })
   })
 
-  // Double-click detection state
-  let lastClickTime = 0
-  let lastClickX = -1
-  let lastClickY = -1
-  const DOUBLE_CLICK_THRESHOLD = 400 // ms
-
-  // Check if a character is a word character (alphanumeric, underscore, or common code chars)
-  const isWordChar = (charCode: number): boolean => {
-    if (charCode === 0 || charCode === 32) return false // null or space
-    const char = String.fromCodePoint(charCode)
-    // Word characters: letters, digits, underscore, hyphen, and common programming chars
-    return /[\w\-]/.test(char)
-  }
-
-  // Find word boundaries at a given position in the render buffer
-  const findWordBoundaries = (x: number, y: number): { startX: number; endX: number } | null => {
-    const buffer = renderer.currentRenderBuffer
-    const width = buffer.width
-    const charBuffer = buffer.buffers.char
-
-    // Get the character at the click position
-    const index = y * width + x
-    if (index < 0 || index >= charBuffer.length) return null
-
-    const clickedChar = charBuffer[index]
-    if (!isWordChar(clickedChar)) return null
-
-    // Find start of word (scan left)
-    let startX = x
-    while (startX > 0) {
-      const prevIndex = y * width + (startX - 1)
-      if (!isWordChar(charBuffer[prevIndex])) break
-      startX--
-    }
-
-    // Find end of word (scan right)
-    let endX = x
-    while (endX < width - 1) {
-      const nextIndex = y * width + (endX + 1)
-      if (!isWordChar(charBuffer[nextIndex])) break
-      endX++
-    }
-
-    return { startX, endX }
-  }
+  // Double-click word selection
+  let click = { time: 0, x: -1, y: -1 }
 
   const handleMouseDown = (evt: MouseEvent) => {
     if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
 
     const now = Date.now()
-    const isDoubleClick = now - lastClickTime < DOUBLE_CLICK_THRESHOLD && evt.x === lastClickX && evt.y === lastClickY
+    const isDouble = now - click.time < 400 && evt.x === click.x && evt.y === click.y
 
-    if (isDoubleClick && evt.target) {
-      // Find word boundaries at click position
-      const boundaries = findWordBoundaries(evt.x, evt.y)
-      if (boundaries) {
-        // Create selection for the word using the same APIs as drag selection
-        renderer.startSelection(evt.target, boundaries.startX, evt.y)
-        renderer.updateSelection(evt.target, boundaries.endX + 1, evt.y)
-      }
-      // Reset to prevent triple-click being detected as another double-click
-      lastClickTime = 0
-      lastClickX = -1
-      lastClickY = -1
-    } else {
-      lastClickTime = now
-      lastClickX = evt.x
-      lastClickY = evt.y
+    click = { time: now, x: evt.x, y: evt.y }
+
+    if (!isDouble || !evt.target) return
+    click.time = 0 // Reset to prevent triple-click
+
+    // Find word boundaries from render buffer
+    const buffer = renderer.currentRenderBuffer
+    const width = buffer.width
+    const chars = buffer.buffers.char
+    const idx = evt.y * width + evt.x
+
+    if (idx < 0 || idx >= chars.length) return
+
+    const isWordChar = (i: number) => {
+      const c = chars[i]
+      if (c === 0 || c === 32) return false
+      return /[\w\-]/.test(String.fromCodePoint(c))
     }
+
+    if (!isWordChar(idx)) return
+
+    let start = evt.x
+    while (start > 0 && isWordChar(evt.y * width + start - 1)) start--
+
+    let end = evt.x
+    while (end < width - 1 && isWordChar(evt.y * width + end + 1)) end++
+
+    renderer.startSelection(evt.target, start, evt.y)
+    renderer.updateSelection(evt.target, end + 1, evt.y)
   }
 
   return (

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,6 +1,6 @@
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
-import { TextAttributes } from "@opentui/core"
+import { TextAttributes, type MouseEvent } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
 import { Installation } from "@/installation"
@@ -575,11 +575,83 @@ function App() {
     })
   })
 
+  // Double-click detection state
+  let lastClickTime = 0
+  let lastClickX = -1
+  let lastClickY = -1
+  const DOUBLE_CLICK_THRESHOLD = 400 // ms
+
+  // Check if a character is a word character (alphanumeric, underscore, or common code chars)
+  const isWordChar = (charCode: number): boolean => {
+    if (charCode === 0 || charCode === 32) return false // null or space
+    const char = String.fromCodePoint(charCode)
+    // Word characters: letters, digits, underscore, hyphen, and common programming chars
+    return /[\w\-]/.test(char)
+  }
+
+  // Find word boundaries at a given position in the render buffer
+  const findWordBoundaries = (x: number, y: number): { startX: number; endX: number } | null => {
+    const buffer = renderer.currentRenderBuffer
+    const width = buffer.width
+    const charBuffer = buffer.buffers.char
+
+    // Get the character at the click position
+    const index = y * width + x
+    if (index < 0 || index >= charBuffer.length) return null
+
+    const clickedChar = charBuffer[index]
+    if (!isWordChar(clickedChar)) return null
+
+    // Find start of word (scan left)
+    let startX = x
+    while (startX > 0) {
+      const prevIndex = y * width + (startX - 1)
+      if (!isWordChar(charBuffer[prevIndex])) break
+      startX--
+    }
+
+    // Find end of word (scan right)
+    let endX = x
+    while (endX < width - 1) {
+      const nextIndex = y * width + (endX + 1)
+      if (!isWordChar(charBuffer[nextIndex])) break
+      endX++
+    }
+
+    return { startX, endX }
+  }
+
+  const handleMouseDown = (evt: MouseEvent) => {
+    if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
+
+    const now = Date.now()
+    const isDoubleClick = now - lastClickTime < DOUBLE_CLICK_THRESHOLD && evt.x === lastClickX && evt.y === lastClickY
+
+    if (isDoubleClick && evt.target) {
+      // Find word boundaries at click position
+      const boundaries = findWordBoundaries(evt.x, evt.y)
+      if (boundaries) {
+        // Create selection for the word using the same APIs as drag selection
+        renderer.startSelection(evt.target, boundaries.startX, evt.y)
+        renderer.updateSelection(evt.target, boundaries.endX + 1, evt.y)
+      }
+      // Reset to prevent triple-click being detected as another double-click
+      lastClickTime = 0
+      lastClickX = -1
+      lastClickY = -1
+    } else {
+      lastClickTime = now
+      lastClickX = evt.x
+      lastClickY = evt.y
+    }
+  }
+
   return (
     <box
       width={dimensions().width}
       height={dimensions().height}
       backgroundColor={theme.background}
+      onMouseDown={handleMouseDown}
       onMouseUp={async () => {
         if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) {
           renderer.clearSelection()

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -593,7 +593,8 @@ function App() {
     const buffer = renderer.currentRenderBuffer
     const width = buffer.width
     const chars = buffer.buffers.char
-    const idx = evt.y * width + evt.x
+    const row = evt.y * width
+    const idx = row + evt.x
 
     if (idx < 0 || idx >= chars.length) return
 
@@ -606,10 +607,10 @@ function App() {
     if (!isWordChar(idx)) return
 
     let start = evt.x
-    while (start > 0 && isWordChar(evt.y * width + start - 1)) start--
+    while (start > 0 && isWordChar(row + start - 1)) start--
 
     let end = evt.x
-    while (end < width - 1 && isWordChar(evt.y * width + end + 1)) end++
+    while (end < width - 1 && isWordChar(row + end + 1)) end++
 
     renderer.startSelection(evt.target, start, evt.y)
     renderer.updateSelection(evt.target, end + 1, evt.y)


### PR DESCRIPTION
## Summary

Double-click on a word to copy it to clipboard, using the same selection mechanism as drag-to-copy.

## Changes

- Detect double-clicks by tracking click time/position (400ms threshold)
- Find word boundaries by scanning the render buffer for word characters
- Create selection using existing `startSelection`/`updateSelection` APIs
- Existing `onMouseUp` handler automatically copies to clipboard with toast notification

## Behavior

- Works anywhere drag-to-copy selection works
- Word characters: letters, digits, underscore, hyphen (unicode-aware)
- Respects `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT` flag



https://github.com/user-attachments/assets/945ce58d-ec9d-4135-b556-896fccfe01b8

