### PR TITLE
Separate context window and session stats in sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -62,7 +62,7 @@ export function Sidebar(props: { sessionID: string }) {
   const sessionTokens = createMemo(() => {
     const total = messages().reduce((sum, x) => {
       if (x.role !== "assistant") return sum
-      return sum + x.tokens.input + x.tokens.output + x.tokens.reasoning + x.tokens.cache.read + x.tokens.cache.write
+      return sum + x.tokens.input + x.tokens.output
     }, 0)
     return total.toLocaleString()
   })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -7,7 +7,6 @@ import path from "path"
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Global } from "@/global"
 import { Installation } from "@/installation"
-import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
@@ -60,6 +59,14 @@ export function Sidebar(props: { sessionID: string }) {
     }
   })
 
+  const sessionTokens = createMemo(() => {
+    const total = messages().reduce((sum, x) => {
+      if (x.role !== "assistant") return sum
+      return sum + x.tokens.input + x.tokens.output + x.tokens.reasoning + x.tokens.cache.read + x.tokens.cache.write
+    }, 0)
+    return total.toLocaleString()
+  })
+
   const directory = useDirectory()
   const kv = useKV()
 
@@ -94,6 +101,12 @@ export function Sidebar(props: { sessionID: string }) {
               </text>
               <text fg={theme.textMuted}>{context()?.tokens ?? 0} tokens</text>
               <text fg={theme.textMuted}>{context()?.percentage ?? 0}% used</text>
+            </box>
+            <box>
+              <text fg={theme.text}>
+                <b>Session</b>
+              </text>
+              <text fg={theme.textMuted}>{sessionTokens()} total tokens</text>
               <text fg={theme.textMuted}>{cost()} spent</text>
             </box>
             <Show when={mcpEntries().length > 0}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -61,6 +61,15 @@ export function Sidebar(props: { sessionID: string }) {
     }
   })
 
+  const sessionTokens = createMemo(() => {
+    const total = messages().reduce((sum, msg) => {
+      if (msg.role !== "assistant") return sum
+      const assistant = msg as AssistantMessage
+      return sum + assistant.tokens.input + assistant.tokens.output
+    }, 0)
+    return total.toLocaleString()
+  })
+
   const directory = useDirectory()
   const kv = useKV()
 
@@ -102,6 +111,7 @@ export function Sidebar(props: { sessionID: string }) {
               <text fg={theme.text}>
                 <b>Session</b>
               </text>
+              <text fg={theme.textMuted}>{sessionTokens()} total tokens</text>
               <text fg={theme.textMuted}>{cost()} spent</text>
             </box>
             <Show when={mcpEntries().length > 0}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -61,25 +61,6 @@ export function Sidebar(props: { sessionID: string }) {
     }
   })
 
-  const sessionTokens = createMemo(() => {
-    const msgs = messages()
-    let total = 0
-    let peakBeforeCompaction = 0
-    for (const msg of msgs) {
-      if (msg.role !== "assistant") continue
-      const assistant = msg as AssistantMessage
-      const tokens = assistant.tokens.input + assistant.tokens.output
-      if (assistant.summary) {
-        total += peakBeforeCompaction
-        peakBeforeCompaction = tokens
-      } else {
-        peakBeforeCompaction = tokens
-      }
-    }
-    total += peakBeforeCompaction
-    return total.toLocaleString()
-  })
-
   const directory = useDirectory()
   const kv = useKV()
 
@@ -121,7 +102,6 @@ export function Sidebar(props: { sessionID: string }) {
               <text fg={theme.text}>
                 <b>Session</b>
               </text>
-              <text fg={theme.textMuted}>{sessionTokens()} total tokens</text>
               <text fg={theme.textMuted}>{cost()} spent</text>
             </box>
             <Show when={mcpEntries().length > 0}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -50,8 +50,7 @@ export function Sidebar(props: { sessionID: string }) {
   const context = createMemo(() => {
     const last = messages().findLast((x) => x.role === "assistant" && x.tokens.output > 0) as AssistantMessage
     if (!last) return
-    const total =
-      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    const total = last.tokens.input + last.tokens.output
     const model = sync.data.provider.find((x) => x.id === last.providerID)?.models[last.modelID]
     const limit = model?.limit.context ?? 0
     return {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -53,17 +53,30 @@ export function Sidebar(props: { sessionID: string }) {
     const total =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     const model = sync.data.provider.find((x) => x.id === last.providerID)?.models[last.modelID]
+    const limit = model?.limit.context ?? 0
     return {
       tokens: total.toLocaleString(),
-      percentage: model?.limit.context ? Math.round((total / model.limit.context) * 100) : null,
+      percentage: limit ? Math.round((total / limit) * 100) : null,
+      limit: limit ? (limit >= 1000000 ? `${(limit / 1000000).toFixed(1)}M` : `${Math.round(limit / 1000)}k`) : null,
     }
   })
 
   const sessionTokens = createMemo(() => {
-    const total = messages().reduce((sum, x) => {
-      if (x.role !== "assistant") return sum
-      return sum + x.tokens.input + x.tokens.output
-    }, 0)
+    const msgs = messages()
+    let total = 0
+    let peakBeforeCompaction = 0
+    for (const msg of msgs) {
+      if (msg.role !== "assistant") continue
+      const assistant = msg as AssistantMessage
+      const tokens = assistant.tokens.input + assistant.tokens.output
+      if (assistant.summary) {
+        total += peakBeforeCompaction
+        peakBeforeCompaction = tokens
+      } else {
+        peakBeforeCompaction = tokens
+      }
+    }
+    total += peakBeforeCompaction
     return total.toLocaleString()
   })
 
@@ -100,7 +113,9 @@ export function Sidebar(props: { sessionID: string }) {
                 <b>Context</b>
               </text>
               <text fg={theme.textMuted}>{context()?.tokens ?? 0} tokens</text>
-              <text fg={theme.textMuted}>{context()?.percentage ?? 0}% used</text>
+              <text fg={theme.textMuted}>
+                {context()?.percentage ?? 0}% used{context()?.limit ? ` of ${context()!.limit}` : ""}
+              </text>
             </box>
             <box>
               <text fg={theme.text}>


### PR DESCRIPTION
## Issue

On some `/compact` instances the session costs would be reset and the token count isn't ongoing which is nice for visuals.

## Summary
- Split the sidebar Context section into two: **Context** (current window) and **Session** (cumulative)
- Context shows tokens and % used from the last assistant message (resets on compaction)
- Session shows total tokens across all messages and cumulative spend (only increases)
- Improves visibility into both current context usage and overall session costs

<img width="329" height="510" alt="image" src="https://github.com/user-attachments/assets/55a8bb7a-0df1-4d0b-bd52-392b40966595" />

## Changes
- Added `sessionTokens` memo that sums tokens from all assistant messages
- Moved spend to Session section alongside total tokens
- Kept Context section focused on current LLM context window