### PR TITLE
feat: add custom skills path configuration

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -853,6 +853,14 @@ export namespace Config {
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
         })
         .optional(),
+      skills: z
+        .object({
+          path: z
+            .array(z.string())
+            .optional()
+            .describe("Additional directories to scan for skills"),
+        })
+        .optional(),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import path from "path"
 import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { NamedError } from "@opencode-ai/util/error"
@@ -40,6 +41,12 @@ export namespace Skill {
 
   export const state = Instance.state(async () => {
     const skills: Record<string, Info> = {}
+
+    const config = await Config.get()
+
+    const customDirs = (config.skills?.path ?? []).map((p) =>
+      p.startsWith("~") ? path.join(Global.Path.home, p.slice(1)) : p,
+    )
 
     const addSkill = async (match: string) => {
       const md = await ConfigMarkdown.parse(match)
@@ -94,6 +101,22 @@ export namespace Skill {
 
     // Scan .opencode/skill/ directories
     for (const dir of await Config.directories()) {
+      for await (const match of OPENCODE_SKILL_GLOB.scan({
+        cwd: dir,
+        absolute: true,
+        onlyFiles: true,
+        followSymlinks: true,
+      })) {
+        await addSkill(match)
+      }
+    }
+
+    // Scan custom skill directories
+    for (const dir of customDirs) {
+      if (!(await exists(dir))) {
+        log.debug("custom skill directory does not exist", { dir })
+        continue
+      }
       for await (const match of OPENCODE_SKILL_GLOB.scan({
         cwd: dir,
         absolute: true,

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -183,3 +183,47 @@ test("returns empty array when no skills exist", async () => {
     },
   })
 })
+
+test("discovers skills from custom paths in config", async () => {
+  await using customDir = await tmpdir({})
+
+  // Create skill in custom directory before Instance.provide
+  const skillDir = path.join(customDir.path, "skills", "custom-path-skill")
+  await Bun.write(
+    path.join(skillDir, "SKILL.md"),
+    `---
+name: custom-path-skill
+description: A skill from a custom path in config.
+---
+
+# Custom Path Skill
+This skill is loaded from a custom directory.
+`,
+  )
+
+  // Create project with config that references custom path
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          skills: { path: [customDir.path] },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      expect(skills.length).toBe(1)
+      const customSkill = skills.find((s) => s.name === "custom-path-skill")
+      expect(customSkill).toBeDefined()
+      expect(customSkill!.description).toBe("A skill from a custom path in config.")
+      expect(customSkill!.location).toContain("custom-path-skill/SKILL.md")
+    },
+  })
+})

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -29,6 +29,31 @@ Global definitions are also loaded from `~/.config/opencode/skill/*/SKILL.md` an
 
 ---
 
+## Custom Skill Directories
+
+Add additional directories to scan for skills beyond the default locations.
+
+```json
+{
+  "skills": {
+    "path": ["~/my-skills", "~/.config/agents/skills"]
+  }
+}
+```
+
+Custom directories must contain a `skill/` or `skills/` subdirectory with skills inside:
+
+```
+~/my-skills/
+└── skills/
+    └── my-skill/
+        └── SKILL.md
+```
+
+Custom directories are scanned in addition to the default locations.
+
+---
+
 ## Write frontmatter
 
 Each `SKILL.md` must start with YAML frontmatter.


### PR DESCRIPTION
## Summary

- Add `skills.path` config option to opencode.json
- Support additional skill directories with ~ expansion
- Scan custom paths in addition to default locations
- Add documentation and tests

## Usage

```json
{
  "skills": {
    "path": ["~/my-skills", "~/.config/agents/skills"]
  }
}
```

Partially addresses #6266 - allows adding custom directories for skill discovery.

Note: This is additive only. Disabling/replacing default paths would be a separate feature if needed.