### PR TITLE
fix(tui): constrain autocomplete height to available screen space

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -653,8 +653,10 @@ export function Autocomplete(props: {
   })
 
   const height = createMemo(() => {
-    if (options().length) return Math.min(10, options().length)
-    return 1
+    const count = options().length || 1
+    if (!store.visible) return Math.min(10, count)
+    positionTick()
+    return Math.min(10, count, Math.max(1, props.anchor().y))
   })
 
   let scroll: ScrollBoxRenderable


### PR DESCRIPTION
Fixes autocomplete dropdown overflowing when terminal height is small by constraining the list height to the available space above the cursor.

before:
<img width="653" height="167" alt="image" src="https://github.com/user-attachments/assets/5026db01-6e35-46e9-b232-ce845bca1eea" />

After :
<img width="662" height="180" alt="image" src="https://github.com/user-attachments/assets/851be4a4-92a8-4055-a199-a083a6e99fe8" />
