### PR TITLE
Easy Message Unqueue with /unqueue

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -396,6 +396,16 @@ export function Session() {
       },
     },
     {
+      title: "Remove queued messages",
+      value: "session.unqueue",
+      keybind: "session_unqueue",
+      category: "Session",
+      onSelect: (dialog) => {
+        sdk.client.session.unqueue({ sessionID: route.sessionID })
+        dialog.clear()
+      },
+    },
+    {
       title: "Unshare session",
       value: "session.unshare",
       keybind: "session_unshare",

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -37,6 +37,7 @@ export namespace Command {
   export const Default = {
     INIT: "init",
     REVIEW: "review",
+    UNQUEUE: "unqueue",
   } as const
 
   const state = Instance.state(async () => {
@@ -53,6 +54,11 @@ export namespace Command {
         description: "review changes [commit|branch|pr], defaults to uncommitted",
         template: PROMPT_REVIEW.replace("${path}", Instance.worktree),
         subtask: true,
+      },
+      [Default.UNQUEUE]: {
+        name: Default.UNQUEUE,
+        description: "remove all queued messages",
+        template: "",
       },
     }
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -458,6 +458,7 @@ export namespace Config {
       session_share: z.string().optional().default("none").describe("Share current session"),
       session_unshare: z.string().optional().default("none").describe("Unshare current session"),
       session_interrupt: z.string().optional().default("escape").describe("Interrupt current session"),
+      session_unqueue: z.string().optional().default("none").describe("Remove queued messages"),
       session_compact: z.string().optional().default("<leader>c").describe("Compact the session"),
       messages_page_up: z.string().optional().default("pageup").describe("Scroll messages up by one page"),
       messages_page_down: z.string().optional().default("pagedown").describe("Scroll messages down by one page"),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -949,6 +949,34 @@ export namespace Server {
         },
       )
       .post(
+        "/session/:sessionID/unqueue",
+        describeRoute({
+          description: "Remove queued messages from session",
+          operationId: "session.unqueue",
+          responses: {
+            200: {
+              description: "Removed queued messages",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: z.string(),
+          }),
+        ),
+        async (c) => {
+          await SessionPrompt.removeQueued(c.req.valid("param").sessionID)
+          return c.json(true)
+        },
+      )
+      .post(
         "/session/:sessionID/share",
         describeRoute({
           summary: "Share session",
@@ -2461,6 +2489,7 @@ export namespace Server {
               session_new: "session.new",
               session_share: "session.share",
               session_interrupt: "session.interrupt",
+              session_unqueue: "session.unqueue",
               session_compact: "session.compact",
               messages_page_up: "session.page.up",
               messages_page_down: "session.page.down",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1292,16 +1292,25 @@ export namespace SessionPrompt {
    */
 
   async function handleUnqueue(sessionID: string) {
-    const messages = []
+    const queuedIDs: string[] = []
+    let foundPending = false
+
     for await (const msg of MessageV2.stream(sessionID)) {
-      messages.push(msg)
+      // Stop at first assistant (boundary between queued and processed)
+      if (msg.info.role === "assistant") {
+        foundPending = !msg.info.time.completed
+        break
+      }
+
+      // Collect user message IDs
+      if (msg.info.role === "user") {
+        queuedIDs.push(msg.info.id)
+      }
     }
 
-    const pending = messages.findLast((x) => x.info.role === "assistant" && !x.info.time.completed)?.info.id
-    const queued = pending ? messages.filter((x) => x.info.role === "user" && x.info.id > pending) : []
-
-    for (const msg of queued) {
-      await Session.removeMessage({ sessionID, messageID: msg.info.id })
+    // Only delete if we found an incomplete assistant
+    if (foundPending && queuedIDs.length > 0) {
+      await Promise.all(queuedIDs.map((messageID) => Session.removeMessage({ sessionID, messageID })))
     }
 
     unqueue(sessionID)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -227,6 +227,18 @@ export namespace SessionPrompt {
     return
   }
 
+  export function unqueue(sessionID: string) {
+    log.info("unqueue", { sessionID })
+    const s = state()
+    const match = s[sessionID]
+    if (!match) return
+
+    for (const callback of match.callbacks) {
+      callback.reject()
+    }
+    match.callbacks = []
+  }
+
   export const loop = fn(Identifier.schema("session"), async (sessionID) => {
     const abort = start(sessionID)
     if (!abort) {
@@ -1279,8 +1291,48 @@ export namespace SessionPrompt {
    * Does not match when preceded by word characters or backticks (to avoid email addresses and quoted references)
    */
 
+  async function handleUnqueue(sessionID: string) {
+    const messages = []
+    for await (const msg of MessageV2.stream(sessionID)) {
+      messages.push(msg)
+    }
+
+    const pending = messages.findLast((x) => x.info.role === "assistant" && !x.info.time.completed)?.info.id
+    const queued = pending ? messages.filter((x) => x.info.role === "user" && x.info.id > pending) : []
+
+    for (const msg of queued) {
+      await Session.removeMessage({ sessionID, messageID: msg.info.id })
+    }
+
+    unqueue(sessionID)
+
+    return {
+      info: {
+        id: "",
+        sessionID,
+        role: "assistant" as const,
+        parentID: "",
+        mode: "",
+        time: { created: 0 },
+        agent: "",
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        path: { cwd: "", root: "" },
+        modelID: "",
+        providerID: "",
+      },
+      parts: [],
+    }
+  }
+
   export async function command(input: CommandInput) {
     log.info("command", input)
+
+    // Special handling for unqueue command
+    if (input.command === "unqueue") {
+      return await handleUnqueue(input.sessionID)
+    }
+
     const command = await Command.get(input.command)
     const agentName = command.agent ?? input.agent ?? (await Agent.defaultAgent())
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -227,8 +227,8 @@ export namespace SessionPrompt {
     return
   }
 
-  export function unqueue(sessionID: string) {
-    log.info("unqueue", { sessionID })
+  export function clearQueue(sessionID: string) {
+    log.info("clearQueue", { sessionID })
     const s = state()
     const match = s[sessionID]
     if (!match) return
@@ -1291,7 +1291,7 @@ export namespace SessionPrompt {
    * Does not match when preceded by word characters or backticks (to avoid email addresses and quoted references)
    */
 
-  async function handleUnqueue(sessionID: string) {
+  export async function removeQueued(sessionID: string) {
     const queued: string[] = []
 
     // MessageV2.stream yields newest->oldest, so queued messages appear first
@@ -1309,7 +1309,11 @@ export namespace SessionPrompt {
       }
     }
 
-    unqueue(sessionID)
+    clearQueue(sessionID)
+  }
+
+  async function handleUnqueue(sessionID: string) {
+    await removeQueued(sessionID)
 
     return {
       info: {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1292,25 +1292,21 @@ export namespace SessionPrompt {
    */
 
   async function handleUnqueue(sessionID: string) {
-    const queuedIDs: string[] = []
-    let foundPending = false
+    const queued: string[] = []
 
+    // MessageV2.stream yields newest->oldest, so queued messages appear first
     for await (const msg of MessageV2.stream(sessionID)) {
-      // Stop at first assistant (boundary between queued and processed)
       if (msg.info.role === "assistant") {
-        foundPending = !msg.info.time.completed
+        // Only delete if incomplete assistant found
+        if (!msg.info.time.completed && queued.length > 0) {
+          await Promise.all(queued.map((messageID) => Session.removeMessage({ sessionID, messageID })))
+        }
         break
       }
 
-      // Collect user message IDs
       if (msg.info.role === "user") {
-        queuedIDs.push(msg.info.id)
+        queued.push(msg.info.id)
       }
-    }
-
-    // Only delete if we found an incomplete assistant
-    if (foundPending && queuedIDs.length > 0) {
-      await Promise.all(queuedIDs.map((messageID) => Session.removeMessage({ sessionID, messageID })))
     }
 
     unqueue(sessionID)

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -73,6 +73,9 @@ import type {
   SessionAbortData,
   SessionAbortResponses,
   SessionAbortErrors,
+  SessionUnqueueData,
+  SessionUnqueueResponses,
+  SessionUnqueueErrors,
   SessionUnshareData,
   SessionUnshareResponses,
   SessionUnshareErrors,
@@ -551,6 +554,16 @@ class Session extends _HeyApiClient {
   public abort<ThrowOnError extends boolean = false>(options: Options<SessionAbortData, ThrowOnError>) {
     return (options.client ?? this._client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
       url: "/session/{id}/abort",
+      ...options,
+    })
+  }
+
+  /**
+   * Remove queued messages from session
+   */
+  public unqueue<ThrowOnError extends boolean = false>(options: Options<SessionUnqueueData, ThrowOnError>) {
+    return (options.client ?? this._client).post<SessionUnqueueResponses, SessionUnqueueErrors, ThrowOnError>({
+      url: "/session/{id}/unqueue",
       ...options,
     })
   }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -831,6 +831,10 @@ export type KeybindsConfig = {
    */
   session_interrupt?: string
   /**
+   * Remove queued messages
+   */
+  session_unqueue?: string
+  /**
    * Compact the session
    */
   session_compact?: string
@@ -2391,6 +2395,39 @@ export type SessionAbortResponses = {
 }
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
+
+export type SessionUnqueueData = {
+  body?: never
+  path: {
+    id: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{id}/unqueue"
+}
+
+export type SessionUnqueueErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionUnqueueError = SessionUnqueueErrors[keyof SessionUnqueueErrors]
+
+export type SessionUnqueueResponses = {
+  /**
+   * Removed queued messages
+   */
+  200: boolean
+}
+
+export type SessionUnqueueResponse = SessionUnqueueResponses[keyof SessionUnqueueResponses]
 
 export type SessionUnshareData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -116,6 +116,8 @@ import type {
   SessionSummarizeResponses,
   SessionTodoErrors,
   SessionTodoResponses,
+  SessionUnqueueErrors,
+  SessionUnqueueResponses,
   SessionUnrevertErrors,
   SessionUnrevertResponses,
   SessionUnshareErrors,
@@ -1038,6 +1040,34 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
       url: "/session/{sessionID}/abort",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Remove queued messages from session
+   */
+  public unqueue<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionUnqueueResponses, SessionUnqueueErrors, ThrowOnError>({
+      url: "/session/{sessionID}/unqueue",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -874,6 +874,10 @@ export type KeybindsConfig = {
    */
   session_interrupt?: string
   /**
+   * Remove queued messages
+   */
+  session_unqueue?: string
+  /**
    * Compact the session
    */
   session_compact?: string
@@ -2747,6 +2751,39 @@ export type SessionAbortResponses = {
 }
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
+
+export type SessionUnqueueData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/unqueue"
+}
+
+export type SessionUnqueueErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionUnqueueError = SessionUnqueueErrors[keyof SessionUnqueueErrors]
+
+export type SessionUnqueueResponses = {
+  /**
+   * Removed queued messages
+   */
+  200: boolean
+}
+
+export type SessionUnqueueResponse = SessionUnqueueResponses[keyof SessionUnqueueResponses]
 
 export type SessionUnshareData = {
   body?: never


### PR DESCRIPTION
## Summary

Adds **/unqueue** slash command to remove queued messages without affecting the current assistant response. It also adds a keybind, "session_unqueue" (default: none), so it can be easily configured by users.

## Problem

Oftentimes after queueing a message, I decide I want to rewrite it or ask something else altogether. In these cases, I’d like to remove all queued messages from the queue.

## Solution

The **/unqueue** command:
- Removes queued user messages
- Deletes them from persistent storage (clean conversation history)
- Rejects in-memory callbacks (messages never execute)
- Silent operation (no UI clutter)

## Demo

https://github.com/user-attachments/assets/cff67730-dc3c-490e-917f-e8079e5af323

---

I experimented with introducing an interactable button in the TUI. (Imagine hovering over the QUEUED button and it prompts you to UNQUEUE) But this approach keeps the implementation simple and focused

