### PR TITLE
fix(tui): make mcp status icon muted when no mcp servers are enabled

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -120,7 +120,7 @@ export function Home() {
                   <span style={{ fg: theme.error }}>⊙ </span>
                 </Match>
                 <Match when={true}>
-                  <span style={{ fg: theme.success }}>⊙ </span>
+                  <span style={{ fg: connectedMcpCount() > 0 ? theme.success : theme.textMuted }}>⊙ </span>
                 </Match>
               </Switch>
               {connectedMcpCount()} MCP


### PR DESCRIPTION
Changes the MCP statusline for 0 active MCP servers from this 
<img width="135" height="32" alt="image" src="https://github.com/user-attachments/assets/b138ec8a-72d2-4b10-b75f-1a61f8da9488" />
to this
<img width="132" height="40" alt="image" src="https://github.com/user-attachments/assets/d4851555-b841-4aa0-b144-7460f730e861" />
