### PR TITLE
feat: add 1M context support for Claude Sonnet 4.5 via env vars

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -73,12 +73,14 @@ export namespace Provider {
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
     async anthropic() {
+      const enable1MContext = Env.get("ANTHROPIC_1M_CONTEXT") === "true"
+      const baseBetas = "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+      const betas = enable1MContext ? `context-1m-2025-08-07,${baseBetas}` : baseBetas
       return {
         autoload: false,
         options: {
           headers: {
-            "anthropic-beta":
-              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+            "anthropic-beta": betas,
           },
         },
       }
@@ -309,6 +311,7 @@ export namespace Provider {
     "google-vertex-anthropic": async () => {
       const project = Env.get("GOOGLE_CLOUD_PROJECT") ?? Env.get("GCP_PROJECT") ?? Env.get("GCLOUD_PROJECT")
       const location = Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "global"
+      const enable1MContext = Env.get("VERTEX_ANTHROPIC_1M_CONTEXT") === "true"
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
       return {
@@ -316,6 +319,11 @@ export namespace Provider {
         options: {
           project,
           location,
+          ...(enable1MContext && {
+            headers: {
+              "anthropic-beta": "context-1m-2025-08-07",
+            },
+          }),
         },
         async getModel(sdk: any, modelID) {
           const id = String(modelID).trim()
@@ -525,7 +533,13 @@ export namespace Provider {
           : undefined,
       },
       limit: {
-        context: model.limit.context,
+        context:
+          model.id.includes("claude-") &&
+          model.id.match(/claude-sonnet-4[.-]5(-\d{8})?/) &&
+          ((provider.id === "anthropic" && Env.get("ANTHROPIC_1M_CONTEXT") === "true") ||
+            (provider.id === "google-vertex-anthropic" && Env.get("VERTEX_ANTHROPIC_1M_CONTEXT") === "true"))
+            ? 1000000
+            : model.limit.context,
         output: model.limit.output,
       },
       capabilities: {


### PR DESCRIPTION
## Summary

This PR adds support for enabling 1M token context windows for **Claude Sonnet 4.5** through environment variables for both Anthropic direct and Vertex AI Anthropic providers.

**Note**: Currently only Claude Sonnet 4.5 supports 1M token context windows. All other Claude models (Opus 4, Haiku 4.5, etc.) remain at 200K tokens according to models.dev.

## Changes

- **Anthropic Direct**: Add `ANTHROPIC_1M_CONTEXT=true` env var to enable 1M context for Sonnet 4.5
  - Preserves existing beta headers (claude-code, interleaved-thinking, fine-grained-tool-streaming)
  - Prepends `context-1m-2025-08-07` beta when enabled
  
- **Vertex AI Anthropic**: Add `VERTEX_ANTHROPIC_1M_CONTEXT=true` env var to enable 1M context for Sonnet 4.5
  - Sets `anthropic-beta: context-1m-2025-08-07` header when enabled
  
- **Model Detection**: Regex pattern specifically matches Claude Sonnet 4.5 variants only
  - Matches patterns: `claude-sonnet-4.5`, `claude-sonnet-4-5`, `claude-sonnet-4.5-20250929`
  - Automatically sets context limit to 1,000,000 tokens when env var is enabled

## Testing

- ✅ All existing provider tests pass (66 tests)
- ✅ TypeScript compilation successful
- ✅ No type errors

## Usage

\`\`\`bash
# For Anthropic direct (Sonnet 4.5 only)
export ANTHROPIC_1M_CONTEXT=true

# For Vertex AI Anthropic (Sonnet 4.5 only)
export VERTEX_ANTHROPIC_1M_CONTEXT=true
\`\`\`