### PR TITLE
fix: filter messages with only step-start parts in toModelMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ opencode.json
 a.out
 target
 .scripts
+
+# Local dev files
+opencode-dev
+logs/

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -539,7 +539,7 @@ export namespace MessageV2 {
       }
     }
 
-    return convertToModelMessages(result.filter((msg) => msg.parts.length > 0))
+    return convertToModelMessages(result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")))
   }
 
   export const stream = fn(Identifier.schema("session"), async function* (sessionID) {


### PR DESCRIPTION
## Summary

Fixes compaction errors caused by messages containing only `step-start` parts being sent to the Claude API, which rejects them with "all messages must have non-empty content".

## Problem

The previous fix (#4811, commit 13f89fdb8) filtered messages with zero parts, but messages containing **only** `step-start` parts still passed through. Since `step-start` is metadata that doesn't produce actual API content, these messages resulted in empty content blocks.

## Solution

Changed the filter from checking `msg.parts.length > 0` to checking `msg.parts.some((part) => part.type !== "step-start")`, ensuring messages have at least one content-producing part (text, tool results, reasoning, etc.) rather than just metadata parts.

## Testing

This fix ensures that during compaction, only messages with meaningful content are sent to the API, preventing the "non-empty content" validation error.