### PR TITLE
Make General SubAgent not hidden

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -88,7 +88,6 @@ export namespace Agent {
         options: {},
         mode: "subagent",
         native: true,
-        hidden: true,
       },
       explore: {
         name: "explore",

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -82,7 +82,7 @@ test("general agent denies todo tools", async () => {
       const general = await Agent.get("general")
       expect(general).toBeDefined()
       expect(general?.mode).toBe("subagent")
-      expect(general?.hidden).toBe(true)
+      expect(general?.hidden).toBeUndefined()
       expect(evalPerm(general, "todoread")).toBe("deny")
       expect(evalPerm(general, "todowrite")).toBe("deny")
     },


### PR DESCRIPTION
I find general agent very useful and i use it a lot of time to trigger parallel tasks, with prompts like: `do each task in a separate @general` when working on big projects, even it's hidden it works.

But i think maybe exposing and maybe adding better docs might help people leverage more on it?

TBH i don't see any reason to general be hidden.

Another argument is that @general is mentioned in the docs: https://opencode.ai/docs/agents/#usage

<img width="1181" height="623" alt="image" src="https://github.com/user-attachments/assets/bca16816-9b6e-4050-b25b-699fef9fd18e" />
