### PR TITLE
fix: display MCP tag for prompts in autocomplete but not in prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -259,7 +259,7 @@ export function Autocomplete(props: {
     const s = session()
     for (const command of sync.data.command) {
       results.push({
-        display: "/" + command.name,
+        display: "/" + command.name + (command.mcp ? " (MCP)" : ""),
         description: command.description,
         onSelect: () => {
           const newText = "/" + command.name + " "

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -27,6 +27,7 @@ export namespace Command {
       description: z.string().optional(),
       agent: z.string().optional(),
       model: z.string().optional(),
+      mcp: z.boolean().optional(),
       // workaround for zod not supporting async functions natively so we use getters
       // https://zod.dev/v4/changelog?id=zfunction
       template: z.promise(z.string()).or(z.string()),
@@ -94,6 +95,7 @@ export namespace Command {
     for (const [name, prompt] of Object.entries(await MCP.prompts())) {
       result[name] = {
         name,
+        mcp: true,
         description: prompt.description,
         get template() {
           // since a getter can't be async we need to manually return a promise here

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -195,7 +195,7 @@ export namespace MCP {
     for (const prompt of prompts.prompts) {
       const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
       const sanitizedPromptName = prompt.name.replace(/[^a-zA-Z0-9_-]/g, "_")
-      const key = sanitizedClientName + ":" + sanitizedPromptName + " (MCP)"
+      const key = sanitizedClientName + ":" + sanitizedPromptName
 
       commands[key] = { ...prompt, client: clientName }
     }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1733,6 +1733,7 @@ export type Command = {
   description?: string
   agent?: string
   model?: string
+  mcp?: boolean
   template: string
   subtask?: boolean
   hints: Array<string>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8982,6 +8982,9 @@
           "model": {
             "type": "string"
           },
+          "mcp": {
+            "type": "boolean"
+          },
           "template": {
             "anyOf": [
               {


### PR DESCRIPTION
A last-minute change from @rekram1-node in #5767 was to add an `(MCP)` tag to the name of the prompt if it was an MCP one. Quite a nice addition to be fair. However, that broke the functionality because now the prompt has a space, meaning the `(MCP)` part is considered an argument by the parser and the name is not matched.

This PR fixes it by adding an `mcp` property to the `Command` object so that we can still display the `(MCP)` tag but then when it's added to the prompt only the uninterrupted name is there which mean the substitution will work fine.

One possible change could be to have a general `tag` property instead of the specific `mcp` one so that if we want to add more tags in the future we can for example display `/my-command (CUSTOMTAG)`...but it might be surperflous.