### PR TITLE
fix(app): avoid unintended submits during IME composition

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1,5 +1,17 @@
 import { useFilteredList } from "@opencode-ai/ui/hooks"
-import { createEffect, on, Component, Show, For, onMount, onCleanup, Switch, Match, createMemo } from "solid-js"
+import {
+  createEffect,
+  on,
+  Component,
+  Show,
+  For,
+  onMount,
+  onCleanup,
+  Switch,
+  Match,
+  createMemo,
+  createSignal,
+} from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { createFocusSignal } from "@solid-primitives/active-element"
 import { useLocal } from "@/context/local"
@@ -246,6 +258,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   const isFocused = createFocusSignal(() => editorRef)
+  const [composing, setComposing] = createSignal(false)
+  const isImeComposing = (event: KeyboardEvent) => event.isComposing || composing() || event.keyCode === 229
 
   const addImageAttachment = async (file: File) => {
     if (!ACCEPTED_FILE_TYPES.includes(file.type)) return
@@ -866,6 +880,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         event.preventDefault()
         return
       }
+    }
+
+    if (event.key === "Enter" && isImeComposing(event)) {
+      return
     }
 
     if (store.popover && (event.key === "ArrowUp" || event.key === "ArrowDown" || event.key === "Enter")) {
@@ -1489,6 +1507,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             }}
             contenteditable="true"
             onInput={handleInput}
+            onCompositionStart={() => setComposing(true)}
+            onCompositionEnd={() => setComposing(false)}
             onKeyDown={handleKeyDown}
             classList={{
               "select-text": true,


### PR DESCRIPTION
## Summary

- Prevent IME conversion-confirmation Enter from submitting the prompt input.


## Problem

IME conversion confirmation (Enter) triggered submit, sending the message unintentionally.

fix: #6950 

## Fix

Guard Enter handling while composition is active using composition events and `event.isComposing`.

<img width="834" height="162" alt="image" src="https://github.com/user-attachments/assets/c328f711-8c66-478a-afd0-4e8678ddc3d2" />
