### PR TITLE
refactor: use Bun.sleep instead of Promise setTimeout

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -281,7 +281,7 @@ async function assertOpencodeConnected() {
       connected = true
       break
     } catch (e) {}
-    await new Promise((resolve) => setTimeout(resolve, 300))
+    await Bun.sleep(300)
   } while (retry++ < 30)
 
   if (!connected) {

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -36,7 +36,7 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
   const method = plugin.auth.methods[index]
 
   // Handle prompts for all auth types
-  await new Promise((resolve) => setTimeout(resolve, 10))
+  await Bun.sleep(10)
   const inputs: Record<string, string> = {}
   if (method.prompts) {
     for (const prompt of method.prompts) {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -348,7 +348,7 @@ export const GithubInstallCommand = cmd({
               }
 
               retries++
-              await new Promise((resolve) => setTimeout(resolve, 1000))
+              await Bun.sleep(1000)
             } while (true)
 
             s.stop("Installed GitHub app")


### PR DESCRIPTION
## Summary

Replace `new Promise((resolve) => setTimeout(resolve, ms))` with `Bun.sleep(ms)`.

## Changes

- `packages/opencode/src/cli/cmd/auth.ts` - 10ms delay before prompts
- `packages/opencode/src/cli/cmd/github.ts` - 1s delay in GitHub app installation retry loop  
- `github/index.ts` - 300ms delay in server connection retry loop

More idiomatic for a Bun codebase. All 3 files are already Bun-only.