### PR TITLE
ci: prevent duplicate PR check from flagging current PR as duplicate

### DIFF
--- a/.github/workflows/duplicate-prs.yml
+++ b/.github/workflows/duplicate-prs.yml
@@ -44,6 +44,8 @@ jobs:
           {
             echo "Check for duplicate PRs related to this new PR:"
             echo ""
+            echo "CURRENT_PR_NUMBER: $PR_NUMBER"
+            echo ""
             echo "Title: $(gh pr view "$PR_NUMBER" --json title --jq .title)"
             echo ""
             echo "Description:"

--- a/.opencode/agent/duplicate-pr.md
+++ b/.opencode/agent/duplicate-pr.md
@@ -12,7 +12,7 @@ You are a duplicate PR detection agent. When a PR is opened, your job is to sear
 
 Use the github-pr-search tool to search for PRs that might be addressing the same issue or feature.
 
-IMPORTANT: The input will contain a line `CURRENT_PR_NUMBER: NNNN`. You MUST pass this number as the `excludePR` parameter to every github-pr-search call to avoid flagging the current PR as a duplicate of itself.
+IMPORTANT: The input will contain a line `CURRENT_PR_NUMBER: NNNN`. This is the current PR number, you should not mark that the current PR as a duplicate of itself.
 
 Search using keywords from the PR title and description. Try multiple searches with different relevant terms.
 

--- a/.opencode/agent/duplicate-pr.md
+++ b/.opencode/agent/duplicate-pr.md
@@ -12,6 +12,8 @@ You are a duplicate PR detection agent. When a PR is opened, your job is to sear
 
 Use the github-pr-search tool to search for PRs that might be addressing the same issue or feature.
 
+IMPORTANT: The input will contain a line `CURRENT_PR_NUMBER: NNNN`. You MUST pass this number as the `excludePR` parameter to every github-pr-search call to avoid flagging the current PR as a duplicate of itself.
+
 Search using keywords from the PR title and description. Try multiple searches with different relevant terms.
 
 If you find potential duplicates:

--- a/.opencode/tool/github-pr-search.ts
+++ b/.opencode/tool/github-pr-search.ts
@@ -19,7 +19,6 @@ async function githubFetch(endpoint: string, options: RequestInit = {}) {
 }
 
 interface PR {
-  number: number
   title: string
   html_url: string
 }
@@ -30,11 +29,6 @@ export default tool({
     query: tool.schema.string().describe("Search query for PR titles and descriptions"),
     limit: tool.schema.number().describe("Maximum number of results to return").default(10),
     offset: tool.schema.number().describe("Number of results to skip for pagination").default(0),
-    excludePR: tool.schema
-      .number()
-      .min(1)
-      .optional()
-      .describe("PR number to exclude from results (typically the current PR)"),
   },
   async execute(args) {
     const owner = "anomalyco"
@@ -50,9 +44,7 @@ export default tool({
       return `No PRs found matching "${args.query}"`
     }
 
-    const allPrs = result.items as PR[]
-    // Exclude the current PR from results to avoid self-duplicate detection
-    const prs = args.excludePR ? allPrs.filter((pr) => pr.number !== args.excludePR) : allPrs
+    const prs = result.items as PR[]
 
     if (prs.length === 0) {
       return `No other PRs found matching "${args.query}"`

--- a/.opencode/tool/github-pr-search.ts
+++ b/.opencode/tool/github-pr-search.ts
@@ -19,6 +19,7 @@ async function githubFetch(endpoint: string, options: RequestInit = {}) {
 }
 
 interface PR {
+  number: number
   title: string
   html_url: string
 }
@@ -29,6 +30,11 @@ export default tool({
     query: tool.schema.string().describe("Search query for PR titles and descriptions"),
     limit: tool.schema.number().describe("Maximum number of results to return").default(10),
     offset: tool.schema.number().describe("Number of results to skip for pagination").default(0),
+    excludePR: tool.schema
+      .number()
+      .min(1)
+      .optional()
+      .describe("PR number to exclude from results (typically the current PR)"),
   },
   async execute(args) {
     const owner = "anomalyco"
@@ -44,7 +50,14 @@ export default tool({
       return `No PRs found matching "${args.query}"`
     }
 
-    const prs = result.items as PR[]
+    const allPrs = result.items as PR[]
+    // Exclude the current PR from results to avoid self-duplicate detection
+    const prs = args.excludePR ? allPrs.filter((pr) => pr.number !== args.excludePR) : allPrs
+
+    if (prs.length === 0) {
+      return `No other PRs found matching "${args.query}"`
+    }
+
     const formatted = prs.map((pr) => `${pr.title}\n${pr.html_url}`).join("\n\n")
 
     return `Found ${result.total_count} PRs (showing ${prs.length}):\n\n${formatted}`


### PR DESCRIPTION
## Problem

When a new PR is opened, the duplicate PR detection workflow searches for similar PRs.
However, the search results include the newly opened PR itself, causing it to be
incorrectly flagged as a "duplicate" of itself.

## Solution

- Added `excludePR` parameter to the `github-pr-search` tool to filter out a specific PR
- Updated the workflow to pass the current PR number explicitly via `CURRENT_PR_NUMBER`
- Updated agent instructions to use this parameter