### PR TITLE
docs: add description for MCP command

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -50,6 +50,7 @@ function isMcpRemote(config: McpEntry): config is McpRemote {
 
 export const McpCommand = cmd({
   command: "mcp",
+  describe: "manage MCP (Model Context Protocol) servers",
   builder: (yargs) =>
     yargs
       .command(McpAddCommand)


### PR DESCRIPTION
This PR adds the missing `opencode mcp` entry to the `opencode --help` output.

The command is already implemented and usable, but it is currently not discoverable from the CLI help, which may confuse users.

### Changes

- Added `mcp` command description to the CLI help output


### Before

`opencode mcp` is not listed in `--help`

<img width="1143" height="610" alt="image" src="https://github.com/user-attachments/assets/a7ba812f-53ac-4e08-8f9e-2738ec9c599d" />

### After

`opencode mcp` appears alongside other commands in the help output

<img width="1145" height="655" alt="image" src="https://github.com/user-attachments/assets/b02c1dca-2194-4e68-9794-533eb8a4fb4d" />
