### PR TITLE
fix: encode non-ASCII directory paths in HTTP headers

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -246,7 +246,12 @@ export namespace Server {
         },
       )
       .use(async (c, next) => {
-        const directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+        let directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+        try {
+          directory = decodeURIComponent(directory)
+        } catch {
+          // fallback to original value
+        }
         return Instance.provide({
           directory,
           init: InstanceBootstrap,

--- a/packages/sdk/js/src/v2/client.ts
+++ b/packages/sdk/js/src/v2/client.ts
@@ -19,9 +19,11 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   if (config?.directory) {
+    const isNonASCII = /[^\x00-\x7F]/.test(config.directory)
+    const encodedDirectory = isNonASCII ? encodeURIComponent(config.directory) : config.directory
     config.headers = {
       ...config.headers,
-      "x-opencode-directory": config.directory,
+      "x-opencode-directory": encodedDirectory,
     }
   }
 


### PR DESCRIPTION
Fixes error when directory paths contain non-ASCII characters (e.g., Chinese) by using percent-encoding for the x-opencode-directory header, as HTTP headers must be ISO-8859-1 compatible.

