### PR TITLE
fix(provider): add support for jp. prefix in Amazon Bedrock cross-region inference profiles

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -195,8 +195,8 @@ export namespace Provider {
           credentialProvider: fromNodeProviderChain(),
         },
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-          // Skip region prefixing if model already has global prefix
-          if (modelID.startsWith("global.")) {
+          // Skip region prefixing if model already has a cross-region inference profile prefix
+          if (modelID.startsWith("global.") || modelID.startsWith("jp.")) {
             return sdk.languageModel(modelID)
           }
 


### PR DESCRIPTION
## Problem

When using Amazon Bedrock with the `jp.` cross-region inference profile prefix (e.g., `jp.anthropic.claude-sonnet-4-5-20250929-v1:0`), OpenCode incorrectly adds an additional region prefix, causing the model invocation to fail.

Currently, OpenCode only skips region prefixing for models starting with `global.`, but AWS Bedrock also provides a `jp.` (Japan) cross-region inference profile, which is required for using certain models in the `ap-northeast-1` (Tokyo) region.

### Example

When configuring:
```json
{
  "model": "amazon-bedrock/jp.anthropic.claude-sonnet-4-5-20250929-v1:0"
}
```

With `AWS_REGION=ap-northeast-1`, OpenCode currently transforms this to `apac.jp.anthropic.claude-sonnet-4-5-20250929-v1:0`, which is invalid.

## Solution

Add `jp.` to the list of prefixes that skip automatic region prefixing, alongside the existing `global.` prefix.

## Changes

- Modified `packages/opencode/src/provider/provider.ts` to recognize `jp.` prefix as a cross-region inference profile prefix that should not have additional region prefixes added.

## Background

The `jp.` prefix is a Japan-specific cross-region inference profile provided by AWS Bedrock. Unlike the `apac.` prefix (which covers broader Asia Pacific regions), the `jp.` prefix routes requests specifically to the Japan (Tokyo) region infrastructure.

Some models like Claude Sonnet 4.5 are available with the `jp.` inference profile but not with the `apac.` profile, making this fix necessary for users in the Japan region.

## Testing

Tested with:
- Model: `jp.anthropic.claude-sonnet-4-5-20250929-v1:0`
- Region: `ap-northeast-1`
- Result: Model invocation succeeds without incorrect prefix transformation