### PR TITLE
fix(tui): ensure forked message text is inserted in prompt (resolves #7257)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1042,6 +1042,10 @@ export function Session() {
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)
+                  // Apply initial prompt when prompt component mounts (e.g., from fork)
+                  if (route.initialPrompt) {
+                    r.set(route.initialPrompt)
+                  }
                 }}
                 disabled={permissions().length > 0}
                 onSubmit={() => {


### PR DESCRIPTION
Fixes regression where forking a session via /fork command or message dialog would not insert the selected message text into the prompt input box.

The issue was a timing problem where the createEffect that handles route.initialPrompt ran before the prompt ref was assigned during component initialization.

Now applies the initial prompt directly in the Prompt component's ref callback, which guarantees the prompt instance is available when setting the initial text.

Resolves issue where forked sessions started with empty prompt input boxes.

Resolves #7257.