### PR TITLE
feat(format): add nixfmt formatter for Nix files

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -322,3 +322,12 @@ export const shfmt: Info = {
     return Bun.which("shfmt") !== null
   },
 }
+
+export const nixfmt: Info = {
+  name: "nixfmt",
+  command: ["nixfmt", "$FILE"],
+  extensions: [".nix"],
+  async enabled() {
+    return Bun.which("nixfmt") !== null
+  },
+}


### PR DESCRIPTION
## Summary

Add `nixfmt` formatter support for `.nix` files.

## Changes

- Add `nixfmt` to built-in formatters in `packages/opencode/src/format/formatter.ts`
- Follows existing formatter pattern (like `gofmt`, `gleam`, `shfmt`)
- Enabled when `nixfmt` binary is available in PATH

Closes #6379