### PR TITLE
feat(mcp): add MCP server to expose custom tools via stdio

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -13,6 +13,8 @@ import { Instance } from "../../project/instance"
 import { Installation } from "../../installation"
 import path from "path"
 import { Global } from "../../global"
+import { McpServer } from "../../mcp/server"
+import { bootstrap } from "../bootstrap"
 
 function getAuthStatusIcon(status: MCP.AuthStatus): string {
   switch (status) {
@@ -45,6 +47,7 @@ export const McpCommand = cmd({
       .command(McpAuthCommand)
       .command(McpLogoutCommand)
       .command(McpDebugCommand)
+      .command(McpServeCommand)
       .demandCommand(),
   async handler() {},
 })
@@ -649,6 +652,66 @@ export const McpDebugCommand = cmd({
 
         prompts.outro("Debug complete")
       },
+    })
+  },
+})
+
+export const McpServeCommand = cmd({
+  command: "serve",
+  describe: "start OpenCode as an MCP server (stdio)",
+  builder: (yargs) =>
+    yargs
+      .option("list", {
+        describe: "list tools that would be exposed, then exit",
+        type: "boolean",
+        default: false,
+      })
+      .option("force", {
+        describe: "start server even if mcpServer.enabled is not true",
+        type: "boolean",
+        default: false,
+      })
+      .option("project", {
+        describe: "project directory (defaults to current working directory)",
+        type: "string",
+      }),
+  async handler(args) {
+    const cwd = args.project ?? process.cwd()
+
+    await bootstrap(cwd, async () => {
+      const config = await Config.get()
+      const mcpServerConfig = config.mcpServer ?? {}
+
+      // Check if MCP server is enabled (unless --force is used)
+      if (!args.force && mcpServerConfig.enabled !== true) {
+        UI.error(
+          "MCP server is not enabled. Set mcpServer.enabled to true in your opencode.json config, or use --force to start anyway.",
+        )
+        process.exit(1)
+      }
+
+      // Handle --list flag: print tools and exit
+      if (args.list) {
+        const tools = await McpServer.listTools()
+
+        if (tools.length === 0) {
+          console.log("No custom tools would be exposed.")
+          console.log("Add custom tools in .opencode/tool/*.{js,ts} or configure mcpServer.tools in opencode.json.")
+        } else {
+          console.log(`Tools that would be exposed (${tools.length}):`)
+          console.log("")
+          for (const tool of tools) {
+            console.log(`  ${tool.id}`)
+            if (tool.description) {
+              console.log(`    ${tool.description}`)
+            }
+          }
+        }
+        return
+      }
+
+      // Start the MCP server
+      await McpServer.start({ cwd })
     })
   },
 })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -611,6 +611,20 @@ export namespace Config {
       ref: "ServerConfig",
     })
 
+  export const McpServer = z
+    .object({
+      enabled: z.boolean().optional().describe("Enable the MCP server to expose custom tools via stdio"),
+      tools: z
+        .record(z.string(), z.boolean())
+        .optional()
+        .describe("Tool filtering rules with wildcard support. Omit to enable all custom tools."),
+    })
+    .strict()
+    .meta({
+      ref: "McpServerConfig",
+    })
+  export type McpServer = z.infer<typeof McpServer>
+
   export const Layout = z.enum(["auto", "stretch"]).meta({
     ref: "LayoutConfig",
   })
@@ -660,6 +674,7 @@ export namespace Config {
       logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),
       server: Server.optional().describe("Server configuration for opencode serve and web commands"),
+      mcpServer: McpServer.optional().describe("MCP server configuration for exposing custom tools via stdio"),
       command: z
         .record(z.string(), Command)
         .optional()

