### PR TITLE
fix(lsp): ESLint LSP server fails to auto-install on Windows

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -196,13 +196,14 @@ export namespace LSPServer {
         }
         await fs.rename(extractedPath, finalPath)
 
-        await $`npm install`.cwd(finalPath).quiet()
-        await $`npm run compile`.cwd(finalPath).quiet()
+        const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm"
+        await $`${npmCmd} install`.cwd(finalPath).quiet()
+        await $`${npmCmd} run compile`.cwd(finalPath).quiet()
 
         log.info("installed VS Code ESLint server", { serverPath })
       }
 
-      const proc = spawn(BunProc.which(), ["--max-old-space-size=8192", serverPath, "--stdio"], {
+      const proc = spawn(BunProc.which(), [serverPath, "--stdio"], {
         cwd: root,
         env: {
           ...process.env,


### PR DESCRIPTION
## Summary

- Use `npm.cmd` instead of `npm` on Windows for running install and compile commands during ESLint LSP server installation
- Remove invalid `--max-old-space-size` V8 flag (Bun uses JavaScriptCore, not V8)

## Problem

On Windows, `npm` is actually `npm.cmd` (a batch file wrapper). Bun's shell may not correctly resolve bare `npm` commands, causing the ESLint server installation to fail silently.

Additionally, the `--max-old-space-size=8192` flag is a V8/Node.js flag, but Bun uses JavaScriptCore. This flag is ignored or could cause unexpected behavior.

## Solution

```typescript
const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm"
await $`${npmCmd} install`.cwd(finalPath).quiet()
await $`${npmCmd} run compile`.cwd(finalPath).quiet()
```

This follows the same pattern used by other LSP implementations in the codebase (e.g., Oxlint at line 232-234).

Fixes #6365