### PR TITLE
fix(desktop): add single-instance protection to prevent multiple app spawns

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-window-state = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-http = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-single-instance = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -189,6 +189,16 @@ pub fn run() {
     let updater_enabled = option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some();
 
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // When a second instance is launched, focus the existing window instead
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_focus();
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = window.unminimize();
+                }
+            }
+        }))
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
@@ -222,6 +232,10 @@ pub fn run() {
                     let timestamp = Instant::now();
                     loop {
                         if timestamp.elapsed() > Duration::from_secs(7) {
+                            // Kill the sidecar before showing dialog to prevent orphaned processes
+                            let _ = child.kill();
+                            println!("Killed sidecar due to startup timeout");
+
                             let res = app.dialog()
                               .message("Failed to spawn OpenCode Server. Copy logs using the button below and send them to the team for assistance.")
                               .title("Startup Failed")


### PR DESCRIPTION
## Summary
- Adds `tauri-plugin-single-instance` to prevent multiple desktop app instances
- **Fixes orphaned sidecar cleanup** - kills the sidecar process on startup timeout before exiting

## Problem
Opening the OpenCode desktop app would spawn orphaned `opencode-cli serve` processes that accumulate over time, even from a **single launch attempt**. Users reported 100+ orphaned processes consuming system resources.

## Root Cause
When the sidecar fails to start within 7 seconds (e.g., due to module loading errors like the `@tarquinen/opencode-dcp` Bun compatibility issue), the app would:
1. Show "Startup Failed" dialog
2. Call `app.exit(1)`
3. **But never kill the spawned sidecar process** - leaving it orphaned

Each failed launch attempt would leave another orphaned process. The random port allocation (`TcpListener::bind("127.0.0.1:0")`) meant each orphan ran on a different port.

## Solution
1. **Kill sidecar on startup failure**: Added `child.kill()` before showing the failure dialog and exiting
2. **Single-instance guard**: Added `tauri-plugin-single-instance` to prevent concurrent launches (secondary fix)

## Changes
- `packages/desktop/src-tauri/Cargo.toml`: Added `tauri-plugin-single-instance = "2"`
- `packages/desktop/src-tauri/src/lib.rs`: 
  - Initialize single-instance plugin with window focus callback
  - Kill sidecar process on startup timeout before exiting