### PR TITLE
fix(cli): clarify error when GitHub event context is missing

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -427,8 +427,12 @@ export const GithubRunCommand = cmd({
       const isMock = args.token || args.event
 
       const context = isMock ? (JSON.parse(args.event!) as Context) : github.context
+      if (!context.eventName) {
+        core.setFailed("No GitHub event context found.")
+        process.exit(1)
+      }
       if (!SUPPORTED_EVENTS.includes(context.eventName as (typeof SUPPORTED_EVENTS)[number])) {
-        core.setFailed(`Unsupported event type: ${context.eventName}`)
+        core.setFailed(`Unsupported event type: ${context.eventName}. Supported events: ${SUPPORTED_EVENTS.join(", ")}`)
         process.exit(1)
       }
 


### PR DESCRIPTION
Fixes #7193 

When running `bun dev github run` without a GitHub Actions event context, the CLI currently fails with an unclear error (`Unsupported event type: undefined`).

This PR detects the missing event context earlier and returns a clearer, more actionable error message, improving the CLI UX without changing behavior.
