### PR TITLE
feat(app): add middle-click to close tabs in review sidebar

### DIFF
--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -39,6 +39,7 @@ export function SortableTab(props: { tab: string; onTabClose: (tab: string) => v
             </Tooltip>
           }
           hideCloseButton
+          onMiddleClick={() => props.onTabClose(props.tab)}
         >
           <Show when={path()}>{(p) => <FileVisual path={p()} />}</Show>
         </Tabs.Trigger>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -993,6 +993,7 @@ export default function Page() {
                           </Tooltip>
                         }
                         hideCloseButton
+                        onMiddleClick={() => tabs().close("context")}
                       >
                         <div class="flex items-center gap-2">
                           <SessionContextUsage variant="indicator" />

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -13,6 +13,7 @@ export interface TabsTriggerProps extends ComponentProps<typeof Kobalte.Trigger>
   }
   hideCloseButton?: boolean
   closeButton?: JSX.Element
+  onMiddleClick?: () => void
 }
 export interface TabsContentProps extends ComponentProps<typeof Kobalte.Content> {}
 
@@ -55,6 +56,7 @@ function TabsTrigger(props: ParentProps<TabsTriggerProps>) {
     "children",
     "closeButton",
     "hideCloseButton",
+    "onMiddleClick",
   ])
   return (
     <div
@@ -62,6 +64,12 @@ function TabsTrigger(props: ParentProps<TabsTriggerProps>) {
       classList={{
         ...(split.classList ?? {}),
         [split.class ?? ""]: !!split.class,
+      }}
+      onAuxClick={(e) => {
+        if (e.button === 1 && split.onMiddleClick) {
+          e.preventDefault()
+          split.onMiddleClick()
+        }
       }}
     >
       <Kobalte.Trigger


### PR DESCRIPTION
## Summary
- Adds middle-click (auxclick button 1) support to close tabs in the review sidebar
- Works on both file tabs and the Context tab
- Uses the same close logic as the existing close button