### PR TITLE
fix(opentui): prevent crash on Up arrow with empty history

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history-core.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history-core.ts
@@ -1,0 +1,51 @@
+import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
+
+export type PromptInfo = {
+  input: string
+  mode?: "normal" | "shell"
+  parts: (
+    | Omit<FilePart, "id" | "messageID" | "sessionID">
+    | Omit<AgentPart, "id" | "messageID" | "sessionID">
+    | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
+        source?: {
+          text: {
+            start: number
+            end: number
+            value: string
+          }
+        }
+      })
+  )[]
+}
+
+export function moveHistory(
+  history: PromptInfo[],
+  currentIndex: number,
+  direction: 1 | -1,
+  input: string,
+): { nextIndex: number; result: PromptInfo | undefined } {
+  if (!history.length) return { nextIndex: currentIndex, result: undefined }
+  const current = history.at(currentIndex)
+  if (!current) return { nextIndex: currentIndex, result: undefined }
+  if (current.input !== input && input.length) return { nextIndex: currentIndex, result: undefined }
+
+  const next = currentIndex + direction
+  if (Math.abs(next) > history.length) {
+    if (currentIndex === 0) {
+      return { nextIndex: currentIndex, result: { input: "", parts: [] } }
+    }
+    return { nextIndex: currentIndex, result: history.at(currentIndex) }
+  }
+  if (next > 0) {
+    if (currentIndex === 0) {
+      return { nextIndex: currentIndex, result: { input: "", parts: [] } }
+    }
+    return { nextIndex: currentIndex, result: history.at(currentIndex) }
+  }
+
+  if (next === 0) {
+    return { nextIndex: 0, result: { input: "", parts: [] } }
+  }
+
+  return { nextIndex: next, result: history.at(next) }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -5,25 +5,9 @@ import { createStore, produce } from "solid-js/store"
 import { clone } from "remeda"
 import { createSimpleContext } from "../../context/helper"
 import { appendFile, writeFile } from "fs/promises"
-import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
+import { moveHistory, type PromptInfo } from "./history-core"
 
-export type PromptInfo = {
-  input: string
-  mode?: "normal" | "shell"
-  parts: (
-    | Omit<FilePart, "id" | "messageID" | "sessionID">
-    | Omit<AgentPart, "id" | "messageID" | "sessionID">
-    | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
-        source?: {
-          text: {
-            start: number
-            end: number
-            value: string
-          }
-        }
-      })
-  )[]
-}
+export type { PromptInfo }
 
 const MAX_HISTORY_ENTRIES = 50
 
