### PR TITLE
fix(ui): prevent iOS Safari auto-zoom on input focus

### DIFF
--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -372,3 +372,17 @@ input:where([type="button"], [type="reset"], [type="submit"]),
 [hidden]:where(:not([hidden="until-found"])) {
   display: none !important;
 }
+
+/*
+  Prevent iOS Safari from auto-zooming on input focus.
+  iOS WebKit zooms on any input with font-size < 16px as an accessibility feature.
+*/
+
+@media (hover: none) and (pointer: coarse) {
+  input,
+  select,
+  textarea,
+  [contenteditable="true"] {
+    font-size: 16px !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Add CSS media query targeting touch devices to prevent iOS Safari auto-zoom on input focus
- Increase font-size to 16px for input, select, textarea, and contenteditable elements on touch devices
- iOS WebKit auto-zooms on inputs with font-size < 16px as an accessibility feature

Fixes #6784