### PR TITLE
Fix(app): @pierre/diffs will crash when a diff has undefined text

### DIFF
--- a/packages/ui/src/components/diff.tsx
+++ b/packages/ui/src/components/diff.tsx
@@ -19,6 +19,8 @@ export function Diff<T>(props: DiffProps<T>) {
     const opts = options()
     const workerPool = getWorkerPool(props.diffStyle)
     const annotations = local.annotations
+    const beforeContents = typeof local.before?.contents === "string" ? local.before.contents : ""
+    const afterContents = typeof local.after?.contents === "string" ? local.after.contents : ""
 
     instance?.cleanUp()
     instance = new FileDiff<T>(opts, workerPool)
@@ -27,11 +29,13 @@ export function Diff<T>(props: DiffProps<T>) {
     instance.render({
       oldFile: {
         ...local.before,
-        cacheKey: checksum(local.before.contents),
+        contents: beforeContents,
+        cacheKey: checksum(beforeContents),
       },
       newFile: {
         ...local.after,
-        cacheKey: checksum(local.after.contents),
+        contents: afterContents,
+        cacheKey: checksum(afterContents),
       },
       lineAnnotations: annotations,
       containerWrapper: container,


### PR DESCRIPTION
<img width="919" height="314" alt="Weixin Image_20260106152229_3556_8" src="https://github.com/user-attachments/assets/2dfe6735-8da5-43db-842b-182c389a6dac" />

TypeError: Cannot read properties of undefined (reading 'split')at zm.tokenize (http://tauri.localhost/assets/index-DYEnwwcr.js:1637:20)at zm.diff (http://tauri.localhost/assets/index-DYEnwwcF.js:1632:11499)at difflines (http://tauri.localhost/assets/index-DYEnwwcr.js:1636:118)at structuredPatch (http://tauri.localhost/assets/index-DyEnwwcr.js:1637:542)at createTwoFilesPatch (http://tauri.localhost/assets/index-DyEnwwcr.js:1641:59)at parseDiffFromFile (http://tauri.localhost/assets/index-DyEnwwcr.js:1645:2327)at FileDiff,render (http://tauri,localhost/assets/index-DYEnwwcE.is:1645:6918)at object.fn (http://tauri.localhost/assets/index-DyEnwwcr.j3:1696:12662)at runComputation(http://tauri.localhost/assets/index-DyEnwwCF.is:2:6697)at updateComputation (http://tauri.localhost/assets/index-DyEnwwcF.js:2:6598)

Fixed the diff renderer to normalize missing file contents so @pierre/diffs won’t crash when a diff has undefined text. The guard lives in packages/ui/src/components/diff.tsx and now coerces non-string before/after contents to "" before computing cache keys and rendering, which prevents the split on undefined seen in the stack trace.