### PR TITLE
feat(cli): New debug agent <name> subcommand

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -1,0 +1,51 @@
+import { EOL } from "os"
+import { basename } from "path"
+import { Agent } from "../../../agent/agent"
+import { Provider } from "../../../provider/provider"
+import { ToolRegistry } from "../../../tool/registry"
+import { Wildcard } from "../../../util/wildcard"
+import { bootstrap } from "../../bootstrap"
+import { cmd } from "../cmd"
+
+export const AgentCommand = cmd({
+  command: "agent <name>",
+  builder: (yargs) =>
+    yargs.positional("name", {
+      type: "string",
+      demandOption: true,
+      description: "Agent name",
+    }),
+  async handler(args) {
+    await bootstrap(process.cwd(), async () => {
+      const agentName = args.name as string
+      const agent = await Agent.get(agentName)
+      if (!agent) {
+        process.stderr.write(
+          `Agent ${agentName} not found, run '${basename(process.execPath)} agent list' to get an agent list` + EOL,
+        )
+        process.exit(1)
+      }
+      const resolvedTools = await resolveTools(agent)
+      const output = {
+        ...agent,
+        tools: resolvedTools,
+        toolOverrides: agent.tools,
+      }
+      process.stdout.write(JSON.stringify(output, null, 2) + EOL)
+    })
+  },
+})
+
+async function resolveTools(agent: Agent.Info) {
+  const providerID = agent.model?.providerID ?? (await Provider.defaultModel()).providerID
+  const toolOverrides = {
+    ...agent.tools,
+    ...(await ToolRegistry.enabled(agent)),
+  }
+  const availableTools = await ToolRegistry.tools(providerID, agent)
+  const resolved: Record<string, boolean> = {}
+  for (const tool of availableTools) {
+    resolved[tool.id] = Wildcard.all(tool.id, toolOverrides) !== false
+  }
+  return resolved
+}

--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -8,6 +8,7 @@ import { RipgrepCommand } from "./ripgrep"
 import { ScrapCommand } from "./scrap"
 import { SkillCommand } from "./skill"
 import { SnapshotCommand } from "./snapshot"
+import { AgentCommand } from "./agent"
 
 export const DebugCommand = cmd({
   command: "debug",
@@ -20,6 +21,7 @@ export const DebugCommand = cmd({
       .command(ScrapCommand)
       .command(SkillCommand)
       .command(SnapshotCommand)
+      .command(AgentCommand)
       .command(PathsCommand)
       .command({
         command: "wait",


### PR DESCRIPTION
When I writing my agent with markdown, I constently found I need to ask LLM to `list your current available tools`, I guess it should be a dedicated command.

```bash
opencode debug agent plan
```

```text
{
  "name": "plan",
  "options": {},
  "permission": {
    "edit": "deny",
    "webfetch": "allow",
    "bash": {
      "*": "ask",
      "cut*": "allow",
      "diff*": "allow",
      "du*": "allow",
      "file *": "allow",
      "find * -delete*": "ask",
      "find * -exec*": "ask",
      "find * -fprint*": "ask",
      "find * -fls*": "ask",
      "find * -fprintf*": "ask",
      "find * -ok*": "ask",
      "find *": "allow",
      "git diff*": "allow",
      "git log*": "allow",
      "git show*": "allow",
      "git status*": "allow",
      "git branch": "allow",
      "git branch -v": "allow",
      "grep*": "allow",
      "head*": "allow",
      "less*": "allow",
      "ls*": "allow",
      "more*": "allow",
      "pwd*": "allow",
      "rg*": "allow",
      "sort --output=*": "ask",
      "sort -o *": "ask",
      "sort*": "allow",
      "stat*": "allow",
      "tail*": "allow",
      "tree -o *": "ask",
      "tree*": "allow",
      "uniq*": "allow",
      "wc*": "allow",
      "whereis*": "allow",
      "which*": "allow"
    },
    "skill": {
      "*": "allow"
    }
  },
  "tools": {
    "invalid": true,
    "bash": true,
    "read": true,
    "glob": true,
    "grep": true,
    "edit": false,
    "write": false,
    "task": true,
    "webfetch": true,
    "todowrite": true,
    "todoread": true,
    "websearch": true,
    "codesearch": true,
    "skill": true,
    "doc_convert": true,
    "internal_search_internal_search": true,
    "websearch_for_china_net": true
  },
  "mode": "primary",
  "native": true,
  "toolOverrides": {}
}
```