### PR TITLE
fix(bun): always check for updates when plugin version is implied latest

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -71,7 +71,8 @@ export namespace BunProc {
       await Bun.write(pkgjson.name!, JSON.stringify(result, null, 2))
       return result
     })
-    if (parsed.dependencies[pkg] === version) return mod
+    // Skip cache for "latest" - always check for updates
+    if (version !== "latest" && parsed.dependencies[pkg] === version) return mod
 
     const proxied = !!(
       process.env.HTTP_PROXY ||
@@ -86,7 +87,8 @@ export namespace BunProc {
       "--force",
       "--exact",
       // TODO: get rid of this case (see: https://github.com/oven-sh/bun/issues/19936)
-      ...(proxied ? ["--no-cache"] : []),
+      // Also bypass cache for "latest" to ensure fresh registry lookup
+      ...(proxied || version === "latest" ? ["--no-cache"] : []),
       "--cwd",
       Global.Path.cache,
       pkg + "@" + version,
@@ -112,8 +114,9 @@ export namespace BunProc {
       )
     })
 
-    // Resolve actual version from installed package when using "latest"
-    // This ensures subsequent starts use the cached version until explicitly updated
+    // Resolve actual version from installed package
+    // For pinned versions, this caches the version to skip reinstalls
+    // For "latest", we still resolve but always check for updates on next start
     let resolvedVersion = version
     if (version === "latest") {
       const installedPkgJson = Bun.file(path.join(mod, "package.json"))


### PR DESCRIPTION
## Summary

Fixes an issue where plugins configured with  implied `"latest"` version (or no version) were not updating to newer versions on subsequent OpenCode starts.

## Problem

When a user configures a plugin like:
```json
{
  "plugin": ["@plannotator/opencode"]
}
```

The install flow was:
1. First start: `version = "latest"`, installs package, resolves to `"0.2.3"`
2. Saves `"@plannotator/opencode": "0.2.3"` to cache
3. Next start: `version = "latest"`, cache has `"0.2.3"`
4. Check: `"0.2.3" === "latest"` → false → proceeds to reinstall
5. But `bun add --force` uses cached registry data, doesn't fetch new version

Users were stuck on old versions unless they manually cleared `~/.cache/opencode/`.

## Solution

Skip the early cache return when `version === "latest"`:

```typescript
// Before
if (parsed.dependencies[pkg] === version) return mod

// After  
if (version !== "latest" && parsed.dependencies[pkg] === version) return mod
```

This ensures:
- **Pinned versions** (e.g., `@pkg@1.0.0`) still skip reinstalls via cache
- **Latest versions** always run `bun add` to check for updates

## Test plan

- [ ] Configure a plugin with `"latest"` version
- [ ] Verify it updates when a new version is published
- [ ] Verify pinned versions still skip unnecessary reinstalls