### PR TITLE
Fix a few mobile screen size issues

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -47,7 +47,7 @@
   </head>
   <body class="antialiased overscroll-none text-12-regular overflow-hidden">
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root" class="flex flex-col h-screen"></div>
+    <div id="root" class="flex flex-col h-dvh"></div>
     <script src="/src/entry.tsx" type="module"></script>
   </body>
 </html>

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -53,8 +53,8 @@ export default function Home() {
   }
 
   return (
-    <div class="mx-auto mt-55">
-      <Logo class="w-xl opacity-12" />
+    <div class="mx-auto mt-55 w-full md:w-auto px-4">
+      <Logo class="md:w-xl opacity-12" />
       <Button
         size="large"
         variant="ghost"


### PR DESCRIPTION
1. Reduce the width of <Home/> on smaller screen devices

old, broken. Notice how "add project" is off-screen

https://github.com/user-attachments/assets/e53684cc-470f-4f36-ab81-a20ae0dc20e6

new, with some scaling. everything fits in a mobile width


https://github.com/user-attachments/assets/29f84d06-6412-4d3f-9f30-90634329076d

2. Fix bottom bar position on Safari iOS 26. 

The height of the main app was set to 100vh (`h-screen`). This was causing it to get clipped by the navbar on iOS 26 Safari. I've changed it to `h-dvh` to be the height of the "dynamic" viewport, depending on the scroll position. Since the main window doesn't scroll, we could probably just do `h-svh` to do the "small" viewport and [avoid the potential performance issue](https://ishadeed.com/article/new-viewport-units/#:~:text=Be%20careful%20with%20the%20dvh,is%20scrolling%20up%20or%20down.) but that felt like premature optimization, since I didn't do any testing on other devices or profiling.

old, clipped bottom prompt bar

<img width="589" height="1280" alt="image" src="https://github.com/user-attachments/assets/8a328cfe-6120-45a5-9e80-064cb16e4f86" />


New, not clipped bottom prompt bar
<img width="589" height="1280" alt="image" src="https://github.com/user-attachments/assets/3f04503b-e074-43ea-9dfa-4ea08ce53af6" />

Photos taken on iPhone 17 Pro Max with iOS 26.3 and tabs set to "compact"
