### PR TITLE
docs: Add opencode-scheduler plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -39,6 +39,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                            |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                     |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control      |
+| [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [opencode-scheduler](https://github.com/different-ai/opencode-scheduler) to the ecosystem page.

**opencode-scheduler** is a plugin that enables scheduling recurring jobs using:
- **launchd** on macOS
- **systemd** on Linux

Features:
- Cron-style scheduling syntax
- Survives reboots
- Catches up on missed runs (if computer was asleep)
- Working directory support for MCP configs
- Environment variable injection for node/npx access

Example use case: Schedule a daily 9am job to search Facebook Marketplace for deals and send results to Telegram.