### PR TITLE
fix: prevent symlink escape in Filesystem.contains

### DIFF
--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -237,8 +237,6 @@ export namespace File {
     const project = Instance.project
     const full = path.join(Instance.directory, file)
 
-    // TODO: Filesystem.contains is lexical only - symlinks inside the project can escape.
-    // TODO: On Windows, cross-drive paths bypass this check. Consider realpath canonicalization.
     if (!Filesystem.contains(Instance.directory, full)) {
       throw new Error(`Access denied: path escapes project directory`)
     }
@@ -297,8 +295,6 @@ export namespace File {
     }
     const resolved = dir ? path.join(Instance.directory, dir) : Instance.directory
 
-    // TODO: Filesystem.contains is lexical only - symlinks inside the project can escape.
-    // TODO: On Windows, cross-drive paths bypass this check. Consider realpath canonicalization.
     if (!Filesystem.contains(Instance.directory, resolved)) {
       throw new Error(`Access denied: path escapes project directory`)
     }

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -23,7 +23,24 @@ export namespace Filesystem {
   }
 
   export function contains(parent: string, child: string) {
-    return !relative(parent, child).startsWith("..")
+    // First try with resolved real paths to prevent symlink escapes
+    try {
+      const realParent = realpathSync(parent)
+      const realChild = realpathSync(child)
+      const rel = relative(realParent, realChild)
+      // On Windows, check for cross-drive paths (e.g., "D:\..." from "C:\...")
+      if (process.platform === "win32" && /^[A-Za-z]:/.test(rel)) {
+        return false
+      }
+      return !rel.startsWith("..")
+    } catch {
+      // If realpath fails (e.g., file doesn't exist yet), fall back to lexical check
+      const rel = relative(parent, child)
+      if (process.platform === "win32" && /^[A-Za-z]:/.test(rel)) {
+        return false
+      }
+      return !rel.startsWith("..")
+    }
   }
 
   export async function findUp(target: string, start: string, stop?: string) {

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -22,25 +22,39 @@ export namespace Filesystem {
     return !relA || !relA.startsWith("..") || !relB || !relB.startsWith("..")
   }
 
-  export function contains(parent: string, child: string) {
-    // First try with resolved real paths to prevent symlink escapes
-    try {
-      const realParent = realpathSync(parent)
-      const realChild = realpathSync(child)
-      const rel = relative(realParent, realChild)
-      // On Windows, check for cross-drive paths (e.g., "D:\..." from "C:\...")
-      if (process.platform === "win32" && /^[A-Za-z]:/.test(rel)) {
-        return false
-      }
-      return !rel.startsWith("..")
-    } catch {
-      // If realpath fails (e.g., file doesn't exist yet), fall back to lexical check
-      const rel = relative(parent, child)
-      if (process.platform === "win32" && /^[A-Za-z]:/.test(rel)) {
-        return false
-      }
-      return !rel.startsWith("..")
+  /**
+   * Check if a relative path is contained (doesn't escape via .. or cross-drive)
+   */
+  function isContained(rel: string): boolean {
+    // On Windows, check for cross-drive paths (e.g., "D:\..." from "C:\...")
+    if (process.platform === "win32" && /^[A-Za-z]:/.test(rel)) {
+      return false
     }
+    return !rel.startsWith("..")
+  }
+
+  export function contains(parent: string, child: string) {
+    // Try to resolve each path individually to prevent symlink escapes.
+    // Use resolved paths when available for maximum security.
+    let resolvedParent = parent
+    let resolvedChild = child
+
+    try {
+      resolvedParent = realpathSync(parent)
+    } catch {
+      // Parent doesn't exist or can't be resolved, use original
+    }
+
+    try {
+      resolvedChild = realpathSync(child)
+    } catch {
+      // Child doesn't exist yet (common for new files), use original
+      // But if parent was resolved, still use resolved parent for safety
+    }
+
+    // Use the best available paths (resolved when possible)
+    const rel = relative(resolvedParent, resolvedChild)
+    return isContained(rel)
   }
 
   export async function findUp(target: string, start: string, stop?: string) {


### PR DESCRIPTION
The `Filesystem.contains()` function previously performed only lexical path checking, which could be bypassed using symlinks inside the project directory. An attacker could create a symlink pointing to sensitive files outside the project (e.g., ~/.ssh/id_rsa), and the file tools would allow reading them.

This fix:
- Uses `realpathSync` to resolve symlinks before checking containment
- Falls back to lexical check if realpath fails (e.g., file doesn't exist)
- Adds explicit handling for Windows cross-drive paths (D:\ vs C:\)
- Removes the TODO comments that documented this issue