### PR TITLE
fix(tui): don't show 'Agent not found' toast for subagents

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -202,7 +202,11 @@ export function Prompt(props: PromptProps) {
 
       syncedSessionID = sessionID
 
-      if (msg.agent) local.agent.set(msg.agent)
+      // Only set agent if it's a primary agent (not a subagent)
+      const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
+      if (msg.agent && isPrimaryAgent) {
+        local.agent.set(msg.agent)
+      }
       if (msg.model) local.model.set(msg.model)
       if (msg.variant) local.model.variant.set(msg.variant)
     }


### PR DESCRIPTION
## Summary

When a command runs with a subagent (e.g., `/init` with `project-initializer`), the TUI incorrectly shows an "Agent not found" toast error.

## Related issues

https://github.com/sst/opencode/issues/6518

## Root Cause

The code added in #6325 (variants toggle) syncs the agent from the last user message to the TUI:

```typescript
if (msg.agent) local.agent.set(msg.agent)
```

However, `local.agent.list()` only includes primary agents (`mode !== 'subagent'`), so when a command runs with a subagent, the `set()` call fails and shows the toast.

The backend correctly creates and runs the subagent session - only the TUI display has this bug.

## Fix

Check if the agent exists in the primary agents list before attempting to set it:

```typescript
if (msg.agent && local.agent.list().some((x) => x.name === msg.agent)) local.agent.set(msg.agent)
```

## Testing

1. Create a custom command that uses a subagent (e.g., `/init` with `agent: "my-subagent"`)
2. Run the command
3. Before: "Agent not found: my-subagent" toast appears
4. After: No toast, command runs correctly