@@ -62,25 +46,9 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
 
     return {
       move(direction: 1 | -1, input: string): PromptInfo | undefined {
-        if (!store.history.length) return undefined
-        const current = store.history.at(store.index)
-        if (!current) return undefined
-        if (current.input !== input && input.length) return undefined
-        setStore(
-          produce((draft) => {
-            const next = store.index + direction
-            if (Math.abs(next) > store.history.length) return
-            if (next > 0) return
-            draft.index = next
-          }),
-        )
-        if (store.index === 0) {
-          return {
-            input: "",
-            parts: [],
-          }
-        }
-        return store.history.at(store.index)
+        const { nextIndex, result } = moveHistory(store.history, store.index, direction, input)
+        setStore("index", nextIndex)
+        return result
       },
       append(item: PromptInfo) {
         const entry = clone(item)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/history.tsx
@@ -61,11 +61,11 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
     })
 
     return {
-      move(direction: 1 | -1, input: string) {
+      move(direction: 1 | -1, input: string): PromptInfo | undefined {
         if (!store.history.length) return undefined
         const current = store.history.at(store.index)
         if (!current) return undefined
-        if (current.input !== input && input.length) return
+        if (current.input !== input && input.length) return undefined
         setStore(
           produce((draft) => {
             const next = store.index + direction
@@ -74,11 +74,12 @@ export const { use: usePromptHistory, provider: PromptHistoryProvider } = create
             draft.index = next
           }),
         )
-        if (store.index === 0)
+        if (store.index === 0) {
           return {
             input: "",
             parts: [],
           }
+        }
         return store.history.at(store.index)
       },
       append(item: PromptInfo) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -886,7 +886,7 @@ export function Prompt(props: PromptProps) {
                     const direction = keybind.match("history_previous", e) ? -1 : 1
                     const item = history.move(direction, input.plainText)
 
-                    if (item) {
+                    if (item && typeof item.input === "string" && Array.isArray(item.parts)) {
                       input.setText(item.input)
                       setStore("prompt", item)
                       setStore("mode", item.mode ?? "normal")

--- a/packages/opencode/test/prompt-history.test.ts
+++ b/packages/opencode/test/prompt-history.test.ts
@@ -1,242 +1,135 @@
-import { describe, test, expect, beforeEach } from "bun:test"
-import { createStore, produce } from "solid-js/store"
+import { describe, test, expect } from "bun:test"
+import { moveHistory, type PromptInfo } from "../src/cli/cmd/tui/component/prompt/history-core"
 
-// Minimal type definition matching the actual PromptInfo
-type PromptInfo = {
-  input: string
-  mode?: "normal" | "shell"
-  parts: any[]
-}
+describe("moveHistory", () => {
+  describe("with empty history", () => {
+    test("should return undefined and not change index when history is empty and pressing Up", () => {
+      const history: PromptInfo[] = []
+      const result = moveHistory(history, 0, -1, "")
 
-/**
- * Standalone implementation of the history move logic for testing.
- * This mirrors the logic in history.tsx without the SolidJS context dependencies.
- */
-function createTestHistory() {
-  let store = {
-    index: 0,
-    history: [] as PromptInfo[],
-  }
-
-  return {
-    setHistory(history: PromptInfo[]) {
-      store.history = history
-      store.index = 0
-    },
-    getIndex() {
-      return store.index
-    },
-    move(direction: 1 | -1, input: string): PromptInfo | undefined {
-      // Guard: no history means nothing to navigate
-      if (!store.history.length) return undefined
-
-      const current = store.history.at(store.index)
-      // Guard: if we can't find current position in history, bail out
-      if (!current) return undefined
-
-      // Guard: if user has modified input from what's in history, don't navigate
-      if (current.input !== input && input.length) return undefined
-
-      const next = store.index + direction
-      // Don't go beyond history bounds
-      if (Math.abs(next) > store.history.length) {
-        // Still at current position, return current or empty
-        if (store.index === 0) {
-          return { input: "", parts: [] }
-        }
-        return store.history.at(store.index)
-      }
-      // Don't go past index 0 (most recent)
-      if (next > 0) {
-        if (store.index === 0) {
-          return { input: "", parts: [] }
-        }
-        return store.history.at(store.index)
-      }
-      
-      store.index = next
-
-      // At index 0, return empty prompt (user's current typing position)
-      if (store.index === 0) {
-        return { input: "", parts: [] }
-      }
-
-      // Return the history entry at current index
-      return store.history.at(store.index)
-    },
-    append(item: PromptInfo) {
-      store.history.push({ ...item })
-      store.index = 0
-    },
-  }
-}
-
-describe("Prompt History", () => {
-  describe("move() with empty history", () => {
-    test("should return undefined when history is empty and pressing Up", () => {
-      const history = createTestHistory()
-      const result = history.move(-1, "")
-      expect(result).toBeUndefined()
+      expect(result.result).toBeUndefined()
+      expect(result.nextIndex).toBe(0)
     })
 
-    test("should return undefined when history is empty and pressing Down", () => {
-      const history = createTestHistory()
-      const result = history.move(1, "")
-      expect(result).toBeUndefined()
+    test("should return undefined and not change index when history is empty and pressing Down", () => {
+      const history: PromptInfo[] = []
+      const result = moveHistory(history, 0, 1, "")
+
+      expect(result.result).toBeUndefined()
+      expect(result.nextIndex).toBe(0)
     })
 
-    test("should return undefined when history is empty with non-empty input", () => {
-      const history = createTestHistory()
-      const result = history.move(-1, "some text")
-      expect(result).toBeUndefined()
+    test("should return undefined and not change index when history is empty with non-empty input", () => {
+      const history: PromptInfo[] = []
+      const result = moveHistory(history, 0, -1, "some text")
+
+      expect(result.result).toBeUndefined()
+      expect(result.nextIndex).toBe(0)
     })
   })
 
-  describe("move() with single history entry", () => {
+  describe("with single history entry", () => {
     test("should navigate to history entry on Up arrow", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "test command", parts: [] }])
-      
-      const result = history.move(-1, "")
-      
-      expect(result).toBeDefined()
-      expect(result?.input).toBe("test command")
-      expect(result?.parts).toEqual([])
+      const history = [{ input: "test command", parts: [] }]
+      const result = moveHistory(history, 0, -1, "")
+
+      expect(result.result).toBeDefined()
+      expect(result.result?.input).toBe("test command")
+      expect(result.result?.parts).toEqual([])
+      expect(result.nextIndex).toBe(-1)
     })
 
     test("should return to empty prompt on Down arrow after navigating up", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "test command", parts: [] }])
-      
-      // Navigate up first
-      history.move(-1, "")
-      
-      // Then navigate down
-      const result = history.move(1, "test command")
-      
-      expect(result).toBeDefined()
-      expect(result?.input).toBe("")
-      expect(result?.parts).toEqual([])
+      const history = [{ input: "test command", parts: [] }]
+
+      const result1 = moveHistory(history, 0, -1, "")
+      expect(result1.result?.input).toBe("test command")
+
+      const result2 = moveHistory(history, result1.nextIndex, 1, "test command")
+      expect(result2.result).toBeDefined()
+      expect(result2.result?.input).toBe("")
+      expect(result2.result?.parts).toEqual([])
+      expect(result2.nextIndex).toBe(0)
     })
 
     test("should not navigate beyond history bounds", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "test command", parts: [] }])
-      
-      // Navigate up once
-      history.move(-1, "")
-      
-      // Try to navigate up again (should stay at same position)
-      const result = history.move(-1, "test command")
-      
-      expect(result).toBeDefined()
-      expect(result?.input).toBe("test command")
+      const history = [{ input: "test command", parts: [] }]
+
+      const result1 = moveHistory(history, 0, -1, "")
+      const result2 = moveHistory(history, result1.nextIndex, -1, "test command")
+
+      expect(result2.result).toBeDefined()
+      expect(result2.result?.input).toBe("test command")
+      expect(result2.nextIndex).toBe(-1)
     })
   })
 
-  describe("move() with multiple history entries", () => {
+  describe("with multiple history entries", () => {
     test("should navigate through multiple entries", () => {
-      const history = createTestHistory()
-      history.setHistory([
+      const history = [
         { input: "first", parts: [] },
         { input: "second", parts: [] },
         { input: "third", parts: [] },
-      ])
-      
-      // Navigate up to most recent (third)
-      let result = history.move(-1, "")
-      expect(result?.input).toBe("third")
-      
-      // Navigate up to second
-      result = history.move(-1, "third")
-      expect(result?.input).toBe("second")
-      
-      // Navigate up to first
-      result = history.move(-1, "second")
-      expect(result?.input).toBe("first")
-      
-      // Navigate down back to second
-      result = history.move(1, "first")
-      expect(result?.input).toBe("second")
+      ]
+
+      let result = moveHistory(history, 0, -1, "")
+      expect(result.result?.input).toBe("third")
+      expect(result.nextIndex).toBe(-1)
+
+      result = moveHistory(history, result.nextIndex, -1, "third")
+      expect(result.result?.input).toBe("second")
+      expect(result.nextIndex).toBe(-2)
+
+      result = moveHistory(history, result.nextIndex, -1, "second")
+      expect(result.result?.input).toBe("first")
+      expect(result.nextIndex).toBe(-3)
+
+      result = moveHistory(history, result.nextIndex, 1, "first")
+      expect(result.result?.input).toBe("second")
+      expect(result.nextIndex).toBe(-2)
     })
   })
 
-  describe("move() input validation", () => {
+  describe("input validation", () => {
     test("should not navigate if input has been modified", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "original", parts: [] }])
-      
-      // Navigate to history
-      history.move(-1, "")
-      
-      // Try to navigate with modified input
-      const result = history.move(-1, "modified text")
-      
-      // Should return undefined because input doesn't match
-      expect(result).toBeUndefined()
+      const history = [{ input: "original", parts: [] }]
+
+      const result1 = moveHistory(history, 0, -1, "")
+      const result2 = moveHistory(history, result1.nextIndex, -1, "modified text")
+
+      expect(result2.result).toBeUndefined()
+      expect(result2.nextIndex).toBe(result1.nextIndex)
     })
 
     test("should allow navigation with empty input", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "test", parts: [] }])
-      
-      const result = history.move(-1, "")
-      
-      expect(result).toBeDefined()
-      expect(result?.input).toBe("test")
+      const history = [{ input: "test", parts: [] }]
+      const result = moveHistory(history, 0, -1, "")
+
+      expect(result.result).toBeDefined()
+      expect(result.result?.input).toBe("test")
     })
   })
 
   describe("returned PromptInfo structure", () => {
     test("should always return valid PromptInfo with input and parts", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "test", parts: [{ type: "text", text: "hello" }] }])
-      
-      const result = history.move(-1, "")
-      
-      expect(result).toBeDefined()
-      expect(typeof result?.input).toBe("string")
-      expect(Array.isArray(result?.parts)).toBe(true)
+      const history = [{ input: "test", parts: [{ type: "text" as const, text: "hello" }] }]
+      const result = moveHistory(history, 0, -1, "")
+
+      expect(result.result).toBeDefined()
+      expect(typeof result.result?.input).toBe("string")
+      expect(Array.isArray(result.result?.parts)).toBe(true)
     })
 
     test("empty prompt return should have valid structure", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "test", parts: [] }])
