### PR TITLE
tool: trim persisted LSP diagnostics

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -131,9 +131,9 @@ export const EditTool = Tool.define("edit", {
 
     let output = ""
     await LSP.touchFile(filePath, true)
-    const diagnostics = await LSP.diagnostics()
+    const allDiagnostics = await LSP.diagnostics()
     const normalizedFilePath = Filesystem.normalizePath(filePath)
-    const issues = diagnostics[normalizedFilePath] ?? []
+    const issues = allDiagnostics[normalizedFilePath] ?? []
     const errors = issues.filter((item) => item.severity === 1)
     if (errors.length > 0) {
       const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
@@ -144,7 +144,9 @@ export const EditTool = Tool.define("edit", {
 
     return {
       metadata: {
-        diagnostics,
+        diagnostics: {
+          [normalizedFilePath]: issues,
+        },
         diff,
         filediff,
       },

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -53,28 +53,36 @@ export const WriteTool = Tool.define("write", {
 
     let output = ""
     await LSP.touchFile(filepath, true)
-    const diagnostics = await LSP.diagnostics()
+    const allDiagnostics = await LSP.diagnostics()
     const normalizedFilepath = Filesystem.normalizePath(filepath)
-    let projectDiagnosticsCount = 0
-    for (const [file, issues] of Object.entries(diagnostics)) {
-      const errors = issues.filter((item) => item.severity === 1)
-      if (errors.length === 0) continue
+    const issues = allDiagnostics[normalizedFilepath] ?? []
+    const errors = issues.filter((item) => item.severity === 1)
+    if (errors.length > 0) {
       const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
       const suffix =
         errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
-      if (file === normalizedFilepath) {
-        output += `\nThis file has errors, please fix\n<file_diagnostics>\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</file_diagnostics>\n`
-        continue
-      }
-      if (projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
-      projectDiagnosticsCount++
+      output += `\nThis file has errors, please fix\n<file_diagnostics>\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</file_diagnostics>\n`
+    }
+
+    const project: string[] = []
+    for (const [file, diagnostics] of Object.entries(allDiagnostics)) {
+      if (file === normalizedFilepath) continue
+      if (project.length >= MAX_PROJECT_DIAGNOSTICS_FILES) break
+      const errors = diagnostics.filter((item) => item.severity === 1)
+      if (errors.length === 0) continue
+      project.push(file)
+      const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+      const suffix =
+        errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
       output += `\n<project_diagnostics>\n${file}\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</project_diagnostics>\n`
     }
 
     return {
       title: path.relative(Instance.worktree, filepath),
       metadata: {
-        diagnostics,
+        diagnostics: {
+          [normalizedFilepath]: issues,
+        },
         filepath,
         exists: exists,
       },

--- a/packages/opencode/test/tool/lsp-diagnostics-metadata.test.ts
+++ b/packages/opencode/test/tool/lsp-diagnostics-metadata.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, mock, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Filesystem } from "../../src/util/filesystem"
+import { FileTime } from "../../src/file/time"
+import { tmpdir } from "../fixture/fixture"
+
+const state = {
+  diagnostics: {} as Record<string, Array<{ severity: number }>>,
+}
+
+mock.module("../../src/lsp", () => ({
+  LSP: {
+    touchFile: () => Promise.resolve(),
+    diagnostics: () => Promise.resolve(state.diagnostics),
+    Diagnostic: {
+      pretty: () => "",
+    },
+  },
+}))
+
+const { EditTool } = await import("../../src/tool/edit")
+const { WriteTool } = await import("../../src/tool/write")
+
+const ctx = {
+  sessionID: "test",
+  messageID: "",
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("tool diagnostics metadata", () => {
+  test("write stores only touched file diagnostics", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const filePath = path.join(tmp.path, "a.lua")
+        const normalizedFilepath = Filesystem.normalizePath(filePath)
+        const otherPath = Filesystem.normalizePath(path.join(tmp.path, "b.lua"))
+        state.diagnostics = {
+          [normalizedFilepath]: [{ severity: 1 }, { severity: 1 }],
+          [otherPath]: Array.from({ length: 250 }, () => ({ severity: 1 })),
+        }
+
+        const tool = await WriteTool.init()
+        const result = await tool.execute(
+          {
+            filePath,
+            content: "print('hi')",
+          },
+          ctx,
+        )
+
+        expect(Object.keys(result.metadata.diagnostics)).toEqual([normalizedFilepath])
+        expect(result.metadata.diagnostics[normalizedFilepath]?.length).toBe(2)
+      },
+    })
+  })
+
+  test("edit stores only touched file diagnostics", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const filePath = path.join(tmp.path, "a.lua")
+        await Bun.write(filePath, "hello\n")
+        FileTime.read(ctx.sessionID, filePath)
+
+        const normalizedFilepath = Filesystem.normalizePath(filePath)
+        const otherPath = Filesystem.normalizePath(path.join(tmp.path, "b.lua"))
+        state.diagnostics = {
+          [normalizedFilepath]: [{ severity: 1 }],
+          [otherPath]: Array.from({ length: 250 }, () => ({ severity: 1 })),
+        }
+
+        const tool = await EditTool.init()
+        const result = await tool.execute(
+          {
+            filePath,
+            oldString: "hello",
+            newString: "world",
+          },
+          ctx,
+        )
+
+        expect(Object.keys(result.metadata.diagnostics)).toEqual([normalizedFilepath])
+        expect(result.metadata.diagnostics[normalizedFilepath]?.length).toBe(1)
+      },
+    })
+  })
+})


### PR DESCRIPTION
 - Trim persisted diagnostics to only the touched file in EditTool and WriteTool (packages/opencode/src/tool/edit.ts:147, packages/opencode/src/tool/write.ts:77) so sessions don’t balloon from workspace-wide Lua diagnostics.
  - Added regression coverage with an LSP mock (packages/opencode/test/tool/lsp-diagnostics-metadata.test.ts:1).