### PR TITLE
fix(provider): omit reasoning id when store is false for third-party …

### DIFF
--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/convert-to-openai-responses-input.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/convert-to-openai-responses-input.ts
@@ -224,9 +224,10 @@ export async function convertToOpenAIResponsesInput({
                   }
 
                   if (reasoningMessage === undefined) {
+                    // When store is false, don't include the id field as third-party APIs
+                    // don't support OpenAI's item_reference mechanism
                     reasoningMessages[reasoningId] = {
                       type: "reasoning",
-                      id: reasoningId,
                       encrypted_content: providerOptions?.reasoningEncryptedContent,
                       summary: summaryParts,
                     }

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-api-types.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-api-types.ts
@@ -198,7 +198,7 @@ export type OpenAIResponsesTool =
 
 export type OpenAIResponsesReasoning = {
   type: "reasoning"
-  id: string
+  id?: string  // Optional: omit when store is false for third-party API compatibility
   encrypted_content?: string | null
   summary: Array<{
     type: "summary_text"


### PR DESCRIPTION
## Fix: Omit reasoning id when store is false for third-party API compatibility

### Problem

When using third-party OpenAI-compatible APIs (e.g., custom proxy endpoints) with GPT-5.x reasoning models, users encounter this error on the second message in a conversation:

```
Item with id 'rs_...' not found. Items are not persisted when `store` is set to false.
```

This happens because:
1. The first response includes reasoning with an `id` (e.g., `rs_0194963fc6ca...`)
2. On subsequent requests, OpenCode sends this `id` in the reasoning object
3. Third-party APIs don't support OpenAI's `item_reference` storage mechanism
4. The API cannot find the referenced item and returns an error

### Solution

When `store: false` is configured, omit the `id` field from the reasoning object. The reasoning content is still sent via the `summary` field, maintaining functionality while avoiding the reference lookup.

### Changes

1. **`openai-responses-api-types.ts`**: Made `id` field optional in `OpenAIResponsesReasoning` type
2. **`convert-to-openai-responses-input.ts`**: Don't include `id` when `store` is false

### Testing

Tested with a third-party OpenAI-compatible API:
- Before: Error on second message in conversation
- After: Multi-turn conversations work correctly

### Configuration

Users with third-party APIs need to add `"store": false` to their model options:

```json
{
  "provider": {
    "openai": {
      "options": {
        "baseURL": "https://your-proxy.example.com/v1"
      },
      "models": {
        "gpt-5.1-codex": {
          "options": {
            "store": false
          }
        }
      }
    }
  }
}
```

### Related Issues

- Fixes #2941
- Fixes #4426
- Fixes #4445
