### PR TITLE
feat: display Anthropic and OpenAI OAuth usage in status dialog and sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -27,15 +27,9 @@ export function DialogStatus() {
 
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
 
-  const [anthropicUsage] = createResource(
-    () => AnthropicUsage.fetch(),
-    { initialValue: null }
-  )
+  const [anthropicUsage] = createResource(() => AnthropicUsage.fetch(), { initialValue: null })
 
-  const [openaiUsage] = createResource(
-    () => OpenAIUsage.fetch(),
-    { initialValue: null }
-  )
+  const [openaiUsage] = createResource(() => OpenAIUsage.fetch(), { initialValue: null })
 
   const plugins = createMemo(() => {
     const list = sync.data.config.plugin ?? []
@@ -62,7 +56,7 @@ export function DialogStatus() {
     return result.toSorted((a, b) => a.name.localeCompare(b.name))
   })
 
-  const colorFor = (percent: number) => colorFor(percent, theme)
+  const colorFor = (percent: number) => getUsageColor(percent, theme)
 
   return (
     <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
@@ -83,11 +77,13 @@ export function DialogStatus() {
               {(fiveHour) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>5h:</text>
-                  <UsageBar percent={fiveHour().utilization} fg={colorFor(fiveHour().utilization)} bgMuted={theme.textMuted} />
+                  <UsageBar
+                    percent={fiveHour().utilization}
+                    fg={colorFor(fiveHour().utilization)}
+                    bgMuted={theme.textMuted}
+                  />
                   <text fg={colorFor(fiveHour().utilization)}>{fiveHour().utilization}%</text>
-                  <text fg={theme.textMuted}>
-                    (reset: {AnthropicUsage.formatResetTime(fiveHour().resets_at)})
-                  </text>
+                  <text fg={theme.textMuted}>(reset: {AnthropicUsage.formatResetTime(fiveHour().resets_at)})</text>
                 </box>
               )}
             </Show>
@@ -95,11 +91,13 @@ export function DialogStatus() {
               {(sevenDay) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>7d:</text>
-                  <UsageBar percent={sevenDay().utilization} fg={colorFor(sevenDay().utilization)} bgMuted={theme.textMuted} />
+                  <UsageBar
+                    percent={sevenDay().utilization}
+                    fg={colorFor(sevenDay().utilization)}
+                    bgMuted={theme.textMuted}
+                  />
                   <text fg={colorFor(sevenDay().utilization)}>{sevenDay().utilization}%</text>
-                  <text fg={theme.textMuted}>
-                    (reset: {AnthropicUsage.formatResetTime(sevenDay().resets_at)})
-                  </text>
+                  <text fg={theme.textMuted}>(reset: {AnthropicUsage.formatResetTime(sevenDay().resets_at)})</text>
                 </box>
               )}
             </Show>
@@ -109,9 +107,7 @@ export function DialogStatus() {
                   <text fg={theme.text}>Opus 7d:</text>
                   <UsageBar percent={opus().utilization} fg={colorFor(opus().utilization)} bgMuted={theme.textMuted} />
                   <text fg={colorFor(opus().utilization)}>{opus().utilization}%</text>
-                  <text fg={theme.textMuted}>
-                    (reset: {AnthropicUsage.formatResetTime(opus().resets_at)})
-                  </text>
+                  <text fg={theme.textMuted}>(reset: {AnthropicUsage.formatResetTime(opus().resets_at)})</text>
                 </box>
               )}
             </Show>
@@ -129,11 +125,13 @@ export function DialogStatus() {
               {(primary) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>{OpenAIUsage.formatWindowDuration(primary().limit_window_seconds)}:</text>
-                  <UsageBar percent={primary().used_percent} fg={colorFor(primary().used_percent)} bgMuted={theme.textMuted} />
+                  <UsageBar
+                    percent={primary().used_percent}
+                    fg={colorFor(primary().used_percent)}
+                    bgMuted={theme.textMuted}
+                  />
                   <text fg={colorFor(primary().used_percent)}>{Math.round(primary().used_percent)}%</text>
-                  <text fg={theme.textMuted}>
-                    (reset: {OpenAIUsage.formatResetTime(primary().reset_at)})
-                  </text>
+                  <text fg={theme.textMuted}>(reset: {OpenAIUsage.formatResetTime(primary().reset_at)})</text>
                 </box>
               )}
             </Show>
@@ -141,11 +139,13 @@ export function DialogStatus() {
               {(secondary) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>{OpenAIUsage.formatWindowDuration(secondary().limit_window_seconds)}:</text>
-                  <UsageBar percent={secondary().used_percent} fg={colorFor(secondary().used_percent)} bgMuted={theme.textMuted} />
+                  <UsageBar
+                    percent={secondary().used_percent}
+                    fg={colorFor(secondary().used_percent)}
+                    bgMuted={theme.textMuted}
+                  />
                   <text fg={colorFor(secondary().used_percent)}>{Math.round(secondary().used_percent)}%</text>
-                  <text fg={theme.textMuted}>
-                    (reset: {OpenAIUsage.formatResetTime(secondary().reset_at)})
-                  </text>
+                  <text fg={theme.textMuted}>(reset: {OpenAIUsage.formatResetTime(secondary().reset_at)})</text>
                 </box>
               )}
             </Show>
@@ -153,9 +153,10 @@ export function DialogStatus() {
               {(credits) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>Credits:</text>
-                  <Show when={credits().unlimited} fallback={
-                    <text fg={theme.text}>{OpenAIUsage.formatCredits(credits().balance)}</text>
-                  }>
+                  <Show
+                    when={credits().unlimited}
+                    fallback={<text fg={theme.text}>{OpenAIUsage.formatCredits(credits().balance)}</text>}
+                  >
                     <text fg={theme.success}>Unlimited</text>
                   </Show>
                 </box>

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -4,12 +4,14 @@ import { useSync } from "@tui/context/sync"
 import { For, Match, Switch, Show, createMemo, createResource } from "solid-js"
 import { AnthropicUsage } from "@/usage/anthropic"
 import { OpenAIUsage } from "@/usage/openai"
+import { getUsageColor, clampPercent } from "@/usage/utils"
 
 export type DialogStatusProps = {}
 
 function UsageBar(props: { percent: number; fg: RGBA; bgMuted: RGBA }) {
   const width = 20
-  const filled = Math.round((props.percent / 100) * width)
+  const clamped = clampPercent(props.percent)
+  const filled = Math.round((clamped / 100) * width)
   const empty = width - filled
   return (
     <text>
@@ -25,12 +27,12 @@ export function DialogStatus() {
 
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
 
-  const [anthropicUsage, { refetch: refetchAnthropicUsage }] = createResource(
+  const [anthropicUsage] = createResource(
     () => AnthropicUsage.fetch(),
     { initialValue: null }
   )
 
-  const [openaiUsage, { refetch: refetchOpenAIUsage }] = createResource(
+  const [openaiUsage] = createResource(
     () => OpenAIUsage.fetch(),
     { initialValue: null }
   )
@@ -60,11 +62,7 @@ export function DialogStatus() {
     return result.toSorted((a, b) => a.name.localeCompare(b.name))
   })
 
-  const getUsageColor = (percent: number) => {
-    if (percent >= 90) return theme.error
-    if (percent >= 70) return theme.warning
-    return theme.success
-  }
+  const colorFor = (percent: number) => colorFor(percent, theme)
 
   return (
     <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
@@ -85,8 +83,8 @@ export function DialogStatus() {
               {(fiveHour) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>5h:</text>
-                  <UsageBar percent={fiveHour().utilization} fg={getUsageColor(fiveHour().utilization)} bgMuted={theme.textMuted} />
-                  <text fg={getUsageColor(fiveHour().utilization)}>{fiveHour().utilization}%</text>
+                  <UsageBar percent={fiveHour().utilization} fg={colorFor(fiveHour().utilization)} bgMuted={theme.textMuted} />
+                  <text fg={colorFor(fiveHour().utilization)}>{fiveHour().utilization}%</text>
                   <text fg={theme.textMuted}>
                     (reset: {AnthropicUsage.formatResetTime(fiveHour().resets_at)})
                   </text>
@@ -97,8 +95,8 @@ export function DialogStatus() {
               {(sevenDay) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>7d:</text>
-                  <UsageBar percent={sevenDay().utilization} fg={getUsageColor(sevenDay().utilization)} bgMuted={theme.textMuted} />
-                  <text fg={getUsageColor(sevenDay().utilization)}>{sevenDay().utilization}%</text>
+                  <UsageBar percent={sevenDay().utilization} fg={colorFor(sevenDay().utilization)} bgMuted={theme.textMuted} />
+                  <text fg={colorFor(sevenDay().utilization)}>{sevenDay().utilization}%</text>
                   <text fg={theme.textMuted}>
                     (reset: {AnthropicUsage.formatResetTime(sevenDay().resets_at)})
                   </text>
@@ -109,8 +107,8 @@ export function DialogStatus() {
               {(opus) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>Opus 7d:</text>
-                  <UsageBar percent={opus().utilization} fg={getUsageColor(opus().utilization)} bgMuted={theme.textMuted} />
-                  <text fg={getUsageColor(opus().utilization)}>{opus().utilization}%</text>
+                  <UsageBar percent={opus().utilization} fg={colorFor(opus().utilization)} bgMuted={theme.textMuted} />
+                  <text fg={colorFor(opus().utilization)}>{opus().utilization}%</text>
                   <text fg={theme.textMuted}>
                     (reset: {AnthropicUsage.formatResetTime(opus().resets_at)})
                   </text>
@@ -131,8 +129,8 @@ export function DialogStatus() {
               {(primary) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>{OpenAIUsage.formatWindowDuration(primary().limit_window_seconds)}:</text>
-                  <UsageBar percent={primary().used_percent} fg={getUsageColor(primary().used_percent)} bgMuted={theme.textMuted} />
-                  <text fg={getUsageColor(primary().used_percent)}>{Math.round(primary().used_percent)}%</text>
+                  <UsageBar percent={primary().used_percent} fg={colorFor(primary().used_percent)} bgMuted={theme.textMuted} />
+                  <text fg={colorFor(primary().used_percent)}>{Math.round(primary().used_percent)}%</text>
                   <text fg={theme.textMuted}>
                     (reset: {OpenAIUsage.formatResetTime(primary().reset_at)})
                   </text>
@@ -143,8 +141,8 @@ export function DialogStatus() {
               {(secondary) => (
                 <box flexDirection="row" gap={1}>
                   <text fg={theme.text}>{OpenAIUsage.formatWindowDuration(secondary().limit_window_seconds)}:</text>
-                  <UsageBar percent={secondary().used_percent} fg={getUsageColor(secondary().used_percent)} bgMuted={theme.textMuted} />
-                  <text fg={getUsageColor(secondary().used_percent)}>{Math.round(secondary().used_percent)}%</text>
+                  <UsageBar percent={secondary().used_percent} fg={colorFor(secondary().used_percent)} bgMuted={theme.textMuted} />
+                  <text fg={colorFor(secondary().used_percent)}>{Math.round(secondary().used_percent)}%</text>
                   <text fg={theme.textMuted}>
                     (reset: {OpenAIUsage.formatResetTime(secondary().reset_at)})
                   </text>

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -1,15 +1,39 @@
-import { TextAttributes } from "@opentui/core"
+import { TextAttributes, RGBA } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useSync } from "@tui/context/sync"
-import { For, Match, Switch, Show, createMemo } from "solid-js"
+import { For, Match, Switch, Show, createMemo, createResource } from "solid-js"
+import { AnthropicUsage } from "@/usage/anthropic"
+import { OpenAIUsage } from "@/usage/openai"
 
 export type DialogStatusProps = {}
+
+function UsageBar(props: { percent: number; fg: RGBA; bgMuted: RGBA }) {
+  const width = 20
+  const filled = Math.round((props.percent / 100) * width)
+  const empty = width - filled
+  return (
+    <text>
+      <span style={{ fg: props.fg }}>{"█".repeat(filled)}</span>
+      <span style={{ fg: props.bgMuted }}>{"░".repeat(empty)}</span>
+    </text>
+  )
+}
 
 export function DialogStatus() {
   const sync = useSync()
   const { theme } = useTheme()
 
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
+
+  const [anthropicUsage, { refetch: refetchAnthropicUsage }] = createResource(
+    () => AnthropicUsage.fetch(),
+    { initialValue: null }
+  )
+
+  const [openaiUsage, { refetch: refetchOpenAIUsage }] = createResource(
+    () => OpenAIUsage.fetch(),
+    { initialValue: null }
+  )
 
   const plugins = createMemo(() => {
     const list = sync.data.config.plugin ?? []
@@ -36,6 +60,12 @@ export function DialogStatus() {
     return result.toSorted((a, b) => a.name.localeCompare(b.name))
   })
 
+  const getUsageColor = (percent: number) => {
+    if (percent >= 90) return theme.error
+    if (percent >= 70) return theme.warning
+    return theme.success
+  }
+
   return (
     <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
       <box flexDirection="row" justifyContent="space-between">
@@ -44,6 +74,99 @@ export function DialogStatus() {
         </text>
         <text fg={theme.textMuted}>esc</text>
       </box>
+
+      <Show when={anthropicUsage()} fallback={null}>
+        {(usage) => (
+          <box>
+            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+              Anthropic Usage
+            </text>
+            <Show when={usage().five_hour}>
+              {(fiveHour) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.text}>5h:</text>
+                  <UsageBar percent={fiveHour().utilization} fg={getUsageColor(fiveHour().utilization)} bgMuted={theme.textMuted} />
+                  <text fg={getUsageColor(fiveHour().utilization)}>{fiveHour().utilization}%</text>
+                  <text fg={theme.textMuted}>
+                    (reset: {AnthropicUsage.formatResetTime(fiveHour().resets_at)})
+                  </text>
+                </box>
+              )}
+            </Show>
+            <Show when={usage().seven_day}>
+              {(sevenDay) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.text}>7d:</text>
+                  <UsageBar percent={sevenDay().utilization} fg={getUsageColor(sevenDay().utilization)} bgMuted={theme.textMuted} />
+                  <text fg={getUsageColor(sevenDay().utilization)}>{sevenDay().utilization}%</text>
+                  <text fg={theme.textMuted}>
+                    (reset: {AnthropicUsage.formatResetTime(sevenDay().resets_at)})
+                  </text>
+                </box>
+              )}
+            </Show>
+            <Show when={usage().seven_day_opus}>
+              {(opus) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.text}>Opus 7d:</text>
+                  <UsageBar percent={opus().utilization} fg={getUsageColor(opus().utilization)} bgMuted={theme.textMuted} />
+                  <text fg={getUsageColor(opus().utilization)}>{opus().utilization}%</text>
+                  <text fg={theme.textMuted}>
+                    (reset: {AnthropicUsage.formatResetTime(opus().resets_at)})
+                  </text>
+                </box>
+              )}
+            </Show>
+          </box>
+        )}
+      </Show>
+
+      <Show when={openaiUsage()} fallback={null}>
+        {(usage) => (
+          <box>
+            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+              OpenAI Usage ({OpenAIUsage.getPlanDisplayName(usage().plan_type)})
+            </text>
+            <Show when={usage().rate_limit?.primary_window}>
+              {(primary) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.text}>{OpenAIUsage.formatWindowDuration(primary().limit_window_seconds)}:</text>
+                  <UsageBar percent={primary().used_percent} fg={getUsageColor(primary().used_percent)} bgMuted={theme.textMuted} />
+                  <text fg={getUsageColor(primary().used_percent)}>{Math.round(primary().used_percent)}%</text>
+                  <text fg={theme.textMuted}>
+                    (reset: {OpenAIUsage.formatResetTime(primary().reset_at)})
+                  </text>
+                </box>
+              )}
+            </Show>
+            <Show when={usage().rate_limit?.secondary_window}>
+              {(secondary) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.text}>{OpenAIUsage.formatWindowDuration(secondary().limit_window_seconds)}:</text>
+                  <UsageBar percent={secondary().used_percent} fg={getUsageColor(secondary().used_percent)} bgMuted={theme.textMuted} />
+                  <text fg={getUsageColor(secondary().used_percent)}>{Math.round(secondary().used_percent)}%</text>
+                  <text fg={theme.textMuted}>
+                    (reset: {OpenAIUsage.formatResetTime(secondary().reset_at)})
+                  </text>
+                </box>
+              )}
+            </Show>
+            <Show when={usage().credits}>
+              {(credits) => (
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.text}>Credits:</text>
+                  <Show when={credits().unlimited} fallback={
+                    <text fg={theme.text}>{OpenAIUsage.formatCredits(credits().balance)}</text>
+                  }>
+                    <text fg={theme.success}>Unlimited</text>
+                  </Show>
+                </box>
+              )}
+            </Show>
+          </box>
+        )}
+      </Show>
+
       <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
           <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useSync } from "@tui/context/sync"
-import { createMemo, For, Show, Switch, Match } from "solid-js"
+import { createMemo, For, Show, Switch, Match, createResource } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
@@ -11,6 +11,8 @@ import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
+import { AnthropicUsage } from "@/usage/anthropic"
+import { OpenAIUsage } from "@/usage/openai"
 
 export function Sidebar(props: { sessionID: string }) {
   const sync = useSync()
@@ -25,7 +27,25 @@ export function Sidebar(props: { sessionID: string }) {
     diff: true,
     todo: true,
     lsp: true,
+    usage: true,
   })
+
+  const [anthropicUsage] = createResource(() => AnthropicUsage.fetch(), { initialValue: null })
+  const [openaiUsage] = createResource(() => OpenAIUsage.fetch(), { initialValue: null })
+
+  const getUsageColor = (percent: number) => {
+    if (percent >= 90) return theme.error
+    if (percent >= 70) return theme.warning
+    return theme.success
+  }
+
+  const usageBar = (percent: number) => {
+    const width = 10
+    const filled = Math.round((percent / 100) * width)
+    return "█".repeat(filled) + "░".repeat(width - filled)
+  }
+
+  const hasUsageData = createMemo(() => anthropicUsage() || openaiUsage())
 
   // Sort MCP servers alphabetically for consistent display order
   const mcpEntries = createMemo(() => Object.entries(sync.data.mcp).sort(([a], [b]) => a.localeCompare(b)))
@@ -96,6 +116,68 @@ export function Sidebar(props: { sessionID: string }) {
               <text fg={theme.textMuted}>{context()?.percentage ?? 0}% used</text>
               <text fg={theme.textMuted}>{cost()} spent</text>
             </box>
+            <Show when={hasUsageData()}>
+              <box>
+                <box
+                  flexDirection="row"
+                  gap={1}
+                  onMouseDown={() => setExpanded("usage", !expanded.usage)}
+                >
+                  <text fg={theme.text}>{expanded.usage ? "▼" : "▶"}</text>
+                  <text fg={theme.text}>
+                    <b>Usage</b>
+                  </text>
+                </box>
+                <Show when={expanded.usage}>
+                  <Show when={anthropicUsage()}>
+                    {(usage) => (
+                      <>
+                        <text fg={theme.textMuted}>Anthropic</text>
+                        <Show when={usage().five_hour}>
+                          {(w) => (
+                            <text fg={theme.textMuted}>
+                              5h <span style={{ fg: getUsageColor(w().utilization) }}>{usageBar(w().utilization)}</span>
+                              {" "}{w().utilization}% ({AnthropicUsage.formatResetTime(w().resets_at)})
+                            </text>
+                          )}
+                        </Show>
+                        <Show when={usage().seven_day}>
+                          {(w) => (
+                            <text fg={theme.textMuted}>
+                              7d <span style={{ fg: getUsageColor(w().utilization) }}>{usageBar(w().utilization)}</span>
+                              {" "}{w().utilization}% ({AnthropicUsage.formatResetTime(w().resets_at)})
+                            </text>
+                          )}
+                        </Show>
+                      </>
+                    )}
+                  </Show>
+                  <Show when={openaiUsage()}>
+                    {(usage) => (
+                      <>
+                        <text fg={theme.textMuted}>OpenAI ({OpenAIUsage.getPlanDisplayName(usage().plan_type)})</text>
+                        <Show when={usage().rate_limit?.primary_window}>
+                          {(w) => (
+                            <text fg={theme.textMuted}>
+                              {OpenAIUsage.formatWindowDuration(w().limit_window_seconds)} <span style={{ fg: getUsageColor(w().used_percent) }}>{usageBar(w().used_percent)}</span>
+                              {" "}{Math.round(w().used_percent)}% ({OpenAIUsage.formatResetTime(w().reset_at)})
+                            </text>
+                          )}
+                        </Show>
+                        <Show when={usage().rate_limit?.secondary_window}>
+                          {(w) => (
+                            <text fg={theme.textMuted}>
+                              {OpenAIUsage.formatWindowDuration(w().limit_window_seconds)} <span style={{ fg: getUsageColor(w().used_percent) }}>{usageBar(w().used_percent)}</span>
+                              {" "}{Math.round(w().used_percent)}% ({OpenAIUsage.formatResetTime(w().reset_at)})
+                            </text>
+                          )}
+                        </Show>
+                      </>
+                    )}
+                  </Show>
+                </Show>
+              </box>
+            </Show>
             <Show when={mcpEntries().length > 0}>
               <box>
                 <box

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -43,7 +43,7 @@ export function Sidebar(props: { sessionID: string }) {
     { defer: true }
   ))
 
-  const colorFor = (percent: number) => colorFor(percent, theme)
+  const colorFor = (percent: number) => getUsageColor(percent, theme)
   const usageBar = (percent: number) => usageBarString(percent, 10)
 
   const hasUsageData = createMemo(() => anthropicUsage() || openaiUsage())

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useSync } from "@tui/context/sync"
-import { createMemo, For, Show, Switch, Match, createResource } from "solid-js"
+import { createMemo, For, Show, Switch, Match, createResource, createEffect, on } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
@@ -13,6 +13,7 @@ import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 import { AnthropicUsage } from "@/usage/anthropic"
 import { OpenAIUsage } from "@/usage/openai"
+import { getUsageColor, usageBarString } from "@/usage/utils"
 
 export function Sidebar(props: { sessionID: string }) {
   const sync = useSync()
@@ -30,20 +31,20 @@ export function Sidebar(props: { sessionID: string }) {
     usage: true,
   })
 
-  const [anthropicUsage] = createResource(() => AnthropicUsage.fetch(), { initialValue: null })
-  const [openaiUsage] = createResource(() => OpenAIUsage.fetch(), { initialValue: null })
+  const [anthropicUsage, { refetch: refetchAnthropic }] = createResource(() => AnthropicUsage.fetch(), { initialValue: null })
+  const [openaiUsage, { refetch: refetchOpenAI }] = createResource(() => OpenAIUsage.fetch(), { initialValue: null })
 
-  const getUsageColor = (percent: number) => {
-    if (percent >= 90) return theme.error
-    if (percent >= 70) return theme.warning
-    return theme.success
-  }
+  createEffect(on(
+    () => messages().length,
+    () => {
+      refetchAnthropic()
+      refetchOpenAI()
+    },
+    { defer: true }
+  ))
 
-  const usageBar = (percent: number) => {
-    const width = 10
-    const filled = Math.round((percent / 100) * width)
-    return "█".repeat(filled) + "░".repeat(width - filled)
-  }
+  const colorFor = (percent: number) => colorFor(percent, theme)
+  const usageBar = (percent: number) => usageBarString(percent, 10)
 
   const hasUsageData = createMemo(() => anthropicUsage() || openaiUsage())
 
@@ -136,7 +137,7 @@ export function Sidebar(props: { sessionID: string }) {
                         <Show when={usage().five_hour}>
                           {(w) => (
                             <text fg={theme.textMuted}>
-                              5h <span style={{ fg: getUsageColor(w().utilization) }}>{usageBar(w().utilization)}</span>
+                              5h <span style={{ fg: colorFor(w().utilization) }}>{usageBar(w().utilization)}</span>
                               {" "}{w().utilization}% ({AnthropicUsage.formatResetTime(w().resets_at)})
                             </text>
                           )}
@@ -144,7 +145,7 @@ export function Sidebar(props: { sessionID: string }) {
                         <Show when={usage().seven_day}>
                           {(w) => (
                             <text fg={theme.textMuted}>
-                              7d <span style={{ fg: getUsageColor(w().utilization) }}>{usageBar(w().utilization)}</span>
+                              7d <span style={{ fg: colorFor(w().utilization) }}>{usageBar(w().utilization)}</span>
                               {" "}{w().utilization}% ({AnthropicUsage.formatResetTime(w().resets_at)})
                             </text>
                           )}
@@ -159,7 +160,7 @@ export function Sidebar(props: { sessionID: string }) {
                         <Show when={usage().rate_limit?.primary_window}>
                           {(w) => (
                             <text fg={theme.textMuted}>
-                              {OpenAIUsage.formatWindowDuration(w().limit_window_seconds)} <span style={{ fg: getUsageColor(w().used_percent) }}>{usageBar(w().used_percent)}</span>
+                              {OpenAIUsage.formatWindowDuration(w().limit_window_seconds)} <span style={{ fg: colorFor(w().used_percent) }}>{usageBar(w().used_percent)}</span>
                               {" "}{Math.round(w().used_percent)}% ({OpenAIUsage.formatResetTime(w().reset_at)})
                             </text>
                           )}
@@ -167,7 +168,7 @@ export function Sidebar(props: { sessionID: string }) {
                         <Show when={usage().rate_limit?.secondary_window}>
                           {(w) => (
                             <text fg={theme.textMuted}>
-                              {OpenAIUsage.formatWindowDuration(w().limit_window_seconds)} <span style={{ fg: getUsageColor(w().used_percent) }}>{usageBar(w().used_percent)}</span>
+                              {OpenAIUsage.formatWindowDuration(w().limit_window_seconds)} <span style={{ fg: colorFor(w().used_percent) }}>{usageBar(w().used_percent)}</span>
                               {" "}{Math.round(w().used_percent)}% ({OpenAIUsage.formatResetTime(w().reset_at)})
                             </text>
                           )}

--- a/packages/opencode/src/usage/anthropic.ts
+++ b/packages/opencode/src/usage/anthropic.ts
@@ -28,6 +28,7 @@ export namespace AnthropicUsage {
           "anthropic-beta": "oauth-2025-04-20",
           Accept: "application/json",
         },
+        signal: AbortSignal.timeout(10_000),
       })
 
       if (!response.ok) {
@@ -54,6 +55,9 @@ export namespace AnthropicUsage {
     const date = new Date(isoString)
     const now = new Date()
     const diffMs = date.getTime() - now.getTime()
+
+    if (diffMs <= 0) return "refreshing"
+
     const diffMins = Math.floor(diffMs / 60000)
     const diffHours = Math.floor(diffMins / 60)
 

--- a/packages/opencode/src/usage/anthropic.ts
+++ b/packages/opencode/src/usage/anthropic.ts
@@ -1,0 +1,72 @@
+import { Auth } from "@/auth"
+import z from "zod"
+
+export namespace AnthropicUsage {
+  const UsageWindow = z.object({
+    utilization: z.number(),
+    resets_at: z.string().nullable(),
+  })
+
+  export const UsageData = z.object({
+    five_hour: UsageWindow.nullish(),
+    seven_day: UsageWindow.nullish(),
+    seven_day_opus: UsageWindow.nullish(),
+  })
+  export type UsageData = z.infer<typeof UsageData>
+
+  export async function fetch(): Promise<UsageData | null> {
+    const auth = await Auth.get("anthropic")
+    if (!auth || auth.type !== "oauth") {
+      return null
+    }
+
+    try {
+      const response = await globalThis.fetch("https://api.anthropic.com/api/oauth/usage", {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${auth.access}`,
+          "anthropic-beta": "oauth-2025-04-20",
+          Accept: "application/json",
+        },
+      })
+
+      if (!response.ok) {
+        console.error(`Anthropic usage API error: ${response.status}`)
+        return null
+      }
+
+      const data = await response.json()
+      const parsed = UsageData.safeParse(data)
+      if (!parsed.success) {
+        console.error("Failed to parse Anthropic usage data:", parsed.error)
+        return null
+      }
+
+      return parsed.data
+    } catch (error) {
+      console.error("Failed to fetch Anthropic usage:", error)
+      return null
+    }
+  }
+
+  export function formatResetTime(isoString: string | null): string {
+    if (!isoString) return "N/A"
+    const date = new Date(isoString)
+    const now = new Date()
+    const diffMs = date.getTime() - now.getTime()
+    const diffMins = Math.floor(diffMs / 60000)
+    const diffHours = Math.floor(diffMins / 60)
+
+    if (diffHours >= 24) {
+      const days = Math.floor(diffHours / 24)
+      return `${days}d ${diffHours % 24}h`
+    }
+    if (diffHours > 0) {
+      return `${diffHours}h ${diffMins % 60}m`
+    }
+    if (diffMins > 0) {
+      return `${diffMins}m`
+    }
+    return "soon"
+  }
+}

--- a/packages/opencode/src/usage/openai.ts
+++ b/packages/opencode/src/usage/openai.ts
@@ -1,0 +1,143 @@
+import { Auth } from "@/auth"
+import z from "zod"
+
+export namespace OpenAIUsage {
+  export const PlanType = z.enum([
+    "free",
+    "plus",
+    "pro",
+    "team",
+    "business",
+    "enterprise",
+    "edu",
+    "education",
+    "guest",
+    "go",
+    "free_workspace",
+    "quorum",
+    "k12",
+  ])
+  export type PlanType = z.infer<typeof PlanType>
+
+  export const RateLimitWindow = z.object({
+    used_percent: z.number(),
+    limit_window_seconds: z.number(),
+    reset_at: z.number(),
+  })
+
+  export const RateLimitDetails = z.object({
+    allowed: z.boolean().optional(),
+    limit_reached: z.boolean().optional(),
+    primary_window: RateLimitWindow.optional().nullable(),
+    secondary_window: RateLimitWindow.optional().nullable(),
+  })
+
+  export const CreditStatus = z.object({
+    has_credits: z.boolean().optional(),
+    unlimited: z.boolean().optional(),
+    balance: z.union([z.string(), z.number()]).optional().nullable(),
+  })
+
+  export const UsageData = z.object({
+    plan_type: PlanType,
+    rate_limit: RateLimitDetails.optional().nullable(),
+    credits: CreditStatus.optional().nullable(),
+  })
+  export type UsageData = z.infer<typeof UsageData>
+
+  export function getPlanDisplayName(planType: PlanType): string {
+    const names: Record<PlanType, string> = {
+      free: "Free",
+      plus: "Plus",
+      pro: "Pro",
+      team: "Team",
+      business: "Business",
+      enterprise: "Enterprise",
+      edu: "Education",
+      education: "Education",
+      guest: "Guest",
+      go: "Go",
+      free_workspace: "Free Workspace",
+      quorum: "Quorum",
+      k12: "K-12",
+    }
+    return names[planType] || planType
+  }
+
+  export async function fetch(): Promise<UsageData | null> {
+    const auth = await Auth.get("openai")
+    if (!auth || auth.type !== "oauth") {
+      return null
+    }
+
+    try {
+      const response = await globalThis.fetch("https://chatgpt.com/backend-api/wham/usage", {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${auth.access}`,
+          Accept: "application/json",
+          "User-Agent": "opencode-cli",
+        },
+      })
+
+      if (!response.ok) {
+        console.error(`OpenAI usage API error: ${response.status}`)
+        return null
+      }
+
+      const data = await response.json()
+      const parsed = UsageData.safeParse(data)
+      if (!parsed.success) {
+        console.error("Failed to parse OpenAI usage data:", parsed.error)
+        return null
+      }
+
+      return parsed.data
+    } catch (error) {
+      console.error("Failed to fetch OpenAI usage:", error)
+      return null
+    }
+  }
+
+  export function formatWindowDuration(seconds: number): string {
+    const minutes = Math.floor(seconds / 60)
+    const hours = Math.floor(minutes / 60)
+    const days = Math.floor(hours / 24)
+
+    if (days >= 1) {
+      return `${days}d`
+    }
+    if (hours >= 1) {
+      return `${hours}h`
+    }
+    return `${minutes}m`
+  }
+
+  export function formatResetTime(unixTimestamp: number): string {
+    const date = new Date(unixTimestamp * 1000)
+    const now = new Date()
+    const diffMs = date.getTime() - now.getTime()
+    const diffMins = Math.floor(diffMs / 60000)
+    const diffHours = Math.floor(diffMins / 60)
+
+    if (diffHours >= 24) {
+      const days = Math.floor(diffHours / 24)
+      return `${days}d ${diffHours % 24}h`
+    }
+    if (diffHours > 0) {
+      return `${diffHours}h ${diffMins % 60}m`
+    }
+    if (diffMins > 0) {
+      return `${diffMins}m`
+    }
+    return "soon"
+  }
+
+  export function formatCredits(balance: string | number | null | undefined): string {
+    if (balance === null || balance === undefined) {
+      return "N/A"
+    }
+    const num = typeof balance === "string" ? parseFloat(balance) : balance
+    return `$${num.toFixed(2)}`
+  }
+}

--- a/packages/opencode/src/usage/openai.ts
+++ b/packages/opencode/src/usage/openai.ts
@@ -78,6 +78,7 @@ export namespace OpenAIUsage {
           Accept: "application/json",
           "User-Agent": "opencode-cli",
         },
+        signal: AbortSignal.timeout(10_000),
       })
 
       if (!response.ok) {
@@ -117,6 +118,9 @@ export namespace OpenAIUsage {
     const date = new Date(unixTimestamp * 1000)
     const now = new Date()
     const diffMs = date.getTime() - now.getTime()
+
+    if (diffMs <= 0) return "refreshing"
+
     const diffMins = Math.floor(diffMs / 60000)
     const diffHours = Math.floor(diffMins / 60)
 
@@ -137,7 +141,10 @@ export namespace OpenAIUsage {
     if (balance === null || balance === undefined) {
       return "N/A"
     }
-    const num = typeof balance === "string" ? parseFloat(balance) : balance
+    const num = typeof balance === "string" ? Number(balance) : balance
+    if (typeof num !== "number" || !Number.isFinite(num)) {
+      return "N/A"
+    }
     return `$${num.toFixed(2)}`
   }
 }

--- a/packages/opencode/src/usage/utils.ts
+++ b/packages/opencode/src/usage/utils.ts
@@ -1,0 +1,17 @@
+import type { RGBA } from "@opentui/core"
+
+export function getUsageColor(percent: number, theme: { error: RGBA; warning: RGBA; success: RGBA }): RGBA {
+  if (percent >= 90) return theme.error
+  if (percent >= 70) return theme.warning
+  return theme.success
+}
+
+export function clampPercent(percent: number): number {
+  return Math.max(0, Math.min(100, percent))
+}
+
+export function usageBarString(percent: number, width: number = 10): string {
+  const clamped = clampPercent(percent)
+  const filled = Math.round((clamped / 100) * width)
+  return "\u2588".repeat(filled) + "\u2591".repeat(width - filled)
+}


### PR DESCRIPTION
## Summary

Adds real-time usage display for Anthropic and OpenAI OAuth accounts in both the status dialog (`/status`) and the sidebar.

## Features

- **Anthropic Usage**: Shows 5-hour and 7-day rate limit windows with utilization % and reset times
- **OpenAI Usage**: Shows primary/secondary rate limit windows, plan type (Free/Plus/Pro/etc), and credits balance
- **Visual Progress Bars**: Color-coded bars (green → yellow → red) based on utilization level
- **Reset Time Display**: Human-readable countdown (e.g., "2h 15m", "5d 3h")

## Screenshots

### Status Dialog (`/status` or `Ctrl+X S`)
```
Anthropic Usage
5h:  ██░░░░░░░░░░░░░░░░░░ 9%   (reset: 2h 15m)
7d:  ████░░░░░░░░░░░░░░░░ 21%  (reset: 5d 3h)

OpenAI Usage (Pro)
5h:  ░░░░░░░░░░░░░░░░░░░░ 0%   (reset: 4h 59m)
7d:  ██████░░░░░░░░░░░░░░ 30%  (reset: 4d 2h)
Credits: $1000.00
```

### Sidebar (collapsible Usage section)
```
▼ Usage
Anthropic
5h █░░░░░░░░░ 9% (2h 15m)
7d ██░░░░░░░░ 21% (5d 3h)
OpenAI (Pro)
5h ░░░░░░░░░░ 0% (4h 59m)
7d ███░░░░░░░ 30% (4d 2h)
```

## Implementation

### New Files
- `src/usage/anthropic.ts`: Fetches from `api.anthropic.com/api/oauth/usage`
- `src/usage/openai.ts`: Fetches from `chatgpt.com/backend-api/wham/usage`

### Modified Files
- `dialog-status.tsx`: Added usage sections with progress bars
- `sidebar.tsx`: Added collapsible Usage section

## API Details

| Provider | Endpoint | Auth |
|----------|----------|------|
| Anthropic | `GET api.anthropic.com/api/oauth/usage` | OAuth token + `anthropic-beta: oauth-2025-04-20` |
| OpenAI | `GET chatgpt.com/backend-api/wham/usage` | OAuth Bearer token |

## Related

- #6298 - Plan usage tracking (z.ai) - Similar feature for different provider. Could potentially be integrated with their registry pattern in the future.

## Notes

- Only shows usage when OAuth is configured (falls back gracefully if not)
- Uses Zod for runtime validation of API responses
- Sidebar uses compact 10-char progress bar; status dialog uses 20-char bar