### PR TITLE
fix(tui): improve model selection dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -21,6 +21,7 @@ export function DialogModel(props: { providerID?: string }) {
   const dialog = useDialog()
   const [ref, setRef] = createSignal<DialogSelectRef<unknown>>()
   const [query, setQuery] = createSignal("")
+  const [showLatestOnly, setShowLatestOnly] = createSignal(true)
 
   const connected = useConnected()
   const providers = createDialogProviderOptions()
@@ -116,14 +117,27 @@ export function DialogModel(props: { providerID?: string }) {
           entries(),
           filter(([_, info]) => info.status !== "deprecated"),
           filter(([_, info]) => (props.providerID ? info.providerID === props.providerID : true)),
+          // Filter out dated model versions when "show latest only" is enabled
+          filter(([model, _]) => !showLatestOnly() || !model.match(/-\d{8}$/)),
           map(([model, info]) => {
             const value = {
               providerID: provider.id,
               modelID: model,
             }
+            // Extract date suffix from model ID (e.g., "20251101" from "claude-opus-4-5-20251101")
+            const dateMatch = model.match(/-(\d{8})$/)
+            let title = info.name ?? model
+            // If model has a date suffix and title doesn't already include it, append it
+            if (dateMatch && !title.includes(dateMatch[1])) {
+              title = `${title} (${dateMatch[1]})`
+            }
+            // If model doesn't have a date suffix and title doesn't say "latest", mark it as latest
+            else if (!dateMatch && !title.toLowerCase().includes("latest")) {
+              title = `${title} (latest)`
+            }
             return {
               value,
-              title: info.name ?? model,
+              title,
               description: favorites.some(
                 (item) => item.providerID === value.providerID && item.modelID === value.modelID,
               )
@@ -150,10 +164,6 @@ export function DialogModel(props: { providerID?: string }) {
               (item) => item.providerID === value.providerID && item.modelID === value.modelID,
             )
             if (inFavorites) return false
-            const inRecents = recents.some(
-              (item) => item.providerID === value.providerID && item.modelID === value.modelID,
-            )
-            if (inRecents) return false
             return true
           }),
           sortBy(
@@ -217,6 +227,14 @@ export function DialogModel(props: { providerID?: string }) {
           disabled: !connected(),
           onTrigger: (option) => {
             local.model.toggleFavorite(option.value as { providerID: string; modelID: string })
+          },
+        },
+        {
+          keybind: Keybind.parse("ctrl+l")[0],
+          title: showLatestOnly() ? "Show all versions" : "Show latest only",
+          disabled: !connected(),
+          onTrigger: () => {
+            setShowLatestOnly(!showLatestOnly())
           },
         },
       ]}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -5,6 +5,7 @@ import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 import { useSDK } from "../context/sdk"
 import { DialogPrompt } from "../ui/dialog-prompt"
+import { Link } from "../ui/link"
 import { useTheme } from "../context/theme"
 import { TextAttributes } from "@opentui/core"
 import type { ProviderAuthAuthorization } from "@opencode-ai/sdk/v2"
@@ -128,7 +129,7 @@ function AutoMethod(props: AutoMethodProps) {
         <text fg={theme.textMuted}>esc</text>
       </box>
       <box gap={1}>
-        <text fg={theme.primary}>{props.authorization.url}</text>
+        <Link href={props.authorization.url} fg={theme.primary} />
         <text fg={theme.textMuted}>{props.authorization.instructions}</text>
       </box>
       <text fg={theme.textMuted}>Waiting for authorization...</text>
@@ -170,7 +171,7 @@ function CodeMethod(props: CodeMethodProps) {
       description={() => (
         <box gap={1}>
           <text fg={theme.textMuted}>{props.authorization.instructions}</text>
-          <text fg={theme.primary}>{props.authorization.url}</text>
+          <Link href={props.authorization.url} fg={theme.primary} />
           <Show when={error()}>
             <text fg={theme.error}>Invalid code</text>
           </Show>

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -10,6 +10,7 @@ import { useTheme } from "../context/theme"
 import { TextAttributes } from "@opentui/core"
 import type { ProviderAuthAuthorization } from "@opencode-ai/sdk/v2"
 import { DialogModel } from "./dialog-model"
+import open from "open"
 
 const PROVIDER_PRIORITY: Record<string, number> = {
   opencode: 0,
@@ -63,11 +64,13 @@ export function createDialogProviderOptions() {
           }
           if (index == null) return
           const method = methods[index]
+
           if (method.type === "oauth") {
             const result = await sdk.client.provider.oauth.authorize({
               providerID: provider.id,
               method: index,
             })
+
             if (result.data?.method === "code") {
               dialog.replace(() => (
                 <CodeMethod providerID={provider.id} title={method.label} index={index} authorization={result.data!} />
@@ -107,6 +110,9 @@ function AutoMethod(props: AutoMethodProps) {
   const sync = useSync()
 
   onMount(async () => {
+    // Automatically open the auth URL in the browser
+    open(props.authorization.url).catch(() => {})
+
     const result = await sdk.client.provider.oauth.callback({
       providerID: props.providerID,
       method: props.index,
@@ -117,7 +123,7 @@ function AutoMethod(props: AutoMethodProps) {
     }
     await sdk.client.instance.dispose()
     await sync.bootstrap()
-    dialog.replace(() => <DialogModel providerID={props.providerID} />)
+    dialog.replace(() => <DialogModel />)
   })
 
   return (
@@ -150,6 +156,11 @@ function CodeMethod(props: CodeMethodProps) {
   const dialog = useDialog()
   const [error, setError] = createSignal(false)
 
+  // Automatically open the auth URL in the browser
+  onMount(() => {
+    open(props.authorization.url).catch(() => {})
+  })
+
   return (
     <DialogPrompt
       title={props.title}
@@ -163,7 +174,7 @@ function CodeMethod(props: CodeMethodProps) {
         if (!error) {
           await sdk.client.instance.dispose()
           await sync.bootstrap()
-          dialog.replace(() => <DialogModel providerID={props.providerID} />)
+          dialog.replace(() => <DialogModel />)
           return
         }
         setError(true)
@@ -218,7 +229,7 @@ function ApiMethod(props: ApiMethodProps) {
         })
         await sdk.client.instance.dispose()
         await sync.bootstrap()
-        dialog.replace(() => <DialogModel providerID={props.providerID} />)
+        dialog.replace(() => <DialogModel />)
       }}
     />
   )

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -1,0 +1,28 @@
+import type { JSX } from "solid-js"
+import type { RGBA } from "@opentui/core"
+import open from "open"
+
+export interface LinkProps {
+  href: string
+  children?: JSX.Element | string
+  fg?: RGBA
+}
+
+/**
+ * Link component that renders clickable hyperlinks.
+ * Clicking anywhere on the link text opens the URL in the default browser.
+ */
+export function Link(props: LinkProps) {
+  const displayText = props.children ?? props.href
+
+  return (
+    <text
+      fg={props.fg}
+      onMouseUp={() => {
+        open(props.href).catch(() => {})
+      }}
+    >
+      {displayText}
+    </text>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -18,6 +18,7 @@ export function Link(props: LinkProps) {
   return (
     <text
       fg={props.fg}
+      underline={true}
       onMouseUp={() => {
         open(props.href).catch(() => {})
       }}

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from "solid-js"
-import type { RGBA } from "@opentui/core"
+import { TextAttributes, type RGBA } from "@opentui/core"
 import open from "open"
 
 export interface LinkProps {
@@ -11,19 +11,21 @@ export interface LinkProps {
 /**
  * Link component that renders clickable hyperlinks.
  * Clicking anywhere on the link text opens the URL in the default browser.
+ * Uses a full-width box wrapper to ensure the entire area is clickable even when text wraps.
  */
 export function Link(props: LinkProps) {
   const displayText = props.children ?? props.href
 
   return (
-    <text
-      fg={props.fg}
-      underline={true}
+    <box
+      flexGrow={1}
       onMouseUp={() => {
         open(props.href).catch(() => {})
       }}
     >
-      {displayText}
-    </text>
+      <text fg={props.fg} attributes={TextAttributes.UNDERLINE}>
+        {displayText}
+      </text>
+    </box>
   )
 }


### PR DESCRIPTION
## Summary

- Auto-open OAuth URLs in browser when auth dialogs mount (no more clicking)
- Show all models in provider section (not filtered by recents anymore)
- Add date/latest suffix disambiguation to model names (e.g., "Claude Opus 4.5 (latest)" vs "Claude Opus 4.5 (20251101)")
- Add `ctrl+l` toggle to filter between latest-only and all model versions (defaults to latest-only)
- Remove providerID filtering after OAuth to show all connected provider models

## Test plan

- [ ] Connect a provider via OAuth and verify URL auto-opens in browser
- [ ] After connecting, verify all provider models appear in model list
- [ ] Verify models show "(latest)" or "(YYYYMMDD)" suffix for disambiguation
- [ ] Press `ctrl+l` in model selector to toggle between latest-only and all versions
- [ ] Verify recent models still appear in Recent section AND provider section

🤖 Generated with [Claude Code](https://claude.com/claude-code)