### PR TITLE
docs: add opencode-skillful plugin to ecosystem page

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -35,6 +35,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notificator](https://github.com/panta/opencode-notificator)                             | Desktop notifications and sound alerts for OpenCode sessions                                   |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                 | Desktop notifications and sound alerts for permission, completion, and error events            |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                           | AI-powered automatic Zellij session naming based on OpenCode context                           |
+| [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                               | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection        |
 
 ---
 


### PR DESCRIPTION
Add `opencode-skillful`, a plugin that enables lazy loading of prompts on demand through skill discovery and injection.