### PR TITLE
fix: prevent session list rows from wrapping to 2 lines

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -314,12 +314,12 @@ function Option(props: {
   return (
     <>
       <Show when={props.current}>
-        <text flexShrink={0} fg={props.active ? fg : props.current ? theme.primary : theme.text} marginRight={0.5}>
+        <text flexShrink={0} fg={props.active ? fg : props.current ? theme.primary : theme.text} marginRight={0}>
           ●
         </text>
       </Show>
       <Show when={!props.current && props.gutter}>
-        <box flexShrink={0} marginRight={0.5}>
+        <box flexShrink={0} marginRight={0}>
           {props.gutter}
         </box>
       </Show>


### PR DESCRIPTION
the session list currently wraps to two lines on long sessions when you select them.

before (left) vs after (right)

<img width="2922" height="1634" alt="Screenshot 2026-01-03 at 11 24 25 PM" src="https://github.com/user-attachments/assets/1d81717f-b548-45f2-9fb2-396c51ed652b" />
