### PR TITLE
fix: cloudflare-ai-gateway sdk.chat undefined error

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -371,7 +371,7 @@ export namespace Provider {
       return {
         autoload: true,
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-          return sdk.chat(modelID)
+          return sdk.languageModel(modelID)
         },
         options: {
           baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gateway}/compat`,


### PR DESCRIPTION
## Summary

Fixes the `sdk.chat is not a function` error when using Cloudflare AI Gateway as a provider.

- Changed `sdk.chat(modelID)` to `sdk.languageModel(modelID)` in the cloudflare-ai-gateway custom loader

## Problem

The `@ai-sdk/openai-compatible` SDK (which Cloudflare AI Gateway uses per models.dev) does not have a `.chat()` method. It only exposes `.languageModel()` and `.chatModel()`. This caused the error:

```
ERROR sdk.chat is not a function. (In 'sdk.chat(modelID)', 'sdk.chat' is undefined)
```

The original PR #5174 was merged with `sdk.chat()`, even though the author [noted in a comment](https://github.com/sst/opencode/pull/5174#issuecomment-3688173351) that they had "fixed the way we call the `openai-compatible` SDK (`.languageModel`)" - that fix was never actually committed.

## Solution

Use `.languageModel()` which is the standard method available on all AI SDK providers and matches how other providers in this file work (see bedrock, google-vertex, sap-ai-core, etc.).

## Testing

Tested locally with Cloudflare AI Gateway credentials - models now load and respond correctly.

---

*This fix was developed entirely using opencode itself* 🎉

Fixes #6262