### PR TITLE
feat(config): add support for environment variable overrides in config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -59,6 +59,17 @@ export namespace Config {
     return merged
   }
 
+  function applyEnv(env: Record<string, string | null> | undefined) {
+    if (!env) return
+    for (const [key, value] of Object.entries(env)) {
+      if (value === null) {
+        delete process.env[key]
+        continue
+      }
+      process.env[key] = value
+    }
+  }
+
   export const state = Instance.state(async () => {
     const auth = await Auth.all()
 
@@ -224,6 +235,8 @@ export namespace Config {
     if (Flag.OPENCODE_DISABLE_PRUNE) {
       result.compaction = { ...result.compaction, prune: false }
     }
+
+    applyEnv(result.env)
 
     result.plugin = deduplicatePlugins(result.plugin ?? [])
 
@@ -1088,6 +1101,10 @@ export namespace Config {
           prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
         })
         .optional(),
+      env: z
+        .record(z.string(), z.string().nullable())
+        .optional()
+        .describe("Environment variable overrides. Set to null to unset."),
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1719,3 +1719,153 @@ describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {
     }
   })
 })
+
+// env field tests
+
+test("env field sets process.env variables", async () => {
+  const originalValue = process.env["CONFIG_TEST_VAR"]
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              CONFIG_TEST_VAR: "test_value",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+        expect(process.env["CONFIG_TEST_VAR"]).toBe("test_value")
+      },
+    })
+  } finally {
+    if (originalValue !== undefined) {
+      process.env["CONFIG_TEST_VAR"] = originalValue
+    } else {
+      delete process.env["CONFIG_TEST_VAR"]
+    }
+  }
+})
+
+test("env field with null unsets process.env variable", async () => {
+  const originalValue = process.env["CONFIG_UNSET_VAR"]
+  process.env["CONFIG_UNSET_VAR"] = "should_be_removed"
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              CONFIG_UNSET_VAR: null,
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Config.get()
+        expect(process.env["CONFIG_UNSET_VAR"]).toBeUndefined()
+      },
+    })
+  } finally {
+    if (originalValue !== undefined) {
+      process.env["CONFIG_UNSET_VAR"] = originalValue
+    } else {
+      delete process.env["CONFIG_UNSET_VAR"]
+    }
+  }
+})
+
+test("env field merges with later config winning", async () => {
+  const originalValue = process.env["CONFIG_MERGE_VAR"]
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const projectDir = path.join(dir, "project")
+        const opencodeDir = path.join(projectDir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              CONFIG_MERGE_VAR: "global_value",
+            },
+          }),
+        )
+
+        await Bun.write(
+          path.join(opencodeDir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              CONFIG_MERGE_VAR: "local_value",
+            },
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: path.join(tmp.path, "project"),
+      fn: async () => {
+        await Config.get()
+        expect(process.env["CONFIG_MERGE_VAR"]).toBe("local_value")
+      },
+    })
+  } finally {
+    if (originalValue !== undefined) {
+      process.env["CONFIG_MERGE_VAR"] = originalValue
+    } else {
+      delete process.env["CONFIG_MERGE_VAR"]
+    }
+  }
+})
+
+test("env template does not see config env vars", async () => {
+  const originalValue = process.env["CONFIG_TEMPLATE_VAR"]
+  delete process.env["CONFIG_TEMPLATE_VAR"]
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            env: {
+              CONFIG_TEMPLATE_VAR: "should_not_appear",
+            },
+            theme: "{env:CONFIG_TEMPLATE_VAR}",
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // Template substitution happens before env is applied, so theme should be empty
+        expect(config.theme).toBe("")
+        // But process.env should have the value after config is loaded
+        expect(process.env["CONFIG_TEMPLATE_VAR"]).toBe("should_not_appear")
+      },
+    })
+  } finally {
+    if (originalValue !== undefined) {
+      process.env["CONFIG_TEMPLATE_VAR"] = originalValue
+    } else {
+      delete process.env["CONFIG_TEMPLATE_VAR"]
+    }
+  }
+})

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -498,6 +498,37 @@ You can control context compaction behavior through the `compaction` option.
 
 ---
 
+### Environment Variables
+
+You can set environment variables through the `env` option. This is useful for configuring tools and providers that rely on environment variables.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "env": {
+    "API_KEY": "your-api-key",
+    "CUSTOM_VAR": "value"
+  }
+}
+```
+
+Use `null` to unset an environment variable:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "env": {
+    "UNWANTED_VAR": null
+  }
+}
+```
+
+:::note
+Environment variables set in config are applied after config loading completes. They won't be available for template substitution (`{env:VAR}`) in the same config file.
+:::
+
+---
+
 ### Watcher
 
 You can configure file watcher ignore patterns through the `watcher` option.


### PR DESCRIPTION
- Introduced `env` option to set environment variables at runtime.
- Added functionality to unset variables by setting them to `null`.
- Updated documentation to reflect new `env` feature and its usage.
- Added tests to ensure correct application of environment variables.

This new feature was initially discussed in the community discord, there's no related issue