### PR TITLE
fix(tui): make lsp status icon muted when no lsps are active

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -64,7 +64,7 @@ export function Footer() {
               </text>
             </Show>
             <text fg={theme.text}>
-              <span style={{ fg: theme.success }}>•</span> {lsp().length} LSP
+              <span style={{ fg: lsp().length > 0 ? theme.success : theme.textMuted }}>•</span> {lsp().length} LSP
             </text>
             <Show when={mcp()}>
               <text fg={theme.text}>


### PR DESCRIPTION
Changes LSP status icon from this 
<img width="72" height="32" alt="image" src="https://github.com/user-attachments/assets/b8dd46ca-e765-49f5-b9c1-c0f1796c43b4" />
to this 
<img width="79" height="33" alt="image" src="https://github.com/user-attachments/assets/f21e8a90-b9bf-492b-bcbc-970627b0aeff" />

when no LSPs are active