### PR TITLE
feat(app): add image preview support in session viewer

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1153,6 +1153,15 @@ export default function Page() {
                     })
                     const contents = createMemo(() => state()?.content?.content ?? "")
                     const cacheKey = createMemo(() => checksum(contents()))
+                    const isImage = createMemo(() => {
+                      const c = state()?.content
+                      return c?.encoding === "base64" && c?.mimeType?.startsWith("image/")
+                    })
+                    const imageDataUrl = createMemo(() => {
+                      if (!isImage()) return
+                      const c = state()?.content
+                      return `data:${c?.mimeType};base64,${c?.content}`
+                    })
                     const selectedLines = createMemo(() => {
                       const p = path()
                       if (!p) return null
@@ -1255,6 +1264,11 @@ export default function Page() {
                           )}
                         </Show>
                         <Switch>
+                          <Match when={state()?.loaded && isImage()}>
+                            <div class="px-6 py-4 pb-40">
+                              <img src={imageDataUrl()} alt={path()} class="max-w-full" />
+                            </div>
+                          </Match>
                           <Match when={state()?.loaded}>
                             <Dynamic
                               component={codeComponent}


### PR DESCRIPTION
## Summary

- Add image preview support for base64-encoded images in the session viewer
- Detect images by checking for `base64` encoding and `image/*` mimeType
- Render images inline with an `<img>` element instead of showing raw base64 data

## Changes

- Added `isImage` memo to detect base64 image content
- Added `imageDataUrl` memo to construct data URL for rendering
- Added new `<Match>` case to render images when detected

Before:
<img width="2727" height="1986" alt="image" src="https://github.com/user-attachments/assets/9dbd2541-17ab-4284-9d71-caf6d3f93fdd" />


After: 
<img width="2781" height="1986" alt="image" src="https://github.com/user-attachments/assets/79ebbc61-dd5d-4509-8750-a4d7fffcd692" />