--- a/packages/opencode/src/mcp/server.ts
+++ b/packages/opencode/src/mcp/server.ts
@@ -1,0 +1,270 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  ErrorCode,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js"
+import z from "zod/v4"
+import { ToolRegistry } from "../tool/registry"
+import { Tool } from "../tool/tool"
+import { Wildcard } from "../util/wildcard"
+import { Log } from "../util/log"
+import { Config } from "../config/config"
+import { randomUUID } from "crypto"
+
+export namespace McpServer {
+  const log = Log.create({ service: "mcp.server" })
+
+  /**
+   * Options for starting the MCP server
+   */
+  export interface Options {
+    /** Project working directory */
+    cwd: string
+  }
+
+  /**
+   * Cached tool definition with initialized parameters
+   */
+  interface CachedTool {
+    id: string
+    description: string
+    parameters: z.ZodType
+    jsonSchema: Record<string, unknown>
+    execute: Awaited<ReturnType<Tool.Info["init"]>>["execute"]
+  }
+
+  /**
+   * Start the MCP server in stdio mode
+   *
+   * This server exposes only custom tools (from `.opencode/tool/*.{js,ts}` and plugins).
+   * Built-in tools (bash, read, write, etc.) are NOT exposed.
+   */
+  export async function start(options: Options): Promise<void> {
+    const config = await Config.get()
+    const mcpServerConfig = config.mcpServer ?? {}
+
+    // Generate a stable session ID for this server instance
+    const serverSessionID = randomUUID()
+
+    // Load and cache custom tools
+    const registryState = await ToolRegistry.state()
+    const customTools = registryState.custom
+
+    // Filter tools based on config
+    const toolsConfig = mcpServerConfig.tools ?? {}
+    const enabledTools: CachedTool[] = []
+
+    for (const toolInfo of customTools) {
+      // Check if tool is enabled via wildcard config
+      // If tools config is empty/undefined, all tools are enabled by default
+      const isEnabled =
+        Object.keys(toolsConfig).length === 0 ? true : Wildcard.all(toolInfo.id, toolsConfig) !== false
+
+      if (!isEnabled) {
+        log.debug("tool disabled by config", { toolId: toolInfo.id })
+        continue
+      }
+
+      try {
+        // Initialize tool and cache result
+        const initialized = await toolInfo.init()
+        const jsonSchema = convertZodToJsonSchema(initialized.parameters)
+
+        enabledTools.push({
+          id: toolInfo.id,
+          description: initialized.description,
+          parameters: initialized.parameters,
+          jsonSchema,
+          execute: initialized.execute,
+        })
+
+        log.debug("tool loaded", { toolId: toolInfo.id })
+      } catch (error) {
+        log.error("failed to initialize tool", {
+          toolId: toolInfo.id,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    log.info("starting mcp server", {
+      cwd: options.cwd,
+      toolCount: enabledTools.length,
+      toolIds: enabledTools.map((t) => t.id),
+    })
+
+    // Create MCP server
+    const server = new Server(
+      {
+        name: "opencode",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {
+          tools: {},
+        },
+      },
+    )
+
+    // Handle listTools request
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return {
+        tools: enabledTools.map((tool) => ({
+          name: tool.id,
+          description: tool.description,
+          inputSchema: tool.jsonSchema,
+        })),
+      }
+    })
+
+    // Handle callTool request
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const toolName = request.params.name
+      const tool = enabledTools.find((t) => t.id === toolName)
+
+      if (!tool) {
+        throw new McpError(ErrorCode.InvalidParams, `Tool "${toolName}" not found`)
+      }
+
+      // Create synthetic context for tool execution
+      const messageID = randomUUID()
+      const abortController = new AbortController()
+
+      const ctx: Tool.Context = {
+        sessionID: serverSessionID,
+        messageID,
+        agent: "mcp-server",
+        abort: abortController.signal,
+        metadata: () => {
+          // No-op in MCP server mode - metadata updates are not supported
+        },
+      }
+
+      try {
+        // Parse and validate arguments
+        const args = request.params.arguments ?? {}
+        const parsedArgs = tool.parameters.parse(args)
+
+        // Execute tool
+        const result = await tool.execute(parsedArgs, ctx)
+
+        // Log if attachments are present (v1 skips them)
+        if (result.attachments && result.attachments.length > 0) {
+          log.debug("tool returned attachments (skipped in v1)", {
+            toolId: toolName,
+            attachmentCount: result.attachments.length,
+          })
+        }
+
+        // Return text-only response
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: result.output,
+            },
+          ],
+        }
+      } catch (error) {
+        // Safe error handling - no stack traces to client
+        const message = error instanceof Error ? error.message : "Tool execution failed"
+
+        log.error("tool execution failed", {
+          toolId: toolName,
+          error: message,
+        })
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: ${message}`,
+            },
+          ],
+          isError: true,
+        }
+      }
+    })
+
+    // Create stdio transport and connect
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+
+    log.info("mcp server connected and ready")
+
+    // Keep server running until process exits
+    await new Promise<void>((resolve) => {
+      process.on("SIGINT", () => {
+        log.info("received SIGINT, shutting down")
+        server.close().finally(resolve)
+      })
+      process.on("SIGTERM", () => {
+        log.info("received SIGTERM, shutting down")
+        server.close().finally(resolve)
+      })
+    })
+  }
+
+  /**
+   * Get list of tools that would be exposed by the MCP server
+   * Useful for --list dry-run mode
+   */
+  export async function listTools(): Promise<Array<{ id: string; description: string }>> {
+    const config = await Config.get()
+    const mcpServerConfig = config.mcpServer ?? {}
+
+    const registryState = await ToolRegistry.state()
+    const customTools = registryState.custom
+
+    const toolsConfig = mcpServerConfig.tools ?? {}
+    const result: Array<{ id: string; description: string }> = []
+
+    for (const toolInfo of customTools) {
+      const isEnabled =
+        Object.keys(toolsConfig).length === 0 ? true : Wildcard.all(toolInfo.id, toolsConfig) !== false
+
+      if (!isEnabled) {
+        continue
+      }
+
+      try {
+        const initialized = await toolInfo.init()
+        result.push({
+          id: toolInfo.id,
+          description: initialized.description,
+        })
+      } catch {
+        // Skip tools that fail to initialize
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Convert Zod schema to JSON Schema
+   * Uses Zod v4's built-in toJSONSchema method
+   */
+  function convertZodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+    try {
+      const jsonSchema = z.toJSONSchema(schema)
+      // Ensure it's always an object type for MCP compatibility
+      return {
+        type: "object",
+        ...jsonSchema,
+      }
+    } catch (error) {
+      log.warn("failed to convert zod schema to json schema", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      // Return empty object schema as fallback
+      return {
+        type: "object",
+        properties: {},
+      }
+    }
+  }
+}

--- a/packages/opencode/test/mcp/server.test.ts
+++ b/packages/opencode/test/mcp/server.test.ts
@@ -1,0 +1,395 @@
+import { describe, test, expect } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Wildcard } from "../../src/util/wildcard"
+import { Instance } from "../../src/project/instance"
+
+// Path to the opencode package's node_modules (for symlinking into temp dirs)
+const opencodePackageRoot = path.resolve(__dirname, "../..")
+const nodeModulesPath = path.join(opencodePackageRoot, "node_modules")
+
+// =============================================================================
+// Unit Tests: Wildcard filtering behavior
+// =============================================================================
+// These tests verify the filtering semantics used by McpServer for tool gating.
+// The actual filtering in server.ts uses Wildcard.all() which is tested here.
+// =============================================================================
+
+describe("mcp server wildcard filtering", () => {
+  test("empty config enables all tools", () => {
+    const toolsConfig: Record<string, boolean> = {}
+    // When tools config is empty, all tools should be enabled
+    // The server.ts logic checks: Object.keys(toolsConfig).length === 0 ? true : ...
+    const isEnabled = Object.keys(toolsConfig).length === 0 ? true : Wildcard.all("any-tool", toolsConfig) !== false
+    expect(isEnabled).toBe(true)
+  })
+
+  test("omitted tools config enables all tools", () => {
+    const toolsConfig = undefined
+    // When tools config is omitted (undefined), all tools should be enabled
+    const resolvedConfig = toolsConfig ?? {}
+    const isEnabled =
+      Object.keys(resolvedConfig).length === 0 ? true : Wildcard.all("any-tool", resolvedConfig) !== false
+    expect(isEnabled).toBe(true)
+  })
+
+  test('{ "*": false, "echo": true } enables only echo', () => {
+    const toolsConfig = { "*": false, echo: true }
+
+    // echo should be enabled
+    const echoEnabled = Wildcard.all("echo", toolsConfig) !== false
+    expect(echoEnabled).toBe(true)
+
+    // other tools should be disabled
+    const otherEnabled = Wildcard.all("other-tool", toolsConfig) !== false
+    expect(otherEnabled).toBe(false)
+
+    const dangerEnabled = Wildcard.all("danger", toolsConfig) !== false
+    expect(dangerEnabled).toBe(false)
+  })
+
+  test('{ "*": true, "danger": false } enables all except danger', () => {
+    const toolsConfig = { "*": true, danger: false }
+
+    // echo should be enabled
+    const echoEnabled = Wildcard.all("echo", toolsConfig) !== false
+    expect(echoEnabled).toBe(true)
+
+    // foo should be enabled
+    const fooEnabled = Wildcard.all("foo", toolsConfig) !== false
+    expect(fooEnabled).toBe(true)
+
+    // danger should be disabled
+    const dangerEnabled = Wildcard.all("danger", toolsConfig) !== false
+    expect(dangerEnabled).toBe(false)
+  })
+
+  test('{ "*": false } disables all tools', () => {
+    const toolsConfig = { "*": false }
+
+    const echoEnabled = Wildcard.all("echo", toolsConfig) !== false
+    expect(echoEnabled).toBe(false)
+
+    const anyToolEnabled = Wildcard.all("any-tool", toolsConfig) !== false
+    expect(anyToolEnabled).toBe(false)
+  })
+
+  test('{ "*": true } enables all tools', () => {
+    const toolsConfig = { "*": true }
+
+    const echoEnabled = Wildcard.all("echo", toolsConfig) !== false
+    expect(echoEnabled).toBe(true)
+
+    const anyToolEnabled = Wildcard.all("any-tool", toolsConfig) !== false
+    expect(anyToolEnabled).toBe(true)
+  })
+
+  test("pattern matching with prefix wildcards", () => {
+    const toolsConfig = { "*": false, "test_*": true }
+
+    // test_foo should be enabled
+    const testFooEnabled = Wildcard.all("test_foo", toolsConfig) !== false
+    expect(testFooEnabled).toBe(true)
+
+    // test_bar should be enabled
+    const testBarEnabled = Wildcard.all("test_bar", toolsConfig) !== false
+    expect(testBarEnabled).toBe(true)
+
+    // other tools should be disabled
+    const otherEnabled = Wildcard.all("other", toolsConfig) !== false
+    expect(otherEnabled).toBe(false)
+  })
+
+  test("more specific pattern overrides general pattern", () => {
+    const toolsConfig = { "*": true, "danger*": false, danger_safe: true }
+
+    // normal tools enabled
+    expect(Wildcard.all("echo", toolsConfig) !== false).toBe(true)
+
+    // danger_foo disabled (matches danger*)
+    expect(Wildcard.all("danger_foo", toolsConfig) !== false).toBe(false)
+
+    // danger_safe enabled (more specific override)
+    expect(Wildcard.all("danger_safe", toolsConfig) !== false).toBe(true)
+  })
+})
+
+// =============================================================================
+// Integration Tests: McpServer.listTools()
+// =============================================================================
+// These tests verify that McpServer.listTools() correctly filters tools
+// based on config and returns proper tool info.
+// =============================================================================
+
+describe("mcp server listTools", () => {
+  test("returns custom tools when mcpServer.enabled is true", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Symlink node_modules so tool files can import zod
+        await fs.symlink(nodeModulesPath, path.join(dir, "node_modules"), "dir")
+
+        // Create .opencode/tool directory structure
+        const toolDir = path.join(dir, ".opencode", "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        // Create a simple echo tool
+        await Bun.write(
+          path.join(toolDir, "echo.ts"),
+          `import z from "zod"
+
+export default {
+  description: "Echo the input message",
+  args: {
+    message: z.string().describe("The message to echo"),
+  },
+  execute: async ({ message }) => message,
+}
+`,
+        )
+
+        // Create config with mcpServer enabled
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            mcpServer: {
+              enabled: true,
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { McpServer } = await import("../../src/mcp/server")
+        const tools = await McpServer.listTools()
+
+        // Should have at least one tool (echo)
+        expect(tools.length).toBeGreaterThanOrEqual(1)
+
+        // Find the echo tool
+        const echoTool = tools.find((t: { id: string; description: string }) => t.id === "echo")
+        expect(echoTool).toBeDefined()
+        expect(echoTool?.description).toBe("Echo the input message")
+      },
+    })
+  })
+
+  test('filters tools with { "*": false }', async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Symlink node_modules so tool files can import zod
+        await fs.symlink(nodeModulesPath, path.join(dir, "node_modules"), "dir")
+
+        // Create .opencode/tool directory structure
+        const toolDir = path.join(dir, ".opencode", "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        // Create a simple echo tool
+        await Bun.write(
+          path.join(toolDir, "echo.ts"),
+          `import z from "zod"
+
+export default {
+  description: "Echo the input message",
+  args: {
+    message: z.string().describe("The message to echo"),
+  },
+  execute: async ({ message }) => message,
+}
+`,
+        )
+
+        // Create config with all tools disabled
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            mcpServer: {
+              enabled: true,
+              tools: {
+                "*": false,
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { McpServer } = await import("../../src/mcp/server")
+        const tools = await McpServer.listTools()
+
+        // Should have no tools when all are disabled
+        expect(tools.length).toBe(0)
+      },
+    })
+  })
+
+  test('selective enable with { "*": false, "echo": true }', async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Symlink node_modules so tool files can import zod
+        await fs.symlink(nodeModulesPath, path.join(dir, "node_modules"), "dir")
+
+        // Create .opencode/tool directory structure
+        const toolDir = path.join(dir, ".opencode", "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        // Create echo tool
+        await Bun.write(
+          path.join(toolDir, "echo.ts"),
+          `import z from "zod"
+
+export default {
+  description: "Echo the input message",
+  args: {
+    message: z.string().describe("The message to echo"),
+  },
+  execute: async ({ message }) => message,
+}
+`,
+        )
+
+        // Create another tool (foo)
+        await Bun.write(
+          path.join(toolDir, "foo.ts"),
+          `import z from "zod"
+
+export default {
+  description: "Foo tool",
+  args: {
+    input: z.string(),
+  },
+  execute: async ({ input }) => "foo: " + input,
+}
+`,
+        )
+
+        // Create config with only echo enabled
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            mcpServer: {
+              enabled: true,
+              tools: {
+                "*": false,
+                echo: true,
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { McpServer } = await import("../../src/mcp/server")
+        const tools = await McpServer.listTools()
+
+        // Should have exactly one tool (echo)
+        expect(tools.length).toBe(1)
+        expect(tools[0].id).toBe("echo")
+      },
+    })
+  })
+
+  test('selective disable with { "*": true, "danger": false }', async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Symlink node_modules so tool files can import zod
+        await fs.symlink(nodeModulesPath, path.join(dir, "node_modules"), "dir")
+
+        // Create .opencode/tool directory structure
+        const toolDir = path.join(dir, ".opencode", "tool")
+        await fs.mkdir(toolDir, { recursive: true })
+
+        // Create echo tool
+        await Bun.write(
+          path.join(toolDir, "echo.ts"),
+          `import z from "zod"
+
+export default {
+  description: "Echo the input message",
+  args: {
+    message: z.string(),
+  },
+  execute: async ({ message }) => message,
+}
+`,
+        )
+
+        // Create danger tool
+        await Bun.write(
+          path.join(toolDir, "danger.ts"),
+          `import z from "zod"
+
+export default {
+  description: "Dangerous tool",
+  args: {
+    input: z.string(),
+  },
+  execute: async ({ input }) => "danger: " + input,
+}
+`,
+        )
+
+        // Create config with danger disabled
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            mcpServer: {
+              enabled: true,
+              tools: {
+                "*": true,
+                danger: false,
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { McpServer } = await import("../../src/mcp/server")
+        const tools = await McpServer.listTools()
+
+        // Should have echo but not danger
+        const toolIds = tools.map((t: { id: string; description: string }) => t.id)
+        expect(toolIds).toContain("echo")
+        expect(toolIds).not.toContain("danger")
+      },
+    })
+  })
+})
+
+// =============================================================================
+// Note: Full MCP subprocess integration tests
+// =============================================================================
+// Full subprocess-based integration tests (starting `opencode mcp serve` as a
+// subprocess and connecting with MCP client SDK) would require additional setup:
+//
+// 1. Building the opencode CLI or having it available
+// 2. Spawning it as a subprocess with stdio pipes
+// 3. Using @modelcontextprotocol/sdk/client to connect
+// 4. Managing process lifecycle and cleanup
+//
+// These tests are more complex and may be flaky in CI environments. The unit
+// tests above cover the core filtering logic, and the integration tests verify
+// that McpServer.listTools() works correctly with real config files.
+//
+// For manual verification, use:
+//   1. Create a project with .opencode/tool/echo.ts and opencode.json config
+//   2. Run: opencode mcp serve --list
+//   3. Verify the tool list output
+// =============================================================================

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -77,6 +77,7 @@ export default defineConfig({
             "permissions",
             "lsp",
             "mcp-servers",
+            "mcp-server",
             "acp",
             "skills",
             "custom-tools",

--- a/packages/web/src/content/docs/mcp-server.mdx
+++ b/packages/web/src/content/docs/mcp-server.mdx
@@ -1,0 +1,162 @@
+---
+title: MCP Server
+description: Run OpenCode as an MCP server to expose custom tools.
+---
+
+OpenCode can run as an MCP server, allowing external MCP clients to access your [custom tools](/docs/custom-tools). This enables integration with other AI tools and editors that support the Model Context Protocol.
+
+:::note
+The MCP server exposes **only custom tools** (from `.opencode/tool/` and plugins). Built-in tools like `bash`, `read`, `write`, etc. are not exposed for security reasons.
+:::
+
+---
+
+## Enable
+
+To enable the MCP server, add `mcpServer` to your OpenCode config and set `enabled` to `true`.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcpServer": {
+    "enabled": true
+  }
+}
+```
+
+---
+
+## Start the server
+
+Use the `opencode mcp serve` command to start the MCP server. The server communicates over STDIO, making it compatible with any MCP client.
+
+```bash
+opencode mcp serve
+```
+
+The server will refuse to start unless `mcpServer.enabled` is `true` in your config. You can bypass this check with the `--force` flag.
+
+```bash
+opencode mcp serve --force
+```
+
+---
+
+### List tools
+
+Use the `--list` flag to see which tools would be exposed without starting the server. This is useful for debugging your configuration.
+
+```bash
+opencode mcp serve --list
+```
+
+This prints the tool names and descriptions, then exits.
+
+---
+
+## Filter tools
+
+By default, all custom tools are exposed. Use the `tools` option to control which tools are available.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcpServer": {
+    "enabled": true,
+    "tools": {
+      "*": false,
+      "echo": true
+    }
+  }
+}
+```
+
+This exposes only the `echo` tool while disabling all others.
+
+---
+
+### Wildcard patterns
+
+The `tools` option supports wildcard patterns, using the same syntax as [tool configuration](/docs/tools).
+
+| Pattern | Description |
+|---------|-------------|
+| `"*": true` | Enable all tools (default) |
+| `"*": false` | Disable all tools |
+| `"echo": true` | Enable the `echo` tool |
+| `"db_*": true` | Enable all tools starting with `db_` |
+| `"*_test": false` | Disable all tools ending with `_test` |
+
+---
+
+### Examples
+
+**Allowlist specific tools:**
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcpServer": {
+    "enabled": true,
+    "tools": {
+      "*": false,
+      "database": true,
+      "search": true
+    }
+  }
+}
+```
+
+**Blocklist specific tools:**
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcpServer": {
+    "enabled": true,
+    "tools": {
+      "*": true,
+      "dangerous_tool": false
+    }
+  }
+}
+```
+
+**Enable tools matching a pattern:**
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcpServer": {
+    "enabled": true,
+    "tools": {
+      "*": false,
+      "api_*": true
+    }
+  }
+}
+```
+
+---
+
+## Configuration options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `enabled` | Boolean | Enable or disable the MCP server. Required to be `true` to start. |
+| `tools` | Object | Map of tool patterns to boolean values for filtering. |
+
+---
+
+## Security
+
+The MCP server is designed with security in mind:
+
+- **Custom tools only** - Built-in tools (`bash`, `read`, `write`, `edit`, `glob`, `grep`) are never exposed. Only tools you create in `.opencode/tool/` or via plugins are available.
+- **User control** - You control which custom tools exist and what they can do.
+- **STDIO transport** - Communication is local via standard input/output, with no network exposure.
+- **Config-driven** - The server only starts when explicitly enabled in your config.
+
+:::tip
+Review your custom tools before enabling the MCP server. Only expose tools that are safe for external access.
+:::


### PR DESCRIPTION
Add ability to run OpenCode as an MCP server, allowing external MCP clients to access custom tools defined in `.opencode/tool/` and plugins.

Features:
- `opencode mcp serve` command to start stdio MCP server
- `opencode mcp serve --list` for dry-run tool listing
- Config-driven: `mcpServer.enabled` and `mcpServer.tools` for filtering
- Wildcard patterns for allowlist/blocklist tool filtering
- Only custom tools exposed (built-ins excluded for security)

Config example:
```json
{
  "mcpServer": {
    "enabled": true,
    "tools": { "*": false, "my-tool": true }
  }
}
```

Relates to: #3306 #1507 #296