### PR TITLE
feat: add read_env permission to allow reading .env files

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -34,6 +34,7 @@ export namespace Agent {
         webfetch: Config.Permission.optional(),
         doom_loop: Config.Permission.optional(),
         external_directory: Config.Permission.optional(),
+        read_env: z.enum(["allow", "deny"]).optional(),
       }),
       model: z
         .object({
@@ -392,6 +393,7 @@ function mergeAgentPermissions(basePermission: any, overridePermission: any): Ag
     skill: mergedSkill ?? { "*": "allow" },
     doom_loop: merged.doom_loop,
     external_directory: merged.external_directory,
+    read_env: merged.read_env,
   }
 
   return result

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -426,6 +426,7 @@ export namespace Config {
           webfetch: Permission.optional(),
           doom_loop: Permission.optional(),
           external_directory: Permission.optional(),
+          read_env: z.enum(["allow", "deny"]).optional().describe("Allow reading .env files (default: deny)"),
         })
         .optional(),
     })
@@ -791,6 +792,7 @@ export namespace Config {
           webfetch: Permission.optional(),
           doom_loop: Permission.optional(),
           external_directory: Permission.optional(),
+          read_env: z.enum(["allow", "deny"]).optional().describe("Allow reading .env files (default: deny)"),
         })
         .optional(),
       tools: z.record(z.string(), z.boolean()).optional(),

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -59,7 +59,7 @@ export const ReadTool = Tool.define("read", {
       }
     }
 
-    const block = iife(() => {
+    const isEnvFile = iife(() => {
       const basename = path.basename(filepath)
       const whitelist = [".env.sample", ".env.example", ".example", ".env.template"]
 
@@ -70,7 +70,7 @@ export const ReadTool = Tool.define("read", {
       return false
     })
 
-    if (block) {
+    if (isEnvFile && agent.permission.read_env !== "allow") {
       throw new Error(`The user has blocked you from reading ${filepath}, DO NOT make further attempts to read it`)
     }
 

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -171,3 +171,91 @@ describe("tool.read env file blocking", () => {
     })
   })
 })
+
+describe("tool.read read_env permission", () => {
+  test("allows reading .env when read_env is allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".env"), "SECRET_KEY=value")
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              read_env: "allow",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, ".env") }, ctx)
+        expect(result.output).toContain("SECRET_KEY=value")
+      },
+    })
+  })
+
+  test("blocks reading .env when read_env is deny", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".env"), "SECRET_KEY=value")
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              read_env: "deny",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, ".env") }, ctx)).rejects.toThrow("blocked")
+      },
+    })
+  })
+
+  test("blocks reading .env by default (no permission set)", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".env"), "SECRET_KEY=value")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, ".env") }, ctx)).rejects.toThrow("blocked")
+      },
+    })
+  })
+
+  test("allows reading .env.local when read_env is allow", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, ".env.local"), "LOCAL_SECRET=value")
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            permission: {
+              read_env: "allow",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, ".env.local") }, ctx)
+        expect(result.output).toContain("LOCAL_SECRET=value")
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a new `read_env` permission option that allows users to explicitly opt-in to letting agents read `.env` files
- By default, `.env` files remain blocked (secure default)
- Only supports `"allow"` or `"deny"` (no `"ask"` option for simplicity)

## Usage

Add to `opencode.json`:

```json
{
  "permission": {
    "read_env": "allow"
  }
}
```

## Changes

- `packages/opencode/src/config/config.ts` - Added `read_env` to permission schema
- `packages/opencode/src/agent/agent.ts` - Added `read_env` to agent permission type and merge function
- `packages/opencode/src/tool/read.ts` - Modified blocking logic to check permission
- `packages/opencode/test/tool/read.test.ts` - Added tests for the new permission