### PR TITLE
Desktop: Edit Project Fix

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -90,7 +90,11 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     }
 
     function enrich(project: { worktree: string; expanded: boolean }) {
-      const metadata = globalSync.data.project.find((x) => x.worktree === project.worktree)
+      const [childStore] = globalSync.child(project.worktree)
+      const projectID = childStore.project
+      const metadata = projectID
+        ? globalSync.data.project.find((x) => x.id === projectID)
+        : globalSync.data.project.find((x) => x.worktree === project.worktree)
       return [
         {
           ...project,


### PR DESCRIPTION
Root Cause: The enrich function in packages/app/src/context/layout.tsx was matching projects by comparing worktree paths. When a user picks a directory (e.g., /Users/user/project/src), but the server resolves the git root to a different path (e.g., /Users/user/project), the paths don't match. Without a match, the project's id wasn't populated, and the handleSubmit function returned early when !props.project.id.

Fix: Modified the enrich function to first look up the child store for the directory (which contains the server-resolved project ID from project.current()), and use that ID to find the project metadata. Only falls back to worktree matching if the ID isn't available yet.