### PR TITLE
feat: add ctx.log() for custom tools

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -892,6 +892,7 @@ export namespace SessionPrompt {
             return pieces
           }
           const url = new URL(part.url)
+          const toolLogger = Log.create({ service: "tool" })
           switch (url.protocol) {
             case "data:":
               if (part.mime === "text/plain") {
@@ -927,7 +928,6 @@ export namespace SessionPrompt {
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filepath = fileURLToPath(part.url)
               const stat = await Bun.file(filepath).stat()
-              const toolLogger = Log.create({ service: "tool" })
 
               if (stat.isDirectory()) {
                 part.mime = "application/x-directory"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -378,6 +378,7 @@ export namespace SessionPrompt {
         )
         let executionError: Error | undefined
         const taskAgent = await Agent.get(task.agent)
+        const toolLogger = Log.create({ service: "tool" })
         const taskCtx: Tool.Context = {
           agent: task.agent,
           messageID: assistantMessage.id,
@@ -401,8 +402,7 @@ export namespace SessionPrompt {
             })
           },
           log(level, message, extra) {
-            const logger = Log.create({ service: "tool" })
-            logger[level](message, extra)
+            toolLogger[level](message, extra)
           },
         }
         const result = await taskTool.execute(taskArgs, taskCtx).catch((error) => {
@@ -644,6 +644,7 @@ export namespace SessionPrompt {
   }) {
     using _ = log.time("resolveTools")
     const tools: Record<string, AITool> = {}
+    const toolLogger = Log.create({ service: "tool" })
 
     const context = (args: any, options: ToolCallOptions): Tool.Context => ({
       sessionID: input.session.id,
@@ -678,8 +679,7 @@ export namespace SessionPrompt {
         })
       },
       log(level, message, extra) {
-        const logger = Log.create({ service: "tool" })
-        logger[level](message, extra)
+        toolLogger[level](message, extra)
       },
     })
 
@@ -927,6 +927,7 @@ export namespace SessionPrompt {
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filepath = fileURLToPath(part.url)
               const stat = await Bun.file(filepath).stat()
+              const toolLogger = Log.create({ service: "tool" })
 
               if (stat.isDirectory()) {
                 part.mime = "application/x-directory"
@@ -992,8 +993,7 @@ export namespace SessionPrompt {
                       metadata: async () => {},
                       ask: async () => {},
                       log(level, message, extra) {
-                        const logger = Log.create({ service: "tool" })
-                        logger[level](message, extra)
+                        toolLogger[level](message, extra)
                       },
                     }
                     const result = await t.execute(args, readCtx)
@@ -1057,8 +1057,7 @@ export namespace SessionPrompt {
                   metadata: async () => {},
                   ask: async () => {},
                   log(level, message, extra) {
-                    const logger = Log.create({ service: "tool" })
-                    logger[level](message, extra)
+                    toolLogger[level](message, extra)
                   },
                 }
                 const result = await ListTool.init().then((t) => t.execute(args, listCtx))

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -400,6 +400,10 @@ export namespace SessionPrompt {
               ruleset: PermissionNext.merge(taskAgent.permission, session.permission ?? []),
             })
           },
+          log(level, message, extra) {
+            const logger = Log.create({ service: "tool" })
+            logger[level](message, extra)
+          },
         }
         const result = await taskTool.execute(taskArgs, taskCtx).catch((error) => {
           executionError = error
@@ -672,6 +676,10 @@ export namespace SessionPrompt {
           tool: { messageID: input.processor.message.id, callID: options.toolCallId },
           ruleset: PermissionNext.merge(input.agent.permission, input.session.permission ?? []),
         })
+      },
+      log(level, message, extra) {
+        const logger = Log.create({ service: "tool" })
+        logger[level](message, extra)
       },
     })
 
