### PR TITLE
fix: add missing await for available skills in `skill` tool

### DIFF
--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -47,7 +47,7 @@ export const SkillTool = Tool.define("skill", async () => {
       const skill = await Skill.get(params.name)
 
       if (!skill) {
-        const available = Skill.all().then((x) => Object.keys(x).join(", "))
+        const available = await Skill.all().then((x) => Object.keys(x).join(", "))
         throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
       }
 


### PR DESCRIPTION
This was causing a confusing error message to hit the agent when trying to load a skill that doesn't exist

<img width="1332" height="92" alt="CleanShot 2026-01-06 at 12 08 31@2x" src="https://github.com/user-attachments/assets/0750f7c5-614a-46a1-8808-e8cf14f26f0d" />
