### PR TITLE
fix(app): fix custom slash commands not showing on initial /

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -441,12 +441,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     active: slashActive,
     onInput: slashOnInput,
     onKeyDown: slashOnKeyDown,
+    refetch: slashRefetch,
   } = useFilteredList<SlashCommand>({
     items: slashCommands,
     key: (x) => x?.id,
     filterKeys: ["trigger", "title", "description"],
     onSelect: handleSlashSelect,
   })
+
+  createEffect(
+    on(
+      () => sync.data.command,
+      () => slashRefetch(),
+      { defer: true },
+    ),
+  )
 
   createEffect(
     on(


### PR DESCRIPTION
### Problem
Custom commands (like `/init`, `/review`, `/commit`) were not showing in the slash command menu when first typing `/`. Users had to type a character and backspace to see them.

### Cause
The `useFilteredList` hook doesn't re-run when `sync.data.command` loads asynchronously after the initial render.

### Solution
Added a `createEffect` that calls `slashRefetch()` when `sync.data.command` changes, ensuring custom commands appear immediately.

### Changes
- `packages/app/src/components/prompt-input.tsx`: Added refetch trigger when commands load


#### Before
https://github.com/user-attachments/assets/96032dbc-8c83-4b9a-a682-bfaae916b0e8

#### After
https://github.com/user-attachments/assets/52070813-50b5-4efa-a07c-9e9f9a7133c7
