### PR TITLE
fix: use selectedForeground's computer colour (or theme's selectedForeground value) for the colour of text in permission selection (resolves #7246)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -102,15 +102,16 @@ type Theme = ThemeColors & {
   thinkingOpacity: number
 }
 
-export function selectedForeground(theme: Theme): RGBA {
+export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
   // If theme explicitly defines selectedListItemText, use it
   if (theme._hasSelectedListItemText) {
     return theme.selectedListItemText
   }
 
-  // For transparent backgrounds, calculate contrast based on primary color
+  // For transparent backgrounds, calculate contrast based on the actual bg (or fallback to primary)
   if (theme.background.a === 0) {
-    const { r, g, b } = theme.primary
+    const targetColor = bg ?? theme.primary
+    const { r, g, b } = targetColor
     const luminance = 0.299 * r + 0.587 * g + 0.114 * b
     return luminance > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
   }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -3,7 +3,7 @@ import { createMemo, For, Match, Show, Switch } from "solid-js"
 import { useKeyboard, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
-import { useTheme } from "../../context/theme"
+import { useTheme, selectedForeground } from "../../context/theme"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../component/border"
@@ -395,7 +395,7 @@ function Prompt<const T extends Record<string, string>>(props: {
                 paddingRight={1}
                 backgroundColor={option === store.selected ? theme.warning : theme.backgroundMenu}
               >
-                <text fg={option === store.selected ? theme.selectedListItemText : theme.textMuted}>
+                <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
                   {props.options[option]}
                 </text>
               </box>


### PR DESCRIPTION
This PR applies the same fix that was applied in the (long since merged) #4369 to solve the similar issue with the text colour when selecting responses to permission promps.

### Before

<img width="382" height="203" alt="Screenshot 2026-01-07 at 1 53 49 PM" src="https://github.com/user-attachments/assets/3b35ffae-72c1-4dc1-a67e-1f4e475ad9c4" />

### After

<img width="336" height="212" alt="Screenshot 2026-01-07 at 3 34 44 PM" src="https://github.com/user-attachments/assets/e96b0092-2182-4cbb-80c3-c04fc3ec3b3e" />

Resolves #7246.