### PR TITLE
chore: activate code coverage in bun test config

### DIFF
--- a/packages/opencode/bunfig.toml
+++ b/packages/opencode/bunfig.toml
@@ -2,3 +2,5 @@ preload = ["@opentui/solid/preload"]
 
 [test]
 preload = ["./test/preload.ts"]
+# Enable code coverage
+coverage = true


### PR DESCRIPTION
Hi,
In order to be able to contribute some revelant tests: i.e. where current code coverage is low, I updated bunfig.toml to activate code coverage.

This is a sample of what I get on my machine when running the tests included in repo:
```
----------------------------------------------------------------------------------------------------------|---------|---------|-------------------
File                                                                                                      | % Funcs | % Lines | Uncovered Line #s
----------------------------------------------------------------------------------------------------------|---------|---------|-------------------
 All files                                                                                                |   45.38 |   52.40 |
 ...
 ...
 ...
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-prepare-tools.ts     |    0.00 |    3.57 | 13-174                                                  
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/tool/code-interpreter.ts              |    0.00 |   91.89 | 84-86                                                   
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/tool/file-search.ts                   |    0.00 |  100.00 |                                                         
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/tool/image-generation.ts              |    0.00 |   91.43 | 111-113
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/tool/local-shell.ts                   |  100.00 |  100.00 |                                                         
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/tool/web-search-preview.ts            |  100.00 |  100.00 | 
 packages/opencode/src/provider/sdk/openai-compatible/src/responses/tool/web-search.ts                    |    0.00 |   93.62 | 99-101
 ...
 ...
 ...
783 expect() calls
Ran 385 tests across 33 files. [33.23s]
```
Cheers,
Didier
