### PR TITLE
fix: Add signature field to ReasoningPart

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -78,6 +78,7 @@ export namespace MessageV2 {
   export const ReasoningPart = PartBase.extend({
     type: z.literal("reasoning"),
     text: z.string(),
+    signature: z.string().optional(),
     metadata: z.record(z.string(), z.any()).optional(),
     time: z.object({
       start: z.number(),
@@ -538,6 +539,7 @@ export namespace MessageV2 {
             assistantMessage.parts.push({
               type: "reasoning",
               text: part.text,
+              signature: part.signature,
               providerMetadata: part.metadata,
             })
           }

--- a/packages/opencode/src/session/message.ts
+++ b/packages/opencode/src/session/message.ts
@@ -69,6 +69,7 @@ export namespace Message {
   export const ReasoningPart = z
     .object({
       type: z.literal("reasoning"),
+      signature: z.string().optional(),
       text: z.string(),
       providerMetadata: z.record(z.string(), z.any()).optional(),
     })


### PR DESCRIPTION
This PR adds the optional `signature` field to the `ReasoningPart` type to support thinking block signatures required by models like Claude.

## Changes

- Added `signature: z.string().optional()` to `ReasoningPart` in `packages/opencode/src/session/message-v2.ts`
- Added `signature: z.string().optional()` to `ReasoningPart` in `packages/opencode/src/session/message.ts`
- Updated `toModelMessage` function to include the signature when converting reasoning parts

## Related Issue

Fixes issue #6418: "Error: Invalid signature in thinking block" when switching models from MiniMax/GLM to Claude
