### PR TITLE
fix: resolve broken forked sessions with compactions due to missing parent-child message references

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -147,12 +147,19 @@ export namespace Session {
         directory: Instance.directory,
       })
       const msgs = await messages({ sessionID: input.sessionID })
+      const idMap = new Map<string, string>()
+
       for (const msg of msgs) {
         if (input.messageID && msg.info.id >= input.messageID) break
+        const newID = Identifier.ascending("message")
+        idMap.set(msg.info.id, newID)
+
+        const parentID = msg.info.role === "assistant" && msg.info.parentID ? idMap.get(msg.info.parentID) : undefined
         const cloned = await updateMessage({
           ...msg.info,
           sessionID: session.id,
-          id: Identifier.ascending("message"),
+          id: newID,
+          ...(parentID && { parentID }),
         })
 
         for (const part of msg.parts) {


### PR DESCRIPTION
## Summary

Forking a compacted session fails with:
```
prompt is too long: 203573 tokens > 200000 maximum
```

The bug was introduced in commit `9a0735de7` on October 6, 2025 with the commit message "Add session forking functionality and simplify remove logic".

This was a bug from day one of the fork feature - it just wasn't noticed until compaction logic (which relies on parent-child relationships) was added later.

## The Bug

When forking was originally implemented, each message gets a new `id` via `Identifier.ascending("message")`, but the code never updated the `parentID` field. Assistant messages have a `parentID` that points to their corresponding user message. After forking, those `parentID` values still reference the old message IDs from the source session, which don't exist in the forked session.

## Fix

Maintain an ID mapping (old -> new) when cloning messages, updating `parentID` references to point to the new IDs. This restores the parent-child relationships that `filterCompacted()` relies on to detect compaction breakpoints.