### PR TITLE
feat: add optional cwd path argument to serve command

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -4,14 +4,21 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 
 export const ServeCommand = cmd({
-  command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  command: "serve [cwd]",
+  builder: (yargs) =>
+    withNetworkOptions(yargs).positional("cwd", {
+      type: "string",
+      describe: "path to start opencode server in",
+    }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
+    if (args.cwd) {
+      process.chdir(args.cwd)
+    }
     const server = Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
     await new Promise(() => {})


### PR DESCRIPTION
Problem:
- for debugging, bun needs to start in the development build directory
- makes it currently impossible to debug different scenarios/projects

This patch adds positional argument for cwd folder `opencode serve [cwd]`

Usage:
```bash
bun run --cwd ${OPENCODE_DEV_PATH} --inspect-wait=ws://localhost:6499/ ./src/index.ts \
  serve --port 4096 /my/project/path
```