### PR TITLE
fix: detect reserved agent name conflicts in custom agents

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -22,6 +22,8 @@ import { ConfigMarkdown } from "./markdown"
 export namespace Config {
   const log = Log.create({ service: "config" })
 
+  export const RESERVED_AGENT_NAMES = ["build", "plan", "general", "explore", "compaction", "title", "summary"] as const
+
   // Custom merge function that concatenates plugin arrays instead of replacing them
   function mergeConfigWithPlugins(target: Info, source: Info): Info {
     const merged = mergeDeep(target, source)
@@ -261,6 +263,13 @@ export namespace Config {
         const relativePath = agentFolderPath.replace(".md", "")
         const pathParts = relativePath.split("/")
         agentName = pathParts.slice(0, -1).join("/") + "/" + pathParts[pathParts.length - 1]
+      }
+
+      if (RESERVED_AGENT_NAMES.includes(agentName as (typeof RESERVED_AGENT_NAMES)[number])) {
+        throw new InvalidError({
+          path: item,
+          message: `"${agentName}" is a reserved agent name. Reserved names: ${RESERVED_AGENT_NAMES.join(", ")}. Choose a different name for your custom agent.`,
+        })
       }
 
       const config = {

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import { tmpdir } from "../fixture/fixture"
 import { Instance } from "../../src/project/instance"
 import { Agent } from "../../src/agent/agent"
+import { Config } from "../../src/config/config"
 
 test("loads built-in agents when no custom agents configured", async () => {
   await using tmp = await tmpdir()
@@ -141,6 +142,39 @@ Custom primary agent`,
       const custom = agents.find((a) => a.name === "custom")
       expect(custom).toBeDefined()
       expect(custom?.mode).toBe("primary")
+    },
+  })
+})
+
+test("throws error when custom agent uses reserved name", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      await fs.mkdir(opencodeDir, { recursive: true })
+      const agentDir = path.join(opencodeDir, "agent")
+      await fs.mkdir(agentDir, { recursive: true })
+
+      await Bun.write(
+        path.join(agentDir, "explore.md"),
+        `---
+model: test/model
+mode: subagent
+---
+Custom explore agent that conflicts with built-in`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        await Agent.list()
+        expect(true).toBe(false)
+      } catch (e: any) {
+        expect(e instanceof Config.InvalidError).toBe(true)
+        expect(e.data?.message).toContain("reserved agent name")
+        expect(e.data?.message).toContain("explore")
+      }
     },
   })
 })


### PR DESCRIPTION
## Summary

- Detects when users create custom agents (via `.opencode/agent/*.md` files) with names that conflict with built-in agents
- Throws a clear `Config.InvalidError` with a helpful message listing all reserved names
- Adds test coverage for the new validation

## Problem

When a user creates a custom agent with a name like `explore.md`, it silently conflicts with the built-in `explore` agent. This can lead to hours of debugging confusing behavior, as the user experienced firsthand.

## Solution

Added validation in `loadAgent()` that checks if the agent name matches any reserved name:
- `build`, `plan`, `general`, `explore`, `compaction`, `title`, `summary`

If a conflict is detected, OpenCode now throws a clear error:
```
"explore" is a reserved agent name. Reserved names: build, plan, general, explore, compaction, title, summary. Choose a different name for your custom agent.
```

## Changes

- `src/config/config.ts`: Added `RESERVED_AGENT_NAMES` constant and validation in `loadAgent()`
- `test/agent/agent.test.ts`: Added test case for reserved name detection