### PR TITLE
fix: restore skill filtering by agent permissions

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -675,7 +675,7 @@ export namespace SessionPrompt {
       },
     })
 
-    for (const item of await ToolRegistry.tools(input.model.providerID)) {
+    for (const item of await ToolRegistry.tools(input.model.providerID, input.agent)) {
       const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
       tools[item.id] = tool({
         id: item.id as any,


### PR DESCRIPTION
## Summary

Restores the ability to filter skills based on agent permission rules, which was broken after the permission system overhaul in PR #6319.

- Pass `agent` to `ToolRegistry.tools()` when building the tool registry
- Filter skills using `PermissionNext.evaluate()` before generating the skill tool description
- Only show skills that are not explicitly denied by the agent's permission rules

## Example Usage

Agents can now control which skills are visible via frontmatter:

```yaml
permission:
  read: allow
  skill:
    "*": deny
    "code-review": allow
    "skill-creator": allow
```

This will only show `code-review` and `skill-creator` in that agent's available skills.

## Changes

- `packages/opencode/src/session/prompt.ts`: Pass agent to `ToolRegistry.tools()`
- `packages/opencode/src/tool/skill.ts`: Filter skills using `PermissionNext.evaluate()`

Closes #6857