### PR TITLE
feat(theme): custom themes can use calculated `system` colors

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -37,7 +37,7 @@ import vesper from "./theme/vesper.json" with { type: "json" }
 import zenburn from "./theme/zenburn.json" with { type: "json" }
 import { useKV } from "./kv"
 import { useRenderer } from "@opentui/solid"
-import { createStore, produce } from "solid-js/store"
+import { createStore } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 
@@ -298,46 +298,32 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       if (theme) setStore("active", theme)
     })
 
-    loadCustomThemes()
-      .then((custom) => {
-        setStore(
-          produce((draft) => {
-            Object.assign(draft.themes, custom)
-          }),
-        )
-      })
-      .catch(() => {
-        if (!(store.active === SPECIAL_THEMES.SYSTEM || store.active in DEFAULT_THEMES)) {
-          setStore("active", SPECIAL_THEMES.FALLBACK)
-        }
-      })
-      .finally(() => {
-        if (store.active !== SPECIAL_THEMES.SYSTEM) {
-          setStore("ready", true)
-        }
-      })
+    const getCustom = loadCustomThemes().then((themes) => {
+      setStore("themes", themes)
+    })
 
-    detectSystemColors()
-      .then((colors) => {
-        setStore(
-          produce((draft) => {
-            draft.themes[SPECIAL_THEMES.SYSTEM] = generateSystemTheme(colors)
-            if (store.active === SPECIAL_THEMES.SYSTEM) {
-              draft.ready = true
-            }
-          }),
-        )
-      })
-      .catch(() => {
-        if (store.active === SPECIAL_THEMES.SYSTEM) {
-          setStore(
-            produce((draft) => {
-              draft.active = SPECIAL_THEMES.FALLBACK
-              draft.ready = true
-            }),
-          )
-        }
-      })
+    const getSystem = detectSystemColors().then((colors) => {
+      const theme = generateSystemTheme(colors)
+      setStore("themes", { [SPECIAL_THEMES.SYSTEM]: theme })
+    })
+
+    let getTheme
+    if (store.active in DEFAULT_THEMES) {
+      /**
+       * To safeguard against a broken experience, we need at least _some_
+       * default themes to not rely on system color detection. Here we're baking
+       * the assumption that _all_ default themes have this property.
+       */
+      getTheme = Promise.resolve()
+    } else if (store.active === SPECIAL_THEMES.SYSTEM) {
+      getTheme = getSystem
+    } else {
+      getTheme = getCustom
+    }
+
+    getTheme
+      .catch(() => setStore("active", SPECIAL_THEMES.FALLBACK))
+      .finally(() => setStore("ready", true))
 
     const values = createMemo(() => {
       return resolveTheme(store.themes[store.active] ?? store.themes[SPECIAL_THEMES.FALLBACK], store.mode)

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,6 +1,6 @@
 import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo } from "solid-js"
+import { createEffect, createMemo, createResource, untrack } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
 import aura from "./theme/aura.json" with { type: "json" }
@@ -40,6 +40,9 @@ import { useRenderer } from "@opentui/solid"
 import { createStore } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
+import { useToast } from "../ui/toast"
+import { iife } from "@/util/iife"
+import { loadSessionResponseSchema } from "@agentclientprotocol/sdk"
 
 type ThemeColors = {
   primary: RGBA
@@ -188,10 +191,11 @@ function resolveTheme(theme: ThemeJson, systemTheme: SystemThemeJson | undefined
       case "transparent":
       case "none":
         return RGBA.fromInts(0, 0, 0, 0)
-      case "system":
+      case "system": {
         const newValue = systemTheme?.theme[systemKey]
         if (newValue === undefined) return RGBA.fromInts(0, 0, 0, 0)
         return resolveColor(newValue, systemKey)
+      }
     }
 
     if (value.startsWith("#")) return RGBA.fromHex(value)
@@ -286,60 +290,127 @@ function ansiToRgba(code: number): RGBA {
   return RGBA.fromInts(0, 0, 0)
 }
 
-const FALLBACK_THEME = "opencode"
-const SYSTEM_THEME = "system"
+const FALLBACK_KEY = "opencode"
+const SYSTEM_KEY = "system"
+
+type LoadResult = "pending" | "succeeded" | "errored"
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (props: { mode: "dark" | "light" }) => {
+    const toast = useToast()
     const sync = useSync()
     const kv = useKV()
+
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
       mode: kv.get("theme_mode", props.mode),
-      active: (sync.data.config.theme ?? kv.get("theme", FALLBACK_THEME)) as string,
-      ready: false,
+      active: undefined as string | undefined,
     })
 
-    createEffect(() => {
-      const theme = sync.data.config.theme
-      console.log("theme", theme)
-      if (theme) setStore("active", theme)
-    })
+    const [customLoad] = createResource(() =>
+      loadCustomThemes()
+        .then((themes) => {
+          setStore("themes", themes)
+        })
+    )
 
-    const getCustom = loadCustomThemes().then((themes) => {
-      setStore("themes", themes)
-      return themes
-    })
+    const [systemLoad] = createResource(() =>
+      detectSystemColors()
+        .then((colors) => {
+          const theme = generateSystemTheme(colors)
+          setStore("themes", { [SYSTEM_KEY]: theme })
+        })
+    )
 
-    const getSystem = detectSystemColors().then((colors) => {
-      const theme = generateSystemTheme(colors)
-      setStore("themes", { [SYSTEM_THEME]: theme })
-    })
+    const loadResult = (key: string): LoadResult => {
+      if (key in DEFAULT_THEMES) {
+        return "succeeded"
+      }
 
-    let getTheme
-    if (store.active in DEFAULT_THEMES) {
-      /**
-       * To safeguard against a broken experience, we need at least _some_
-       * default themes to not rely on system color detection. Here we're baking
-       * the assumption that _all_ default themes have this property.
-       */
-      getTheme = Promise.resolve()
-    } else if (store.active === SYSTEM_THEME) {
-      getTheme = getSystem
-    } else {
-      getTheme = getCustom.then((themes) => {
-        const theme = themes[store.active]
-        if (!theme) throw new Error("Missing custom theme")
-        if (referencesSystemTheme(theme)) return getSystem
+      const systemLoadResult = iife(() => {
+        switch (systemLoad.state) {
+          case "ready":
+            return "succeeded"
+          case "errored":
+            return "errored"
+          default:
+            return "pending"
+        }
       })
+
+      if (key === SYSTEM_KEY) {
+        return systemLoadResult
+      }
+
+      switch (customLoad.state) {
+        case "ready": {
+          const theme = store.themes[key]
+          if (!theme) return "errored"
+          if (referencesSystemTheme(theme))
+            return systemLoadResult
+
+          return "succeeded"
+        }
+        case "errored":
+          return "errored"
+        default:
+          return "pending"
+      }
     }
 
-    getTheme.catch(() => setStore("active", FALLBACK_THEME)).finally(() => setStore("ready", true))
+    const toastWarning =
+      (key: string) => toast.show({
+        message: `Theme ${key} is not available`,
+        variant: "warning", duration: 3000,
+      })
+
+    const updateTheme =
+      (key: string): boolean => {
+        switch (loadResult(key)) {
+          case "succeeded":
+            setStore("active", key)
+            return true
+          case "pending":
+          case "errored":
+            toastWarning(key)
+            return false
+        }
+      }
+
+    const initializeTheme =
+      (key: string): boolean => {
+        switch (loadResult(key)) {
+          case "succeeded":
+            setStore("active", key)
+            return true
+          case "pending":
+            return false
+          case "errored":
+            setStore("active", FALLBACK_KEY)
+            toastWarning(key)
+            return true
+        }
+      }
+
+    createEffect((initialized: boolean) => {
+      const key = sync.data.config.theme
+
+      if (initialized) {
+        if (key) updateTheme(key)
+      } else {
+        initialized = initializeTheme(key || untrack(() =>
+          kv.get("theme") as string | undefined)
+          || FALLBACK_KEY
+        )
+      }
+
+      return initialized
+    }, false)
 
     const values = createMemo(() => {
-      const theme = store.themes[store.active] ?? store.themes[FALLBACK_THEME]
-      const systemTheme = store.themes[SYSTEM_THEME] as SystemThemeJson
+      const theme = store.themes[store.active ?? FALLBACK_KEY] ?? store.themes[FALLBACK_KEY]
+      const systemTheme = store.themes[SYSTEM_KEY] as SystemThemeJson
       return resolveTheme(theme, systemTheme, store.mode)
     })
 
@@ -368,12 +439,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         setStore("mode", mode)
         kv.set("theme_mode", mode)
       },
-      set(theme: string) {
-        setStore("active", theme)
-        kv.set("theme", theme)
+      set(theme?: string) {
+        if (!theme) return
+        const success = updateTheme(theme)
+        if (success) kv.set("theme", theme)
       },
       get ready() {
-        return store.ready
+        return store.active !== undefined
       },
     }
   },

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -286,10 +286,8 @@ function ansiToRgba(code: number): RGBA {
   return RGBA.fromInts(0, 0, 0)
 }
 
-const SPECIAL_THEMES = {
-  FALLBACK: "opencode",
-  SYSTEM: "system",
-} as const
+const FALLBACK_THEME = "opencode"
+const SYSTEM_THEME = "system"
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
@@ -299,7 +297,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
       mode: kv.get("theme_mode", props.mode),
-      active: (sync.data.config.theme ?? kv.get("theme", SPECIAL_THEMES.FALLBACK)) as string,
+      active: (sync.data.config.theme ?? kv.get("theme", FALLBACK_THEME)) as string,
       ready: false,
     })
 
