### PR TITLE
feat(server): add session parameter to /event endpoint

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2749,6 +2749,11 @@ export namespace Server {
               if (sessionFilter) {
                 const eventSessionID =
                   event.properties?.sessionID || event.properties?.info?.sessionID || event.properties?.part?.sessionID
+                // Only allow server.* events (connected, heartbeat, etc.) to pass through without sessionID
+                // All other events without sessionID are filtered out to prevent cross-session leakage
+                if (!eventSessionID && !event.type.startsWith("server.")) {
+                  return
+                }
                 if (eventSessionID && eventSessionID !== sessionFilter) {
                   return
                 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2714,7 +2714,8 @@ export namespace Server {
         "/event",
         describeRoute({
           summary: "Subscribe to events",
-          description: "Get events",
+          description:
+            "Subscribe to server-sent events. Optionally filter events by session ID to only receive events for a specific session.",
           operationId: "event.subscribe",
           responses: {
             200: {
@@ -2727,8 +2728,15 @@ export namespace Server {
             },
           },
         }),
+        validator(
+          "query",
+          z.object({
+            session: z.string().optional().meta({ description: "Filter events by session ID" }),
+          }),
+        ),
         async (c) => {
-          log.info("event connected")
+          const sessionFilter = c.req.valid("query").session
+          log.info("event connected", { session: sessionFilter })
           return streamSSE(c, async (stream) => {
             stream.writeSSE({
               data: JSON.stringify({
@@ -2737,6 +2745,14 @@ export namespace Server {
               }),
             })
             const unsub = Bus.subscribeAll(async (event) => {
+              // Filter by session if specified
+              if (sessionFilter) {
+                const eventSessionID =
+                  event.properties?.sessionID || event.properties?.info?.sessionID || event.properties?.part?.sessionID
+                if (eventSessionID && eventSessionID !== sessionFilter) {
+                  return
+                }
+              }
               await stream.writeSSE({
                 data: JSON.stringify(event),
               })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2810,15 +2810,26 @@ export class Event extends HeyApiClient {
   /**
    * Subscribe to events
    *
-   * Get events
+   * Subscribe to server-sent events. Optionally filter events by session ID to only receive events for a specific session.
    */
   public subscribe<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
+      session?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
-    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "session" },
+          ],
+        },
+      ],
+    )
     return (options?.client ?? this.client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
       url: "/event",
       ...options,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4513,6 +4513,10 @@ export type EventSubscribeData = {
   path?: never
   query?: {
     directory?: string
+    /**
+     * Filter events by session ID
+     */
+    session?: string
   }
   url: "/event"
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -5285,10 +5285,18 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "session",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter events by session ID"
           }
         ],
         "summary": "Subscribe to events",
-        "description": "Get events",
+        "description": "Subscribe to server-sent events. Optionally filter events by session ID to only receive events for a specific session.",
         "responses": {
           "200": {
             "description": "Event stream",


### PR DESCRIPTION
## Summary

- Add optional `session` query parameter to the `/event` SSE endpoint
- Implement server-side filtering to only send events for the specified session
- Update OpenAPI spec and regenerate SDK (v2)

## Details

The `/event` endpoint now accepts an optional `session` query parameter. When provided, only events related to that session are streamed to the client.

### Filtering Logic

When `session` parameter is specified:

| Event Type | Has sessionID? | Behavior |
|------------|----------------|----------|
| `session.*`, `message.*`, etc. | ✅ matching | ✅ Pass through |
| `session.*`, `message.*`, etc. | ✅ non-matching | ❌ Filtered out |
| `server.connected`, `server.heartbeat` | ❌ | ✅ Pass through (connection-level) |
| `ide.*`, `file.*`, `lsp.*`, `mcp.*`, etc. | ❌ | ❌ Filtered out |

This prevents cross-session event leakage. Events without sessionID (except `server.*`) are filtered out to maintain strict session isolation.

### Backward Compatibility

This change is fully backward compatible:
- **Without `session` parameter**: Behavior is unchanged - all events are streamed
- **With `session` parameter**: Only session-specific events + server.* events are streamed

### SDK Support

- ✅ `@opencode-ai/sdk/v2` - Fully supported
- ⚠️ `@opencode-ai/sdk` (v1) - Types not yet updated, will follow up separately

Fixes #6686

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.