### PR TITLE
fix: make message nav tooltip scrollable for long session lists

### DIFF
--- a/packages/ui/src/components/message-nav.css
+++ b/packages/ui/src/components/message-nav.css
@@ -102,6 +102,8 @@
   align-items: center;
   border-radius: var(--radius-md);
   background: var(--surface-raised-stronger-non-alpha);
+  max-height: min(400px, 60vh);
+  overflow-y: auto;
 
   /* border/shadow-xs/base */
   box-shadow:


### PR DESCRIPTION
## Summary

- Add `max-height` and `overflow-y: auto` to the message nav tooltip content
- Allows scrolling within the tooltip when there are many messages in a session

## Problem

On smaller screens (below 88rem/1408px), the message navigation rail shows in compact mode with tick marks. Hovering reveals a tooltip with the full message list. When there are many messages, the tooltip content overflows but cannot be scrolled, making it impossible to see/select later messages.

## Solution

Added to `[data-slot="message-nav-tooltip-content"]`:
```css
max-height: min(400px, 60vh);
overflow-y: auto;
```

This limits the tooltip height to 400px or 60% of viewport height (whichever is smaller) and enables vertical scrolling.