### PR TITLE
Better Permission Always for specific patterns

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -60,7 +60,7 @@ export namespace PermissionNext {
       permission: z.string(),
       patterns: z.string().array(),
       metadata: z.record(z.string(), z.any()),
-      always: z.string().array(),
+      always: z.string().array().optional(),
       tool: z
         .object({
           messageID: z.string(),
@@ -131,6 +131,7 @@ export namespace PermissionNext {
             const info: Request = {
               id,
               ...request,
+              always: request.always ?? [rule.pattern],
             }
             s.pending[id] = {
               info,
@@ -183,7 +184,7 @@ export namespace PermissionNext {
         return
       }
       if (input.reply === "always") {
-        for (const pattern of existing.info.always) {
+        for (const pattern of existing.info.always!) {
           s.approved.push({
             permission: existing.info.permission,
             pattern,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -739,7 +739,6 @@ export namespace SessionPrompt {
           permission: key,
           metadata: {},
           patterns: ["*"],
-          always: ["*"],
         })
 
         const result = await execute(args, opts)

--- a/packages/opencode/src/tool/codesearch.ts
+++ b/packages/opencode/src/tool/codesearch.ts
@@ -53,7 +53,6 @@ export const CodeSearchTool = Tool.define("codesearch", {
     await ctx.ask({
       permission: "codesearch",
       patterns: [params.query],
-      always: ["*"],
       metadata: {
         query: params.query,
         tokensNum: params.tokensNum,

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -63,7 +63,6 @@ export const EditTool = Tool.define("edit", {
         await ctx.ask({
           permission: "edit",
           patterns: [path.relative(Instance.worktree, filePath)],
-          always: ["*"],
           metadata: {
             filepath: filePath,
             diff,
@@ -91,7 +90,6 @@ export const EditTool = Tool.define("edit", {
       await ctx.ask({
         permission: "edit",
         patterns: [path.relative(Instance.worktree, filePath)],
-        always: ["*"],
         metadata: {
           filepath: filePath,
           diff,

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -20,7 +20,6 @@ export const GlobTool = Tool.define("glob", {
     await ctx.ask({
       permission: "glob",
       patterns: [params.pattern],
-      always: ["*"],
       metadata: {
         pattern: params.pattern,
         path: params.path,

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -22,7 +22,6 @@ export const GrepTool = Tool.define("grep", {
     await ctx.ask({
       permission: "grep",
       patterns: [params.pattern],
-      always: ["*"],
       metadata: {
         pattern: params.pattern,
         path: params.path,

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -46,7 +46,6 @@ export const ListTool = Tool.define("list", {
     await ctx.ask({
       permission: "list",
       patterns: [searchPath],
-      always: ["*"],
       metadata: {
         path: searchPath,
       },

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -30,7 +30,6 @@ export const LspTool = Tool.define("lsp", {
     await ctx.ask({
       permission: "lsp",
       patterns: ["*"],
-      always: ["*"],
       metadata: {},
     })
 

--- a/packages/opencode/src/tool/patch.ts
+++ b/packages/opencode/src/tool/patch.ts
@@ -136,7 +136,6 @@ export const PatchTool = Tool.define("patch", {
     await ctx.ask({
       permission: "edit",
       patterns: fileChanges.map((c) => path.relative(Instance.worktree, c.filePath)),
-      always: ["*"],
       metadata: {
         diff: totalDiff,
       },

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -43,7 +43,6 @@ export const ReadTool = Tool.define("read", {
     await ctx.ask({
       permission: "read",
       patterns: [filepath],
-      always: ["*"],
       metadata: {},
     })
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -33,7 +33,6 @@ export const TaskTool = Tool.define("task", async () => {
       await ctx.ask({
         permission: "task",
         patterns: [params.subagent_type],
-        always: ["*"],
         metadata: {
           description: params.description,
           subagent_type: params.subagent_type,

--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -12,7 +12,6 @@ export const TodoWriteTool = Tool.define("todowrite", {
     await ctx.ask({
       permission: "todowrite",
       patterns: ["*"],
-      always: ["*"],
       metadata: {},
     })
 
@@ -37,7 +36,6 @@ export const TodoReadTool = Tool.define("todoread", {
     await ctx.ask({
       permission: "todoread",
       patterns: ["*"],
-      always: ["*"],
       metadata: {},
     })
 

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -26,7 +26,6 @@ export const WebFetchTool = Tool.define("webfetch", {
     await ctx.ask({
       permission: "webfetch",
       patterns: [params.url],
-      always: ["*"],
       metadata: {
         url: params.url,
         format: params.format,

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -60,7 +60,6 @@ export const WebSearchTool = Tool.define("websearch", {
     await ctx.ask({
       permission: "websearch",
       patterns: [params.query],
-      always: ["*"],
       metadata: {
         query: params.query,
         numResults: params.numResults,

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -38,7 +38,6 @@ export const WriteTool = Tool.define("write", {
     await ctx.ask({
       permission: "edit",
       patterns: [path.relative(Instance.worktree, filepath)],
-      always: ["*"],
       metadata: {
         filepath,
         diff,

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -198,8 +198,8 @@ describe("tool.bash permissions", () => {
           testCtx,
         )
         expect(requests.length).toBe(1)
-        expect(requests[0].always.length).toBeGreaterThan(0)
-        expect(requests[0].always.some((p) => p.endsWith("*"))).toBe(true)
+        expect(requests[0].always?.length).toBeGreaterThan(0)
+        expect(requests[0].always?.some((p) => p.endsWith("*"))).toBe(true)
       },
     })
   })


### PR DESCRIPTION
Currently if we have multiple patterns for permission, like edit, we are always allowing all, this makes it be per pattern:

config:
```
    "read": "ask",
```
<img width="2557" height="1014" alt="image" src="https://github.com/user-attachments/assets/cd8ae8f5-f523-4ef3-99fd-ed0a1dc57cc4" />

config:
```
    "read": {
      "*README.md": "ask",
      "*Dockerfile": "ask",
    }
```
<img width="2557" height="1009" alt="image" src="https://github.com/user-attachments/assets/40d51492-5dea-4001-b522-9536fbf8456e" />
<img width="2553" height="1014" alt="image" src="https://github.com/user-attachments/assets/c4065975-2e63-428e-be6e-cfe2fcc5bfef" />
