### PR TITLE
ci: use env vars for DRY workflow config

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 */12 * * *"
   workflow_dispatch:
 
+env:
+  LOOKBACK_HOURS: 4
+
 jobs:
   update-docs:
     if: github.repository == 'sst/opencode'
@@ -25,9 +28,9 @@ jobs:
       - name: Get recent commits
         id: commits
         run: |
-          COMMITS=$(git log --since="4 hours ago" --pretty=format:"- %h %s" 2>/dev/null || echo "")
+          COMMITS=$(git log --since="${{ env.LOOKBACK_HOURS }} hours ago" --pretty=format:"- %h %s" 2>/dev/null || echo "")
           if [ -z "$COMMITS" ]; then
-            echo "No commits in the last 4 hours"
+            echo "No commits in the last ${{ env.LOOKBACK_HOURS }} hours"
             echo "has_commits=false" >> $GITHUB_OUTPUT
           else
             echo "has_commits=true" >> $GITHUB_OUTPUT
@@ -47,7 +50,7 @@ jobs:
           model: opencode/gpt-5.2
           agent: docs
           prompt: |
-            Review the following commits from the last 4 hours and identify any new features that may need documentation.
+            Review the following commits from the last ${{ env.LOOKBACK_HOURS }} hours and identify any new features that may need documentation.
 
             <recent_commits>
             ${{ steps.commits.outputs.list }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,10 @@ on:
     - cron: "30 1 * * *" # Daily at 1:30 AM
   workflow_dispatch:
 
+env:
+  DAYS_BEFORE_STALE: 90
+  DAYS_BEFORE_CLOSE: 7
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -13,17 +17,17 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-stale: 90
-          days-before-close: 7
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
           stale-issue-label: "stale"
           close-issue-message: |
-            [automated] Closing due to 90+ days of inactivity.
+            [automated] Closing due to ${{ env.DAYS_BEFORE_STALE }}+ days of inactivity.
 
             Feel free to reopen if you still need this!
           stale-issue-message: |
-            [automated] This issue has had no activity for 90 days.
+            [automated] This issue has had no activity for ${{ env.DAYS_BEFORE_STALE }} days.
 
-            It will be closed in 7 days if there's no new activity.
+            It will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days if there's no new activity.
           remove-stale-when-updated: true
           exempt-issue-labels: "pinned,security,feature-request,on-hold"
           start-date: "2025-12-27"


### PR DESCRIPTION
## Summary

- Extract hardcoded day values in `stale-issues.yml` to `DAYS_BEFORE_STALE` and `DAYS_BEFORE_CLOSE` env vars
- Extract hardcoded lookback hours in `docs-update.yml` to `LOOKBACK_HOURS` env var

This ensures config values and their corresponding messages stay in sync.

Closes #6394