### PR TITLE
fix: style multiple commands in input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -680,6 +680,13 @@ function getSyntaxRules(theme: Theme) {
       },
     },
     {
+      scope: ["extmark.command"],
+      style: {
+        foreground: theme.accent,
+        bold: true,
+      },
+    },
+    {
       scope: ["comment"],
       style: {
         foreground: theme.syntaxComment,


### PR DESCRIPTION
**Problem:** When multiple slash commands were typed in the TUI prompt (e.g., /help /status), only the first command was styled.

**Root Cause:** There was no highlighting mechanism for slash commands in the prompt input. The existing code only had styles for @file references, @agent references, and pasted content - but not for / commands.

**Solution:** Added a new extmark.command style and a function to highlight all slash commands:
1. Added extmark.command style in packages/opencode/src/cli/cmd/tui/context/theme.tsx:
   - Uses theme.accent color with bold styling (consistent with the prompt theme scope)
2. Added highlighting logic in packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx:
   - Created highlightSlashCommands() function that:
     - Removes previous command highlights using a reference counter
     - Uses regex /\/[a-zA-Z_][a-zA-Z0-9_-]*/g to find all slash commands
     - Applies the extmark.command style to each match
   - Called this function in onContentChange so highlights update as the user types
Now when you type multiple slash commands like /help /status /new, all three will be styled consistently with the accent color and bold formatting.