### PR TITLE
fix(webfetch): make format parameter optional with markdown default

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -15,7 +15,8 @@ export const WebFetchTool = Tool.define("webfetch", {
     url: z.string().describe("The URL to fetch content from"),
     format: z
       .enum(["text", "markdown", "html"])
-      .describe("The format to return the content in (text, markdown, or html)"),
+      .default("markdown")
+      .describe("The format to return the content in (text, markdown, or html). Defaults to markdown."),
     timeout: z.number().describe("Optional timeout in seconds (max 120)").optional(),
   }),
   async execute(params, ctx) {

--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -1,13 +1,13 @@
 - Fetches content from a specified URL
-- Takes a URL and a prompt as input
-- Fetches the URL content, converts HTML to markdown
-- Returns the model's response about the content
+- Takes a URL and optional format as input
+- Fetches the URL content, converts to requested format (markdown by default)
+- Returns the content in the specified format
 - Use this tool when you need to retrieve and analyze web content
 
 Usage notes:
   - IMPORTANT: if another tool is present that offers better web fetching capabilities, is more targeted to the task, or has fewer restrictions, prefer using that tool instead of this one.
   - The URL must be a fully-formed valid URL
   - HTTP URLs will be automatically upgraded to HTTPS
-  - The prompt should describe what information you want to extract from the page
+  - Format options: "markdown" (default), "text", or "html"
   - This tool is read-only and does not modify any files
   - Results may be summarized if the content is very large


### PR DESCRIPTION
## Summary

Fixes the webfetch tool failing when called without a `format` parameter.

**Problem:**
- The `format` parameter was required in the zod schema but not documented
- Calling `webfetch` without `format` produced validation error:
  ```
  Invalid option: expected one of "text"|"markdown"|"html"
  ```

**Solution:**
- Add `.default("markdown")` to the format parameter
- Update tool description to document format options
- Remove outdated "prompt" reference from description

## Changes
- `packages/opencode/src/tool/webfetch.ts`: Add default value for format
- `packages/opencode/src/tool/webfetch.txt`: Update description

## Testing
Verified the schema now accepts calls without explicit format parameter.