### PR TITLE
feat: add status bar registry for plugin status items

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -26,6 +26,8 @@ import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
+import { TuiEvent } from "../event"
+import type { StatusState } from "@/status/registry"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -65,6 +67,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
       path: Path
+      pluginStatus: StatusState["items"]
     }>({
       provider_next: {
         all: [],
@@ -90,6 +93,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: [],
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
+      pluginStatus: {},
     })
 
     const sdk = useSDK()
@@ -257,6 +261,11 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           break
         }
       }
+    })
+
+    // Listen for plugin status updates via TUI event bus
+    sdk.event.on(TuiEvent.StatusUpdated.type, (evt) => {
+      setStore("pluginStatus", reconcile(evt.properties.items))
     })
 
     const exit = useExit()

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -28,6 +28,7 @@ import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
 import { TuiEvent } from "../event"
 import type { StatusState } from "@/status/registry"
+import { Bus } from "@/bus"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -264,7 +265,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     // Listen for plugin status updates via TUI event bus
-    sdk.event.on(TuiEvent.StatusUpdated.type, (evt) => {
+    Bus.subscribe(TuiEvent.StatusUpdated, (evt) => {
       setStore("pluginStatus", reconcile(evt.properties.items))
     })
 

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -4,6 +4,32 @@ import z from "zod"
 
 export const TuiEvent = {
   PromptAppend: BusEvent.define("tui.prompt.append", z.object({ text: z.string() })),
+  StatusUpdated: BusEvent.define(
+    "tui.status.updated",
+    z.object({
+      items: z.record(
+        z.object({
+          id: z.string(),
+          priority: z.number().optional(),
+          long: z.object({
+            icon: z.string().optional(),
+            text: z.string(),
+            color: z.enum(["default", "green", "yellow", "red", "blue", "gray"]).optional(),
+            detail: z.string().optional(),
+            progress: z.number().optional(),
+            subtext: z.string().optional(),
+          }),
+          short: z
+            .object({
+              icon: z.string().optional(),
+              text: z.string(),
+              color: z.enum(["default", "green", "yellow", "red", "blue", "gray"]).optional(),
+            })
+            .nullable(),
+        }),
+      ),
+    }),
+  ),
   CommandExecute: BusEvent.define(
     "tui.command.execute",
     z.object({

--- a/packages/opencode/src/cli/cmd/tui/event.ts
+++ b/packages/opencode/src/cli/cmd/tui/event.ts
@@ -1,5 +1,4 @@
 import { BusEvent } from "@/bus/bus-event"
-import { Bus } from "@/bus"
 import z from "zod"
 
 export const TuiEvent = {
@@ -8,6 +7,7 @@ export const TuiEvent = {
     "tui.status.updated",
     z.object({
       items: z.record(
+        z.string(),
         z.object({
           id: z.string(),
           priority: z.number().optional(),

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import { createMemo, Match, onMount, Show, Switch } from "solid-js"
+import { createMemo, For, Match, onMount, Show, Switch } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { Logo } from "../component/logo"
 import { DidYouKnow, randomizeTip } from "../component/did-you-know"
@@ -13,6 +13,7 @@ import { usePromptRef } from "../context/prompt"
 import { Installation } from "@/installation"
 import { useKV } from "../context/kv"
 import { useCommandDialog } from "../component/dialog-command"
+import type { StatusColor } from "@/status/registry"
 
 // TODO: what is the best way to do this?
 let once = false
@@ -35,6 +36,18 @@ export function Home() {
 
   const isFirstTimeUser = createMemo(() => sync.data.session.length === 0)
   const tipsHidden = createMemo(() => kv.get("tips_hidden", false))
+
+  const pluginStatus = createMemo(() => {
+    const items = Object.values(sync.data.pluginStatus)
+    return items
+      .filter((item) => item.short !== null)
+      .map((item) => ({
+        id: item.id,
+        render: item.short!,
+        priority: item.priority,
+      }))
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+  })
   const showTips = createMemo(() => {
     return false
     // Don't show tips for first-time users
@@ -127,6 +140,29 @@ export function Home() {
             </text>
             <text fg={theme.textMuted}>/status</text>
           </Show>
+          <For each={pluginStatus()}>
+            {(item) => {
+              const color = item.render.color ?? "default"
+              const colorMap = {
+                default: theme.text,
+                green: theme.success,
+                yellow: theme.warning,
+                red: theme.error,
+                blue: theme.info,
+                gray: theme.textMuted,
+              }
+              const textColor = colorMap[color]
+              return (
+                <text fg={textColor}>
+                  <span style={{ fg: textColor }}>
+                    {item.render.icon ?? ""}
+                    {item.render.icon ? " " : ""}
+                    {item.render.text}
+                  </span>
+                </text>
+              )
+            }}
+          </For>
         </box>
         <box flexGrow={1} />
         <box flexShrink={0}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -1,10 +1,11 @@
-import { createMemo, Match, onCleanup, onMount, Show, Switch } from "solid-js"
+import { createMemo, Match, onCleanup, onMount, Show, Switch, For } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { useSync } from "../../context/sync"
 import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/dialog-model"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import type { StatusColor } from "@/status/registry"
 
 export function Footer() {
   const { theme } = useTheme()
@@ -19,6 +20,18 @@ export function Footer() {
   })
   const directory = useDirectory()
   const connected = useConnected()
+
+  const pluginStatus = createMemo(() => {
+    const items = Object.values(sync.data.pluginStatus)
+    return items
+      .filter((item) => item.short !== null)
+      .map((item) => ({
+        id: item.id,
+        render: item.short!,
+        priority: item.priority,
+      }))
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+  })
 
   const [store, setStore] = createStore({
     welcome: false,
@@ -63,6 +76,29 @@ export function Footer() {
                 {permissions().length > 1 ? "s" : ""}
               </text>
             </Show>
+            <For each={pluginStatus()}>
+              {(item) => {
+                const color = item.render.color ?? "default"
+                const colorMap = {
+                  default: theme.text,
+                  green: theme.success,
+                  yellow: theme.warning,
+                  red: theme.error,
+                  blue: theme.info,
+                  gray: theme.textMuted,
+                }
+                const textColor = colorMap[color]
+                return (
+                  <text fg={textColor}>
+                    <span style={{ fg: textColor }}>
+                      {item.render.icon ?? ""}
+                      {item.render.icon ? " " : ""}
+                      {item.render.text}
+                    </span>
+                  </text>
+                )
+              }}
+            </For>
             <text fg={theme.text}>
               <span style={{ fg: theme.success }}>•</span> {lsp().length} LSP
             </text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -11,6 +11,7 @@ import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
+import type { StatusColor } from "@/status/registry"
 
 export function Sidebar(props: { sessionID: string }) {
   const sync = useSync()
@@ -67,6 +68,17 @@ export function Sidebar(props: { sessionID: string }) {
     sync.data.provider.some((x) => x.id !== "opencode" || Object.values(x.models).some((y) => y.cost?.input !== 0)),
   )
   const gettingStartedDismissed = createMemo(() => kv.get("dismissed_getting_started", false))
+
+  const pluginStatus = createMemo(() => {
+    const items = Object.values(sync.data.pluginStatus)
+    return items
+      .map((item) => ({
+        id: item.id,
+        render: item.long,
+        priority: item.priority,
+      }))
+      .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+  })
 
   return (
     <Show when={session()}>
@@ -267,6 +279,44 @@ export function Sidebar(props: { sessionID: string }) {
         </scrollbox>
 
         <box flexShrink={0} gap={1} paddingTop={1}>
+          <Show when={pluginStatus().length > 0}>
+            <For each={pluginStatus()}>
+              {(item) => {
+                const color = item.render.color ?? "default"
+                const colorMap = {
+                  default: theme.text,
+                  green: theme.success,
+                  yellow: theme.warning,
+                  red: theme.error,
+                  blue: theme.info,
+                  gray: theme.textMuted,
+                }
+                const textColor = colorMap[color]
+                return (
+                  <box>
+                    <text fg={textColor}>
+                      {item.render.icon ?? "•"} {item.render.text}
+                    </text>
+                    <Show when={item.render.detail}>
+                      <text fg={theme.textMuted}>
+                        {"  "}
+                        {item.render.detail}
+                      </text>
+                    </Show>
+                    <Show when={item.render.progress !== undefined}>
+                      <text fg={theme.textMuted}> {item.render.progress}%</text>
+                    </Show>
+                    <Show when={item.render.subtext}>
+                      <text fg={theme.textMuted}>
+                        {"  "}
+                        {item.render.subtext}
+                      </text>
+                    </Show>
+                  </box>
+                )
+              }}
+            </For>
+          </Show>
           <Show when={!hasProviders() && !gettingStartedDismissed()}>
             <box
               backgroundColor={theme.backgroundElement}

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -7,6 +7,7 @@ import { Server } from "../server/server"
 import { BunProc } from "../bun"
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
+import { statusRegistry } from "../status/registry"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -28,6 +29,7 @@ export namespace Plugin {
       directory: Instance.directory,
       serverUrl: Server.url(),
       $: Bun.$,
+      status: statusRegistry,
     }
     const plugins = [...(config.plugin ?? [])]
     if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {

--- a/packages/opencode/src/status/registry.ts
+++ b/packages/opencode/src/status/registry.ts
@@ -1,0 +1,136 @@
+import { createStore, produce } from "solid-js/store"
+
+export type StatusColor = "default" | "green" | "yellow" | "red" | "blue" | "gray"
+
+export interface StatusRenderBase {
+  icon?: string
+  text: string
+  color?: StatusColor
+}
+
+export interface StatusRenderLong extends StatusRenderBase {
+  detail?: string
+  progress?: number
+  subtext?: string
+}
+
+export type StatusRenderShort = StatusRenderBase
+
+export type StatusItemRender = {
+  long: StatusRenderLong
+  short: StatusRenderShort | null
+}
+
+export interface StatusItem {
+  id: string
+  priority?: number
+  render: {
+    long: () => StatusRenderLong
+    short?: () => StatusRenderShort | null
+  }
+}
+
+export interface StatusHandle {
+  update: (render: { long?: Partial<StatusRenderLong>; short?: Partial<StatusRenderShort> | null }) => void
+  remove: () => void
+}
+
+type StatusItemState = {
+  id: string
+  priority?: number
+  long: StatusRenderLong
+  short: StatusRenderShort | null
+}
+
+export type StatusState = {
+  items: Record<string, StatusItemState>
+}
+
+// Local store for status items - TUI receives updates via event bus
+const [statusStore, setStatusStore] = createStore<StatusState>({ items: {} })
+
+// Publish status updates via the event bus so TUI can receive them
+async function publishStatusUpdate() {
+  // Use dynamic imports to avoid circular dependencies and context issues in tests
+  try {
+    const { Bus } = await import("../bus")
+    const { TuiEvent } = await import("../cli/cmd/tui/event")
+    Bus.publish(TuiEvent.StatusUpdated, { items: statusStore.items })
+  } catch {
+    // Ignore errors when context is not available (e.g., in tests)
+  }
+}
+
+export function register(item: StatusItem): StatusHandle {
+  setStatusStore("items", item.id, {
+    id: item.id,
+    priority: item.priority,
+    long: item.render.long(),
+    short: item.render.short?.() ?? null,
+  })
+  publishStatusUpdate()
+
+  return {
+    update: ({ long, short }) => {
+      setStatusStore((state) => {
+        const existing = state.items[item.id]
+        if (!existing) return state
+
+        const updated = { ...existing }
+        if (long) {
+          updated.long = { ...existing.long, ...long }
+        }
+        if (short === null) {
+          updated.short = null
+        } else if (short !== undefined) {
+          if (existing.short) {
+            updated.short = { ...existing.short, ...short }
+          } else {
+            updated.short = short as StatusRenderShort
+          }
+        }
+        return {
+          ...state,
+          items: {
+            ...state.items,
+            [item.id]: updated,
+          },
+        }
+      })
+      publishStatusUpdate()
+    },
+    remove: () => {
+      setStatusStore(
+        produce((state) => {
+          delete state.items[item.id]
+        }),
+      )
+      publishStatusUpdate()
+    },
+  }
+}
+
+export function getAll(): Array<{ id: string; priority?: number }> {
+  return Object.values(statusStore.items)
+}
+
+export function getFooterItems(): Array<{ id: string; render: StatusRenderShort; priority?: number }> {
+  return Object.values(statusStore.items)
+    .filter((item): item is StatusItemState & { short: StatusRenderShort } => item.short !== null)
+    .map((item) => ({ id: item.id, render: item.short, priority: item.priority }))
+}
+
+export function getSidebarItems(): Array<{ id: string; render: StatusRenderLong; priority?: number }> {
+  return Object.values(statusStore.items).map((item) => ({
+    id: item.id,
+    render: item.long,
+    priority: item.priority,
+  }))
+}
+
+export const statusRegistry = {
+  register,
+  getAll,
+  getFooterItems,
+  getSidebarItems,
+}

--- a/packages/opencode/src/status/registry.ts
+++ b/packages/opencode/src/status/registry.ts
@@ -46,19 +46,15 @@ export type StatusState = {
   items: Record<string, StatusItemState>
 }
 
-// Local store for status items - TUI receives updates via event bus
 const [statusStore, setStatusStore] = createStore<StatusState>({ items: {} })
 
-// Publish status updates via the event bus so TUI can receive them
-async function publishStatusUpdate() {
-  // Use dynamic imports to avoid circular dependencies and context issues in tests
-  try {
-    const { Bus } = await import("../bus")
-    const { TuiEvent } = await import("../cli/cmd/tui/event")
-    Bus.publish(TuiEvent.StatusUpdated, { items: statusStore.items })
-  } catch {
-    // Ignore errors when context is not available (e.g., in tests)
-  }
+function publishStatusUpdate() {
+  if (process.env["OPENCODE_TEST_HOME"]) return
+
+  import("../bus")
+    .then(({ Bus }) => import("../cli/cmd/tui/event").then(({ TuiEvent }) => ({ Bus, TuiEvent })))
+    .then(({ Bus, TuiEvent }) => Bus.publish(TuiEvent.StatusUpdated, { items: statusStore.items }))
+    .catch(() => {})
 }
 
 export function register(item: StatusItem): StatusHandle {

--- a/packages/opencode/src/status/registry.ts
+++ b/packages/opencode/src/status/registry.ts
@@ -78,12 +78,9 @@ export function register(item: StatusItem): StatusHandle {
         }
         if (short === null) {
           updated.short = null
-        } else if (short !== undefined) {
-          if (existing.short) {
-            updated.short = { ...existing.short, ...short }
-          } else {
-            updated.short = short as StatusRenderShort
-          }
+        }
+        if (short !== null && short !== undefined) {
+          updated.short = existing.short ? { ...existing.short, ...short } : (short as StatusRenderShort)
         }
         return {
           ...state,

--- a/packages/opencode/test/status/registry.test.ts
+++ b/packages/opencode/test/status/registry.test.ts
@@ -1,0 +1,325 @@
+import { test, expect } from "bun:test"
+import { register, getFooterItems, getSidebarItems, getAll, type StatusItem } from "../../src/status/registry"
+
+test("register creates status item with initial render", () => {
+  const handle = register({
+    id: "test-status",
+    priority: 10,
+    render: {
+      long: () => ({ icon: "🔍", text: "Test status", color: "green" }),
+      short: () => ({ icon: "🔍", text: "Test", color: "green" }),
+    },
+  })
+
+  expect(handle).toBeDefined()
+  const all = getAll()
+  expect(all).toHaveLength(1)
+  expect(all[0].id).toBe("test-status")
+  expect(all[0].priority).toBe(10)
+})
+
+test("register with priority default is 0", () => {
+  register({
+    id: "no-priority-status",
+    render: {
+      long: () => ({ text: "No priority" }),
+      short: () => ({ text: "NoPrio" }),
+    },
+  })
+
+  const all = getAll()
+  const item = all.find((x) => x.id === "no-priority-status")
+  expect(item?.priority).toBeUndefined()
+})
+
+test("getSidebarItems returns long format for all items", () => {
+  register({
+    id: "sidebar-test",
+    render: {
+      long: () => ({
+        icon: "💾",
+        text: "Sidebar item",
+        detail: "Detail text",
+        color: "blue",
+      }),
+    },
+  })
+
+  const sidebarItems = getSidebarItems()
+  expect(sidebarItems.length).toBeGreaterThan(0)
+  const sidebarItem = sidebarItems.find((x) => x.id === "sidebar-test")
+  expect(sidebarItem).toBeDefined()
+  expect(sidebarItem?.render.text).toBe("Sidebar item")
+  expect(sidebarItem?.render.icon).toBe("💾")
+  expect(sidebarItem?.render.detail).toBe("Detail text")
+  expect(sidebarItem?.render.color).toBe("blue")
+})
+
+test("getFooterItems filters out items with null short format", () => {
+  register({
+    id: "no-short",
+    render: {
+      long: () => ({ text: "Only long format" }),
+      short: () => null,
+    },
+  })
+
+  const footerItems = getFooterItems()
+  const noShortItem = footerItems.find((x) => x.id === "no-short")
+  expect(noShortItem).toBeUndefined()
+
+  const sidebarItems = getSidebarItems()
+  const noShortSidebar = sidebarItems.find((x) => x.id === "no-short")
+  expect(noShortSidebar).toBeDefined()
+  expect(noShortSidebar?.render.text).toBe("Only long format")
+})
+
+test("getFooterItems returns items with short format", () => {
+  register({
+    id: "with-short",
+    render: {
+      long: () => ({ text: "Long format" }),
+      short: () => ({ icon: "✅", text: "Short", color: "green" }),
+    },
+  })
+
+  const footerItems = getFooterItems()
+  const item = footerItems.find((x) => x.id === "with-short")
+  expect(item).toBeDefined()
+  expect(item?.render.text).toBe("Short")
+  expect(item?.render.icon).toBe("✅")
+  expect(item?.render.color).toBe("green")
+})
+
+test("update modifies long format", () => {
+  const handle = register({
+    id: "update-long",
+    render: {
+      long: () => ({ icon: "🔄", text: "Initial", color: "yellow" }),
+    },
+  })
+
+  handle.update({
+    long: { text: "Updated", icon: "✅", color: "green" },
+  })
+
+  const sidebarItems = getSidebarItems()
+  const item = sidebarItems.find((x) => x.id === "update-long")
+  expect(item?.render.text).toBe("Updated")
+  expect(item?.render.icon).toBe("✅")
+  expect(item?.render.color).toBe("green")
+})
+
+test("update partial long format merges with existing", () => {
+  const handle = register({
+    id: "partial-update",
+    render: {
+      long: () => ({ icon: "📊", text: "Original", detail: "Original detail", color: "default" }),
+    },
+  })
+
+  handle.update({
+    long: { text: "Updated text" },
+  })
+
+  const sidebarItems = getSidebarItems()
+  const item = sidebarItems.find((x) => x.id === "partial-update")
+  expect(item?.render.text).toBe("Updated text")
+  expect(item?.render.icon).toBe("📊")
+  expect(item?.render.detail).toBe("Original detail")
+  expect(item?.render.color).toBe("default")
+})
+
+test("update sets short format to null", () => {
+  const handle = register({
+    id: "remove-short",
+    render: {
+      long: () => ({ text: "Long only" }),
+      short: () => ({ text: "Has short" }),
+    },
+  })
+
+  let footerItems = getFooterItems()
+  expect(footerItems.find((x) => x.id === "remove-short")).toBeDefined()
+
+  handle.update({
+    short: null,
+  })
+
+  footerItems = getFooterItems()
+  expect(footerItems.find((x) => x.id === "remove-short")).toBeUndefined()
+})
+
+test("update modifies short format", () => {
+  const handle = register({
+    id: "update-short",
+    render: {
+      long: () => ({ text: "Long" }),
+      short: () => ({ icon: "⚠️", text: "Warning", color: "yellow" }),
+    },
+  })
+
+  handle.update({
+    short: { icon: "✅", text: "Success", color: "green" },
+  })
+
+  const footerItems = getFooterItems()
+  const item = footerItems.find((x) => x.id === "update-short")
+  expect(item?.render.text).toBe("Success")
+  expect(item?.render.icon).toBe("✅")
+  expect(item?.render.color).toBe("green")
+})
+
+test("update merges short format with existing", () => {
+  const handle = register({
+    id: "merge-short",
+    render: {
+      long: () => ({ text: "Long" }),
+      short: () => ({ icon: "🔵", text: "Original", color: "blue" }),
+    },
+  })
+
+  handle.update({
+    short: { text: "Updated short" },
+  })
+
+  const footerItems = getFooterItems()
+  const item = footerItems.find((x) => x.id === "merge-short")
+  expect(item?.render.text).toBe("Updated short")
+  expect(item?.render.icon).toBe("🔵")
+  expect(item?.render.color).toBe("blue")
+})
+
+test("update both long and short simultaneously", () => {
+  const handle = register({
+    id: "update-both",
+    render: {
+      long: () => ({ icon: "🔴", text: "Initial long", detail: "Initial detail", color: "red" }),
+      short: () => ({ icon: "🔴", text: "Init short", color: "red" }),
+    },
+  })
+
+  handle.update({
+    long: { text: "Updated long", color: "green" },
+    short: { text: "Updated short", icon: "🟢" },
+  })
+
+  const sidebarItems = getSidebarItems()
+  const sidebarItem = sidebarItems.find((x) => x.id === "update-both")
+  expect(sidebarItem?.render.text).toBe("Updated long")
+  expect(sidebarItem?.render.color).toBe("green")
+  expect(sidebarItem?.render.detail).toBe("Initial detail")
+
+  const footerItems = getFooterItems()
+  const footerItem = footerItems.find((x) => x.id === "update-both")
+  expect(footerItem?.render.text).toBe("Updated short")
+  expect(footerItem?.render.icon).toBe("🟢")
+})
+
+test("remove deletes status item", () => {
+  const handle = register({
+    id: "to-remove",
+    render: {
+      long: () => ({ text: "Will be removed" }),
+      short: () => ({ text: "Remove me" }),
+    },
+  })
+
+  let all = getAll()
+  expect(all.find((x) => x.id === "to-remove")).toBeDefined()
+
+  handle.remove()
+
+  all = getAll()
+  expect(all.find((x) => x.id === "to-remove")).toBeUndefined()
+})
+
+test("remove after update works", () => {
+  const handle = register({
+    id: "remove-after-update",
+    render: {
+      long: () => ({ text: "Initial" }),
+    },
+  })
+
+  handle.update({
+    long: { text: "Updated" },
+  })
+
+  let items = getSidebarItems()
+  expect(items.find((x) => x.id === "remove-after-update")?.render.text).toBe("Updated")
+
+  handle.remove()
+
+  items = getSidebarItems()
+  expect(items.find((x) => x.id === "remove-after-update")).toBeUndefined()
+})
+
+test("multiple status items with different priorities", () => {
+  register({ id: "prio-1", priority: 1, render: { long: () => ({ text: "1" }), short: () => ({ text: "1" }) } })
+  register({ id: "prio-5", priority: 5, render: { long: () => ({ text: "5" }), short: () => ({ text: "5" }) } })
+  register({ id: "prio-10", priority: 10, render: { long: () => ({ text: "10" }), short: () => ({ text: "10" }) } })
+
+  const all = getAll()
+  expect(all.length).toBeGreaterThanOrEqual(3)
+
+  const sidebarItems = getSidebarItems()
+  expect(sidebarItems.length).toBeGreaterThanOrEqual(3)
+
+  const footerItems = getFooterItems()
+  expect(footerItems.length).toBeGreaterThanOrEqual(3)
+})
+
+test("status item without icon works", () => {
+  register({
+    id: "no-icon",
+    render: {
+      long: () => ({ text: "No icon here", color: "gray" }),
+      short: () => ({ text: "NoIcon", color: "gray" }),
+    },
+  })
+
+  const sidebarItem = getSidebarItems().find((x) => x.id === "no-icon")
+  expect(sidebarItem?.render.icon).toBeUndefined()
+  expect(sidebarItem?.render.text).toBe("No icon here")
+
+  const footerItem = getFooterItems().find((x) => x.id === "no-icon")
+  expect(footerItem?.render.icon).toBeUndefined()
+  expect(footerItem?.render.text).toBe("NoIcon")
+})
+
+test("status item with detail and progress in long format", () => {
+  register({
+    id: "rich-long",
+    render: {
+      long: () => ({
+        icon: "📈",
+        text: "Processing",
+        detail: "Analyzing files...",
+        progress: 45,
+        color: "blue",
+      }),
+    },
+  })
+
+  const sidebarItem = getSidebarItems().find((x) => x.id === "rich-long")
+  expect(sidebarItem?.render.detail).toBe("Analyzing files...")
+  expect(sidebarItem?.render.progress).toBe(45)
+})
+
+test("status item with subtext in long format", () => {
+  register({
+    id: "with-subtext",
+    render: {
+      long: () => ({
+        icon: "💾",
+        text: "Auto-save",
+        subtext: "Last saved: 2s ago",
+        color: "green",
+      }),
+    },
+  })
+
+  const sidebarItem = getSidebarItems().find((x) => x.id === "with-subtext")
+  expect(sidebarItem?.render.subtext).toBe("Last saved: 2s ago")
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,6 +23,63 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type StatusRegistry = {
+  register: (item: {
+    id: string
+    priority?: number
+    render: {
+      long: () => {
+        icon?: string
+        text: string
+        color?: "default" | "green" | "yellow" | "red" | "blue" | "gray"
+        detail?: string
+        progress?: number
+        subtext?: string
+      }
+      short?: () => {
+        icon?: string
+        text: string
+        color?: "default" | "green" | "yellow" | "red" | "blue" | "gray"
+      } | null
+    }
+  }) => {
+    update: (render: {
+      long?: Partial<{
+        icon?: string
+        text: string
+        color?: "default" | "green" | "yellow" | "red" | "blue" | "gray"
+        detail?: string
+        progress?: number
+        subtext?: string
+      }>
+      short?: Partial<{
+        icon?: string
+        text: string
+        color?: "default" | "green" | "yellow" | "red" | "blue" | "gray"
+      }> | null
+    }) => void
+    remove: () => void
+  }
+  getAll: () => Array<{ id: string; priority?: number }>
+  getFooterItems: () => Array<{
+    id: string
+    render: { icon?: string; text: string; color?: "default" | "green" | "yellow" | "red" | "blue" | "gray" }
+    priority?: number
+  }>
+  getSidebarItems: () => Array<{
+    id: string
+    render: {
+      icon?: string
+      text: string
+      color?: "default" | "green" | "yellow" | "red" | "blue" | "gray"
+      detail?: string
+      progress?: number
+      subtext?: string
+    }
+    priority?: number
+  }>
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -30,6 +87,7 @@ export type PluginInput = {
   worktree: string
   serverUrl: URL
   $: BunShell
+  status?: StatusRegistry
 }
 
 export type Plugin = (input: PluginInput) => Promise<Hooks>


### PR DESCRIPTION
Summary

  - Adds a status registry system that allows plugins to register dynamic status items
  - Status items can display in two formats: short (footer bar) and long (sidebar with detail/progress)
  - Supports colors, icons, priorities, and real-time updates via the event bus
  
  
![sidebar_demo](https://github.com/user-attachments/assets/ed0488f3-38dd-4bce-9ba0-6a1323227a84)
![footer_demo](https://github.com/user-attachments/assets/3101005c-cfe1-456f-a139-b379ed2c465e)
