### PR TITLE
fix(lsp): add shell option for Dart LSP on Windows

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1559,6 +1559,7 @@ export namespace LSPServer {
       return {
         process: spawn(dart, ["language-server", "--lsp"], {
           cwd: root,
+          shell: process.platform === "win32",
         }),
       }
     },


### PR DESCRIPTION
## Summary

Fixes the Dart LSP failing on Windows with "Command not found: dart" error by adding `shell: true` to the spawn options when running on Windows.

## Problem

On Windows, the Dart LSP server fails to start even when `dart` is correctly installed and in PATH. The error occurs because:

1. `Bun.which("dart")` finds a valid path (e.g., `C:\Users\...\bin\dart.exe`)
2. However, `spawn()` without `shell: true` can fail on Windows for certain executable configurations

## Solution

Add `shell: process.platform === "win32"` to the spawn options, following the same pattern used elsewhere in the codebase (e.g., `npm.cmd` handling in ESLint LSP).

## Testing

- Verified on Windows 10/11 with Dart SDK 3.5.4
- Confirmed `dart language-server --lsp` works via shell
- Minimal change, no impact on non-Windows platforms

Fixes #6861

cc @thdxr @adamdotdevin