### PR TITLE
feat: add model/agent slot keybinds for direct switching

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -382,6 +382,22 @@ function App() {
         local.agent.move(-1)
       },
     },
+    ...([1, 2, 3, 4, 5] as const).map((i) => ({
+      title: `Model slot ${i}`,
+      value: `model.slot_${i}`,
+      keybind: `model_slot_${i}` as keyof import("@opencode-ai/sdk/v2").KeybindsConfig,
+      category: "Agent" as const,
+      disabled: true,
+      onSelect: () => local.model.setFavorite(i - 1),
+    })),
+    ...([1, 2, 3, 4, 5] as const).map((i) => ({
+      title: `Agent slot ${i}`,
+      value: `agent.slot_${i}`,
+      keybind: `agent_slot_${i}` as keyof import("@opencode-ai/sdk/v2").KeybindsConfig,
+      category: "Agent" as const,
+      disabled: true,
+      onSelect: () => local.agent.setSlot(i - 1),
+    })),
     {
       title: "Connect provider",
       value: "provider.connect",

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -99,6 +99,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (index === -1) return colors()[0]
           return colors()[index % colors().length]
         },
+        setSlot(index: number) {
+          const list = agents()
+          const target = list[index]
+          if (!target) {
+            toast.show({ variant: "info", message: `No agent at slot ${index + 1}`, duration: 3000 })
+            return
+          }
+          setAgentStore("current", target.name)
+        },
       }
     })
 
@@ -308,6 +317,19 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             setModelStore("favorite", next)
             save()
           })
+        },
+        setFavorite(index: number) {
+          const favorites = modelStore.favorite.filter((item) => isModelValid(item))
+          const target = favorites[index]
+          if (!target) {
+            toast.show({ variant: "info", message: `No favorite model at slot ${index + 1}`, duration: 3000 })
+            return
+          }
+          setModelStore("model", agent.current().name, { ...target })
+          const uniq = uniqueBy([target, ...modelStore.recent], (x) => x.providerID + x.modelID)
+          if (uniq.length > 10) uniq.pop()
+          setModelStore("recent", uniq)
+          save()
         },
       }
     })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -579,6 +579,16 @@ export namespace Config {
       terminal_suspend: z.string().optional().default("ctrl+z").describe("Suspend terminal"),
       terminal_title_toggle: z.string().optional().default("none").describe("Toggle terminal title"),
       tips_toggle: z.string().optional().default("<leader>h").describe("Toggle tips on home screen"),
+      model_slot_1: z.string().optional().default("none").describe("Jump to favorite model #1"),
+      model_slot_2: z.string().optional().default("none").describe("Jump to favorite model #2"),
+      model_slot_3: z.string().optional().default("none").describe("Jump to favorite model #3"),
+      model_slot_4: z.string().optional().default("none").describe("Jump to favorite model #4"),
+      model_slot_5: z.string().optional().default("none").describe("Jump to favorite model #5"),
+      agent_slot_1: z.string().optional().default("none").describe("Jump to agent #1"),
+      agent_slot_2: z.string().optional().default("none").describe("Jump to agent #2"),
+      agent_slot_3: z.string().optional().default("none").describe("Jump to agent #3"),
+      agent_slot_4: z.string().optional().default("none").describe("Jump to agent #4"),
+      agent_slot_5: z.string().optional().default("none").describe("Jump to agent #5"),
     })
     .strict()
     .meta({


### PR DESCRIPTION
## Summary
- Add `model_slot_1-5` keybinds to jump directly to favorite models
- Add `agent_slot_1-5` keybinds to jump directly to agents by index
- Add `setFavorite(index)` method to model store
- Add `setSlot(index)` method to agent store

## Motivation
Currently switching models requires cycling through all favorites with Tab/F2. This PR enables direct keybind mapping for faster workflow - press F1 for favorite model 1, f5 for agent 1, etc.

## Example Config
```json
"keybinds": {
  "model_cycle_recent": "none",
  "model_slot_1": "f1",
  "model_slot_2": "f2", 
  "model_slot_3": "f3",
  
  "agent_slot_1": "f5",
  "agent_slot_2": "f6"
}
```

## Files Changed
- `packages/opencode/src/config/config.ts` - Add 10 keybind entries
- `packages/opencode/src/cli/cmd/tui/context/local.tsx` - Add setFavorite/setSlot methods
- `packages/opencode/src/cli/cmd/tui/app.tsx` - Register slot commands