### PR TITLE
docs: fix permission rule ordering in examples

### DIFF
--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -128,10 +128,10 @@ Control which skills agents can access using pattern-based permissions in `openc
 {
   "permission": {
     "skill": {
+      "*": "allow",
       "pr-review": "allow",
       "internal-*": "deny",
-      "experimental-*": "ask",
-      "*": "allow"
+      "experimental-*": "ask"
     }
   }
 }


### PR DESCRIPTION
## Problem
Permission examples show catch-all `"*"` rules at the bottom, but OpenCode uses ["last matching rule wins"](https://github.com/anomalyco/opencode/blob/dev/packages/web/src/content/docs/permissions.mdx#L70) — so the catch-all overrides all specific rules above it.

## Solution
Move `"*"` rules to the top of permission blocks so specific rules can override them.

## Changes
- `agents.mdx`: Fix YAML and JSON examples, clarify explanatory text
- `skills.mdx`: Fix JSON example