### PR TITLE
docs: add shell alias installation options for Bun and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@
 
 ---
 
+### Always Updated (via shell aliases)
+
+Add these aliases to your `~/.bashrc`, `~/.zshrc`, or equivalent shell config to always run the latest version:
+
+```bash
+# Bun (recommended - faster)
+alias opencode='bunx --bun opencode-ai@latest'
+alias opencode-dev='bunx --bun opencode-ai@dev'
+
+# npm
+alias opencode='npx opencode-ai@latest'
+alias opencode-dev='npx opencode-ai@dev'
+```
+
+> [!NOTE]
+> These aliases will automatically fetch the latest version each time you run them. Use `opencode-dev` to test the latest development branch features.
+
 ### Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- Added "Always Updated" section to README with shell alias installation options
- Supports both Bun (recommended) and npm package managers
- Provides aliases for stable (@latest) and development (@dev) versions
- Users can now always run the latest version without manual updates

## Changes
- New section with `opencode` and `opencode-dev` aliases
- Clear guidance on adding to shell config files
- Note explaining auto-update behavior

## Motivation
Users want to always run the latest OpenCode without manually updating. Shell aliases provide a convenient way to fetch and run the latest version on each execution.