### PR TITLE
fix(tui): make bash outputs respect "Show tool details" toggle

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -93,6 +93,8 @@ const context = createContext<{
   showDetails: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
+  toolExpanded: (partId: string) => boolean
+  toggleToolExpanded: (partId: string) => void
 }>()
 
 function use() {
@@ -893,7 +895,22 @@ export function Session() {
   const dialog = useDialog()
   const renderer = useRenderer()
 
-  // snap to bottom when session changes
+  const [expandedToolPartIds, setExpandedToolPartIds] = createSignal<Set<string>>(new Set())
+
+  const toolExpanded = (partId: string) => expandedToolPartIds().has(partId)
+
+  const toggleToolExpanded = (partId: string) => {
+    setExpandedToolPartIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(partId)) {
+        next.delete(partId)
+      } else {
+        next.add(partId)
+      }
+      return next
+    })
+  }
+
   createEffect(on(() => route.sessionID, toBottom))
 
   return (
@@ -910,6 +927,8 @@ export function Session() {
         showDetails,
         diffWrapMode,
         sync,
+        toolExpanded,
+        toggleToolExpanded,
       }}
     >
       <box flexDirection="row">
@@ -1459,11 +1478,27 @@ function InlineTool(props: { icon: string; complete: any; pending: string; child
   )
 }
 
-function BlockTool(props: { title: string; children: JSX.Element; onClick?: () => void; part?: ToolPart }) {
+function BlockTool(props: {
+  title: string
+  children: JSX.Element
+  onClick?: () => void
+  onExpand?: () => void
+  part?: ToolPart
+}) {
   const { theme } = useTheme()
   const renderer = useRenderer()
+  const keybind = useKeybind()
   const [hover, setHover] = createSignal(false)
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
+
+  useKeyboard((evt) => {
+    if (!hover()) return
+    if (evt.name === "o" && props.onExpand) {
+      evt.preventDefault()
+      props.onExpand()
+    }
+  })
+
   return (
     <box
       border={["left"]}
@@ -1475,11 +1510,15 @@ function BlockTool(props: { title: string; children: JSX.Element; onClick?: () =
       backgroundColor={hover() ? theme.backgroundMenu : theme.backgroundPanel}
       customBorderChars={SplitBorder.customBorderChars}
       borderColor={theme.background}
-      onMouseOver={() => props.onClick && setHover(true)}
+      onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
         if (renderer.getSelection()?.getSelectedText()) return
-        props.onClick?.()
+        if (props.onExpand) {
+          props.onExpand()
+        } else {
+          props.onClick?.()
+        }
       }}
     >
       <text paddingLeft={3} fg={theme.textMuted}>
@@ -1494,15 +1533,48 @@ function BlockTool(props: { title: string; children: JSX.Element; onClick?: () =
 }
 
 function Bash(props: ToolProps<typeof BashTool>) {
+  const ctx = use()
   const output = createMemo(() => stripAnsi(props.metadata.output?.trim() ?? ""))
   const { theme } = useTheme()
+
+  const MAX_LINES = 5
+
+  const outputLines = createMemo(() => output().split("\n"))
+  const isLongOutput = createMemo(() => outputLines().length > MAX_LINES)
+  const isExpanded = createMemo(() => ctx.toolExpanded(props.part.id))
+
+  const displayOutput = createMemo(() => {
+    if (!ctx.showDetails() && !isExpanded()) {
+      if (isLongOutput()) {
+        return outputLines().slice(0, MAX_LINES).join("\n")
+      }
+    }
+    return output()
+  })
+
+  const hiddenLines = createMemo(() => {
+    if (!ctx.showDetails() && !isExpanded() && isLongOutput()) {
+      return outputLines().length - MAX_LINES
+    }
+    return 0
+  })
+
   return (
     <Switch>
       <Match when={props.metadata.output !== undefined}>
-        <BlockTool title={"# " + (props.input.description ?? "Shell")} part={props.part}>
+        <BlockTool
+          title={"# " + (props.input.description ?? "Shell")}
+          part={props.part}
+          onExpand={() => ctx.toggleToolExpanded(props.part.id)}
+        >
           <box gap={1}>
-            <text fg={theme.text}>$ {props.input.command}</text>
-            <text fg={theme.text}>{output()}</text>
+            <Show when={ctx.showDetails() || isExpanded()}>
+              <text fg={theme.text}>$ {props.input.command}</text>
+            </Show>
+            <text fg={theme.text}>{displayOutput()}</text>
+            <Show when={hiddenLines() > 0}>
+              <text fg={theme.textMuted}>... +{hiddenLines()} lines (press 'o' to expand)</text>
+            </Show>
           </box>
         </BlockTool>
       </Match>


### PR DESCRIPTION
## Summary

Completes the existing "Show tool details" feature (`Ctrl+P` command palette) by making it affect bash output rendering in the live TUI view, not just transcript exports.

## Problem

The "Show tool details" toggle only affected transcript exports. Bash outputs in the live TUI always showed:
- Full commands with hundreds of characters of environment variables
- Complete output regardless of length  
- No way to collapse verbose outputs

This made the TUI difficult to navigate and scan through session history.

## Solution

- Bash outputs now respect the `showDetails()` setting
- Truncate output to 5 lines when tool details are hidden
- Hide verbose env var prefixes when collapsed
- Add 'o' key to toggle individual bash output expansion
- Show "... +N lines (press 'o' to expand)" indicator

## User Experience

**Before** (tool details always shown):
```
# Push to remote
$ export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never HOMEBREW_NO_AUTO_UPDATE=1 GIT_EDITOR=: EDITOR=: VISUAL='' GIT_SEQUENCE_EDITOR=: GIT_MERGE_AUTOEDIT=no GIT_PAGER=cat PAGER=cat npm_config_yes=true PIP_NO_INPUT=1 YARN_ENABLE_IMMUTABLE_INSTALLS=false; git push origin main

Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 328 bytes | 328.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:user/repo.git
   abc1234..def5678  main -> main
[20+ lines total...]
```

**After** (respects "Show tool details" setting):
```
# Push to remote
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 328 bytes | 328.00 KiB/s, done.
... +15 lines (press 'o' to expand)
```

## Changes

- Added per-tool expansion state tracking
- Updated `BlockTool` component to support `onExpand` callback and 'o' key handler  
- Modified `Bash` component to respect `showDetails()` setting
- 5-line truncation threshold with line count indicator

## Testing

1. Run bash commands with varying output lengths
2. Toggle "Show tool details" via `Ctrl+P`
3. Press 'o' on individual outputs to expand/collapse
4. Verify truncated outputs show "... +N lines" indicator
