### PR TITLE
fix(ui): fix slight vertical overflow in project selector

### DIFF
--- a/packages/ui/src/components/select.css
+++ b/packages/ui/src/components/select.css
@@ -112,6 +112,9 @@
       pointer-events: none;
     }
     [data-slot="select-select-item-indicator"] {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       margin-left: auto;
       width: 16px;
       height: 16px;


### PR DESCRIPTION
Fixes #6588 

## Changes

- There is a small vertical overflow in the project selector if you only have 1 project, or multiple and have the last one in list selected. It's mostly visible if you have a mouse plugged in. This PR fixes this issue by making the item indicator a flex container and centering it's content.

## Screenshots

### Before
<img width="1074" height="704" alt="CleanShot 2026-01-01 at 18 34 24@2x" src="https://github.com/user-attachments/assets/d5c9d1cf-24b7-4f74-b6df-73df66573538" />

### After
<img width="1056" height="700" alt="CleanShot 2026-01-01 at 18 34 50@2x" src="https://github.com/user-attachments/assets/31028c03-53ed-4106-b88b-1f6f7abd2123" />

