### PR TITLE
fix(app): open review sidebar when selecting file from picker

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -27,6 +27,7 @@ export function DialogSelectFile() {
             const value = file.tab(path)
             tabs().open(value)
             file.load(path)
+            layout.review.open()
           }
           dialog.close()
         }}


### PR DESCRIPTION
## Summary
- Opens the review sidebar when selecting a file from the file picker (CMD+P)
- Previously, if the sidebar was closed, the file would open in a tab but remain hidden