### PR TITLE
fix: sidebar title padding to prevent scrollbar edge case

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -80,7 +80,7 @@ export function Sidebar(props: { sessionID: string }) {
       >
         <scrollbox flexGrow={1}>
           <box flexShrink={0} gap={1} paddingRight={1}>
-            <box>
+            <box paddingRight={1}>
               <text fg={theme.text}>
                 <b>{session().title}</b>
               </text>


### PR DESCRIPTION
## Summary

Fixes an edge case bug where the sidebar session title causes a visual glitch when the scrollbar activates.

## Problem

When the session title is exactly the right character length to fill the sidebar width, it triggers the scrollbar to appear at a precise moment during rendering. This causes mouse drag events to incorrectly propagate to list items below, resulting in unexpected highlighting/selection behavior.

## Solution

Added `paddingRight={1}` to the session title box to ensure there's always room reserved for the scrollbar, preventing the timing edge case.

## Testing

Tested with session titles of various lengths including the exact edge case length that triggered the bug.