### PR TITLE
Desktop: Improve Big Session Navigation - Scrollable

### DIFF
--- a/packages/ui/src/components/message-nav.css
+++ b/packages/ui/src/components/message-nav.css
@@ -102,6 +102,8 @@
   align-items: center;
   border-radius: var(--radius-md);
   background: var(--surface-raised-stronger-non-alpha);
+  max-height: calc(100vh - 6rem);
+  overflow-y: auto;
 
   /* border/shadow-xs/base */
   box-shadow:

--- a/packages/ui/src/components/session-message-rail.css
+++ b/packages/ui/src/components/session-message-rail.css
@@ -7,6 +7,9 @@
   position: absolute;
   left: 1.5rem;
   margin-top: 0.625rem;
+  top: 0;
+  bottom: 8rem;
+  overflow-y: auto;
 }
 
 [data-slot="session-message-rail-compact"] {


### PR DESCRIPTION
Currently you can't reach the last messages if you passed the height as it's not scrollable.

Before:
<img width="730" height="1004" alt="image" src="https://github.com/user-attachments/assets/bdace3a4-e6cd-4aa1-8eaf-5218078af1e0" />
<img width="667" height="1014" alt="image" src="https://github.com/user-attachments/assets/eb568598-b30a-41f4-9910-c2de91dcc0a5" />


After:
<img width="721" height="1003" alt="image" src="https://github.com/user-attachments/assets/9b024f65-21c8-4160-97e7-57a9303d376f" />
<img width="673" height="1014" alt="image" src="https://github.com/user-attachments/assets/1f44cfd5-112e-4465-8e69-5629a95b9a16" />
