### PR TITLE
docs: enhance MCP servers documentation with a tip

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -48,6 +48,10 @@ You can also disable a server by setting `enabled` to `false`. This is useful if
 
 Add local MCP servers using `type` to `"local"` within the MCP object.
 
+:::tip
+Visit the [Config](https://opencode.ai/docs/config/) documentation to see where the `opencode.json` or `opencode.jsonc` files are/can be stored.
+:::
+
 ```jsonc title="opencode.jsonc" {15}
 {
   "$schema": "https://opencode.ai/config.json",

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -23,7 +23,7 @@ Certain MCP servers, like the GitHub MCP server, tend to add a lot of tokens and
 
 ## Enable
 
-You can define MCP servers in your OpenCode config under `mcp`. Add each MCP with a unique name. You can refer to that MCP by name when prompting the LLM.
+You can define MCP servers in your [OpenCode Config](https://opencode.ai/docs/config/) under `mcp`. Add each MCP with a unique name. You can refer to that MCP by name when prompting the LLM.
 
 ```jsonc title="opencode.jsonc" {6}
 {
@@ -47,10 +47,6 @@ You can also disable a server by setting `enabled` to `false`. This is useful if
 ## Local
 
 Add local MCP servers using `type` to `"local"` within the MCP object.
-
-:::tip
-Visit the [Config](https://opencode.ai/docs/config/) documentation to see where the `opencode.json` or `opencode.jsonc` files are/can be stored.
-:::
 
 ```jsonc title="opencode.jsonc" {15}
 {


### PR DESCRIPTION
Added a tip to the MCP servers documentation about the Config documentation to help users find their config files and/or know where to store them