### PR TITLE
perf: filter archived sessions and sort by update time in session list API

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -702,7 +702,11 @@ export namespace Server {
           },
         }),
         async (c) => {
-          const sessions = await Array.fromAsync(Session.list())
+          const sessions = pipe(
+            await Array.fromAsync(Session.list()),
+            filter((s) => !s.time.archived),
+            sortBy((s) => -s.time.updated),
+          )
           return c.json(sessions)
         },
       )


### PR DESCRIPTION
## Summary

- Filter out archived sessions server-side in the `/session` list endpoint
- Sort sessions by most recently updated first (descending)

## Problem

The session list API was returning all sessions including archived ones, leaving filtering to the client. This causes:
1. Unnecessary data transfer for archived sessions
2. Client-side filtering overhead
3. Sessions returned in arbitrary order

## Solution

Use `pipe()` with `filter()` and `sortBy()` from remeda to:
1. Exclude sessions where `time.archived` is set
2. Sort by `-time.updated` (descending, most recent first)

```typescript
const sessions = pipe(
  await Array.fromAsync(Session.list()),
  filter((s) => !s.time.archived),
  sortBy((s) => -s.time.updated),
)
```

## Note

The client-side code in `global-sync.tsx` and `sync.tsx` already does similar filtering/sorting, but doing it server-side reduces data transfer and is more efficient.