### PR TITLE
fix(desktop): Windows support for PTY and cross-platform build scripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -176,6 +176,7 @@
       "version": "1.0.218",
       "dependencies": {
         "@opencode-ai/app": "workspace:*",
+        "@opencode-ai/util": "workspace:*",
         "@solid-primitives/storage": "catalog:",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "~2",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@opencode-ai/app": "workspace:*",
+    "@opencode-ai/util": "workspace:*",
     "@solid-primitives/storage": "catalog:",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "~2",

--- a/packages/desktop/scripts/predev.ts
+++ b/packages/desktop/scripts/predev.ts
@@ -1,12 +1,10 @@
 import { $ } from "bun"
 
-import { copyBinaryToSidecarFolder, getCurrentSidecar } from "./utils"
+import { copyBinaryToSidecarFolder, getCurrentSidecar, RUST_TARGET } from "./utils"
 
-const RUST_TARGET = Bun.env.TAURI_ENV_TARGET_TRIPLE
+const sidecarConfig = getCurrentSidecar()
 
-const sidecarConfig = getCurrentSidecar(RUST_TARGET)
-
-const binaryPath = `../opencode/dist/${sidecarConfig.ocBinary}/bin/opencode`
+const binaryPath = `../opencode/dist/${sidecarConfig.ocBinary}/bin/opencode${process.platform === "win32" ? ".exe" : ""}`
 
 await $`cd ../opencode && bun run build --single`
 

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs/promises"
+import { getPtyLibName } from "@opencode-ai/util/pty"
 
 export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; assetExt: string }> = [
   {
@@ -55,20 +56,9 @@ export async function copyBinaryToSidecarFolder(source: string, target = RUST_TA
 
   console.log(`Copied ${source} to ${dest}`)
 
-  const isWindows = target.includes("windows")
-  const isLinux = target.includes("linux")
-  const isArm64 = target.startsWith("aarch64")
-
-  const ptyLib = isWindows
-    ? "rust_pty.dll"
-    : isLinux
-      ? isArm64
-        ? "librust_pty_arm64.so"
-        : "librust_pty.so"
-      : isArm64
-        ? "librust_pty_arm64.dylib"
-        : "librust_pty.dylib"
-
+  const os = target.includes("windows") ? "win32" : target.includes("linux") ? "linux" : "darwin"
+  const arch = target.startsWith("aarch64") ? "arm64" : "x64"
+  const ptyLib = getPtyLibName(os, arch)
   const ptySource = path.join(path.dirname(source), ptyLib)
   const ptySourceExists = await fs
     .access(ptySource)

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -1,4 +1,5 @@
-import { $ } from "bun"
+import path from "path"
+import fs from "fs/promises"
 
 export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; assetExt: string }> = [
   {
@@ -28,21 +29,53 @@ export const SIDECAR_BINARIES: Array<{ rustTarget: string; ocBinary: string; ass
   },
 ]
 
-export const RUST_TARGET = Bun.env.RUST_TARGET
+export const RUST_TARGET =
+  Bun.env.RUST_TARGET ||
+  Bun.env.TAURI_ENV_TARGET_TRIPLE ||
+  (process.platform === "win32"
+    ? "x86_64-pc-windows-msvc"
+    : process.platform === "darwin"
+      ? process.arch === "arm64"
+        ? "aarch64-apple-darwin"
+        : "x86_64-apple-darwin"
+      : "x86_64-unknown-linux-gnu")
 
 export function getCurrentSidecar(target = RUST_TARGET) {
-  if (!target && !RUST_TARGET) throw new Error("RUST_TARGET not set")
-
   const binaryConfig = SIDECAR_BINARIES.find((b) => b.rustTarget === target)
-  if (!binaryConfig) throw new Error(`Sidecar configuration not available for Rust target '${RUST_TARGET}'`)
+  if (!binaryConfig) throw new Error(`Sidecar configuration not available for Rust target '${target}'`)
 
   return binaryConfig
 }
 
 export async function copyBinaryToSidecarFolder(source: string, target = RUST_TARGET) {
-  await $`mkdir -p src-tauri/sidecars`
-  const dest = `src-tauri/sidecars/opencode-cli-${target}${process.platform === "win32" ? ".exe" : ""}`
-  await $`cp ${source} ${dest}`
+  const destDir = "src-tauri/sidecars"
+  await fs.mkdir(destDir, { recursive: true })
+  const dest = `${destDir}/opencode-cli-${target}${process.platform === "win32" ? ".exe" : ""}`
+  await fs.copyFile(source, dest)
 
   console.log(`Copied ${source} to ${dest}`)
+
+  const isWindows = target.includes("windows")
+  const isLinux = target.includes("linux")
+  const isArm64 = target.startsWith("aarch64")
+
+  const ptyLib = isWindows
+    ? "rust_pty.dll"
+    : isLinux
+      ? isArm64
+        ? "librust_pty_arm64.so"
+        : "librust_pty.so"
+      : isArm64
+        ? "librust_pty_arm64.dylib"
+        : "librust_pty.dylib"
+
+  const ptySource = path.join(path.dirname(source), ptyLib)
+  const ptySourceExists = await fs
+    .access(ptySource)
+    .then(() => true)
+    .catch(() => false)
+  if (ptySourceExists) {
+    await fs.copyFile(ptySource, path.join(destDir, ptyLib))
+    console.log(`Copied ${ptySource} to ${destDir}/${ptyLib}`)
+  }
 }

--- a/packages/desktop/scripts/utils.ts
+++ b/packages/desktop/scripts/utils.ts
@@ -50,7 +50,7 @@ export function getCurrentSidecar(target = RUST_TARGET) {
 export async function copyBinaryToSidecarFolder(source: string, target = RUST_TARGET) {
   const destDir = "src-tauri/sidecars"
   await fs.mkdir(destDir, { recursive: true })
-  const dest = `${destDir}/opencode-cli-${target}${process.platform === "win32" ? ".exe" : ""}`
+  const dest = `${destDir}/opencode-cli-${target}${target.includes("windows") ? ".exe" : ""}`
   await fs.copyFile(source, dest)
 
   console.log(`Copied ${source} to ${dest}`)

--- a/packages/desktop/src-tauri/tauri.windows.conf.json
+++ b/packages/desktop/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": {
+      "sidecars/rust_pty.dll": "./"
+    }
+  }
+}

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -100,6 +100,7 @@ const binaries: Record<string, string> = {}
 if (!skipInstall) {
   await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
   await $`bun install --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
+  await $`bun install --os="*" --cpu="*" bun-pty@${pkg.dependencies["bun-pty"]}`
 }
 for (const item of targets) {
   const name = [
@@ -147,6 +148,21 @@ for (const item of targets) {
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },
   })
+
+  const ptyLib =
+    item.os === "win32"
+      ? "rust_pty.dll"
+      : item.os === "linux"
+        ? item.arch === "arm64"
+          ? "librust_pty_arm64.so"
+          : "librust_pty.so"
+        : item.arch === "arm64"
+          ? "librust_pty_arm64.dylib"
+          : "librust_pty.dylib"
+  const ptySource = path.resolve(dir, "node_modules/bun-pty/rust-pty/target/release", ptyLib)
+  if (fs.existsSync(ptySource)) {
+    fs.copyFileSync(ptySource, path.join(`dist/${name}/bin`, ptyLib))
+  }
 
   await $`rm -rf ./dist/${name}/bin/tui`
   await Bun.file(`dist/${name}/package.json`).write(

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -14,6 +14,7 @@ process.chdir(dir)
 
 import pkg from "../package.json"
 import { Script } from "@opencode-ai/script"
+import { getPtyLibName } from "@opencode-ai/util/pty"
 
 const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
@@ -149,16 +150,7 @@ for (const item of targets) {
     },
   })
 
-  const ptyLib =
-    item.os === "win32"
-      ? "rust_pty.dll"
-      : item.os === "linux"
-        ? item.arch === "arm64"
-          ? "librust_pty_arm64.so"
-          : "librust_pty.so"
-        : item.arch === "arm64"
-          ? "librust_pty_arm64.dylib"
-          : "librust_pty.dylib"
+  const ptyLib = getPtyLibName(item.os, item.arch)
   const ptySource = path.resolve(dir, "node_modules/bun-pty/rust-pty/target/release", ptyLib)
   if (fs.existsSync(ptySource)) {
     fs.copyFileSync(ptySource, path.join(`dist/${name}/bin`, ptyLib))

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -2,6 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { type IPty } from "bun-pty"
 import z from "zod"
+import path from "path"
 import { Identifier } from "../id/id"
 import { Log } from "../util/log"
 import type { WSContext } from "hono/ws"
@@ -15,23 +16,20 @@ export namespace Pty {
   const log = Log.create({ service: "pty" })
 
   const pty = lazy(async () => {
-    if (!Installation.isLocal()) {
-      const path = require(
-        `bun-pty/rust-pty/target/release/${
-          process.platform === "win32"
-            ? "rust_pty.dll"
-            : process.platform === "linux" && process.arch === "x64"
-              ? "librust_pty.so"
-              : process.platform === "darwin" && process.arch === "x64"
-                ? "librust_pty.dylib"
-                : process.platform === "darwin" && process.arch === "arm64"
-                  ? "librust_pty_arm64.dylib"
-                  : process.platform === "linux" && process.arch === "arm64"
-                    ? "librust_pty_arm64.so"
-                    : ""
-        }`,
-      )
-      process.env.BUN_PTY_LIB = path
+    if (!Installation.isLocal() && !process.env.BUN_PTY_LIB) {
+      const ptyLib =
+        process.platform === "win32"
+          ? "rust_pty.dll"
+          : process.platform === "linux"
+            ? process.arch === "arm64"
+              ? "librust_pty_arm64.so"
+              : "librust_pty.so"
+            : process.arch === "arm64"
+              ? "librust_pty_arm64.dylib"
+              : "librust_pty.dylib"
+
+      const libPath = path.join(path.dirname(process.execPath), ptyLib)
+      process.env.BUN_PTY_LIB = libPath
     }
     const { spawn } = await import("bun-pty")
     return spawn
@@ -118,51 +116,61 @@ export namespace Pty {
       args.push("-l")
     }
 
-    const cwd = input.cwd || Instance.directory
+    const cwd = (input.cwd || Instance.directory).replaceAll("\\", "/")
     const env = { ...process.env, ...input.env, TERM: "xterm-256color" } as Record<string, string>
-    log.info("creating session", { id, cmd: command, args, cwd })
+    let normalizedCommand = command.replaceAll("\\", "/")
+    // Quote command if it contains spaces (bun-pty doesn't quote the command path)
+    if (normalizedCommand.includes(" ")) {
+      normalizedCommand = `"${normalizedCommand}"`
+    }
+    log.info("creating session", { id, cmd: normalizedCommand, args, cwd })
 
     const spawn = await pty()
-    const ptyProcess = spawn(command, args, {
-      name: "xterm-256color",
-      cwd,
-      env,
-    })
-    const info = {
-      id,
-      title: input.title || `Terminal ${id.slice(-4)}`,
-      command,
-      args,
-      cwd,
-      status: "running",
-      pid: ptyProcess.pid,
-    } as const
-    const session: ActiveSession = {
-      info,
-      process: ptyProcess,
-      buffer: "",
-      subscribers: new Set(),
-    }
-    state().set(id, session)
-    ptyProcess.onData((data) => {
-      if (session.subscribers.size === 0) {
-        session.buffer += data
-        return
+    try {
+      const ptyProcess = spawn(normalizedCommand, args, {
+        name: "xterm-256color",
+        cwd,
+        env,
+      })
+      const info = {
+        id,
+        title: input.title || `Terminal ${id.slice(-4)}`,
+        command,
+        args,
+        cwd,
+        status: "running",
+        pid: ptyProcess.pid,
+      } as const
+      const session: ActiveSession = {
+        info,
+        process: ptyProcess,
+        buffer: "",
+        subscribers: new Set(),
       }
-      for (const ws of session.subscribers) {
-        if (ws.readyState === 1) {
-          ws.send(data)
+      state().set(id, session)
+      ptyProcess.onData((data) => {
+        if (session.subscribers.size === 0) {
+          session.buffer += data
+          return
         }
-      }
-    })
-    ptyProcess.onExit(({ exitCode }) => {
-      log.info("session exited", { id, exitCode })
-      session.info.status = "exited"
-      Bus.publish(Event.Exited, { id, exitCode })
-      state().delete(id)
-    })
-    Bus.publish(Event.Created, { info })
-    return info
+        for (const ws of session.subscribers) {
+          if (ws.readyState === 1) {
+            ws.send(data)
+          }
+        }
+      })
+      ptyProcess.onExit(({ exitCode }) => {
+        log.info("session exited", { id, exitCode })
+        session.info.status = "exited"
+        Bus.publish(Event.Exited, { id, exitCode })
+        state().delete(id)
+      })
+      Bus.publish(Event.Created, { info })
+      return info
+    } catch (e) {
+      log.error("failed to spawn pty", { error: e })
+      throw e
+    }
   }
 
   export async function update(id: string, input: UpdateInput) {

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -8,6 +8,7 @@ import { Log } from "../util/log"
 import type { WSContext } from "hono/ws"
 import { Instance } from "../project/instance"
 import { lazy } from "@opencode-ai/util/lazy"
+import { getPtyLibName } from "@opencode-ai/util/pty"
 import {} from "process"
 import { Installation } from "@/installation"
 import { Shell } from "@/shell/shell"
@@ -17,18 +18,7 @@ export namespace Pty {
 
   const pty = lazy(async () => {
     if (!Installation.isLocal() && !process.env.BUN_PTY_LIB) {
-      const ptyLib =
-        process.platform === "win32"
-          ? "rust_pty.dll"
-          : process.platform === "linux"
-            ? process.arch === "arm64"
-              ? "librust_pty_arm64.so"
-              : "librust_pty.so"
-            : process.arch === "arm64"
-              ? "librust_pty_arm64.dylib"
-              : "librust_pty.dylib"
-
-      const libPath = path.join(path.dirname(process.execPath), ptyLib)
+      const libPath = path.join(path.dirname(process.execPath), getPtyLibName())
       process.env.BUN_PTY_LIB = libPath
     }
     const { spawn } = await import("bun-pty")

--- a/packages/util/src/pty.ts
+++ b/packages/util/src/pty.ts
@@ -1,0 +1,8 @@
+export function getPtyLibName(os?: string, arch?: string): string {
+  const platform = os ?? process.platform
+  const architecture = arch ?? process.arch
+
+  if (platform === "win32") return "rust_pty.dll"
+  if (platform === "linux") return architecture === "arm64" ? "librust_pty_arm64.so" : "librust_pty.so"
+  return architecture === "arm64" ? "librust_pty_arm64.dylib" : "librust_pty.dylib"
+}


### PR DESCRIPTION
## Summary
- Add Windows PTY library support at runtime with proper path handling
- Bundle PTY library for all target platforms in build process
- Fix desktop build scripts to work cross-platform without requiring env vars

## Changes
- **packages/opencode/src/pty/index.ts**: Add Windows 
ust_pty.dll detection, normalize paths with forward slashes, quote commands with spaces, add try-catch for better error logging
- **packages/opencode/script/build.ts**: Install un-pty for all OS/CPU combinations, copy platform-specific PTY library to dist
- **packages/desktop/scripts/utils.ts**: Add RUST_TARGET fallback for local dev, use s API instead of shell commands, derive PTY library name from target triple (not process.platform)
- **packages/desktop/scripts/predev.ts**: Handle .exe extension for Windows binaries