### PR TITLE
fix(mdns): use named import for bonjour-service (resolves #6422)

### DIFF
--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -1,5 +1,5 @@
 import { Log } from "@/util/log"
-import Bonjour from "bonjour-service"
+import { Bonjour } from "bonjour-service"
 
 const log = Log.create({ service: "mdns" })
 


### PR DESCRIPTION
Fixes #6422

## Problem

`opencode web --mdns` fails to initialize mDNS service in bundled binaries. The server displays "mDNS: opencode.local" but no UDP socket is bound and the service is not discoverable.

From logs (`~/.local/share/opencode/log/*.log`):
```
ERROR service=mdns error=Object is not a constructor (evaluating 'new import_bonjour_service.default') mDNS publish failed
```

## Root Cause

The `bonjour-service` library is a CommonJS module that exports both:
- `exports.default = Bonjour`
- `exports.Bonjour = Bonjour`

When using `import Bonjour from "bonjour-service"` (default import), Bun's bundler (`Bun.build({ compile: {...} })`) has issues with the ESM/CJS interop. The bundled code attempts `new Bonjour()` but the constructor is not properly resolved.

This only affects the compiled binary - `bun dev` works fine because it doesn't go through the same bundling process.

## Solution

Use the named export instead of the default export:
```typescript
// Before (broken in bundled binary)
import Bonjour from "bonjour-service"

// After (works in both dev and bundled binary)
import { Bonjour } from "bonjour-service"
```

## Verification

- ✅ `bun run typecheck` passes
- ✅ `bun test` - all 366 tests pass
- ✅ Dev build (`bun dev web --mdns`) works
- ✅ Bundled binary (`./script/build.ts --single`) works
- ✅ UDP 5353 socket is bound by opencode process
- ✅ mDNS resolution works from Windows host (WSL2 mirrored networking)