### PR TITLE
Desktop: Fix Responsive Menu

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -47,7 +47,7 @@ export function SessionHeader() {
   }
 
   return (
-    <header class="h-12 shrink-0 bg-background-base border-b border-border-weak-base flex" data-tauri-drag-region>
+    <header class="h-12 shrink-0 bg-background-base border-b border-border-weak-base flex">
       <button
         type="button"
         class="xl:hidden w-12 shrink-0 flex items-center justify-center border-r border-border-weak-base hover:bg-surface-raised-base-hover active:bg-surface-raised-base-active transition-colors"


### PR DESCRIPTION
The data-tauri-drag-region attribute was on the header which contains interactive elements like the mobile menu button. In Tauri, this attribute makes the element act as a window drag area, which intercepts click events before they reach child elements.

Since there's already a dedicated drag region div in packages/desktop/src/index.tsx:201 for macOS, the header doesn't need this attribute. Removing it allows click events to properly propagate to the mobile menu button.