### PR TITLE
fix(tui): restore attach session lookup behavior

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -22,11 +22,10 @@ export const AttachCommand = cmd({
       }),
   handler: async (args) => {
     if (args.dir) process.chdir(args.dir)
-    const directory = process.cwd()
     await tui({
       url: args.url,
       args: { sessionID: args.session },
-      directory,
+      directory: args.dir ? process.cwd() : undefined,
     })
   },
 })


### PR DESCRIPTION
## Summary

Fixes regression where `opencode attach --session` fails with "Session not found" when run from a different directory than where the session was created.

## The issue

PR #6715 (commit 401b498c7) introduced a regression by always sending `process.cwd()` as the directory context. Sessions are stored per-project, so when the client's cwd differs from the session's directory, lookup fails.

## The fix

Only send the directory header when `--dir` is explicitly provided. Otherwise, let the server fall back to its own working directory (the pre-v1.1.1 behavior).

Fixes #7149