### PR TITLE
feat(plugin): add ToolResult type for structured tool responses

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -87,10 +87,10 @@ export namespace ToolRegistry {
               output: out.truncated ? out.content : result.output,
             }
           }
-          const out = await Truncate.output(result, {}, initCtx?.agent)
+          const out = await Truncate.output(result as string, {}, initCtx?.agent)
           return {
             title: "",
-            output: out.truncated ? out.content : result,
+            output: out.truncated ? out.content : (result as string),
             metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
           }
         },

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -16,7 +16,7 @@ import { Tool } from "./tool"
 import { Instance } from "../project/instance"
 import { Config } from "../config/config"
 import path from "path"
-import { type ToolDefinition } from "@opencode-ai/plugin"
+import { type ToolDefinition, type ToolResult } from "@opencode-ai/plugin"
 import z from "zod"
 import { Plugin } from "../plugin"
 import { WebSearchTool } from "./websearch"
@@ -58,15 +58,6 @@ export namespace ToolRegistry {
     return { custom }
   })
 
-  function isStructuredResult(result: unknown): result is Partial<Tool.Result> & { output: string } {
-    return (
-      typeof result === "object" &&
-      result !== null &&
-      "output" in result &&
-      typeof (result as Record<string, unknown>).output === "string"
-    )
-  }
-
   function fromPlugin(id: string, def: ToolDefinition): Tool.Info {
     return {
       id,
@@ -75,23 +66,24 @@ export namespace ToolRegistry {
         description: def.description,
         execute: async (args, ctx) => {
           const result = await def.execute(args as any, ctx)
-          if (isStructuredResult(result)) {
-            const out = await Truncate.output(result.output, {}, initCtx?.agent)
+          if (typeof result === "string") {
+            const out = await Truncate.output(result, {}, initCtx?.agent)
             return {
-              title: result.title ?? "",
-              metadata: {
-                ...result.metadata,
-                truncated: out.truncated,
-                outputPath: out.truncated ? out.outputPath : undefined,
-              },
-              output: out.truncated ? out.content : result.output,
+              title: "",
+              output: out.truncated ? out.content : result,
+              metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
             }
           }
-          const out = await Truncate.output(result as string, {}, initCtx?.agent)
+          const out = await Truncate.output(result.output, {}, initCtx?.agent)
           return {
-            title: "",
-            output: out.truncated ? out.content : (result as string),
-            metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
+            title: result.title ?? "",
+            metadata: {
+              ...result.metadata,
+              truncated: out.truncated,
+              outputPath: out.truncated ? out.outputPath : undefined,
+            },
+            output: out.truncated ? out.content : result.output,
+            attachments: result.attachments,
           }
         },
       }),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -58,6 +58,15 @@ export namespace ToolRegistry {
     return { custom }
   })
 
+  function isStructuredResult(result: unknown): result is Partial<Tool.Result> & { output: string } {
+    return (
+      typeof result === "object" &&
+      result !== null &&
+      "output" in result &&
+      typeof (result as Record<string, unknown>).output === "string"
+    )
+  }
+
   function fromPlugin(id: string, def: ToolDefinition): Tool.Info {
     return {
       id,
@@ -66,6 +75,18 @@ export namespace ToolRegistry {
         description: def.description,
         execute: async (args, ctx) => {
           const result = await def.execute(args as any, ctx)
+          if (isStructuredResult(result)) {
+            const out = await Truncate.output(result.output, {}, initCtx?.agent)
+            return {
+              title: result.title ?? "",
+              metadata: {
+                ...result.metadata,
+                truncated: out.truncated,
+                outputPath: out.truncated ? out.outputPath : undefined,
+              },
+              output: out.truncated ? out.content : result.output,
+            }
+          }
           const out = await Truncate.output(result, {}, initCtx?.agent)
           return {
             title: "",

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -23,20 +23,20 @@ export namespace Tool {
     metadata(input: { title?: string; metadata?: M }): void
     ask(input: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">): Promise<void>
   }
+
+  export interface Result<M extends Metadata = Metadata> {
+    title: string
+    metadata: M
+    output: string
+    attachments?: MessageV2.FilePart[]
+  }
+
   export interface Info<Parameters extends z.ZodType = z.ZodType, M extends Metadata = Metadata> {
     id: string
     init: (ctx?: InitContext) => Promise<{
       description: string
       parameters: Parameters
-      execute(
-        args: z.infer<Parameters>,
-        ctx: Context,
-      ): Promise<{
-        title: string
-        metadata: M
-        output: string
-        attachments?: MessageV2.FilePart[]
-      }>
+      execute(args: z.infer<Parameters>, ctx: Context): Promise<Result<M>>
       formatValidationError?(error: z.ZodError): string
     }>
   }

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -7,10 +7,25 @@ export type ToolContext = {
   abort: AbortSignal
 }
 
+/**
+ * Structured result for plugin tools.
+ *
+ * Return this instead of a plain string to provide rich metadata
+ * that integrates with streaming updates.
+ */
+export interface ToolResult {
+  /** Title displayed in the UI */
+  title: string
+  /** Arbitrary metadata passed to tool.execute.after hooks */
+  metadata: Record<string, unknown>
+  /** The text output returned to the model */
+  output: string
+}
+
 export function tool<Args extends z.ZodRawShape>(input: {
   description: string
   args: Args
-  execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<string>
+  execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<string | ToolResult>
 }) {
   return input
 }

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import type { FilePart } from "@opencode-ai/sdk"
 
 export type ToolContext = {
   sessionID: string
@@ -20,6 +21,8 @@ export interface ToolResult {
   metadata: Record<string, unknown>
   /** The text output returned to the model */
   output: string
+  /** Optional file attachments to include with the result */
+  attachments?: FilePart[]
 }
 
 export function tool<Args extends z.ZodRawShape>(input: {

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -6,6 +6,7 @@ export type ToolContext = {
   messageID: string
   agent: string
   abort: AbortSignal
+  metadata(input: { title?: string; metadata?: Record<string, unknown> }): void
 }
 
 /**


### PR DESCRIPTION
## Problem

Plugin tools could only return a plain string. This prevented:
- Structured responses with titles, metadata, and attachments
- Real-time streaming updates during long-running operations
- Subagent result propagation (tool counts, progress, etc.)

## Solution

Add ToolResult interface and metadata() method to plugin SDK:

- ToolResult interface: { title, metadata, output, attachments? }
- ctx.metadata(): Emit streaming updates during execution
- Backward compatible: tools can still return plain strings
- Core extraction: Tool.Result interface for unified typing

## Changes

- packages/plugin/src/tool.ts - Add ToolResult interface, metadata() method
- packages/opencode/src/tool/tool.ts - Extract Tool.Result interface
- packages/opencode/src/tool/registry.ts - Handle structured results in fromPlugin

## Usage

```typescript
import { tool, type ToolResult } from "@opencode-ai/plugin"

export default tool({
  description: "My tool",
  args: { input: z.string() },
  async execute(args, ctx): Promise<ToolResult> {
    ctx.metadata({ title: "Processing...", metadata: { step: 1 } })
    // ... work ...
    return {
      title: "Done",
      metadata: { count: 42 },
      output: "Result text"
    }
  }
})
```

## Related

- Resolves #7590
