### PR TITLE
docs: polish markdown wording and capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,7 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ### Agents
 
-OpenCode includes two built-in agents you can switch between,
-you can switch between these using the `Tab` key.
+OpenCode includes two built-in agents you can switch between with the `Tab` key.
 
 - **build** - Default, full access agent for development work
 - **plan** - Read-only agent for analysis and code exploration

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -1,8 +1,8 @@
 ## Usage
 
-Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
+Dependencies for these templates are managed with [pnpm](https://pnpm.io) using `pnpm up -Lri`.
 
-This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely be removed once you clone a template.
+This is the reason you see a `pnpm-lock.yaml`. That said, any package manager will work. This file can safely be removed once you clone a template.
 
 ```bash
 $ npm install # or pnpm install or yarn install

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -1,6 +1,6 @@
 # Tauri + Vanilla TS
 
-This template should help get you started developing with Tauri in vanilla HTML, CSS and Typescript.
+This template should help get you started developing with Tauri in vanilla HTML, CSS and TypeScript.
 
 ## Recommended IDE Setup
 

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/README.md
@@ -1,5 +1,5 @@
-This is a temporary package used primarily for github copilot compatibility.
+This is a temporary package used primarily for GitHub Copilot compatibility.
 
-Avoid making changes to these files unless you want to only affect Copilot provider.
+Avoid making changes to these files unless you only want to affect the Copilot provider.
 
-Also this should ONLY be used for Copilot provider.
+Also, this should ONLY be used for the Copilot provider.

--- a/specs/project.md
+++ b/specs/project.md
@@ -1,7 +1,6 @@
 ## project
 
-goal is to let a single instance of opencode be able to run sessions for
-multiple projects and different worktrees per project
+The goal is to let a single instance of OpenCode run sessions for multiple projects and different worktrees per project.
 
 ### api
 


### PR DESCRIPTION
  ## Summary
  - fix grammar/wording across README files
  - normalize capitalization for GitHub/TypeScript
  - clarify brief API/usage descriptions

  ## Testing
  - not needed (docs only)
