### PR TITLE
fix: lucent-orng bg transparency for slash commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
+++ b/packages/opencode/src/cli/cmd/tui/context/theme/lucent-orng.json
@@ -11,6 +11,7 @@
     "darkBlue": "#6ba1e6",
     "darkCyan": "#56b6c2",
     "darkYellow": "#e5c07b",
+    "darkPanelBg": "#2a1a1599",
     "lightStep6": "#d4d4d4",
     "lightStep11": "#8a8a8a",
     "lightStep12": "#1a1a1a",
@@ -20,7 +21,8 @@
     "lightOrange": "#EC5B2B",
     "lightBlue": "#0062d1",
     "lightCyan": "#318795",
-    "lightYellow": "#b0851f"
+    "lightYellow": "#b0851f",
+    "lightPanelBg": "#fff5f099"
   },
   "theme": {
     "primary": {
@@ -70,6 +72,10 @@
     "backgroundElement": {
       "dark": "transparent",
       "light": "transparent"
+    },
+    "backgroundMenu": {
+      "dark": "darkPanelBg",
+      "light": "lightPanelBg"
     },
     "border": {
       "dark": "darkOrange",


### PR DESCRIPTION
The background for `/` commands in the `lucent-orng` theme is slightly broken at the moment:

<img width="1266" height="336" alt="image" src="https://github.com/user-attachments/assets/8ae1c1ce-2f5c-45d9-a4c8-12df0f354372" />

Fixed it in this PR to something sane. Open to other color suggestions.

<img width="1266" height="391" alt="image" src="https://github.com/user-attachments/assets/a1520703-403a-40b3-a430-8e3271eeb210" />

