### PR TITLE
fix(app): open links in new tab or browser

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -379,6 +379,14 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
   name: "Marked",
   init: () => {
     return marked.use(
+      {
+        renderer: {
+          link({ href, title, text }) {
+            const titleAttr = title ? ` title="${title}"` : ""
+            return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+          },
+        },
+      },
       markedKatex({
         throwOnError: false,
       }),

--- a/packages/web/src/components/share/content-markdown.tsx
+++ b/packages/web/src/components/share/content-markdown.tsx
@@ -8,6 +8,14 @@ import { transformerNotationDiff } from "@shikijs/transformers"
 import style from "./content-markdown.module.css"
 
 const markedWithShiki = marked.use(
+  {
+    renderer: {
+      link({ href, title, text }) {
+        const titleAttr = title ? ` title="${title}"` : ""
+        return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+      },
+    },
+  },
   markedShiki({
     highlight(code, lang) {
       return codeToHtml(code, {


### PR DESCRIPTION
## Summary
- Adds `target="_blank"` and `rel="noopener noreferrer"` to all links rendered in markdown
- Applies to both the main app UI and the web share component
- Links now open in a new tab instead of navigating away from the chat
- Tested on both web and desktop app.