### PR TITLE
fix: handle redirected_statement treesitter node in bash permissions

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -91,6 +91,10 @@ export const BashTool = Tool.define("bash", async () => {
 
       for (const node of tree.rootNode.descendantsOfType("command")) {
         if (!node) continue
+
+        // Get full command text including redirects if present
+        let commandText = node.parent?.type === "redirected_statement" ? node.parent.text : node.text
+
         const command = []
         for (let i = 0; i < node.childCount; i++) {
           const child = node.child(i)
@@ -131,8 +135,8 @@ export const BashTool = Tool.define("bash", async () => {
 
         // cd covered by above check
         if (command.length && command[0] !== "cd") {
-          patterns.add(command.join(" "))
-          always.add(BashArity.prefix(command).join(" ") + "*")
+          patterns.add(commandText)
+          always.add(BashArity.prefix(command).join(" ") + " *")
         }
       }
 


### PR DESCRIPTION
Fixes #5330 

This patch fixes two issues in bash tool permission handling:

**1. bash redirect statements are not handled (treesitter-bash usage)**

Any commands parsed don't have redirects included (e.g. `ls foo > bar` results in `ls foo`) which prevents permission rules to match properly (e.g. `"ls *>*": "deny"` does not apply).

Cause: Redirect statements are parents of commands, thus not recognized in the loop over `descendantsOfType("command")`
```bash
$ echo "ls hello > /dev/null" | tree-sitter parse

(program [0, 0] - [1, 0]
  (redirected_statement [0, 0] - [0, 20]
    body: (command [0, 0] - [0, 8]
      name: (command_name [0, 0] - [0, 2]
        (word [0, 0] - [0, 2]))
      argument: (word [0, 3] - [0, 8]))
    redirect: (file_redirect [0, 9] - [0, 20]
      destination: (word [0, 11] - [0, 20]))))
```

Solution: use `node.parent.text` for the pattern matching, which includes the full command

----

**2. bash always pattern lacks a space after the command**

Approving `ls` adds `ls*` as an always pattern, which allows also other commands (e.g. `lsof`) which is not intended.

Solution: add a space so `ls*` becomes `ls *` in the pattern