### PR TITLE
feat(lsp): add phpactor lsp support for php

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1488,6 +1488,55 @@ export namespace LSPServer {
     },
   }
 
+  export const PHPActor: Info = {
+    id: "phpactor",
+    extensions: [".php"],
+    root: NearestRoot([".phpactor.json", "composer.json", "composer.lock"]),
+    async spawn(root) {
+      let bin = Bun.which("phpactor")
+      if (!bin) {
+        const composerPaths = [
+          path.join(os.homedir(), ".composer", "vendor", "bin", "phpactor"),
+          path.join(os.homedir(), ".config", "composer", "vendor", "bin", "phpactor"),
+        ]
+        for (const phpactorPath of composerPaths) {
+          if (await Bun.file(phpactorPath).exists()) {
+            bin = phpactorPath
+            break
+          }
+        }
+      }
+      if (!bin) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+        log.info("downloading phpactor from GitHub releases")
+
+        const downloadResponse = await fetch("https://github.com/phpactor/phpactor/releases/latest/download/phpactor.phar")
+        if (!downloadResponse.ok) {
+          log.error("Failed to download phpactor")
+          return
+        }
+
+        bin = path.join(Global.Path.bin, "phpactor")
+        await Bun.file(bin).write(downloadResponse)
+
+        if (process.platform !== "win32") {
+          await $`chmod +x ${bin}`.quiet().nothrow()
+        }
+
+        log.info("installed phpactor", { binary: bin })
+      }
+      return {
+        process: spawn(bin, ["language-server"], {
+          cwd: root,
+          env: {
+            ...process.env,
+          },
+        }),
+        initialization: {},
+      }
+    },
+  }
+
   export const PHPIntelephense: Info = {
     id: "php intelephense",
     extensions: [".php"],

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -31,6 +31,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | nixd               | .nix                                                                | `nixd` command available                                     |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` command available                                 |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependency in project                               |
+| phpactor           | .php                                                                | Auto-installs for PHP projects                               |
 | php intelephense   | .php                                                                | Auto-installs for PHP projects                               |
 | prisma             | .prisma                                                             | `prisma` command available                                   |
 | pyright            | .py, .pyi                                                           | `pyright` dependency installed                               |


### PR DESCRIPTION
Hello!

This adds support for the [phpactor](https://github.com/phpactor/phpactor) lsp for php files. phpactor has several benefits over the intelephense lsp that is currently included for php:

- 100% free (does not require a license key, unlike intelephense)
- open source
- active maintainer that is responsive to issues and bug reports
- interfaces with phpstan and other php tools

> [!NOTE]
> Currently both the intelephense and phpactor lsp servers would be started for php files, there's a couple of paths forward depending on how y'all would like to handle this:
> 1. do nothing, it probably won't hurt to have both lsps running and users could simply disable the one they don't want
> 2. add some heuristics to determine which one should run (e.g., run intelephense if the user has the license file)
> 3. make one the default (e.g., phpactor since it's free) that autodownloads, the other would not autodownload, but could be used if the user installs the binary manually and disables the default
> 4. remove the autodownload from both, this would allow the user to determine which one is installed and used

Just let me know how y'all would like to proceed.

Thanks!