### PR TITLE
fix(desktop): make dev server port configuration more flexible

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -265,8 +265,12 @@ pub fn run() {
                       .map(|m| m.size().to_logical(m.scale_factor()))
                       .unwrap_or(LogicalSize::new(1920, 1080));
 
-                  let mut window_builder =
-                      WebviewWindow::builder(&app, "main", WebviewUrl::App("/".into()))
+                let dev_url = match app.config().build.dev_url.as_ref() {
+                    Some(url) => url.clone(),
+                    None => "http://localhost:1420".parse().unwrap(),
+                };
+                let window_builder =
+                    WebviewWindow::builder(&app, "main", WebviewUrl::External(dev_url))
                           .title("OpenCode")
                           .inner_size(size.width as f64, size.height as f64)
                           .decorations(true)

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -6,7 +6,6 @@
   "version": "../package.json",
   "build": {
     "beforeDevCommand": "bun run dev",
-    "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "bun run build",
     "frontendDist": "../dist"
   },

--- a/packages/desktop/vite.config.ts
+++ b/packages/desktop/vite.config.ts
@@ -17,10 +17,9 @@ export default defineConfig({
   // build: {
   // sourcemap: true,
   // },
-  // 2. tauri expects a fixed port, fail if that port is not available
   server: {
     port: 1420,
-    strictPort: true,
+    strictPort: false,
     host: host || false,
     hmr: host
       ? {


### PR DESCRIPTION
Without this patch, the desktop application requires a strict port configuration (port 1420) and hardcodes the `devUrl` in `tauri.conf.json`.  This causes issues when the port is already in use during development.

This is a problem because developers cannot easily run multiple instances or work around port conflicts without manual configuration changes.

This patch solves the problem by removing the hardcoded `devUrl` from `tauri.conf.json`, setting `strictPort` to `false` in `vite.config.ts` to allow Vite to find an available port, and updating the Rust code to read the dev URL from the Tauri config or fall back to the default localhost:1420.

Closes #6943.