### PR TITLE
Fix for #7229 Fix/project sidebar folder name

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -7,14 +7,10 @@ import { createMemo, createSignal, For, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { type LocalProject, getAvatarColors } from "@/context/layout"
+import { getFilename } from "@opencode-ai/util/path"
 import { Avatar } from "@opencode-ai/ui/avatar"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
-
-function getFilename(input: string) {
-  const parts = input.split("/")
-  return parts[parts.length - 1] || input
-}
 
 export function DialogEditProject(props: { project: LocalProject }) {
   const dialog = useDialog()

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -868,7 +868,7 @@ export default function Layout(props: ParentProps) {
             </Collapsible>
           </Match>
           <Match when={true}>
-            <Tooltip placement="right" value={props.project.worktree}>
+            <Tooltip placement="right" value={getFilename(props.project.worktree)}>
               <ProjectVisual project={props.project} />
             </Tooltip>
           </Match>

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -1,7 +1,7 @@
 export function getFilename(path: string | undefined) {
   if (!path) return ""
-  const trimmed = path.replace(/[\/]+$/, "")
-  const parts = trimmed.split("/")
+  const trimmed = path.replace(/[\/\\]+$/, "")
+  const parts = trimmed.split(/[\/\\]/)
   return parts[parts.length - 1] ?? ""
 }
 


### PR DESCRIPTION
Fix for #7229  : Project sidebar displays full paths instead of folder names on Windows

Problem:

On Windows, the sidebar showed full paths like C:\Users{name}...\project-name instead of just project-name
The tooltip on hover also displayed the full path
Root cause:

getFilename() utility only split by /, not handling Windows \ separator
Tooltip directly used worktree instead of extracting the folder name
Duplicate getFilename function in dialog-edit-project.tsx
Changes:

Updated getFilename() in packages/util/src/path.ts to split by both / and
Changed tooltip in packages/app/src/pages/layout.tsx to show folder name
Removed duplicate function, using imported utility in packages/app/src/components/dialog-edit-project.tsx

Before:
<img width="336" height="166" alt="sidebar" src="https://github.com/user-attachments/assets/862e70f7-c4b4-4cf1-8c24-e730b0178917" />

After:
<img width="359" height="180" alt="sidebar2" src="https://github.com/user-attachments/assets/4d4db2e2-50e4-4356-982f-b49df055e36c" />

Note: this is a redo of #7230 as I messed up and included commits from an unmerged PR in it and so closed and redid it here
