### PR TITLE
feat(tui): add Project Files viewer/editor with vi mode support

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -30,6 +30,8 @@ import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
+import type { PromptExtension, PromptKeyEvent } from "../../lib/prompt-extension"
+import { createViBasicExtension } from "../../lib/vi-basic-extension"
 
 export type PromptProps = {
   sessionID?: string
@@ -72,6 +74,19 @@ export function Prompt(props: PromptProps) {
   const renderer = useRenderer()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+
+  // Prompt extensions - vi basic
+  const extensions: PromptExtension[] = []
+  const viBasicExtension = createViBasicExtension({
+    textarea: () => input,
+    onContentChange: () => {
+      const value = input.plainText
+      setStore("prompt", "input", value)
+      autocomplete.onInput(value)
+      syncExtmarksWithPromptParts()
+    },
+  })
+  extensions.push(viBasicExtension)
 
   function promptModelWarning() {
     toast.show({
@@ -196,11 +211,18 @@ export function Prompt(props: PromptProps) {
         title: "Interrupt session",
         value: "session.interrupt",
         keybind: "session_interrupt",
-        disabled: status().type === "idle",
+        disabled: status().type === "idle" || extensions.some((ext) => ext.blockInterrupt?.()),
         category: "Session",
         onSelect: (dialog) => {
           if (autocomplete.visible) return
           if (!input.focused) return
+          // Check if any extension handles escape
+          for (const ext of extensions) {
+            if (ext.handleEscape?.()) {
+              dialog.clear()
+              return
+            }
+          }
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")
@@ -450,6 +472,19 @@ export function Prompt(props: PromptProps) {
         ))
       },
     },
+    // Extension commands
+    ...extensions.flatMap(
+      (ext) =>
+        ext.commands?.().map((cmd) => ({
+          title: cmd.title,
+          value: cmd.value,
+          category: cmd.category ?? "Extensions",
+          onSelect: (dialog: { clear: () => void }) => {
+            cmd.onSelect()
+            dialog.clear()
+          },
+        })) ?? [],
+    ),
   ])
 
   props.ref?.({
@@ -779,6 +814,79 @@ export function Prompt(props: PromptProps) {
                   e.preventDefault()
                   return
                 }
+
+                // Vi mode handling
+                if (viBasicExtension.enabled() && !autocomplete.visible) {
+                  // History navigation: match standard mode behavior using cursor offset
+                  const viState = viBasicExtension.getState?.()
+                  const isUp = e.name === "up" || (viState === "normal" && e.name === "k")
+                  const isDown = e.name === "down" || (viState === "normal" && e.name === "j")
+                  const atStart = input.cursorOffset === 0
+                  const atEnd = input.cursorOffset === input.plainText.length
+
+                  if ((isUp && atStart) || (isDown && atEnd)) {
+                    const direction = isUp ? -1 : 1
+                    const item = history.move(direction, input.plainText)
+                    if (item) {
+                      input.setText(item.input)
+                      setStore("prompt", item)
+                      setStore("mode", item.mode ?? "normal")
+                      restoreExtmarksFromParts(item.parts)
+                      e.preventDefault()
+                      if (direction === -1) input.cursorOffset = 0
+                      if (direction === 1) input.cursorOffset = input.plainText.length
+                      return
+                    }
+                  }
+
+                  // Arrow keys and j/k in normal mode: match standard mode behavior
+                  // including "smart positioning" - jump to start/end at visual row boundaries
+                  if (viState === "normal" && (isUp || isDown)) {
+                    const atFirstRow = input.visualCursor.visualRow === 0
+                    const atLastRow = input.visualCursor.visualRow === input.height - 1
+
+                    if (isUp) {
+                      input.moveCursorUp()
+                      // Smart positioning: if at first row, jump to start
+                      if (atFirstRow) input.cursorOffset = 0
+                    } else {
+                      input.moveCursorDown()
+                      // Smart positioning: if at last row, jump to end
+                      if (atLastRow) input.cursorOffset = input.plainText.length
+                    }
+                    e.preventDefault()
+                    return
+                  }
+
+                  // Arrow keys in insert mode: let them fall through to standard handling
+                  // so they match standard mode behavior (cursor move, or history at boundaries)
+                  if (viState === "insert" && (e.name === "up" || e.name === "down")) {
+                    // Don't handle here - let it fall through to standard mode handling below
+                  }
+
+                  // "/" at position 0 opens command menu - pass through to autocomplete
+                  // "@" triggers file/agent autocomplete - pass through
+                  if (e.name === "/" && input.cursorOffset === 0) {
+                    // Let it fall through to autocomplete handling
+                  } else if (e.name === "@") {
+                    // Let it fall through to autocomplete handling
+                  } else {
+                    // Handle vi mode key
+                    const keyEvent: PromptKeyEvent = {
+                      name: e.name,
+                      ctrl: e.ctrl,
+                      meta: e.meta,
+                      shift: e.shift,
+                      sequence: e.sequence,
+                      preventDefault: () => e.preventDefault(),
+                      defaultPrevented: e.defaultPrevented,
+                    }
+                    if (viBasicExtension.handleKey?.(keyEvent, undefined as any)) {
+                      return
+                    }
+                  }
+                }
+
                 // Handle clipboard paste (Ctrl+V) - check for images first on Windows
                 // This is needed because Windows terminal doesn't properly send image data
                 // through bracketed paste, so we need to intercept the keypress and
@@ -806,10 +914,9 @@ export function Prompt(props: PromptProps) {
                   setStore("extmarkToPartIndex", new Map())
                   return
                 }
-                if (keybind.match("app_exit", e)) {
+                if (keybind.match("app_exit", e) && !e.defaultPrevented) {
                   if (store.prompt.input === "") {
                     await exit()
-                    // Don't preventDefault - let textarea potentially handle the event
                     e.preventDefault()
                     return
                   }
@@ -1075,6 +1182,8 @@ export function Prompt(props: PromptProps) {
                   </text>
                 </Match>
               </Switch>
+              {/* Extension status indicators */}
+              {extensions.map((ext) => ext.StatusIndicator?.())}
             </box>
           </Show>
         </box>

--- a/packages/opencode/src/cli/cmd/tui/lib/prompt-extension.ts
+++ b/packages/opencode/src/cli/cmd/tui/lib/prompt-extension.ts
@@ -1,0 +1,206 @@
+import type { ParsedKey, TextareaRenderable } from "@opentui/core"
+import type { JSX } from "solid-js"
+
+/**
+ * Safe context for prompt extensions to interact with the textarea
+ * without directly accessing internal state management
+ */
+export interface PromptExtensionContext {
+  /** Get current text content */
+  getText: () => string
+  /** Set text content and sync prompt state */
+  setText: (text: string) => void
+  /** Get cursor position */
+  getCursor: () => { row: number; col: number; offset: number }
+  /** Set cursor position */
+  setCursor: (row: number, col: number) => void
+  /** Insert text at cursor and sync state */
+  insertText: (text: string) => void
+  /** Delete character at cursor */
+  deleteChar: () => void
+  /** Delete character before cursor */
+  deleteCharBackward: () => void
+  /** Move cursor */
+  moveCursor: (direction: "left" | "right" | "up" | "down") => void
+  /** Move by word */
+  moveWord: (direction: "forward" | "backward") => void
+  /** Get line count */
+  getLineCount: () => number
+  /** Get visible height */
+  getHeight: () => number
+  /** Get visual cursor row (for wrapped lines) */
+  getVisualRow: () => number
+  /** Native undo */
+  undo: () => void
+  /** Native redo */
+  redo: () => void
+  /** Request render update */
+  requestRender: () => void
+  /** Access to raw textarea for advanced operations */
+  readonly textarea: TextareaRenderable
+}
+
+/**
+ * Key event with full context for extensions
+ */
+export interface PromptKeyEvent {
+  name: string
+  ctrl: boolean
+  meta: boolean
+  shift: boolean
+  sequence: string
+  preventDefault: () => void
+  defaultPrevented?: boolean
+}
+
+/**
+ * Command item for extension commands
+ */
+export interface ExtensionCommand {
+  title: string
+  value: string
+  category?: string
+  keybind?: string
+  onSelect: () => void
+}
+
+/**
+ * Key handling phase - determines order of execution
+ * - "pre": Before standard handling (history, autocomplete)
+ * - "normal": Standard phase
+ * - "post": After standard handling
+ */
+export type KeyHandlingPhase = "pre" | "normal" | "post"
+
+/**
+ * Prompt extension interface
+ *
+ * Extensions can hook into the prompt to provide custom editing modes,
+ * key bindings, status indicators, and commands.
+ */
+export interface PromptExtension {
+  /** Unique identifier for the extension */
+  id: string
+
+  /** Whether the extension is currently enabled */
+  enabled: () => boolean
+
+  /**
+   * Handle key events
+   * @param event - The key event
+   * @param ctx - Safe context for interacting with the textarea
+   * @returns true if the key was handled and should not propagate
+   */
+  handleKey?: (event: PromptKeyEvent, ctx: PromptExtensionContext) => boolean
+
+  /** Key handling phase - defaults to "normal" */
+  keyPhase?: KeyHandlingPhase
+
+  /**
+   * Handle escape key specifically
+   * Called before standard escape handling (interrupt, etc.)
+   * @returns true if escape was handled
+   */
+  handleEscape?: () => boolean
+
+  /**
+   * Check if session interrupt should be blocked
+   * @returns true to block interrupt
+   */
+  blockInterrupt?: () => boolean
+
+  /**
+   * Status indicator component for the prompt footer
+   */
+  StatusIndicator?: () => JSX.Element
+
+  /**
+   * Additional commands to add to the command palette
+   */
+  commands?: () => ExtensionCommand[]
+
+  /**
+   * Overlay component (e.g., help dialog)
+   */
+  Overlay?: () => JSX.Element
+
+  /**
+   * Called when extension is enabled/disabled
+   */
+  onToggle?: (enabled: boolean) => void
+
+  /**
+   * Reset extension state
+   */
+  reset?: () => void
+
+  /**
+   * Get current mode state (for vi mode: "normal" | "insert")
+   * Used by prompt for mode-aware handling
+   */
+  getState?: () => string
+}
+
+/**
+ * Create a prompt extension context from a textarea
+ */
+export function createExtensionContext(
+  textarea: TextareaRenderable,
+  onContentChange: () => void,
+): PromptExtensionContext {
+  return {
+    getText: () => textarea.plainText,
+    setText: (text: string) => {
+      textarea.setText(text)
+      onContentChange()
+    },
+    getCursor: () => {
+      const cursor = textarea.editorView.getCursor()
+      return { row: cursor.row, col: cursor.col, offset: textarea.cursorOffset }
+    },
+    setCursor: (row: number, col: number) => {
+      textarea.editBuffer.setCursor(row, col)
+    },
+    insertText: (text: string) => {
+      textarea.insertText(text)
+      onContentChange()
+    },
+    deleteChar: () => {
+      textarea.deleteChar()
+      onContentChange()
+    },
+    deleteCharBackward: () => {
+      textarea.deleteCharBackward()
+      onContentChange()
+    },
+    moveCursor: (direction) => {
+      switch (direction) {
+        case "left":
+          textarea.moveCursorLeft()
+          break
+        case "right":
+          textarea.moveCursorRight()
+          break
+        case "up":
+          textarea.moveCursorUp()
+          break
+        case "down":
+          textarea.moveCursorDown()
+          break
+      }
+    },
+    moveWord: (direction) => {
+      if (direction === "forward") textarea.moveWordForward()
+      else textarea.moveWordBackward()
+    },
+    getLineCount: () => textarea.lineCount,
+    getHeight: () => textarea.height,
+    getVisualRow: () => textarea.visualCursor.visualRow,
+    undo: () => textarea.undo(),
+    redo: () => textarea.redo(),
+    requestRender: () => textarea.requestRender(),
+    get textarea() {
+      return textarea
+    },
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/lib/vi-basic-core.ts
+++ b/packages/opencode/src/cli/cmd/tui/lib/vi-basic-core.ts
@@ -1048,15 +1048,15 @@ export function useViBasic(options: ViBasicOptions): ViBasicResult {
 
     // Search commands (only for full mode, not prompt)
     if (mode === "full") {
-      // / - start forward search
-      if (key === "/") {
+      // / - start forward search (but not ctrl+/ which is a global keybind)
+      if (key === "/" && !evt.ctrl && !evt.meta) {
         setSearchMode(true)
         setSearchBuffer("")
         setSearchDirection("forward")
         return handled()
       }
       // ? - start backward search
-      if (key === "?") {
+      if (key === "?" && !evt.ctrl && !evt.meta) {
         setSearchMode(true)
         setSearchBuffer("")
         setSearchDirection("backward")

--- a/packages/opencode/src/cli/cmd/tui/lib/vi-basic-core.ts
+++ b/packages/opencode/src/cli/cmd/tui/lib/vi-basic-core.ts
@@ -1,0 +1,1104 @@
+import { createSignal } from "solid-js"
+import type { TextareaRenderable, LineNumberRenderable } from "@opentui/core"
+import { Clipboard } from "../util/clipboard"
+
+export type ViBasicState = "normal" | "insert"
+export type ViBasicType = "full" | "prompt"
+
+export interface ViBasicOptions {
+  textarea: () => TextareaRenderable | undefined
+  onContentChange?: () => void
+  mode?: ViBasicType
+  /** Copy single char deletes (x) to clipboard. Default: false */
+  clipX?: boolean
+  /** Optional LineNumberRenderable to force gutter redraw on content changes */
+  lineNumbers?: () => LineNumberRenderable | undefined
+}
+
+interface KeyEvent {
+  name?: string
+  ctrl?: boolean
+  shift?: boolean
+  meta?: boolean
+  sequence?: string
+  preventDefault: () => void
+}
+
+export interface ViBasicResult {
+  state: () => ViBasicState
+  command: () => string
+  yank: () => string
+  replaceMode: () => boolean
+  handleKey: (evt: KeyEvent) => boolean
+  reset: () => void
+  // Search state
+  searchMode: () => boolean
+  searchBuffer: () => string
+  searchPattern: () => string
+}
+
+const MODE_CONFIG: Record<
+  ViBasicType,
+  {
+    startInsert: boolean
+    moveCursorOnEscape: boolean
+    passInsert: string[]
+  }
+> = {
+  full: {
+    startInsert: false,
+    moveCursorOnEscape: true,
+    passInsert: [],
+  },
+  prompt: {
+    startInsert: true,
+    moveCursorOnEscape: false,
+    passInsert: [],
+  },
+}
+
+export function useViBasic(options: ViBasicOptions): ViBasicResult {
+  const mode: ViBasicType = options.mode ?? "full"
+  const config = MODE_CONFIG[mode]
+
+  const [state, setState] = createSignal<ViBasicState>(config.startInsert ? "insert" : "normal")
+  const [command, setCommand] = createSignal("")
+  const [yankReg, setYankReg] = createSignal("")
+  const [lastAction, setLastAction] = createSignal<(() => void) | null>(null)
+  const [replaceMode, setReplaceMode] = createSignal(false)
+  // Search state
+  const [searchMode, setSearchMode] = createSignal(false)
+  const [searchBuffer, setSearchBuffer] = createSignal("")
+  const [searchPattern, setSearchPattern] = createSignal("")
+  const [searchDirection, setSearchDirection] = createSignal<"forward" | "backward">("forward")
+  const [searchOperator, setSearchOperator] = createSignal<"d" | "c" | "y" | null>(null)
+
+  const setYank = (text: string) => {
+    setYankReg(text)
+    Clipboard.copy(text)
+  }
+
+  const handleKey = (evt: KeyEvent): boolean => {
+    const textarea = options.textarea()
+    if (!textarea) return false
+
+    // Pass through ctrl keys in prompt mode (except f/b/r)
+    if (mode === "prompt" && evt.ctrl && evt.name !== "f" && evt.name !== "b" && evt.name !== "r") {
+      return false
+    }
+
+    const key = evt.shift && evt.name?.length === 1 ? evt.name.toUpperCase() : evt.name || ""
+
+    // Helper to mark event as handled
+    const handled = () => {
+      evt.preventDefault()
+      return true
+    }
+
+    // Search: find next/prev match and move cursor (defined early for search mode)
+    const findMatch = (pattern: string, direction: "forward" | "backward"): boolean => {
+      if (!pattern) return false
+      const text = textarea.plainText
+      const offset = textarea.cursorOffset
+
+      // Try to compile as regex, fall back to literal if invalid
+      let regex: RegExp
+      try {
+        regex = new RegExp(pattern, "g")
+      } catch {
+        // Invalid regex, escape special chars and use as literal
+        const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        regex = new RegExp(escaped, "g")
+      }
+
+      if (direction === "forward") {
+        // Search from cursor+1 to end, then wrap to beginning
+        const afterCursor = text.slice(offset + 1)
+        const match = regex.exec(afterCursor)
+        if (match) {
+          textarea.cursorOffset = offset + 1 + match.index
+          textarea.requestRender()
+          return true
+        }
+        // Wrap around - search from beginning
+        regex.lastIndex = 0
+        const wrapMatch = regex.exec(text.slice(0, offset))
+        if (wrapMatch) {
+          textarea.cursorOffset = wrapMatch.index
+          textarea.requestRender()
+          return true
+        }
+      } else {
+        // Search backward: find all matches before cursor, take last one
+        const beforeCursor = text.slice(0, offset)
+        let lastMatch: RegExpExecArray | null = null
+        let match: RegExpExecArray | null
+        regex.lastIndex = 0
+        while ((match = regex.exec(beforeCursor)) !== null) {
+          lastMatch = match
+        }
+        if (lastMatch) {
+          textarea.cursorOffset = lastMatch.index
+          textarea.requestRender()
+          return true
+        }
+        // Wrap around - find all matches after cursor, take last one
+        const afterCursor = text.slice(offset + 1)
+        lastMatch = null
+        regex.lastIndex = 0
+        while ((match = regex.exec(afterCursor)) !== null) {
+          lastMatch = match
+        }
+        if (lastMatch) {
+          textarea.cursorOffset = offset + 1 + lastMatch.index
+          textarea.requestRender()
+          return true
+        }
+      }
+      return false
+    }
+
+    // Search: find match and return offset (for operator motions)
+    const findMatchOffset = (pattern: string, direction: "forward" | "backward"): number | null => {
+      if (!pattern) return null
+      const text = textarea.plainText
+      const offset = textarea.cursorOffset
+
+      let regex: RegExp
+      try {
+        regex = new RegExp(pattern, "g")
+      } catch {
+        const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        regex = new RegExp(escaped, "g")
+      }
+
+      if (direction === "forward") {
+        const afterCursor = text.slice(offset + 1)
+        const match = regex.exec(afterCursor)
+        if (match) return offset + 1 + match.index
+        regex.lastIndex = 0
+        const wrapMatch = regex.exec(text.slice(0, offset))
+        if (wrapMatch) return wrapMatch.index
+      } else {
+        const beforeCursor = text.slice(0, offset)
+        let lastMatch: RegExpExecArray | null = null
+        let match: RegExpExecArray | null
+        regex.lastIndex = 0
+        while ((match = regex.exec(beforeCursor)) !== null) {
+          lastMatch = match
+        }
+        if (lastMatch) return lastMatch.index
+        const afterCursor = text.slice(offset + 1)
+        lastMatch = null
+        regex.lastIndex = 0
+        while ((match = regex.exec(afterCursor)) !== null) {
+          lastMatch = match
+        }
+        if (lastMatch) return offset + 1 + lastMatch.index
+      }
+      return null
+    }
+
+    // Helpers
+    const lines = () => textarea.plainText.split("\n")
+    const cursor = () => textarea.editorView.getCursor()
+    const lineLen = (row: number) => lines()[row]?.length || 0
+    const maxCol = (row: number) => Math.max(0, lineLen(row) - 1)
+
+    const setCursor = (row: number, col: number, clamp = true) => {
+      const ls = lines()
+      const r = Math.max(0, Math.min(row, ls.length - 1))
+      const max = clamp ? maxCol(r) : lineLen(r)
+      const c = Math.max(0, Math.min(col, max))
+      textarea.editBuffer.setCursor(r, c)
+      textarea.requestRender()
+    }
+
+    const clamp = () => {
+      const c = cursor()
+      const max = maxCol(c.row)
+      if (c.col > max) setCursor(c.row, max)
+    }
+
+    // Notify content change and force gutter redraw
+    const contentChanged = () => {
+      // Force gutter redraw by re-setting line numbers (workaround for opentui bug)
+      // The gutter's handleLineInfoChange only calls remeasure(), not requestRender()
+      const ln = options.lineNumbers?.()
+      if (ln) ln.setLineNumbers(ln.getLineNumbers())
+      textarea.requestRender()
+      options.onContentChange?.()
+    }
+
+    const yankLines = (count: number) => {
+      const ls = lines()
+      const c = cursor()
+      const yanked = ls.slice(c.row, c.row + count).join("\n") + "\n"
+      setYank(yanked)
+      return yanked
+    }
+
+    const deleteLines = (count: number) => {
+      yankLines(count)
+      const ls = lines()
+      const c = cursor()
+      const startRow = c.row
+      const endRow = Math.min(c.row + count, ls.length)
+      if (endRow >= ls.length) {
+        const lastLen = ls[ls.length - 1]?.length || 0
+        if (startRow > 0) {
+          const prevLen = ls[startRow - 1]?.length || 0
+          textarea.deleteRange(startRow - 1, prevLen, ls.length - 1, lastLen)
+        }
+        if (startRow === 0) {
+          textarea.deleteRange(0, 0, ls.length - 1, lastLen)
+        }
+      }
+      if (endRow < ls.length) {
+        textarea.deleteRange(startRow, 0, endRow, 0)
+      }
+      textarea.requestRender()
+      contentChanged()
+    }
+
+    const repeat = (n: number, fn: () => void) => {
+      for (let i = 0; i < n; i++) fn()
+    }
+
+    const enterInsert = (_reason: string) => {
+      setState("insert")
+    }
+
+    // Search mode handling (only for full mode, not prompt)
+    if (searchMode() && mode === "full") {
+      if (key === "escape") {
+        setSearchMode(false)
+        setSearchBuffer("")
+        setSearchOperator(null)
+        setSearchPattern("")
+        return handled()
+      }
+      if (key === "return") {
+        // Use buffer if typed, otherwise use previous pattern
+        const pattern = searchBuffer() || searchPattern()
+        const op = searchOperator()
+        if (pattern) {
+          setSearchPattern(pattern)
+          const matchOffset = findMatchOffset(pattern, searchDirection())
+          if (matchOffset !== null && op) {
+            // Operator pending - delete/change/yank from cursor to match
+            const startOffset = textarea.cursorOffset
+            const endOffset = matchOffset
+            if (startOffset !== endOffset) {
+              const text = textarea.plainText
+              const from = Math.min(startOffset, endOffset)
+              const to = Math.max(startOffset, endOffset)
+              const yanked = text.slice(from, to)
+              setYank(yanked)
+              if (op === "d" || op === "c") {
+                // Delete the range as single operation for proper undo
+                const fromPos = textarea.editBuffer.offsetToPosition(from)
+                const toPos = textarea.editBuffer.offsetToPosition(to)
+                if (fromPos && toPos) {
+                  textarea.deleteRange(fromPos.row, fromPos.col, toPos.row, toPos.col)
+                }
+                textarea.cursorOffset = from
+                contentChanged()
+                if (op === "c") {
+                  enterInsert("c/<pattern>")
+                }
+              }
+            }
+          } else if (matchOffset !== null) {
+            // No operator - just move cursor
+            textarea.cursorOffset = matchOffset
+            textarea.requestRender()
+          }
+        }
+        setSearchMode(false)
+        setSearchBuffer("")
+        setSearchOperator(null)
+        return handled()
+      }
+      if (key === "backspace") {
+        setSearchBuffer(searchBuffer().slice(0, -1))
+        return handled()
+      }
+      // Regular character input
+      if (key.length === 1 && !evt.ctrl && !evt.meta) {
+        setSearchBuffer(searchBuffer() + key)
+        return handled()
+      }
+      return handled()
+    }
+
+    const deleteWords = (count: number) => {
+      const c = cursor()
+      const startOffset = textarea.cursorOffset
+      for (let i = 0; i < count; i++) textarea.moveWordForward()
+      const endOffset = textarea.cursorOffset
+      const text = textarea.getTextRange(startOffset, endOffset)
+      setYank(text)
+      textarea.editBuffer.setCursor(c.row, c.col)
+      for (let i = 0; i < count; i++) textarea.deleteWordForward()
+      contentChanged()
+    }
+
+    const deleteToLine = (targetLine: number) => {
+      const c = cursor()
+      const ls = lines()
+      const startRow = Math.min(c.row, targetLine)
+      const endRow = Math.max(c.row, targetLine)
+      const yanked = ls.slice(startRow, endRow + 1).join("\n") + "\n"
+      setYank(yanked)
+      if (endRow >= ls.length - 1) {
+        const lastLen = ls[ls.length - 1]?.length || 0
+        if (startRow > 0) {
+          const prevLen = ls[startRow - 1]?.length || 0
+          textarea.deleteRange(startRow - 1, prevLen, ls.length - 1, lastLen)
+        }
+        if (startRow === 0) {
+          textarea.deleteRange(0, 0, ls.length - 1, lastLen)
+        }
+      }
+      if (endRow < ls.length - 1) {
+        textarea.deleteRange(startRow, 0, endRow + 1, 0)
+      }
+      textarea.requestRender()
+      setCursor(startRow, 0)
+      contentChanged()
+    }
+
+    // INSERT MODE
+    if (state() === "insert") {
+      if (key === "escape") {
+        setState("normal")
+        if (config.moveCursorOnEscape) textarea.moveCursorLeft()
+        return handled()
+      }
+      if (key === "return") {
+        if (mode === "prompt") return false
+        textarea.insertText("\n")
+        contentChanged()
+        return handled()
+      }
+      if (key === "linefeed") {
+        textarea.insertText("\n")
+        contentChanged()
+        return handled()
+      }
+      // Arrow keys - pass through to native textarea handling
+      if (key === "left" || key === "right" || key === "up" || key === "down") {
+        return false
+      }
+      if (config.passInsert.includes(key)) return false
+      if (key === "space") {
+        textarea.insertText(" ")
+        contentChanged()
+        return handled()
+      }
+      if (key === "backspace") {
+        textarea.deleteCharBackward()
+        contentChanged()
+        return handled()
+      }
+      if (key.length === 1 && !evt.ctrl && !evt.meta) {
+        textarea.insertText(key)
+        contentChanged()
+        return handled()
+      }
+      if (mode === "prompt") return false
+      return handled()
+    }
+
+    // REPLACE MODE
+    if (replaceMode()) {
+      setReplaceMode(false)
+      if (key.length === 1 && !evt.ctrl && !evt.meta && key !== "escape") {
+        const char = key
+        const action = () => {
+          textarea.deleteChar()
+          textarea.insertText(char)
+          textarea.moveCursorLeft()
+        }
+        action()
+        setLastAction(() => action)
+        contentChanged()
+      }
+      return handled()
+    }
+
+    // NORMAL MODE - Command parsing
+    const pending = command()
+
+    // Escape aborts pending command
+    if (key === "escape" && pending) {
+      setCommand("")
+      return handled()
+    }
+
+    const cmd = pending + key
+
+    // Operator patterns: dd, d3d, yy, y5y, cc, c2c
+    const opMatch = cmd.match(/^([dyc])(\d*)([dyc])$/)
+    if (opMatch && opMatch[1] === opMatch[3]) {
+      setCommand("")
+      const op = opMatch[1]
+      const count = opMatch[2] ? parseInt(opMatch[2], 10) : 1
+      if (op === "d") {
+        const action = () => deleteLines(count)
+        action()
+        setLastAction(() => action)
+        return handled()
+      }
+      if (op === "y") {
+        yankLines(count)
+        return handled()
+      }
+      if (op === "c") {
+        enterInsert("cc/c{n}c")
+        deleteLines(count)
+        return handled()
+      }
+    }
+
+    // d/, c/, y/ - operator with forward search motion
+    // d?, c?, y? - operator with backward search motion
+    const opSearchMatch = cmd.match(/^([dyc])([/?])$/)
+    if (opSearchMatch && mode === "full") {
+      setCommand("")
+      const op = opSearchMatch[1] as "d" | "c" | "y"
+      const dir = opSearchMatch[2] === "/" ? "forward" : "backward"
+      setSearchOperator(op)
+      setSearchMode(true)
+      setSearchBuffer("")
+      setSearchDirection(dir)
+      return handled()
+    }
+
+    // dG - delete to end
+    if (cmd === "dG") {
+      setCommand("")
+
+      const action = () => deleteToLine(lines().length - 1)
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // d{n}G - delete to line N
+    const dGMatch = cmd.match(/^d(\d+)G$/)
+    if (dGMatch) {
+      setCommand("")
+
+      const target = parseInt(dGMatch[1], 10) - 1
+      const action = () => deleteToLine(target)
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // d{n}w, c{n}w
+    const opWordMatch = cmd.match(/^([dc])(\d*)w$/)
+    if (opWordMatch) {
+      setCommand("")
+      const op = opWordMatch[1]
+      const count = opWordMatch[2] ? parseInt(opWordMatch[2], 10) : 1
+
+      const action = () => deleteWords(count)
+      action()
+      setLastAction(() => action)
+
+      if (op === "c") {
+        // After deleting, if cursor is on non-whitespace, insert space to preserve word separation
+        const c = cursor()
+        const char = lines()[c.row]?.[c.col]
+        if (char && !/\s/.test(char)) {
+          textarea.insertText(" ")
+          textarea.moveCursorLeft()
+          contentChanged()
+        }
+        enterInsert("c{n}w")
+      }
+      return handled()
+    }
+
+    // y$
+    if (cmd === "y$") {
+      setCommand("")
+      const c = cursor()
+      const yanked = lines()[c.row]?.slice(c.col) || ""
+      if (yanked) setYank(yanked)
+      return handled()
+    }
+
+    // yG - yank from current position to end of file
+    if (cmd === "yG") {
+      setCommand("")
+      const c = cursor()
+      const ls = lines()
+      const currentLineRest = ls[c.row]?.slice(c.col) || ""
+      const remainingLines = ls.slice(c.row + 1)
+      const yanked = currentLineRest + (remainingLines.length ? "\n" + remainingLines.join("\n") : "")
+      if (yanked) setYank(yanked)
+      return handled()
+    }
+
+    // y% - yank to matching bracket
+    if (cmd === "y%") {
+      setCommand("")
+      const text = textarea.plainText
+      const startOffset = textarea.cursorOffset
+      const char = text[startOffset]
+      const pairs: Record<string, string> = {
+        "(": ")",
+        ")": "(",
+        "[": "]",
+        "]": "[",
+        "{": "}",
+        "}": "{",
+      }
+      const match = pairs[char]
+      if (match) {
+        const isOpen = "([{".includes(char)
+        let depth = 1
+        let endOffset = startOffset
+
+        if (isOpen) {
+          for (let i = startOffset + 1; i < text.length; i++) {
+            if (text[i] === char) depth++
+            if (text[i] === match) depth--
+            if (depth === 0) {
+              endOffset = i
+              break
+            }
+          }
+        } else {
+          for (let i = startOffset - 1; i >= 0; i--) {
+            if (text[i] === char) depth++
+            if (text[i] === match) depth--
+            if (depth === 0) {
+              endOffset = i
+              break
+            }
+          }
+        }
+        const start = Math.min(startOffset, endOffset)
+        const end = Math.max(startOffset, endOffset) + 1
+        const yanked = text.slice(start, end)
+        if (yanked) setYank(yanked)
+      }
+      return handled()
+    }
+
+    // y} - yank to next paragraph
+    if (cmd === "y}") {
+      setCommand("")
+      const c = cursor()
+      const ls = lines()
+      const startOffset = textarea.cursorOffset
+      const target = ls.slice(c.row + 1).findIndex((line, i) => {
+        const prev = ls[c.row + i]
+        return line.trim() === "" && prev && prev.trim() !== ""
+      })
+      const targetRow = target === -1 ? ls.length - 1 : c.row + 1 + target
+      const targetOffset = ls.slice(0, targetRow).join("\n").length
+      const yanked = textarea.plainText.slice(startOffset, targetOffset)
+      if (yanked) setYank(yanked)
+      return handled()
+    }
+
+    // y{ - yank to previous paragraph
+    if (cmd === "y{") {
+      setCommand("")
+      const c = cursor()
+      const ls = lines()
+      const startOffset = textarea.cursorOffset
+      const target = ls
+        .slice(0, c.row)
+        .reverse()
+        .findIndex((line, i) => {
+          const prev = ls[c.row - 1 - i - 1]
+          return line.trim() !== "" && (!prev || prev.trim() === "")
+        })
+      const targetRow = target === -1 ? 0 : c.row - 1 - target
+      const targetOffset = ls.slice(0, targetRow).join("\n").length
+      const start = Math.min(startOffset, targetOffset)
+      const end = Math.max(startOffset, targetOffset)
+      const yanked = textarea.plainText.slice(start, end)
+      if (yanked) setYank(yanked)
+      return handled()
+    }
+
+    // d$ - delete to end of line (same as D)
+    if (cmd === "d$") {
+      setCommand("")
+
+      const action = () => {
+        const c = cursor()
+        const yanked = lines()[c.row]?.slice(c.col) || ""
+        if (yanked) setYank(yanked)
+        textarea.deleteToLineEnd()
+        clamp()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // g{n}g
+    const gMatch = cmd.match(/^g(\d*)g$/)
+    if (gMatch) {
+      setCommand("")
+      const num = gMatch[1] ? parseInt(gMatch[1], 10) : 1
+      setCursor(num - 1, 0)
+      return handled()
+    }
+
+    // {n}G
+    const countGMatch = cmd.match(/^(\d+)G$/)
+    if (countGMatch) {
+      setCommand("")
+      const num = parseInt(countGMatch[1], 10)
+      setCursor(num - 1, 0)
+      return handled()
+    }
+
+    // {n}x
+    const countXMatch = cmd.match(/^(\d+)x$/)
+    if (countXMatch) {
+      setCommand("")
+
+      const count = parseInt(countXMatch[1], 10)
+      const action = () => {
+        const c = cursor()
+        const len = lineLen(c.row)
+        const deleteCount = Math.min(count, len - c.col)
+        if (deleteCount > 0) {
+          const yanked = lines()[c.row].slice(c.col, c.col + deleteCount)
+          setYank(yanked)
+          textarea.deleteRange(c.row, c.col, c.row, c.col + deleteCount)
+          textarea.requestRender()
+        }
+        clamp()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // {n}{motion}
+    const countMotionMatch = cmd.match(/^(\d+)([hjklwb])$/)
+    if (countMotionMatch) {
+      setCommand("")
+      const count = parseInt(countMotionMatch[1], 10)
+      const motion = countMotionMatch[2]
+      if (motion === "h") repeat(count, () => textarea.moveCursorLeft())
+      if (motion === "j") {
+        repeat(count, () => textarea.moveCursorDown())
+        clamp()
+      }
+      if (motion === "k") {
+        repeat(count, () => textarea.moveCursorUp())
+        clamp()
+      }
+      if (motion === "l") {
+        repeat(count, () => {
+          if (cursor().col < maxCol(cursor().row)) textarea.moveCursorRight()
+        })
+      }
+      if (motion === "w") {
+        repeat(count, () => textarea.moveWordForward())
+        clamp()
+      }
+      if (motion === "b") repeat(count, () => textarea.moveWordBackward())
+      return handled()
+    }
+
+    // Pending commands
+    if (/^[dycg]\d*$/.test(cmd) || /^[1-9]\d*$/.test(cmd)) {
+      setCommand(cmd)
+      return handled()
+    }
+
+    setCommand("")
+
+    // Single key movements - pass through to native handling
+    if (key === "h" || key === "left") {
+      textarea.moveCursorLeft()
+      return handled()
+    }
+    if (key === "j" || key === "down") {
+      textarea.moveCursorDown()
+      return handled()
+    }
+    if (key === "k" || key === "up") {
+      textarea.moveCursorUp()
+      return handled()
+    }
+    if (key === "l" || key === "right") {
+      textarea.moveCursorRight()
+      return handled()
+    }
+    if (key === "w") {
+      textarea.moveWordForward()
+      clamp()
+      return handled()
+    }
+    if (key === "b" && !evt.ctrl) {
+      textarea.moveWordBackward()
+      return handled()
+    }
+    if (key === "e") {
+      textarea.moveWordForward()
+      textarea.moveCursorLeft()
+      clamp()
+      return handled()
+    }
+    if (key === "0") {
+      setCursor(cursor().row, 0)
+      return handled()
+    }
+    if (key === "$") {
+      setCursor(cursor().row, maxCol(cursor().row))
+      return handled()
+    }
+    if (key === "G" && !pending) {
+      textarea.gotoBufferEnd()
+      clamp()
+      return handled()
+    }
+    if (key === "{") {
+      const c = cursor()
+      const ls = lines()
+      const target = ls
+        .slice(0, c.row)
+        .reverse()
+        .findIndex((line, i) => {
+          const prev = ls[c.row - 1 - i - 1]
+          return line.trim() !== "" && (!prev || prev.trim() === "")
+        })
+      setCursor(target === -1 ? 0 : c.row - 1 - target, 0)
+      return handled()
+    }
+    if (key === "}") {
+      const c = cursor()
+      const ls = lines()
+      const target = ls.slice(c.row + 1).findIndex((line, i) => {
+        const prev = ls[c.row + i]
+        return line.trim() === "" && prev && prev.trim() !== ""
+      })
+      setCursor(target === -1 ? ls.length - 1 : c.row + 1 + target, 0)
+      return handled()
+    }
+
+    // Match bracket
+    if (key === "%") {
+      const c = cursor()
+      const line = lines()[c.row]
+      const char = line?.[c.col]
+      const pairs: Record<string, string> = {
+        "(": ")",
+        ")": "(",
+        "[": "]",
+        "]": "[",
+        "{": "}",
+        "}": "{",
+      }
+      const match = pairs[char]
+      if (match) {
+        const isOpen = "([{".includes(char)
+        const text = textarea.plainText
+        const startOffset = textarea.cursorOffset
+        let depth = 1
+
+        if (isOpen) {
+          for (let i = startOffset + 1; i < text.length; i++) {
+            if (text[i] === char) depth++
+            if (text[i] === match) depth--
+            if (depth === 0) {
+              textarea.cursorOffset = i
+              break
+            }
+          }
+        } else {
+          for (let i = startOffset - 1; i >= 0; i--) {
+            if (text[i] === char) depth++
+            if (text[i] === match) depth--
+            if (depth === 0) {
+              textarea.cursorOffset = i
+              break
+            }
+          }
+        }
+      }
+      return handled()
+    }
+
+    // Insert entry
+    if (key === "i") {
+      enterInsert("i")
+      return handled()
+    }
+    if (key === "a") {
+      setCursor(cursor().row, cursor().col + 1, false)
+      enterInsert("a")
+      return handled()
+    }
+    if (key === "I") {
+      enterInsert("I")
+      setCursor(cursor().row, 0, false)
+      return handled()
+    }
+    if (key === "A") {
+      setCursor(cursor().row, lineLen(cursor().row), false)
+      enterInsert("A")
+      return handled()
+    }
+    if (key === "o") {
+      enterInsert("o")
+      textarea.gotoLineEnd()
+      textarea.insertText("\n")
+      contentChanged()
+      return handled()
+    }
+    if (key === "O") {
+      enterInsert("O")
+      setCursor(cursor().row, 0, false)
+      textarea.insertText("\n")
+      textarea.moveCursorUp()
+      contentChanged()
+      return handled()
+    }
+
+    // Delete
+    if (key === "x") {
+      const action = () => {
+        const c = cursor()
+        const char = lines()[c.row]?.[c.col]
+        if (char && options.clipX) setYank(char)
+        textarea.deleteChar()
+        clamp()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+    if (key === "D") {
+      const action = () => {
+        const c = cursor()
+        const yanked = lines()[c.row]?.slice(c.col) || ""
+        if (yanked) setYank(yanked)
+        textarea.deleteToLineEnd()
+        clamp()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // Change
+    if (key === "C") {
+      const c = cursor()
+      const yanked = lines()[c.row]?.slice(c.col) || ""
+      if (yanked) setYank(yanked)
+      enterInsert("C")
+      textarea.deleteToLineEnd()
+      contentChanged()
+      return handled()
+    }
+
+    // Paste
+    if (key === "p") {
+      const action = () => {
+        const y = yankReg()
+        if (!y) return
+        if (y.endsWith("\n")) {
+          const c = cursor()
+          textarea.gotoLineEnd()
+          textarea.insertText("\n" + y.slice(0, -1))
+          setCursor(c.row + 1, 0)
+        }
+        if (!y.endsWith("\n")) {
+          textarea.moveCursorRight()
+          textarea.insertText(y)
+        }
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+    if (key === "P") {
+      const action = () => {
+        const y = yankReg()
+        if (!y) return
+        if (y.endsWith("\n")) {
+          const c = cursor()
+          setCursor(c.row, 0, false)
+          textarea.insertText(y)
+          setCursor(c.row, 0)
+        }
+        if (!y.endsWith("\n")) {
+          textarea.insertText(y)
+        }
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // Join
+    if (key === "J") {
+      const action = () => {
+        const c = cursor()
+        const ls = lines()
+        if (c.row >= ls.length - 1) return
+        const len = lineLen(c.row)
+        textarea.deleteRange(c.row, len, c.row + 1, 0)
+        const next = ls[c.row + 1]?.[0]
+        if (next && next !== " ") {
+          setCursor(c.row, len, false)
+          textarea.insertText(" ")
+        }
+        textarea.requestRender()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // Repeat
+    if (key === ".") {
+      const action = lastAction()
+      if (action) action()
+      return handled()
+    }
+
+    // Replace
+    if (key === "r" && !evt.ctrl) {
+      setReplaceMode(true)
+      return handled()
+    }
+
+    // Substitute
+    if (key === "s") {
+      enterInsert("s")
+      const action = () => {
+        textarea.deleteChar()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // Toggle case
+    if (key === "~") {
+      const action = () => {
+        const c = cursor()
+        const char = lines()[c.row]?.[c.col]
+        if (!char) return
+        const toggled = char === char.toUpperCase() ? char.toLowerCase() : char.toUpperCase()
+        textarea.deleteChar()
+        textarea.insertText(toggled)
+        clamp()
+        contentChanged()
+      }
+      action()
+      setLastAction(() => action)
+      return handled()
+    }
+
+    // Undo - use native textarea undo
+    if (key === "u") {
+      textarea.undo()
+      clamp()
+      contentChanged()
+      return handled()
+    }
+
+    // Redo
+    if (evt.ctrl && evt.name === "r") {
+      textarea.redo()
+      clamp()
+      contentChanged()
+      return handled()
+    }
+
+    // Page movement
+    if (evt.ctrl && key === "f") {
+      const size = textarea.height - 2
+      repeat(size, () => textarea.moveCursorDown())
+      clamp()
+      return handled()
+    }
+    if (evt.ctrl && key === "b") {
+      const size = textarea.height - 2
+      repeat(size, () => textarea.moveCursorUp())
+      clamp()
+      return handled()
+    }
+
+    // Search commands (only for full mode, not prompt)
+    if (mode === "full") {
+      // / - start forward search
+      if (key === "/") {
+        setSearchMode(true)
+        setSearchBuffer("")
+        setSearchDirection("forward")
+        return handled()
+      }
+      // ? - start backward search
+      if (key === "?") {
+        setSearchMode(true)
+        setSearchBuffer("")
+        setSearchDirection("backward")
+        return handled()
+      }
+      // n - next match (same direction)
+      if (key === "n") {
+        const pattern = searchPattern()
+        if (pattern) findMatch(pattern, searchDirection())
+        return handled()
+      }
+      // N - previous match (opposite direction)
+      if (key === "N") {
+        const pattern = searchPattern()
+        if (pattern) findMatch(pattern, searchDirection() === "forward" ? "backward" : "forward")
+        return handled()
+      }
+    }
+
+    if (key === "escape") return handled()
+
+    return false
+  }
+
+  const reset = () => {
+    setState(config.startInsert ? "insert" : "normal")
+    setCommand("")
+    setReplaceMode(false)
+    setSearchMode(false)
+    setSearchBuffer("")
+    setSearchOperator(null)
+  }
+
+  return {
+    state,
+    command,
+    yank: yankReg,
+    replaceMode,
+    handleKey,
+    reset,
+    searchMode,
+    searchBuffer,
+    searchPattern,
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/lib/vi-basic-extension.tsx
+++ b/packages/opencode/src/cli/cmd/tui/lib/vi-basic-extension.tsx
@@ -1,0 +1,110 @@
+import type { TextareaRenderable } from "@opentui/core"
+import type { PromptExtension, PromptKeyEvent } from "./prompt-extension"
+import { useViBasic } from "./vi-basic-core"
+import { useKV } from "../context/kv"
+import { useTheme } from "../context/theme"
+
+export interface ViBasicExtensionOptions {
+  textarea: () => TextareaRenderable | undefined
+  onContentChange: () => void
+}
+
+/**
+ * Create a vi basic extension for the prompt
+ */
+export function createViBasicExtension(options: ViBasicExtensionOptions): PromptExtension {
+  const kv = useKV()
+  const { theme } = useTheme()
+
+  const enabled = () => kv.get("prompt_vi_basic", false) as boolean
+  const setEnabled = (value: boolean) => kv.set("prompt_vi_basic", value)
+  const clipX = () => kv.get("vi_basic_clip_x", false) as boolean
+
+  const viBasic = useViBasic({
+    textarea: options.textarea,
+    onContentChange: options.onContentChange,
+    mode: "prompt",
+    clipX: clipX(),
+  })
+
+  return {
+    id: "vi-basic",
+
+    enabled,
+
+    handleKey: (event: PromptKeyEvent) => {
+      if (!enabled()) return false
+
+      return viBasic.handleKey(event)
+    },
+
+    keyPhase: "pre",
+
+    handleEscape: () => {
+      if (!enabled()) return false
+
+      // In vi insert mode, escape exits insert mode
+      if (viBasic.state() === "insert") {
+        viBasic.handleKey({ name: "escape", preventDefault: () => {} })
+        return true
+      }
+
+      // In vi command mode with pending command, escape aborts the command
+      if (viBasic.command()) {
+        viBasic.handleKey({ name: "escape", preventDefault: () => {} })
+        return true
+      }
+
+      return false
+    },
+
+    blockInterrupt: () => {
+      if (!enabled()) return false
+      // Block interrupt when in insert mode or with pending command
+      return viBasic.state() === "insert" || !!viBasic.command()
+    },
+
+    StatusIndicator: () => {
+      if (!enabled()) return <></>
+
+      const isInsert = viBasic.state() === "insert"
+
+      return (
+        <text>
+          <span
+            style={{
+              fg: isInsert ? theme.background : theme.textMuted,
+              bg: isInsert ? theme.success : theme.backgroundElement,
+            }}
+          >
+            {isInsert ? "  INSERT  " : viBasic.command() ? ` ${viBasic.command().padEnd(8, " ")} ` : " vi basic "}
+          </span>
+        </text>
+      )
+    },
+
+    commands: () => [
+      {
+        title: enabled() ? "Use standard prompt editor" : "Use vi basic prompt editor",
+        value: "prompt.toggle.vi",
+        category: "Prompt",
+        onSelect: () => {
+          const newValue = !enabled()
+          setEnabled(newValue)
+          viBasic.reset()
+        },
+      },
+    ],
+
+    reset: () => {
+      viBasic.reset()
+    },
+
+    onToggle: (value: boolean) => {
+      setEnabled(value)
+      if (!value) viBasic.reset()
+    },
+
+    getState: () => viBasic.state(),
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/content-panel.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/content-panel.tsx
@@ -1,0 +1,95 @@
+import { createEffect, createMemo, createSignal, Show } from "solid-js"
+import { useTheme } from "../../context/theme"
+import { useKV } from "../../context/kv"
+import { FileViewer } from "./file-viewer"
+import type { MouseEvent } from "@opentui/core"
+
+interface ContentPanelProps {
+  filePath: string | null
+  sessionID: string
+  totalWidth: number
+  onClose: () => void
+  onActiveFileChange?: (filePath: string | null) => void
+  onFocusChange?: (focused: boolean) => void
+  onWidthChange?: (width: number) => void
+  onEnterEdit?: () => void
+  onExitEdit?: () => void
+}
+
+export function ContentPanel(props: ContentPanelProps) {
+  const { theme } = useTheme()
+  const kv = useKV()
+  const [focused, setFocused] = createSignal(false)
+  const [width, setWidth] = createSignal<number>(kv.get("content_panel_width", 60))
+  const [dragging, setDragging] = createSignal(false)
+  const [displayedFile, setDisplayedFile] = createSignal<string | null>(null)
+
+  const clampedWidth = createMemo(() => {
+    const minWidth = 65
+    const maxWidth = props.totalWidth - 30
+    return Math.max(minWidth, Math.min(maxWidth, width()))
+  })
+
+  // Auto-focus when a file is opened
+  createEffect(() => {
+    if (props.filePath) {
+      setFocused(true)
+      props.onFocusChange?.(true)
+    }
+  })
+
+  // Notify parent of width changes
+  createEffect(() => {
+    const w = props.filePath ? clampedWidth() + 1 : 0
+    props.onWidthChange?.(w)
+  })
+
+  // Notify parent of displayed file changes
+  createEffect(() => {
+    props.onActiveFileChange?.(displayedFile())
+  })
+
+  const handleFocus = () => {
+    setFocused(true)
+    props.onFocusChange?.(true)
+  }
+
+  const handleClose = () => {
+    setFocused(false)
+    setDisplayedFile(null)
+    props.onFocusChange?.(false)
+    props.onClose()
+  }
+
+  return (
+    <Show when={props.filePath}>
+      <box
+        width={1}
+        backgroundColor={dragging() ? theme.accent : theme.border}
+        onMouseDown={() => setDragging(true)}
+        onMouseDrag={(e: MouseEvent) => {
+          if (dragging()) {
+            const newWidth = Math.max(20, Math.min(props.totalWidth - 30, props.totalWidth - e.x))
+            setWidth(newWidth)
+          }
+        }}
+        onMouseDragEnd={() => {
+          setDragging(false)
+          kv.set("content_panel_width", width())
+        }}
+      />
+      <box width={clampedWidth()}>
+        <FileViewer
+          filePath={props.filePath!}
+          sessionID={props.sessionID}
+          focused={focused()}
+          onFocus={handleFocus}
+          onClose={handleClose}
+          onFileChange={(file: string) => setDisplayedFile(file)}
+          onEnterEdit={props.onEnterEdit}
+          onExitEdit={props.onExitEdit}
+        />
+      </box>
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/file-viewer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/file-viewer.tsx
@@ -1,0 +1,730 @@
+import { createEffect, createMemo, createSignal, on, onMount, Show, untrack } from "solid-js"
+import { useTheme } from "../../context/theme"
+import { useSync } from "@tui/context/sync"
+import { useToast } from "../../ui/toast"
+import { useDialog } from "../../ui/dialog"
+import { DialogConfirm } from "../../ui/dialog-confirm"
+import { useKeyboard } from "@opentui/solid"
+import { useKV } from "../../context/kv"
+import { useViBasic } from "../../lib/vi-basic-core"
+import path from "path"
+import { createTwoFilesPatch } from "diff"
+import type {
+  TextareaRenderable,
+  BoxRenderable,
+  ScrollBoxRenderable,
+  MouseEvent,
+  LineNumberRenderable,
+} from "@opentui/core"
+
+interface FileViewerProps {
+  filePath: string
+  sessionID: string
+  focused: boolean
+  onFocus: () => void
+  onClose: () => void
+  onFileChange?: (filePath: string) => void
+  onEnterEdit?: () => void
+  onExitEdit?: () => void
+}
+
+export function FileViewer(props: FileViewerProps) {
+  const { theme, syntax } = useTheme()
+  const sync = useSync()
+  const toast = useToast()
+  const dialog = useDialog()
+  const kv = useKV()
+  const [content, setContent] = createSignal("")
+  const [originalContent, setOriginalContent] = createSignal("")
+  const [currentFile, setCurrentFile] = createSignal(props.filePath)
+  const [loading, setLoading] = createSignal(true)
+  const [error, setError] = createSignal<string | null>(null)
+  const [showDiff, setShowDiff] = createSignal(true)
+  const [editMode, setEditMode] = createSignal(false)
+  const [saving, setSaving] = createSignal(false)
+  const [mouseDownPos, setMouseDownPos] = createSignal<{ x: number; y: number } | null>(null)
+  const [savedScrollPercent, setSavedScrollPercent] = createSignal(0)
+  const [pendingScrollRestore, setPendingScrollRestore] = createSignal(false)
+
+  let textareaRef: TextareaRenderable | undefined
+  let containerRef: BoxRenderable | undefined
+  let scrollRef: ScrollBoxRenderable | undefined
+  let lineNumberRef: LineNumberRenderable | undefined
+
+  // Editor mode (standard or vi)
+  const editorMode = () => kv.get("editor_mode", "standard") as "standard" | "vi"
+  const setEditorMode = (mode: "standard" | "vi") => kv.set("editor_mode", mode)
+
+  // Vi mode hook
+  const viMode = useViBasic({
+    textarea: () => textareaRef,
+    onContentChange: () => setContent(textareaRef?.plainText ?? ""),
+    lineNumbers: () => lineNumberRef,
+  })
+
+  // Blur textarea when focus is lost
+  createEffect(() => {
+    if (!props.focused && textareaRef) {
+      textareaRef.blur()
+    }
+  })
+
+  // Manual click routing for header buttons when hit grid is broken by scroll
+  const handleContainerClick = (e: MouseEvent) => {
+    if (!containerRef) return
+    const localY = e.y - containerRef.y
+    if (localY === 0) {
+      const localX = e.x - containerRef.x
+      const w = containerRef.width
+      const xFromRight = w - localX
+      if (xFromRight <= 3) {
+        if (editMode() && hasChanges()) {
+          toast.show({ message: "edit canceled", variant: "info" })
+        }
+        discardChanges()
+        props.onClose()
+        e.stopPropagation()
+      } else if (xFromRight <= 10) {
+        if (!editMode()) toggleEdit()
+        e.stopPropagation()
+      } else if (xFromRight <= 17) {
+        if (fileDiff() && !editMode()) setShowDiff(!showDiff())
+        e.stopPropagation()
+      } else if (xFromRight <= 24) {
+        if (!editMode()) openFile()
+        e.stopPropagation()
+      }
+    }
+  }
+
+  const directory = createMemo(() => sync.data.path.directory || process.cwd())
+  const worktree = createMemo(() => sync.data.path.worktree || directory())
+
+  const fullPath = createMemo(() => {
+    const file = currentFile()
+    if (path.isAbsolute(file)) return file
+    return path.join(directory(), file)
+  })
+
+  const relativePath = createMemo(() => {
+    const full = fullPath()
+    const root = worktree()
+    if (full.startsWith(root)) return full.slice(root.length + 1)
+    return currentFile()
+  })
+
+  const fileDiff = createMemo(() => {
+    const diffs = sync.data.session_diff[props.sessionID] ?? []
+    return diffs.find((d) => d.file === relativePath())
+  })
+
+  createEffect(() => {
+    currentFile()
+    if (fileDiff()) setShowDiff(true)
+  })
+
+  const diffContent = createMemo(() => {
+    const fd = fileDiff()
+    if (!fd) return null
+    return createTwoFilesPatch(currentFile(), currentFile(), fd.before, fd.after)
+  })
+
+  const hasChanges = createMemo(() => content() !== originalContent())
+
+  const filetype = createMemo(() => {
+    const ext = path.extname(currentFile()).slice(1).toLowerCase()
+    const name = path.basename(currentFile()).toLowerCase()
+
+    const nameMap: Record<string, string> = {
+      dockerfile: "dockerfile",
+      makefile: "makefile",
+      cmakelists: "cmake",
+      gemfile: "ruby",
+      rakefile: "ruby",
+      procfile: "yaml",
+      vagrantfile: "ruby",
+      brewfile: "ruby",
+      justfile: "makefile",
+    }
+
+    const extMap: Record<string, string> = {
+      ts: "typescript",
+      tsx: "tsx",
+      js: "javascript",
+      jsx: "jsx",
+      py: "python",
+      rb: "ruby",
+      rs: "rust",
+      go: "go",
+      java: "java",
+      c: "c",
+      cpp: "cpp",
+      h: "c",
+      hpp: "cpp",
+      cs: "csharp",
+      php: "php",
+      swift: "swift",
+      kt: "kotlin",
+      scala: "scala",
+      sh: "bash",
+      bash: "bash",
+      zsh: "bash",
+      fish: "fish",
+      ps1: "powershell",
+      sql: "sql",
+      html: "html",
+      css: "css",
+      scss: "scss",
+      less: "less",
+      json: "json",
+      yaml: "yaml",
+      yml: "yaml",
+      xml: "xml",
+      md: "markdown",
+      mdx: "mdx",
+      txt: "text",
+      toml: "toml",
+      ini: "ini",
+      cfg: "ini",
+      conf: "ini",
+      env: "dotenv",
+      zig: "zig",
+      nim: "nim",
+      lua: "lua",
+      r: "r",
+      jl: "julia",
+      ex: "elixir",
+      exs: "elixir",
+      erl: "erlang",
+      hs: "haskell",
+      ml: "ocaml",
+      fs: "fsharp",
+      clj: "clojure",
+      lisp: "lisp",
+      scm: "scheme",
+      vue: "vue",
+      svelte: "svelte",
+      astro: "astro",
+    }
+
+    return nameMap[name] || extMap[ext] || ext || undefined
+  })
+
+  const loadFile = async () => {
+    setLoading(true)
+    setError(null)
+    setEditMode(false)
+    const file = Bun.file(fullPath())
+    const exists = await file.exists()
+    if (!exists) {
+      setError("File not found")
+      setLoading(false)
+      return
+    }
+    const text = await file.text().catch(() => null)
+    if (text === null) {
+      setError("Failed to read file")
+      setLoading(false)
+      return
+    }
+    setContent(text)
+    setOriginalContent(text)
+    setLoading(false)
+  }
+
+  onMount(() => {
+    props.onFileChange?.(props.filePath)
+  })
+
+  const saveFile = async () => {
+    if (!hasChanges() || saving()) return
+    setSaving(true)
+    const result = await Bun.write(fullPath(), content()).catch(() => null)
+    if (result === null) {
+      toast.show({ message: "failed to save file", variant: "error" })
+      setSaving(false)
+      return
+    }
+    setOriginalContent(content())
+    setSaving(false)
+    if (textareaRef) {
+      const maxScroll = textareaRef.editorView.getTotalVirtualLineCount() - textareaRef.height
+      setSavedScrollPercent(maxScroll > 0 ? textareaRef.scrollY / maxScroll : 0)
+    }
+    setPendingScrollRestore(true)
+    setEditMode(false)
+    props.onExitEdit?.()
+  }
+
+  const toggleEdit = () => {
+    const newEditMode = !editMode()
+    if (newEditMode) {
+      if (scrollRef) {
+        const maxScroll = Math.max(0, scrollRef.scrollHeight - scrollRef.height)
+        setSavedScrollPercent(maxScroll > 0 ? scrollRef.scrollTop / maxScroll : 0)
+      }
+      setEditMode(true)
+      props.onEnterEdit?.()
+      queueMicrotask(() => {
+        try {
+          if (textareaRef) {
+            textareaRef.focus()
+            const viewport = textareaRef.editorView.getViewport()
+            const maxScroll = textareaRef.editorView.getTotalVirtualLineCount() - viewport.height
+            const targetY = Math.round(savedScrollPercent() * Math.max(0, maxScroll))
+            textareaRef.editorView.setViewport(viewport.offsetX, targetY, viewport.width, viewport.height, true)
+          }
+        } catch {
+          // EditorView may be destroyed if component unmounted
+        }
+      })
+    } else {
+      if (textareaRef) {
+        const maxScroll = textareaRef.editorView.getTotalVirtualLineCount() - textareaRef.height
+        setSavedScrollPercent(maxScroll > 0 ? textareaRef.scrollY / maxScroll : 0)
+      }
+      setPendingScrollRestore(true)
+      setEditMode(false)
+      props.onExitEdit?.()
+    }
+  }
+
+  const discardChanges = () => {
+    if (editMode() && textareaRef) {
+      const maxScroll = textareaRef.editorView.getTotalVirtualLineCount() - textareaRef.height
+      setSavedScrollPercent(maxScroll > 0 ? textareaRef.scrollY / maxScroll : 0)
+      setPendingScrollRestore(true)
+      props.onExitEdit?.()
+    }
+    setContent(originalContent())
+    setEditMode(false)
+  }
+
+  const openFile = () => {
+    const file = fullPath()
+    const opts = { stdout: "ignore" as const, stderr: "ignore" as const }
+    if (process.platform === "darwin") {
+      Bun.spawn(["open", file], opts)
+    } else if (process.platform === "win32") {
+      Bun.spawn(["cmd", "/c", "start", "", file], opts)
+    } else {
+      Bun.spawn(["xdg-open", file], opts)
+    }
+  }
+
+  createEffect(
+    on(
+      () => props.filePath,
+      (newFile) => {
+        if (newFile === untrack(currentFile)) {
+          loadFile()
+          return
+        }
+        if (untrack(editMode) && untrack(hasChanges)) {
+          DialogConfirm.show(dialog, "Unsaved Changes", "Discard changes and open file?").then((confirmed) => {
+            if (confirmed) {
+              setCurrentFile(newFile)
+              props.onFileChange?.(newFile)
+              loadFile()
+            }
+          })
+          return
+        }
+        setCurrentFile(newFile)
+        props.onFileChange?.(newFile)
+        loadFile()
+      },
+    ),
+  )
+
+  useKeyboard((evt) => {
+    if (!props.focused) return
+
+    // ctrl+c: if editing, cancel edit; if viewing, close panel
+    if (evt.name === "c" && evt.ctrl) {
+      evt.preventDefault()
+      if (editMode()) {
+        discardChanges()
+      } else {
+        props.onClose()
+      }
+      return
+    }
+
+    // Edit mode handling
+    if (editMode() && textareaRef) {
+      // ctrl+/: toggle editor mode (standard/vi)
+      if (evt.name === "\u001f" || evt.sequence === "\u001f") {
+        evt.preventDefault()
+        const newMode = editorMode() === "vi" ? "standard" : "vi"
+        setEditorMode(newMode)
+        viMode.reset()
+        return
+      }
+
+      // ctrl+s: save (works in both standard and vi mode)
+      if (evt.name === "s" && evt.ctrl) {
+        evt.preventDefault()
+        saveFile()
+        return
+      }
+
+      // Vi mode handling - only when textarea is focused
+      if (editorMode() === "vi" && textareaRef.focused) {
+        if (viMode.handleKey(evt)) return
+      }
+
+      // Regular edit mode (standard) - only when textarea is focused
+      // Enter key inserts newline
+      if (evt.name === "return" && textareaRef.focused) {
+        evt.preventDefault()
+        textareaRef.insertText("\n")
+        return
+      }
+
+      const pageSize = textareaRef.height - 2
+      if (evt.name === "up" && evt.ctrl) {
+        for (let i = 0; i < pageSize; i++) textareaRef.moveCursorUp()
+        return
+      }
+      if (evt.name === "down" && evt.ctrl) {
+        for (let i = 0; i < pageSize; i++) textareaRef.moveCursorDown()
+        return
+      }
+      if (evt.name === "o" && evt.ctrl) {
+        openFile()
+        return
+      }
+    }
+
+    // View mode shortcuts
+    if (!editMode()) {
+      if (evt.name === "e" && evt.ctrl) {
+        toggleEdit()
+        return
+      }
+      if (evt.name === "o" && evt.ctrl) {
+        openFile()
+        return
+      }
+      if (evt.name === "d" && evt.ctrl && fileDiff()) {
+        setShowDiff(!showDiff())
+        return
+      }
+      if (scrollRef) {
+        const pageSize = scrollRef.height - 2
+        if (evt.name === "up" && evt.ctrl) {
+          scrollRef.scrollBy(-pageSize)
+          return
+        }
+        if (evt.name === "down" && evt.ctrl) {
+          scrollRef.scrollBy(pageSize)
+          return
+        }
+        if (evt.name === "home") {
+          scrollRef.scrollTo(0)
+          return
+        }
+        if (evt.name === "end") {
+          scrollRef.scrollTo(scrollRef.scrollHeight)
+          return
+        }
+      }
+    }
+  })
+
+  return (
+    <box
+      ref={(r) => (containerRef = r)}
+      flexGrow={1}
+      flexDirection="column"
+      overflow="hidden"
+      onMouseDown={props.onFocus}
+      onMouseUp={handleContainerClick}
+    >
+      {/* Header */}
+      <box
+        flexDirection="row"
+        justifyContent="space-between"
+        paddingLeft={2}
+        paddingRight={2}
+        backgroundColor={theme.backgroundElement}
+        borderColor={props.focused ? theme.accent : theme.border}
+        border={["left"]}
+        flexShrink={0}
+      >
+        <box flexGrow={1} flexShrink={1}>
+          <text fg={theme.text}>
+            <b>{relativePath()}</b>
+            <Show when={hasChanges()}>
+              <span style={{ fg: theme.warning }}> [modified]</span>
+            </Show>
+          </text>
+        </box>
+        <box flexDirection="row" gap={1} flexShrink={0}>
+          <text
+            fg={hasChanges() ? theme.success : theme.textMuted}
+            onMouseUp={(e: MouseEvent) => {
+              e.stopPropagation()
+              saveFile()
+            }}
+            visible={editMode()}
+          >
+            {saving() ? "[saving...]" : "[save]"}
+          </text>
+          <text
+            fg={theme.warning}
+            onMouseUp={(e: MouseEvent) => {
+              e.stopPropagation()
+              discardChanges()
+            }}
+            visible={editMode()}
+          >
+            [cancel]
+          </text>
+          <Show when={fileDiff()}>
+            <text fg={theme.diffAdded}>+{fileDiff()!.additions}</text>
+            <text fg={theme.diffRemoved}>-{fileDiff()!.deletions}</text>
+          </Show>
+          <text
+            fg={editMode() ? theme.textMuted : theme.text}
+            onMouseUp={(e: MouseEvent) => {
+              e.stopPropagation()
+              if (!editMode()) openFile()
+            }}
+          >
+            [open]
+          </text>
+          <text
+            fg={!fileDiff() || editMode() ? theme.textMuted : showDiff() ? theme.accent : theme.text}
+            onMouseUp={(e: MouseEvent) => {
+              e.stopPropagation()
+              if (fileDiff() && !editMode()) setShowDiff(!showDiff())
+            }}
+          >
+            [diff]
+          </text>
+          <text
+            fg={editMode() ? theme.textMuted : theme.text}
+            onMouseUp={(e: MouseEvent) => {
+              e.stopPropagation()
+              if (!editMode()) toggleEdit()
+            }}
+          >
+            [edit]
+          </text>
+          <text
+            fg={theme.textMuted}
+            onMouseUp={(e: MouseEvent) => {
+              e.stopPropagation()
+              if (editMode() && hasChanges()) {
+                toast.show({ message: "edit canceled", variant: "info" })
+              }
+              discardChanges()
+              props.onClose()
+            }}
+          >
+            [x]
+          </text>
+        </box>
+      </box>
+
+      {/* Content */}
+      <Show when={loading()}>
+        <box
+          flexGrow={1}
+          paddingLeft={2}
+          paddingTop={1}
+          borderColor={props.focused ? theme.accent : theme.border}
+          border={["left"]}
+        >
+          <text fg={theme.textMuted}>Loading...</text>
+        </box>
+      </Show>
+
+      <Show when={error()}>
+        <box
+          flexGrow={1}
+          paddingLeft={2}
+          paddingTop={1}
+          borderColor={props.focused ? theme.accent : theme.border}
+          border={["left"]}
+        >
+          <text fg={theme.error}>{error()}</text>
+        </box>
+      </Show>
+
+      <Show when={!loading() && !error()}>
+        <Show when={editMode()}>
+          <box
+            flexGrow={1}
+            flexDirection="column"
+            borderColor={props.focused ? theme.accent : theme.border}
+            border={["left"]}
+            onMouseDown={() => textareaRef?.focus()}
+          >
+            <line_number
+              flexGrow={1}
+              fg={theme.textMuted}
+              bg={theme.background}
+              ref={(r: LineNumberRenderable) => {
+                lineNumberRef = r
+                import("@opentui/core").then(({ TextareaRenderable }) => {
+                  const ctx = (r as any).ctx
+                  const textarea = new TextareaRenderable(ctx, {
+                    id: "file-editor-textarea",
+                    initialValue: content(),
+                    backgroundColor: theme.background,
+                    textColor: theme.text,
+                    wrapMode: "word",
+                    showCursor: true,
+                    cursorColor: theme.accent,
+                    flexGrow: 1,
+                    keyBindings: [
+                      { name: "return", action: "newline" as const },
+                      { name: "s", ctrl: true, action: "submit" as const },
+                    ],
+                    onSubmit: saveFile,
+                    onContentChange: () => {
+                      setContent(textarea.plainText)
+                    },
+                  })
+                  textareaRef = textarea
+                  r.add(textarea)
+                  r.setLineNumbers(new Map([[textarea.lineCount - 1, textarea.lineCount]]))
+                  if (props.focused) textarea.focus()
+                })
+              }}
+            />
+            <Show when={editorMode() === "vi" && viMode.searchMode()}>
+              <box flexShrink={0} paddingLeft={1} backgroundColor={theme.background}>
+                <text>
+                  <span style={{ fg: theme.accent }}>/</span>
+                  <span style={{ fg: theme.text }}>{viMode.searchBuffer()}</span>
+                  <span style={{ fg: theme.accent }}>_</span>
+                </text>
+              </box>
+            </Show>
+            <box
+              flexShrink={0}
+              flexDirection="row"
+              backgroundColor="#000000"
+              justifyContent="space-between"
+              paddingLeft={2}
+              paddingRight={2}
+            >
+              <box flexDirection="row" gap={2}>
+                <Show when={editorMode() === "vi"} fallback={<text fg={theme.textMuted}>standard</text>}>
+                  <text fg={theme.accent}>vi</text>
+                </Show>
+                <text>
+                  <span style={{ fg: theme.text }}>ctrl+/</span>
+                  <span style={{ fg: theme.textMuted }}>{editorMode() === "vi" ? " use standard" : " use vi"}</span>
+                </text>
+                <Show when={editorMode() === "vi"}>
+                  <text
+                    style={{
+                      fg: viMode.state() === "insert" ? "#000000" : "#888888",
+                      bg: viMode.state() === "insert" ? "#98c379" : "#333333",
+                    }}
+                  >
+                    {viMode.state() === "insert"
+                      ? " INSERT "
+                      : viMode.command()
+                        ? ` ${viMode.command().padEnd(7, " ")} `
+                        : " NORMAL "}
+                  </text>
+                </Show>
+              </box>
+              <box flexDirection="row" gap={2}>
+                <text fg={theme.text}>ctrl+{"\u2191\u2193"}</text>
+                <text>
+                  <span style={{ fg: theme.text }}>ctrl+s</span>
+                  <span style={{ fg: theme.textMuted }}>ave</span>
+                </text>
+                <text>
+                  <span style={{ fg: theme.text }}>ctrl+c</span>
+                  <span style={{ fg: theme.textMuted }}>ancel</span>
+                </text>
+              </box>
+            </box>
+          </box>
+        </Show>
+        <Show when={!editMode()}>
+          <box
+            flexGrow={1}
+            flexDirection="column"
+            borderColor={props.focused ? theme.accent : theme.border}
+            border={["left"]}
+          >
+            <scrollbox
+              ref={(r) => {
+                scrollRef = r
+                if (r && pendingScrollRestore()) {
+                  setPendingScrollRestore(false)
+                  setTimeout(() => {
+                    const maxScroll = Math.max(0, r.scrollHeight - r.height)
+                    r.scrollTo(Math.round(savedScrollPercent() * maxScroll))
+                  }, 0)
+                }
+              }}
+              flexGrow={1}
+              paddingLeft={1}
+              paddingRight={1}
+              onMouseDown={(e: MouseEvent) => setMouseDownPos({ x: e.x, y: e.y })}
+              onMouseUp={(e: MouseEvent) => {
+                const down = mouseDownPos()
+                setMouseDownPos(null)
+                if (down && down.x === e.x && down.y === e.y) {
+                  toggleEdit()
+                }
+              }}
+            >
+              <Show
+                when={diffContent() && showDiff()}
+                fallback={<code content={content()} filetype={filetype()} syntaxStyle={syntax()} />}
+              >
+                <diff
+                  diff={diffContent()!}
+                  filetype={filetype()}
+                  syntaxStyle={syntax()}
+                  showLineNumbers={true}
+                  width="100%"
+                  fg={theme.text}
+                  addedBg={theme.diffAddedBg}
+                  removedBg={theme.diffRemovedBg}
+                />
+              </Show>
+            </scrollbox>
+            <box
+              flexShrink={0}
+              flexDirection="row"
+              backgroundColor="#000000"
+              justifyContent="flex-end"
+              paddingRight={2}
+              gap={2}
+            >
+              <text fg={theme.text}>ctrl+{"\u2191\u2193"}</text>
+              <text>
+                <span style={{ fg: theme.text }}>ctrl+e</span>
+                <span style={{ fg: theme.textMuted }}>dit</span>
+              </text>
+              <text>
+                <span style={{ fg: theme.text }}>ctrl+o</span>
+                <span style={{ fg: theme.textMuted }}>pen</span>
+              </text>
+              <text>
+                <span style={{ fg: theme.text }}>ctrl+d</span>
+                <span style={{ fg: theme.textMuted }}>iff</span>
+              </text>
+              <text>
+                <span style={{ fg: theme.text }}>ctrl+c</span>
+                <span style={{ fg: theme.textMuted }}>lose</span>
+              </text>
+            </box>
+          </box>
+        </Show>
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/file-viewer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/file-viewer.tsx
@@ -354,7 +354,8 @@ export function FileViewer(props: FileViewerProps) {
     // Edit mode handling
     if (editMode() && textareaRef) {
       // ctrl+/: toggle editor mode (standard/vi)
-      if (evt.name === "\u001f" || evt.sequence === "\u001f") {
+      // Some terminals send \u001f, others send "/" with ctrl flag
+      if (evt.name === "\u001f" || evt.sequence === "\u001f" || (evt.name === "/" && evt.ctrl)) {
         evt.preventDefault()
         const newMode = editorMode() === "vi" ? "standard" : "vi"
         setEditorMode(newMode)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -56,6 +56,7 @@ import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
 import { Sidebar } from "./sidebar"
+import { ContentPanel } from "./content-panel"
 import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
 import parsers from "../../../../../../parsers-config.ts"
 import { Clipboard } from "../../util/clipboard"
@@ -140,6 +141,10 @@ export function Session() {
   const [showScrollbar, setShowScrollbar] = createSignal(kv.get("scrollbar_visible", false))
   const [diffWrapMode, setDiffWrapMode] = createSignal<"word" | "none">("word")
   const [animationsEnabled, setAnimationsEnabled] = createSignal(kv.get("animations_enabled", true))
+  // Content panel state (file viewer)
+  const [requestedFile, setRequestedFile] = createSignal<string | null>(null)
+  const [activeFile, setActiveFile] = createSignal<string | null>(null)
+  const [contentPanelWidth, setContentPanelWidth] = createSignal(0)
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -149,6 +154,9 @@ export function Session() {
     return false
   })
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+
+  // Content panel total width for passing to ContentPanel
+  const contentPanelTotalWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
 
   const scrollAcceleration = createMemo(() => {
     const tui = sync.data.config.tui
@@ -557,6 +565,19 @@ export function Session() {
       },
     },
     {
+      title:
+        kv.get("editor_mode", "standard") === "vi"
+          ? "Use standard project file editor"
+          : "Use vi basic project file editor",
+      value: "session.toggle.file_editor_mode",
+      category: "Session",
+      onSelect: (dialog) => {
+        const current = kv.get("editor_mode", "standard") as "standard" | "vi"
+        kv.set("editor_mode", current === "vi" ? "standard" : "vi")
+        dialog.clear()
+      },
+    },
+    {
       title: "Page up",
       value: "session.page.up",
       keybind: "messages_page_up",
@@ -900,7 +921,8 @@ export function Session() {
     <context.Provider
       value={{
         get width() {
-          return contentWidth()
+          // Subtract file viewer panel width when it's open
+          return contentWidth() - contentPanelWidth()
         },
         sessionID: route.sessionID,
         conceal,
@@ -918,120 +940,135 @@ export function Session() {
             <Show when={!sidebarVisible()}>
               <Header />
             </Show>
-            <scrollbox
-              ref={(r) => (scroll = r)}
-              viewportOptions={{
-                paddingRight: showScrollbar() ? 1 : 0,
-              }}
-              verticalScrollbarOptions={{
-                paddingLeft: 1,
-                visible: showScrollbar(),
-                trackOptions: {
-                  backgroundColor: theme.backgroundElement,
-                  foregroundColor: theme.border,
-                },
-              }}
-              stickyScroll={true}
-              stickyStart="bottom"
-              flexGrow={1}
-              scrollAcceleration={scrollAcceleration()}
-            >
-              <For each={messages()}>
-                {(message, index) => (
-                  <Switch>
-                    <Match when={message.id === revert()?.messageID}>
-                      {(function () {
-                        const command = useCommandDialog()
-                        const [hover, setHover] = createSignal(false)
-                        const dialog = useDialog()
+            <box flexDirection="row" flexGrow={1}>
+              <scrollbox
+                ref={(r) => (scroll = r)}
+                viewportOptions={{
+                  paddingRight: showScrollbar() ? 1 : 0,
+                }}
+                verticalScrollbarOptions={{
+                  paddingLeft: 1,
+                  visible: showScrollbar(),
+                  trackOptions: {
+                    backgroundColor: theme.backgroundElement,
+                    foregroundColor: theme.border,
+                  },
+                }}
+                stickyScroll={true}
+                stickyStart="bottom"
+                flexGrow={1}
+                scrollAcceleration={scrollAcceleration()}
+              >
+                <For each={messages()}>
+                  {(message, index) => (
+                    <Switch>
+                      <Match when={message.id === revert()?.messageID}>
+                        {(function () {
+                          const command = useCommandDialog()
+                          const [hover, setHover] = createSignal(false)
+                          const dialog = useDialog()
 
-                        const handleUnrevert = async () => {
-                          const confirmed = await DialogConfirm.show(
-                            dialog,
-                            "Confirm Redo",
-                            "Are you sure you want to restore the reverted messages?",
-                          )
-                          if (confirmed) {
-                            command.trigger("session.redo")
+                          const handleUnrevert = async () => {
+                            const confirmed = await DialogConfirm.show(
+                              dialog,
+                              "Confirm Redo",
+                              "Are you sure you want to restore the reverted messages?",
+                            )
+                            if (confirmed) {
+                              command.trigger("session.redo")
+                            }
                           }
-                        }
 
-                        return (
-                          <box
-                            onMouseOver={() => setHover(true)}
-                            onMouseOut={() => setHover(false)}
-                            onMouseUp={handleUnrevert}
-                            marginTop={1}
-                            flexShrink={0}
-                            border={["left"]}
-                            customBorderChars={SplitBorder.customBorderChars}
-                            borderColor={theme.backgroundPanel}
-                          >
+                          return (
                             <box
-                              paddingTop={1}
-                              paddingBottom={1}
-                              paddingLeft={2}
-                              backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
+                              onMouseOver={() => setHover(true)}
+                              onMouseOut={() => setHover(false)}
+                              onMouseUp={handleUnrevert}
+                              marginTop={1}
+                              flexShrink={0}
+                              border={["left"]}
+                              customBorderChars={SplitBorder.customBorderChars}
+                              borderColor={theme.backgroundPanel}
                             >
-                              <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
-                              <text fg={theme.textMuted}>
-                                <span style={{ fg: theme.text }}>{keybind.print("messages_redo")}</span> or /redo to
-                                restore
-                              </text>
-                              <Show when={revert()!.diffFiles?.length}>
-                                <box marginTop={1}>
-                                  <For each={revert()!.diffFiles}>
-                                    {(file) => (
-                                      <text fg={theme.text}>
-                                        {file.filename}
-                                        <Show when={file.additions > 0}>
-                                          <span style={{ fg: theme.diffAdded }}> +{file.additions}</span>
-                                        </Show>
-                                        <Show when={file.deletions > 0}>
-                                          <span style={{ fg: theme.diffRemoved }}> -{file.deletions}</span>
-                                        </Show>
-                                      </text>
-                                    )}
-                                  </For>
-                                </box>
-                              </Show>
+                              <box
+                                paddingTop={1}
+                                paddingBottom={1}
+                                paddingLeft={2}
+                                backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
+                              >
+                                <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
+                                <text fg={theme.textMuted}>
+                                  <span style={{ fg: theme.text }}>{keybind.print("messages_redo")}</span> or /redo to
+                                  restore
+                                </text>
+                                <Show when={revert()!.diffFiles?.length}>
+                                  <box marginTop={1}>
+                                    <For each={revert()!.diffFiles}>
+                                      {(file) => (
+                                        <text fg={theme.text}>
+                                          {file.filename}
+                                          <Show when={file.additions > 0}>
+                                            <span style={{ fg: theme.diffAdded }}> +{file.additions}</span>
+                                          </Show>
+                                          <Show when={file.deletions > 0}>
+                                            <span style={{ fg: theme.diffRemoved }}> -{file.deletions}</span>
+                                          </Show>
+                                        </text>
+                                      )}
+                                    </For>
+                                  </box>
+                                </Show>
+                              </box>
                             </box>
-                          </box>
-                        )
-                      })()}
-                    </Match>
-                    <Match when={revert()?.messageID && message.id >= revert()!.messageID}>
-                      <></>
-                    </Match>
-                    <Match when={message.role === "user"}>
-                      <UserMessage
-                        index={index()}
-                        onMouseUp={() => {
-                          if (renderer.getSelection()?.getSelectedText()) return
-                          dialog.replace(() => (
-                            <DialogMessage
-                              messageID={message.id}
-                              sessionID={route.sessionID}
-                              setPrompt={(promptInfo) => prompt.set(promptInfo)}
-                            />
-                          ))
-                        }}
-                        message={message as UserMessage}
-                        parts={sync.data.part[message.id] ?? []}
-                        pending={pending()}
-                      />
-                    </Match>
-                    <Match when={message.role === "assistant"}>
-                      <AssistantMessage
-                        last={lastAssistant()?.id === message.id}
-                        message={message as AssistantMessage}
-                        parts={sync.data.part[message.id] ?? []}
-                      />
-                    </Match>
-                  </Switch>
-                )}
-              </For>
-            </scrollbox>
+                          )
+                        })()}
+                      </Match>
+                      <Match when={revert()?.messageID && message.id >= revert()!.messageID}>
+                        <></>
+                      </Match>
+                      <Match when={message.role === "user"}>
+                        <UserMessage
+                          index={index()}
+                          onMouseUp={() => {
+                            if (renderer.getSelection()?.getSelectedText()) return
+                            dialog.replace(() => (
+                              <DialogMessage
+                                messageID={message.id}
+                                sessionID={route.sessionID}
+                                setPrompt={(promptInfo) => prompt.set(promptInfo)}
+                              />
+                            ))
+                          }}
+                          message={message as UserMessage}
+                          parts={sync.data.part[message.id] ?? []}
+                          pending={pending()}
+                        />
+                      </Match>
+                      <Match when={message.role === "assistant"}>
+                        <AssistantMessage
+                          last={lastAssistant()?.id === message.id}
+                          message={message as AssistantMessage}
+                          parts={sync.data.part[message.id] ?? []}
+                        />
+                      </Match>
+                    </Switch>
+                  )}
+                </For>
+              </scrollbox>
+              <ContentPanel
+                filePath={requestedFile()}
+                sessionID={route.sessionID}
+                totalWidth={contentPanelTotalWidth()}
+                onClose={() => {
+                  setRequestedFile(null)
+                  prompt?.focus()
+                }}
+                onActiveFileChange={setActiveFile}
+                onWidthChange={setContentPanelWidth}
+                onEnterEdit={() => prompt?.blur()}
+                onExitEdit={() => prompt?.focus()}
+              />
+            </box>
             <box flexShrink={0}>
               <Show when={permissions().length > 0}>
                 <PermissionPrompt request={permissions()[0]} />
@@ -1056,7 +1093,11 @@ export function Session() {
           <Toast />
         </box>
         <Show when={sidebarVisible()}>
-          <Sidebar sessionID={route.sessionID} />
+          <Sidebar
+            sessionID={route.sessionID}
+            onFileSelect={(file) => setRequestedFile(file)}
+            activeFile={activeFile()}
+          />
         </Show>
       </box>
     </context.Provider>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/project-files.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/project-files.tsx
@@ -1,0 +1,195 @@
+import { createMemo, createSignal, For, Show } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useTheme } from "../../context/theme"
+import { useSync } from "@tui/context/sync"
+import path from "path"
+import fs from "fs/promises"
+
+const SKIP_FOLDERS = new Set([
+  "node_modules",
+  ".git",
+  "dist",
+  "build",
+  ".next",
+  ".nuxt",
+  ".output",
+  ".turbo",
+  ".vercel",
+  ".cache",
+  "coverage",
+  "__pycache__",
+  ".pytest_cache",
+  "venv",
+  ".venv",
+  "target",
+  ".cargo",
+])
+
+interface FileEntry {
+  name: string
+  path: string
+  type: "file" | "directory" | "error"
+}
+
+interface DirState {
+  loading: boolean
+  entries: FileEntry[]
+  expanded: boolean
+}
+
+interface ProjectFilesProps {
+  expanded: boolean
+  onToggle: () => void
+  onFileClick: (filePath: string) => void
+  activeFile?: string | null
+}
+
+export function ProjectFiles(props: ProjectFilesProps) {
+  const { theme } = useTheme()
+  const sync = useSync()
+  const [dirs, setDirs] = createStore<Record<string, DirState>>({})
+  const [rootLoading, setRootLoading] = createSignal(false)
+  const [rootEntries, setRootEntries] = createSignal<FileEntry[]>([])
+
+  const directory = createMemo(() => sync.data.path.directory || process.cwd())
+
+  const loadDir = async (dirPath: string, relativePath: string): Promise<FileEntry[]> => {
+    const fullPath = relativePath ? path.join(dirPath, relativePath) : dirPath
+    const entries = await fs.readdir(fullPath, { withFileTypes: true }).catch(() => null)
+    if (entries === null) {
+      return [{ name: "(unable to read)", path: "", type: "error" as const }]
+    }
+    const nodes: FileEntry[] = []
+
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") && entry.name !== ".env") continue
+      if (SKIP_FOLDERS.has(entry.name)) continue
+
+      const entryRelPath = relativePath ? path.join(relativePath, entry.name) : entry.name
+
+      if (entry.isDirectory()) {
+        nodes.push({
+          name: entry.name,
+          path: entryRelPath,
+          type: "directory",
+        })
+      } else if (entry.isFile()) {
+        nodes.push({
+          name: entry.name,
+          path: entryRelPath,
+          type: "file",
+        })
+      }
+    }
+
+    nodes.sort((a, b) => {
+      if (a.type === "directory" && b.type === "file") return -1
+      if (a.type === "file" && b.type === "directory") return 1
+      return a.name.localeCompare(b.name)
+    })
+
+    return nodes
+  }
+
+  const loadRootDir = async () => {
+    setRootLoading(true)
+    const entries = await loadDir(directory(), "")
+    setRootEntries(entries)
+    setRootLoading(false)
+  }
+
+  const toggleDir = async (dirPath: string) => {
+    const current = dirs[dirPath]
+    if (current?.expanded) {
+      setDirs(dirPath, "expanded", false)
+    } else {
+      setDirs(dirPath, { loading: true, entries: [], expanded: true })
+      const entries = await loadDir(directory(), dirPath)
+      setDirs(dirPath, { loading: false, entries, expanded: true })
+    }
+  }
+
+  const handleToggle = async () => {
+    if (!props.expanded) {
+      await loadRootDir()
+    }
+    props.onToggle()
+  }
+
+  function TreeNode(nodeProps: { entry: FileEntry; depth: number }) {
+    const isActive = createMemo(() => props.activeFile === nodeProps.entry.path)
+    const indent = nodeProps.depth * 2
+
+    if (nodeProps.entry.type === "directory") {
+      const dirState = createMemo(() => dirs[nodeProps.entry.path])
+      const isExpanded = createMemo(() => dirState()?.expanded ?? false)
+      const isLoading = createMemo(() => dirState()?.loading ?? false)
+      const children = createMemo(() => dirState()?.entries ?? [])
+
+      return (
+        <box>
+          <box flexDirection="row" gap={1} paddingLeft={indent} onMouseUp={() => toggleDir(nodeProps.entry.path)}>
+            <text fg={theme.text}>{isExpanded() ? "v" : ">"}</text>
+            <text fg={theme.text} wrapMode="char">
+              {nodeProps.entry.name}/
+            </text>
+          </box>
+          <Show when={isExpanded()}>
+            <Show when={isLoading()}>
+              <text fg={theme.textMuted} paddingLeft={indent + 4}>
+                ...
+              </text>
+            </Show>
+            <Show when={!isLoading()}>
+              <For each={children()}>{(child) => <TreeNode entry={child} depth={nodeProps.depth + 1} />}</For>
+            </Show>
+          </Show>
+        </box>
+      )
+    }
+
+    if (nodeProps.entry.type === "error") {
+      return (
+        <box flexDirection="row" paddingLeft={indent + 2}>
+          <text fg={theme.error}>{nodeProps.entry.name}</text>
+        </box>
+      )
+    }
+
+    return (
+      <box
+        flexDirection="row"
+        paddingLeft={indent + 2}
+        onMouseUp={() => props.onFileClick(nodeProps.entry.path)}
+        backgroundColor={isActive() ? theme.backgroundElement : undefined}
+      >
+        <text fg={isActive() ? theme.text : theme.textMuted} wrapMode="char">
+          {nodeProps.entry.name}
+        </text>
+      </box>
+    )
+  }
+
+  return (
+    <box>
+      <box flexDirection="row" gap={1} onMouseDown={handleToggle} flexShrink={0}>
+        <text fg={theme.text}>{props.expanded ? "▼" : "▶"}</text>
+        <text fg={theme.text}>
+          <b>Project Files</b>
+        </text>
+      </box>
+      <Show when={props.expanded}>
+        <Show when={rootLoading()}>
+          <text fg={theme.textMuted} paddingLeft={2}>
+            Loading...
+          </text>
+        </Show>
+        <Show when={!rootLoading()}>
+          <box>
+            <For each={rootEntries()}>{(entry) => <TreeNode entry={entry} depth={0} />}</For>
+          </box>
+        </Show>
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -80,7 +80,7 @@ export function Sidebar(props: { sessionID: string }) {
       >
         <scrollbox flexGrow={1}>
           <box flexShrink={0} gap={1} paddingRight={1}>
-            <box>
+            <box paddingRight={1}>
               <text fg={theme.text}>
                 <b>{session().title}</b>
               </text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -11,8 +11,13 @@ import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
+import { ProjectFiles } from "./project-files"
 
-export function Sidebar(props: { sessionID: string }) {
+export function Sidebar(props: {
+  sessionID: string
+  onFileSelect?: (filePath: string) => void
+  activeFile?: string | null
+}) {
   const sync = useSync()
   const { theme } = useTheme()
   const session = createMemo(() => sync.session.get(props.sessionID)!)
@@ -20,11 +25,15 @@ export function Sidebar(props: { sessionID: string }) {
   const todo = createMemo(() => sync.data.todo[props.sessionID] ?? [])
   const messages = createMemo(() => sync.data.message[props.sessionID] ?? [])
 
+  // worktree = git project root (for Modified Files)
+  const worktree = createMemo(() => sync.data.path.worktree || sync.data.path.directory || process.cwd())
+
   const [expanded, setExpanded] = createStore({
     mcp: true,
     diff: true,
     todo: true,
     lsp: true,
+    files: false,
   })
 
   // Sort MCP servers alphabetically for consistent display order
@@ -219,6 +228,12 @@ export function Sidebar(props: { sessionID: string }) {
                 </Show>
               </box>
             </Show>
+            <ProjectFiles
+              expanded={expanded.files}
+              onToggle={() => setExpanded("files", !expanded.files)}
+              onFileClick={(filePath) => props.onFileSelect?.(filePath)}
+              activeFile={props.activeFile ?? null}
+            />
             <Show when={diff().length > 0}>
               <box>
                 <box
@@ -236,17 +251,24 @@ export function Sidebar(props: { sessionID: string }) {
                 <Show when={diff().length <= 2 || expanded.diff}>
                   <For each={diff() || []}>
                     {(item) => {
-                      const file = createMemo(() => {
+                      const displayName = createMemo(() => {
                         const splits = item.file.split(path.sep).filter(Boolean)
                         const last = splits.at(-1)!
                         const rest = splits.slice(0, -1).join(path.sep)
                         if (!rest) return last
                         return Locale.truncateMiddle(rest, 30 - last.length) + "/" + last
                       })
+                      const isActive = createMemo(() => props.activeFile === item.file)
                       return (
-                        <box flexDirection="row" gap={1} justifyContent="space-between">
-                          <text fg={theme.textMuted} wrapMode="char">
-                            {file()}
+                        <box
+                          flexDirection="row"
+                          gap={1}
+                          justifyContent="space-between"
+                          onMouseDown={() => props.onFileSelect?.(path.join(worktree(), item.file))}
+                          backgroundColor={isActive() ? theme.backgroundElement : undefined}
+                        >
+                          <text fg={isActive() ? theme.text : theme.textMuted} wrapMode="char">
+                            {displayName()}
                           </text>
                           <box flexDirection="row" gap={1} flexShrink={0}>
                             <Show when={item.additions}>


### PR DESCRIPTION
## Summary

Adds a file browser and viewer/editor panel to the TUI for viewing and editing project files directly within OpenCode.

Activate vi prompt in command menu: Use vi basic prompt editor / Use standard prompt editor
Activate vi editor in command menu: Use vi basic project file editor / Use standard project file editor

**Depends on:** #7016 (vi basic mode extension)

## Features

- **Project Files Browser** - File tree in sidebar showing project files with expand/collapse
- **File Viewer Panel** - View files with syntax highlighting, resizable panel with drag divider
- **File Editor** - Edit files directly in the TUI with save (`ctrl+s`) and cancel (`ctrl+c`)
- **Vi Mode Integration** - Optional vi basic mode for editing (toggle with `ctrl+/`)
  - Status bar showing INSERT/NORMAL state and command buffer
  - Search: `/` forward, `?` backward, `n`/`N` next/prev match
  - Search bar UI displays when typing search pattern
- **Focus Management** - Proper keyboard focus between editor and prompt
  - Click to refocus editor panel
  - Keys only captured when editor textarea is focused

## Configuration

- `editor_mode` KV setting: `"standard"` or `"vi"` (default: standard)
- Toggle via `ctrl+/` in edit mode or command menu

## Files Changed

| File | Changes |
|------|---------|
| `routes/session/project-files.tsx` | File tree component |
| `routes/session/content-panel.tsx` | Panel wrapper with resize divider |
| `routes/session/file-viewer.tsx` | View/edit with vi mode integration |
| `routes/session/sidebar.tsx` | ProjectFiles integration |
| `routes/session/index.tsx` | ContentPanel + editor mode toggle |