### PR TITLE
fix: auto-detect system theme changes at runtime

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,6 +1,6 @@
 import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo, onMount } from "solid-js"
+import { createEffect, createMemo, onCleanup, onMount } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
 import aura from "./theme/aura.json" with { type: "json" }
@@ -311,6 +311,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         })
     })
 
+    function detectMode(bg: string): "dark" | "light" {
+      const rgba = RGBA.fromHex(bg)
+      const luminance = 0.299 * rgba.r + 0.587 * rgba.g + 0.114 * rgba.b
+      return luminance > 0.5 ? "light" : "dark"
+    }
+
     function resolveSystemTheme() {
       console.log("resolved system theme")
       renderer
@@ -329,9 +335,12 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
             }
             return
           }
+          const bg = colors.defaultBackground ?? colors.palette[0]
+          const mode = detectMode(bg)
           setStore(
             produce((draft) => {
-              draft.themes.system = generateSystem(colors, store.mode)
+              draft.mode = mode
+              draft.themes.system = generateSystem(colors, mode)
               if (store.active === "system") {
                 draft.ready = true
               }
@@ -354,6 +363,23 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     const syntax = createMemo(() => generateSyntax(values()))
     const subtleSyntax = createMemo(() => generateSubtleSyntax(values()))
+
+    const intervalId = setInterval(async () => {
+      renderer.clearPaletteCache() // opentui caches palette, must clear to get fresh values
+      const colors = await renderer.getPalette({ size: 1 })
+      const bg = colors.defaultBackground ?? colors.palette[0]
+      if (!bg) return
+      const mode = detectMode(bg)
+      if (mode !== store.mode) {
+        if (store.active === "system") {
+          resolveSystemTheme()
+        } else {
+          setStore("mode", mode)
+          kv.set("theme_mode", mode)
+        }
+      }
+    }, 5000)
+    onCleanup(() => clearInterval(intervalId))
 
     return {
       theme: new Proxy(values(), {


### PR DESCRIPTION
 Another option other than polling is on focus if we want to do that instead, opus got this one to work but fair note it's AI generated and I'm not familiar enough with the render to know for accuracy atm - I can investigate this more deeply if needed


https://github.com/user-attachments/assets/ef0a9617-3147-4d46-90ba-4b94d9a5b99f

==== AI Generated Below ===

## Summary
- Polls terminal background color every 5 seconds to detect system theme changes
- Updates theme mode (dark/light) automatically when terminal colors change
- Works for both `system` theme and named themes with dark/light variants (like `opencode`)

## Changes
- Added `detectMode()` helper to calculate dark/light from terminal background color
- Added polling interval that re-queries terminal palette and updates mode when changed
- Updated `resolveSystemTheme()` to detect and apply the correct mode

## Testing
1. Set theme to `opencode` (or any theme with dark/light variants)
2. Change system/terminal theme from light to dark (or vice versa)
3. Wait ~5 seconds - opencode should automatically switch to match