### PR TITLE
fix: remove outdated Haiku filter for GitHub Copilot

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1026,10 +1026,6 @@ export namespace Provider {
         "gemini-2.5-flash",
         "gpt-5-nano",
       ]
-      // claude-haiku-4.5 is considered a premium model in github copilot, we shouldn't use premium requests for title gen
-      if (providerID === "github-copilot") {
-        priority = priority.filter((m) => m !== "claude-haiku-4.5")
-      }
       if (providerID.startsWith("opencode")) {
         priority = ["gpt-5-nano"]
       }


### PR DESCRIPTION
## Summary
Removes the GitHub Copilot filter that excluded Claude Haiku 4.5 from small model selection.

## Problem
Session titles weren't being auto-generated for GitHub Copilot users - they stayed as "New session - 2026-01-01..." instead of getting meaningful names.

The issue: Haiku 4.5 was filtered out based on outdated assumptions. When the filter was added in Oct 2025, Haiku was considered a premium model. Now it has a 0.33x multiplier, same as other small models in the priority list (Gemini 3 Flash, GPT-5.1-Codex-Mini - [Pricing page](https://docs.github.com/en/copilot/concepts/billing/copilot-requests#model-multipliers)).

## Solution
Remove the filter. Haiku 4.5 is now cost-effective and should be available for title generation.

## Changes
- Removed 4 lines from `provider.ts` that filtered out `claude-haiku-4.5` for GitHub Copilot

Fixes #4040