### PR TITLE
fix: await dependency installation before loading custom tools

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -23,6 +23,9 @@ import { existsSync } from "fs"
 export namespace Config {
   const log = Log.create({ service: "config" })
 
+  // Track install promises per directory so tools can wait for their dependencies
+  const installPromises = new Map<string, Promise<void>>()
+
   // Custom merge function that concatenates array fields instead of replacing them
   function mergeConfigConcatArrays(target: Info, source: Info): Info {
     const merged = mergeDeep(target, source)
@@ -106,6 +109,7 @@ export namespace Config {
 
       const exists = existsSync(path.join(dir, "node_modules"))
       const installing = installDependencies(dir)
+      installPromises.set(dir, installing)
       if (!exists) await installing
 
       result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
@@ -162,6 +166,7 @@ export namespace Config {
     return {
       config: result,
       directories,
+      installPromises,
     }
   })
 
@@ -1117,5 +1122,10 @@ export namespace Config {
 
   export async function directories() {
     return state().then((x) => x.directories)
+  }
+
+  export async function getInstallPromise(dir: string): Promise<void> {
+    const promises = await state().then((x) => x.installPromises)
+    return promises.get(dir) ?? Promise.resolve()
   }
 }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -32,6 +32,9 @@ export namespace ToolRegistry {
     const glob = new Bun.Glob("tool/*.{js,ts}")
 
     for (const dir of await Config.directories()) {
+      // Wait for dependencies to be installed before loading tools from this directory
+      await Config.getInstallPromise(dir)
+
       for await (const match of glob.scan({
         cwd: dir,
         absolute: true,


### PR DESCRIPTION
Fixes an issue where custom tools fail to load with `"Cannot find module '@opencode-ai/plugin'"` errors due to a tool loading vs. dependency installation "race".

**This builds on #6302 by ensuring dependency installation completes before attempting to load custom tools that depend on those packages without impacting OpenCode startup time - e.g. we don't block app startup, just tool loading (which is already on-demand).**

notably, this implementation ensures that _tools wait only for their own directory's dependencies (minimal blocking)_.

**problem**: After #6302, OpenCode runs `bun install` for each config directory to install dependencies. However, if `node_modules` already exists, the installation runs asynchronously in the background without waiting. When custom tools are loaded immediately after, they fail to import `@opencode-ai/plugin` or other dependencies because the install hasn't finished yet.

**fix**: Track the install promise for each config directory and await it before loading tools from that directory:

* Config directories start installing dependencies in parallel (non-blocking)
* When the tool registry loads tools from a directory, it awaits that directory's install promise
* This ensures tools only import after their dependencies are ready