### PR TITLE
chore: update repository references from sst/opencode to anomalyco/opencode

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run opencode
         if: steps.commits.outputs.has_commits == 'true'
-        uses: sst/opencode/github@latest
+        uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:

--- a/.opencode/tool/github-pr-search.txt
+++ b/.opencode/tool/github-pr-search.txt
@@ -1,6 +1,6 @@
 Use this tool to search GitHub pull requests by title and description.
 
-This tool searches PRs in the sst/opencode repository and returns LLM-friendly results including:
+This tool searches PRs in the anomalyco/opencode repository and returns LLM-friendly results including:
 - PR number and title
 - Author
 - State (open/closed/merged)

--- a/packages/opencode/test/cli/github-remote.test.ts
+++ b/packages/opencode/test/cli/github-remote.test.ts
@@ -2,27 +2,33 @@ import { test, expect } from "bun:test"
 import { parseGitHubRemote } from "../../src/cli/cmd/github"
 
 test("parses https URL with .git suffix", () => {
-  expect(parseGitHubRemote("https://github.com/sst/opencode.git")).toEqual({ owner: "sst", repo: "opencode" })
+  expect(parseGitHubRemote("https://github.com/anomalyco/opencode.git")).toEqual({
+    owner: "anomalyco",
+    repo: "opencode",
+  })
 })
 
 test("parses https URL without .git suffix", () => {
-  expect(parseGitHubRemote("https://github.com/sst/opencode")).toEqual({ owner: "sst", repo: "opencode" })
+  expect(parseGitHubRemote("https://github.com/anomalyco/opencode")).toEqual({ owner: "anomalyco", repo: "opencode" })
 })
 
 test("parses git@ URL with .git suffix", () => {
-  expect(parseGitHubRemote("git@github.com:sst/opencode.git")).toEqual({ owner: "sst", repo: "opencode" })
+  expect(parseGitHubRemote("git@github.com:anomalyco/opencode.git")).toEqual({ owner: "anomalyco", repo: "opencode" })
 })
 
 test("parses git@ URL without .git suffix", () => {
-  expect(parseGitHubRemote("git@github.com:sst/opencode")).toEqual({ owner: "sst", repo: "opencode" })
+  expect(parseGitHubRemote("git@github.com:anomalyco/opencode")).toEqual({ owner: "anomalyco", repo: "opencode" })
 })
 
 test("parses ssh:// URL with .git suffix", () => {
-  expect(parseGitHubRemote("ssh://git@github.com/sst/opencode.git")).toEqual({ owner: "sst", repo: "opencode" })
+  expect(parseGitHubRemote("ssh://git@github.com/anomalyco/opencode.git")).toEqual({
+    owner: "anomalyco",
+    repo: "opencode",
+  })
 })
 
 test("parses ssh:// URL without .git suffix", () => {
-  expect(parseGitHubRemote("ssh://git@github.com/sst/opencode")).toEqual({ owner: "sst", repo: "opencode" })
+  expect(parseGitHubRemote("ssh://git@github.com/anomalyco/opencode")).toEqual({ owner: "anomalyco", repo: "opencode" })
 })
 
 test("parses http URL", () => {


### PR DESCRIPTION
Updates all references from `sst/opencode` to `anomalyco/opencode` following the repository transfer to the new organization.