### PR TITLE
feat(tui): add 24-hour time format option for session view

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -39,6 +39,7 @@ export function DialogSessionList() {
 
   const options = createMemo(() => {
     const today = new Date().toDateString()
+    const timeFormat = sync.data.config.tui?.time_format ?? "12h"
     return sessions()
       .filter((x) => x.parentID === undefined)
       .toSorted((a, b) => b.time.updated - a.time.updated)
@@ -56,7 +57,7 @@ export function DialogSessionList() {
           bg: isDeleting ? theme.error : undefined,
           value: x.id,
           category,
-          footer: Locale.time(x.time.updated),
+          footer: Locale.time(x.time.updated, timeFormat),
           gutter: isWorking ? (
             <Show when={kv.get("animations_enabled", true)} fallback={<text fg={theme.textMuted}>[⋯]</text>}>
               <spinner frames={spinnerFrames} interval={80} color={theme.primary} />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -20,6 +20,7 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
 
   const options = createMemo((): DialogSelectOption<string>[] => {
     const messages = sync.data.message[props.sessionID] ?? []
+    const timeFormat = sync.data.config.tui?.time_format ?? "12h"
     const result = [] as DialogSelectOption<string>[]
     for (const message of messages) {
       if (message.role !== "user") continue
@@ -30,7 +31,7 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
       result.push({
         title: part.text.replace(/\n/g, " "),
         value: message.id,
-        footer: Locale.time(message.time.created),
+        footer: Locale.time(message.time.created, timeFormat),
         onSelect: async (dialog) => {
           const forked = await sdk.client.session.fork({
             sessionID: props.sessionID,

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
@@ -21,6 +21,7 @@ export function DialogTimeline(props: {
 
   const options = createMemo((): DialogSelectOption<string>[] => {
     const messages = sync.data.message[props.sessionID] ?? []
+    const timeFormat = sync.data.config.tui?.time_format ?? "12h"
     const result = [] as DialogSelectOption<string>[]
     for (const message of messages) {
       if (message.role !== "user") continue
@@ -31,7 +32,7 @@ export function DialogTimeline(props: {
       result.push({
         title: part.text.replace(/\n/g, " "),
         value: message.id,
-        footer: Locale.time(message.time.created),
+        footer: Locale.time(message.time.created, timeFormat),
         onSelect: (dialog) => {
           dialog.replace(() => (
             <DialogMessage messageID={message.id} sessionID={props.sessionID} setPrompt={props.setPrompt} />

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -696,6 +696,7 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    time_format: z.enum(["12h", "24h"]).optional().describe("Time format for timestamps in TUI"),
   })
 
   export const Server = z

--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -3,28 +3,28 @@ export namespace Locale {
     return str.replace(/\b\w/g, (c) => c.toUpperCase())
   }
 
-  export function time(input: number): string {
+  export function time(input: number, format: "12h" | "24h" = "12h"): string {
     const date = new Date(input)
-    return date.toLocaleTimeString(undefined, { timeStyle: "short" })
+    return date.toLocaleTimeString(undefined, { timeStyle: "short", hour12: format === "12h" })
   }
 
-  export function datetime(input: number): string {
+  export function datetime(input: number, format: "12h" | "24h" = "12h"): string {
     const date = new Date(input)
-    const localTime = time(input)
+    const localTime = time(input, format)
     const localDate = date.toLocaleDateString()
     return `${localTime} · ${localDate}`
   }
 
-  export function todayTimeOrDateTime(input: number): string {
+  export function todayTimeOrDateTime(input: number, format: "12h" | "24h" = "12h"): string {
     const date = new Date(input)
     const now = new Date()
     const isToday =
       date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth() && date.getDate() === now.getDate()
 
     if (isToday) {
-      return time(input)
+      return time(input, format)
     } else {
-      return datetime(input)
+      return datetime(input, format)
     }
   }
 

--- a/packages/opencode/test/util/locale.test.ts
+++ b/packages/opencode/test/util/locale.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { Locale } from "../../src/util/locale"
+
+describe("Locale", () => {
+  describe("time", () => {
+    test("formats time in 12h format by default", () => {
+      const date = new Date("2023-01-01T15:30:00")
+      // Note: The exact output depends on the system locale, but we expect AM/PM
+      // We can check if it contains PM or AM, or matches a pattern
+      const result = Locale.time(date.getTime())
+      expect(result).toMatch(/(\d{1,2}:\d{2}\s*[AP]M)|(\d{1,2}:\d{2})/i)
+    })
+
+    test("formats time in 12h format explicitly", () => {
+      const date = new Date("2023-01-01T15:30:00")
+      const result = Locale.time(date.getTime(), "12h")
+      // Should look like 3:30 PM
+      expect(result).toMatch(/3:30\s*PM/)
+    })
+
+    test("formats time in 24h format explicitly", () => {
+      const date = new Date("2023-01-01T15:30:00")
+      const result = Locale.time(date.getTime(), "24h")
+      // Should look like 15:30
+      expect(result).toBe("15:30")
+    })
+  })
+
+  describe("datetime", () => {
+    test("formats datetime in 12h format by default", () => {
+      const date = new Date("2023-01-01T15:30:00")
+      const result = Locale.datetime(date.getTime())
+      expect(result).toContain("3:30 PM")
+    })
+
+    test("formats datetime in 24h format", () => {
+      const date = new Date("2023-01-01T15:30:00")
+      const result = Locale.datetime(date.getTime(), "24h")
+      expect(result).toContain("15:30")
+    })
+  })
+
+  describe("todayTimeOrDateTime", () => {
+    test("returns time for today", () => {
+      const now = new Date()
+      const result = Locale.todayTimeOrDateTime(now.getTime(), "24h")
+      // Should be just time, e.g. 15:30, length is short
+      expect(result.length).toBeLessThan(10)
+      expect(result).toMatch(/^\d{1,2}:\d{2}$/)
+    })
+
+    test("returns datetime for past date", () => {
+      const past = new Date("2020-01-01T12:00:00")
+      const result = Locale.todayTimeOrDateTime(past.getTime(), "24h")
+      expect(result).toContain("12:00")
+      expect(result).toContain("2020")
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1492,6 +1492,10 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Time format for session view
+     */
+    time_format?: "12h" | "24h"
   }
   server?: ServerConfig
   /**


### PR DESCRIPTION
## Description
Adds support for 24-hour time format in the TUI session view, addressing [Issue #7208](https://github.com/anomalyco/opencode/issues/7208).

Users can now configure whether timestamps in the session view display in 12-hour (AM/PM) or 24-hour format.

## Before & After

### Before (12-hour format - default)
<img width="672" height="262" alt="7bc66c04-e643-433e-bd20-f4b7f35de2e5" src="https://github.com/user-attachments/assets/43e158c3-c4b3-47ea-a044-fe18400e6c17" />

### After (24-hour format)
<img width="645" height="256" alt="52a1a39e-fc0e-4fc5-8a66-46cb8c9f9113" src="https://github.com/user-attachments/assets/07a539fd-2d1a-4652-8208-e0ea44bb51fd" />

## Changes
- Added `time_format` configuration option to TUI settings (supports "12h" and "24h" formats)
- Updated time formatting utilities (`Locale.time`, `Locale.datetime`, `Locale.todayTimeOrDateTime`) to accept format parameter
- Applied time format configuration to:
  - Session list view
  - Fork from timeline dialog
  - Timeline view
- Added unit tests for time formatting functions

## Configuration Example

Add the following to your `opencode.jsonc` or `.opencode/opencode.jsonc`:

```jsonc
{
  "tui": {
    // Use 24-hour time format (default is 12-hour)
    "time_format": "24h"
  }
}
```

Or use 12-hour format explicitly:

```jsonc
{
  "tui": {
    "time_format": "12h"
  }
}
```

## Testing
- Session list displays correct time format based on configuration
- Fork dialog shows correct time format
- Timeline view respects time format setting
- Unit tests pass for both 12h and 24h formats

## Related Issue
Closes [#7208](https://github.com/anomalyco/opencode/issues/7208)