### PR TITLE
docs: Correct theme command in tui.mdx

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -235,7 +235,7 @@ Share current session. [Learn more](/docs/share).
 List available themes.
 
 ```bash frame="none"
-/themes
+/theme
 ```
 
 **Keybind:** `ctrl+x t`


### PR DESCRIPTION
This pull request updates the documentation in `tui.mdx` to correct the command for listing available themes.

- Documentation update:
  * Changed the example command from `/themes` to `/theme` in the "List available themes" section to reflect the correct usage.