### PR TITLE
feat: add support for sql file formatting with sqlfluff

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -340,3 +340,29 @@ export const rustfmt: Info = {
     return Bun.which("rustfmt") !== null
   },
 }
+
+export const sqlfluff: Info = {
+  name: "sqlfluff",
+  command: ["sqlfluff", "format", "$FILE"],
+  extensions: [".sql"],
+  async enabled() {
+    if (!Bun.which("sqlfluff")) return false
+
+    const configs = [".sqlfluff", "pyproject.toml", "setup.cfg", "tox.ini", "pep8.ini"]
+
+    for (const config of configs) {
+      const found = await Filesystem.findUp(config, Instance.directory, Instance.worktree)
+      if (found.length > 0) {
+        const content = await Bun.file(found[0]).text()
+
+        const header = config === "pyproject.toml" ? "[tool.sqlfluff]" : "[sqlfluff]"
+
+        if (content.includes(header) && /dialect\s*=/.test(content)) {
+          return true
+        }
+      }
+    }
+
+    return false
+  },
+}

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -34,7 +34,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | nixfmt               | .nix                                                                                                     | `nixfmt` command available                                                                            |
 | shfmt                | .sh, .bash                                                                                               | `shfmt` command available                                                                             |
 | oxfmt (Experimental) | .js, .jsx, .ts, .tsx                                                                                     | `oxfmt` dependency in `package.json` and an [experimental env variable flag](/docs/cli/#experimental) |
-| sqlfluff             | .sql                                                                                                     | `sqlfluff` command available with config                                                              |
+| sqlfluff             | .sql                                                                                                     | `sqlfluff` command available and config file with dialect set                                         |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -34,6 +34,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | nixfmt               | .nix                                                                                                     | `nixfmt` command available                                                                            |
 | shfmt                | .sh, .bash                                                                                               | `shfmt` command available                                                                             |
 | oxfmt (Experimental) | .js, .jsx, .ts, .tsx                                                                                     | `oxfmt` dependency in `package.json` and an [experimental env variable flag](/docs/cli/#experimental) |
+| sqlfluff             | .sql                                                                                                     | `sqlfluff` command available with config                                                              |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 


### PR DESCRIPTION
Support for using sqlfluff to format sql files.

Checks if config file is present with dialect set, this is a requirement for "sqlfluff format" to run.