### PR TITLE
feat: update BashTool command parsing logic

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -99,6 +99,7 @@ export const BashTool = Tool.define("bash", async () => {
         for (let i = 0; i < node.childCount; i++) {
           const child = node.child(i)
           if (!child) continue
+
           if (
             child.type !== "command_name" &&
             child.type !== "word" &&
@@ -110,6 +111,8 @@ export const BashTool = Tool.define("bash", async () => {
           }
           command.push(child.text)
         }
+
+        if (command.length === 0) continue
 
         // not an exhaustive list, but covers most common cases
         if (["cd", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown", "cat"].includes(command[0])) {


### PR DESCRIPTION
Refined the command parsing logic in BashTool by adding a check for empty command arrays during tree-sitter traversal. This prevent processing malformed shell structures that could lead to unexpected execution behavior.

Security Risk: Potential for command injection or agent escape if malformed input nodes are processed without validation.

Fixes #7478
Fixes #7504