### PR TITLE
fix: yaml-ls initialization and bootstrap environment issues

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1322,39 +1322,22 @@ export namespace LSPServer {
   export const YamlLS: Info = {
     id: "yaml-ls",
     extensions: [".yaml", ".yml"],
-    root: NearestRoot(["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"]),
+    root: NearestRoot([
+      "package-lock.json",
+      "bun.lockb",
+      "bun.lock",
+      "pnpm-lock.yaml",
+      "yarn.lock",
+      ".yamllint",
+      ".yamllint.yml",
+      ".yamllint.yaml",
+      "kustomization.yaml",
+      "kustomization.yml",
+      "docker-compose.yaml",
+      "docker-compose.yml",
+    ]),
     async spawn(root) {
-      let binary = Bun.which("yaml-language-server")
-      const args: string[] = []
-      if (!binary) {
-        const js = path.join(
-          Global.Path.bin,
-          "node_modules",
-          "yaml-language-server",
-          "out",
-          "server",
-          "src",
-          "server.js",
-        )
-        const exists = await Bun.file(js).exists()
-        if (!exists) {
-          if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
-          await Bun.spawn([BunProc.which(), "install", "yaml-language-server"], {
-            cwd: Global.Path.bin,
-            env: {
-              ...process.env,
-              BUN_BE_BUN: "1",
-            },
-            stdout: "pipe",
-            stderr: "pipe",
-            stdin: "pipe",
-          }).exited
-        }
-        binary = BunProc.which()
-        args.push("run", js)
-      }
-      args.push("--stdio")
-      const proc = spawn(binary, args, {
+      const proc = spawn(BunProc.which(), ["x", "yaml-language-server", "--stdio"], {
         cwd: root,
         env: {
           ...process.env,
@@ -1363,6 +1346,16 @@ export namespace LSPServer {
       })
       return {
         process: proc,
+        initialization: {
+          yaml: {
+            completion: true,
+            validate: true,
+            hover: true,
+            schemaStore: {
+              enable: true,
+            },
+          },
+        },
       }
     },
   }


### PR DESCRIPTION
 ### Summary

This PR fixes the `yaml-ls` language server which was failing to initialize due to incorrect executable paths and restrictive root detection.

### Changes
 YAML LSP (`yaml-ls`)
- **Provisioning Strategy:** Switched from hardcoded JS paths to `bun x yaml-language-server --stdio`. This ensures the server works reliably by using the package manager to resolve the binary, avoiding "file not found" errors caused by version-specific path changes in `node_modules`.
- **Root Detection:** Added support for common YAML project files (`.yamllint`, `kustomization.yaml`, `docker-compose.yaml`) to correctly identify workspace roots in non-Node.js projects.
- **Default Configuration:** Enabled `completion`, `hover`, `validation`, and `schemaStore` by default in the server initialization options.
 
### Verification
- Verified that `yaml-ls` now correctly identifies syntax errors and provides schema-based diagnostics.
- Verified that the server spawns correctly using `bun x`.
<img width="738" height="298" alt="image" src="https://github.com/user-attachments/assets/01fef2dc-2790-423c-9c1d-621f29af5091" />

Issue: https://github.com/anomalyco/opencode/issues/7842

With the changes, meaning, LSP working:

<img width="952" height="1133" alt="image" src="https://github.com/user-attachments/assets/c1f9d5d3-922a-40e9-add6-5f816066814b" />

Latest OpenCode 1.1.14:

<img width="951" height="1145" alt="image" src="https://github.com/user-attachments/assets/d034e8b0-9fb3-4bbb-8282-c1dc072ba756" />

Adding again a new key, with the fix applied:

<img width="960" height="1162" alt="image" src="https://github.com/user-attachments/assets/31b2d134-4f40-4e96-8264-a654e835c232" />

<img width="972" height="1154" alt="image" src="https://github.com/user-attachments/assets/c9994027-788f-4c49-aa33-f158558a99c2" />
