### PR TITLE
chore: add license field to package.json

### DIFF
--- a/github/package.json
+++ b/github/package.json
@@ -3,6 +3,7 @@
   "module": "index.ts",
   "type": "module",
   "private": true,
+  "license": "MIT",
   "devDependencies": {
     "@types/bun": "catalog:"
   },

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -2,6 +2,7 @@
   "name": "@opencode-ai/console-app",
   "version": "1.0.224",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev --host 0.0.0.0",

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.224",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-sts": "3.782.0",
     "@jsx-email/render": "1.1.1",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -4,6 +4,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "typecheck": "tsgo --noEmit"
   },

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -17,5 +17,6 @@
   "scripts": {
     "dev": "email preview emails/templates"
   },
-  "type": "module"
+  "type": "module",
+  "license": "MIT"
 }

--- a/packages/console/resource/package.json
+++ b/packages/console/resource/package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-resource",
+  "license": "MIT",
   "dependencies": {
     "@cloudflare/workers-types": "catalog:"
   },

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.224",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "typecheck": "tsgo -b",
     "predev": "bun ./scripts/predev.ts",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.224",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "dev": "vite dev",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -4,6 +4,7 @@
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
     "@tsconfig/node22": "22.0.2",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.224",
   "name": "opencode",
   "type": "module",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "typecheck": "tsgo --noEmit",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -3,6 +3,7 @@
   "name": "@opencode-ai/plugin",
   "version": "1.0.224",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "tsc"

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "@opencode-ai/script",
+  "license": "MIT",
   "devDependencies": {
     "@types/bun": "catalog:"
   },

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -3,6 +3,7 @@
   "name": "@opencode-ai/sdk",
   "version": "1.0.224",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "typecheck": "tsgo --noEmit",
     "build": "./script/build.ts"

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -2,6 +2,7 @@
   "name": "@opencode-ai/slack",
   "version": "1.0.224",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "dev": "bun run src/index.ts",
     "typecheck": "tsgo --noEmit"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,7 @@
   "name": "@opencode-ai/ui",
   "version": "1.0.224",
   "type": "module",
+  "license": "MIT",
   "exports": {
     "./*": "./src/components/*.tsx",
     "./pierre": "./src/pierre/index.ts",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.224",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "exports": {
     "./*": "./src/*.ts"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opencode-ai/web",
   "type": "module",
+  "license": "MIT",
   "version": "1.0.224",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
* Sets `license` field in all `package.json` files where not previously specified.
* Closes #6684

## Testing
Standard run and build:
```shell
bun install
bun dev
./packages/opencode/script/build.ts --single
```

Additional spot checking that the packaging is happy:
```shell
jojo@x:~/repos/opencode/packages/plugin$ bun pm pack
bun pack v1.3.5 (1e86cebd)

packed 0.59KB package.json

opencode-ai-plugin-1.0.224.tgz

Total files: 1
Shasum: 02bafc0c63443a12965515331da9e5862268c526
Integrity: sha512-V+Rl1dTT8QiSl[...]f9zCw/D7eg1Kg==
Unpacked size: 0.59KB
Packed size: 403B
jojo@x:~/repos/opencode/packages/plugin$ tar -xOf opencode-ai-plugin-1.0.224.tgz package/package.json | grep license
  "license": "MIT",
```