### PR TITLE
fix: use session list filter result instead of discarding it

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -702,11 +702,10 @@ export namespace Server {
           },
         }),
         async (c) => {
-          const sessions = await Array.fromAsync(Session.list())
-          pipe(
+          const sessions = pipe(
             await Array.fromAsync(Session.list()),
             filter((s) => !s.time.archived),
-            sortBy((s) => s.time.updated),
+            sortBy((s) => -s.time.updated),
           )
           return c.json(sessions)
         },


### PR DESCRIPTION
## Summary
- The `pipe()` result filtering archived sessions and sorting by update time was computed but never assigned or returned
- The original unfiltered `sessions` array was returned instead, causing duplicate/archived sessions to appear

## Changes
- Assign the `pipe()` result to `sessions` variable
- Return the filtered and sorted result

## Testing
- Session list should now only show non-archived sessions
- Sessions should be sorted by most recently updated first