### PR TITLE
feat: use ISO 8601 date format

### DIFF
--- a/packages/console/app/src/routes/workspace/common.tsx
+++ b/packages/console/app/src/routes/workspace/common.tsx
@@ -19,18 +19,19 @@ export function formatDateForTable(date: Date) {
 }
 
 export function formatDateUTC(date: Date) {
-  const options: Intl.DateTimeFormatOptions = {
+  const isoDate = date.toLocaleDateString("en-CA", { timeZone: "UTC" })
+  const weekday = date.toLocaleDateString("en-US", {
     weekday: "short",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
+    timeZone: "UTC",
+  })
+  const time = date.toLocaleTimeString("en-US", {
     hour: "numeric",
     minute: "2-digit",
     second: "2-digit",
     timeZoneName: "short",
     timeZone: "UTC",
-  }
-  return date.toLocaleDateString(undefined, options)
+  })
+  return `${isoDate} ${weekday} ${time}`
 }
 
 export function formatBalance(amount: number) {

--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -11,7 +11,7 @@ export namespace Locale {
   export function datetime(input: number): string {
     const date = new Date(input)
     const localTime = time(input)
-    const localDate = date.toLocaleDateString()
+    const localDate = date.toLocaleDateString("en-CA")
     return `${localTime} · ${localDate}`
   }
 


### PR DESCRIPTION
Closes #12401

## Summary

This PR standardizes date formatting across the codebase to use the ISO 8601 format (YYYY-MM-DD) instead of locale-dependent formats.

## Changes

- Updated `Locale.datetime()` in `packages/opencode/src/util/locale.ts` to use `en-CA` locale for `toLocaleDateString()`, which outputs dates in YYYY-MM-DD format
- Renamed variable from `localDate` to `isoDate` for clarity

## Rationale

<img width="4096" height="1609" alt="image" src="https://github.com/user-attachments/assets/f9fc7af4-9bf9-44e9-b1ea-fc374fc25cc5" />

- **Consistency**: ISO 8601 is an internationally recognized standard for date representation
- **Sortability**: YYYY-MM-DD format is lexicographically sortable
- **Clarity**: Removes ambiguity between MM/DD/YYYY (US) and DD/MM/YYYY (European) formats
- **Interoperability**: Better for data exchange and API responses

---

reopen of #6450 as fork got deleted