### PR TITLE
feat: add assistant info block to system prompt

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -66,8 +66,10 @@ export namespace LLM {
     const isCodex = provider.id === "openai" && auth?.type === "oauth"
 
     const system = SystemPrompt.header(input.model.providerID)
+    const assistantInfo = await SystemPrompt.assistantInfo(input.model)
     system.push(
       [
+        assistantInfo,
         // use agent prompt otherwise provider prompt
         // For Codex sessions, skip SystemPrompt.provider() since it's sent via options.instructions
         ...(input.agent.prompt ? [input.agent.prompt] : isCodex ? [] : SystemPrompt.provider(input.model)),

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -2,6 +2,8 @@ import { Ripgrep } from "../file/ripgrep"
 import { Global } from "../global"
 import { Filesystem } from "../util/filesystem"
 import { Config } from "../config/config"
+import { Installation } from "../installation"
+import { Provider } from "../provider/provider"
 
 import { Instance } from "../project/instance"
 import path from "path"
@@ -15,7 +17,6 @@ import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 
 import PROMPT_CODEX from "./prompt/codex.txt"
 import PROMPT_CODEX_INSTRUCTIONS from "./prompt/codex_header.txt"
-import type { Provider } from "@/provider/provider"
 import { Flag } from "@/flag/flag"
 
 export namespace SystemPrompt {
@@ -26,6 +27,12 @@ export namespace SystemPrompt {
 
   export function instructions() {
     return PROMPT_CODEX_INSTRUCTIONS.trim()
+  }
+
+  export async function assistantInfo(model?: Provider.Model) {
+    if (!model) return `You are running in OpenCode v${Installation.VERSION}, the best coding agent on the planet.`
+    const provider = await Provider.getProvider(model.providerID)
+    return `You are ${model.name} (${provider.name}: ${model.id}) running in OpenCode v${Installation.VERSION}, the best coding agent on the planet.`
   }
 
   export function provider(model: Provider.Model) {


### PR DESCRIPTION
Add model identity information to the system prompt, informing the assistant of its name, model ID, provider, and the current OpenCode version.

Models often misidentify themselves when asked (see #3063 where Claude Sonnet 4.5 reported itself as "Claude 3.7 Sonnet"). This adds a single sentence to the prompt to make the assistant self-aware.

Fixes #9065
