### PR TITLE
docs: add cc-safety-net plugin to the ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -42,6 +42,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                      |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                          |
+| [cc-safety-net](https://github.com/kenryu42/claude-code-safety-net)                                | Intercept and prevent destructive Git and filesystem commands before execution                 |
 
 ---
 


### PR DESCRIPTION
Hello, this PR adds a new plugin to the https://opencode.ai/docs/ecosystem/ page.

## `cc-safety-net`

This plugin acts as a **safety net for AI coding agents**, catching destructive git and filesystem commands before they execute. It provides semantic command analysis that goes beyond simple prefix matching—parsing arguments, understanding flag combinations, recursively analyzing shell wrappers, and distinguishing safe operations from dangerous ones.

**Key features:**

- Blocks destructive git commands (`git reset --hard`, `git push --force`, `git checkout --`, etc.)
- Prevents dangerous filesystem operations (`rm -rf` outside cwd, root/home deletion)
- Detects shell wrappers (`bash -c`, `sh -c`) and interpreter one-liners (`python -c`)
- Supports custom blocking rules via `.safety-net.json`
- Includes audit logging and secret redaction

**npm:** [`cc-safety-net`](https://www.npmjs.com/package/cc-safety-net)
Read more about it [here](https://github.com/kenryu42/claude-code-safety-net).

Thanks.