### PR TITLE
fix(permission): trigger permission.ask plugin hook in PermissionNext

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -3,6 +3,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Config } from "@/config/config"
 import { Identifier } from "@/id/id"
 import { Instance } from "@/project/instance"
+import { Plugin } from "@/plugin"
 import { Storage } from "@/storage/storage"
 import { fn } from "@/util/fn"
 import { Log } from "@/util/log"
@@ -127,11 +128,24 @@ export namespace PermissionNext {
           throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
         if (rule.action === "ask") {
           const id = input.id ?? Identifier.ascending("permission")
+          const info: Request = {
+            id,
+            ...request,
+          }
+
+          // Allow plugins to intercept permission requests (fixes #7006)
+          const hookStatus = await Plugin.trigger("permission.ask", info, { status: "ask" as const }).then((x) => x.status)
+          if (hookStatus === "allow") {
+            log.info("plugin auto-approved", { permission: request.permission, pattern })
+            continue // Auto-approve
+          }
+          if (hookStatus === "deny") {
+            log.info("plugin auto-denied", { permission: request.permission, pattern })
+            throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
+          }
+
+          // If hook returns "ask" or nothing, proceed with UI prompt
           return new Promise<void>((resolve, reject) => {
-            const info: Request = {
-              id,
-              ...request,
-            }
             s.pending[id] = {
               info,
               resolve,

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -134,17 +134,20 @@ export namespace PermissionNext {
           }
 
           // Allow plugins to intercept permission requests (fixes #7006)
-          const hookStatus = await Plugin.trigger("permission.ask", info, { status: "ask" as const }).then((x) => x.status)
-          if (hookStatus === "allow") {
-            log.info("plugin auto-approved", { permission: request.permission, pattern })
-            continue // Auto-approve
-          }
-          if (hookStatus === "deny") {
-            log.info("plugin auto-denied", { permission: request.permission, pattern })
-            throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
+          switch (
+            await Plugin.trigger("permission.ask", info, {
+              status: "ask",
+            }).then((x) => x.status)
+          ) {
+            case "allow":
+              log.info("plugin auto-approved", { permission: request.permission, pattern })
+              continue // Auto-approve
+            case "deny":
+              log.info("plugin auto-denied", { permission: request.permission, pattern })
+              throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
           }
 
-          // If hook returns "ask" or nothing, proceed with UI prompt
+          // If hook returns "ask" or unchanged, proceed with UI prompt
           return new Promise<void>((resolve, reject) => {
             s.pending[id] = {
               info,


### PR DESCRIPTION
## Summary

Implements the `permission.ask` plugin hook that was defined but never triggered in `PermissionNext.ask()`.

## Problem

Issue #7006: Plugins cannot intercept permission requests because `Plugin.trigger("permission.ask", ...)` is never called in the permission system.

This prevents plugins like oh-my-opencode from implementing PreToolUse hooks for:
- Auto-approving safe operations
- Auto-denying restricted file patterns
- Delegation enforcement for orchestrator agents

## Solution

Add `Plugin.trigger("permission.ask", info, { status: "ask" })` call in `PermissionNext.ask()` before showing the UI prompt:

- If plugin returns `"allow"` → auto-approve (continue)
- If plugin returns `"deny"` → throw DeniedError
- If plugin returns `"ask"` or unchanged → proceed with existing UI prompt flow

## Testing

This change follows the exact same pattern used in `permission/index.ts` which already has working `Plugin.trigger("permission.ask", ...)` integration.

## Impact

- Enables oh-my-opencode and other plugins to implement PreToolUse hooks
- Backward compatible - no behavior change if no plugin handles the hook
- Unblocks delegation enforcement patterns for orchestrator agents

Fixes #7006