### PR TITLE
feat(plugin): add chat.variant hook for programmatic thinking/variant control

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -83,7 +83,24 @@ export namespace LLM {
 
     const provider = await Provider.getProvider(input.model.providerID)
     const small = input.small ? ProviderTransform.smallOptions(input.model) : {}
-    const variant = input.model.variants && input.user.variant ? input.model.variants[input.user.variant] : {}
+
+    // Allow plugins to override variant selection
+    const availableVariants = input.model.variants ? Object.keys(input.model.variants) : []
+    const variantHook = await Plugin.trigger(
+      "chat.variant",
+      {
+        sessionID: input.sessionID,
+        agent: input.agent.name,
+        model: input.model,
+        currentVariant: input.user.variant,
+        availableVariants,
+      },
+      { variant: input.user.variant, options: {} },
+    )
+    const variantName = variantHook.variant
+    const variantOptions = input.model.variants && variantName ? input.model.variants[variantName] : {}
+    const variant = mergeDeep(variantOptions as Record<string, any>, variantHook.options)
+
     const options = pipe(
       ProviderTransform.options(input.model, input.sessionID, provider.options),
       mergeDeep(small),

--- a/packages/opencode/test/plugin/variant-hook.test.ts
+++ b/packages/opencode/test/plugin/variant-hook.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test"
+import type { Hooks } from "@opencode-ai/plugin"
+import type { Model } from "@opencode-ai/sdk"
+
+describe("chat.variant hook", () => {
+  test("should accept valid hook definition with variant override", async () => {
+    // #given
+    const hook: Hooks["chat.variant"] = async (input, output) => {
+      output.variant = "high"
+    }
+
+    const input = {
+      sessionID: "test-session",
+      agent: "build",
+      model: { id: "claude-sonnet-4" } as Model,
+      currentVariant: undefined,
+      availableVariants: ["high", "max"],
+    }
+    const output = { variant: undefined as string | undefined, options: {} }
+
+    // #when
+    await hook!(input, output)
+
+    // #then
+    expect(output.variant).toBe("high")
+  })
+
+  test("should accept valid hook definition with options override", async () => {
+    // #given
+    const hook: Hooks["chat.variant"] = async (input, output) => {
+      output.options = { thinking: { budget_tokens: 50000 } }
+    }
+
+    const input = {
+      sessionID: "test-session",
+      agent: "build",
+      model: { id: "claude-sonnet-4" } as Model,
+      currentVariant: "high",
+      availableVariants: ["high", "max"],
+    }
+    const output = { variant: "high" as string | undefined, options: {} as Record<string, any> }
+
+    // #when
+    await hook!(input, output)
+
+    // #then
+    expect(output.options).toEqual({ thinking: { budget_tokens: 50000 } })
+  })
+
+  test("should preserve currentVariant when hook does not modify output", async () => {
+    // #given
+    const hook: Hooks["chat.variant"] = async (_input, _output) => {}
+
+    const input = {
+      sessionID: "test-session",
+      agent: "build",
+      model: { id: "claude-sonnet-4" } as Model,
+      currentVariant: "max",
+      availableVariants: ["high", "max"],
+    }
+    const output = { variant: "max" as string | undefined, options: {} }
+
+    // #when
+    await hook!(input, output)
+
+    // #then
+    expect(output.variant).toBe("max")
+  })
+
+  test("should receive correct input parameters", async () => {
+    // #given
+    let receivedInput: Parameters<NonNullable<Hooks["chat.variant"]>>[0] | undefined
+
+    const hook: Hooks["chat.variant"] = async (input, _output) => {
+      receivedInput = input
+    }
+
+    const input = {
+      sessionID: "ses_123",
+      agent: "plan",
+      model: { id: "gpt-4", providerID: "openai" } as Model,
+      currentVariant: "high",
+      availableVariants: ["low", "high", "max"],
+    }
+    const output = { variant: "high" as string | undefined, options: {} }
+
+    // #when
+    await hook!(input, output)
+
+    // #then
+    expect(receivedInput).toBeDefined()
+    expect(receivedInput!.sessionID).toBe("ses_123")
+    expect(receivedInput!.agent).toBe("plan")
+    expect(receivedInput!.model.id).toBe("gpt-4")
+    expect(receivedInput!.currentVariant).toBe("high")
+    expect(receivedInput!.availableVariants).toEqual(["low", "high", "max"])
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -164,6 +164,25 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { temperature: number; topP: number; topK: number; options: Record<string, any> },
   ) => Promise<void>
+  /**
+   * Modify the variant used for LLM requests. Allows plugins to override
+   * thinking/reasoning levels programmatically.
+   *
+   * - `variant`: The variant name (e.g., "high", "max") to select from model's available variants
+   * - `options`: Direct provider options to merge (overrides variant selection)
+   *
+   * If both are set, `options` takes precedence over `variant`.
+   */
+  "chat.variant"?: (
+    input: {
+      sessionID: string
+      agent: string
+      model: Model
+      currentVariant: string | undefined
+      availableVariants: string[]
+    },
+    output: { variant: string | undefined; options: Record<string, any> },
+  ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },


### PR DESCRIPTION
## Summary

Add `chat.variant` plugin hook that allows plugins to programmatically control the thinking/variant level (high, max) before LLM requests are made.

## Changes

- Add `chat.variant` hook type definition in `@opencode/plugin`
- Trigger hook in `llm.ts` before variant options are applied
- Plugin receives current variant state and can override via `output.variant` or `output.options`

## Use Case

Plugins can now programmatically control:
- Anthropic's thinking budget (high/max)
- OpenAI's reasoning effort
- Other provider-specific variant options

This enables use cases like:
- Always use high thinking for specific models
- Dynamic thinking level based on conversation context
- Conditional variant selection based on session/agent type

## Example Usage

```typescript
const myPlugin: Plugin = async () => ({
  "chat.variant": async (input, output) => {
    // Always use high thinking for Claude
    if (input.model.id.includes("claude")) {
      output.variant = "high"
    }
  }
})
```

---
Generated with assistance of [OhMyOpenCode](https://github.com/code-yeongyu/oh-my-opencode)
