### PR TITLE
Improve permission request messages; add external directory check for write tool

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -30,6 +30,7 @@ import { Todo } from "@/session/todo"
 import { z } from "zod"
 import { LoadAPIKeyError } from "ai"
 import type { OpencodeClient, SessionMessageResponse } from "@opencode-ai/sdk/v2"
+import { Permission } from "../permission"
 
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
@@ -80,7 +81,11 @@ export namespace ACP {
                     toolCall: {
                       toolCallId: permission.tool?.callID ?? permission.id,
                       status: "pending",
-                      title: permission.permission,
+                      title: Permission.formatPermissionMessage(
+                        permission.permission,
+                        permission.patterns,
+                        permission.metadata,
+                      ),
                       rawInput: permission.metadata,
                       kind: toToolKind(permission.permission),
                       locations: toLocations(permission.permission, permission.metadata),

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -11,6 +11,7 @@ import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2"
 import { Server } from "../../server/server"
 import { Provider } from "../../provider/provider"
 import { Agent } from "../../agent/agent"
+import { Permission } from "../../permission"
 
 const TOOL: Record<string, [string, string]> = {
   todowrite: ["Todo", UI.Style.TEXT_WARNING_BOLD],
@@ -206,7 +207,11 @@ export const RunCommand = cmd({
             const permission = event.properties
             if (permission.sessionID !== sessionID) continue
             const result = await select({
-              message: `Permission required: ${permission.permission} (${permission.patterns.join(", ")})`,
+              message: Permission.formatPermissionMessage(
+                permission.permission,
+                permission.patterns,
+                permission.metadata,
+              ),
               options: [
                 { value: "once", label: "Allow once" },
                 { value: "always", label: "Always allow: " + permission.always.join(", ") },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -76,10 +76,10 @@ function EditBody(props: { request: PermissionRequest }) {
   )
 }
 
-function TextBody(props: { title: string; description?: string; icon?: string }) {
+function PermissionBody(props: { icon?: string; title: string; children?: any }) {
   const { theme } = useTheme()
   return (
-    <>
+    <box flexDirection="column" gap={0}>
       <box flexDirection="row" gap={1} paddingLeft={1}>
         <Show when={props.icon}>
           <text fg={theme.textMuted} flexShrink={0}>
@@ -88,12 +88,10 @@ function TextBody(props: { title: string; description?: string; icon?: string })
         </Show>
         <text fg={theme.textMuted}>{props.title}</text>
       </box>
-      <Show when={props.description}>
-        <box paddingLeft={1}>
-          <text fg={theme.text}>{props.description}</text>
-        </box>
+      <Show when={props.children}>
+        <box paddingLeft={3}>{props.children}</box>
       </Show>
-    </>
+    </box>
   )
 }
 
@@ -126,7 +124,9 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
           body={
             <Switch>
               <Match when={props.request.always.length === 1 && props.request.always[0] === "*"}>
-                <TextBody title={"This will allow " + props.request.permission + " until OpenCode is restarted."} />
+                <PermissionBody
+                  title={"This will allow " + props.request.permission + " until OpenCode is restarted."}
+                />
               </Match>
               <Match when={true}>
                 <box paddingLeft={1} gap={1}>
@@ -159,55 +159,131 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
       </Match>
       <Match when={!store.always}>
         <Prompt
-          title="Permission required"
+          title={`Permission required (${props.request.permission})`}
           body={
             <Switch>
               <Match when={props.request.permission === "edit"}>
                 <EditBody request={props.request} />
               </Match>
               <Match when={props.request.permission === "read"}>
-                <TextBody icon="→" title={`Read ` + normalizePath(input().filePath as string)} />
+                <PermissionBody
+                  icon="→"
+                  title={
+                    `Read ` +
+                    normalizePath((props.request.metadata?.filepath as string) ?? (input().filePath as string) ?? "")
+                  }
+                />
               </Match>
               <Match when={props.request.permission === "glob"}>
-                <TextBody icon="✱" title={`Glob "` + (input().pattern ?? "") + `"`} />
+                <PermissionBody
+                  icon="✱"
+                  title={`Glob "` + (props.request.metadata?.pattern ?? input().pattern ?? "") + `"`}
+                />
               </Match>
               <Match when={props.request.permission === "grep"}>
-                <TextBody icon="✱" title={`Grep "` + (input().pattern ?? "") + `"`} />
+                <PermissionBody
+                  icon="✱"
+                  title={`Grep "` + (props.request.metadata?.pattern ?? input().pattern ?? "") + `"`}
+                />
               </Match>
               <Match when={props.request.permission === "list"}>
-                <TextBody icon="→" title={`List ` + normalizePath(input().path as string)} />
+                <PermissionBody
+                  icon="→"
+                  title={
+                    `List ` + normalizePath((props.request.metadata?.path as string) ?? (input().path as string) ?? "")
+                  }
+                />
               </Match>
               <Match when={props.request.permission === "bash"}>
-                <TextBody
-                  icon="#"
-                  title={(input().description as string) ?? ""}
-                  description={("$ " + input().command) as string}
-                />
+                <PermissionBody icon="#" title={(input().description as string) ?? "Run bash command"}>
+                  <box flexDirection="column" gap={0}>
+                    <For each={props.request.patterns as string[]}>
+                      {(pattern) => (
+                        <box flexDirection="row" gap={1}>
+                          <text fg={theme.text}>•</text>
+                          <text fg={theme.text}>{pattern}</text>
+                        </box>
+                      )}
+                    </For>
+                    <Show when={!props.request.patterns?.length && (input().command as string)}>
+                      <text fg={theme.text}>{input().command}</text>
+                    </Show>
+                  </box>
+                </PermissionBody>
               </Match>
               <Match when={props.request.permission === "task"}>
-                <TextBody
+                <PermissionBody
                   icon="#"
                   title={`${Locale.titlecase((input().subagent_type as string) ?? "Unknown")} Task`}
-                  description={"◉ " + input().description}
-                />
+                >
+                  <text fg={theme.text}>{"◉ " + ((input().description as string) ?? "")}</text>
+                </PermissionBody>
               </Match>
               <Match when={props.request.permission === "webfetch"}>
-                <TextBody icon="%" title={`WebFetch ` + (input().url ?? "")} />
+                <PermissionBody icon="%" title={`WebFetch ` + (props.request.metadata?.url ?? input().url ?? "")} />
               </Match>
               <Match when={props.request.permission === "websearch"}>
-                <TextBody icon="◈" title={`Exa Web Search "` + (input().query ?? "") + `"`} />
+                <PermissionBody
+                  icon="◈"
+                  title={`Exa Web Search "` + (props.request.metadata?.query ?? input().query ?? "") + `"`}
+                />
               </Match>
               <Match when={props.request.permission === "codesearch"}>
-                <TextBody icon="◇" title={`Exa Code Search "` + (input().query ?? "") + `"`} />
+                <PermissionBody
+                  icon="◇"
+                  title={`Exa Code Search "` + (props.request.metadata?.query ?? input().query ?? "") + `"`}
+                />
               </Match>
               <Match when={props.request.permission === "external_directory"}>
-                <TextBody icon="←" title={`Access external directory ` + normalizePath(input().path as string)} />
+                <PermissionBody icon="←" title={`Access external directory`}>
+                  <text fg={theme.text}>
+                    {normalizePath(
+                      (props.request.metadata?.filepath as string) ??
+                        (props.request.metadata?.parentDir as string) ??
+                        (input().path as string) ??
+                        "",
+                    )}
+                  </text>
+                </PermissionBody>
               </Match>
-              <Match when={props.request.permission === "doom_loop"}>
-                <TextBody icon="⟳" title="Continue after repeated failures" />
+              <Match when={props.request.permission === "patch"}>
+                <PermissionBody
+                  icon="◧"
+                  title={
+                    `Apply patch to ` +
+                    normalizePath((props.request.metadata?.filePath as string) ?? (input().patchText ? "(patch)" : ""))
+                  }
+                />
+              </Match>
+              <Match when={props.request.permission === "write"}>
+                <PermissionBody
+                  icon="✎"
+                  title={
+                    `Write to ` +
+                    normalizePath((props.request.metadata?.filepath as string) ?? (input().filePath as string) ?? "")
+                  }
+                />
+              </Match>
+              <Match when={props.request.permission === "skill"}>
+                <PermissionBody icon="◎" title={`Run skill`}>
+                  <text fg={theme.text}>
+                    {(props.request.metadata?.skill as string) ??
+                      (input().name as string) ??
+                      (input().skill as string) ??
+                      ""}
+                  </text>
+                </PermissionBody>
+              </Match>
+              <Match when={props.request.permission === "todowrite"}>
+                <PermissionBody icon="☑" title={`Update todos`}>
+                  <text fg={theme.text}>{`${props.request.metadata?.count ?? "todo"} items`}</text>
+                </PermissionBody>
+              </Match>
+              <Match when={props.request.permission === "todoread"}>
+                <PermissionBody icon="☑" title={`Read todos`} />
               </Match>
               <Match when={true}>
-                <TextBody icon="⚙" title={`Call tool ` + props.request.permission} />
+                <PermissionBody icon="⚙" title={`Call tool ` + props.request.permission} />
               </Match>
             </Switch>
           }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -38,6 +38,62 @@ export namespace Permission {
     })
   export type Info = z.infer<typeof Info>
 
+  export function formatPermissionMessage(
+    type: string,
+    patterns: string | string[] | undefined,
+    metadata: Record<string, unknown>,
+    fallback: string = "",
+  ): string {
+    switch (type) {
+      case "bash":
+        if (patterns) {
+          const pats = Array.isArray(patterns) ? patterns : [patterns]
+          return `Permission required to run bash command matching pattern(s):\n${pats.map((p) => `  ${p}`).join("\n")}`
+        }
+        return `Permission required to run bash command${fallback ? `: ${fallback}` : ""}`
+      case "read":
+        return `Permission required to read file: ${metadata.filepath || fallback}`
+      case "write":
+        return `Permission required to write to: ${metadata.filePath || fallback}`
+      case "edit":
+        return `Permission required to edit: ${metadata.filePath || fallback}`
+      case "patch":
+        return `Permission required to apply patch: ${metadata.filePath || fallback}`
+      case "external_directory":
+        let msg = `Permission required to access paths outside working directory`
+        if (metadata.filepath) {
+          msg += `:\n  ${metadata.filepath}`
+        } else if (metadata.parentDir) {
+          msg += `:\n  ${metadata.parentDir}`
+        }
+        return msg
+      case "webfetch":
+        return `Permission required to fetch URL: ${metadata.url || fallback}`
+      case "websearch":
+        return `Permission required to search web for: ${metadata.query || fallback}`
+      case "grep":
+        return `Permission required to search in files: ${metadata.path || fallback}${
+          metadata.pattern ? `\nSearch pattern: ${metadata.pattern}` : ""
+        }`
+      case "glob":
+        return `Permission required to list files matching: ${metadata.path || fallback}${
+          metadata.pattern ? `\nPattern: ${metadata.pattern}` : ""
+        }`
+      case "list":
+        return `Permission required to list directory: ${metadata.path || fallback}`
+      case "codesearch":
+        return `Permission required for code search: ${metadata.query || fallback}${
+          metadata.path ? `\nIn directory: ${metadata.path}` : ""
+        }`
+      case "doom_loop":
+        return fallback || "Continue after repeated failures"
+      case "skill":
+        return `Permission required to run skill: ${metadata.skill || fallback}`
+      default:
+        return fallback || `Permission required: ${type}`
+    }
+  }
+
   export const Event = {
     Updated: BusEvent.define("permission.updated", Info),
     Replied: BusEvent.define(

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -120,28 +120,33 @@ export namespace PermissionNext {
     async (input) => {
       const s = await state()
       const { ruleset, ...request } = input
+      const askPatterns: string[] = []
       for (const pattern of request.patterns ?? []) {
         const rule = evaluate(request.permission, pattern, ruleset, s.approved)
         log.info("evaluated", { permission: request.permission, pattern, action: rule })
         if (rule.action === "deny")
           throw new AutoRejectedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
         if (rule.action === "ask") {
-          const id = input.id ?? Identifier.ascending("permission")
-          return new Promise<void>((resolve, reject) => {
-            const info: Request = {
-              id,
-              ...request,
-            }
-            s.pending[id] = {
-              info,
-              resolve,
-              reject,
-            }
-            Bus.publish(Event.Asked, info)
-          })
+          askPatterns.push(pattern)
         }
-        if (rule.action === "allow") continue
+        // if allow, continue
       }
+      // If no patterns need approval, return
+      if (askPatterns.length === 0) return
+      const id = input.id ?? Identifier.ascending("permission")
+      return new Promise<void>((resolve, reject) => {
+        const info: Request = {
+          id,
+          ...request,
+          patterns: askPatterns,
+        }
+        s.pending[id] = {
+          info,
+          resolve,
+          reject,
+        }
+        Bus.publish(Event.Asked, info)
+      })
     },
   )
 

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -134,11 +134,15 @@ export const BashTool = Tool.define("bash", async () => {
       }
 
       if (directories.size > 0) {
+        const dirs = Array.from(directories)
         await ctx.ask({
           permission: "external_directory",
-          patterns: Array.from(directories),
-          always: Array.from(directories).map((x) => path.dirname(x) + "*"),
-          metadata: {},
+          patterns: dirs,
+          always: dirs.map((x) => path.dirname(x) + "*"),
+          metadata: {
+            filepath: dirs.length === 1 ? dirs[0] : undefined,
+            parentDir: dirs.length === 1 ? dirs[0] : undefined,
+          },
         })
       }
 
@@ -147,7 +151,9 @@ export const BashTool = Tool.define("bash", async () => {
           permission: "bash",
           patterns: Array.from(patterns),
           always: Array.from(always),
-          metadata: {},
+          metadata: {
+            command: params.command,
+          },
         })
       }
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -44,7 +44,9 @@ export const ReadTool = Tool.define("read", {
       permission: "read",
       patterns: [filepath],
       always: ["*"],
-      metadata: {},
+      metadata: {
+        filepath,
+      },
     })
 
     const block = iife(() => {

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -55,7 +55,9 @@ export const SkillTool = Tool.define("skill", async () => {
         permission: "skill",
         patterns: [params.name],
         always: [params.name],
-        metadata: {},
+        metadata: {
+          skill: params.name,
+        },
       })
       // Load and parse skill content
       const parsed = await ConfigMarkdown.parse(skill.location)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -22,12 +22,18 @@ export const WriteTool = Tool.define("write", {
   }),
   async execute(params, ctx) {
     const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
-    /* TODO
     if (!Filesystem.contains(Instance.directory, filepath)) {
       const parentDir = path.dirname(filepath)
-      ...
+      await ctx.ask({
+        permission: "external_directory",
+        patterns: [parentDir],
+        always: [parentDir + "/*"],
+        metadata: {
+          filepath,
+          parentDir,
+        },
+      })
     }
-    */
 
     const file = Bun.file(filepath)
     const exists = await file.exists()


### PR DESCRIPTION
## Summary

This PR improves permission request messages in opencode to provide users with
clear, actionable information about what they're approving. It also fixes a
security gap where write operations to external directories were not being
checked for permission.

---

## Commit 1: `5b988f9a` - feat: improve permission request messages with context-aware formatting

### Problem

Permission prompts would show full bash commands; however users couldn't see
which specific commands or files were being requested permission.  This made it
a lot harder to understand and manage the impact of configured or per-session
allow lists.

### Solution

- Introduce centralized `Permission.formatMessage()` function that generates
  context-aware messages based on permission type and metadata.
- Change `<TextBody>` to `<PermissionBody>` and include more comprehensive
  details in each prompt.

### Changes by File

| File                                                              | Change                                                                     |
| ----------------------------------------------------------------- | -------------------------------------------------------------------------- |
| `packages/opencode/src/permission/index.ts`                       | Added centralized `formatMessage()` function with type-specific formatting |
| `packages/opencode/src/cli/cmd/run.ts`                            | Use formatted messages in CLI permission prompts                           |
| `packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx` | Updated TUI permission display with `PermissionBody` component             |
| `packages/opencode/src/acp/agent.ts`                              | Use formatted messages for Zed extension                                   |
| `packages/opencode/src/tool/bash.ts`                              | Add patterns to metadata for bash commands                                 |
| `packages/opencode/src/tool/read.ts`                              | Add filepath to metadata for read operations                               |
| `packages/opencode/src/tool/skill.ts`                             | Add skill name to metadata                                                 |

### Message Example

**Before:**

```
$ git log --oneline | grep bug | head -n 20
```

**After:**

(assuming `grep` is already allowed)

```
• git log --oneline
• head -n 20
```

---

## Commit 2: `eeee56a` - feat(write): add external directory permission check

### Problem

The `write` tool had a TODO comment for checking external directory permissions
but the implementation was incomplete. Write operations to paths outside the
working directory would proceed without requesting user permission.

This is a security concern since writes outside the project directory could be
sensitive.

### Solution

Implemented the external directory permission check using `ctx.ask()` with the
`external_directory` permission type, following the same pattern used in read
and bash tools.

### Changes

| File                                  | Change                                                                               |
| ------------------------------------- | ------------------------------------------------------------------------------------ |
| `packages/opencode/src/tool/write.ts` | Added external directory permission check with parent directory pattern and metadata |

---

## Testing

- Write to external file in /tmp prompts for permission
- Read from external file prompts for permission
- Bash commands show matched patterns with bullet points
- All permission messages display relevant file paths and metadata
