### PR TITLE
fix(provider): validate baseURL format to prevent ERR_INVALID_URL

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -869,7 +869,15 @@ export namespace Provider {
         options["includeUsage"] = true
       }
 
-      if (!options["baseURL"]) options["baseURL"] = model.api.url
+      // Clean up invalid baseURL to let SDK use its default
+      // baseURL must be a valid URL (starts with http:// or https://)
+      const isValidUrl = (url: string | undefined | null): url is string => {
+        return typeof url === "string" && (url.startsWith("http://") || url.startsWith("https://"))
+      }
+      if (!isValidUrl(options["baseURL"])) {
+        delete options["baseURL"]
+        if (isValidUrl(model.api.url)) options["baseURL"] = model.api.url
+      }
       if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
       if (model.headers)
         options["headers"] = {


### PR DESCRIPTION
## Summary

- Adds URL format validation for provider `baseURL`/`api` fields
- Prevents cryptic `ERR_INVALID_URL` errors when invalid values like `"anthropic"` or `""` reach the SDK
- Defense-in-depth with two validation layers

## Changes

### Phase 1: Runtime Validation (`provider.ts`)
- Validates `baseURL` is a proper URL (`http://` or `https://`) before passing to SDK
- Invalid values are filtered out, letting SDK use its default endpoint

### Phase 2: Config-Time Validation (`config.ts`)
- Catches invalid `api` field values at config load time
- Hybrid strategy: validates against models.dev cache when available, falls back to URL format check
- Provides helpful error messages with hints

## Root Cause

The `@ai-sdk/*` SDKs use nullish coalescing (`??`) for baseURL defaults, which doesn't catch empty strings or non-URL values—only `null`/`undefined`.

## Test Plan

- [x] Typecheck passes
- [x] Invalid config values (`"api": "anthropic"`) caught with clear error message
- [x] Valid configs load normally
- [x] SDK uses default URL when invalid baseURL is filtered

## Example Error Message

```
Invalid provider configuration:

  provider.anthropic.api: Invalid value "anthropic"
    Hint: Remove the "api" field to use the default anthropic endpoint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)