### PR TITLE
fix(tui): add missing `theme_list` keybind

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -412,6 +412,7 @@ function App() {
     {
       title: "Switch theme",
       value: "theme.switch",
+      keybind: "theme_list",
       onSelect: () => {
         dialog.replace(() => <DialogThemeList />)
       },


### PR DESCRIPTION
Without this patch, users could not quickly access the theme switcher via key bindings.

This is a problem because `theme_list` was already documented as working in `packages/web/src/content/docs/keybinds.mdx`.

So add the `theme_list` keybind to the Switch theme menu option, allowing binding of quick keyboard access to theme switching as documented.