### PR TITLE
fix(provider): add jp. prefix auto-assignment for Tokyo region (ap-northeast-1)

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -977,12 +977,36 @@ export namespace Provider {
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
 
-    const info = provider.models[modelID]
+    // For amazon-bedrock, strip cross-region inference profile prefixes before lookup
+    let lookupModelID = modelID
+    if (providerID === "amazon-bedrock") {
+      const crossRegionPrefixes = ["us.", "eu.", "apac.", "global.", "jp.", "au."]
+      for (const prefix of crossRegionPrefixes) {
+        if (modelID.startsWith(prefix)) {
+          lookupModelID = modelID.slice(prefix.length)
+          break
+        }
+      }
+    }
+
+    const info = provider.models[lookupModelID]
     if (!info) {
       const availableModels = Object.keys(provider.models)
-      const matches = fuzzysort.go(modelID, availableModels, { limit: 3, threshold: -10000 })
+      const matches = fuzzysort.go(lookupModelID, availableModels, { limit: 3, threshold: -10000 })
       const suggestions = matches.map((m) => m.target)
-      throw new ModelNotFoundError({ providerID, modelID, suggestions })
+      throw new ModelNotFoundError({ providerID, modelID: lookupModelID, suggestions })
+    }
+
+    // If a cross-region prefix was used, return model info with the original prefixed modelID
+    if (lookupModelID !== modelID) {
+      return {
+        ...info,
+        id: modelID,
+        api: {
+          ...info.api,
+          id: modelID,
+        },
+      }
     }
     return info
   }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -266,13 +266,24 @@ export namespace Provider {
             }
             case "ap": {
               const isAustraliaRegion = ["ap-southeast-2", "ap-southeast-4"].includes(region)
+              const isTokyoRegion = region === "ap-northeast-1"
               if (
                 isAustraliaRegion &&
                 ["anthropic.claude-sonnet-4-5", "anthropic.claude-haiku"].some((m) => modelID.includes(m))
               ) {
                 regionPrefix = "au"
                 modelID = `${regionPrefix}.${modelID}`
+              } else if (isTokyoRegion) {
+                // Tokyo region uses jp. prefix for cross-region inference
+                const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
+                  modelID.includes(m),
+                )
+                if (modelRequiresPrefix) {
+                  regionPrefix = "jp"
+                  modelID = `${regionPrefix}.${modelID}`
+                }
               } else {
+                // Other APAC regions use apac. prefix
                 const modelRequiresPrefix = ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) =>
                   modelID.includes(m),
                 )
@@ -977,36 +988,12 @@ export namespace Provider {
       throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
 
-    // For amazon-bedrock, strip cross-region inference profile prefixes before lookup
-    let lookupModelID = modelID
-    if (providerID === "amazon-bedrock") {
-      const crossRegionPrefixes = ["us.", "eu.", "apac.", "global.", "jp.", "au."]
-      for (const prefix of crossRegionPrefixes) {
-        if (modelID.startsWith(prefix)) {
-          lookupModelID = modelID.slice(prefix.length)
-          break
-        }
-      }
-    }
-
-    const info = provider.models[lookupModelID]
+    const info = provider.models[modelID]
     if (!info) {
       const availableModels = Object.keys(provider.models)
-      const matches = fuzzysort.go(lookupModelID, availableModels, { limit: 3, threshold: -10000 })
+      const matches = fuzzysort.go(modelID, availableModels, { limit: 3, threshold: -10000 })
       const suggestions = matches.map((m) => m.target)
-      throw new ModelNotFoundError({ providerID, modelID: lookupModelID, suggestions })
-    }
-
-    // If a cross-region prefix was used, return model info with the original prefixed modelID
-    if (lookupModelID !== modelID) {
-      return {
-        ...info,
-        id: modelID,
-        api: {
-          ...info.api,
-          id: modelID,
-        },
-      }
+      throw new ModelNotFoundError({ providerID, modelID, suggestions })
     }
     return info
   }


### PR DESCRIPTION
## Summary

Add automatic `jp.` prefix assignment for Amazon Bedrock cross-region inference when using Tokyo region (`ap-northeast-1`).

Currently, the APAC region case uses `apac.` prefix for all AP regions, but Tokyo region requires `jp.` prefix for cross-region inference profiles.

## Changes

- Add `isTokyoRegion` check in the `case "ap"` block
- Tokyo region (`ap-northeast-1`) → uses `jp.` prefix
- Other APAC regions → continue using `apac.` prefix

## Test

Tested with GitHub Actions workflow using:
- Model: `amazon-bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0` (without prefix)
- Region: `ap-northeast-1`
- Result: Successfully called Bedrock API with auto-prefixed `jp.anthropic.claude-sonnet-4-5-20250929-v1:0`

## Related

This complements the existing cross-region prefix skip logic (merged in #6916) by providing automatic prefix assignment for Tokyo region users.