### PR TITLE
fix(file): resolve 1ms timestamp race in sequential file edits (#8624)

### DIFF
--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -3,6 +3,11 @@ import { Log } from "../util/log"
 
 export namespace FileTime {
   const log = Log.create({ service: "file.time" })
+
+  // Tolerance in milliseconds to account for filesystem timestamp granularity
+  // and async metadata updates (especially on Windows NTFS, WSL2 9p)
+  const TOLERANCE_MS = 10
+
   // Per-session read times plus per-file write locks.
   // All tools that overwrite existing files should run their
   // assert/read/write/update sequence inside withLock(filepath, ...)
@@ -20,11 +25,18 @@ export namespace FileTime {
     }
   })
 
-  export function read(sessionID: string, file: string) {
+  /**
+   * Record when a file was last read or written.
+   * @param sessionID - The session ID
+   * @param file - The file path
+   * @param mtime - Optional: Use the file's actual mtime instead of current time.
+   *                This should be passed after writes to avoid race conditions.
+   */
+  export function read(sessionID: string, file: string, mtime?: Date) {
     log.info("read", { sessionID, file })
     const { read } = state()
     read[sessionID] = read[sessionID] || {}
-    read[sessionID][file] = new Date()
+    read[sessionID][file] = mtime ?? new Date()
   }
 
   export function get(sessionID: string, file: string) {
@@ -51,11 +63,20 @@ export namespace FileTime {
     }
   }
 
+  /**
+   * Assert that a file has not been modified since it was last read.
+   * Includes a small tolerance to handle filesystem timestamp granularity.
+   */
   export async function assert(sessionID: string, filepath: string) {
     const time = get(sessionID, filepath)
     if (!time) throw new Error(`You must read the file ${filepath} before overwriting it. Use the Read tool first`)
     const stats = await Bun.file(filepath).stat()
-    if (stats.mtime.getTime() > time.getTime()) {
+    // Add tolerance to handle filesystem timestamp race conditions
+    // The mtime can be slightly ahead of our recorded time due to:
+    // - Filesystem timestamp granularity (varies by FS)
+    // - Async metadata updates (Windows NTFS, WSL2 9p)
+    // - System clock variations
+    if (stats.mtime.getTime() > time.getTime() + TOLERANCE_MS) {
       throw new Error(
         `File ${filepath} has been modified since it was last read.\nLast modification: ${stats.mtime.toISOString()}\nLast read: ${time.toISOString()}\n\nPlease read the file again before modifying it.`,
       )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1115,7 +1115,8 @@ export namespace SessionPrompt {
               }
 
               const file = Bun.file(filepath)
-              FileTime.read(input.sessionID, filepath)
+              const stats = await Bun.file(filepath).stat()
+              FileTime.read(input.sessionID, filepath, stats.mtime)
               return [
                 {
                   id: Identifier.ascending("part"),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -63,7 +63,8 @@ export const EditTool = Tool.define("edit", {
         await Bus.publish(File.Event.Edited, {
           file: filePath,
         })
-        FileTime.read(ctx.sessionID, filePath)
+        const statsAfterWrite = await Bun.file(filePath).stat()
+        FileTime.read(ctx.sessionID, filePath, statsAfterWrite.mtime)
         return
       }
 

--- a/packages/opencode/src/tool/patch.ts
+++ b/packages/opencode/src/tool/patch.ts
@@ -174,10 +174,11 @@ export const PatchTool = Tool.define("patch", {
           break
       }
 
-      // Update file time tracking
-      FileTime.read(ctx.sessionID, change.filePath)
-      if (change.movePath) {
-        FileTime.read(ctx.sessionID, change.movePath)
+      // Update file time tracking with actual mtime
+      if (change.type !== "delete") {
+        const targetPath = change.movePath || change.filePath
+        const statsAfterPatch = await Bun.file(targetPath).stat()
+        FileTime.read(ctx.sessionID, targetPath, statsAfterPatch.mtime)
       }
     }
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -129,7 +129,8 @@ export const ReadTool = Tool.define("read", {
 
     // just warms the lsp client
     LSP.touchFile(filepath, false)
-    FileTime.read(ctx.sessionID, filepath)
+    const stats = await file.stat()
+    FileTime.read(ctx.sessionID, filepath, stats.mtime)
 
     return {
       title,

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -45,7 +45,8 @@ export const WriteTool = Tool.define("write", {
     await Bus.publish(File.Event.Edited, {
       file: filepath,
     })
-    FileTime.read(ctx.sessionID, filepath)
+    const statsAfterWrite = await Bun.file(filepath).stat()
+    FileTime.read(ctx.sessionID, filepath, statsAfterWrite.mtime)
 
     let output = "Wrote file successfully."
     await LSP.touchFile(filepath, true)


### PR DESCRIPTION
Issue #8624 

Issue Fixed in this PR:

Sequential file edits fail with "File modified since it was last read" showing 1-10ms timestamp differences, even with no external modifications.

Root cause: `FileTime.read()` stores `new Date()` instead of the file's actual mtime. After writes, filesystem mtime updates can lag slightly (especially Windows NTFS, and WSL2), causing false positives in `assert()`.

Fix:
- `FileTime.read()` now accepts optional `mtime` parameter
- All write operations pass actual file mtime after writes
- Added 10ms tolerance in `assert()` for edge cases

