### PR TITLE
fix: add support for ACP writeTextFile clientCapability

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -323,13 +323,33 @@ export namespace ACP {
               } finally {
                 break
               }
+
+            case "file.edited":
+              if (this.config.clientCapabilities?.fs?.writeTextFile) {
+                const filepath = event.properties.file
+                try {
+                  const content = await Bun.file(filepath).text()
+                  await this.connection.writeTextFile({
+                    sessionId,
+                    path: filepath,
+                    content,
+                  })
+                  log.info("synced file edit to ACP client", { filepath, sessionId })
+                } catch (err) {
+                  log.error("failed to sync file edit to ACP client", { error: err, filepath, sessionId })
+                }
+              }
+              break
           }
         }
       })
     }
 
     async initialize(params: InitializeRequest): Promise<InitializeResponse> {
-      log.info("initialize", { protocolVersion: params.protocolVersion })
+      log.info("initialize", { protocolVersion: params.protocolVersion, clientCapabilities: params.clientCapabilities })
+
+      // Store client capabilities for use in session event handling
+      this.config.clientCapabilities = params.clientCapabilities
 
       const authMethod: AuthMethod = {
         description: "Run `opencode auth login` in the terminal",

--- a/packages/opencode/src/acp/types.ts
+++ b/packages/opencode/src/acp/types.ts
@@ -1,4 +1,4 @@
-import type { McpServer } from "@agentclientprotocol/sdk"
+import type { ClientCapabilities, McpServer } from "@agentclientprotocol/sdk"
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 
 export interface ACPSessionState {
@@ -19,4 +19,5 @@ export interface ACPConfig {
     providerID: string
     modelID: string
   }
+  clientCapabilities?: ClientCapabilities
 }


### PR DESCRIPTION
This is an attempt to fix the issue called out in issue [4240](https://github.com/anomalyco/opencode/issues/4240). By mirroring the write back to the client it causes the local review flows to trigger. It feels a bit inefficient, but it seems to match with the expectations of the [spec](https://agentclientprotocol.com/protocol/file-system#writing-files). I looked at hijacking the tool call to just do the writes and reads through the client, but I couldn't find a good pattern to make that fit. 