### PR TITLE
feat(app): highlight collapsed active project in sidebar

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -759,6 +759,10 @@ export default function Layout(props: ParentProps) {
     const isExpanded = createMemo(() =>
       props.mobile ? mobileProjects.expanded(props.project.worktree) : props.project.expanded,
     )
+    const isActive = createMemo(() => {
+      const current = params.dir ? base64Decode(params.dir) : ""
+      return props.project.worktree === current || props.project.sandboxes?.includes(current)
+    })
     const handleOpenChange = (open: boolean) => {
       if (props.mobile) {
         if (open) mobileProjects.expand(props.project.worktree)
@@ -777,7 +781,10 @@ export default function Layout(props: ParentProps) {
               <Button
                 as={"div"}
                 variant="ghost"
-                class="group/session flex items-center justify-between gap-3 w-full px-1.5 self-stretch h-auto border-none rounded-lg"
+                classList={{
+                  "group/session flex items-center justify-between gap-3 w-full px-1.5 self-stretch h-auto border-none rounded-lg": true,
+                  "bg-surface-raised-base-hover": isActive() && !isExpanded(),
+                }}
               >
                 <Collapsible.Trigger class="group/trigger flex items-center gap-3 p-0 text-left min-w-0 grow border-none">
                   <ProjectAvatar


### PR DESCRIPTION
Fixes #6957 

## Changes

- Highlight the active project in the sidebar when it is collapsed to make it more clear which project you're working in. When it's expanded, the session is highlighted, so it's not really needed to highlight the project.

## Screenshots

### Before

<img width="1238" height="818" alt="image" src="https://github.com/user-attachments/assets/34b72caa-e5dd-4ffb-82cb-2f05d7f9f965" />


### After

<img width="1139" height="626" alt="image" src="https://github.com/user-attachments/assets/33f00a37-d914-42f7-b07b-0d3fac0947da" />

