### PR TITLE
feat(app): add session search and rename functionality

### DIFF
--- a/packages/app/src/components/dialog-session-list.tsx
+++ b/packages/app/src/components/dialog-session-list.tsx
@@ -1,0 +1,157 @@
+import { Button } from "@opencode-ai/ui/button"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { createSignal, createMemo, createResource, For, Show } from "solid-js"
+import { useSync } from "@/context/sync"
+import { useSDK } from "@/context/sdk"
+import { showToast } from "@opencode-ai/ui/toast"
+import { DialogSessionRename } from "./dialog-session-rename"
+import { DateTime } from "luxon"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+interface DialogSessionListProps {
+  currentSessionId?: string
+  onSelect: (session: Session) => void
+}
+
+export function DialogSessionList(props: DialogSessionListProps) {
+  const dialog = useDialog()
+  const sync = useSync()
+  const sdk = useSDK()
+  const [search, setSearch] = createSignal("")
+  const [deleting, setDeleting] = createSignal<string>()
+
+  const [searchResults] = createResource(
+    () => search().trim(),
+    async (query) => {
+      if (!query) return undefined
+      const result = await sdk.client.session.list({ search: query, limit: 30 })
+      return result.data ?? []
+    },
+  )
+
+  const sessions = createMemo(() => {
+    const results = searchResults()
+    const localSessions = sync.data.session ?? []
+    const source = results ?? localSessions
+    return source.filter((s) => !s.parentID).toSorted((a, b) => b.time.updated - a.time.updated)
+  })
+
+  const groupedSessions = createMemo(() => {
+    const today = new Date().toDateString()
+    const yesterday = new Date(Date.now() - 86400000).toDateString()
+    const groups: Record<string, Session[]> = {}
+
+    for (const session of sessions()) {
+      const date = new Date(session.time.updated)
+      let category = date.toDateString()
+      if (category === today) category = "Today"
+      else if (category === yesterday) category = "Yesterday"
+
+      if (!groups[category]) groups[category] = []
+      groups[category].push(session)
+    }
+
+    return Object.entries(groups)
+  })
+
+  async function handleDelete(session: Session) {
+    if (deleting() === session.id) {
+      setDeleting(undefined)
+      try {
+        await sdk.client.session.delete({ sessionID: session.id })
+        showToast({ title: "Session deleted" })
+      } catch (err) {
+        showToast({ title: "Failed to delete session", description: String(err) })
+      }
+      return
+    }
+    setDeleting(session.id)
+  }
+
+  function handleRename(session: Session) {
+    dialog.show(() => <DialogSessionRename session={session} />)
+  }
+
+  function handleSelect(session: Session) {
+    props.onSelect(session)
+    dialog.close()
+  }
+
+  return (
+    <Dialog title="Sessions" class="w-[500px] max-w-[90vw]">
+      <div class="flex flex-col gap-4 px-2.5 pb-3">
+        <TextField
+          autofocus
+          type="text"
+          placeholder="Search sessions..."
+          value={search()}
+          onChange={setSearch}
+          class="w-full"
+        />
+        <div class="max-h-[400px] overflow-y-auto -mx-2.5 px-2.5">
+          <Show
+            when={sessions().length > 0}
+            fallback={
+              <div class="py-8 text-center text-14-regular text-text-weak">
+                {search() ? "No sessions found" : "No sessions yet"}
+              </div>
+            }
+          >
+            <div class="flex flex-col gap-4">
+              <For each={groupedSessions()}>
+                {([category, items]) => (
+                  <div class="flex flex-col gap-1">
+                    <div class="text-12-medium text-text-weak px-2 py-1">{category}</div>
+                    <For each={items}>
+                      {(session) => (
+                        <div
+                          class="group flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer transition-colors"
+                          classList={{
+                            "bg-surface-info-base": props.currentSessionId === session.id,
+                            "hover:bg-surface-raised-base-hover": props.currentSessionId !== session.id,
+                            "bg-surface-critical-base/20": deleting() === session.id,
+                          }}
+                          onClick={() => handleSelect(session)}
+                        >
+                          <div class="flex-1 min-w-0">
+                            <div class="text-14-regular text-text-strong truncate">
+                              {deleting() === session.id ? "Click delete again to confirm" : session.title}
+                            </div>
+                            <div class="text-12-regular text-text-weak">
+                              {DateTime.fromMillis(session.time.updated).toRelative()}
+                            </div>
+                          </div>
+                          <div
+                            class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <Tooltip value="Rename">
+                              <IconButton icon="edit-small-2" variant="ghost" onClick={() => handleRename(session)} />
+                            </Tooltip>
+                            <Tooltip value={deleting() === session.id ? "Click to confirm" : "Delete"}>
+                              <IconButton
+                                icon="close"
+                                variant="ghost"
+                                class={deleting() === session.id ? "text-text-critical" : ""}
+                                onClick={() => handleDelete(session)}
+                              />
+                            </Tooltip>
+                          </div>
+                        </div>
+                      )}
+                    </For>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/dialog-session-rename.tsx
+++ b/packages/app/src/components/dialog-session-rename.tsx
@@ -1,0 +1,66 @@
+import { Button } from "@opencode-ai/ui/button"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { createSignal } from "solid-js"
+import { useSDK } from "@/context/sdk"
+import { showToast } from "@opencode-ai/ui/toast"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+interface DialogSessionRenameProps {
+  session: Session
+}
+
+export function DialogSessionRename(props: DialogSessionRenameProps) {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const [title, setTitle] = createSignal(props.session.title)
+  const [saving, setSaving] = createSignal(false)
+
+  async function handleSubmit(e: SubmitEvent) {
+    e.preventDefault()
+    const newTitle = title().trim()
+    if (!newTitle || newTitle === props.session.title) {
+      dialog.close()
+      return
+    }
+
+    setSaving(true)
+    try {
+      await sdk.client.session.update({
+        sessionID: props.session.id,
+        title: newTitle,
+      })
+      showToast({ title: "Session renamed" })
+      dialog.close()
+    } catch (err) {
+      console.error("Failed to rename session", err)
+      showToast({ title: "Failed to rename session", description: String(err) })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog title="Rename session">
+      <form onSubmit={handleSubmit} class="flex flex-col gap-6 px-2.5 pb-3">
+        <TextField
+          autofocus
+          type="text"
+          label="Title"
+          placeholder="Enter session title"
+          value={title()}
+          onChange={setTitle}
+        />
+        <div class="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="large" onClick={() => dialog.close()}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" size="large" disabled={saving()}>
+            {saving() ? "Saving..." : "Save"}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -17,6 +17,8 @@ import { Select } from "@opencode-ai/ui/select"
 import { Popover } from "@opencode-ai/ui/popover"
 import { TextField } from "@opencode-ai/ui/text-field"
 import { DialogSelectServer } from "@/components/dialog-select-server"
+import { DialogSessionList } from "@/components/dialog-session-list"
+import { DialogSessionRename } from "@/components/dialog-session-rename"
 import { SessionLspIndicator } from "@/components/session-lsp-indicator"
 import { SessionMcpIndicator } from "@/components/session-mcp-indicator"
 import type { Session } from "@opencode-ai/sdk/v2/client"
@@ -46,6 +48,18 @@ export function SessionHeader() {
   function navigateToSession(session: Session | undefined) {
     if (!session) return
     navigate(`/${params.dir}/session/${session.id}`)
+  }
+
+  function openSessionList() {
+    dialog.show(() => (
+      <DialogSessionList currentSessionId={params.id} onSelect={(session) => navigateToSession(session)} />
+    ))
+  }
+
+  function openRenameDialog() {
+    const session = currentSession()
+    if (!session) return
+    dialog.show(() => <DialogSessionRename session={session} />)
   }
 
   return (
@@ -79,18 +93,19 @@ export function SessionHeader() {
               </Select>
               <div class="text-text-weaker">/</div>
             </div>
-            <Select
-              options={sessions()}
-              current={currentSession()}
-              placeholder="New session"
-              label={(x) => x.title}
-              value={(x) => x.id}
-              onSelect={navigateToSession}
-              class="text-14-regular text-text-base max-w-[calc(100vw-180px)] md:max-w-md"
+            <Button
               variant="ghost"
-            />
+              class="text-14-regular text-text-base max-w-[calc(100vw-180px)] md:max-w-md"
+              onClick={openSessionList}
+            >
+              <span class="truncate">{currentSession()?.title ?? "New session"}</span>
+              <Icon name="chevron-down" size="small" />
+            </Button>
           </div>
           <Show when={currentSession()}>
+            <Tooltip class="hidden xl:block" value="Rename session">
+              <IconButton icon="pencil-line" variant="ghost" onClick={openRenameDialog} />
+            </Tooltip>
             <TooltipKeybind class="hidden xl:block" title="New session" keybind={command.keybind("session.new")}>
               <IconButton as={A} href={`/${params.dir}/session`} icon="edit-small-2" variant="ghost" />
             </TooltipKeybind>

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -47,6 +47,8 @@ import {
   SortableTerminalTab,
   NewSessionView,
 } from "@/components/session"
+import { DialogSessionList } from "@/components/dialog-session-list"
+import { DialogSessionRename } from "@/components/dialog-session-rename"
 import { usePlatform } from "@/context/platform"
 import { same } from "@/utils/same"
 
@@ -336,6 +338,33 @@ export default function Page() {
       keybind: "mod+shift+s",
       slash: "new",
       onSelect: () => navigate(`/${params.dir}/session`),
+    },
+    {
+      id: "session.list",
+      title: "Open session list",
+      description: "Browse and search all sessions",
+      category: "Session",
+      keybind: "mod+o",
+      slash: "sessions",
+      onSelect: () =>
+        dialog.show(() => (
+          <DialogSessionList
+            currentSessionId={params.id}
+            onSelect={(session) => navigate(`/${params.dir}/session/${session.id}`)}
+          />
+        )),
+    },
+    {
+      id: "session.rename",
+      title: "Rename session",
+      description: "Rename the current session",
+      category: "Session",
+      keybind: "mod+shift+e",
+      disabled: !params.id,
+      onSelect: () => {
+        const session = sync.session.get(params.id ?? "")
+        if (session) dialog.show(() => <DialogSessionRename session={session} />)
+      },
     },
     {
       id: "file.open",

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,11 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}


### PR DESCRIPTION
## Summary

- Add searchable session list dialog with date grouping and inline actions
- Add session rename dialog  
- Add keyboard shortcuts: `Cmd+O` for session list, `Cmd+Shift+E` for rename
- Fix corrupted custom-elements.d.ts files in app and enterprise packages

## Changes

### New Components
- `DialogSessionList` - Searchable session list with:
  - Server-side search via `sdk.client.session.list({ search })`
  - Date grouping (Today, Yesterday, older dates)
  - Inline rename and delete buttons with click-to-confirm delete
  - Current session highlighting
- `DialogSessionRename` - Simple rename dialog using `sdk.client.session.update()`

### Modified
- `session-header.tsx` - Replaced `<Select>` dropdown with `<Button>` that opens session list dialog, added rename button
- `session.tsx` - Added command registrations for `session.list` and `session.rename`

### Fixed
- Restored corrupted `custom-elements.d.ts` files that contained file paths instead of actual TypeScript declarations