### PR TITLE
feat(tui): add per-workspace TUI display settings

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -118,16 +118,36 @@ export function Session() {
   })
 
   const dimensions = useTerminalDimensions()
-  const [sidebar, setSidebar] = createSignal<"show" | "hide" | "auto">(kv.get("sidebar", "auto"))
+  const [sidebar, setSidebar] = createSignal<"show" | "hide" | "auto">(
+    sync.data.config.tui?.sidebar ?? kv.get("sidebar", "auto"),
+  )
   const [conceal, setConceal] = createSignal(true)
-  const [showThinking, setShowThinking] = createSignal(kv.get("thinking_visibility", true))
-  const [showTimestamps, setShowTimestamps] = createSignal(kv.get("timestamps", "hide") === "show")
-  const [usernameVisible, setUsernameVisible] = createSignal(kv.get("username_visible", true))
-  const [showDetails, setShowDetails] = createSignal(kv.get("tool_details_visibility", true))
-  const [showScrollbar, setShowScrollbar] = createSignal(kv.get("scrollbar_visible", false))
-  const [userMessageMarkdown, setUserMessageMarkdown] = createSignal(kv.get("user_message_markdown", true))
+  const [showThinking, setShowThinking] = createSignal(
+    sync.data.config.tui?.show_thinking ?? kv.get("thinking_visibility", true),
+  )
+  const [showTimestamps, setShowTimestamps] = createSignal(
+    sync.data.config.tui?.timestamps === "show"
+      ? true
+      : sync.data.config.tui?.timestamps === "hide"
+        ? false
+        : kv.get("timestamps", "hide") === "show",
+  )
+  const [usernameVisible, setUsernameVisible] = createSignal(
+    sync.data.config.tui?.show_username ?? kv.get("username_visible", true),
+  )
+  const [showDetails, setShowDetails] = createSignal(
+    sync.data.config.tui?.show_tool_details ?? kv.get("tool_details_visibility", true),
+  )
+  const [showScrollbar, setShowScrollbar] = createSignal(
+    sync.data.config.tui?.show_scrollbar ?? kv.get("scrollbar_visible", false),
+  )
+  const [userMessageMarkdown, setUserMessageMarkdown] = createSignal(
+    sync.data.config.tui?.user_message_markdown ?? kv.get("user_message_markdown", true),
+  )
   const [diffWrapMode, setDiffWrapMode] = createSignal<"word" | "none">("word")
-  const [animationsEnabled, setAnimationsEnabled] = createSignal(kv.get("animations_enabled", true))
+  const [animationsEnabled, setAnimationsEnabled] = createSignal(
+    sync.data.config.tui?.animations ?? kv.get("animations_enabled", true),
+  )
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -577,6 +577,14 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    show_thinking: z.boolean().optional().describe("Show thinking blocks in assistant responses"),
+    show_tool_details: z.boolean().optional().describe("Show detailed tool call information"),
+    sidebar: z.enum(["show", "hide", "auto"]).optional().describe("Sidebar visibility mode"),
+    timestamps: z.enum(["show", "hide"]).optional().describe("Show message timestamps"),
+    show_username: z.boolean().optional().describe("Show username in message headers"),
+    show_scrollbar: z.boolean().optional().describe("Show scrollbar in message list"),
+    animations: z.boolean().optional().describe("Enable TUI animations"),
+    user_message_markdown: z.boolean().optional().describe("Render user messages as markdown"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1454,6 +1454,38 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Show thinking blocks in assistant responses
+     */
+    show_thinking?: boolean
+    /**
+     * Show detailed tool call information
+     */
+    show_tool_details?: boolean
+    /**
+     * Sidebar visibility mode
+     */
+    sidebar?: "show" | "hide" | "auto"
+    /**
+     * Show message timestamps
+     */
+    timestamps?: "show" | "hide"
+    /**
+     * Show username in message headers
+     */
+    show_username?: boolean
+    /**
+     * Show scrollbar in message list
+     */
+    show_scrollbar?: boolean
+    /**
+     * Enable TUI animations
+     */
+    animations?: boolean
+    /**
+     * Render user messages as markdown
+     */
+    user_message_markdown?: boolean
   }
   server?: ServerConfig
   /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8304,6 +8304,40 @@
                 "description": "Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column",
                 "type": "string",
                 "enum": ["auto", "stacked"]
+              },
+              "show_thinking": {
+                "description": "Show thinking blocks in assistant responses",
+                "type": "boolean"
+              },
+              "show_tool_details": {
+                "description": "Show detailed tool call information",
+                "type": "boolean"
+              },
+              "sidebar": {
+                "description": "Sidebar visibility mode",
+                "type": "string",
+                "enum": ["show", "hide", "auto"]
+              },
+              "timestamps": {
+                "description": "Show message timestamps",
+                "type": "string",
+                "enum": ["show", "hide"]
+              },
+              "show_username": {
+                "description": "Show username in message headers",
+                "type": "boolean"
+              },
+              "show_scrollbar": {
+                "description": "Show scrollbar in message list",
+                "type": "boolean"
+              },
+              "animations": {
+                "description": "Enable TUI animations",
+                "type": "boolean"
+              },
+              "user_message_markdown": {
+                "description": "Render user messages as markdown",
+                "type": "boolean"
               }
             }
           },


### PR DESCRIPTION
## Summary

- Add configurable TUI display settings that can be set per-workspace via `opencode.json`
- Enables different visual configurations for different contexts (technical vs non-technical sessions)

## Disclaimer

This PR was created with the assistance of Claude. Manual testing has been done in the TUI but additional testing would be appreciated.

## Changes

### Problem

TUI display settings (thinking visibility, sidebar, timestamps, etc.) are stored in a global KV store (`~/.local/state/opencode/kv.json`). Toggling `/thinking` off in one workspace affects all workspaces.

I've been building a life-coach/personal assistant setup using OpenCode where thinking blocks add visual clutter. But in coding workspaces, I want them visible. Currently requires manual toggling every context switch.

### Solution

Expose TUI display settings in the config schema:

```json
{
  "tui": {
    "show_thinking": false,
    "sidebar": "hide"
  }
}
```

Config values act as workspace defaults. Runtime toggles still work as session-only overrides.

### Backward Compatibility

- All new config fields are optional with no defaults
- When config fields are unset, existing KV behavior is preserved exactly
- Users without any `tui` config see zero change

### Files Changed

- `packages/opencode/src/config/config.ts` - Add 8 optional TUI schema fields
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` - Config defaults with KV fallback
- `packages/sdk/js/src/v2/gen/types.gen.ts` - Regenerated SDK types
- `packages/sdk/openapi.json` - Updated OpenAPI spec

## Testing

- TypeScript passes (turbo typecheck: 12/12 packages)
- Config schema validates correctly
- Backward compatible: no config = existing KV behavior preserved