### PR TITLE
docs: fix order of permissions in agents docs (permissions subsection)

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -426,9 +426,9 @@ mode: subagent
 permission:
   edit: deny
   bash:
+    "*": ask
     "git diff": allow
     "git log*": allow
-    "*": ask
   webfetch: deny
 ---
 
@@ -470,7 +470,7 @@ This can take a glob pattern.
 ```
 
 And you can also use the `*` wildcard to manage permissions for all commands.
-Where the specific rule can override the `*` wildcard.
+Since the last matching rule takes precedence, put the `*` wildcard first and specific rules after.
 
 ```json title="opencode.json" {8}
 {
@@ -479,8 +479,8 @@ Where the specific rule can override the `*` wildcard.
     "build": {
       "permission": {
         "bash": {
-          "git status": "allow",
-          "*": "ask"
+          "*": "ask",
+          "git status": "allow"
         }
       }
     }


### PR DESCRIPTION
Permission rules are evaluated last-match-wins, so `*` wildcard should come first with specific rules after. Updated examples to reflect this.

Addresses some confusion in [https://github.com/anomalyco/opencode/issues/6856#issuecomment-3708694403](https://github.com/anomalyco/opencode/issues/6856#issuecomment-3708694403)