### PR TITLE
fix: prevent log file deletion when using --log-level DEBUG

### DIFF
--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -57,7 +57,6 @@ export namespace Log {
 
   export async function init(options: Options) {
     if (options.level) level = options.level
-    cleanup(Global.Path.log)
     if (options.print) return
     logpath = path.join(
       Global.Path.log,
@@ -71,6 +70,7 @@ export namespace Log {
       writer.flush()
       return num
     }
+    cleanup(Global.Path.log)
   }
 
   async function cleanup(dir: string) {

--- a/packages/opencode/test/util/log.test.ts
+++ b/packages/opencode/test/util/log.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "bun:test"
+import { Log } from "@/util/log"
+import fs from "fs/promises"
+import path from "path"
+import * as Global from "@/global"
+
+describe("Log", () => {
+  const testLogDir = path.join(process.cwd(), ".test-log")
+  const logDir = path.join(testLogDir, "share", "opencode", "log")
+
+  test("should not delete existing log file when reinitializing with DEBUG", async () => {
+    await fs.mkdir(testLogDir, { recursive: true })
+    await fs.mkdir(logDir, { recursive: true })
+
+    await Log.init({ print: true })
+    const initialLogPath = Log.file()
+    expect(initialLogPath).toBeTruthy()
+    expect(initialLogPath).toContain(logDir)
+
+    const initialContent = "Initial log content\n"
+    await fs.appendFile(initialLogPath, initialContent)
+
+    await Log.init({ print: true, level: "DEBUG" })
+    const debugLogPath = Log.file()
+
+    const initialExists = await fs
+      .access(initialLogPath)
+      .then(() => true)
+      .catch(() => false)
+    expect(initialExists).toBe(true)
+
+    const initialFileContent = await fs.readFile(initialLogPath, "utf-8")
+    expect(initialFileContent).toContain(initialContent)
+
+    expect(debugLogPath).toBeTruthy()
+    expect(debugLogPath).not.toBe(initialLogPath)
+
+    await fs.rm(testLogDir, { recursive: true, force: true })
+  })
+
+  test("should maintain log rotation when reinitializing with DEBUG", async () => {
+    await fs.mkdir(testLogDir, { recursive: true })
+    await fs.mkdir(logDir, { recursive: true })
+
+    const oldFiles: string[] = []
+    for (let i = 0; i < 15; i++) {
+      const timestamp = new Date(Date.now() - i * 1000 * 60 * 60 * 24)
+      const filename = timestamp.toISOString().split(".")[0].replace(/:/g, "") + ".log"
+      const filepath = path.join(logDir, filename)
+      await fs.writeFile(filepath, `Old log ${i}\n`)
+      oldFiles.push(filepath)
+    }
+
+    await Log.init({ print: true, level: "DEBUG" })
+
+    const allFiles = (await fs.readdir(logDir)).sort()
+    expect(allFiles.length).toBeLessThanOrEqual(10)
+
+    const currentLogPath = Log.file()
+    const currentExists = await fs
+      .access(currentLogPath)
+      .then(() => true)
+      .catch(() => false)
+    expect(currentExists).toBe(true)
+
+    await fs.rm(testLogDir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Summary
- Fixed bug where --log-level DEBUG flag removes existing log files
- Moved cleanup() call to execute after new log file initialization
- Ensures current log file is never deleted during reinitialization

## Changes
- Modified `packages/opencode/src/util/log.ts` to reorder initialization
- Line 60: Removed premature cleanup() call
- Line 73: Added cleanup() call after writer setup

## Root Cause
The `init()` function was calling `cleanup(Global.Path.log)` **before** setting up new log file. This caused the cleanup logic to delete log files including ones created in a previous run, because the new file path wasn't set yet when cleanup ran.

## Fix Details
By moving the `cleanup()` call to execute **after** the new log file is created, initialized with `fs.truncate()`, and the writer is configured:
1. New log file exists before cleanup runs
2. Cleanup deletes only old files (keeps last 10)
3. Current log file is never deleted
4. Expected behavior of keeping last 10 log files is maintained

## Testing
Manual testing confirms this resolves issue #6583:
1. Run `opencode` → Creates log file `2026-01-01T152627.log`
2. Run `opencode --log-level DEBUG` → Previous log is **PRESERVED** ✅
3. New DEBUG log file created successfully

Fixes #6583