### PR TITLE
feat(tui): add disable_mouse option for Linux right-click paste support

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -96,13 +96,26 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   })
 }
 
-export function tui(input: { url: string; args: Args; onExit?: () => Promise<void> }) {
+export function tui(input: { url: string; args: Args; onExit?: () => Promise<void>; disableMouse?: boolean }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
     const mode = await getTerminalBackgroundColor()
     const onExit = async () => {
       await input.onExit?.()
       resolve()
+    }
+
+    // Disable mouse tracking if requested (for terminals with PuTTY-style right-click paste)
+    if (input.disableMouse) {
+      // Disable mouse tracking after render initializes
+      // These escape sequences disable various mouse tracking modes:
+      // ?1000l - Disable button press/release tracking
+      // ?1002l - Disable button motion tracking  
+      // ?1003l - Disable all motion tracking
+      // ?1006l - Disable SGR extended mouse mode
+      process.nextTick(() => {
+        process.stdout.write("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
+      })
     }
 
     render(
@@ -194,9 +207,19 @@ function App() {
     renderer.clearSelection()
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
+  const [mouseDisabled, setMouseDisabled] = createSignal(false)
 
   createEffect(() => {
     console.log(JSON.stringify(route.data))
+  })
+
+  createEffect(() => {
+    if (mouseDisabled()) return
+    const tui = sync.data.config.tui
+    if (tui?.disable_mouse) {
+      process.stdout.write("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l")
+      setMouseDisabled(true)
+    }
   })
 
   // Update terminal window title based on current route and session

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -19,12 +19,17 @@ export const AttachCommand = cmd({
         alias: ["s"],
         type: "string",
         describe: "session id to continue",
+      })
+      .option("disable-mouse", {
+        type: "boolean",
+        describe: "disable mouse capture to allow terminal's native right-click paste",
       }),
   handler: async (args) => {
     if (args.dir) process.chdir(args.dir)
     await tui({
       url: args.url,
       args: { sessionID: args.session },
+      disableMouse: args["disable-mouse"],
     })
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -43,6 +43,10 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      .option("disable-mouse", {
+        type: "boolean",
+        describe: "disable mouse capture to allow terminal's native right-click paste",
       }),
   handler: async (args) => {
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
@@ -94,6 +98,7 @@ export const TuiThreadCommand = cmd({
         model: args.model,
         prompt,
       },
+      disableMouse: args["disable-mouse"],
       onExit: async () => {
         await client.call("shutdown", undefined)
       },

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -593,6 +593,10 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    disable_mouse: z
+      .boolean()
+      .optional()
+      .describe("Disable mouse capture to allow terminal's native right-click paste (useful for Linux terminals with PuTTY-style paste)"),
   })
 
   export const Server = z


### PR DESCRIPTION
## Summary

Adds a `--disable-mouse` CLI flag and `tui.disable_mouse` config option to allow users to disable mouse tracking, enabling native terminal right-click paste functionality on Linux terminals that use PuTTY-style paste (e.g., Terminator).

Fixes #4754

## Changes

- Added `disable_mouse: boolean` to TUI config schema (`config.ts`)
- Added `--disable-mouse` CLI flag to both `thread.ts` and `attach.ts` commands
- Implemented mouse tracking disable logic in `app.tsx` using ANSI escape sequences

## Usage

**CLI flag:**
```bash
opencode --disable-mouse
```

**Config file (opencode.json):**
```json
{
  "tui": {
    "disable_mouse": true
  }
}
```

## Technical Details

When enabled, sends ANSI escape sequences to disable all mouse tracking modes:
- `\x1b[?1000l` - Disable button press/release tracking
- `\x1b[?1002l` - Disable button motion tracking
- `\x1b[?1003l` - Disable all motion tracking
- `\x1b[?1006l` - Disable SGR extended mouse mode

This allows the terminal's native right-click paste behavior to work instead of being intercepted by opentui.