### PR TITLE
fix(opencode): preserve user model variants

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -616,11 +616,21 @@ export namespace Config {
   })
   export type Layout = z.infer<typeof Layout>
 
+  const ModelVariant = z
+    .object({
+      disabled: z.boolean().optional(),
+    })
+    .catchall(z.any())
+
+  const ModelConfig = ModelsDev.Model.partial().extend({
+    variants: z.record(z.string(), ModelVariant).optional(),
+  })
+
   export const Provider = ModelsDev.Provider.partial()
     .extend({
       whitelist: z.array(z.string()).optional(),
       blacklist: z.array(z.string()).optional(),
-      models: z.record(z.string(), ModelsDev.Model.partial()).optional(),
+      models: z.record(z.string(), ModelConfig).optional(),
       options: z
         .object({
           apiKey: z.string().optional(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -698,6 +698,10 @@ export namespace Provider {
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
         }
+
+        const variantSource = model.variants ?? existingModel?.variants ?? ProviderTransform.variants(parsedModel)
+        parsedModel.variants = mapValues(variantSource ?? {}, (variant) => ({ disabled: false, ...variant }))
+
         parsed.models[modelID] = parsedModel
       }
       database[providerID] = parsed


### PR DESCRIPTION
## Summary
- Preserve user-defined model variants and per-variant fields instead of clobbering them with auto-generated defaults
- Fall back to ProviderTransform.variants only when the user model does not define variants
- Allow per-variant config payloads (e.g. "reasoningEffort": "medium") in user config

## Details
During provider parsing, we iterate each user-defined model (by model ID) and build a parsed model. For variants, we now choose the first available source in order: `model.variants` (from user config), `existingModel?.variants` (from registry), then `ProviderTransform.variants(parsedModel)` as a fallback. This preserves explicit user per-variant settings like `reasoningEffort: "medium"` while still auto-generating variants when none are provided.

Checked on both Codex Auth & Gemini Antigrav Proxy. Codex receives the correct reasoning effort, but it's harder to measure. Gemini visibly thinks differently while cycling low/medium/high.