### PR TITLE
feat: add custom server url setting

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -21,6 +21,7 @@ import Layout from "@/pages/layout"
 import Home from "@/pages/home"
 import DirectoryLayout from "@/pages/directory-layout"
 import Session from "@/pages/session"
+import ServerSettings from "@/pages/server-settings"
 import { ErrorPage } from "./pages/error"
 import { iife } from "@opencode-ai/util/iife"
 
@@ -32,7 +33,14 @@ declare global {
 
 const url = iife(() => {
   const param = new URLSearchParams(document.location.search).get("url")
-  if (param) return param
+
+  if (param) {
+    localStorage.setItem("opencode-server-url", param)
+    return param
+  }
+
+  const stored = localStorage.getItem("opencode-server-url")
+  if (stored) return stored
 
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (window.__OPENCODE__) return `http://127.0.0.1:${window.__OPENCODE__.port}`
@@ -64,6 +72,7 @@ export function App() {
                             )}
                           >
                             <Route path="/" component={Home} />
+                            <Route path="/server-settings" component={ServerSettings} />
                             <Route path="/:dir" component={DirectoryLayout}>
                               <Route path="/" component={() => <Navigate href="session" />} />
                               <Route

--- a/packages/app/src/pages/error.tsx
+++ b/packages/app/src/pages/error.tsx
@@ -118,6 +118,14 @@ interface ErrorPageProps {
 
 export const ErrorPage: Component<ErrorPageProps> = (props) => {
   const platform = usePlatform()
+  const errorMessage = formatError(props.error)
+  const isConnectionError = errorMessage.includes("Could not connect to server") || errorMessage.includes("connection")
+
+  function resetServerUrl() {
+    localStorage.removeItem("opencode-server-url")
+    platform.restart()
+  }
+
   return (
     <div class="relative flex-1 h-screen w-screen min-h-0 flex flex-col items-center justify-center bg-background-base font-sans">
       <div class="w-2/3 max-w-3xl flex flex-col items-center justify-center gap-8">
@@ -127,7 +135,7 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
           <p class="text-sm text-text-weak">An error occurred while loading the application.</p>
         </div>
         <TextField
-          value={formatError(props.error)}
+          value={errorMessage}
           readOnly
           copyable
           multiline
@@ -135,9 +143,24 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
           label="Error Details"
           hideLabel
         />
-        <Button size="large" onClick={platform.restart}>
-          Restart
-        </Button>
+        <div class="flex flex-col gap-2">
+          <Button size="large" onClick={platform.restart}>
+            Restart
+          </Button>
+          <Show when={isConnectionError}>
+            <div class="flex flex-col gap-2 w-full">
+              <Button size="large" onClick={resetServerUrl}>
+                Reset local server URL
+              </Button>
+              <div class="text-xs text-text-weak text-center flex flex-col gap-1">
+                <div>
+                  Or add <code class="bg-background-stronger px-1.5 py-0.5 rounded">?url=https://your-server.com</code>{" "}
+                  to address bar
+                </div>
+              </div>
+            </div>
+          </Show>
+        </div>
         <div class="flex flex-col items-center gap-2">
           <div class="flex items-center justify-center gap-1">
             Please report this error to the OpenCode team

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -959,6 +959,18 @@ export default function Layout(props: ParentProps) {
               </Button>
             </Tooltip>
           </Show>
+          <Tooltip placement="right" value="Server settings" inactive={expanded()}>
+            <Button
+              as={A}
+              href="/server-settings"
+              class="flex w-full text-left justify-start text-text-base stroke-[1.5px] rounded-lg px-2"
+              variant="ghost"
+              size="large"
+              icon="code"
+            >
+              <Show when={expanded()}>Server settings</Show>
+            </Button>
+          </Tooltip>
           <Tooltip placement="right" value="Share feedback" inactive={expanded()}>
             <Button
               as={"a"}

--- a/packages/app/src/pages/server-settings.tsx
+++ b/packages/app/src/pages/server-settings.tsx
@@ -1,0 +1,102 @@
+import { createSignal, For, Show } from "solid-js"
+import { Button } from "@opencode-ai/ui/button"
+import { showToast } from "@opencode-ai/ui/toast"
+
+const STORAGE_KEY = "opencode-server-url"
+const HISTORY_KEY = "opencode-server-url-history"
+const MAX_HISTORY = 5
+
+function loadHistory(): string[] {
+  try {
+    const stored = localStorage.getItem(HISTORY_KEY)
+    return stored ? JSON.parse(stored) : []
+  } catch {
+    return []
+  }
+}
+
+function saveHistory(url: string) {
+  const history = loadHistory().filter((u) => u !== url)
+  history.unshift(url)
+  if (history.length > MAX_HISTORY) history.pop()
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history))
+}
+
+export default function ServerSettings() {
+  const [inputUrl, setInputUrl] = createSignal("")
+  const [history, setHistory] = createSignal(loadHistory())
+  const currentUrl = () => localStorage.getItem(STORAGE_KEY) || ""
+
+  function setServerUrl(url: string) {
+    if (!url) return
+    localStorage.setItem(STORAGE_KEY, url)
+    saveHistory(url)
+    setHistory(loadHistory())
+    showToast({
+      title: "Server URL updated",
+      description: "Reloading to apply changes...",
+    })
+    setTimeout(() => window.location.reload(), 1000)
+  }
+
+  function clearUrl() {
+    localStorage.removeItem(STORAGE_KEY)
+    showToast({
+      title: "Server URL cleared",
+      description: "Reloading to apply changes...",
+    })
+    setTimeout(() => window.location.reload(), 1000)
+  }
+
+  return (
+    <div class="mx-auto mt-55 max-w-lg w-full">
+      <div class="text-14-medium text-text-strong mb-6">Server Settings</div>
+
+      <div class="bg-background-stronger rounded-lg p-4 mb-4">
+        <div class="text-12-regular text-text-weak mb-2">Current server URL</div>
+        <div class="flex items-center gap-2">
+          <div class="text-14-mono text-text-strong flex-1">{currentUrl() || "Not set"}</div>
+          <Show when={currentUrl()}>
+            <Button variant="ghost" icon="close" size="normal" onClick={clearUrl}>
+              Clear
+            </Button>
+          </Show>
+        </div>
+      </div>
+
+      <div class="bg-background-stronger rounded-lg p-4 mb-4">
+        <div class="text-12-regular text-text-weak mb-2">Set server URL</div>
+        <div class="flex gap-2 items-center">
+          <input
+            type="text"
+            placeholder="https://your-server.com"
+            value={inputUrl()}
+            onInput={(e) => setInputUrl(e.currentTarget.value)}
+            class="flex-1 bg-background-base border border-border-weak-base rounded-md px-3 py-2 text-14-regular text-text-strong focus:outline-none focus:border-border-strong-base"
+          />
+          <Button onClick={() => setServerUrl(inputUrl())}>Set</Button>
+        </div>
+      </div>
+
+      <Show when={history().length > 0}>
+        <div class="bg-background-stronger rounded-lg p-4">
+          <div class="text-12-regular text-text-weak mb-3">Recent URLs</div>
+          <div class="flex flex-col gap-2">
+            <For each={history()}>
+              {(url) => (
+                <Button
+                  variant="ghost"
+                  size="large"
+                  class="text-left justify-start text-14-mono"
+                  onClick={() => setServerUrl(url)}
+                >
+                  {url}
+                </Button>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </div>
+  )
+}


### PR DESCRIPTION
- Introduced a new route for server settings in the app.
- Added Setting of server url into local storage through UI and `url` query
- Updated error page to include a reset server URL button for connection errors.
- Improved error message handling and user guidance for server URL configuration.

Ideal for #6311 


https://github.com/user-attachments/assets/e2336fd9-f9ec-4fff-b6d1-27e704c4de78

