### PR TITLE
tool: restore list tool

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -8,6 +8,7 @@ import { TaskTool } from "./task"
 import { TodoWriteTool, TodoReadTool } from "./todo"
 import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
+import { ListTool } from "./ls"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
 import type { Agent } from "../agent/agent"
@@ -94,6 +95,7 @@ export namespace ToolRegistry {
       ReadTool,
       GlobTool,
       GrepTool,
+      ListTool,
       EditTool,
       WriteTool,
       TaskTool,

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { ToolRegistry } from "../../src/tool/registry"
+
+const projectRoot = path.join(__dirname, "../..")
+
+describe("tool.registry", () => {
+  test("includes list tool", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).toContain("list")
+      },
+    })
+  })
+})
+


### PR DESCRIPTION
- Re-adds ListTool in packages/opencode/src/tool/registry.ts:93
  - Adds a guard test packages/opencode/test/tool/registry.test.ts:1 so it doesn’t get removed again