### PR TITLE
fix(tui): make auth URLs clickable regardless of line wrapping

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -5,6 +5,7 @@ import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 import { useSDK } from "../context/sdk"
 import { DialogPrompt } from "../ui/dialog-prompt"
+import { Link } from "../ui/link"
 import { useTheme } from "../context/theme"
 import { TextAttributes } from "@opentui/core"
 import type { ProviderAuthAuthorization } from "@opencode-ai/sdk/v2"
@@ -128,7 +129,7 @@ function AutoMethod(props: AutoMethodProps) {
         <text fg={theme.textMuted}>esc</text>
       </box>
       <box gap={1}>
-        <text fg={theme.primary}>{props.authorization.url}</text>
+        <Link href={props.authorization.url} fg={theme.primary} />
         <text fg={theme.textMuted}>{props.authorization.instructions}</text>
       </box>
       <text fg={theme.textMuted}>Waiting for authorization...</text>
@@ -170,7 +171,7 @@ function CodeMethod(props: CodeMethodProps) {
       description={() => (
         <box gap={1}>
           <text fg={theme.textMuted}>{props.authorization.instructions}</text>
-          <text fg={theme.primary}>{props.authorization.url}</text>
+          <Link href={props.authorization.url} fg={theme.primary} />
           <Show when={error()}>
             <text fg={theme.error}>Invalid code</text>
           </Show>

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -1,0 +1,28 @@
+import type { JSX } from "solid-js"
+import type { RGBA } from "@opentui/core"
+import open from "open"
+
+export interface LinkProps {
+  href: string
+  children?: JSX.Element | string
+  fg?: RGBA
+}
+
+/**
+ * Link component that renders clickable hyperlinks.
+ * Clicking anywhere on the link text opens the URL in the default browser.
+ */
+export function Link(props: LinkProps) {
+  const displayText = props.children ?? props.href
+
+  return (
+    <text
+      fg={props.fg}
+      onMouseUp={() => {
+        open(props.href).catch(() => {})
+      }}
+    >
+      {displayText}
+    </text>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -18,6 +18,7 @@ export function Link(props: LinkProps) {
   return (
     <text
       fg={props.fg}
+      underline={true}
       onMouseUp={() => {
         open(props.href).catch(() => {})
       }}


### PR DESCRIPTION
## Summary
- Add new `Link` component that opens URLs in browser when clicked
- Fix OAuth authorization URLs that wrap across multiple lines being only partially clickable
- Works in all terminal emulators (not dependent on OSC 8 support)

## Problem
When connecting to a provider (e.g., Anthropic Claude Pro/Max), the OAuth URL displayed in the dialog often wraps across multiple lines. Previously, only the first line was clickable, making it impossible to open the full URL.

## Solution
Created a `Link` component that uses `onMouseUp` handler with the `open` package to open the URL in the default browser when any part of the link text is clicked.

## Test plan
- [x] Run `bun run dev` and use `/connect` → anthropic → Claude Pro/Max
- [x] Verify clicking anywhere on the wrapped URL opens the complete URL in browser
- [x] TypeScript compiles without errors
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)