### PR TITLE
feat: add ask_user tool for interactive user questions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -16,6 +16,7 @@ import type {
   ProviderAuthMethod,
   VcsInfo,
 } from "@opencode-ai/sdk/v2"
+import type { AskRequest } from "@/tool/ask"
 import { createStore, produce, reconcile } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
 import { Binary } from "@opencode-ai/util/binary"
@@ -40,6 +41,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       command: Command[]
       permission: {
         [sessionID: string]: PermissionRequest[]
+      }
+      ask: {
+        [sessionID: string]: AskRequest[]
       }
       config: Config
       session: Session[]
@@ -76,6 +80,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       status: "loading",
       agent: [],
       permission: {},
+      ask: {},
       command: [],
       provider: [],
       provider_default: {},
@@ -132,6 +137,44 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             request.sessionID,
             produce((draft) => {
               draft.splice(match.index, 0, request)
+            }),
+          )
+          break
+        }
+
+        case "askuser.question": {
+          const request = event.properties as AskRequest
+          const requests = store.ask[request.sessionID]
+          if (!requests) {
+            setStore("ask", request.sessionID, [request])
+            break
+          }
+          const match = Binary.search(requests, request.id, (r) => r.id)
+          if (match.found) {
+            setStore("ask", request.sessionID, match.index, reconcile(request))
+            break
+          }
+          setStore(
+            "ask",
+            request.sessionID,
+            produce((draft) => {
+              draft.splice(match.index, 0, request)
+            }),
+          )
+          break
+        }
+
+        case "askuser.answer":
+        case "askuser.cancelled": {
+          const requests = store.ask[event.properties.sessionID]
+          if (!requests) break
+          const match = Binary.search(requests, event.properties.id, (r) => r.id)
+          if (!match.found) break
+          setStore(
+            "ask",
+            event.properties.sessionID,
+            produce((draft) => {
+              draft.splice(match.index, 1)
             }),
           )
           break

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -69,6 +69,7 @@ import { Filesystem } from "@/util/filesystem"
 import { PermissionPrompt } from "./permission"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { DialogAsk } from "../../ui/dialog-ask"
 
 addDefaultParsers(parsers.parsers)
 
@@ -118,6 +119,11 @@ export function Session() {
   const permissions = createMemo(() => {
     if (session().parentID) return sync.data.permission[route.sessionID] ?? []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+  })
+
+  const askRequests = createMemo(() => {
+    if (session().parentID) return sync.data.ask[route.sessionID] ?? []
+    return children().flatMap((x) => sync.data.ask[x.id] ?? [])
   })
 
   const pending = createMemo(() => {
@@ -1024,13 +1030,34 @@ export function Session() {
               <Show when={permissions().length > 0}>
                 <PermissionPrompt request={permissions()[0]} />
               </Show>
+              <Show when={permissions().length === 0 && askRequests().length > 0}>
+                <DialogAsk
+                  request={askRequests()[0]}
+                  onSelect={(value) => {
+                    const request = askRequests()[0]
+                    sdk.client.ask.reply({
+                      id: request.id,
+                      sessionID: request.sessionID,
+                      selected: value,
+                    })
+                  }}
+                  onCancel={() => {
+                    const request = askRequests()[0]
+                    sdk.client.ask.reply({
+                      id: request.id,
+                      sessionID: request.sessionID,
+                      cancelled: true,
+                    })
+                  }}
+                />
+              </Show>
               <Prompt
-                visible={!session().parentID && permissions().length === 0}
+                visible={!session().parentID && permissions().length === 0 && askRequests().length === 0}
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)
                 }}
-                disabled={permissions().length > 0}
+                disabled={permissions().length > 0 || askRequests().length > 0}
                 onSubmit={() => {
                   toBottom()
                 }}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-ask.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-ask.tsx
@@ -1,0 +1,120 @@
+import { createStore } from "solid-js/store"
+import { createMemo, For, Show } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
+import { useTheme, selectedForeground } from "../context/theme"
+import { SplitBorder } from "../component/border"
+import type { AskRequest, AskOption } from "@/tool/ask"
+
+export function DialogAsk(props: { request: AskRequest; onSelect: (value: string) => void; onCancel: () => void }) {
+  const { theme } = useTheme()
+  const [store, setStore] = createStore({
+    selected: 0,
+  })
+
+  const options = createMemo(() => props.request.options)
+  const selectedOption = createMemo(() => options()[store.selected])
+
+  useKeyboard((evt) => {
+    if (evt.name === "up" || evt.name === "k") {
+      evt.preventDefault()
+      setStore("selected", (prev) => (prev - 1 + options().length) % options().length)
+    }
+
+    if (evt.name === "down" || evt.name === "j") {
+      evt.preventDefault()
+      setStore("selected", (prev) => (prev + 1) % options().length)
+    }
+
+    const num = parseInt(evt.name, 10)
+    if (num >= 1 && num <= 6 && num <= options().length) {
+      evt.preventDefault()
+      setStore("selected", num - 1)
+    }
+
+    if (evt.name === "return") {
+      evt.preventDefault()
+      const option = selectedOption()
+      if (option) {
+        props.onSelect(option.value)
+      }
+    }
+
+    if (evt.name === "escape") {
+      evt.preventDefault()
+      props.onCancel()
+    }
+  })
+
+  const fg = selectedForeground(theme)
+
+  return (
+    <box
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.primary}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <box flexDirection="row" gap={1} paddingLeft={1}>
+          <text fg={theme.primary}>{"?"}</text>
+          <text fg={theme.text}>{props.request.question}</text>
+        </box>
+        <Show when={props.request.context}>
+          <box paddingLeft={3}>
+            <text fg={theme.textMuted}>{props.request.context}</text>
+          </box>
+        </Show>
+        <box paddingLeft={2} paddingTop={1}>
+          <For each={options()}>
+            {(option, index) => {
+              const isSelected = createMemo(() => index() === store.selected)
+              return (
+                <box flexDirection="column" paddingBottom={1}>
+                  <box flexDirection="row" gap={1}>
+                    <text fg={isSelected() ? theme.primary : theme.textMuted} flexShrink={0}>
+                      {isSelected() ? "❯" : " "} {index() + 1}.
+                    </text>
+                    <text fg={isSelected() ? fg : theme.text}>{option.label}</text>
+                  </box>
+                  <Show when={option.description}>
+                    <box paddingLeft={5}>
+                      <text fg={theme.textMuted}>{option.description}</text>
+                    </box>
+                  </Show>
+                </box>
+              )
+            }}
+          </For>
+        </box>
+      </box>
+      <box
+        flexDirection="row"
+        flexShrink={0}
+        gap={2}
+        paddingTop={1}
+        paddingLeft={2}
+        paddingRight={3}
+        paddingBottom={1}
+        backgroundColor={theme.backgroundElement}
+        justifyContent="space-between"
+      >
+        <box flexDirection="row" gap={2}>
+          <text fg={theme.text}>
+            {"↑↓"} <span style={{ fg: theme.textMuted }}>navigate</span>
+          </text>
+          <text fg={theme.text}>
+            {"1-" + options().length} <span style={{ fg: theme.textMuted }}>select</span>
+          </text>
+        </box>
+        <box flexDirection="row" gap={2}>
+          <text fg={theme.text}>
+            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+          </text>
+          <text fg={theme.text}>
+            esc <span style={{ fg: theme.textMuted }}>cancel</span>
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -9,6 +9,7 @@ export namespace Identifier {
     user: "usr",
     part: "prt",
     pty: "pty",
+    ask: "ask",
   } as const
 
   export function schema(prefix: keyof typeof prefixes) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -48,6 +48,7 @@ import { errors } from "./error"
 import { Pty } from "@/pty"
 import { PermissionNext } from "@/permission/next"
 import { Installation } from "@/installation"
+import { AskUser } from "@/tool/ask"
 import { MDNS } from "./mdns"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
@@ -1611,6 +1612,56 @@ export namespace Server {
         async (c) => {
           const permissions = await PermissionNext.list()
           return c.json(permissions)
+        },
+      )
+      .post(
+        "/ask/:id/reply",
+        describeRoute({
+          summary: "Respond to ask request",
+          description: "Respond to an ask_user question from the AI assistant.",
+          operationId: "ask.reply",
+          responses: {
+            200: {
+              description: "Response processed successfully",
+              content: {
+                "application/json": {
+                  schema: resolver(z.boolean()),
+                },
+              },
+            },
+            ...errors(400),
+          },
+        }),
+        validator(
+          "param",
+          z.object({
+            id: z.string(),
+          }),
+        ),
+        validator(
+          "json",
+          z.object({
+            sessionID: z.string(),
+            selected: z.string().optional(),
+            cancelled: z.boolean().optional(),
+          }),
+        ),
+        async (c) => {
+          const params = c.req.valid("param")
+          const json = c.req.valid("json")
+          if (json.cancelled) {
+            await Bus.publish(AskUser.Event.Cancelled, {
+              id: params.id,
+              sessionID: json.sessionID,
+            })
+          } else if (json.selected) {
+            await Bus.publish(AskUser.Event.Answered, {
+              id: params.id,
+              sessionID: json.sessionID,
+              selected: json.selected,
+            })
+          }
+          return c.json(true)
         },
       )
       .get(

--- a/packages/opencode/src/tool/ask.ts
+++ b/packages/opencode/src/tool/ask.ts
@@ -1,0 +1,176 @@
+import z from "zod"
+import { Tool } from "./tool"
+import DESCRIPTION from "./ask.txt"
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { Identifier } from "@/id/id"
+
+const OptionSchema = z.object({
+  value: z.string().describe("Unique identifier for this option"),
+  label: z.string().describe("Short display label"),
+  description: z.string().optional().describe("Detailed explanation of this option"),
+})
+
+export type AskOption = z.infer<typeof OptionSchema>
+
+const AskRequestSchema = z.object({
+  id: z.string(),
+  sessionID: z.string(),
+  messageID: z.string(),
+  question: z.string(),
+  options: OptionSchema.array(),
+  context: z.string().optional(),
+})
+
+export type AskRequest = z.infer<typeof AskRequestSchema>
+
+const AskResponseSchema = z.object({
+  id: z.string(),
+  sessionID: z.string(),
+  selected: z.string(),
+})
+
+export type AskResponse = z.infer<typeof AskResponseSchema>
+
+export namespace AskUser {
+  export const Event = {
+    Asked: BusEvent.define("askuser.question", AskRequestSchema),
+    Answered: BusEvent.define("askuser.answer", AskResponseSchema),
+    Cancelled: BusEvent.define(
+      "askuser.cancelled",
+      z.object({
+        id: z.string(),
+        sessionID: z.string(),
+      }),
+    ),
+  }
+}
+
+export class UserCancelledError extends Error {
+  constructor() {
+    super(
+      "The user cancelled the question. Do not ask the same question again. " +
+        "Either proceed with a reasonable default or ask a different, more specific question.",
+    )
+    this.name = "UserCancelledError"
+  }
+}
+
+function formatOutput(question: string, selected: AskOption, allOptions: AskOption[]): string {
+  const otherOptions = allOptions
+    .filter((o) => o.value !== selected.value)
+    .map((o) => `- ${o.label}`)
+    .join("\n")
+
+  return `## User Response
+
+**Question**: ${question}
+
+**Selected**: ${selected.label}${selected.description ? ` - ${selected.description}` : ""}
+
+**Value**: \`${selected.value}\`
+
+**Rejected alternatives**:
+${otherOptions}
+
+---
+
+Proceed with the implementation based on the user's choice of "${selected.label}".`
+}
+
+export const AskUserTool = Tool.define<
+  z.ZodObject<{
+    question: z.ZodString
+    options: z.ZodArray<typeof OptionSchema>
+    context: z.ZodOptional<z.ZodString>
+  }>,
+  { question: string; selected: string; label: string }
+>("ask_user", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    question: z
+      .string()
+      .min(10)
+      .max(500)
+      .describe("The clarifying question to ask the user. Be specific and actionable."),
+    options: OptionSchema.array()
+      .min(2)
+      .max(6)
+      .describe("2-6 distinct options for the user to choose from. Each must have unique value."),
+    context: z
+      .string()
+      .max(300)
+      .optional()
+      .describe("Optional context explaining why this decision matters or its implications."),
+  }),
+
+  async execute(params, ctx) {
+    const values = params.options.map((o) => o.value)
+    if (new Set(values).size !== values.length) {
+      throw new Error("Each option must have a unique 'value' field")
+    }
+
+    const id = Identifier.ascending("ask")
+
+    const answer = await new Promise<string>((resolve, reject) => {
+      const unsubAnswer = Bus.subscribe(AskUser.Event.Answered, (event) => {
+        if (event.properties.id === id) {
+          cleanup()
+          resolve(event.properties.selected)
+        }
+      })
+
+      const unsubCancel = Bus.subscribe(AskUser.Event.Cancelled, (event) => {
+        if (event.properties.id === id) {
+          cleanup()
+          reject(new UserCancelledError())
+        }
+      })
+
+      const onAbort = () => {
+        cleanup()
+        reject(new Error("Session aborted"))
+      }
+      ctx.abort.addEventListener("abort", onAbort)
+
+      const cleanup = () => {
+        unsubAnswer()
+        unsubCancel()
+        ctx.abort.removeEventListener("abort", onAbort)
+      }
+
+      Bus.publish(AskUser.Event.Asked, {
+        id,
+        sessionID: ctx.sessionID,
+        messageID: ctx.messageID,
+        question: params.question,
+        options: params.options,
+        context: params.context,
+      })
+    })
+
+    const selected = params.options.find((o) => o.value === answer)
+    if (!selected) {
+      throw new Error(`Invalid selection: ${answer}`)
+    }
+
+    ctx.metadata({
+      title: `Asked: ${params.question.slice(0, 50)}...`,
+      metadata: {
+        question: params.question,
+        selected: answer,
+        label: selected.label,
+      },
+    })
+
+    return {
+      title: `User selected: ${selected.label}`,
+      metadata: {
+        question: params.question,
+        selected: answer,
+        label: selected.label,
+      },
+      output: formatOutput(params.question, selected, params.options),
+    }
+  },
+})

--- a/packages/opencode/src/tool/ask.txt
+++ b/packages/opencode/src/tool/ask.txt
@@ -1,0 +1,72 @@
+Ask the user a clarifying question when you need their input to make a decision.
+
+## When to Use
+
+Use this tool when:
+- Multiple valid implementation approaches exist
+- The specification is ambiguous about a key detail
+- You're about to make an architectural decision with significant impact
+- User preference genuinely matters for the outcome
+- You're in "interview mode" building a spec
+
+## When NOT to Use
+
+Do NOT use this tool for:
+- Trivial decisions you can reasonably make yourself
+- Questions already answered in the conversation or context
+- Every small implementation detail (be autonomous)
+- Confirming things that are obvious from context
+- Asking the same question twice
+
+## Best Practices
+
+1. **Be specific**: "Which date library?" not "How should I handle dates?"
+2. **Provide context**: Explain why the choice matters
+3. **Limit options**: 2-4 options is ideal, max 6
+4. **Unique values**: Each option needs a distinct `value` field
+5. **Helpful descriptions**: Add descriptions for non-obvious options
+
+## Example
+
+Good question:
+```json
+{
+  "question": "How should we handle authentication token storage?",
+  "options": [
+    {
+      "value": "httponly_cookie",
+      "label": "HttpOnly Cookie",
+      "description": "Most secure. Automatic CSRF protection needed."
+    },
+    {
+      "value": "localstorage",
+      "label": "LocalStorage",
+      "description": "Easier to implement. XSS vulnerable."
+    },
+    {
+      "value": "memory",
+      "label": "In-Memory Only",
+      "description": "Most secure but lost on refresh."
+    }
+  ],
+  "context": "This affects security posture and will require different middleware."
+}
+```
+
+Bad question:
+```json
+{
+  "question": "Should I continue?",
+  "options": [
+    {"value": "yes", "label": "Yes"},
+    {"value": "no", "label": "No"}
+  ]
+}
+```
+
+## Behavior
+
+- Tool execution pauses until user responds
+- User can cancel with Esc (throws UserCancelledError)
+- Response includes the selected value and label
+- Use the response to guide your next steps

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -1,3 +1,4 @@
+import { AskUserTool } from "./ask"
 import { BashTool } from "./bash"
 import { EditTool } from "./edit"
 import { GlobTool } from "./glob"
@@ -103,6 +104,7 @@ export namespace ToolRegistry {
       WebSearchTool,
       CodeSearchTool,
       SkillTool,
+      AskUserTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...custom,


### PR DESCRIPTION
Similar to AskUserQuestion tool in ClaudeCode. Adds a new tool that allows the AI to pause execution and present clarifying questions with selectable options to the user. Useful for gathering user preferences before proceeding with implementation.

- Tool: ask_user with question, options (2-6), and optional context
- TUI: DialogAsk component with keyboard navigation (↑/↓/j/k, 1-6, Enter, Esc)
- Server: POST /ask/:id/reply endpoint for user responses
- Events: askuser.question, askuser.answer, askuser.cancelled


## Summary
- Adds ask_user tool enabling the AI to pause and present clarifying questions with selectable options
- Implements TUI dialog with full keyboard navigation for option selection
- Follows existing permission system architecture (Bus events → SSE → TUI → API reply)
- Events: askuser.question, askuser.answer, askuser.cancelled


## Changes
New Files:
- src/tool/ask.ts - Tool definition with Bus events and promise-based execution
- src/tool/ask.txt - LLM description explaining when to use/avoid the tool
- src/cli/cmd/tui/ui/dialog-ask.tsx - SolidJS dialog component


## Modified Files:
- src/server/server.ts - Added POST /ask/:id/reply endpoint
- src/tool/registry.ts - Registered AskUserTool
- src/cli/cmd/tui/context/sync.tsx - Added ask event handlers to sync state
- src/cli/cmd/tui/routes/session/index.tsx - Renders DialogAsk, handles responses
- src/id/id.ts - Added "ask" prefix for ID generation
- packages/sdk/ - Regenerated client SDK


## Testing
cd packages/opencode && bun dev

Try prompts like:
- "Help me choose a testing framework for TypeScript"
- "Interview me about building a REST API"

The AI should present options with keyboard navigation (↑ / ↓ / j / k , 1-6 number keys, Enter to select, Esc to cancel).