### PR TITLE
fix(tui): enable app exit via Ctrl-C/Ctrl-D during permission requests

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -44,6 +44,7 @@ import { useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@open
 import { useSDK } from "@tui/context/sdk"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "@tui/context/keybind"
+import { useExit } from "../../context/exit"
 import { Header } from "./header"
 import { parsePatch } from "diff"
 import { useDialog } from "../../ui/dialog"
@@ -880,9 +881,26 @@ export function Session() {
 
   const dialog = useDialog()
   const renderer = useRenderer()
+  const exit = useExit()
 
   // snap to bottom when session changes
   createEffect(on(() => route.sessionID, toBottom))
+
+  // Global handler for Ctrl-C/Ctrl-D during permission requests
+  // This ensures users can always exit regardless of keyboard focus
+  useKeyboard((evt) => {
+    if (permissions().length === 0) return
+    if ((evt.ctrl && evt.name === "c") || evt.name === "d") {
+      evt.preventDefault()
+      for (const permission of permissions()) {
+        sdk.client.permission.reply({
+          reply: "reject",
+          requestID: permission.id,
+        })
+      }
+      exit()
+    }
+  })
 
   return (
     <context.Provider

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -122,6 +122,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
       <Match when={store.always}>
         <Prompt
           title="Always allow"
+          request={props.request}
           body={
             <Switch>
               <Match when={props.request.always.length === 1 && props.request.always[0] === "*"}>
@@ -158,6 +159,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
       <Match when={!store.always}>
         <Prompt
           title="Permission required"
+          request={props.request}
           body={
             <Switch>
               <Match when={props.request.permission === "edit"}>
@@ -231,14 +233,25 @@ function Prompt<const T extends Record<string, string>>(props: {
   body: JSX.Element
   options: T
   onSelect: (option: keyof T) => void
+  request: PermissionRequest
 }) {
   const { theme } = useTheme()
+  const sdk = useSDK()
   const keys = Object.keys(props.options) as (keyof T)[]
   const [store, setStore] = createStore({
     selected: keys[0],
   })
 
   useKeyboard((evt) => {
+    if ((evt.ctrl && evt.name === "c") || evt.name === "d") {
+      evt.preventDefault()
+      sdk.client.permission.reply({
+        reply: "reject",
+        requestID: props.request.id,
+      })
+      return
+    }
+
     if (evt.name === "left" || evt.name == "h") {
       evt.preventDefault()
       const idx = keys.indexOf(store.selected)


### PR DESCRIPTION
## Summary
Users were unable to exit the application via Ctrl-C or Ctrl-D when a permission request was displayed.

## Changes

This fix implements a two-layer defense:

### 1. Component-level handler (`permission.tsx`)
- Added `request` prop to `Prompt` component
- Ctrl-C/Ctrl-D in the permission prompt rejects the permission request

### 2. Global handler (`session/index.tsx`)
- Added global `useKeyboard` handler at the Session level
- When permissions are pending, Ctrl-C/Ctrl-D:
  - Rejects all pending permissions via the SDK
  - Exits the application via `exit()`
  
## Why two handlers?
- Component handler: Works when user is interacting with the permission prompt
- Global handler: Works regardless of keyboard focus (e.g., if user is typing in the command prompt while a permission is pending)

## Testing
All existing permission tests pass:
bun test test/permission/next.test.ts
55 pass

## Related
- Issue: #6644 
- Related PR: #6632 (similar fix with component-level handling only)