### PR TITLE
fix(desktop): add single-instance plugin to prevent multiple windows

### DIFF
--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-window-state = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-http = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-single-instance = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -189,6 +189,13 @@ pub fn run() {
     let updater_enabled = option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some();
 
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            // Focus existing window when another instance is launched
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_focus();
+                let _ = window.unminimize();
+            }
+        }))
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())


### PR DESCRIPTION
## Problem
When launching the desktop app on Windows with plugins that take time to load (like oh-my-opencode), multiple instances spawn continuously because there's no single-instance guard. This causes 10+ windows to open.

## Solution
Add `tauri-plugin-single-instance` which:
- Prevents multiple app instances from running simultaneously
- Focuses existing window when user tries to launch another instance
- Unminimizes window if it was minimized

## Changes
- `packages/desktop/src-tauri/Cargo.toml`: Add `tauri-plugin-single-instance = "2"`
- `packages/desktop/src-tauri/src/lib.rs`: Initialize single-instance plugin with focus handler

## Testing
1. Build desktop app with slow-loading plugins
2. Try launching app multiple times quickly
3. **Expected**: Only one window opens, subsequent launches focus existing window

Fixes #6965