### PR TITLE
docs: Add plannotator plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -37,7 +37,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                           | AI-powered automatic Zellij session naming based on OpenCode context                           |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                               | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection        |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                     | Persistent memory across sessions using Supermemory                                            |
-
+| [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin)| Interactive plan review with visual annotation and private/offline sharing                                                 |
 ---
 
 ## Projects


### PR DESCRIPTION
Plans are becoming first-class artifacts in agent workflows, but review and collaboration around them still feels ad hoc; 

## What this plugin does
Plannotator hooks into plan mode, submits a plan and opens an interactive UI, feedback is automated back to opencode - approval launches opencode into build mode. Local-first, no backend and explicit annotation.

Plannotator is something i just built 2 days ago. But seeing a lot of cool capability potential. 

The plugin works better than cc hooks, as i can automatically launch opencode into build.

https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin