### PR TITLE
Add support for LSP workspace/didChangeWatchedFiles

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -154,7 +154,7 @@ export namespace LSPClient {
 
           const version = files[input.path]
           if (version !== undefined) {
-            log.info("workspace/didChangeWatchedFiles", input);
+            log.info("workspace/didChangeWatchedFiles", input)
             await connection.sendNotification("workspace/didChangeWatchedFiles", {
               changes: [
                 {
@@ -162,7 +162,7 @@ export namespace LSPClient {
                   type: 2, // Changed
                 },
               ],
-            });
+            })
 
             const next = version + 1
             files[input.path] = next
@@ -180,7 +180,7 @@ export namespace LSPClient {
             return
           }
 
-          log.info("workspace/didChangeWatchedFiles", input);
+          log.info("workspace/didChangeWatchedFiles", input)
           await connection.sendNotification("workspace/didChangeWatchedFiles", {
             changes: [
               {
@@ -188,7 +188,7 @@ export namespace LSPClient {
                 type: 1, // Created
               },
             ],
-          });
+          })
 
           log.info("textDocument/didOpen", input)
           diagnostics.delete(input.path)

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -98,6 +98,9 @@ export namespace LSPClient {
           },
           workspace: {
             configuration: true,
+            didChangeWatchedFiles: {
+              dynamicRegistration: true,
+            },
           },
           textDocument: {
             synchronization: {
@@ -151,6 +154,16 @@ export namespace LSPClient {
 
           const version = files[input.path]
           if (version !== undefined) {
+            log.info("workspace/didChangeWatchedFiles", input);
+            await connection.sendNotification("workspace/didChangeWatchedFiles", {
+              changes: [
+                {
+                  uri: pathToFileURL(input.path).href,
+                  type: 2, // Changed
+                },
+              ],
+            });
+
             const next = version + 1
             files[input.path] = next
             log.info("textDocument/didChange", {
@@ -166,6 +179,16 @@ export namespace LSPClient {
             })
             return
           }
+
+          log.info("workspace/didChangeWatchedFiles", input);
+          await connection.sendNotification("workspace/didChangeWatchedFiles", {
+            changes: [
+              {
+                uri: pathToFileURL(input.path).href,
+                type: 1, // Created
+              },
+            ],
+          });
 
           log.info("textDocument/didOpen", input)
           diagnostics.delete(input.path)


### PR DESCRIPTION
Some LSP servers (e.g. pyright) rely on `workspace/didChangeWatchedFiles` to register new files/modules after creation to be able to resolve imports. Without this the LSP server will always return error diagnostics that it can't resolve the import until restarted. This makes working with python/pyright annoying since it will make the LLM go out of it's way to resolve this error.