### PR TITLE
fix: prevent main model thinking variant from applying to small model

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -83,7 +83,8 @@ export namespace LLM {
 
     const provider = await Provider.getProvider(input.model.providerID)
     const small = input.small ? ProviderTransform.smallOptions(input.model) : {}
-    const variant = input.model.variants && input.user.variant ? input.model.variants[input.user.variant] : {}
+    const variant =
+      !input.small && input.model.variants && input.user.variant ? input.model.variants[input.user.variant] : {}
     const options = pipe(
       ProviderTransform.options(input.model, input.sessionID, provider.options),
       mergeDeep(small),


### PR DESCRIPTION
**Summary**

When changing thinking level (ctrl+t) for the main model, the selected variant (e.g., reasoningEffort) was incorrectly applied to small model calls (title/summary generation). This caused API errors when the small model didn't support the parameter.

**Problem**

```
small=true agent=title params={"options":{"reasoningEffort":"low"}}
ERROR "Model grok-code does not support parameter reasoningEffort."
```

The variant from `input.user.variant` was applied regardless of whether `small: true` was set.

**Fix**

Skip variant application when `small: true` in  `llm.ts`:

```ts
// Before
const variant = input.model.variants && input.user.variant ? input.model.variants[input.user.variant] : {}
// After
const variant = !input.small && input.model.variants && input.user.variant ? input.model.variants[input.user.variant] : {}
```