### PR TITLE
Set smallOptions for google models on openrouter

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -316,6 +316,9 @@ export namespace ProviderTransform {
         thinkingBudget: 0,
       }
     }
+    if (model.providerID === "openrouter" && model.api.id.includes("google")) {
+      options["reasoning"] = { effort: undefined, max_tokens: 0 }
+    }
 
     return options
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -317,7 +317,7 @@ export namespace ProviderTransform {
       }
     }
     if (model.providerID === "openrouter" && model.api.id.includes("google")) {
-      options["reasoning"] = { effort: undefined, max_tokens: 0 }
+      options["reasoning"] = { enabled: false }
     }
 
     return options

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -302,25 +302,22 @@ export namespace ProviderTransform {
   }
 
   export function smallOptions(model: Provider.Model) {
-    const options: Record<string, any> = {}
-
     if (model.providerID === "openai" || model.api.id.includes("gpt-5")) {
       if (model.api.id.includes("5.")) {
-        options["reasoningEffort"] = "low"
-      } else {
-        options["reasoningEffort"] = "minimal"
+        return { reasoningEffort: "low" }
       }
+      return { reasoningEffort: "minimal" }
     }
     if (model.providerID === "google") {
-      options["thinkingConfig"] = {
-        thinkingBudget: 0,
+      return { thinkingConfig: { thinkingBudget: 0 } }
+    }
+    if (model.providerID === "openrouter") {
+      if (model.api.id.includes("google")) {
+        return { reasoning: { enabled: false } }
       }
+      return { reasoningEffort: "minimal" }
     }
-    if (model.providerID === "openrouter" && model.api.id.includes("google")) {
-      options["reasoning"] = { enabled: false }
-    }
-
-    return options
+    return {}
   }
 
   export function providerOptions(model: Provider.Model, options: { [x: string]: any }) {


### PR DESCRIPTION
While the thinking budget is set to 0 for the google provider, this didn't affect google models on openrouter.

With this small change, we can have flash 3 generate titles without 450 unnecessary reasoning tokens first.