### PR TITLE
docs: clarify that MCP tools require glob patterns to disable

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -354,9 +354,9 @@ If you have a large number of MCP servers you may want to only enable them per a
 
 #### Glob patterns
 
-The glob pattern uses simple regex globbing patterns.
+MCP tools are registered with names that include the server name as a prefix (e.g., `my-mcp_tool-name`). To disable all tools from a server, you must use a glob pattern to match the full name.
 
-- `*` matches zero or more of any character
+- `*` matches zero or more of any character (e.g., `"my-mcp*"` matches `my-mcp_search`, `my-mcp_list`, etc.)
 - `?` matches exactly one character
 - All other characters match literally
 

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -354,11 +354,19 @@ If you have a large number of MCP servers you may want to only enable them per a
 
 #### Glob patterns
 
-MCP tools are registered with names that include the server name as a prefix (e.g., `my-mcp_tool-name`). To disable all tools from a server, you must use a glob pattern to match the full name.
+The glob pattern uses simple regex globbing patterns:
 
 - `*` matches zero or more of any character (e.g., `"my-mcp*"` matches `my-mcp_search`, `my-mcp_list`, etc.)
 - `?` matches exactly one character
 - All other characters match literally
+
+:::note
+MCP server tools are registered with server name as prefix, so to diable all tools for a server simply use:
+```
+"mymcpservername_*": false
+```
+:::
+
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a note explaining that MCP tools are registered with names like `server-name_tool-name`
- Clarifies why glob patterns (e.g., `"my-mcp*"`) are needed instead of exact server names

Related issues: #5373, #2953

Users setting `"my-mcp": false` in their tools config expect it to disable all tools from that MCP server, but it doesn't work because the actual tool names are prefixed (e.g., `my-mcp_search`). This note makes the naming convention explicit.