### PR TITLE
docs: add Simplified Chinese README

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,115 @@
+<p align="center">
+  <a href="https://opencode.ai">
+    <picture>
+      <source srcset="packages/console/app/src/asset/logo-ornate-dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="packages/console/app/src/asset/logo-ornate-light.svg" media="(prefers-color-scheme: light)">
+      <img src="packages/console/app/src/asset/logo-ornate-light.svg" alt="OpenCode logo">
+    </picture>
+  </a>
+</p>
+<p align="center">开源的 AI Coding Agent。</p>
+<p align="center">
+  <a href="https://opencode.ai/discord"><img alt="Discord" src="https://img.shields.io/discord/1391832426048651334?style=flat-square&label=discord" /></a>
+  <a href="https://www.npmjs.com/package/opencode-ai"><img alt="npm" src="https://img.shields.io/npm/v/opencode-ai?style=flat-square" /></a>
+  <a href="https://github.com/anomalyco/opencode/actions/workflows/publish.yml"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/anomalyco/opencode/publish.yml?style=flat-square&branch=dev" /></a>
+</p>
+
+[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+
+---
+
+### 安装
+
+```bash
+# 直接安装 (YOLO)
+curl -fsSL https://opencode.ai/install | bash
+
+# 软件包管理器
+npm i -g opencode-ai@latest        # 也可使用 bun/pnpm/yarn
+scoop bucket add extras; scoop install extras/opencode  # Windows
+choco install opencode             # Windows
+brew install opencode              # macOS 和 Linux
+paru -S opencode-bin               # Arch Linux
+mise use -g opencode               # 任意系统
+nix run nixpkgs#opencode           # 或用 github:anomalyco/opencode 获取最新 dev 分支
+```
+
+> [!TIP]
+> 安装前请先移除 0.1.x 之前的旧版本。
+
+### 桌面应用程序 (BETA)
+
+OpenCode 也提供桌面版应用。可直接从 [发布页 (releases page)](https://github.com/anomalyco/opencode/releases) 或 [opencode.ai/download](https://opencode.ai/download) 下载。
+
+| 平台                  | 下载文件                              |
+| --------------------- | ------------------------------------- |
+| macOS (Apple Silicon) | `opencode-desktop-darwin-aarch64.dmg` |
+| macOS (Intel)         | `opencode-desktop-darwin-x64.dmg`     |
+| Windows               | `opencode-desktop-windows-x64.exe`    |
+| Linux                 | `.deb`、`.rpm` 或 AppImage            |
+
+```bash
+# macOS (Homebrew Cask)
+brew install --cask opencode-desktop
+```
+
+#### 安装目录
+
+安装脚本按照以下优先级决定安装路径：
+
+1. `$OPENCODE_INSTALL_DIR` - 自定义安装目录
+2. `$XDG_BIN_DIR` - 符合 XDG 基础目录规范的路径
+3. `$HOME/bin` - 如果存在或可创建的用户二进制目录
+4. `$HOME/.opencode/bin` - 默认备用路径
+
+```bash
+# 示例
+OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
+XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
+```
+
+### Agents
+
+OpenCode 内置两种 Agent，可用 `Tab` 键快速切换：
+
+- **build** - 默认模式，具备完整权限，适合开发工作
+- **plan** - 只读模式，适合代码分析与探索
+  - 默认拒绝修改文件
+  - 运行 bash 命令前会询问
+  - 便于探索未知代码库或规划改动
+
+另外还包含一个 **general** 子 Agent，用于复杂搜索和多步任务，内部使用，也可在消息中输入 `@general` 调用。
+
+了解更多 [Agents](https://opencode.ai/docs/agents) 相关信息。
+
+### 文档
+
+更多配置说明请查看我们的 [**官方文档**](https://opencode.ai/docs)。
+
+### 参与贡献
+
+如有兴趣贡献代码，请在提交 PR 前阅读 [贡献指南 (Contributing Docs)](./CONTRIBUTING.md)。
+
+### 基于 OpenCode 进行开发
+
+如果你在项目名中使用了 “opencode”（如 “opencode-dashboard” 或 “opencode-mobile”），请在 README 里注明该项目不是 OpenCode 团队官方开发，且不存在隶属关系。
+
+### 常见问题 (FAQ)
+
+#### 这和 Claude Code 有什么不同？
+
+功能上很相似，关键差异：
+
+- 100% 开源。
+- 不绑定特定提供商。推荐使用 [OpenCode Zen](https://opencode.ai/zen) 的模型，但也可搭配 Claude、OpenAI、Google 甚至本地模型。模型迭代会缩小差异、降低成本，因此保持 provider-agnostic 很重要。
+- 内置 LSP 支持。
+- 聚焦终端界面 (TUI)。OpenCode 由 Neovim 爱好者和 [terminal.shop](https://terminal.shop) 的创建者打造，会持续探索终端的极限。
+- 客户端/服务器架构。可在本机运行，同时用移动设备远程驱动。TUI 只是众多潜在客户端之一。
+
+#### 另一个同名的仓库是什么？
+
+另一个名字相近的仓库与本项目无关。[点击这里了解背后故事](https://x.com/thdxr/status/1933561254481666466)。
+
+---
+
+**加入我们的社区** [Discord](https://discord.gg/opencode) | [X.com](https://x.com/opencode)


### PR DESCRIPTION
  ## Summary
  - add README.zh-CN.md with Simplified Chinese content aligned to the main README
  - covers installation, desktop app, agents, docs, contributing, and FAQ
  - provides clearer onboarding for mainland Chinese users

  ## Testing
  - not needed (docs only)
