### PR TITLE
fix: clear FileTime cache when sessions are deleted

### DIFF
--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -7,18 +7,29 @@ export namespace FileTime {
   // All tools that overwrite existing files should run their
   // assert/read/write/update sequence inside withLock(filepath, ...)
   // so concurrent writes to the same file are serialized.
-  export const state = Instance.state(() => {
-    const read: {
-      [sessionID: string]: {
-        [path: string]: Date | undefined
+  export const state = Instance.state(
+    () => {
+      const read: {
+        [sessionID: string]: {
+          [path: string]: Date | undefined
+        }
+      } = {}
+      const locks = new Map<string, Promise<void>>()
+      return {
+        read,
+        locks,
       }
-    } = {}
-    const locks = new Map<string, Promise<void>>()
-    return {
-      read,
-      locks,
-    }
-  })
+    },
+    // Explicit cleanup on instance disposal. While the state object is GC'd
+    // when the instance is disposed, this makes the lifecycle explicit for
+    // long-running sessions with many subtasks.
+    async (current) => {
+      for (const key of Object.keys(current.read)) {
+        delete current.read[key]
+      }
+      current.locks.clear()
+    },
+  )
 
   export function read(sessionID: string, file: string) {
     log.info("read", { sessionID, file })
@@ -60,5 +71,11 @@ export namespace FileTime {
         `File ${filepath} has been modified since it was last read.\nLast modification: ${stats.mtime.toISOString()}\nLast read: ${time.toISOString()}\n\nPlease read the file again before modifying it.`,
       )
     }
+  }
+
+  // Clears read timestamps for a deleted session. Called by Session.remove()
+  // to prevent orphaned entries from accumulating when sessions/subtasks are deleted.
+  export function clearSession(sessionID: string) {
+    delete state().read[sessionID]
   }
 }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -16,6 +16,7 @@ import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
 import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
+import { FileTime } from "@/file/time"
 
 import type { Provider } from "@/provider/provider"
 import { PermissionNext } from "@/permission/next"
@@ -326,6 +327,8 @@ export namespace Session {
         await Storage.remove(msg)
       }
       await Storage.remove(["session", project.id, sessionID])
+      // Clear file read timestamps - session is gone, timestamps are orphaned
+      FileTime.clearSession(sessionID)
       Bus.publish(Event.Deleted, {
         info: session,
       })


### PR DESCRIPTION
Clears per-session file read timestamps when sessions are deleted, preventing memory accumulation during long-running sessions.

This is fairly low impact, but non-zero. The leak only occurs within a single opencode process lifetime and is cleared on exit via `Instance.disposeAll()`. 

#### Quantified growth rates:

- **Daily restarts** (typical): <1 MB peak, reset on exit
- **8-hour extended session**: 1-5 MB peak
- **Week-long session without restart**: 20-50 MB peak (unlikely usage pattern)
- **128 MB threshold**: Would require ~2,150 complex tasks (each spawning 5 subtasks reading ~30 files) in a single session - approximately one task every 2 minutes for 72 hours straight

The leak scales with `# of sessions × # of unique files read`, at ~160 bytes per file entry. Subtasks are the primary driver since each creates a new sessionID, so sub-task heavy users/agents are likely to see this happen more.

note: _this was a bit of an exploration to see what memory leaks existed and could be tested for. I was only looking for leaks that could genuinely accumulate >= 128MB of RAM over typical-to-heavy usage, not a few KB a day. I've seen things get slow across long-running / multi-day processes and went looking for potential fixes._