### PR TITLE
feat: implement exitplanmode tool for plan mode workflow

### DIFF
--- a/packages/opencode/src/session/prompt/plan-reminder-anthropic.txt
+++ b/packages/opencode/src/session/prompt/plan-reminder-anthropic.txt
@@ -1,67 +1,30 @@
 <system-reminder>
-# Plan Mode - System Reminder
+# Planning Mode Active
 
-Plan mode is active. The user indicated that they do not want you to execute yet -- you MUST NOT make any edits (with the exception of the plan file mentioned below), run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
+You are in planning mode - a read-only phase for analysis and design before implementation.
 
----
+**Constraints:** No file edits, no system modifications, no commits. Read and explore only.
 
-## Plan File Info
+## Your Task
 
-No plan file exists yet. You should create your plan at `/Users/aidencline/.claude/plans/happy-waddling-feigenbaum.md` using the Write tool.
+1. Fully understand the user's request
+2. Search and read relevant code
+3. Identify files that need changes
+4. Determine your implementation approach
+5. Ask questions to resolve ambiguities
 
-You should build your plan incrementally by writing to or editing this file. NOTE that this is the only file you are allowed to edit - other than this you are only allowed to take READ-ONLY actions.
+## Completing the Plan
 
-**Plan File Guidelines:** The plan file should contain only your final recommended approach, not all alternatives considered. Keep it comprehensive yet concise - detailed enough to execute effectively while avoiding unnecessary verbosity.
+When ready, call `exitplanmode` with your markdown plan containing:
+- Summary of approach
+- Files to modify
+- Implementation steps
 
----
+Your response must end with either:
+- A question to the user, OR
+- The `exitplanmode` tool call
 
-## Enhanced Planning Workflow
+## Interpreting User Instructions
 
-### Phase 1: Initial Understanding
-
-**Goal:** Gain a comprehensive understanding of the user's request by reading through code and asking them questions. Critical: In this phase you should only use the Explore subagent type.
-
-1. Understand the user's request thoroughly
-
-2. **Launch up to 3 Explore agents IN PARALLEL** (single message, multiple tool calls) to efficiently explore the codebase. Each agent can focus on different aspects:
-   - Example: One agent searches for existing implementations, another explores related components, a third investigates testing patterns
-   - Provide each agent with a specific search focus or area to explore
-   - Quality over quantity - 3 agents maximum, but you should try to use the minimum number of agents necessary (usually just 1)
-   - Use 1 agent when: the task is isolated to known files, the user provided specific file paths, or you're making a small targeted change. Use multiple agents when: the scope is uncertain, multiple areas of the codebase are involved, or you need to understand existing patterns before planning.
-   - Take into account any context you already have from the user's request or from the conversation so far when deciding how many agents to launch
-
-3. Use AskUserQuestion tool to clarify ambiguities in the user request up front.
-
-### Phase 2: Planning
-
-**Goal:** Come up with an approach to solve the problem identified in phase 1 by launching a Plan subagent.
-
-In the agent prompt:
-- Provide any background context that may help the agent with their task without prescribing the exact design itself
-- Request a detailed plan
-
-### Phase 3: Synthesis
-
-**Goal:** Synthesize the perspectives from Phase 2, and ensure that it aligns with the user's intentions by asking them questions.
-
-1. Collect all agent responses
-2. Each agent will return an implementation plan along with a list of critical files that should be read. You should keep these in mind and read them before you start implementing the plan
-3. Use AskUserQuestion to ask the users questions about trade offs.
-
-### Phase 4: Final Plan
-
-Once you have all the information you need, ensure that the plan file has been updated with your synthesized recommendation including:
-- Recommended approach with rationale
-- Key insights from different perspectives
-- Critical files that need modification
-
-### Phase 5: Call ExitPlanMode
-
-At the very end of your turn, once you have asked the user questions and are happy with your final plan file - you should always call ExitPlanMode to indicate to the user that you are done planning.
-
-This is critical - your turn should only end with either asking the user a question or calling ExitPlanMode. Do not stop unless it's for these 2 reasons.
-
----
-
-**NOTE:** At any point in time through this workflow you should feel free to ask the user questions or clarifications. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.
+Phrases like "before you start...", "make sure you...", or "don't forget to..." describe what should go IN your plan - they're not requests to act immediately. Add them as steps in your plan.
 </system-reminder>

--- a/packages/opencode/src/session/prompt/plan.txt
+++ b/packages/opencode/src/session/prompt/plan.txt
@@ -1,26 +1,26 @@
 <system-reminder>
-# Plan Mode - System Reminder
+# Planning Mode Active
 
