### PR TITLE
fix(kotlin-ls): improve root detection for Gradle multi-project builds

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1212,7 +1212,15 @@ export namespace LSPServer {
   export const KotlinLS: Info = {
     id: "kotlin-ls",
     extensions: [".kt", ".kts"],
-    root: NearestRoot(["build.gradle", "build.gradle.kts", "settings.gradle.kts", "pom.xml"]),
+    root: (start) =>
+      // 1) Nearest Gradle root (multi-project or included build)
+      NearestRoot(["settings.gradle.kts", "settings.gradle"])(start) ??
+      // 2) Gradle wrapper (strong root signal)
+      NearestRoot(["gradlew", "gradlew.bat"])(start) ??
+      // 3) Single-project or module-level build
+      NearestRoot(["build.gradle.kts", "build.gradle"])(start) ??
+      // 4) Maven fallback
+      NearestRoot(["pom.xml"])(start),
     async spawn(root) {
       const distPath = path.join(Global.Path.bin, "kotlin-ls")
       const launcherScript =

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1212,15 +1212,19 @@ export namespace LSPServer {
   export const KotlinLS: Info = {
     id: "kotlin-ls",
     extensions: [".kt", ".kts"],
-    root: (start) =>
-      // 1) Nearest Gradle root (multi-project or included build)
-      NearestRoot(["settings.gradle.kts", "settings.gradle"])(start) ??
-      // 2) Gradle wrapper (strong root signal)
-      NearestRoot(["gradlew", "gradlew.bat"])(start) ??
-      // 3) Single-project or module-level build
-      NearestRoot(["build.gradle.kts", "build.gradle"])(start) ??
-      // 4) Maven fallback
-      NearestRoot(["pom.xml"])(start),
+    root: async (file) => {
+          // 1) Nearest Gradle root (multi-project or included build)
+          const settingsRoot = await NearestRoot(["settings.gradle.kts", "settings.gradle"])(file)
+          if (settingsRoot) return settingsRoot
+          // 2) Gradle wrapper (strong root signal)
+          const wrapperRoot = await NearestRoot(["gradlew", "gradlew.bat"])(file)
+          if (wrapperRoot) return wrapperRoot
+          // 3) Single-project or module-level build
+          const buildRoot = await NearestRoot(["build.gradle.kts", "build.gradle"])(file)
+          if (buildRoot) return buildRoot
+          // 4) Maven fallback
+          return NearestRoot(["pom.xml"])(file)
+    },
     async spawn(root) {
       const distPath = path.join(Global.Path.bin, "kotlin-ls")
       const launcherScript =


### PR DESCRIPTION
Ensure the Kotlin language server is started at the correct Gradle root for multi-project and composite builds.

The root resolution now prioritizes settings.gradle(.kts), followed by the Gradle wrapper, before falling back to module-level build files or Maven projects. This prevents submodules from being incorrectly detected as the workspace root.

Follow up for #6601 