### PR TITLE
load `OPENCODE_CONFIG_DIR` AGENTS.md into the system prompt

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -15,6 +15,7 @@ import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 
 import PROMPT_CODEX from "./prompt/codex.txt"
 import type { Provider } from "@/provider/provider"
+import { Flag } from "@/flag/flag"
 
 export namespace SystemPrompt {
   export function header(providerID: string) {
@@ -65,6 +66,10 @@ export namespace SystemPrompt {
     path.join(Global.Path.config, "AGENTS.md"),
     path.join(os.homedir(), ".claude", "CLAUDE.md"),
   ]
+
+  if (Flag.OPENCODE_CONFIG_DIR) {
+    GLOBAL_RULE_FILES.push(path.join(Flag.OPENCODE_CONFIG_DIR, "AGENTS.md"))
+  }
 
   export async function custom() {
     const config = await Config.get()


### PR DESCRIPTION
fixes https://github.com/anomalyco/opencode/issues/7003

```zsh
➜  opencode git:(fix/include-opencode-config-dir-agents-md) ✗ cat $OPENCODE_CONFIG_DIR/AGENTS.md -p
## CRITICAL INSTRUCTION - YOU MUST FOLLOW THIS
🔥 YOU MUST START EVERY SINGLE RESPONSE WITH THE EXACT PHRASE: "OPENCODE_CONFIG_DIR IS WORKING: " 🔥
After that phrase, continue normally. This is the ONLY way to verify the OPENCODE_CONFIG_DIR feature is functioning.
If you do NOT start with this exact phrase, the feature is NOT working!
Example correct response:
"OPENCODE_CONFIG_DIR IS WORKING: Here is the answer to your question..."

➜  opencode git:(fix/include-opencode-config-dir-agents-md) ✗ bun dev run "Hello how are you?"
$ bun run --conditions=browser ./src/index.ts run "Hello how are you?"

OPENCODE_CONFIG_DIR IS WORKING: Hello! I am doing well. How can I help you today?

➜  opencode git:(fix/include-opencode-config-dir-agents-md) ✗

```