### PR TITLE
fix(desktop): prevent multiple app instances with single-instance plugin

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-window-state = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-http = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-single-instance = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -189,6 +189,17 @@ pub fn run() {
     let updater_enabled = option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some();
 
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // When a second instance is launched, focus the existing window
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_focus();
+                #[cfg(target_os = "windows")]
+                {
+                    // On Windows, also unminimize if minimized
+                    let _ = window.unminimize();
+                }
+            }
+        }))
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())


### PR DESCRIPTION
## Summary

- Adds `tauri-plugin-single-instance` to prevent multiple instances of OpenCode Desktop from running simultaneously
- When a second instance is launched, it focuses the existing window instead of spawning a new one

## Problem

When launching OpenCode Desktop multiple times (intentionally or accidentally), the app spawns multiple instances. Each instance:
1. Calls `get_sidecar_port()` which binds to a **random free port** (since `OPENCODE_PORT` is typically not set)
2. Checks `is_server_running(port)` which returns `false` for the new random port
3. Spawns a new `opencode-cli serve --port=XXXXX` process

This leads to:
- Multiple windows opening unexpectedly
- Multiple background `opencode-cli serve` processes consuming resources
- Port exhaustion in extreme cases
- User confusion

## Solution

Uses Tauri's official `tauri-plugin-single-instance` plugin:
1. On app launch, the plugin acquires a system-wide lock
2. If another instance already holds the lock, the new instance sends its arguments to the existing instance and exits
3. The existing instance receives a callback and focuses its window

This is the standard pattern recommended by Tauri for single-instance apps.

## Changes

- `Cargo.toml`: Added `tauri-plugin-single-instance = "2"` dependency
- `lib.rs`: Added single-instance plugin initialization with window focus callback

## Testing

- Launch app → works normally
- Launch app again → existing window focuses, no new instance spawned
- Close app → lock released, can launch fresh instance