-      
-      // Navigate up then down to get empty prompt
-      history.move(-1, "")
-      const result = history.move(1, "test")
-      
-      expect(result).toBeDefined()
-      expect(result?.input).toBe("")
-      expect(Array.isArray(result?.parts)).toBe(true)
-      expect(result?.parts.length).toBe(0)
-    })
-  })
+      const history = [{ input: "test", parts: [] }]
 
-  describe("append()", () => {
-    test("should add entry to history", () => {
-      const history = createTestHistory()
-      
-      history.append({ input: "new entry", parts: [] })
-      
-      const result = history.move(-1, "")
-      expect(result?.input).toBe("new entry")
-    })
+      const result1 = moveHistory(history, 0, -1, "")
+      const result2 = moveHistory(history, result1.nextIndex, 1, "test")
 
-    test("should reset index after append", () => {
-      const history = createTestHistory()
-      history.setHistory([{ input: "old", parts: [] }])
-      
-      // Navigate into history
-      history.move(-1, "")
-      
-      // Append new entry
-      history.append({ input: "new", parts: [] })
-      
-      // Index should be reset, so navigating up should show "new"
-      const result = history.move(-1, "")
-      expect(result?.input).toBe("new")
+      expect(result2.result).toBeDefined()
+      expect(result2.result?.input).toBe("")
+      expect(Array.isArray(result2.result?.parts)).toBe(true)
+      expect(result2.result?.parts.length).toBe(0)
     })
   })
 })

