### PR TITLE
perf: optimize model dialog visibility lookups

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -160,6 +160,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         ),
       )
 
+      const latestSet = createMemo(() => new Set(latest().map((x) => `${x.providerID}:${x.modelID}`)))
+
+      const userVisibilityMap = createMemo(() => {
+        const map = new Map<string, "show" | "hide">()
+        for (const item of store.user) {
+          map.set(`${item.providerID}:${item.modelID}`, item.visibility)
+        }
+        return map
+      })
+
       const list = createMemo(() =>
         available().map((m) => ({
           ...m,
@@ -264,12 +274,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           })
         },
         visible(model: ModelKey) {
-          const user = store.user.find((x) => x.modelID === model.modelID && x.providerID === model.providerID)
-          return (
-            user?.visibility !== "hide" &&
-            (latest().find((x) => x.modelID === model.modelID && x.providerID === model.providerID) ||
-              user?.visibility === "show")
-          )
+          const key = `${model.providerID}:${model.modelID}`
+          const visibility = userVisibilityMap().get(key)
+          return visibility !== "hide" && (latestSet().has(key) || visibility === "show")
         },
         setVisibility(model: ModelKey, visible: boolean) {
           updateVisibility(model, visible ? "show" : "hide")


### PR DESCRIPTION
## Summary

- Fixes model dialog lag that occurs during longer sessions
- Replaces O(n) array lookups with O(1) Set/Map lookups in the `visible()` function

## Problem

The `visible()` function in `packages/app/src/context/local.tsx` was called inside a `.filter()` loop for each model. Each call performed:
1. A linear search through `store.user` array
2. A linear search through `latest()` array (which involves expensive date computations)

With many models, this became O(n²) and caused noticeable lag when opening the model selector.

## Solution

Added two memoized lookup structures:
- `latestSet`: A `Set` for O(1) lookup of whether a model is "latest"
- `userVisibilityMap`: A `Map` for O(1) lookup of user visibility preferences

The memos are only recomputed when their underlying data changes, not on every `visible()` call.