### PR TITLE
fix(tui): use OSC 8 hyperlinks for multiline link support

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -8,21 +8,18 @@ export interface LinkProps {
   fg?: RGBA
 }
 
-/**
- * Link component that renders clickable hyperlinks.
- * Clicking anywhere on the link text opens the URL in the default browser.
- */
 export function Link(props: LinkProps) {
   const displayText = props.children ?? props.href
 
   return (
     <text
-      fg={props.fg}
       onMouseUp={() => {
         open(props.href).catch(() => {})
       }}
     >
-      {displayText}
+      <a href={props.href} style={{ fg: props.fg }}>
+        {displayText}
+      </a>
     </text>
   )
 }


### PR DESCRIPTION
Use `<a href>` element to generate OSC 8 terminal hyperlinks for the Link component

Fixes #6639