### PR TITLE
fix(opencode): handle ENOENT when attached file is deleted

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -827,7 +827,34 @@ export namespace SessionPrompt {
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filepath = fileURLToPath(part.url)
-              const stat = await Bun.file(filepath).stat()
+              const stat = await Bun.file(filepath)
+                .stat()
+                .catch(() => null)
+
+              if (!stat) {
+                const message = `File not found: ${filepath}`
+                log.error("file not found", { filepath })
+                Bus.publish(Session.Event.Error, {
+                  sessionID: input.sessionID,
+                  error: new NamedError.Unknown({ message }).toObject(),
+                })
+                return [
+                  {
+                    id: Identifier.ascending("part"),
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: message,
+                  },
+                  {
+                    ...part,
+                    id: part.id ?? Identifier.ascending("part"),
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                  },
+                ]
+              }
 
               if (stat.isDirectory()) {
                 part.mime = "application/x-directory"


### PR DESCRIPTION
Fixes #8807

### Problem
**TL;DR** - attach/mention (e.g., `@somefile.txt`) any file and ask OpenCode to delete it, wait for completion, up arrow, enter.

### Solution
Wrap the stat() call with .catch(() => null) and handle the missing file case:
1. Publish Session.Event.Error - triggers a toast notification in TUI
2. Add a synthetic text part with the error message - visible to the model
3. Preserve the original file part - user's intent is recorded

This follows the existing pattern used by ReadTool error handling in the same file.

### Verification
**Tested:**
1. Attached `@somefile.txt`.
2. Deleted `somefile.txt` from the OS.
3. Submitted the message.

**Result:**
Instead of crashing with a raw TUI error, the client now shows a toast notification and the model receives the error context gracefully.

<img width="1795" height="1373" alt="Screenshot 2026-01-02 111516" src="https://github.com/user-attachments/assets/9225775e-5cd5-4467-9dd5-22503656b63e" />

<img width="798" height="504" alt="Screenshot 2026-01-02 113007" src="https://github.com/user-attachments/assets/2920990f-02f0-4d2f-93e6-2ef34a75f974" />

