### PR TITLE
fix(plugin): prevent duplicate plugin function initialization

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -47,7 +47,10 @@ export namespace Plugin {
         if (!plugin) continue
       }
       const mod = await import(plugin)
+      const seen = new Set<PluginInstance>()
       for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+        if (seen.has(fn)) continue
+        seen.add(fn)
         const init = await fn(input)
         hooks.push(init)
       }

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -47,6 +47,9 @@ export namespace Plugin {
         if (!plugin) continue
       }
       const mod = await import(plugin)
+      // Prevent duplicate initialization when plugins export the same function
+      // as both a named export and default export (e.g., `export const X` and `export default X`).
+      // Object.entries(mod) would return both entries pointing to the same function reference.
       const seen = new Set<PluginInstance>()
       for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
         if (seen.has(fn)) continue


### PR DESCRIPTION
Fixes #6596 If in plugin file you have two exports:
export const YourPlugin: Plugin = async () => { ... }
export default YourPlugin

// When imported:
const mod = await import(plugin)
Object.entries(mod)
// Returns: [["YourPlugin", fn], ["default", fn]]
// Both point to the SAME function reference

So the plugin function fn gets called twice in the loop, creating two separate hook instances. The seen Set now catches this by checking if we've already processed that exact function reference.

Im building an opencode plugin and noticed the issue, in the video you can see i run bun run dev with the fix and when running oc alias for opencode it calls plugin twice. 


https://github.com/user-attachments/assets/d25e123a-dfc4-4b6b-9681-352bbba2bf09

