### PR TITLE
fix: variants for custom models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -697,7 +697,9 @@ export namespace Provider {
           headers: mergeDeep(existingModel?.headers ?? {}, model.headers ?? {}),
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
+          variants: {},
         }
+        parsedModel.variants = mapValues(ProviderTransform.variants(parsedModel), (v) => ({ disabled: false, ...v }))
         parsed.models[modelID] = parsedModel
       }
       database[providerID] = parsed


### PR DESCRIPTION
Models defined in user config (opencode.jsonc) with custom providers now get auto-generated variants via `ProviderTransform.variants()`.