### PR TITLE
docs: update GHA examples to use `actions/checkout@v6`

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -82,7 +82,7 @@ This will walk you through installing the GitHub app, creating the workflow, and
          id-token: write
        steps:
          - name: Checkout repository
-           uses: actions/checkout@v4
+           uses: actions/checkout@v6
            with:
              fetch-depth: 1
 

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -393,7 +393,7 @@ jobs:
       issues: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest${envStr}

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -58,7 +58,7 @@ Or you can set it up manually.
          id-token: write
        steps:
          - name: Checkout repository
-           uses: actions/checkout@v4
+           uses: actions/checkout@v6
            with:
              fetch-depth: 1
 
@@ -134,7 +134,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
@@ -171,7 +171,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: anomalyco/opencode/github@latest
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -221,7 +221,7 @@ jobs:
             return days >= 30;
           result-encoding: string
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.check.outputs.result == 'true'
 
       - uses: anomalyco/opencode/github@latest


### PR DESCRIPTION
Updates all GitHub Action workflow examples in documentation and code templates from `actions/checkout@v4` to `actions/checkout@v6`.

PR #6667 added code compatibility for `actions/checkout@v6`, which changed credential storage from `.git/config` to a separate file using `includeIf.gitdir`. The documentation and CLI-generated workflow templates still reference `actions/checkout@v4`.

Refs: #6667 #5827

#### Changes

- `packages/web/src/content/docs/github.mdx` - Updated 4 workflow examples
- `github/README.md` - Updated manual setup example
- `packages/opencode/src/cli/cmd/github.ts` - Updated generated workflow template