--- a/packages/opencode/test/prompt-history.test.ts
+++ b/packages/opencode/test/prompt-history.test.ts
@@ -1,0 +1,242 @@
+import { describe, test, expect, beforeEach } from "bun:test"
+import { createStore, produce } from "solid-js/store"
+
+// Minimal type definition matching the actual PromptInfo
+type PromptInfo = {
+  input: string
+  mode?: "normal" | "shell"
+  parts: any[]
+}
+
+/**
+ * Standalone implementation of the history move logic for testing.
+ * This mirrors the logic in history.tsx without the SolidJS context dependencies.
+ */
+function createTestHistory() {
+  let store = {
+    index: 0,
+    history: [] as PromptInfo[],
+  }
+
+  return {
+    setHistory(history: PromptInfo[]) {
+      store.history = history
+      store.index = 0
+    },
+    getIndex() {
+      return store.index
+    },
+    move(direction: 1 | -1, input: string): PromptInfo | undefined {
+      // Guard: no history means nothing to navigate
+      if (!store.history.length) return undefined
+
+      const current = store.history.at(store.index)
+      // Guard: if we can't find current position in history, bail out
+      if (!current) return undefined
+
+      // Guard: if user has modified input from what's in history, don't navigate
+      if (current.input !== input && input.length) return undefined
+
+      const next = store.index + direction
+      // Don't go beyond history bounds
+      if (Math.abs(next) > store.history.length) {
+        // Still at current position, return current or empty
+        if (store.index === 0) {
+          return { input: "", parts: [] }
+        }
+        return store.history.at(store.index)
+      }
+      // Don't go past index 0 (most recent)
+      if (next > 0) {
+        if (store.index === 0) {
+          return { input: "", parts: [] }
+        }
+        return store.history.at(store.index)
+      }
+      
+      store.index = next
+
+      // At index 0, return empty prompt (user's current typing position)
+      if (store.index === 0) {
+        return { input: "", parts: [] }
+      }
+
+      // Return the history entry at current index
+      return store.history.at(store.index)
+    },
+    append(item: PromptInfo) {
+      store.history.push({ ...item })
+      store.index = 0
+    },
+  }
+}
+
+describe("Prompt History", () => {
+  describe("move() with empty history", () => {
+    test("should return undefined when history is empty and pressing Up", () => {
+      const history = createTestHistory()
+      const result = history.move(-1, "")
+      expect(result).toBeUndefined()
+    })
+
+    test("should return undefined when history is empty and pressing Down", () => {
+      const history = createTestHistory()
+      const result = history.move(1, "")
+      expect(result).toBeUndefined()
+    })
+
+    test("should return undefined when history is empty with non-empty input", () => {
+      const history = createTestHistory()
+      const result = history.move(-1, "some text")
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("move() with single history entry", () => {
+    test("should navigate to history entry on Up arrow", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "test command", parts: [] }])
+      
+      const result = history.move(-1, "")
+      
+      expect(result).toBeDefined()
+      expect(result?.input).toBe("test command")
+      expect(result?.parts).toEqual([])
+    })
+
+    test("should return to empty prompt on Down arrow after navigating up", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "test command", parts: [] }])
+      
+      // Navigate up first
+      history.move(-1, "")
+      
+      // Then navigate down
+      const result = history.move(1, "test command")
+      
+      expect(result).toBeDefined()
+      expect(result?.input).toBe("")
+      expect(result?.parts).toEqual([])
+    })
+
+    test("should not navigate beyond history bounds", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "test command", parts: [] }])
+      
+      // Navigate up once
+      history.move(-1, "")
+      
+      // Try to navigate up again (should stay at same position)
+      const result = history.move(-1, "test command")
+      
+      expect(result).toBeDefined()
+      expect(result?.input).toBe("test command")
+    })
+  })
+
+  describe("move() with multiple history entries", () => {
+    test("should navigate through multiple entries", () => {
+      const history = createTestHistory()
+      history.setHistory([
+        { input: "first", parts: [] },
+        { input: "second", parts: [] },
+        { input: "third", parts: [] },
+      ])
+      
+      // Navigate up to most recent (third)
+      let result = history.move(-1, "")
+      expect(result?.input).toBe("third")
+      
+      // Navigate up to second
+      result = history.move(-1, "third")
+      expect(result?.input).toBe("second")
+      
+      // Navigate up to first
+      result = history.move(-1, "second")
+      expect(result?.input).toBe("first")
+      
+      // Navigate down back to second
+      result = history.move(1, "first")
+      expect(result?.input).toBe("second")
+    })
+  })
+
+  describe("move() input validation", () => {
+    test("should not navigate if input has been modified", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "original", parts: [] }])
+      
+      // Navigate to history
+      history.move(-1, "")
+      
+      // Try to navigate with modified input
+      const result = history.move(-1, "modified text")
+      
+      // Should return undefined because input doesn't match
+      expect(result).toBeUndefined()
+    })
+
+    test("should allow navigation with empty input", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "test", parts: [] }])
+      
+      const result = history.move(-1, "")
+      
+      expect(result).toBeDefined()
+      expect(result?.input).toBe("test")
+    })
+  })
+
+  describe("returned PromptInfo structure", () => {
+    test("should always return valid PromptInfo with input and parts", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "test", parts: [{ type: "text", text: "hello" }] }])
+      
+      const result = history.move(-1, "")
+      
+      expect(result).toBeDefined()
+      expect(typeof result?.input).toBe("string")
+      expect(Array.isArray(result?.parts)).toBe(true)
+    })
+
+    test("empty prompt return should have valid structure", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "test", parts: [] }])
+      
+      // Navigate up then down to get empty prompt
+      history.move(-1, "")
+      const result = history.move(1, "test")
+      
+      expect(result).toBeDefined()
+      expect(result?.input).toBe("")
+      expect(Array.isArray(result?.parts)).toBe(true)
+      expect(result?.parts.length).toBe(0)
+    })
+  })
+
+  describe("append()", () => {
+    test("should add entry to history", () => {
+      const history = createTestHistory()
+      
+      history.append({ input: "new entry", parts: [] })
+      
+      const result = history.move(-1, "")
+      expect(result?.input).toBe("new entry")
+    })
+
+    test("should reset index after append", () => {
+      const history = createTestHistory()
+      history.setHistory([{ input: "old", parts: [] }])
+      
+      // Navigate into history
+      history.move(-1, "")
+      
+      // Append new entry
+      history.append({ input: "new", parts: [] })
+      
+      // Index should be reset, so navigating up should show "new"
+      const result = history.move(-1, "")
+      expect(result?.input).toBe("new")
+    })
+  })
+})


### PR DESCRIPTION
Fixes #3414
Related: #3221

Pressing Up/Down arrow with empty input history crashes the TUI.

Changes:
- Added explicit return type to `history.move()`
- Changed implicit `return` to explicit `return undefined`
- Added validation before using history items
- Added regression tests
