### PR TITLE
fix(session): strip reasoning blocks for Claude Code compatibility

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -548,7 +548,14 @@ export namespace MessageV2 {
       }
     }
 
-    return convertToModelMessages(result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")))
+    return convertToModelMessages(
+      result
+        .filter((msg) => msg.parts.some((part) => part.type !== "step-start"))
+        .map((msg) => ({
+          ...msg,
+          parts: msg.parts.filter((part) => part.type !== "reasoning"),
+        })),
+    )
   }
 
   export const stream = fn(Identifier.schema("session"), async function* (sessionID) {


### PR DESCRIPTION
## Summary

Strip reasoning blocks from message history when converting to model format, enabling seamless switching between reasoning and non-reasoning models.

## Problem

When using a reasoning model (e.g., Claude with extended thinking) and then switching to Claude Code, the session fails with an "Invalid signature" error. This happens because Claude Code's API doesn't recognize the reasoning blocks that were added by the previous model.

## Solution

Filter out `reasoning` type parts from messages in `convertToModelMessages()` before sending to the model API. This ensures compatibility regardless of which models were used earlier in the session.

## Changes

- `packages/opencode/src/session/message-v2.ts` - Filter reasoning parts in message conversion

## Testing

- Verified typecheck passes
- Manual testing: Start session with reasoning model, switch to Claude Code, continue conversation without errors