### PR TITLE
feat: add Cmd+Backspace and Option+Backspace support in text inputs

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -629,7 +629,11 @@ export namespace Config {
       input_select_buffer_end: z.string().optional().default("shift+end").describe("Select to end of buffer in input"),
       input_delete_line: z.string().optional().default("ctrl+shift+d").describe("Delete line in input"),
       input_delete_to_line_end: z.string().optional().default("ctrl+k").describe("Delete to end of line in input"),
-      input_delete_to_line_start: z.string().optional().default("ctrl+u").describe("Delete to start of line in input"),
+      input_delete_to_line_start: z
+        .string()
+        .optional()
+        .default("ctrl+u,super+backspace")
+        .describe("Delete to start of line in input"),
       input_backspace: z.string().optional().default("backspace,shift+backspace").describe("Backspace in input"),
       input_delete: z.string().optional().default("ctrl+d,delete,shift+delete").describe("Delete character in input"),
       input_undo: z.string().optional().default("ctrl+-,super+z").describe("Undo in input"),

--- a/packages/opencode/test/keybind.test.ts
+++ b/packages/opencode/test/keybind.test.ts
@@ -418,4 +418,79 @@ describe("Keybind.parse", () => {
       },
     ])
   })
+
+  test("should parse super+backspace for Cmd+Backspace", () => {
+    const result = Keybind.parse("super+backspace")
+    expect(result).toEqual([
+      {
+        ctrl: false,
+        meta: false,
+        shift: false,
+        super: true,
+        leader: false,
+        name: "backspace",
+      },
+    ])
+  })
+
+  test("should parse alt+backspace for Option+Backspace", () => {
+    const result = Keybind.parse("alt+backspace")
+    expect(result).toEqual([
+      {
+        ctrl: false,
+        meta: true,
+        shift: false,
+        leader: false,
+        name: "backspace",
+      },
+    ])
+  })
+
+  test("should parse delete-to-line-start keybind with super+backspace", () => {
+    const result = Keybind.parse("ctrl+u,super+backspace")
+    expect(result).toEqual([
+      {
+        ctrl: true,
+        meta: false,
+        shift: false,
+        leader: false,
+        name: "u",
+      },
+      {
+        ctrl: false,
+        meta: false,
+        shift: false,
+        super: true,
+        leader: false,
+        name: "backspace",
+      },
+    ])
+  })
+
+  test("should parse delete-word-backward keybind with alt+backspace", () => {
+    const result = Keybind.parse("ctrl+w,ctrl+backspace,alt+backspace")
+    expect(result).toEqual([
+      {
+        ctrl: true,
+        meta: false,
+        shift: false,
+        leader: false,
+        name: "w",
+      },
+      {
+        ctrl: true,
+        meta: false,
+        shift: false,
+        leader: false,
+        name: "backspace",
+      },
+      {
+        ctrl: false,
+        meta: true,
+        shift: false,
+        leader: false,
+        name: "backspace",
+      },
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `super+backspace` (Cmd+Backspace on macOS) keybinding to `input_delete_to_line_start` for deleting text from cursor to line start
- Option+Backspace (`alt+backspace`) was already configured for `input_delete_word_backward`

## Changes

- **config.ts**: Added `super+backspace` to the default keybindings for `input_delete_to_line_start`
- **keybind.test.ts**: Added 4 new tests for modifier+backspace keybind parsing

## Testing

All 51 keybind tests pass, including the new tests for:
- `super+backspace` parsing (Cmd+Backspace)
- `alt+backspace` parsing (Option+Backspace)  
- Combined keybind strings for both operations