### PR TITLE
docs: Remove opencode-skills entry from ecosystem.mdx

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -18,7 +18,6 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                                                               | Description                                                                                    |
 | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                             |
-| [opencode-skills](https://github.com/malhashemi/opencode-skills)                                   | Manage and organize OpenCode skills and capabilities                                           |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                          |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                  |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                           |


### PR DESCRIPTION
Removed the opencode-skills entry from the ecosystem documentation, since this has been graduated to native OpenCode support