### PR TITLE
feat(opencode): add `privatemode-ai` provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -748,6 +748,19 @@ export namespace Provider {
         },
       }
     },
+    "privatemode-ai": async () => {
+      const endpoint = Env.get("PRIVATEMODE_ENDPOINT") || "http://localhost:8080/v1"
+
+      return {
+        autoload: true,
+        options: {
+          baseURL: endpoint,
+        },
+        async getModel(sdk: any, modelID: string) {
+          return sdk(modelID)
+        },
+      }
+    },
   }
 
   export const Model = z


### PR DESCRIPTION
This adds provider configuration for [Privatemode AI](https://privatemode.ai/).

The default URL points to `http://localhost:8080` as Privatemode AI relies on a locally-run proxy to provide end-to-end encryption.

Related PR in models.dev: https://github.com/anomalyco/models.dev/pull/602

Tested this locally with the relevant model entries in `opencode.json`.

Closes #19126 