### PR TITLE
feat(highlight): add nix syntax highlighting

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -235,5 +235,19 @@ export default {
         ],
       },
     },
+    {
+      filetype: "nix",
+      // TODO: Replace with official tree-sitter-nix WASM when published
+      // See: https://github.com/nix-community/tree-sitter-nix/issues/66
+      wasm: "https://github.com/ast-grep/ast-grep.github.io/raw/40b84530640aa83a0d34a20a2b0623d7b8e5ea97/website/public/parsers/tree-sitter-nix.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/nix/highlights.scm",
+        ],
+        locals: [
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/nix/locals.scm",
+        ],
+      },
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- Add tree-sitter parser config for Nix files
- Use ast-grep WASM (pinned SHA) as temporary source until official release
- Include highlights.scm and locals.scm from nvim-treesitter

## Why ast-grep?

Official tree-sitter-nix doesn't publish WASM binaries (nix-community/tree-sitter-nix#66 open 1.5+ years). ast-grep is a reliable alternative:
- 11k+ stars, actively maintained
- WASM compiled by main maintainer
- Commit SHA pinned for stability

When upstream publishes official WASM, it's a one-line URL swap.

Closes #6385