### PR TITLE
fix(cli): properly pass directory context in attach command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -21,12 +21,11 @@ export const AttachCommand = cmd({
         describe: "session id to continue",
       }),
   handler: async (args) => {
-    if (args.dir) process.chdir(args.dir)
-    const directory = process.cwd()
+    const directory = args.dir ? args.dir : process.cwd()
     await tui({
       url: args.url,
-      args: { sessionID: args.session },
       directory,
+      args: { sessionID: args.session },
     })
   },
 })


### PR DESCRIPTION
This PR fixes an issue where the `attach` command would not correctly pass the directory context to the server, resulting in the TUI session running in a default context instead of the specified or current directory.

**Changes:**
- Update `AttachCommand` in `attach.ts` to resolve the directory (defaulting to `process.cwd()`) and pass it to `tui`.
- Update `tui` signature in `app.tsx` to accept and propagate the `directory` parameter.
- Update `SDKProvider` in `sdk.tsx` to initialize the client with the directory context.
- Add `build-fullstack.ts` and `install-systemd-service.sh` scripts to support local fullstack development and deployment.
- Add scalar documentation support.