### PR TITLE
fix(ui): fix select chevron alignment

### DIFF
--- a/packages/ui/src/components/select.css
+++ b/packages/ui/src/components/select.css
@@ -11,6 +11,9 @@
     [data-slot="select-select-trigger-icon"] {
       width: 16px;
       height: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       flex-shrink: 0;
       color: var(--text-weak);
       transition: transform 0.1s ease-in-out;


### PR DESCRIPTION
## Changes

- Align chevron icon in select menus horizontally

## Screenshots

### Before

<img width="492" height="250" alt="image" src="https://github.com/user-attachments/assets/da4c1dea-5a72-4238-8efe-612fad31f8a2" />

### After

<img width="474" height="242" alt="image" src="https://github.com/user-attachments/assets/d949f014-a1c0-4a1d-be2f-97ae0c20b582" />
