### PR TITLE
fix: improve permission dialog responsiveness and keyboard handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -69,6 +69,7 @@ export function Autocomplete(props: {
   fileStyleId: number
   agentStyleId: number
   promptPartTypeId: () => number
+  disabled?: boolean
 }) {
   const sdk = useSDK()
   const sync = useSync()
@@ -83,6 +84,13 @@ export function Autocomplete(props: {
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
+
+  // Close autocomplete when disabled (e.g., when permission dialog appears)
+  createEffect(() => {
+    if (props.disabled && store.visible) {
+      hide()
+    }
+  })
 
   createEffect(() => {
     if (store.visible) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -799,6 +799,7 @@ export function Prompt(props: PromptProps) {
         fileStyleId={fileStyleId}
         agentStyleId={agentStyleId}
         promptPartTypeId={() => promptPartTypeId}
+        disabled={props.disabled}
       />
       <box ref={(r) => (anchor = r)} visible={props.visible !== false}>
         <box

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -107,16 +107,20 @@ export function Session() {
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
-  const session = createMemo(() => sync.session.get(route.sessionID)!)
+  const session = createMemo(() => sync.session.get(route.sessionID))
   const children = createMemo(() => {
-    const parentID = session()?.parentID ?? session()?.id
+    const s = session()
+    const parentID = s?.parentID ?? s?.id
+    if (!parentID) return []
     return sync.data.session
       .filter((x) => x.parentID === parentID || x.id === parentID)
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const permissions = createMemo(() => {
-    if (session().parentID) return sync.data.permission[route.sessionID] ?? []
+    const s = session()
+    if (!s) return []
+    if (s.parentID) return sync.data.permission[route.sessionID] ?? []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
   })
 
@@ -381,7 +385,7 @@ export function Session() {
       onSelect: async (dialog) => {
         const status = sync.data.session_status?.[route.sessionID]
         if (status?.type !== "idle") await sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
-        const revert = session().revert?.messageID
+        const revert = session()?.revert?.messageID
         const message = messages().findLast((x) => (!revert || x.id < revert) && x.role === "user")
         if (!message) return
         sdk.client.session
@@ -416,7 +420,7 @@ export function Session() {
       category: "Session",
       onSelect: (dialog) => {
         dialog.clear()
-        const messageID = session().revert?.messageID
+        const messageID = session()?.revert?.messageID
         if (!messageID) return
         const message = messages().find((x) => x.role === "user" && x.id > messageID)
         if (!message) {
@@ -715,6 +719,7 @@ export function Session() {
       onSelect: async (dialog) => {
         try {
           const sessionData = session()
+          if (!sessionData) return
           const sessionMessages = messages()
           const transcript = formatTranscript(
             sessionData,
@@ -741,6 +746,7 @@ export function Session() {
       onSelect: async (dialog) => {
         try {
           const sessionData = session()
+          if (!sessionData) return
           const sessionMessages = messages()
 
           const defaultFilename = `session-${sessionData.id.slice(0, 8)}.md`
@@ -1025,7 +1031,7 @@ export function Session() {
                 <PermissionPrompt request={permissions()[0]} />
               </Show>
               <Prompt
-                visible={!session().parentID && permissions().length === 0}
+                visible={!session()?.parentID && permissions().length === 0}
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { createMemo, createSignal, For, Match, onMount, Show, Switch } from "solid-js"
-import { useKeyboard, useTerminalDimensions, type JSX } from "@opentui/solid"
+import { useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { useTheme } from "../../context/theme"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
@@ -38,11 +38,13 @@ function EditBody(props: { request: PermissionRequest }) {
   // This allows the permission dialog to become responsive immediately
   const [showDiff, setShowDiff] = createSignal(false)
   onMount(() => {
-    // Use requestAnimationFrame to defer diff rendering
-    // This lets the UI paint first, making it feel responsive
-    requestAnimationFrame(() => {
+    // Use setTimeout with a small delay to ensure the UI is fully painted
+    // and responsive before starting to render the potentially heavy diff.
+    // requestAnimationFrame alone isn't enough as the diff render itself
+    // can still block during the next frame.
+    setTimeout(() => {
       setShowDiff(true)
-    })
+    }, 16) // ~1 frame delay to allow UI to stabilize
   })
 
   const view = createMemo(() => {
@@ -253,12 +255,34 @@ function Prompt<const T extends Record<string, string>>(props: {
   onSelect: (option: keyof T) => void
 }) {
   const { theme } = useTheme()
+  const renderer = useRenderer()
   const keys = Object.keys(props.options) as (keyof T)[]
   const [store, setStore] = createStore({
     selected: keys[0],
   })
 
+  // Track when the component is ready to handle keyboard events
+  // This prevents race conditions during component mounting
+  const [ready, setReady] = createSignal(false)
+
+  onMount(() => {
+    // Blur any currently focused element to prevent keyboard conflicts
+    const currentFocus = renderer.currentFocusedRenderable
+    if (currentFocus) {
+      currentFocus.blur()
+    }
+
+    // Small delay to ensure the component is fully mounted and stable
+    // before accepting keyboard input
+    setTimeout(() => {
+      setReady(true)
+    }, 50)
+  })
+
   useKeyboard((evt) => {
+    // Don't process events until component is ready
+    if (!ready()) return
+
     if (evt.name === "left" || evt.name == "h") {
       evt.preventDefault()
       const idx = keys.indexOf(store.selected)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { createMemo, For, Match, Show, Switch } from "solid-js"
+import { createMemo, createSignal, For, Match, onMount, Show, Switch } from "solid-js"
 import { useKeyboard, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { useTheme } from "../../context/theme"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
@@ -34,6 +34,17 @@ function EditBody(props: { request: PermissionRequest }) {
   const filepath = createMemo(() => (props.request.metadata?.filepath as string) ?? "")
   const diff = createMemo(() => (props.request.metadata?.diff as string) ?? "")
 
+  // Defer diff rendering to prevent blocking the UI
+  // This allows the permission dialog to become responsive immediately
+  const [showDiff, setShowDiff] = createSignal(false)
+  onMount(() => {
+    // Use requestAnimationFrame to defer diff rendering
+    // This lets the UI paint first, making it feel responsive
+    requestAnimationFrame(() => {
+      setShowDiff(true)
+    })
+  })
+
   const view = createMemo(() => {
     const diffStyle = sync.data.config.tui?.diff_style
     if (diffStyle === "stacked") return "unified"
@@ -42,14 +53,23 @@ function EditBody(props: { request: PermissionRequest }) {
 
   const ft = createMemo(() => filetype(filepath()))
 
+  // Limit initial diff height more aggressively to improve performance
+  const maxDiffHeight = createMemo(() => Math.min(Math.floor(dimensions().height / 4), 15))
+
   return (
     <box flexDirection="column" gap={1}>
       <box flexDirection="row" gap={1} paddingLeft={1}>
         <text fg={theme.textMuted}>{"→"}</text>
         <text fg={theme.textMuted}>Edit {normalizePath(filepath())}</text>
       </box>
-      <Show when={diff()}>
-        <box maxHeight={Math.floor(dimensions().height / 4)} overflow="scroll">
+      <Show when={diff() && showDiff()} fallback={
+        <Show when={diff()}>
+          <box paddingLeft={1}>
+            <text fg={theme.textMuted}>Loading diff...</text>
+          </box>
+        </Show>
+      }>
+        <box maxHeight={maxDiffHeight()} overflow="scroll">
           <diff
             diff={diff()}
             view={view()}


### PR DESCRIPTION
## Summary

Fixes the issue where the input box becomes unresponsive when the permission dialog appears during heavy workloads.

- Add ready guard to prevent keyboard event processing before component is fully mounted
- Blur focused elements on mount to prevent keyboard conflicts with the prompt textarea
- Use `setTimeout` instead of `requestAnimationFrame` for more reliable diff rendering deferral

## Root Cause

The issue was a race condition where:
1. The permission prompt's `useKeyboard` handler activated immediately while other components were still transitioning
2. Multiple keyboard handlers competed for events during the transition
3. `requestAnimationFrame` only deferred one frame, which wasn't enough for complex diffs

## Changes

**permission.tsx:**
- Added `ready` signal that only becomes true after 50ms delay, ensuring keyboard handling waits for component stabilization
- Added explicit blur of any focused element on mount to prevent conflicts
- Changed diff rendering deferral from `requestAnimationFrame` to `setTimeout(fn, 16)` for more reliable UI stabilization

## Related Issues

- Fixes #6616 - UI becomes unresponsive when tool permission dialog appears
- Related to #5820 - Autocomplete dropdown conflicts with permission dialog
- Related to #3846 - No response to user input