### PR TITLE
fix(app) TypeError: Failed to execute 'set' on 'Headers': String contains non IS0-8859-1 code point.

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -252,8 +252,12 @@ export namespace Server {
           if (!rawDirectory.startsWith(prefix)) return rawDirectory
           try {
             return decodeURIComponent(rawDirectory.slice(prefix.length))
-          } catch {
-            return rawDirectory.slice(prefix.length)
+          } catch (error) {
+            Log.warn("Failed to decode opencode-uri directory, falling back to process.cwd()", {
+              rawDirectory,
+              error,
+            })
+            return process.cwd()
           }
         })()
         return Instance.provide({

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -246,7 +246,16 @@ export namespace Server {
         },
       )
       .use(async (c, next) => {
-        const directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+        const rawDirectory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+        const directory = (() => {
+          const prefix = "opencode-uri:"
+          if (!rawDirectory.startsWith(prefix)) return rawDirectory
+          try {
+            return decodeURIComponent(rawDirectory.slice(prefix.length))
+          } catch {
+            return rawDirectory.slice(prefix.length)
+          }
+        })()
         return Instance.provide({
           directory,
           init: InstanceBootstrap,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -253,7 +253,7 @@ export namespace Server {
           try {
             return decodeURIComponent(rawDirectory.slice(prefix.length))
           } catch (error) {
-            Log.warn("Failed to decode opencode-uri directory, falling back to process.cwd()", {
+            log.warn("Failed to decode opencode-uri directory, falling back to process.cwd()", {
               rawDirectory,
               error,
             })

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -5,6 +5,8 @@ import { type Config } from "./gen/client/types.gen.js"
 import { OpencodeClient } from "./gen/sdk.gen.js"
 export { type Config as OpencodeClientConfig, OpencodeClient }
 
+const OPENCODE_DIRECTORY_HEADER_PREFIX = "opencode-uri:"
+
 export function createOpencodeClient(config?: Config & { directory?: string }) {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
@@ -19,9 +21,22 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   if (config?.directory) {
-    config.headers = {
-      ...config.headers,
-      "x-opencode-directory": config.directory,
+    const directoryHeader = OPENCODE_DIRECTORY_HEADER_PREFIX + encodeURIComponent(config.directory)
+    if (config.headers instanceof Headers || Array.isArray(config.headers)) {
+      const headers = new Headers(config.headers)
+      headers.set("x-opencode-directory", directoryHeader)
+      config = {
+        ...config,
+        headers,
+      }
+    } else {
+      config = {
+        ...config,
+        headers: {
+          ...(config.headers ?? {}),
+          "x-opencode-directory": directoryHeader,
+        },
+      }
     }
   }
 

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -5,6 +5,8 @@ import { type Config } from "./gen/client/types.gen.js"
 import { OpencodeClient } from "./gen/sdk.gen.js"
 export { type Config as OpencodeClientConfig, OpencodeClient }
 
+const OPENCODE_DIRECTORY_HEADER_PREFIX = "opencode-uri:"
+
 export function createOpencodeClient(config?: Config & { directory?: string }) {
   if (!config?.fetch) {
     const customFetch: any = (req: any) => {
@@ -19,9 +21,22 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   if (config?.directory) {
-    config.headers = {
-      ...config.headers,
-      "x-opencode-directory": config.directory,
+    const directoryHeader = OPENCODE_DIRECTORY_HEADER_PREFIX + encodeURIComponent(config.directory)
+    if (config.headers instanceof Headers || Array.isArray(config.headers)) {
+      const headers = new Headers(config.headers)
+      headers.set("x-opencode-directory", directoryHeader)
+      config = {
+        ...config,
+        headers,
+      }
+    } else {
+      config = {
+        ...config,
+        headers: {
+          ...(config.headers ?? {}),
+          "x-opencode-directory": directoryHeader,
+        },
+      }
     }
   }
 


### PR DESCRIPTION
## Why it crashed

mergeConfigs() calls mergeHeaders(), which ends up doing Headers.set(...). In Tauri/WebView, Headers.set() throws if the header key/value contains characters outside ISO‑8859‑1. We were putting a raw filesystem path into x-opencode-directory, and paths can contain Unicode.

## Fix (implemented)

SDK: URL-encode the directory header as opencode-uri: + encodeURIComponent(directory) (done for both v1 + v2 clients).
Server: If the incoming directory value starts with opencode-uri:, decode it before using it.

<img width="953" height="516" alt="企业微信截图_17676675582211" src="https://github.com/user-attachments/assets/5ef5dfba-6203-4858-b0d8-869800f434c3" />
