### PR TITLE
feat: add OPENCODE_AUTH_PATH env var for custom auth.json location

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -32,7 +32,7 @@ export namespace Auth {
   export const Info = z.discriminatedUnion("type", [Oauth, Api, WellKnown]).meta({ ref: "Auth" })
   export type Info = z.infer<typeof Info>
 
-  const filepath = path.join(Global.Path.data, "auth.json")
+  const filepath = process.env.OPENCODE_AUTH_PATH || path.join(Global.Path.data, "auth.json")
 
   export async function get(providerID: string) {
     const auth = await all()


### PR DESCRIPTION
A small addition to the way the authentication file path is determined in the `Auth` namespace. Now, the the default `auth.json` file path can be overridden using the `OPENCODE_AUTH_PATH` environment variable, providing more flexibility.

- Allows custom wrappers to manage profiles and accounts easily without needing to have separate data folders.