### PR TITLE
fix: windows fallback for "less" cmd in `session list`

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -9,19 +9,26 @@ import { EOL } from "os"
 import path from "path"
 
 function pagerCmd(): string[] {
+  const lessOptions = ["-R", "-S"]
   if (process.platform !== "win32") {
-    return ["less", "-R", "-S"]
+    return ["less", ...lessOptions]
+  }
+
+  // user could have less installed via other options
+  const lessOnPath = Bun.which("less")
+  if (lessOnPath) {
+    if (Bun.file(lessOnPath).size) return [lessOnPath, ...lessOptions]
   }
 
   if (Flag.OPENCODE_GIT_BASH_PATH) {
     const less = path.join(Flag.OPENCODE_GIT_BASH_PATH, "..", "..", "usr", "bin", "less.exe")
-    if (Bun.file(less).size) return [less, "-R", "-S"]
+    if (Bun.file(less).size) return [less, ...lessOptions]
   }
 
   const git = Bun.which("git")
   if (git) {
     const less = path.join(git, "..", "..", "usr", "bin", "less.exe")
-    if (Bun.file(less).size) return [less, "-R", "-S"]
+    if (Bun.file(less).size) return [less, ...lessOptions]
   }
 
   // Fall back to Windows built-in more (via cmd.exe)

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -4,7 +4,29 @@ import { Session } from "../../session"
 import { bootstrap } from "../bootstrap"
 import { UI } from "../ui"
 import { Locale } from "../../util/locale"
+import { Flag } from "../../flag/flag"
 import { EOL } from "os"
+import path from "path"
+
+function pagerCmd(): string[] {
+  if (process.platform !== "win32") {
+    return ["less", "-R", "-S"]
+  }
+
+  if (Flag.OPENCODE_GIT_BASH_PATH) {
+    const less = path.join(Flag.OPENCODE_GIT_BASH_PATH, "..", "..", "usr", "bin", "less.exe")
+    if (Bun.file(less).size) return [less, "-R", "-S"]
+  }
+
+  const git = Bun.which("git")
+  if (git) {
+    const less = path.join(git, "..", "..", "usr", "bin", "less.exe")
+    if (Bun.file(less).size) return [less, "-R", "-S"]
+  }
+
+  // Fall back to Windows built-in more (via cmd.exe)
+  return ["cmd", "/c", "more"]
+}
 
 export const SessionCommand = cmd({
   command: "session",
@@ -58,7 +80,7 @@ export const SessionListCommand = cmd({
 
       if (shouldPaginate) {
         const proc = Bun.spawn({
-          cmd: ["less", "-R", "-S"],
+          cmd: pagerCmd(),
           stdin: "pipe",
           stdout: "inherit",
           stderr: "inherit",


### PR DESCRIPTION
Since `Bun.Shell` doesn't natively implement `less`, we use fallbacks to determine the best option on Windows - 

We try to locate `less.exe` from:
- Existing installations (via `choco`) by checking PATH
- The `OPENCODE_GIT_BASH_PATH` custom location
- The Git installation directory (found via git in PATH)

if `less` cannot be located, we finally fall back to the built-in `more` command.