### PR TITLE
feat(cli): add --cwd flag to web and serve commands

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,12 +1,27 @@
 import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import path from "path"
 
 export const ServeCommand = cmd({
   command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("cwd", {
+      describe: "working directory",
+      type: "string",
+    }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
+    // Resolve working directory similar to TUI command
+    const baseCwd = process.env.PWD ?? process.cwd()
+    const cwd = args.cwd ? path.resolve(baseCwd, args.cwd) : process.cwd()
+    try {
+      process.chdir(cwd)
+    } catch (e) {
+      console.error("Failed to change directory to " + cwd)
+      return
+    }
+
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -4,6 +4,7 @@ import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import open from "open"
 import { networkInterfaces } from "os"
+import path from "path"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -29,9 +30,23 @@ function getNetworkIPs() {
 
 export const WebCommand = cmd({
   command: "web",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("cwd", {
+      describe: "working directory",
+      type: "string",
+    }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
+    // Resolve working directory similar to TUI command
+    const baseCwd = process.env.PWD ?? process.cwd()
+    const cwd = args.cwd ? path.resolve(baseCwd, args.cwd) : process.cwd()
+    try {
+      process.chdir(cwd)
+    } catch (e) {
+      UI.error("Failed to change directory to " + cwd)
+      return
+    }
+
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
     UI.empty()


### PR DESCRIPTION
## Summary

The `opencode web` and `opencode serve` commands did not preserve the working directory, causing `process.cwd()` to return an unexpected value (often `/`) when the server handles requests. This resulted in sessions being created with `worktree: "/"` instead of the intended project directory.

## Changes

- Added `--cwd` flag to both `web` and `serve` commands
- Commands now call `process.chdir()` before starting the server, following the same pattern used by the TUI command (`thread.ts`)

## Testing

- Typecheck passes
- Manual verification: `--cwd` option appears in `--help` output for both commands

## Root Cause

The server middleware in `server.ts` (line 249) determines the directory per-request:
```typescript
const directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
```

Unlike the TUI command which calls `process.chdir(cwd)` before starting, the `web` and `serve` commands did not set the working directory, causing the fallback to `process.cwd()` to return an unintended value.