### PR TITLE
feat: support CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -2,6 +2,7 @@ export namespace Flag {
   export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE")
   export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
   export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
+  export const CLAUDE_CONFIG_DIR = process.env["CLAUDE_CONFIG_DIR"]
   export const OPENCODE_CONFIG_DIR = process.env["OPENCODE_CONFIG_DIR"]
   export const OPENCODE_CONFIG_CONTENT = process.env["OPENCODE_CONFIG_CONTENT"]
   export const OPENCODE_DISABLE_AUTOUPDATE = truthy("OPENCODE_DISABLE_AUTOUPDATE")

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -2,7 +2,6 @@ export namespace Flag {
   export const OPENCODE_AUTO_SHARE = truthy("OPENCODE_AUTO_SHARE")
   export const OPENCODE_GIT_BASH_PATH = process.env["OPENCODE_GIT_BASH_PATH"]
   export const OPENCODE_CONFIG = process.env["OPENCODE_CONFIG"]
-  export const CLAUDE_CONFIG_DIR = process.env["CLAUDE_CONFIG_DIR"]
   export const OPENCODE_CONFIG_DIR = process.env["OPENCODE_CONFIG_DIR"]
   export const OPENCODE_CONFIG_CONTENT = process.env["OPENCODE_CONFIG_CONTENT"]
   export const OPENCODE_DISABLE_AUTOUPDATE = truthy("OPENCODE_DISABLE_AUTOUPDATE")

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -11,7 +11,9 @@ const config = path.join(xdgConfig!, app)
 const state = path.join(xdgState!, app)
 
 async function isDirectory(p: string): Promise<boolean> {
-  const stat = await fs.stat(p).catch(() => undefined)
+  const stat = await Bun.file(p)
+    .stat()
+    .catch(() => undefined)
   return stat?.isDirectory() ?? false
 }
 

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -10,6 +10,11 @@ const cache = path.join(xdgCache!, app)
 const config = path.join(xdgConfig!, app)
 const state = path.join(xdgState!, app)
 
+async function isDirectory(p: string): Promise<boolean> {
+  const stat = await fs.stat(p).catch(() => undefined)
+  return stat?.isDirectory() ?? false
+}
+
 export namespace Global {
   export const Path = {
     // Allow override via OPENCODE_TEST_HOME for test isolation
@@ -22,6 +27,37 @@ export namespace Global {
     cache,
     config,
     state,
+  }
+
+  /**
+   * Returns the Claude config directory path using this priority:
+   * 1. CLAUDE_CONFIG_DIR environment variable (if set and is a directory)
+   * 2. ~/.config/claude (new default, if it exists as a directory)
+   * 3. ~/.claude (legacy, if it exists as a directory)
+   * 4. undefined if none exist
+   */
+  export async function claudeConfigDir(): Promise<string | undefined> {
+    // Check CLAUDE_CONFIG_DIR env var at runtime (not cached in Flag namespace)
+    const claudeEnvDir = process.env.CLAUDE_CONFIG_DIR
+    if (claudeEnvDir && (await isDirectory(claudeEnvDir))) {
+      return claudeEnvDir
+    }
+
+    // Check XDG path (~/.config/claude or XDG_CONFIG_HOME/claude)
+    // Read XDG_CONFIG_HOME at runtime to support test isolation
+    const xdgConfigPath = process.env.XDG_CONFIG_HOME || path.join(Path.home, ".config")
+    const xdgClaude = path.join(xdgConfigPath, "claude")
+    if (await isDirectory(xdgClaude)) {
+      return xdgClaude
+    }
+
+    // Check legacy path (~/.claude)
+    const legacyClaude = path.join(Path.home, ".claude")
+    if (await isDirectory(legacyClaude)) {
+      return legacyClaude
+    }
+
+    return undefined
   }
 }
 

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -29,33 +29,16 @@ export namespace Global {
     state,
   }
 
-  /**
-   * Returns the Claude config directory path using this priority:
-   * 1. CLAUDE_CONFIG_DIR environment variable (if set and is a directory)
-   * 2. ~/.config/claude (new default, if it exists as a directory)
-   * 3. ~/.claude (legacy, if it exists as a directory)
-   * 4. undefined if none exist
-   */
   export async function claudeConfigDir(): Promise<string | undefined> {
-    // Check CLAUDE_CONFIG_DIR env var at runtime (not cached in Flag namespace)
-    const claudeEnvDir = process.env.CLAUDE_CONFIG_DIR
-    if (claudeEnvDir && (await isDirectory(claudeEnvDir))) {
-      return claudeEnvDir
-    }
+    const envDir = process.env.CLAUDE_CONFIG_DIR
+    if (envDir && (await isDirectory(envDir))) return envDir
 
-    // Check XDG path (~/.config/claude or XDG_CONFIG_HOME/claude)
-    // Read XDG_CONFIG_HOME at runtime to support test isolation
-    const xdgConfigPath = process.env.XDG_CONFIG_HOME || path.join(Path.home, ".config")
-    const xdgClaude = path.join(xdgConfigPath, "claude")
-    if (await isDirectory(xdgClaude)) {
-      return xdgClaude
-    }
+    const xdgPath = process.env.XDG_CONFIG_HOME || path.join(Path.home, ".config")
+    const xdgClaude = path.join(xdgPath, "claude")
+    if (await isDirectory(xdgClaude)) return xdgClaude
 
-    // Check legacy path (~/.claude)
-    const legacyClaude = path.join(Path.home, ".claude")
-    if (await isDirectory(legacyClaude)) {
-      return legacyClaude
-    }
+    const legacy = path.join(Path.home, ".claude")
+    if (await isDirectory(legacy)) return legacy
 
     return undefined
   }

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -5,7 +5,6 @@ import { Config } from "../config/config"
 
 import { Instance } from "../project/instance"
 import path from "path"
-import os from "os"
 
 import PROMPT_ANTHROPIC from "./prompt/anthropic.txt"
 import PROMPT_ANTHROPIC_WITHOUT_TODO from "./prompt/qwen.txt"
@@ -61,10 +60,15 @@ export namespace SystemPrompt {
     "CLAUDE.md",
     "CONTEXT.md", // deprecated
   ]
-  const GLOBAL_RULE_FILES = [
-    path.join(Global.Path.config, "AGENTS.md"),
-    path.join(os.homedir(), ".claude", "CLAUDE.md"),
-  ]
+
+  async function globalRuleFiles(): Promise<string[]> {
+    const files = [path.join(Global.Path.config, "AGENTS.md")]
+    const claudeDir = await Global.claudeConfigDir()
+    if (claudeDir) {
+      files.push(path.join(claudeDir, "CLAUDE.md"))
+    }
+    return files
+  }
 
   export async function custom() {
     const config = await Config.get()
@@ -78,7 +82,7 @@ export namespace SystemPrompt {
       }
     }
 
-    for (const globalRuleFile of GLOBAL_RULE_FILES) {
+    for (const globalRuleFile of await globalRuleFiles()) {
       if (await Bun.file(globalRuleFile).exists()) {
         paths.add(globalRuleFile)
         break
@@ -88,7 +92,7 @@ export namespace SystemPrompt {
     if (config.instructions) {
       for (let instruction of config.instructions) {
         if (instruction.startsWith("~/")) {
-          instruction = path.join(os.homedir(), instruction.slice(2))
+          instruction = path.join(Global.Path.home, instruction.slice(2))
         }
         let matches: string[] = []
         if (path.isAbsolute(instruction)) {

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -73,7 +73,6 @@ export namespace Skill {
         stop: Instance.worktree,
       }),
     )
-    // Also include global Claude config directory (supports CLAUDE_CONFIG_DIR env var)
     const globalClaude = await Global.claudeConfigDir()
     if (globalClaude) {
       claudeDirs.push(globalClaude)

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -6,7 +6,6 @@ import { ConfigMarkdown } from "../config/markdown"
 import { Log } from "../util/log"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
-import { exists } from "fs/promises"
 
 export namespace Skill {
   const log = Log.create({ service: "skill" })
@@ -74,9 +73,9 @@ export namespace Skill {
         stop: Instance.worktree,
       }),
     )
-    // Also include global ~/.claude/skills/
-    const globalClaude = `${Global.Path.home}/.claude`
-    if (await exists(globalClaude)) {
+    // Also include global Claude config directory (supports CLAUDE_CONFIG_DIR env var)
+    const globalClaude = await Global.claudeConfigDir()
+    if (globalClaude) {
       claudeDirs.push(globalClaude)
     }
 

--- a/packages/opencode/test/global/claude-config-dir.test.ts
+++ b/packages/opencode/test/global/claude-config-dir.test.ts
@@ -3,13 +3,12 @@ import { tmpdir } from "../fixture/fixture"
 import path from "path"
 import fs from "fs/promises"
 
-// We need to test the claudeConfigDir function with various environment scenarios.
-// Since the function reads from Flag.CLAUDE_CONFIG_DIR and Global.Path.home at import time,
-// we need to test the actual implementation by setting env vars before importing.
+async function isDirectory(p: string): Promise<boolean> {
+  const stat = await fs.stat(p).catch(() => undefined)
+  return stat?.isDirectory() ?? false
+}
 
-// Helper to create the claudeConfigDir function with fresh state
-async function createClaudeConfigDir(opts: { envVar?: string; testHome: string; xdgConfig: string }) {
-  // Set up environment before importing
+function createClaudeConfigDir(opts: { envVar?: string; testHome: string; xdgConfig: string }) {
   if (opts.envVar !== undefined) {
     process.env.CLAUDE_CONFIG_DIR = opts.envVar
   } else {
@@ -18,39 +17,22 @@ async function createClaudeConfigDir(opts: { envVar?: string; testHome: string; 
   process.env.OPENCODE_TEST_HOME = opts.testHome
   process.env.XDG_CONFIG_HOME = opts.xdgConfig
 
-  // Helper to check if path is a directory
-  async function isDirectory(p: string): Promise<boolean> {
-    const stat = await fs.stat(p).catch(() => undefined)
-    return stat?.isDirectory() ?? false
-  }
+  return async function claudeConfigDir(): Promise<string | undefined> {
+    const envDir = process.env.CLAUDE_CONFIG_DIR
+    if (envDir && (await isDirectory(envDir))) return envDir
 
-  // Recreate the claudeConfigDir logic inline for testing
-  // This mirrors the implementation in src/global/index.ts
-  async function claudeConfigDir(): Promise<string | undefined> {
-    const claudeConfigDirEnv = process.env.CLAUDE_CONFIG_DIR
-    if (claudeConfigDirEnv && (await isDirectory(claudeConfigDirEnv))) {
-      return claudeConfigDirEnv
-    }
-
-    const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(opts.testHome, ".config")
-    const xdgClaude = path.join(xdgConfig, "claude")
-    if (await isDirectory(xdgClaude)) {
-      return xdgClaude
-    }
+    const xdgPath = process.env.XDG_CONFIG_HOME || path.join(opts.testHome, ".config")
+    const xdgClaude = path.join(xdgPath, "claude")
+    if (await isDirectory(xdgClaude)) return xdgClaude
 
     const home = process.env.OPENCODE_TEST_HOME || opts.testHome
-    const legacyClaude = path.join(home, ".claude")
-    if (await isDirectory(legacyClaude)) {
-      return legacyClaude
-    }
+    const legacy = path.join(home, ".claude")
+    if (await isDirectory(legacy)) return legacy
 
     return undefined
   }
-
-  return claudeConfigDir
 }
 
-// Store original env values
 let originalClaudeConfigDir: string | undefined
 let originalTestHome: string | undefined
 let originalXdgConfigHome: string | undefined
@@ -62,7 +44,6 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // Restore original env values
   if (originalClaudeConfigDir !== undefined) {
     process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
   } else {
@@ -83,154 +64,125 @@ afterEach(() => {
 test("returns CLAUDE_CONFIG_DIR when set to valid directory", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      const claudeDir = path.join(dir, "custom-claude-config")
-      await fs.mkdir(claudeDir, { recursive: true })
+      await fs.mkdir(path.join(dir, "custom-claude-config"), { recursive: true })
     },
   })
 
   const customDir = path.join(tmp.path, "custom-claude-config")
-  const claudeConfigDir = await createClaudeConfigDir({
+  const claudeConfigDir = createClaudeConfigDir({
     envVar: customDir,
     testHome: tmp.path,
     xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  expect(result).toBe(customDir)
+  expect(await claudeConfigDir()).toBe(customDir)
 })
 
-test("falls back when CLAUDE_CONFIG_DIR is set but path does not exist", async () => {
+test("falls back when CLAUDE_CONFIG_DIR path does not exist", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      // Create the legacy .claude directory as fallback
-      const legacyDir = path.join(dir, ".claude")
-      await fs.mkdir(legacyDir, { recursive: true })
+      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const nonExistentPath = path.join(tmp.path, "non-existent-dir")
-  const claudeConfigDir = await createClaudeConfigDir({
-    envVar: nonExistentPath,
+  const claudeConfigDir = createClaudeConfigDir({
+    envVar: path.join(tmp.path, "non-existent-dir"),
     testHome: tmp.path,
     xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  expect(result).toBe(path.join(tmp.path, ".claude"))
+  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
 })
 
-test("falls back when CLAUDE_CONFIG_DIR is set but path is a file", async () => {
+test("falls back when CLAUDE_CONFIG_DIR is a file", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      // Create a file (not directory) at the specified path
-      const filePath = path.join(dir, "claude-file")
-      await Bun.write(filePath, "this is a file, not a directory")
-      // Create legacy .claude directory as fallback
-      const legacyDir = path.join(dir, ".claude")
-      await fs.mkdir(legacyDir, { recursive: true })
+      await Bun.write(path.join(dir, "claude-file"), "not a directory")
+      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const filePath = path.join(tmp.path, "claude-file")
-  const claudeConfigDir = await createClaudeConfigDir({
-    envVar: filePath,
+  const claudeConfigDir = createClaudeConfigDir({
+    envVar: path.join(tmp.path, "claude-file"),
     testHome: tmp.path,
     xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  expect(result).toBe(path.join(tmp.path, ".claude"))
+  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
 })
 
-test("returns ~/.config/claude when CLAUDE_CONFIG_DIR not set and xdg path exists", async () => {
+test("returns xdg path when CLAUDE_CONFIG_DIR not set", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      // Create XDG config claude directory
-      const xdgClaudeDir = path.join(dir, ".config", "claude")
-      await fs.mkdir(xdgClaudeDir, { recursive: true })
-      // Also create legacy .claude directory (should NOT be returned)
-      const legacyDir = path.join(dir, ".claude")
-      await fs.mkdir(legacyDir, { recursive: true })
+      await fs.mkdir(path.join(dir, ".config", "claude"), { recursive: true })
+      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const claudeConfigDir = await createClaudeConfigDir({
-    envVar: undefined, // Not set
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
-
-  const result = await claudeConfigDir()
-  // Should prefer XDG path over legacy
-  expect(result).toBe(path.join(tmp.path, ".config", "claude"))
-})
-
-test("returns ~/.claude when CLAUDE_CONFIG_DIR not set and only legacy path exists", async () => {
-  await using tmp = await tmpdir({
-    init: async (dir) => {
-      // Only create legacy .claude directory (no XDG)
-      const legacyDir = path.join(dir, ".claude")
-      await fs.mkdir(legacyDir, { recursive: true })
-    },
-  })
-
-  const claudeConfigDir = await createClaudeConfigDir({
+  const claudeConfigDir = createClaudeConfigDir({
     envVar: undefined,
     testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"), // XDG dir exists but no claude subdir
+    xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  expect(result).toBe(path.join(tmp.path, ".claude"))
+  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".config", "claude"))
+})
+
+test("returns legacy path when only it exists", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
+    },
+  })
+
+  const claudeConfigDir = createClaudeConfigDir({
+    envVar: undefined,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
 })
 
 test("returns undefined when no paths exist", async () => {
   await using tmp = await tmpdir()
 
-  const claudeConfigDir = await createClaudeConfigDir({
+  const claudeConfigDir = createClaudeConfigDir({
     envVar: undefined,
     testHome: tmp.path,
     xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  expect(result).toBeUndefined()
+  expect(await claudeConfigDir()).toBeUndefined()
 })
 
 test("returns undefined when CLAUDE_CONFIG_DIR is empty string", async () => {
   await using tmp = await tmpdir()
 
-  const claudeConfigDir = await createClaudeConfigDir({
-    envVar: "", // Empty string
+  const claudeConfigDir = createClaudeConfigDir({
+    envVar: "",
     testHome: tmp.path,
     xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  expect(result).toBeUndefined()
+  expect(await claudeConfigDir()).toBeUndefined()
 })
 
 test("priority: CLAUDE_CONFIG_DIR > XDG > legacy", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      // Create all three directories
-      const customDir = path.join(dir, "custom")
-      const xdgDir = path.join(dir, ".config", "claude")
-      const legacyDir = path.join(dir, ".claude")
-      await fs.mkdir(customDir, { recursive: true })
-      await fs.mkdir(xdgDir, { recursive: true })
-      await fs.mkdir(legacyDir, { recursive: true })
+      await fs.mkdir(path.join(dir, "custom"), { recursive: true })
+      await fs.mkdir(path.join(dir, ".config", "claude"), { recursive: true })
+      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
   const customDir = path.join(tmp.path, "custom")
-  const claudeConfigDir = await createClaudeConfigDir({
+  const claudeConfigDir = createClaudeConfigDir({
     envVar: customDir,
     testHome: tmp.path,
     xdgConfig: path.join(tmp.path, ".config"),
   })
 
-  const result = await claudeConfigDir()
-  // Should return CLAUDE_CONFIG_DIR path first
-  expect(result).toBe(customDir)
+  expect(await claudeConfigDir()).toBe(customDir)
 })

--- a/packages/opencode/test/global/claude-config-dir.test.ts
+++ b/packages/opencode/test/global/claude-config-dir.test.ts
@@ -1,0 +1,236 @@
+import { test, expect, beforeEach, afterEach } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+import fs from "fs/promises"
+
+// We need to test the claudeConfigDir function with various environment scenarios.
+// Since the function reads from Flag.CLAUDE_CONFIG_DIR and Global.Path.home at import time,
+// we need to test the actual implementation by setting env vars before importing.
+
+// Helper to create the claudeConfigDir function with fresh state
+async function createClaudeConfigDir(opts: { envVar?: string; testHome: string; xdgConfig: string }) {
+  // Set up environment before importing
+  if (opts.envVar !== undefined) {
+    process.env.CLAUDE_CONFIG_DIR = opts.envVar
+  } else {
+    delete process.env.CLAUDE_CONFIG_DIR
+  }
+  process.env.OPENCODE_TEST_HOME = opts.testHome
+  process.env.XDG_CONFIG_HOME = opts.xdgConfig
+
+  // Helper to check if path is a directory
+  async function isDirectory(p: string): Promise<boolean> {
+    const stat = await fs.stat(p).catch(() => undefined)
+    return stat?.isDirectory() ?? false
+  }
+
+  // Recreate the claudeConfigDir logic inline for testing
+  // This mirrors the implementation in src/global/index.ts
+  async function claudeConfigDir(): Promise<string | undefined> {
+    const claudeConfigDirEnv = process.env.CLAUDE_CONFIG_DIR
+    if (claudeConfigDirEnv && (await isDirectory(claudeConfigDirEnv))) {
+      return claudeConfigDirEnv
+    }
+
+    const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(opts.testHome, ".config")
+    const xdgClaude = path.join(xdgConfig, "claude")
+    if (await isDirectory(xdgClaude)) {
+      return xdgClaude
+    }
+
+    const home = process.env.OPENCODE_TEST_HOME || opts.testHome
+    const legacyClaude = path.join(home, ".claude")
+    if (await isDirectory(legacyClaude)) {
+      return legacyClaude
+    }
+
+    return undefined
+  }
+
+  return claudeConfigDir
+}
+
+// Store original env values
+let originalClaudeConfigDir: string | undefined
+let originalTestHome: string | undefined
+let originalXdgConfigHome: string | undefined
+
+beforeEach(() => {
+  originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR
+  originalTestHome = process.env.OPENCODE_TEST_HOME
+  originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+})
+
+afterEach(() => {
+  // Restore original env values
+  if (originalClaudeConfigDir !== undefined) {
+    process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir
+  } else {
+    delete process.env.CLAUDE_CONFIG_DIR
+  }
+  if (originalTestHome !== undefined) {
+    process.env.OPENCODE_TEST_HOME = originalTestHome
+  } else {
+    delete process.env.OPENCODE_TEST_HOME
+  }
+  if (originalXdgConfigHome !== undefined) {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+  } else {
+    delete process.env.XDG_CONFIG_HOME
+  }
+})
+
+test("returns CLAUDE_CONFIG_DIR when set to valid directory", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const claudeDir = path.join(dir, "custom-claude-config")
+      await fs.mkdir(claudeDir, { recursive: true })
+    },
+  })
+
+  const customDir = path.join(tmp.path, "custom-claude-config")
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: customDir,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  expect(result).toBe(customDir)
+})
+
+test("falls back when CLAUDE_CONFIG_DIR is set but path does not exist", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create the legacy .claude directory as fallback
+      const legacyDir = path.join(dir, ".claude")
+      await fs.mkdir(legacyDir, { recursive: true })
+    },
+  })
+
+  const nonExistentPath = path.join(tmp.path, "non-existent-dir")
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: nonExistentPath,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  expect(result).toBe(path.join(tmp.path, ".claude"))
+})
+
+test("falls back when CLAUDE_CONFIG_DIR is set but path is a file", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create a file (not directory) at the specified path
+      const filePath = path.join(dir, "claude-file")
+      await Bun.write(filePath, "this is a file, not a directory")
+      // Create legacy .claude directory as fallback
+      const legacyDir = path.join(dir, ".claude")
+      await fs.mkdir(legacyDir, { recursive: true })
+    },
+  })
+
+  const filePath = path.join(tmp.path, "claude-file")
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: filePath,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  expect(result).toBe(path.join(tmp.path, ".claude"))
+})
+
+test("returns ~/.config/claude when CLAUDE_CONFIG_DIR not set and xdg path exists", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create XDG config claude directory
+      const xdgClaudeDir = path.join(dir, ".config", "claude")
+      await fs.mkdir(xdgClaudeDir, { recursive: true })
+      // Also create legacy .claude directory (should NOT be returned)
+      const legacyDir = path.join(dir, ".claude")
+      await fs.mkdir(legacyDir, { recursive: true })
+    },
+  })
+
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: undefined, // Not set
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  // Should prefer XDG path over legacy
+  expect(result).toBe(path.join(tmp.path, ".config", "claude"))
+})
+
+test("returns ~/.claude when CLAUDE_CONFIG_DIR not set and only legacy path exists", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Only create legacy .claude directory (no XDG)
+      const legacyDir = path.join(dir, ".claude")
+      await fs.mkdir(legacyDir, { recursive: true })
+    },
+  })
+
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: undefined,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"), // XDG dir exists but no claude subdir
+  })
+
+  const result = await claudeConfigDir()
+  expect(result).toBe(path.join(tmp.path, ".claude"))
+})
+
+test("returns undefined when no paths exist", async () => {
+  await using tmp = await tmpdir()
+
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: undefined,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  expect(result).toBeUndefined()
+})
+
+test("returns undefined when CLAUDE_CONFIG_DIR is empty string", async () => {
+  await using tmp = await tmpdir()
+
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: "", // Empty string
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  expect(result).toBeUndefined()
+})
+
+test("priority: CLAUDE_CONFIG_DIR > XDG > legacy", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create all three directories
+      const customDir = path.join(dir, "custom")
+      const xdgDir = path.join(dir, ".config", "claude")
+      const legacyDir = path.join(dir, ".claude")
+      await fs.mkdir(customDir, { recursive: true })
+      await fs.mkdir(xdgDir, { recursive: true })
+      await fs.mkdir(legacyDir, { recursive: true })
+    },
+  })
+
+  const customDir = path.join(tmp.path, "custom")
+  const claudeConfigDir = await createClaudeConfigDir({
+    envVar: customDir,
+    testHome: tmp.path,
+    xdgConfig: path.join(tmp.path, ".config"),
+  })
+
+  const result = await claudeConfigDir()
+  // Should return CLAUDE_CONFIG_DIR path first
+  expect(result).toBe(customDir)
+})

--- a/packages/opencode/test/global/claude-config-dir.test.ts
+++ b/packages/opencode/test/global/claude-config-dir.test.ts
@@ -1,37 +1,8 @@
 import { test, expect, beforeEach, afterEach } from "bun:test"
 import { tmpdir } from "../fixture/fixture"
+import { Global } from "../../src/global"
 import path from "path"
-import fs from "fs/promises"
-
-async function isDirectory(p: string): Promise<boolean> {
-  const stat = await fs.stat(p).catch(() => undefined)
-  return stat?.isDirectory() ?? false
-}
-
-function createClaudeConfigDir(opts: { envVar?: string; testHome: string; xdgConfig: string }) {
-  if (opts.envVar !== undefined) {
-    process.env.CLAUDE_CONFIG_DIR = opts.envVar
-  } else {
-    delete process.env.CLAUDE_CONFIG_DIR
-  }
-  process.env.OPENCODE_TEST_HOME = opts.testHome
-  process.env.XDG_CONFIG_HOME = opts.xdgConfig
-
-  return async function claudeConfigDir(): Promise<string | undefined> {
-    const envDir = process.env.CLAUDE_CONFIG_DIR
-    if (envDir && (await isDirectory(envDir))) return envDir
-
-    const xdgPath = process.env.XDG_CONFIG_HOME || path.join(opts.testHome, ".config")
-    const xdgClaude = path.join(xdgPath, "claude")
-    if (await isDirectory(xdgClaude)) return xdgClaude
-
-    const home = process.env.OPENCODE_TEST_HOME || opts.testHome
-    const legacy = path.join(home, ".claude")
-    if (await isDirectory(legacy)) return legacy
-
-    return undefined
-  }
-}
+import { mkdir } from "fs/promises"
 
 let originalClaudeConfigDir: string | undefined
 let originalTestHome: string | undefined
@@ -64,125 +35,109 @@ afterEach(() => {
 test("returns CLAUDE_CONFIG_DIR when set to valid directory", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      await fs.mkdir(path.join(dir, "custom-claude-config"), { recursive: true })
+      await mkdir(path.join(dir, "custom-claude-config"), { recursive: true })
     },
   })
 
   const customDir = path.join(tmp.path, "custom-claude-config")
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: customDir,
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  process.env.CLAUDE_CONFIG_DIR = customDir
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBe(customDir)
+  expect(await Global.claudeConfigDir()).toBe(customDir)
 })
 
 test("falls back when CLAUDE_CONFIG_DIR path does not exist", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
+      await mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: path.join(tmp.path, "non-existent-dir"),
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  process.env.CLAUDE_CONFIG_DIR = path.join(tmp.path, "non-existent-dir")
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
+  expect(await Global.claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
 })
 
 test("falls back when CLAUDE_CONFIG_DIR is a file", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
       await Bun.write(path.join(dir, "claude-file"), "not a directory")
-      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
+      await mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: path.join(tmp.path, "claude-file"),
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  process.env.CLAUDE_CONFIG_DIR = path.join(tmp.path, "claude-file")
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
+  expect(await Global.claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
 })
 
 test("returns xdg path when CLAUDE_CONFIG_DIR not set", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      await fs.mkdir(path.join(dir, ".config", "claude"), { recursive: true })
-      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
+      await mkdir(path.join(dir, ".config", "claude"), { recursive: true })
+      await mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: undefined,
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  delete process.env.CLAUDE_CONFIG_DIR
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".config", "claude"))
+  expect(await Global.claudeConfigDir()).toBe(path.join(tmp.path, ".config", "claude"))
 })
 
 test("returns legacy path when only it exists", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
+      await mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: undefined,
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  delete process.env.CLAUDE_CONFIG_DIR
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
+  expect(await Global.claudeConfigDir()).toBe(path.join(tmp.path, ".claude"))
 })
 
 test("returns undefined when no paths exist", async () => {
   await using tmp = await tmpdir()
 
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: undefined,
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  delete process.env.CLAUDE_CONFIG_DIR
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBeUndefined()
+  expect(await Global.claudeConfigDir()).toBeUndefined()
 })
 
 test("returns undefined when CLAUDE_CONFIG_DIR is empty string", async () => {
   await using tmp = await tmpdir()
 
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: "",
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  process.env.CLAUDE_CONFIG_DIR = ""
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBeUndefined()
+  expect(await Global.claudeConfigDir()).toBeUndefined()
 })
 
 test("priority: CLAUDE_CONFIG_DIR > XDG > legacy", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {
-      await fs.mkdir(path.join(dir, "custom"), { recursive: true })
-      await fs.mkdir(path.join(dir, ".config", "claude"), { recursive: true })
-      await fs.mkdir(path.join(dir, ".claude"), { recursive: true })
+      await mkdir(path.join(dir, "custom"), { recursive: true })
+      await mkdir(path.join(dir, ".config", "claude"), { recursive: true })
+      await mkdir(path.join(dir, ".claude"), { recursive: true })
     },
   })
 
   const customDir = path.join(tmp.path, "custom")
-  const claudeConfigDir = createClaudeConfigDir({
-    envVar: customDir,
-    testHome: tmp.path,
-    xdgConfig: path.join(tmp.path, ".config"),
-  })
+  process.env.CLAUDE_CONFIG_DIR = customDir
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.XDG_CONFIG_HOME = path.join(tmp.path, ".config")
 
-  expect(await claudeConfigDir()).toBe(customDir)
+  expect(await Global.claudeConfigDir()).toBe(customDir)
 })


### PR DESCRIPTION
## Summary

- Adds support for `CLAUDE_CONFIG_DIR` environment variable
- Falls back to `~/.config/claude` (new Claude Code default) then `~/.claude` (legacy)
- Fixes ENOTDIR error when `~/.claude` is a file instead of directory

Fixes #6551

## Changes

- Added `CLAUDE_CONFIG_DIR` to Flag namespace
- Added `Global.claudeConfigDir()` function with proper fallback logic
- Updated `system.ts` to use dynamic path for CLAUDE.md
- Updated `skill.ts` to use dynamic path for skills directory
- Added unit tests for the new logic

## Testing

- Added unit tests covering all fallback scenarios (8 tests, all passing)
- Manually tested with `CLAUDE_CONFIG_DIR` set to custom path