### PR TITLE
feat(plugin): add tui.session.select API endpoint for TUI navigation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -535,6 +535,13 @@ function App() {
     })
   })
 
+  sdk.event.on(TuiEvent.SessionSelect.type, (evt) => {
+    route.navigate({
+      type: "session",
+      sessionID: evt.properties.sessionID,
+    })
+  })
+
   sdk.event.on(SessionApi.Event.Deleted.type, (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {
       route.navigate({ type: "home" })

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -37,4 +37,10 @@ export const TuiEvent = {
       duration: z.number().default(5000).optional().describe("Duration in milliseconds"),
     }),
   ),
+  SessionSelect: BusEvent.define(
+    "tui.session.select",
+    z.object({
+      sessionID: z.string().regex(/^ses/).describe("Session ID to navigate to"),
+    }),
+  ),
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -975,6 +975,37 @@ export namespace Server {
         },
       )
       .post(
+        "/session/:sessionID/select",
+        describeRoute({
+          summary: "Select session",
+          description: "Navigate the TUI to display the specified session.",
+          operationId: "session.select",
+          responses: {
+            200: {
+              description: "Session selected successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            sessionID: Session.get.schema,
+          }),
+        ),
+        async (c) => {
+          const sessionID = c.req.valid("param").sessionID
+          await Session.get(sessionID)
+          await Bus.publish(TuiEvent.SessionSelect, { sessionID })
+          return c.json(true)
+        },
+      )
+      .post(
         "/session/:sessionID/share",
         describeRoute({
           summary: "Share session",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -974,37 +974,7 @@ export namespace Server {
           return c.json(true)
         },
       )
-      .post(
-        "/session/:sessionID/select",
-        describeRoute({
-          summary: "Select session",
-          description: "Navigate the TUI to display the specified session.",
-          operationId: "session.select",
-          responses: {
-            200: {
-              description: "Session selected successfully",
-              content: {
-                "application/json": {
-                  schema: resolver(z.boolean()),
-                },
-              },
-            },
-            ...errors(400, 404),
-          },
-        }),
-        validator(
-          "param",
-          z.object({
-            sessionID: Session.get.schema,
-          }),
-        ),
-        async (c) => {
-          const sessionID = c.req.valid("param").sessionID
-          await Session.get(sessionID)
-          await Bus.publish(TuiEvent.SessionSelect, { sessionID })
-          return c.json(true)
-        },
-      )
+
       .post(
         "/session/:sessionID/share",
         describeRoute({
@@ -2595,6 +2565,32 @@ export namespace Server {
         async (c) => {
           const evt = c.req.valid("json")
           await Bus.publish(Object.values(TuiEvent).find((def) => def.type === evt.type)!, evt.properties)
+          return c.json(true)
+        },
+      )
+      .post(
+        "/tui/select-session",
+        describeRoute({
+          summary: "Select session",
+          description: "Navigate the TUI to display the specified session.",
+          operationId: "tui.selectSession",
+          responses: {
+            200: {
+              description: "Session selected successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400, 404),
+          },
+        }),
+        validator("json", TuiEvent.SessionSelect.properties),
+        async (c) => {
+          const { sessionID } = c.req.valid("json")
+          await Session.get(sessionID)
+          await Bus.publish(TuiEvent.SessionSelect, { sessionID })
           return c.json(true)
         },
       )

--- a/packages/opencode/test/server/session-select.test.ts
+++ b/packages/opencode/test/server/session-select.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session.select endpoint", () => {
+  test("should return 200 when called with valid session", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        // #given
+        const session = await Session.create({})
+
+        // #when
+        const app = Server.App()
+        const response = await app.request(`/session/${session.id}/select`, {
+          method: "POST",
+        })
+
+        // #then
+        expect(response.status).toBe(200)
+        const body = await response.json()
+        expect(body).toBe(true)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("should return 404 when session does not exist", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        // #given
+        const nonExistentSessionID = "ses_nonexistent123"
+
+        // #when
+        const app = Server.App()
+        const response = await app.request(`/session/${nonExistentSessionID}/select`, {
+          method: "POST",
+        })
+
+        // #then
+        expect(response.status).toBe(404)
+      },
+    })
+  })
+
+  test("should return 400 when session ID format is invalid", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        // #given
+        const invalidSessionID = "invalid_session_id"
+
+        // #when
+        const app = Server.App()
+        const response = await app.request(`/session/${invalidSessionID}/select`, {
+          method: "POST",
+        })
+
+        // #then
+        expect(response.status).toBe(400)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/server/session-select.test.ts
+++ b/packages/opencode/test/server/session-select.test.ts
@@ -8,7 +8,7 @@ import { Server } from "../../src/server/server"
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
 
-describe("session.select endpoint", () => {
+describe("tui.selectSession endpoint", () => {
   test("should return 200 when called with valid session", async () => {
     await Instance.provide({
       directory: projectRoot,
@@ -18,8 +18,10 @@ describe("session.select endpoint", () => {
 
         // #when
         const app = Server.App()
-        const response = await app.request(`/session/${session.id}/select`, {
+        const response = await app.request("/tui/select-session", {
           method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: session.id }),
         })
 
         // #then
@@ -41,8 +43,10 @@ describe("session.select endpoint", () => {
 
         // #when
         const app = Server.App()
-        const response = await app.request(`/session/${nonExistentSessionID}/select`, {
+        const response = await app.request("/tui/select-session", {
           method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: nonExistentSessionID }),
         })
 
         // #then
@@ -60,8 +64,10 @@ describe("session.select endpoint", () => {
 
         // #when
         const app = Server.App()
-        const response = await app.request(`/session/${invalidSessionID}/select`, {
+        const response = await app.request("/tui/select-session", {
           method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ sessionID: invalidSessionID }),
         })
 
         // #then

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -19,6 +19,7 @@ import type {
   EventSubscribeResponses,
   EventTuiCommandExecute,
   EventTuiPromptAppend,
+  EventTuiSessionSelect,
   EventTuiToastShow,
   FileListResponses,
   FilePartInput,
@@ -106,6 +107,8 @@ import type {
   SessionPromptResponses,
   SessionRevertErrors,
   SessionRevertResponses,
+  SessionSelectErrors,
+  SessionSelectResponses,
   SessionShareErrors,
   SessionShareResponses,
   SessionShellErrors,
@@ -1038,6 +1041,36 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
       url: "/session/{sessionID}/abort",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Select session
+   *
+   * Navigate the TUI to display the specified session.
+   */
+  public select<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionSelectResponses, SessionSelectErrors, ThrowOnError>({
+      url: "/session/{sessionID}/select",
       ...options,
       ...params,
     })
@@ -2644,7 +2677,7 @@ export class Tui extends HeyApiClient {
   public publish<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
-      body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow
+      body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -107,8 +107,6 @@ import type {
   SessionPromptResponses,
   SessionRevertErrors,
   SessionRevertResponses,
-  SessionSelectErrors,
-  SessionSelectResponses,
   SessionShareErrors,
   SessionShareResponses,
   SessionShellErrors,
@@ -144,6 +142,8 @@ import type {
   TuiOpenThemesResponses,
   TuiPublishErrors,
   TuiPublishResponses,
+  TuiSelectSessionErrors,
+  TuiSelectSessionResponses,
   TuiShowToastResponses,
   TuiSubmitPromptResponses,
   VcsGetResponses,
@@ -1041,36 +1041,6 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<SessionAbortResponses, SessionAbortErrors, ThrowOnError>({
       url: "/session/{sessionID}/abort",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Select session
-   *
-   * Navigate the TUI to display the specified session.
-   */
-  public select<ThrowOnError extends boolean = false>(
-    parameters: {
-      sessionID: string
-      directory?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "path", key: "sessionID" },
-            { in: "query", key: "directory" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<SessionSelectResponses, SessionSelectErrors, ThrowOnError>({
-      url: "/session/{sessionID}/select",
       ...options,
       ...params,
     })
@@ -2684,6 +2654,41 @@ export class Tui extends HeyApiClient {
     const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }, { in: "body" }] }])
     return (options?.client ?? this.client).post<TuiPublishResponses, TuiPublishErrors, ThrowOnError>({
       url: "/tui/publish",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Select session
+   *
+   * Navigate the TUI to display the specified session.
+   */
+  public selectSession<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      sessionID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "sessionID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<TuiSelectSessionResponses, TuiSelectSessionErrors, ThrowOnError>({
+      url: "/tui/select-session",
       ...options,
       ...params,
       headers: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2791,39 +2791,6 @@ export type SessionAbortResponses = {
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
 
-export type SessionSelectData = {
-  body?: never
-  path: {
-    sessionID: string
-  }
-  query?: {
-    directory?: string
-  }
-  url: "/session/{sessionID}/select"
-}
-
-export type SessionSelectErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-  /**
-   * Not found
-   */
-  404: NotFoundError
-}
-
-export type SessionSelectError = SessionSelectErrors[keyof SessionSelectErrors]
-
-export type SessionSelectResponses = {
-  /**
-   * Session selected successfully
-   */
-  200: boolean
-}
-
-export type SessionSelectResponse = SessionSelectResponses[keyof SessionSelectResponses]
-
 export type SessionUnshareData = {
   body?: never
   path: {
@@ -4357,6 +4324,42 @@ export type TuiPublishResponses = {
 }
 
 export type TuiPublishResponse = TuiPublishResponses[keyof TuiPublishResponses]
+
+export type TuiSelectSessionData = {
+  body?: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/tui/select-session"
+}
+
+export type TuiSelectSessionErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type TuiSelectSessionError = TuiSelectSessionErrors[keyof TuiSelectSessionErrors]
+
+export type TuiSelectSessionResponses = {
+  /**
+   * Session selected successfully
+   */
+  200: boolean
+}
+
+export type TuiSelectSessionResponse = TuiSelectSessionResponses[keyof TuiSelectSessionResponses]
 
 export type TuiControlNextData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -593,6 +593,16 @@ export type EventTuiToastShow = {
   }
 }
 
+export type EventTuiSessionSelect = {
+  type: "tui.session.select"
+  properties: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID: string
+  }
+}
+
 export type EventMcpToolsChanged = {
   type: "mcp.tools.changed"
   properties: {
@@ -766,6 +776,7 @@ export type Event =
   | EventTuiPromptAppend
   | EventTuiCommandExecute
   | EventTuiToastShow
+  | EventTuiSessionSelect
   | EventMcpToolsChanged
   | EventCommandExecuted
   | EventSessionCreated
@@ -2780,6 +2791,39 @@ export type SessionAbortResponses = {
 
 export type SessionAbortResponse = SessionAbortResponses[keyof SessionAbortResponses]
 
+export type SessionSelectData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/select"
+}
+
+export type SessionSelectErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionSelectError = SessionSelectErrors[keyof SessionSelectErrors]
+
+export type SessionSelectResponses = {
+  /**
+   * Session selected successfully
+   */
+  200: boolean
+}
+
+export type SessionSelectResponse = SessionSelectResponses[keyof SessionSelectResponses]
+
 export type SessionUnshareData = {
   body?: never
   path: {
@@ -4288,7 +4332,7 @@ export type TuiShowToastResponses = {
 export type TuiShowToastResponse = TuiShowToastResponses[keyof TuiShowToastResponses]
 
 export type TuiPublishData = {
-  body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow
+  body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
   path?: never
   query?: {
     directory?: string


### PR DESCRIPTION
## Summary

Add plugin API endpoint (`POST /session/{sessionID}/select`) that allows plugins to programmatically navigate the TUI to a different session.

## Changes

### Server (`packages/opencode/src/server/server.ts`)
- Add `POST /session/:sessionID/select` endpoint
- Validates session exists before emitting event
- Returns 404 for invalid session ID

### TUI (`packages/opencode/src/cli/cmd/tui/`)
- Add `SessionSelect` event type in `event.ts`
- Handle `SessionSelect` event in `app.tsx` to switch displayed session

### SDK (`packages/sdk/js/`)
- Regenerated with `client.session.select()` method

## Usage

### From Plugin (Native)

```typescript
import type { Plugin } from "@opencode-ai/plugin"

const plugin: Plugin = async ({ client }) => ({
  tool: {
    switch_session: {
      description: "Switch to a different session",
      parameters: z.object({ sessionID: z.string() }),
      async execute({ parameters }) {
        await client.session.select({ sessionID: parameters.sessionID })
        return { output: `Switched to session ${parameters.sessionID}` }
      },
    },
  },
})

export default plugin
```

### From External SDK

```typescript
import { createClient } from "@opencode-ai/sdk"

const client = createClient({ baseUrl: "http://localhost:34127" })
await client.session.select({ sessionID: "ses_abc123" })
```
