### PR TITLE
feat: Add 'extra_body' parameter support for provider and model options

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -464,6 +464,13 @@ export namespace ProviderTransform {
         result["reasoningSummary"] = "auto"
       }
     }
+
+    const extraBody = { ...providerOptions?.extraBody, ...model.options?.extraBody }
+    if (Object.keys(extraBody).length > 0) {
+      // Merge in extra body options
+      Object.assign(result, extraBody)
+    }
+
     return result
   }
 

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1457,6 +1457,9 @@ Here's an example setting the `apiKey`, `headers`, and model `limit` options.
         "apiKey": "{env:ANTHROPIC_API_KEY}",
         "headers": {
           "Authorization": "Bearer custom-token"
+        },
+        "extraBody": {
+          "provider-scoped-extra-body-param-key": "value"
         }
       },
       "models": {
@@ -1465,6 +1468,11 @@ Here's an example setting the `apiKey`, `headers`, and model `limit` options.
           "limit": {
             "context": 200000,
             "output": 65536
+          },
+          "options": {
+            "extraBody": {
+              "enable_thinking": true
+            }
           }
         }
       }
@@ -1479,6 +1487,7 @@ Configuration details:
 - **headers**: Custom headers sent with each request.
 - **limit.context**: Maximum input tokens the model accepts.
 - **limit.output**: Maximum tokens the model can generate.
+- **options.extraBody**: Extra body params which will be sent to the provider.
 
 The `limit` fields allow OpenCode to understand how much context you have left. Standard providers pull these from models.dev automatically.
 


### PR DESCRIPTION
In the OpenAI Python SDK, the `Completions.create` method includes an `extra_body` parameter that lets users add custom JSON properties to the request payload. This feature is particularly useful in various scenarios—such as enabling capabilities like thinking [1][2], search, topP, temperature, and more, across different LLM providers.

Here[3] is the implementation in the Python SDK for reference.


[1] https://bailian.console.alibabacloud.com/?tab=api#/api/?type=model&url=2712576
[2] https://docs.z.ai/api-reference/llm/chat-completion
[3] https://github.com/openai/openai-python/blob/af8f606b3eef1af99f98929847f1b5baf19171ae/src/openai/resources/chat/completions.py#L76