### PR TITLE
fix(tui): subscribe to global events for bidirectional Web sync

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -1,4 +1,4 @@
-import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2"
+import { createOpencodeClient, type Event, type GlobalEvent } from "@opencode-ai/sdk/v2"
 import { createSimpleContext } from "./helper"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { batch, onCleanup, onMount } from "solid-js"
@@ -20,12 +20,9 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     onMount(async () => {
       while (true) {
         if (abort.signal.aborted) break
-        const events = await sdk.event.subscribe(
-          {},
-          {
-            signal: abort.signal,
-          },
-        )
+        const events = await sdk.global.event({
+          signal: abort.signal,
+        })
         let queue: Event[] = []
         let timer: Timer | undefined
         let last = 0
@@ -45,7 +42,11 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         }
 
         for await (const event of events.stream) {
-          queue.push(event)
+          const globalEvent = event as GlobalEvent
+          const payload = globalEvent.payload as Event
+          if (payload) {
+            queue.push(payload)
+          }
           const elapsed = Date.now() - last
 
           if (timer) continue


### PR DESCRIPTION
## Use Case

Many users primarily work with TUI at their desk, but occasionally need to continue working from a mobile device or browser when away from the computer.

**Current behavior**: When you send messages from Web UI while away, returning to TUI shows no updates - you need to restart TUI to see the messages sent from Web.

**Expected behavior**: TUI should receive and display messages sent from Web UI in real-time, allowing seamless transition between TUI and Web workflows.

This is a practical scenario:
1. Work on TUI at desk
2. Step away, continue conversation via Web UI on phone/tablet
3. Return to desk, TUI immediately shows all messages from Web session
4. Continue working on TUI without missing any context

## Problem

- TUI → Web: ✅ syncs in real-time
- Web → TUI: ❌ requires TUI restart to see messages

## Root Cause

TUI subscribes to `/event` endpoint (instance-level Bus), while Web UI publishes events to GlobalBus via `/global/event`.

## Solution

Change TUI to subscribe to `/global/event` endpoint instead of `/event`.

## Trade-off

TUI will receive events from all directories (if server manages multiple projects). However:
1. TUI only renders matching sessionID - no incorrect data displayed
2. Single-project usage (most common) has no impact
3. Directory filtering can be added client-side if needed

## Changes

Minimal change - only 1 file, ~10 lines:

- `packages/opencode/src/cli/cmd/tui/context/sdk.tsx`
  - Import `GlobalEvent` type
  - Change `sdk.event.subscribe()` to `sdk.global.event()`
  - Extract payload from `GlobalEvent.payload`

## Testing

Verified bidirectional sync works:
1. Start TUI with `opencode`
2. Open Web UI at `http://localhost:<port>`
3. Send message from Web UI → TUI shows it ✅
4. Send message from TUI → Web UI shows it ✅