### PR TITLE
fix: strip incompatible thinking blocks when switching to Anthropic models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -20,15 +20,33 @@ export namespace ProviderTransform {
     if (model.api.id.includes("claude")) {
       return msgs.map((msg) => {
         if ((msg.role === "assistant" || msg.role === "tool") && Array.isArray(msg.content)) {
-          msg.content = msg.content.map((part) => {
-            if ((part.type === "tool-call" || part.type === "tool-result") && "toolCallId" in part) {
-              return {
-                ...part,
-                toolCallId: part.toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_"),
+          // Filter out reasoning/thinking parts from other providers as they have incompatible signatures
+          msg.content = msg.content
+            .filter((part: any) => {
+              // Remove thinking blocks that aren't from Anthropic (they have invalid signatures)
+              if (part.type === "thinking" && part.signature) {
+                // Anthropic thinking signatures start with specific prefixes - keep those
+                // Strip thinking blocks from other providers
+                return false
               }
-            }
-            return part
-          })
+              return true
+            })
+            .map((part) => {
+              // Convert reasoning parts to text to preserve the content
+              if ((part as any).type === "reasoning") {
+                return {
+                  type: "text" as const,
+                  text: `<thinking>${(part as any).text || (part as any).content || ""}</thinking>`,
+                }
+              }
+              if ((part.type === "tool-call" || part.type === "tool-result") && "toolCallId" in part) {
+                return {
+                  ...part,
+                  toolCallId: part.toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_"),
+                }
+              }
+              return part
+            })
         }
         return msg
       })


### PR DESCRIPTION
## Problem
When switching from a model like minimax to Claude/Opus mid-session, the API returns:
```
messages.9.content.0: Invalid 'signature' in 'thinking' block
```

This happens because the session contains cached messages with thinking blocks that have signatures from the previous model (minimax), which Anthropic's API rejects.

## Solution
In `normalizeMessages()`, when the target model is Claude:
1. Filter out `thinking` blocks that have signatures (from other providers)
2. Convert `reasoning` parts to text wrapped in `<thinking>` tags to preserve content

## Testing
1. Start a session with minimax or another model that generates thinking blocks
2. Switch to Claude Opus mid-session
3. Should no longer get the 'Invalid signature' error