### PR TITLE
fix(app): fix image dragging in project edit dialog

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -303,6 +303,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const handleGlobalDragOver = (event: DragEvent) => {
+    if (dialog.active) return
+
     event.preventDefault()
     const hasFiles = event.dataTransfer?.types.includes("Files")
     if (hasFiles) {
@@ -311,6 +313,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const handleGlobalDragLeave = (event: DragEvent) => {
+    if (dialog.active) return
+
     // relatedTarget is null when leaving the document window
     if (!event.relatedTarget) {
       setStore("dragging", false)
@@ -318,6 +322,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const handleGlobalDrop = async (event: DragEvent) => {
+    if (dialog.active) return
+
     event.preventDefault()
     setStore("dragging", false)
 


### PR DESCRIPTION
Fixes #6699 

## Changes

- Check whether or not we have an active dialog when listening for drag events in the prompt input, and return early if that's the case.

## Demo

### Before

https://github.com/user-attachments/assets/9b65f984-1078-4731-b9f2-68d0ce46d87c

### After

https://github.com/user-attachments/assets/e60586e4-ba83-4a78-bb5e-012ed5c9ffb8