@@ -983,6 +991,10 @@ export namespace SessionPrompt {
                       extra: { bypassCwdCheck: true, model },
                       metadata: async () => {},
                       ask: async () => {},
+                      log(level, message, extra) {
+                        const logger = Log.create({ service: "tool" })
+                        logger[level](message, extra)
+                      },
                     }
                     const result = await t.execute(args, readCtx)
                     pieces.push({
@@ -1044,6 +1056,10 @@ export namespace SessionPrompt {
                   extra: { bypassCwdCheck: true },
                   metadata: async () => {},
                   ask: async () => {},
+                  log(level, message, extra) {
+                    const logger = Log.create({ service: "tool" })
+                    logger[level](message, extra)
+                  },
                 }
                 const result = await ListTool.init().then((t) => t.execute(args, listCtx))
                 return [

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -21,6 +21,7 @@ export namespace Tool {
     extra?: { [key: string]: any }
     metadata(input: { title?: string; metadata?: M }): void
     ask(input: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">): Promise<void>
+    log(level: "debug" | "info" | "warn" | "error", message: string, extra?: Record<string, unknown>): void
   }
   export interface Info<Parameters extends z.ZodType = z.ZodType, M extends Metadata = Metadata> {
     id: string

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -13,6 +13,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  log: () => {},
 }
 
 const projectRoot = path.join(__dirname, "../..")

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -12,6 +12,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  log: () => {},
 }
 
 const projectRoot = path.join(__dirname, "../..")

--- a/packages/opencode/test/tool/patch.test.ts
+++ b/packages/opencode/test/tool/patch.test.ts
@@ -14,6 +14,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  log: () => {},
 }
 
 const patchTool = await PatchTool.init()

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -14,6 +14,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   metadata: () => {},
   ask: async () => {},
+  log: () => {},
 }
 
 describe("tool.read external_directory permission", () => {

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -5,6 +5,7 @@ export type ToolContext = {
   messageID: string
   agent: string
   abort: AbortSignal
+  log(level: "debug" | "info" | "warn" | "error", message: string, extra?: Record<string, unknown>): void
 }
 
 export function tool<Args extends z.ZodRawShape>(input: {

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -105,7 +105,12 @@ export const MyPlugin = async (ctx) => {
 
 ```js title=".opencode/plugin/example.js"
 export const MyPlugin = async ({ project, client, $, directory, worktree }) => {
-  console.log("Plugin initialized!")
+  // Use client.app.log() instead of console.log to avoid leaking output
+  await client.app.log({
+    service: "my-plugin",
+    level: "info",
+    message: "Plugin initialized",
+  })
 
   return {
     // Hook implementations go here
@@ -290,7 +295,11 @@ Your custom tools will be available to opencode alongside built-in tools.
 
 ### Logging
 
-Use `client.app.log()` instead of `console.log` for structured logging:
+Use structured logging instead of `console.log` to avoid output leaking to stdout.
+
+#### In plugins
+
+Use `client.app.log()` for logging in plugin initialization and hooks:
 
 ```ts title=".opencode/plugin/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
@@ -300,6 +309,29 @@ export const MyPlugin = async ({ client }) => {
     message: "Plugin initialized",
     extra: { foo: "bar" },
   })
+}
+```
+
+#### In custom tools
+
+Use `ctx.log()` for logging in custom tool implementations:
+
+```ts title=".opencode/plugin/custom-tool.ts"
+import { type Plugin, tool } from "@opencode-ai/plugin"
+
+export const CustomToolPlugin: Plugin = async (ctx) => {
+  return {
+    tool: {
+      mytool: tool({
+        description: "A tool that logs",
+        args: { name: tool.schema.string() },
+        async execute(args, ctx) {
+          ctx.log("info", "Tool executed", { name: args.name })
+          return `Hello ${args.name}!`
+        },
+      }),
+    },
+  }
 }
 ```
 


### PR DESCRIPTION
Fixes #6830 and #6833 by adding `ctx.log()` for custom tools to avoid console.log output leaking to stdout.

**problem**: 

* Custom plugins had `ctx.client.app.log` available to them, but custom tools did not - there was no logger exposed to tools (making it hard to debug)
* the docs still guided console.log (missed this in #6833)

**solution**: 
- Added `ctx.log(level, message, extra)` to ToolContext for custom tool implementations
- Logs using OpenCode's internal `Log.create()` API (appropriate since tools execute in-process)
- Logger instances created once per context to avoid overhead
- Updated plugin docs to show `ctx.log()` for custom tools and `client.app.log()` for plugin initialization
- Clarified that console.log leaks to stdout

I also had to update test sites for built-in tools to plumb `log` through into the `ToolContext`, hence the larger number of changed files here.

Custom tools now have structured logging that writes to OpenCode's log files instead of polluting terminal output.