### PR TITLE
fix(tui): directory handling in AttachCommand

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -22,11 +22,10 @@ export const AttachCommand = cmd({
       }),
   handler: async (args) => {
     if (args.dir) process.chdir(args.dir)
-    const directory = process.cwd()
     await tui({
       url: args.url,
       args: { sessionID: args.session },
-      directory,
+      directory: args.dir ? process.cwd() : undefined,
     })
   },
 })


### PR DESCRIPTION
Fixes ENOENT errors when attaching to remote opencode servers.

The v1.1.1 attach command always sent the client's cwd to the server via `x-opencode-directory` header. For remote servers, this path doesn't exist, causing MCP connections, bash tool and more execution to fail with ENOENT.
Now `directory` is only sent when `--dir` is explicitly provided, letting the server use its own cwd by default.

related #6715