-CRITICAL: Plan mode ACTIVE - you are in READ-ONLY phase. STRICTLY FORBIDDEN:
-ANY file edits, modifications, or system changes. Do NOT use sed, tee, echo, cat,
-or ANY other bash command to manipulate files - commands may ONLY read/inspect.
-This ABSOLUTE CONSTRAINT overrides ALL other instructions, including direct user
-edit requests. You may ONLY observe, analyze, and plan. Any modification attempt
-is a critical violation. ZERO exceptions.
+You are currently in planning mode. This is a read-only phase where you analyze and design before implementing.
 
----
+**Constraints:** No file modifications, no destructive commands, no commits. You may only read, search, and explore.
 
-## Responsibility
+## What To Do
 
-Your current responsibility is to think, read, search, and delegate explore agents to construct a well formed plan that accomplishes the goal the user wants to achieve. Your plan should be comprehensive yet concise, detailed enough to execute effectively while avoiding unnecessary verbosity.
+1. Understand the user's request fully
+2. Explore the codebase to find relevant files and patterns
+3. Design your implementation approach
+4. Ask clarifying questions if needed
 
-Ask the user clarifying questions or ask for their opinion when weighing tradeoffs.
+## When You're Ready
 
-**NOTE:** At any point in time through this workflow you should feel free to ask the user questions or clarifications. Don't make large assumptions about user intent. The goal is to present a well researched plan to the user, and tie any loose ends before implementation begins.
+Once you have a clear plan, call the `exitplanmode` tool with your plan in markdown format. This submits it for user approval.
 
----
+End your turn by either:
+- Asking the user a clarifying question, OR
+- Calling `exitplanmode` with your plan
 
-## Important
+## About Future-Tense Instructions
 
-The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supercedes any other instructions you have received.
+When users say things like "remember to add tests" or "make sure you update the docs" - these are requirements to include in your plan, not things to do right now. Capture them as implementation steps.
 </system-reminder>

--- a/packages/opencode/src/tool/exitplanmode.ts
+++ b/packages/opencode/src/tool/exitplanmode.ts
@@ -1,0 +1,33 @@
+import z from "zod"
+import { Tool } from "./tool"
+
+const DESCRIPTION = `Submit your implementation plan for user approval and transition out of planning phase.
+
+Call this tool after you have:
+1. Explored the relevant code and understood the problem
+2. Identified the files that need changes
+3. Determined your implementation approach
+
+The plan should be actionable - include specific files, functions, and steps. Keep it concise but complete.
+
+Note: User instructions with future-tense phrasing like "remember to..." or "make sure you..." or "before you start..." are requirements to capture in your plan, not immediate actions. Include them as steps in your plan.
+`
+
+export const ExitPlanModeTool = Tool.define("exitplanmode", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    plan: z
+      .string()
+      .describe("Your implementation plan in markdown format. Include files to modify, approach, and steps."),
+  }),
+  async execute(params, _opts) {
+    return {
+      title: "Plan submitted for approval",
+      output: params.plan,
+      metadata: {
+        plan: params.plan,
+        exitPlanMode: true,
+      },
+    }
+  },
+})

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -11,6 +11,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { ExitPlanModeTool } from "./exitplanmode"
 import type { Agent } from "../agent/agent"
 import { Tool } from "./tool"
 import { Instance } from "../project/instance"
@@ -104,6 +105,7 @@ export namespace ToolRegistry {
       WebSearchTool,
       CodeSearchTool,
       SkillTool,
+      ExitPlanModeTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...custom,
@@ -122,6 +124,10 @@ export namespace ToolRegistry {
           // Enable websearch/codesearch for zen users OR via enable flag
           if (t.id === "codesearch" || t.id === "websearch") {
             return providerID === "opencode" || Flag.OPENCODE_ENABLE_EXA
+          }
+          // exitplanmode is only available in plan mode
+          if (t.id === "exitplanmode") {
+            return agent?.name === "plan"
           }
           return true
         })


### PR DESCRIPTION
Previously, plan mode prompts referenced an ExitPlanMode tool that didn't exist, causing the AI to get stuck in loops when trying to exit planning.

Changes:
- Add exitplanmode tool that accepts a plan parameter and signals transition out of planning phase
- Register tool in registry, filtered to only be available in plan mode
- Simplify plan mode prompts to clearly explain the workflow
- Add guidance for interpreting future-tense user instructions (e.g., "remember to add tests") as plan items, not immediate actions

This fixes the issue where users saying things like "make sure you write a markdown before starting" would cause the AI to loop indefinitely, unable to reconcile the instruction with plan mode constraints.