### PR TITLE
feat(tool/bash): expose session context via environment variables

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -156,6 +156,8 @@ export const BashTool = Tool.define("bash", async () => {
         cwd,
         env: {
           ...process.env,
+          OPENCODE_SESSION_ID: ctx.sessionID,
+          OPENCODE_MESSAGE_ID: ctx.messageID,
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -35,6 +35,32 @@ describe("tool.bash", () => {
       },
     })
   })
+
+  test("injects session context into subprocess environment", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const testSessionID = "ses_test123"
+        const testMessageID = "msg_test456"
+        const testCtx = {
+          ...ctx,
+          sessionID: testSessionID,
+          messageID: testMessageID,
+        }
+        const result = await bash.execute(
+          {
+            command: "echo $OPENCODE_SESSION_ID,$OPENCODE_MESSAGE_ID",
+            description: "Echo session context environment variables",
+          },
+          testCtx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.output).toContain(testSessionID)
+        expect(result.metadata.output).toContain(testMessageID)
+      },
+    })
+  })
 })
 
 describe("tool.bash permissions", () => {


### PR DESCRIPTION
## Summary

Injects `OPENCODE_SESSION_ID` and `OPENCODE_MESSAGE_ID` into subprocess environment when executing bash commands, enabling spawned processes to identify their parent session context.

## Motivation

Currently, when OpenCode spawns bash subprocesses, those processes have no way to identify which session they belong to. This limits:

- **Session self-awareness**: Agents cannot query their own session history
- **Cross-session communication**: Scripts cannot interact with session APIs
- **Context propagation**: Tooling cannot correlate subprocess activity with sessions

## Changes

- `packages/opencode/src/tool/bash.ts`: Added `OPENCODE_SESSION_ID` and `OPENCODE_MESSAGE_ID` to the subprocess environment
- `packages/opencode/test/tool/bash.test.ts`: Added test verifying environment variable injection

## Use Cases

```bash
# Agent can now read its own session history
echo "Current session: $OPENCODE_SESSION_ID"

# Scripts can interact with session APIs
curl "http://localhost:4096/session/$OPENCODE_SESSION_ID/messages"

# Cross-session communication patterns
opencode-session-id info $OPENCODE_SESSION_ID
```

## Testing

- Added unit test that verifies both environment variables are correctly passed to subprocess
- All existing bash tool tests continue to pass (9/9)