### PR TITLE
fix: disable SGR mouse tracking on exit to prevent ASCII codes

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -7,6 +7,22 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
   init: (input: { onExit?: () => Promise<void> }) => {
     const renderer = useRenderer()
     return async (reason?: any) => {
+      // Disable SGR mouse tracking to prevent ASCII codes appearing after exit
+      // These sequences disable various mouse tracking modes that opentui may have enabled
+      const disableMouseTracking = [
+        "\x1b[?1000l", // Disable basic mouse tracking
+        "\x1b[?1002l", // Disable button-event mouse tracking
+        "\x1b[?1005l", // Disable SGR mouse tracking
+        "\x1b[?1006l", // Disable SGR 1006 mode
+        "\x1b[?1015l", // Disable URXVT mouse tracking
+        "\x1b[?1003l", // Disable all motion tracking
+      ]
+
+      // Send all disable sequences to ensure mouse tracking is disabled
+      for (const seq of disableMouseTracking) {
+        process.stdout.write(seq)
+      }
+
       // Reset window title before destroying renderer
       renderer.setTerminalTitle("")
       renderer.destroy()


### PR DESCRIPTION
**Problem:** When users press CTRL+C in OpenCode TUI, the application exits without properly disabling mouse causes the terminal to continue tracking modes. This displaying SGR mouse tracking codes as ASCII strings when moving the mouse.

**Solution:** We now send mouse tracking disable escape sequences before destroying the renderer, covering all common mouse tracking protocols: basic, button events, SGR, SGR 1006, URXVT, and all motion tracking modes.