### PR TITLE
docs: add OpenCode-Obsidian plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk  |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode            |
+| [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embedds OpenCode in Obsidian's UI          |
 
 ---
 


### PR DESCRIPTION
Adds [opencode-obsidian](https://github.com/mtymek/opencode-obsidian) to the Projects list.

OpenCode-Obsidian is an Obsidian plugin that spawns the server and embeds web version of OpenCode in Obsidian's tab:

<img width="2970" height="1818" alt="image" src="https://github.com/user-attachments/assets/d672bb2f-73f6-4ebd-829f-096f9333ee80" />