@@ -316,7 +314,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     const getSystem = detectSystemColors().then((colors) => {
       const theme = generateSystemTheme(colors)
-      setStore("themes", { [SPECIAL_THEMES.SYSTEM]: theme })
+      setStore("themes", { [SYSTEM_THEME]: theme })
     })
 
     let getTheme
@@ -327,7 +325,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
        * the assumption that _all_ default themes have this property.
        */
       getTheme = Promise.resolve()
-    } else if (store.active === SPECIAL_THEMES.SYSTEM) {
+    } else if (store.active === SYSTEM_THEME) {
       getTheme = getSystem
     } else {
       getTheme = getCustom.then((themes) => {
@@ -337,11 +335,11 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       })
     }
 
-    getTheme.catch(() => setStore("active", SPECIAL_THEMES.FALLBACK)).finally(() => setStore("ready", true))
+    getTheme.catch(() => setStore("active", FALLBACK_THEME)).finally(() => setStore("ready", true))
 
     const values = createMemo(() => {
-      const theme = store.themes[store.active] ?? store.themes[SPECIAL_THEMES.FALLBACK]
-      const systemTheme = store.themes[SPECIAL_THEMES.SYSTEM] as SystemThemeJson
+      const theme = store.themes[store.active] ?? store.themes[FALLBACK_THEME]
+      const systemTheme = store.themes[SYSTEM_THEME] as SystemThemeJson
       return resolveTheme(theme, systemTheme, store.mode)
     })
 
