### PR TITLE
feat(tui): enable plugin tools to use Task component rendering

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1803,11 +1803,16 @@ function Task(props: ToolProps<typeof TaskTool>) {
   const current = createMemo(() => props.metadata.summary?.findLast((x) => x.state.status !== "pending"))
   const color = createMemo(() => local.agent.color(props.input.subagent_type ?? "unknown"))
 
+  const agentName = createMemo(() => {
+    const input = props.input as Record<string, unknown>
+    return (input.subagent_type ?? input.agent ?? input.category ?? props.tool ?? "unknown") as string
+  })
+
   return (
     <Switch>
-      <Match when={props.input.description || props.input.subagent_type}>
+      <Match when={props.metadata.sessionId || props.input.description || props.input.subagent_type}>
         <BlockTool
-          title={"# " + Locale.titlecase(props.input.subagent_type ?? "unknown") + " Task"}
+          title={"# " + Locale.titlecase(agentName()) + " Task"}
           onClick={
             props.metadata.sessionId
               ? () => navigate({ type: "session", sessionID: props.metadata.sessionId! })
@@ -1817,7 +1822,8 @@ function Task(props: ToolProps<typeof TaskTool>) {
         >
           <box>
             <text style={{ fg: theme.textMuted }}>
-              {props.input.description} ({props.metadata.summary?.length ?? 0} toolcalls)
+              {props.input.description}
+              <Show when={props.metadata.summary?.length}> ({props.metadata.summary?.length} toolcalls)</Show>
             </text>
             <Show when={current()}>
               <text style={{ fg: current()!.state.status === "error" ? theme.error : theme.textMuted }}>
@@ -1835,8 +1841,13 @@ function Task(props: ToolProps<typeof TaskTool>) {
         </BlockTool>
       </Match>
       <Match when={true}>
-        <InlineTool icon="#" pending="Delegating..." complete={props.input.subagent_type} part={props.part}>
-          {props.input.subagent_type} Task {props.input.description}
+        <InlineTool
+          icon="◉"
+          pending="Delegating..."
+          complete={agentName() ?? props.input.description}
+          part={props.part}
+        >
+          {Locale.titlecase(agentName())} Task "{props.input.description}"
         </InlineTool>
       </Match>
     </Switch>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1436,7 +1436,7 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
         <Match when={props.part.tool === "edit"}>
           <Edit {...toolprops} />
         </Match>
-        <Match when={props.part.tool === "task"}>
+        <Match when={props.part.tool === "task" || toolprops.metadata.sessionId}>
           <Task {...toolprops} />
         </Match>
         <Match when={props.part.tool === "apply_patch"}>

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -67,17 +67,28 @@ export namespace ToolRegistry {
         parameters: z.object(def.args),
         description: def.description,
         execute: async (args, ctx) => {
-          const pluginCtx = {
+          let capturedTitle = ""
+          let capturedMetadata: Record<string, unknown> = {}
+          const wrappedCtx = {
             ...ctx,
             directory: Instance.directory,
             worktree: Instance.worktree,
-          } as unknown as PluginToolContext
-          const result = await def.execute(args as any, pluginCtx)
+            metadata: (input: { title?: string; metadata?: Record<string, unknown> }) => {
+              if (input.title) capturedTitle = input.title
+              if (input.metadata) capturedMetadata = { ...capturedMetadata, ...input.metadata }
+              return ctx.metadata(input)
+            },
+          }
+          const result = await def.execute(args as Record<string, unknown>, wrappedCtx as unknown as PluginToolContext)
           const out = await Truncate.output(result, {}, initCtx?.agent)
           return {
-            title: "",
+            title: capturedTitle,
             output: out.truncated ? out.content : result,
-            metadata: { truncated: out.truncated, outputPath: out.truncated ? out.outputPath : undefined },
+            metadata: {
+              ...capturedMetadata,
+              truncated: out.truncated,
+              outputPath: out.truncated ? out.outputPath : undefined,
+            },
           }
         },
       }),


### PR DESCRIPTION
## Summary

This PR enables external plugin tools to use the built-in Task component's TUI rendering, providing a consistent visual experience for custom task implementations.

### Changes

- **TUI Routing**: Route plugin tools with `sessionId` metadata to Task/BlockTool component
- **Task Component**: Support flexible input shapes from external tools (agentName fallback chain, conditional toolcalls display)
- **Registry**: Preserve plugin tool metadata by wrapping context and capturing `metadata()` calls

### How it works

Plugin tools can now call `ctx.metadata({ metadata: { sessionId: "..." } })` to opt into BlockTool rendering. The TUI checks for `metadata.sessionId` presence and routes accordingly.

### Technical Details

- Removed `as any` type assertion in registry, replaced with explicit types
- Added `wrappedCtx` to intercept and capture metadata from plugin tool execution
- Task component now derives `agentName` from multiple sources: `subagent_type → agent → category → tool`
