### PR TITLE
fix(server): handle query params in MIME type detection for proxied assets

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2666,10 +2666,10 @@ export namespace Server {
         })
         // Cloudflare doesn't return Content-Type for static assets, so we need to add it
         const mimeTypes: Record<string, string> = {
-          ".js": "application/javascript",
-          ".mjs": "application/javascript",
-          ".css": "text/css",
-          ".json": "application/json",
+          ".js": "application/javascript; charset=utf-8",
+          ".mjs": "application/javascript; charset=utf-8",
+          ".css": "text/css; charset=utf-8",
+          ".json": "application/json; charset=utf-8",
           ".wasm": "application/wasm",
           ".svg": "image/svg+xml",
           ".png": "image/png",
@@ -2683,8 +2683,10 @@ export namespace Server {
           ".ttf": "font/ttf",
           ".eot": "application/vnd.ms-fontobject",
         }
+        // Extract pathname without query parameters or hash fragments
+        const pathname = path.split("?")[0].split("#")[0]
         for (const [ext, mime] of Object.entries(mimeTypes)) {
-          if (path.endsWith(ext)) {
+          if (pathname.endsWith(ext)) {
             const headers = new Headers(response.headers)
             headers.set("Content-Type", mime)
             return new Response(response.body, {


### PR DESCRIPTION
## Summary
Improves upon #6587 by fixing a bug where MIME type detection fails for URLs with query parameters or hash fragments.
## Problem
The current implementation (from #6587) uses `path.endsWith(ext)` which fails for:
- `/assets/file.js?v=123` - common for cache busting
- `/assets/file.js#source-map` - used in source maps
This causes these files to be served without Content-Type headers, breaking module loading.
## Changes
- Extract pathname without query params/hash before extension checking
- Add `charset=utf-8` to text-based MIME types (JS, CSS, JSON) for standards compliance