### PR TITLE
feat(acp): add attach option to acp command

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -22,7 +22,6 @@ import { Log } from "../util/log"
 import { ACPSessionManager } from "./session"
 import type { ACPConfig, ACPSessionState } from "./types"
 import { Provider } from "../provider/provider"
-import { Agent as AgentModule } from "../agent/agent"
 import { Installation } from "@/installation"
 import { MessageV2 } from "@/session/message-v2"
 import { Config } from "@/config/config"
@@ -701,10 +700,10 @@ export namespace ACP {
           id: agent.name,
           name: agent.name,
           description: agent.description,
+          default: agent.default,
         }))
 
-      const defaultAgentName = await AgentModule.defaultAgent()
-      const currentModeId = availableModes.find((m) => m.name === defaultAgentName)?.id ?? availableModes[0].id
+      const currentModeId = availableModes.find((m) => m.default)?.id ?? availableModes[0]?.id
 
       const mcpServers: Record<string, Config.Mcp> = {}
       for (const server of params.mcpServers) {
@@ -806,7 +805,11 @@ export namespace ACP {
       if (!current) {
         this.sessionManager.setModel(session.id, model)
       }
-      const agent = session.modeId ?? (await AgentModule.defaultAgent())
+      const agent =
+        session.modeId ??
+        (await this.sdk.app
+          .agents({ directory }, { throwOnError: true })
+          .then((x) => x.data?.find((a) => a.default)?.name ?? x.data?.[0]?.name))
 
       const parts: Array<
         { type: "text"; text: string } | { type: "file"; url: string; filename: string; mime: string }

--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -4,66 +4,79 @@ import { cmd } from "./cmd"
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk"
 import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
-import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 
 const log = Log.create({ service: "acp-command" })
+
+async function setupAcpConnection(sdk: OpencodeClient) {
+  const input = new WritableStream<Uint8Array>({
+    write(chunk) {
+      return new Promise<void>((resolve, reject) => {
+        process.stdout.write(chunk, (err) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+      })
+    },
+  })
+  const output = new ReadableStream<Uint8Array>({
+    start(controller) {
+      process.stdin.on("data", (chunk: Buffer) => {
+        controller.enqueue(new Uint8Array(chunk))
+      })
+      process.stdin.on("end", () => controller.close())
+      process.stdin.on("error", (err) => controller.error(err))
+    },
+  })
+
+  const stream = ndJsonStream(input, output)
+  const agent = await ACP.init({ sdk })
+
+  new AgentSideConnection((conn) => {
+    return agent.create(conn, { sdk })
+  }, stream)
+
+  log.info("setup connection")
+  process.stdin.resume()
+  await new Promise((resolve, reject) => {
+    process.stdin.on("end", resolve)
+    process.stdin.on("error", reject)
+  })
+}
 
 export const AcpCommand = cmd({
   command: "acp",
   describe: "start ACP (Agent Client Protocol) server",
   builder: (yargs) => {
-    return withNetworkOptions(yargs).option("cwd", {
-      describe: "working directory",
-      type: "string",
-      default: process.cwd(),
-    })
+    return withNetworkOptions(yargs)
+      .option("cwd", {
+        describe: "working directory",
+        type: "string",
+        default: process.cwd(),
+      })
+      .option("attach", {
+        type: "string",
+        describe: "attach to a running opencode server (e.g., http://localhost:4096)",
+      })
   },
   handler: async (args) => {
-    await bootstrap(process.cwd(), async () => {
+    if (args.attach) {
+      const sdk = createOpencodeClient({ baseUrl: args.attach })
+      await setupAcpConnection(sdk)
+      return
+    }
+
+    await bootstrap(args.cwd, async () => {
       const opts = await resolveNetworkOptions(args)
       const server = Server.listen(opts)
-
       const sdk = createOpencodeClient({
         baseUrl: `http://${server.hostname}:${server.port}`,
       })
-
-      const input = new WritableStream<Uint8Array>({
-        write(chunk) {
-          return new Promise<void>((resolve, reject) => {
-            process.stdout.write(chunk, (err) => {
-              if (err) {
-                reject(err)
-              } else {
-                resolve()
-              }
-            })
-          })
-        },
-      })
-      const output = new ReadableStream<Uint8Array>({
-        start(controller) {
-          process.stdin.on("data", (chunk: Buffer) => {
-            controller.enqueue(new Uint8Array(chunk))
-          })
-          process.stdin.on("end", () => controller.close())
-          process.stdin.on("error", (err) => controller.error(err))
-        },
-      })
-
-      const stream = ndJsonStream(input, output)
-      const agent = await ACP.init({ sdk })
-
-      new AgentSideConnection((conn) => {
-        return agent.create(conn, { sdk })
-      }, stream)
-
-      log.info("setup connection")
-      process.stdin.resume()
-      await new Promise((resolve, reject) => {
-        process.stdin.on("end", resolve)
-        process.stdin.on("error", reject)
-      })
+      await setupAcpConnection(sdk)
     })
   },
 })

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -479,11 +479,12 @@ This command starts an ACP server that communicates via stdin/stdout using nd-JS
 
 #### Flags
 
-| Flag         | Description           |
-| ------------ | --------------------- |
-| `--cwd`      | Working directory     |
-| `--port`     | Port to listen on     |
-| `--hostname` | Hostname to listen on |
+| Flag         | Description                                                       |
+| ------------ | ----------------------------------------------------------------- |
+| `--cwd`      | Working directory                                                 |
+| `--port`     | Port to listen on                                                 |
+| `--hostname` | Hostname to listen on                                             |
+| `--attach`   | Attach to a running opencode server (e.g., http://localhost:4096) |
 
 ---
 


### PR DESCRIPTION
This adds a `--attach` flag to the acp command. It was almost straight forward except for the default agent relying on bootstrap being run, switched it to use the sdk to get the default model instead.