### PR TITLE
fix(clipboard): add OSC 52 fallback for SSH/tmux environments

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -58,6 +58,20 @@ export namespace Clipboard {
     }
   }
 
+  // OSC 52: terminal escape sequence for clipboard access (works over SSH/tmux with iTerm2, etc.)
+  // Format: ESC ] 52 ; c ; <base64> BEL  |  Tmux needs passthrough: ESC P tmux ; ESC <seq> ESC \
+  function copyViaOSC52(text: string): void {
+    const base64 = Buffer.from(text).toString("base64")
+    const sequence = `\x1b]52;c;${base64}\x07`
+
+    if (process.env["TMUX"]) {
+      const tmuxSequence = `\x1bPtmux;\x1b${sequence}\x1b\\`
+      process.stdout.write(tmuxSequence)
+    } else {
+      process.stdout.write(sequence)
+    }
+  }
+
   const getCopyMethod = lazy(() => {
     const os = platform()
 
@@ -115,9 +129,15 @@ export namespace Clipboard {
       }
     }
 
-    console.log("clipboard: no native support")
+    console.log("clipboard: using clipboardy with OSC 52 fallback")
     return async (text: string) => {
-      await clipboardy.write(text).catch(() => {})
+      const success = await clipboardy
+        .write(text)
+        .then(() => true)
+        .catch(() => false)
+      if (!success) {
+        copyViaOSC52(text)
+      }
     }
   })
 


### PR DESCRIPTION
# Problem
Clipboard copy operations (e.g., Ctrl+X Y to copy assistant message) silently fail when running opencode over SSH or in tmux on a remote Linux server without X11/Wayland display.

**Root cause**: The fallback path uses clipboardy, which relies on xsel/xclip and requires a local display ($DISPLAY or $WAYLAND_DISPLAY). In headless SSH/tmux environments, these tools aren't available or don't work, causing clipboard operations to fail silently.

# Solution

Add OSC 52 escape sequence support as a fallback when clipboardy fails.
[OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands) is a terminal escape sequence standard that allows applications to set the system clipboard through the terminal emulator. It's supported by:
- iTerm2
- kitty
- Alacritty
- Windows Terminal
- tmux (with set-clipboard option)
- Many other modern terminal emulators

# Changes
- Added copyViaOSC52() function that sends OSC 52 escape sequences
- Handles tmux passthrough wrapping when $TMUX is set
- Modified fallback logic: try clipboardy first → fall back to OSC 52 on failure

# Behavior

| Environment | Before | After |
|-------------|--------|-------|
| macOS local | osascript ✅ | osascript ✅ (unchanged) |
| Linux + X11/Wayland | xclip/xsel/wl-copy ✅ | xclip/xsel/wl-copy ✅ (unchanged) |
| Windows | powershell ✅ | powershell ✅ (unchanged) |
| SSH/tmux (no display) | clipboardy ❌ (silent fail) | clipboardy → OSC 52 ✅ |

No breaking changes - existing behavior preserved for all native clipboard methods.

# Testing
1. SSH into a remote Linux server
2. Run opencode in tmux with iTerm2 integration
3. Get a response from the assistant
4. Press Ctrl+X Y to copy the assistant's message
5. Cmd+V on local machine to verify clipboard content

# Prerequisite

* Enable "Applications in terminal may access clipboard" in iTerm2 Preferences → General → Selection