### PR TITLE
feat: add logging and error handling for wellknown config

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -229,7 +229,30 @@ export const AuthLoginCommand = cmd({
         UI.empty()
         prompts.intro("Add credential")
         if (args.url) {
-          const wellknown = await fetch(`${args.url}/.well-known/opencode`).then((x) => x.json() as any)
+          let url: string
+          try {
+            url = new URL(args.url).origin
+          } catch {
+            prompts.log.error(`Invalid URL: ${args.url}`)
+            prompts.outro("Done")
+            return
+          }
+
+          let wellknown: any
+          try {
+            const response = await fetch(`${url}/.well-known/opencode`)
+            if (!response.ok) {
+              prompts.log.error(`Failed to fetch the config: received a ${response.status} from ${url}`)
+              prompts.outro("Done")
+              return
+            }
+            wellknown = await response.json()
+          } catch {
+            prompts.log.error(`Failed to fetch the config from ${url}`)
+            prompts.outro("Done")
+            return
+          }
+
           prompts.log.info(`Running \`${wellknown.auth.command.join(" ")}\``)
           const proc = Bun.spawn({
             cmd: wellknown.auth.command,
@@ -242,12 +265,12 @@ export const AuthLoginCommand = cmd({
             return
           }
           const token = await new Response(proc.stdout).text()
-          await Auth.set(args.url, {
+          await Auth.set(url, {
             type: "wellknown",
             key: wellknown.auth.env,
             token: token.trim(),
           })
-          prompts.log.success("Logged into " + args.url)
+          prompts.log.success("Logged into " + url)
           prompts.outro("Done")
           return
         }


### PR DESCRIPTION
Adds debug logging and error handling for `.well-known/opencode` config fetches in enterprise installs.

Logs output both the config path (not present today) and a SHA-256 of the config so you can identify what version of the config is being pulled (or was, historically, when someone shares logs!) for a user.

Example log output with `--print-logs`:
```
DEBUG service=config url=https://opencode.example.com/.well-known/opencode fetching wellknown config
DEBUG service=config url=https://opencode.example.com/ hash=4142764bad628c8c8883665f9b17b4b32af24cb7ca9d4d4da57f85cc5ca21c18 loaded wellknown config
```