### PR TITLE
fix: improve PATH handling in install script

### DIFF
--- a/install
+++ b/install
@@ -358,41 +358,63 @@ case $current_shell in
     ;;
 esac
 
-if [[ "$no_modify_path" != "true" ]]; then
-    config_file=""
-    for file in $config_files; do
-        if [[ -f $file ]]; then
-            config_file=$file
-            break
+# if opencode found in user path assume env is configured
+if command -v opencode 2>/dev/null | grep -q "^$HOME/"; then
+    location=$(command -v opencode)
+    if [[ $location == "$INSTALL_DIR/opencode" ]]; then
+        print_message info "${MUTED}Opencode found in ${NC}$location"
+    elif [[ $location == "$HOME/.local/bin/opencode" ]]; then
+        if [[ -L $location ]]; then
+            target=$(readlink -f $location)
+            if [[ "$target" != "$INSTALL_DIR/opencode" ]]; then
+                print_message warning "${MUTED}$HOME/.local/bin/opencode symlinked to ${NC}$target"
+            else
+                print_message info "${MUTED}Opencode found in ${NC}$location"
+            fi
+        else
+            print_message warning "${MUTED}Opencode script/bin found in ${NC}$location"
         fi
-    done
+    else
+        print_message warning "${MUTED}Alternate opencode in path ${NC}$location"
+    fi
+    no_modify_path="true"
+fi
 
-    if [[ -z $config_file ]]; then
-        print_message warning "No config file found for $current_shell. You may need to manually add to PATH:"
-        print_message info "  export PATH=$INSTALL_DIR:\$PATH"
-    elif [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-        case $current_shell in
-            fish)
-                add_to_path "$config_file" "fish_add_path $INSTALL_DIR"
-            ;;
-            zsh)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-            ;;
-            bash)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-            ;;
-            ash)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-            ;;
-            sh)
-                add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
-            ;;
-            *)
-                export PATH=$INSTALL_DIR:$PATH
-                print_message warning "Manually add the directory to $config_file (or similar):"
-                print_message info "  export PATH=$INSTALL_DIR:\$PATH"
-            ;;
-        esac
+if [[ "$no_modify_path" != "true" ]]; then
+    if [[ -d "$HOME/.local/bin" ]] && [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+        if [[ ! -e $HOME/.local/bin/opencode ]]; then
+            print_message info "${MUTED}Creating symlink ${NC}$HOME/.local/bin/opencode${MUTED} to ${NC}$INSTALL_DIR/opencode"
+            ln -s $INSTALL_DIR/opencode $HOME/.local/bin/opencode
+        else
+            print_message info "${MUTED}Opencode found in ${NC}$HOME/.local/bin/opencode"
+        fi
+    else
+        config_file=""
+        for file in $config_files; do
+            if [[ -f $file ]]; then
+                config_file=$file
+                break
+            fi
+        done
+    
+        if [[ -z $config_file ]]; then
+            print_message warning "No config file found for $current_shell. You may need to manually add to PATH:"
+            print_message info "  export PATH=$INSTALL_DIR:\$PATH"
+        elif [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+            case $current_shell in
+                zsh|bash|ash|sh)
+                    add_to_path "$config_file" "export PATH=$INSTALL_DIR:\$PATH"
+                ;;
+                fish)
+                    add_to_path "$config_file" "fish_add_path $INSTALL_DIR"
+                ;;
+                *)
+                    export PATH=$INSTALL_DIR:$PATH
+                    print_message warning "Manually add the directory to $config_file (or similar):"
+                    print_message info "  export PATH=$INSTALL_DIR:\$PATH"
+                ;;
+            esac
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

The current installer has issues with adding multiple PATH entries in shell configs in many scenarios and does not follow best practices. After much consideration this enhancement is the least invasive "first step" to a much more standard and robust installer.

This update standardizes the install script's PATH handling to prefer standard conventions and simple checks to avoid duplicate entries. There are many more improvements that can be made but this change is as minimal and safe as possible to solve the immediate problem.

## Changes

- Check if opencode already exists in user PATH before modifying shell configs
- Prefer symlinking to `~/.local/bin` when available (standard user bin, often already in PATH)
- Consolidate shell case statements (zsh|bash|ash|sh)
- Add warnings for alternate opencode installations (symlinks pointing elsewhere, custom binaries)

## Future Improvements

The following best practices would further improve the install experience and avoid "binary in use" issues during upgrades:

- Migrate `INSTALL_DIR` from `~/.opencode/bin` to `~/.local/share/opencode/`
- Install binary to `$INSTALL_DIR/versions/$VERSION`
- Symlink `~/.local/bin/opencode` to versioned binary