@@ -448,7 +446,7 @@ function generateSystemTheme(colors: TerminalColors): SystemThemeJson {
   const graysDark = generateGrayScale(bg, true)
   const grays: Record<number, RGBAVariant> = {}
 
-  Object.keys(graysDark).forEach(index => {
+  Object.keys(graysDark).forEach((index) => {
     const i = Number(index)
     grays[i] = {
       dark: graysDark[i],

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -293,7 +293,7 @@ function ansiToRgba(code: number): RGBA {
 const FALLBACK_KEY = "opencode"
 const SYSTEM_KEY = "system"
 
-type LoadResult = "pending" | "succeeded" | "errored"
+type LoadingStatus = "pending" | "succeeded" | "errored"
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
@@ -323,12 +323,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         })
     )
 
-    const loadResult = (key: string): LoadResult => {
+    const loadingStatus = (key: string): LoadingStatus => {
       if (key in DEFAULT_THEMES) {
         return "succeeded"
       }
 
-      const systemLoadResult = iife(() => {
+      const systemLoadingStatus = iife(() => {
         switch (systemLoad.state) {
           case "ready":
             return "succeeded"
@@ -340,7 +340,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       })
 
       if (key === SYSTEM_KEY) {
-        return systemLoadResult
+        return systemLoadingStatus
       }
 
       switch (customLoad.state) {
@@ -348,7 +348,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
           const theme = store.themes[key]
           if (!theme) return "errored"
           if (referencesSystemTheme(theme))
-            return systemLoadResult
+            return systemLoadingStatus
 
           return "succeeded"
         }
@@ -359,50 +359,42 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       }
     }
 
-    const toastWarning =
-      (key: string) => toast.show({
-        message: `Theme ${key} is not available`,
-        variant: "warning", duration: 3000,
-      })
+    const setTheme = (
+      key: string,
+      { fallback }: { fallback: boolean }
+    ): boolean => {
+      switch (loadingStatus(key)) {
+        case "succeeded":
+          setStore("active", key)
+          return true
+        case "pending":
+          return false
+        case "errored":
+          toast.show({
+            message: `Theme ${key} could not resolve correctly`,
+            variant: "warning", duration: 3000,
+          })
 
-    const updateTheme =
-      (key: string): boolean => {
-        switch (loadResult(key)) {
-          case "succeeded":
-            setStore("active", key)
-            return true
-          case "pending":
-          case "errored":
-            toastWarning(key)
-            return false
-        }
-      }
-
-    const initializeTheme =
-      (key: string): boolean => {
-        switch (loadResult(key)) {
-          case "succeeded":
-            setStore("active", key)
-            return true
-          case "pending":
-            return false
-          case "errored":
+          if (fallback) {
             setStore("active", FALLBACK_KEY)
-            toastWarning(key)
             return true
-        }
+          }
+
+          return false
       }
+    }
 
     createEffect((initialized: boolean) => {
-      const key = sync.data.config.theme
+      let key = sync.data.config.theme
+      if (!initialized) {
+        key ||= untrack(() => kv.get("theme") as string | undefined)
+        key ||= FALLBACK_KEY
+      }
 
-      if (initialized) {
-        if (key) updateTheme(key)
-      } else {
-        initialized = initializeTheme(key || untrack(() =>
-          kv.get("theme") as string | undefined)
-          || FALLBACK_KEY
-        )
+      if (key) {
+        initialized ||= setTheme(key, {
+          fallback: !initialized
+        })
       }
 
       return initialized
@@ -441,8 +433,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       },
       set(theme?: string) {
         if (!theme) return
-        const success = updateTheme(theme)
-        if (success) kv.set("theme", theme)
+
+        const success = setTheme(theme, {
+          fallback: false
+        })
+
+        if (success)
+          kv.set("theme", theme)
       },
       get ready() {
         return store.active !== undefined

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -40,7 +40,6 @@ import { useRenderer } from "@opentui/solid"
 import { createStore, produce } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
-import { useSDK } from "./sdk"
 
 type ThemeColors = {
   primary: RGBA
@@ -311,42 +310,32 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         })
     })
 
-    function resolveSystemTheme() {
-      console.log("resolved system theme")
-      renderer
-        .getPalette({
-          size: 16,
-        })
-        .then((colors) => {
-          if (!colors.palette[0]) {
-            if (store.active === "system") {
-              setStore(
-                produce((draft) => {
-                  draft.active = "opencode"
-                  draft.ready = true
-                }),
-              )
-            }
-            return
-          }
-          setStore(
-            produce((draft) => {
-              draft.themes.system = generateSystem(colors, store.mode)
-              if (store.active === "system") {
-                draft.ready = true
-              }
-            }),
-          )
-        })
-    }
-
     const renderer = useRenderer()
-    resolveSystemTheme()
-
-    const sdk = useSDK()
-    sdk.event.on("server.instance.disposed", () => {
-      resolveSystemTheme()
-    })
+    renderer
+      .getPalette({
+        size: 16,
+      })
+      .then((colors) => {
+        if (!colors.palette[0]) {
+          if (store.active === "system") {
+            setStore(
+              produce((draft) => {
+                draft.active = "opencode"
+                draft.ready = true
+              }),
+            )
+          }
+          return
+        }
+        setStore(
+          produce((draft) => {
+            draft.themes.system = generateSystem(colors, store.mode)
+            if (store.active === "system") {
+              draft.ready = true
+            }
+          }),
+        )
+      })
 
     const values = createMemo(() => {
       return resolveTheme(store.themes[store.active] ?? store.themes.opencode, store.mode)

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -199,7 +199,9 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
     Object.entries(theme.theme)
       .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
       .map(([key, value]) => {
-        return [key, resolveColor(value as ColorValue)]
+        // TODO: Resolve "system" to use `generateSystem`'s output for this key.
+        const v = value === "system" ? "none" : value
+        return [key, resolveColor(v as ColorValue)]
       }),
   ) as Partial<ThemeColors>
 

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -302,6 +302,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     const getCustom = loadCustomThemes().then((themes) => {
       setStore("themes", themes)
+      return themes
     })
 
     const getSystem = detectSystemColors().then((colors) => {
@@ -320,12 +321,14 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     } else if (store.active === SPECIAL_THEMES.SYSTEM) {
       getTheme = getSystem
     } else {
-      getTheme = getCustom
+      getTheme = getCustom.then((themes) => {
+        const theme = themes[store.active]
+        if (!theme) throw new Error("Missing custom theme")
+        if (referencesSystemTheme(theme)) return getSystem
+      })
     }
 
-    getTheme
-      .catch(() => setStore("active", SPECIAL_THEMES.FALLBACK))
-      .finally(() => setStore("ready", true))
+    getTheme.catch(() => setStore("active", SPECIAL_THEMES.FALLBACK)).finally(() => setStore("ready", true))
 
     const values = createMemo(() => {
       return resolveTheme(store.themes[store.active] ?? store.themes[SPECIAL_THEMES.FALLBACK], store.mode)
@@ -372,6 +375,17 @@ async function detectSystemColors() {
   if (colors.palette[0]) return colors
 
   throw new Error("System color detection failed")
+}
+
+function referencesSystemTheme(value: unknown) {
+  switch (typeof value) {
+    case "object":
+      return Object.values(value || {}).some(referencesSystemTheme)
+    case "string":
+      return value === "system"
+    default:
+      return false
+  }
 }
 
 const CUSTOM_THEME_GLOB = new Bun.Glob("themes/*.json")

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,6 +1,6 @@
 import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo, onMount } from "solid-js"
+import { createEffect, createMemo } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
 import aura from "./theme/aura.json" with { type: "json" }
@@ -291,24 +291,22 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       if (theme) setStore("active", theme)
     })
 
-    createEffect(() => {
-      getCustomThemes()
-        .then((custom) => {
-          setStore(
-            produce((draft) => {
-              Object.assign(draft.themes, custom)
-            }),
-          )
-        })
-        .catch(() => {
-          setStore("active", "opencode")
-        })
-        .finally(() => {
-          if (store.active !== "system") {
-            setStore("ready", true)
-          }
-        })
-    })
+    getCustomThemes()
+      .then((custom) => {
+        setStore(
+          produce((draft) => {
+            Object.assign(draft.themes, custom)
+          }),
+        )
+      })
+      .catch(() => {
+        setStore("active", "opencode")
+      })
+      .finally(() => {
+        if (store.active !== "system") {
+          setStore("ready", true)
+        }
+      })
 
     const renderer = useRenderer()
     renderer

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -122,20 +122,24 @@ type HexColor = `#${string}`
 type RefName = string
 type AnsiCode = number
 type PrimitiveColor = HexColor | RefName | AnsiCode | RGBA
-type Variant = {
-  dark: PrimitiveColor
-  light: PrimitiveColor
-}
+type Variant = { dark: PrimitiveColor; light: PrimitiveColor }
 type ColorValue = PrimitiveColor | Variant
-type ThemeJson = {
+
+type BaseThemeJson<V> = {
   $schema?: string
   defs?: Record<string, HexColor | RefName>
-  theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
-    selectedListItemText?: ColorValue
-    backgroundMenu?: ColorValue
+  theme: Omit<Record<keyof ThemeColors, V>, "selectedListItemText" | "backgroundMenu"> & {
+    selectedListItemText?: V
+    backgroundMenu?: V
     thinkingOpacity?: number
   }
 }
+
+type ThemeJson = BaseThemeJson<ColorValue>
+
+type RGBAVariant = { dark: RGBA; light: RGBA }
+type RGBAValue = RGBA | RGBAVariant
+type SystemThemeJson = BaseThemeJson<RGBAValue>
 
 export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   aura,
@@ -172,43 +176,48 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   zenburn,
 }
 
-function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
+function resolveTheme(theme: ThemeJson, systemTheme: SystemThemeJson | undefined, mode: "dark" | "light") {
   const defs = theme.defs ?? {}
-  function resolveColor(c: ColorValue): RGBA {
-    if (c instanceof RGBA) return c
-    if (typeof c === "string") {
-      if (c === "transparent" || c === "none") return RGBA.fromInts(0, 0, 0, 0)
 
-      if (c.startsWith("#")) return RGBA.fromHex(c)
+  function resolveColor(value: ColorValue, systemKey: keyof ThemeColors): RGBA {
+    if (value instanceof RGBA) return value
+    if (typeof value === "number") return ansiToRgba(value)
+    if (typeof value !== "string") return resolveColor(value[mode], systemKey)
 
-      if (defs[c] != null) {
-        return resolveColor(defs[c])
-      } else if (theme.theme[c as keyof ThemeColors] !== undefined) {
-        return resolveColor(theme.theme[c as keyof ThemeColors]!)
-      } else {
-        throw new Error(`Color reference "${c}" not found in defs or theme`)
-      }
+    switch (value) {
+      case "transparent":
+      case "none":
+        return RGBA.fromInts(0, 0, 0, 0)
+      case "system":
+        const newValue = systemTheme?.theme[systemKey]
+        if (newValue === undefined) return RGBA.fromInts(0, 0, 0, 0)
+        return resolveColor(newValue, systemKey)
     }
-    if (typeof c === "number") {
-      return ansiToRgba(c)
-    }
-    return resolveColor(c[mode])
+
+    if (value.startsWith("#")) return RGBA.fromHex(value)
+    if (defs[value] !== undefined) return resolveColor(defs[value], systemKey)
+
+    const newKey = value as keyof ThemeColors
+    const newValue = theme.theme[newKey]
+    if (newValue !== undefined)
+      // Cross-referencing must update `systemKey`.
+      return resolveColor(newValue, newKey)
+
+    throw new Error(`Color reference "${value}" not found in defs or theme`)
   }
 
   const resolved = Object.fromEntries(
     Object.entries(theme.theme)
       .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
       .map(([key, value]) => {
-        // TODO: Resolve "system" to use `generateSystem`'s output for this key.
-        const v = value === "system" ? "none" : value
-        return [key, resolveColor(v as ColorValue)]
+        return [key, resolveColor(value as ColorValue, key as keyof ThemeColors)]
       }),
   ) as Partial<ThemeColors>
 
   // Handle selectedListItemText separately since it's optional
   const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
   if (hasSelectedListItemText) {
-    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!)
+    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!, "selectedListItemText")
   } else {
     // Backward compatibility: if selectedListItemText is not defined, use background color
     // This preserves the current behavior for all existing themes
@@ -217,7 +226,7 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
 
   // Handle backgroundMenu - optional with fallback to backgroundElement
   if (theme.theme.backgroundMenu !== undefined) {
-    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
+    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu, "backgroundMenu")
   } else {
     resolved.backgroundMenu = resolved.backgroundElement
   }
@@ -331,7 +340,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     getTheme.catch(() => setStore("active", SPECIAL_THEMES.FALLBACK)).finally(() => setStore("ready", true))
 
     const values = createMemo(() => {
-      return resolveTheme(store.themes[store.active] ?? store.themes[SPECIAL_THEMES.FALLBACK], store.mode)
+      const theme = store.themes[store.active] ?? store.themes[SPECIAL_THEMES.FALLBACK]
+      const systemTheme = store.themes[SPECIAL_THEMES.SYSTEM] as SystemThemeJson
+      return resolveTheme(theme, systemTheme, store.mode)
     })
 
     const syntax = createMemo(() => generateSyntax(values()))
@@ -415,7 +426,7 @@ async function loadCustomThemes() {
   return result
 }
 
-function generateSystemTheme(colors: TerminalColors): ThemeJson {
+function generateSystemTheme(colors: TerminalColors): SystemThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
 
@@ -435,18 +446,15 @@ function generateSystemTheme(colors: TerminalColors): ThemeJson {
   // Generate gray scale based on terminal background
   const graysLight = generateGrayScale(bg, false)
   const graysDark = generateGrayScale(bg, true)
-  const grays = Object.keys(graysDark).reduce(
-    (acc, index) => {
-      const i = Number(index)
-      acc[i] = {
-        dark: graysDark[i],
-        light: graysLight[i],
-      }
+  const grays: Record<number, RGBAVariant> = {}
 
-      return acc
-    },
-    {} as Record<number, Variant>,
-  )
+  Object.keys(graysDark).forEach(index => {
+    const i = Number(index)
+    grays[i] = {
+      dark: graysDark[i],
+      light: graysLight[i],
+    }
+  })
 
   const textMuted = {
     dark: generateMutedTextColor(bg, true),

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -120,11 +120,13 @@ export function selectedForeground(theme: Theme): RGBA {
 
 type HexColor = `#${string}`
 type RefName = string
+type AnsiCode = number
+type PrimitiveColor = HexColor | RefName | AnsiCode | RGBA
 type Variant = {
-  dark: HexColor | RefName
-  light: HexColor | RefName
+  dark: PrimitiveColor
+  light: PrimitiveColor
 }
-type ColorValue = HexColor | RefName | Variant | RGBA
+type ColorValue = PrimitiveColor | Variant
 type ThemeJson = {
   $schema?: string
   defs?: Record<string, HexColor | RefName>
@@ -327,7 +329,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         }
         setStore(
           produce((draft) => {
-            draft.themes.system = generateSystem(colors, store.mode)
+            draft.themes.system = generateSystem(colors)
             if (store.active === "system") {
               draft.ready = true
             }
@@ -402,10 +404,9 @@ async function getCustomThemes() {
   return result
 }
 
-function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
+function generateSystem(colors: TerminalColors): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
-  const isDark = mode == "dark"
 
   const col = (i: number) => {
     const value = colors.palette[i]
@@ -421,8 +422,25 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
   }
 
   // Generate gray scale based on terminal background
-  const grays = generateGrayScale(bg, isDark)
-  const textMuted = generateMutedTextColor(bg, isDark)
+  const graysLight = generateGrayScale(bg, false)
+  const graysDark = generateGrayScale(bg, true)
+  const grays = Object.keys(graysDark).reduce(
+    (acc, index) => {
+      const i = Number(index)
+      acc[i] = {
+        dark: graysDark[i],
+        light: graysLight[i],
+      }
+
+      return acc
+    },
+    {} as Record<number, Variant>,
+  )
+
+  const textMuted = {
+    dark: generateMutedTextColor(bg, true),
+    light: generateMutedTextColor(bg, false),
+  }
 
   // ANSI color references
   const ansiColors = {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,6 +1,6 @@
 import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo, createResource, untrack } from "solid-js"
+import { createEffect, createMemo, createResource, on, untrack } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
 import aura from "./theme/aura.json" with { type: "json" }
@@ -42,7 +42,6 @@ import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { useToast } from "../ui/toast"
 import { iife } from "@/util/iife"
-import { loadSessionResponseSchema } from "@agentclientprotocol/sdk"
 
 type ThemeColors = {
   primary: RGBA
@@ -290,18 +289,16 @@ function ansiToRgba(code: number): RGBA {
   return RGBA.fromInts(0, 0, 0)
 }
 
-const FALLBACK_KEY = "opencode"
-const SYSTEM_KEY = "system"
+const FALLBACK_THEME_KEY = "opencode"
+const SYSTEM_THEME_KEY = "system"
 
 type LoadingStatus = "pending" | "succeeded" | "errored"
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (props: { mode: "dark" | "light" }) => {
-    const toast = useToast()
     const sync = useSync()
     const kv = useKV()
-
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
       mode: kv.get("theme_mode", props.mode),
@@ -319,7 +316,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       detectSystemColors()
         .then((colors) => {
           const theme = generateSystemTheme(colors)
-          setStore("themes", { [SYSTEM_KEY]: theme })
+          setStore("themes", { [SYSTEM_THEME_KEY]: theme })
         })
     )
 
@@ -339,7 +336,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         }
       })
 
-      if (key === SYSTEM_KEY) {
+      if (key === SYSTEM_THEME_KEY) {
         return systemLoadingStatus
       }
 
@@ -359,50 +356,73 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       }
     }
 
-    const setTheme = (
-      key: string,
-      { fallback }: { fallback: boolean }
-    ): boolean => {
+    const toast = useToast()
+    const toastWarning = (key: string) => toast.show({
+      message: `Theme ${key} could not resolve correctly`,
+      variant: "warning", duration: 3000,
+    })
+
+    const initialized = () => {
+      return store.active !== undefined
+    }
+
+    const initialize = (key: string) => {
       switch (loadingStatus(key)) {
+        case "pending":
+          return
         case "succeeded":
           setStore("active", key)
-          return true
-        case "pending":
-          return false
+          return
         case "errored":
-          toast.show({
-            message: `Theme ${key} could not resolve correctly`,
-            variant: "warning", duration: 3000,
-          })
-
-          if (fallback) {
-            setStore("active", FALLBACK_KEY)
-            return true
-          }
-
-          return false
+          setStore("active", FALLBACK_THEME_KEY)
+          toastWarning(key)
+          return
       }
     }
 
-    createEffect((initialized: boolean) => {
-      let key = sync.data.config.theme
-      if (!initialized) {
-        key ||= untrack(() => kv.get("theme") as string | undefined)
-        key ||= FALLBACK_KEY
+    createEffect(() => {
+      if (initialized()) return
+
+      const key = sync.data.config.theme
+        || untrack(() => kv.get("theme") as string | undefined)
+        || FALLBACK_THEME_KEY
+
+      initialize(key)
+    })
+
+    const update = (key: string) => {
+      const succeeded =
+        loadingStatus(key) === "succeeded"
+
+      if (succeeded) {
+        setStore("active", key)
+      } else {
+        toastWarning(key)
       }
 
-      if (key) {
-        initialized ||= setTheme(key, {
-          fallback: !initialized
-        })
-      }
+      return succeeded
+    }
 
-      return initialized
-    }, false)
+    createEffect(on(
+      () => sync.data.config.theme,
+      (key) => {
+        if (!initialized()) return
+        if (!key) return
+
+        update(key)
+      },
+    ))
+
+    createEffect(() => {
+      if (!initialized()) return
+      if (loadingStatus(store.active!) !== "errored") return
+
+      toastWarning(store.active!)
+    })
 
     const values = createMemo(() => {
-      const theme = store.themes[store.active ?? FALLBACK_KEY] ?? store.themes[FALLBACK_KEY]
-      const systemTheme = store.themes[SYSTEM_KEY] as SystemThemeJson
+      const theme = store.themes[store.active ?? FALLBACK_THEME_KEY] ?? store.themes[FALLBACK_THEME_KEY]
+      const systemTheme = store.themes[SYSTEM_THEME_KEY] as SystemThemeJson
       return resolveTheme(theme, systemTheme, store.mode)
     })
 
@@ -431,18 +451,13 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         setStore("mode", mode)
         kv.set("theme_mode", mode)
       },
-      set(theme?: string) {
-        if (!theme) return
-
-        const success = setTheme(theme, {
-          fallback: false
-        })
-
-        if (success)
-          kv.set("theme", theme)
+      set(themeKey?: string) {
+        if (!themeKey) return
+        if (!update(themeKey)) return
+        kv.set("theme", themeKey)
       },
       get ready() {
-        return store.active !== undefined
+        return initialized()
       },
     }
   },

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -42,6 +42,7 @@ import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { useToast } from "../ui/toast"
 import { iife } from "@/util/iife"
+import { useSDK } from "./sdk"
 
 type ThemeColors = {
   primary: RGBA
@@ -305,14 +306,14 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       active: undefined as string | undefined,
     })
 
-    const [customLoad] = createResource(() =>
+    const [customLoad, { refetch: reloadCustom }] = createResource(() =>
       loadCustomThemes()
         .then((themes) => {
           setStore("themes", themes)
         })
     )
 
-    const [systemLoad] = createResource(() =>
+    const [systemLoad, { refetch: reloadSystem }] = createResource(() =>
       detectSystemColors()
         .then((colors) => {
           const theme = generateSystemTheme(colors)
@@ -418,6 +419,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       if (loadingStatus(store.active!) !== "errored") return
 
       toastWarning(store.active!)
+    })
+
+    const sdk = useSDK()
+    sdk.event.on("server.instance.disposed", () => {
+      reloadCustom()
+      reloadSystem()
     })
 
     const values = createMemo(() => {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -302,7 +302,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         )
       })
       .catch(() => {
-        setStore("active", "opencode")
+        if (!(store.active === "system" || store.active in DEFAULT_THEMES)) {
+          setStore("active", "opencode")
+        }
       })
       .finally(() => {
         if (store.active !== "system") {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -275,6 +275,11 @@ function ansiToRgba(code: number): RGBA {
   return RGBA.fromInts(0, 0, 0)
 }
 
+const SPECIAL_THEMES = {
+  FALLBACK: "opencode",
+  SYSTEM: "system",
+} as const
+
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
   init: (props: { mode: "dark" | "light" }) => {
@@ -283,7 +288,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
       mode: kv.get("theme_mode", props.mode),
-      active: (sync.data.config.theme ?? kv.get("theme", "opencode")) as string,
+      active: (sync.data.config.theme ?? kv.get("theme", SPECIAL_THEMES.FALLBACK)) as string,
       ready: false,
     })
 
@@ -302,12 +307,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         )
       })
       .catch(() => {
-        if (!(store.active === "system" || store.active in DEFAULT_THEMES)) {
-          setStore("active", "opencode")
+        if (!(store.active === SPECIAL_THEMES.SYSTEM || store.active in DEFAULT_THEMES)) {
+          setStore("active", SPECIAL_THEMES.FALLBACK)
         }
       })
       .finally(() => {
-        if (store.active !== "system") {
+        if (store.active !== SPECIAL_THEMES.SYSTEM) {
           setStore("ready", true)
         }
       })
@@ -319,10 +324,10 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       })
       .then((colors) => {
         if (!colors.palette[0]) {
-          if (store.active === "system") {
+          if (store.active === SPECIAL_THEMES.SYSTEM) {
             setStore(
               produce((draft) => {
-                draft.active = "opencode"
+                draft.active = SPECIAL_THEMES.FALLBACK
                 draft.ready = true
               }),
             )
@@ -331,8 +336,8 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         }
         setStore(
           produce((draft) => {
-            draft.themes.system = generateSystem(colors)
-            if (store.active === "system") {
+            draft.themes[SPECIAL_THEMES.SYSTEM] = generateSystem(colors)
+            if (store.active === SPECIAL_THEMES.SYSTEM) {
               draft.ready = true
             }
           }),
@@ -340,7 +345,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       })
 
     const values = createMemo(() => {
-      return resolveTheme(store.themes[store.active] ?? store.themes.opencode, store.mode)
+      return resolveTheme(store.themes[store.active] ?? store.themes[SPECIAL_THEMES.FALLBACK], store.mode)
     })
 
     const syntax = createMemo(() => generateSyntax(values()))

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -564,11 +564,30 @@ function generateSystemTheme(colors: TerminalColors): SystemThemeJson {
     greenBright: col(10),
   }
 
-  const diffAlpha = isDark ? 0.22 : 0.14
-  const diffAddedBg = tint(bg, ansiColors.green, diffAlpha)
-  const diffRemovedBg = tint(bg, ansiColors.red, diffAlpha)
-  const diffAddedLineNumberBg = tint(grays[3], ansiColors.green, diffAlpha)
-  const diffRemovedLineNumberBg = tint(grays[3], ansiColors.red, diffAlpha)
+  const diffAlpha = {
+    dark: 0.22,
+    light: 0.14,
+  }
+
+  const diffAddedBg = {
+    dark: tint(bg, ansiColors.green, diffAlpha.dark),
+    light: tint(bg, ansiColors.green, diffAlpha.light),
+  }
+
+  const diffRemovedBg = {
+    dark: tint(bg, ansiColors.red, diffAlpha.dark),
+    light: tint(bg, ansiColors.red, diffAlpha.light),
+  }
+
+  const diffAddedLineNumberBg = {
+    dark: tint(grays[3].dark, ansiColors.green, diffAlpha.dark),
+    light: tint(grays[3].light, ansiColors.green, diffAlpha.light),
+  }
+
+  const diffRemovedLineNumberBg = {
+    dark: tint(grays[3].dark, ansiColors.red, diffAlpha.dark),
+    light: tint(grays[3].light, ansiColors.red, diffAlpha.light),
+  }
 
   return {
     theme: {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -298,7 +298,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       if (theme) setStore("active", theme)
     })
 
-    getCustomThemes()
+    loadCustomThemes()
       .then((custom) => {
         setStore(
           produce((draft) => {
@@ -317,31 +317,26 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         }
       })
 
-    const renderer = useRenderer()
-    renderer
-      .getPalette({
-        size: 16,
-      })
+    detectSystemColors()
       .then((colors) => {
-        if (!colors.palette[0]) {
-          if (store.active === SPECIAL_THEMES.SYSTEM) {
-            setStore(
-              produce((draft) => {
-                draft.active = SPECIAL_THEMES.FALLBACK
-                draft.ready = true
-              }),
-            )
-          }
-          return
-        }
         setStore(
           produce((draft) => {
-            draft.themes[SPECIAL_THEMES.SYSTEM] = generateSystem(colors)
+            draft.themes[SPECIAL_THEMES.SYSTEM] = generateSystemTheme(colors)
             if (store.active === SPECIAL_THEMES.SYSTEM) {
               draft.ready = true
             }
           }),
         )
+      })
+      .catch(() => {
+        if (store.active === SPECIAL_THEMES.SYSTEM) {
+          setStore(
+            produce((draft) => {
+              draft.active = SPECIAL_THEMES.FALLBACK
+              draft.ready = true
+            }),
+          )
+        }
       })
 
     const values = createMemo(() => {
@@ -384,8 +379,15 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   },
 })
 
+async function detectSystemColors() {
+  const colors = await useRenderer().getPalette({ size: 16 })
+  if (colors.palette[0]) return colors
+
+  throw new Error("System color detection failed")
+}
+
 const CUSTOM_THEME_GLOB = new Bun.Glob("themes/*.json")
-async function getCustomThemes() {
+async function loadCustomThemes() {
   const directories = [
     Global.Path.config,
     ...(await Array.fromAsync(
@@ -411,7 +413,7 @@ async function getCustomThemes() {
   return result
 }
 
-function generateSystem(colors: TerminalColors): ThemeJson {
+function generateSystemTheme(colors: TerminalColors): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
 

--- a/packages/web/public/theme.json
+++ b/packages/web/public/theme.json
@@ -25,8 +25,8 @@
             },
             {
               "type": "string",
-              "enum": ["none"],
-              "description": "No color (uses terminal default)"
+              "enum": ["none", "system"],
+              "description": "No color (uses terminal default or system-calculated color)"
             }
           ]
         }
@@ -111,8 +111,8 @@
         },
         {
           "type": "string",
-          "enum": ["none"],
-          "description": "No color (uses terminal default)"
+          "enum": ["none", "system"],
+          "description": "No color (uses terminal default) or system-calculated color"
         },
         {
           "type": "string",
@@ -137,8 +137,8 @@
                 },
                 {
                   "type": "string",
-                  "enum": ["none"],
-                  "description": "No color (uses terminal default)"
+                  "enum": ["none", "system"],
+                  "description": "No color (uses terminal default or system-calculated color)"
                 },
                 {
                   "type": "string",
@@ -162,8 +162,8 @@
                 },
                 {
                   "type": "string",
-                  "enum": ["none"],
-                  "description": "No color (uses terminal default)"
+                  "enum": ["none", "system"],
+                  "description": "No color (uses terminal default or system-calculated color)"
                 },
                 {
                   "type": "string",


### PR DESCRIPTION
[GH Issue](https://github.com/sst/opencode/issues/6322)

This makes it possible for custom themes to configure specific theme colors to use the calculated `system` values, e.g.:
```json
{ "theme": { "accent": "system", "background": "#000000" } }
```

### Example
In this example, [pop-dark.json](https://github.com/user-attachments/files/24362414/pop-dark.json), I have a custom theme which sets specific syntax colors, but falls back to `"system"` for everything else. This "extreme" example shows syntax highlighting I took from Helix's "Pop Dark" theme, and everything else OpenCode is deriving given that Ghostty's theme is set to "HaX0R Blue".

<img width="954" height="219" alt="Screenshot 2025-12-28 at 5 57 00 PM" src="https://github.com/user-attachments/assets/1aea31de-1efb-425b-990f-af8339b215c9" />

### Description
OpenCode themes address UI concepts that don't necessarily exist in themes for other tools like Helix, e.g.:
- `backgroundElement`
- `backgroundMenu`
- `backgroundPanel`
- `border`
- `borderActive`
- `borderSubtle`

In my case, I wanted to make a custom theme that matches what I have in Helix. I also already have terminal ANSI colors that match my Helix theme. Rather than go through the manual work to choose colors for _every_ slot OpenCode offers, this change lets you customize _some_ colors, while falling back to the values of the calculated `system` theme for the rest.

### Commits
This PR has a series of preliminary refactor and fix commits that set up the implementation of the feature. The preliminary refactor half of this change might be desirable to merge on its own terms, even if the feature request is rejected.

#### Preliminary fixes
Admittedly the two fixes are not directly about the feature, but maybe they're welcome to be brought in with the rest of the changes to this file:
- `fix(theme): system light & dark`
  - `system` theme now reacts to `Toggle appearance`
- `fix(theme): custom theme load error fallback`
  - Stops custom theme loading error handling from switching away from themes that don't depend on custom themes

#### Feature implementation
The rest of the non-refactor commits implement the feature:
- `feat(theme): add "system" color value to theme schema`
- `feat(theme): init considers system-like custom themes`
- `feat(theme): resolveTheme resolves "system"`
