### PR TITLE
tui: apply direnv env for user shell commands

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1202,6 +1202,9 @@ export namespace SessionPrompt {
           `
             [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
             [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
+            if command -v direnv >/dev/null 2>&1; then
+              eval "$(direnv export zsh)"
+            fi
             eval ${JSON.stringify(input.command)}
           `,
         ],
@@ -1213,6 +1216,9 @@ export namespace SessionPrompt {
           `
             shopt -s expand_aliases
             [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
+            if command -v direnv >/dev/null 2>&1; then
+              eval "$(direnv export bash)"
+            fi
             eval ${JSON.stringify(input.command)}
           `,
         ],


### PR DESCRIPTION
- run direnv export <shell> inside the bash/zsh wrapper before eval so .envrc gets applied even for non-interactive ! commands.
  - Change is in packages/opencode/src/session/prompt.ts:1206 (zsh) and packages/opencode/src/session/prompt.ts:1220 (bash).