### PR TITLE
fix: enable MCP server after OAuth completion

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -817,7 +817,7 @@ export namespace MCP {
 
       // Re-add the MCP server to establish connection
       pendingOAuthTransports.delete(mcpName)
-      const result = await add(mcpName, mcpConfig)
+      const result = await add(mcpName, { ...mcpConfig, enabled: true })
 
       const statusRecord = result.status as Record<string, Status>
       return statusRecord[mcpName] ?? { status: "failed", error: "Unknown error after auth" }


### PR DESCRIPTION
 Summary
- Fix `opencode mcp auth <server>` returns "Unexpected status: disabled" after successful OAuth

When running `opencode mcp auth <server>`, users see:
┌  MCP OAuth Authentication
│
■  Unexpected status: disabled
│
└  Done

I have some MCPs which are disabled by default: `enabled:false`.  The `create()` function returns `{ status: "disabled" }` for disabled servers, which the CLI doesn't handle. 

Toggling the server via `/mcp` in the TUI works as `connect()` explicitly sets `enabled: true`. 

FIX:

After successful OAuth completion, always enable the server (If a user is actively authenticating an MCP server, they want it enabled)
