### PR TITLE
feat: display Google Gemini cached token stats

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -311,7 +311,7 @@ export namespace Session {
       for (const child of await children(sessionID)) {
         await remove(child.id)
       }
-      await unshare(sessionID).catch(() => {})
+      await unshare(sessionID).catch(() => { })
       for (const msg of await Storage.list(["message", sessionID])) {
         for (const part of await Storage.list(["part", msg.at(-1)!])) {
           await Storage.remove(part)
@@ -397,7 +397,9 @@ export namespace Session {
       metadata: z.custom<ProviderMetadata>().optional(),
     }),
     (input) => {
-      const cachedInputTokens = input.usage.cachedInputTokens ?? 0
+      // Google returns cached token counts in usageMetadata.cachedContentTokenCount rather than the standard location
+      const cachedInputTokens =
+        input.usage.cachedInputTokens ?? (input.metadata?.["google"] as any)?.usageMetadata?.cachedContentTokenCount ?? 0
       const excludesCachedTokens = !!(input.metadata?.["anthropic"] || input.metadata?.["bedrock"])
       const adjustedInputTokens = excludesCachedTokens
         ? (input.usage.inputTokens ?? 0)
@@ -426,6 +428,7 @@ export namespace Session {
         input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
           ? input.model.cost.experimentalOver200K
           : input.model.cost
+
       return {
         cost: safe(
           new Decimal(0)


### PR DESCRIPTION
# feat: display Google Gemini cached token stats

Closes https://github.com/anomalyco/opencode/issues/6851

## What

One-line fix to read cached token counts from Google's metadata so they show up in session stats.

## Why

Google returns cached token counts in a different spot than Anthropic:
- Anthropic: `usage.cachedInputTokens`
- Google: `providerMetadata.google.usageMetadata.cachedContentTokenCount`

Implicit caching was already working server-side (and saving money), we just weren't displaying it.

## The fix

```diff
- const cachedInputTokens = input.usage.cachedInputTokens ?? 0
+ const cachedInputTokens = input.usage.cachedInputTokens ?? 
+   (input.metadata?.["google"] as any)?.usageMetadata?.cachedContentTokenCount ?? 0
```

## Tested

Verified locally with a couple of gemini conversations.

---

## Future: Explicit Caching

Google has two caching modes:
- **Implicit** (what we're using): Automatic, server-side, probabilistic
- **Explicit**: Guaranteed cache hits, requires managing cache objects

For explicit caching, we'd need:
1. Add `@google/generative-ai` dependency
2. Use `GoogleAICacheManager` to create/update/delete caches with TTL
3. Pass cache name via `providerOptions.google.cachedContent`

This is a bigger lift but would give guaranteed savings. See:
- [Google caching docs](https://ai.google.dev/gemini-api/docs/caching)
- [Cline's implementation](https://github.com/cline/cline/pull/3181) for reference
