### PR TITLE
feat(prompt): include time in Today's date env

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -40,7 +40,7 @@ export namespace SystemPrompt {
         `  Working directory: ${Instance.directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
-        `  Today's date: ${new Date().toDateString()}`,
+        `  Today's date: ${new Date().toDateString()} ${new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })}`,
         `</env>`,
         `<files>`,
         `  ${


### PR DESCRIPTION
## Summary

- Adds time (HH:MM) to the `Today's date` field in the env block
- Changes output from `Sun Jan 04 2026` to `Sun Jan 04 2026 13:45`

This lets the LLM know the current time without needing to run a shell command, useful for time-sensitive context. Antigravity also shows the time and I find it very useful to not make it run time every time.