### PR TITLE
fix(server): inherit agent from previous message in session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -177,15 +177,18 @@ export function Session() {
     }
   })
 
-  // On session change, set model to last used model
+  // On session change, set model/agent to last used
   createEffect(
     on(
       () => session()?.id,
       (sessionId) => {
         const lastUserMessage = sync.data.message[sessionId]?.findLast((x) => x.role === "user")
         if (!lastUserMessage) return
-
         local.model.set(lastUserMessage.model)
+
+        const agent = sync.data.agent.find((x) => x.name === lastUserMessage.agent)
+        if (agent?.mode === "subagent" || agent?.hidden) return
+        local.agent.set(lastUserMessage.agent)
       },
     ),
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -168,6 +168,7 @@ export function Session() {
 
   const toast = useToast()
   const sdk = useSDK()
+  const local = useLocal()
 
   // Handle initial prompt from fork
   createEffect(() => {
@@ -175,6 +176,19 @@ export function Session() {
       prompt.set(route.initialPrompt)
     }
   })
+
+  // On session change, set model to last used model
+  createEffect(
+    on(
+      () => session()?.id,
+      (sessionId) => {
+        const lastUserMessage = sync.data.message[sessionId]?.findLast((x) => x.role === "user")
+        if (!lastUserMessage) return
+
+        local.model.set(lastUserMessage.model)
+      },
+    ),
+  )
 
   // Auto-navigate to whichever session currently needs permission input
   createEffect(() => {
@@ -276,8 +290,6 @@ export function Session() {
       if (scroll) scroll.scrollTo(scroll.scrollHeight)
     }, 50)
   }
-
-  const local = useLocal()
 
   function moveChild(direction: number) {
     const parentID = session()?.parentID ?? session()?.id

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -569,6 +569,13 @@ export namespace SessionPrompt {
     return Provider.defaultModel()
   }
 
+  async function lastAgent(sessionID: string) {
+    for await (const item of MessageV2.stream(sessionID)) {
+      if (item.info.role === "user" && item.info.agent) return item.info.agent
+    }
+    return Agent.defaultAgent()
+  }
+
   async function resolveTools(input: {
     agent: Agent.Info
     model: Provider.Model
@@ -715,7 +722,7 @@ export namespace SessionPrompt {
   }
 
   async function createUserMessage(input: PromptInput) {
-    const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
+    const agent = await Agent.get(input.agent ?? (await lastAgent(input.sessionID)))
     const info: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
       role: "user",


### PR DESCRIPTION
## Summary
- Fix agent not being inherited across prompts when using the server API

## Problem
When using `opencode serve` and sending prompts via `/session/:id/prompt_async`, the `agent` parameter was only used for the first message. Subsequent prompts without an explicit `agent` defaulted to "build" instead of inheriting the agent from the previous message in the session.

## Solution
Added `lastAgent()` function (similar to existing `lastModel()`) that looks up the last agent used in the session, and use it as the fallback in `createUserMessage()` instead of `Agent.defaultAgent()`.

Related to #6160 which fixes the same issue for the TUI.