### PR TITLE
docs: typo in subtask documentation

### DIFF
--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -277,7 +277,7 @@ This is an **optional** config option. If not specified, defaults to your curren
 ### Subtask
 
 Use the `subtask` boolean to force the command to trigger a [subagent](/docs/agents/#subagents) invocation.
-This useful if you want the command to not pollute your primary context and will **force** the agent to act as a subagent,
+This is useful if you want the command to not pollute your primary context and will **force** the agent to act as a subagent,
 even if `mode` is set to `primary` on the [agent](/docs/agents) configuration.
 
 ```json title="opencode.json"


### PR DESCRIPTION
just added a missing 'is'