### PR TITLE
fix: use actual version in install script

### DIFF
--- a/install
+++ b/install
@@ -208,11 +208,8 @@ check_version() {
     if command -v opencode >/dev/null 2>&1; then
         opencode_path=$(which opencode)
 
-
-        ## TODO: check if version is installed
-        # installed_version=$(opencode version)
-        installed_version="0.0.1"
-        installed_version=$(echo $installed_version | awk '{print $2}')
+        ## Check the installed version
+        installed_version=$(opencode --version 2>/dev/null || echo "")
 
         if [[ "$installed_version" != "$specific_version" ]]; then
             print_message info "${MUTED}Installed version: ${NC}$installed_version."


### PR DESCRIPTION
## Problem
The install script has a TODO comment on line 212 indicating the version check should use the actual installed version instead of a hardcoded value.
## Solution
Changed the `check_version()` function to call `opencode --version` instead of using a hardcoded version.