### PR TITLE
fix: skip local agent validation in attach mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -227,6 +227,7 @@ export const RunCommand = cmd({
       // Validate agent if specified
       const resolvedAgent = await (async () => {
         if (!args.agent) return undefined
+        if (args.attach) return args.agent
         const agent = await Agent.get(args.agent)
         if (!agent) {
           UI.println(


### PR DESCRIPTION
## Summary

- Skip local agent validation when using `--attach` flag to connect to a remote server
- Fixes regression introduced in #5843 where `Agent.get()` requires `Instance` context that isn't available in attach mode

## Problem

When running:
```bash
opencode run --attach "http://server:4096" --agent "explore" "prompt"
```

The CLI crashes with:
```
Error: instance: No context found for instance
    at use (src/util/context.ts:16:21)
    at directory (src/project/instance.ts:41:20)
    ...
```

## Root Cause

PR #5843 added agent validation that calls `Agent.get()` which requires `Instance` context from `bootstrap()`. In attach mode, `bootstrap()` is never called, so there's no context available.

## Solution

Add early return in the agent validation block to skip local validation when in attach mode. The remote server handles agent validation instead.

```typescript
if (args.attach) return args.agent
```

Fixes #6489