### PR TITLE
refactor: use structuredClone instead of JSON parse/stringify

### DIFF
--- a/packages/plugin/script/publish.ts
+++ b/packages/plugin/script/publish.ts
@@ -7,7 +7,7 @@ process.chdir(dir)
 
 await $`bun tsc`
 const pkg = await import("../package.json").then((m) => m.default)
-const original = JSON.parse(JSON.stringify(pkg))
+const original = structuredClone(pkg)
 for (const [key, value] of Object.entries(pkg.exports)) {
   const file = value.replace("./src/", "./dist/").replace(".ts", "")
   // @ts-ignore

--- a/packages/sdk/js/script/publish.ts
+++ b/packages/sdk/js/script/publish.ts
@@ -9,7 +9,7 @@ process.chdir(dir)
 await import("./build")
 
 const pkg = await import("../package.json").then((m) => m.default)
-const original = JSON.parse(JSON.stringify(pkg))
+const original = structuredClone(pkg)
 for (const [key, value] of Object.entries(pkg.exports)) {
   const file = value.replace("./src/", "./dist/").replace(".ts", "")
   /// @ts-expect-error


### PR DESCRIPTION
Replace `JSON.parse(JSON.stringify(x))` with `structuredClone(x)` for deep cloning in publish scripts.

`structuredClone` is the modern native API for this - cleaner and handles more edge cases correctly.