### PR TITLE
chore: declare ai sdk global and fix plugin fetch typing

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -14,10 +14,14 @@ export namespace Plugin {
   const BUILTIN = ["opencode-copilot-auth@0.0.9", "opencode-anthropic-auth@0.0.5"]
 
   const state = Instance.state(async () => {
+    const localFetch: typeof fetch = async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      return Server.App().fetch(request)
+    }
+
     const client = createOpencodeClient({
       baseUrl: "http://localhost:4096",
-      // @ts-ignore - fetch type incompatibility
-      fetch: async (...args) => Server.App().fetch(...args),
+      fetch: localFetch,
     })
     const config = await Config.get()
     const hooks = []

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -14,10 +14,14 @@ export namespace Plugin {
   const BUILTIN = ["opencode-copilot-auth@0.0.9", "opencode-anthropic-auth@0.0.5"]
 
   const state = Instance.state(async () => {
-    const localFetch: typeof fetch = async (input, init) => {
-      const request = input instanceof Request ? input : new Request(input, init)
-      return Server.App().fetch(request)
-    }
+    const localFetch = Object.assign(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init)
+        return Server.App().fetch(request)
+      },
+      // Bun's fetch includes a preconnect helper; mirror it to satisfy the expected type.
+      { preconnect: fetch.preconnect?.bind(fetch) },
+    ) as typeof fetch
 
     const client = createOpencodeClient({
       baseUrl: "http://localhost:4096",

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -52,7 +52,7 @@ import { Installation } from "@/installation"
 import { MDNS } from "./mdns"
 import { Worktree } from "../worktree"
 
-// @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
+// Prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
 
 export namespace Server {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -45,7 +45,6 @@ import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 
-// @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
 
 export namespace SessionPrompt {

--- a/packages/opencode/src/types/ai-sdk-log-warnings.d.ts
+++ b/packages/opencode/src/types/ai-sdk-log-warnings.d.ts
@@ -1,0 +1,5 @@
+export {}
+
+declare global {
+  var AI_SDK_LOG_WARNINGS: boolean | undefined
+}


### PR DESCRIPTION
  ## Summary
  - declare the global AI_SDK_LOG_WARNINGS flag to remove ts-ignore while keeping ai-sdk warnings disabled
  - wrap local Hono fetch with a standard fetch signature for the plugin client
  - keep behavior unchanged; this is type hygiene only

  ## Testing
  - not run (type-only change)