### PR TITLE
docs/troubleshooting.mdx: add workaround for poor performance in large codebases

### DIFF
--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -163,3 +163,20 @@ export DISPLAY=:99.0
 ```
 
 opencode will detect if you're using Wayland and prefer `wl-clipboard`, otherwise it will try to find clipboard tools in order of: `xclip` and `xsel`.
+
+---
+
+### Extremely slow in large codebases
+
+OpenCode uses [Git worktrees](https://git-scm.com/docs/git-worktree) to snapshot the codebase on every message.
+
+This can lead to extremely slow conversation turns in large codebases with hundreds of thousands of files.
+
+Consider disabling snapshots in the [config](/docs/config) as a workaround:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "snapshot": false
+}
+```


### PR DESCRIPTION
38x faster for a simple "hello" in the chromium codebase (~400k+ files):

```
$ git ls-files | wc -l
468753
```

~2m6s without opencode.json (default):

<img width="715" height="463" alt="Screenshot 2026-01-03 at 12 34 40 PM" src="https://github.com/user-attachments/assets/95b50053-7ff0-477a-a51c-be7ee8815fb5" />

~3s with snapshot=false in opencode.json:

<img width="715" height="462" alt="Screenshot 2026-01-03 at 12 37 05 PM" src="https://github.com/user-attachments/assets/21f2467f-ccca-4ff9-8ecf-58dd92d26523" />