### PR TITLE
Desktop: Fix Big Messages

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -77,7 +77,7 @@
 
   [data-slot="user-message-text"] {
     white-space: pre-wrap;
-    overflow: hidden;
+    overflow-x: auto;
     background: var(--surface-base);
     padding: 8px 12px;
     border-radius: 4px;

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -59,6 +59,7 @@
 
   [data-slot="session-turn-message-content"] {
     margin-top: -18px;
+    max-width: 100%;
   }
 
   [data-slot="session-turn-message-title"] {


### PR DESCRIPTION
Right now big messages breaks layout:

<img width="2560" height="1060" alt="image" src="https://github.com/user-attachments/assets/b13f3513-10e1-4032-abd9-87eccf09b98e" />
<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/dcb3e8f0-23fc-482a-a1b9-92969d57d53e" />

This adds horizontal school to the user message:

<img width="2279" height="1008" alt="image" src="https://github.com/user-attachments/assets/4c7074c9-86b0-47c1-87f3-23cd4042f1a6" />