### PR TITLE
fix(core): normalize file paths in read tool output

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -8,6 +8,7 @@ import DESCRIPTION from "./read.txt"
 import { Instance } from "../project/instance"
 import { Identifier } from "../id/id"
 import { assertExternalDirectory } from "./external-directory"
+import { Filesystem } from "../util/filesystem"
 import { InstructionPrompt } from "../session/instruction"
 
 const DEFAULT_READ_LIMIT = 2000

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -29,7 +29,9 @@ export const ReadTool = Tool.define("read", {
     if (!path.isAbsolute(filepath)) {
       filepath = path.resolve(Instance.directory, filepath)
     }
-    const title = path.relative(Instance.worktree, filepath)
+    const title = Filesystem.contains(Instance.worktree, filepath)
+      ? path.relative(Instance.worktree, filepath)
+      : filepath
 
     const file = Bun.file(filepath)
     const stat = await file.stat().catch(() => undefined)


### PR DESCRIPTION
Closes #12394

## Summary

- Show clean relative paths for files inside the worktree
- Show absolute paths for files outside the worktree instead of ugly `../../../../../../` paths

## Changes

Modified the read tool to check if a file is within the worktree before deciding how to display the path:
- **Inside worktree**: Show relative path (e.g., `src/tool/read.ts`)
- **Outside worktree**: Show absolute path (e.g., `/home/user/other/file.ts`)

This improves UX by avoiding confusing paths like `read ../../../../../../home/scarf/foo/bar/baz.ts`.

## Testing

Verified that `lsp_diagnostics` passes on the modified file.