### PR TITLE
feat(tui): Dynamic Details - compact tool output with click-to-expand

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -98,6 +98,7 @@ const context = createContext<{
   showThinking: () => boolean
   showTimestamps: () => boolean
   showDetails: () => boolean
+  dynamicDetails: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
 }>()
@@ -147,6 +148,7 @@ export function Session() {
   const [showThinking, setShowThinking] = kv.signal("thinking_visibility", true)
   const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
   const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
+  const [dynamicDetails, setDynamicDetails] = kv.signal("dynamic_details", true)
   const [showAssistantMetadata, setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
   const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
@@ -568,6 +570,15 @@ export function Session() {
       },
     },
     {
+      title: dynamicDetails() ? "Disable dynamic details" : "Enable dynamic details",
+      value: "session.toggle.dynamic_details",
+      category: "Session",
+      onSelect: (dialog) => {
+        setDynamicDetails((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
       title: "Toggle session scrollbar",
       value: "session.toggle.scrollbar",
       keybind: "scrollbar_toggle",
@@ -951,6 +962,7 @@ export function Session() {
         showThinking,
         showTimestamps,
         showDetails,
+        dynamicDetails,
         diffWrapMode,
         sync,
       }}
@@ -1578,17 +1590,82 @@ function InlineTool(props: {
   )
 }
 
+// Safely convert value to string for line counting
+function safeString(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value == null) return ""
+  return String(value)
+}
+
+// Helper to count lines from tool data (with trimEnd to ignore trailing whitespace)
+function getDataLineCount(part: ToolPart | undefined): number {
+  if (!part) return 0
+  if (part.state.status !== "completed") return 0
+
+  const tool = part.tool
+  const state = part.state
+
+  if (tool === "bash") {
+    const cmd = safeString(state.input?.command).trimEnd()
+    const out = stripAnsi(safeString(state.metadata?.output)).trimEnd()
+    const cmdLines = cmd ? cmd.split("\n").length : 0
+    const outLines = out ? out.split("\n").length : 0
+    return cmdLines + outLines
+  }
+
+  if (tool === "edit") {
+    const diff = safeString(state.metadata?.diff).trimEnd()
+    return diff ? diff.split("\n").length : 0
+  }
+
+  if (tool === "write") {
+    const content = safeString(state.input?.content).trimEnd()
+    return content ? content.split("\n").length : 0
+  }
+
+  if (tool === "patch") {
+    const output = safeString(state.output).trimEnd()
+    return output ? output.split("\n").length : 0
+  }
+
+  // Default: use output field
+  const output = safeString(state.output).trimEnd()
+  return output ? output.split("\n").length : 0
+}
+
 function BlockTool(props: {
   title: string
   children: JSX.Element
   onClick?: () => void
   part?: ToolPart
   spinner?: boolean
+  disableDynamic?: boolean
 }) {
   const { theme } = useTheme()
+  const { dynamicDetails, sync } = use()
   const renderer = useRenderer()
-  const [hover, setHover] = createSignal(false)
+  const [collapsed, setCollapsed] = createSignal(true)
+  const [visualLines, setVisualLines] = createSignal(0)
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
+
+  const maxLines = createMemo(() => sync.data.config.tui?.dynamic_details_max_lines ?? 15)
+  const showArrows = createMemo(() => sync.data.config.tui?.dynamic_details_show_arrows ?? false)
+  const dataLines = createMemo(() => getDataLineCount(props.part))
+  const shouldCollapse = createMemo(() => {
+    if (props.disableDynamic) return false
+    if (!dynamicDetails()) return false
+    return dataLines() > maxLines()
+  })
+
+  const handleClick = () => {
+    if (renderer.getSelection()?.getSelectedText()) return
+    if (shouldCollapse()) {
+      setCollapsed(!collapsed())
+    } else {
+      props.onClick?.()
+    }
+  }
+
   return (
     <box
       border={["left"]}
@@ -1597,14 +1674,38 @@ function BlockTool(props: {
       paddingLeft={2}
       marginTop={1}
       gap={1}
-      backgroundColor={hover() ? theme.backgroundMenu : theme.backgroundPanel}
+      backgroundColor={theme.backgroundPanel}
       customBorderChars={SplitBorder.customBorderChars}
       borderColor={theme.background}
-      onMouseOver={() => props.onClick && setHover(true)}
-      onMouseOut={() => setHover(false)}
-      onMouseUp={() => {
-        if (renderer.getSelection()?.getSelectedText()) return
-        props.onClick?.()
+      maxHeight={shouldCollapse() && collapsed() ? maxLines() + 3 : undefined}
+      overflow={shouldCollapse() && collapsed() ? "hidden" : undefined}
+      justifyContent={shouldCollapse() && collapsed() ? "flex-start" : undefined}
+      onMouseUp={handleClick}
+      renderBefore={function () {
+        if (!shouldCollapse()) return
+        const el = this as any
+        const countVisualLines = (node: any): number => {
+          const children = node.getChildren?.() ?? []
+          const isSplitView = "view" in node && node.view === "split"
+          let maxChildLines = 0
+          let sumChildLines = 0
+          for (const child of children) {
+            let childLines = 0
+            if ("virtualLineCount" in child && typeof child.virtualLineCount === "number") {
+              childLines = child.virtualLineCount
+            }
+            if (child.getChildren) {
+              childLines = Math.max(childLines, countVisualLines(child))
+            }
+            maxChildLines = Math.max(maxChildLines, childLines)
+            sumChildLines += childLines
+          }
+          return isSplitView ? maxChildLines : sumChildLines
+        }
+        const count = countVisualLines(el)
+        if (count > 0 && count !== visualLines()) {
+          setVisualLines(count)
+        }
       }}
     >
       <Show
@@ -1618,6 +1719,22 @@ function BlockTool(props: {
         <Spinner color={theme.textMuted}>{props.title.replace(/^# /, "")}</Spinner>
       </Show>
       {props.children}
+      <Show when={shouldCollapse() && (visualLines() === 0 || visualLines() > maxLines())}>
+        <box flexDirection="row">
+          <box backgroundColor={theme.backgroundElement} paddingLeft={2} paddingRight={2}>
+            <text fg={theme.textMuted}>
+              {collapsed() ? (
+                <>
+                  {showArrows() ? "▶ " : ""}Click to expand{" "}
+                  <span style={{ fg: theme.border }}>(+{Math.max(1, visualLines() - maxLines())})</span>
+                </>
+              ) : (
+                <>{showArrows() ? "▼ " : ""}Click to collapse</>
+              )}
+            </text>
+          </box>
+        </box>
+      </Show>
       <Show when={error()}>
         <text fg={theme.error}>{error()}</text>
       </Show>
@@ -1628,11 +1745,12 @@ function BlockTool(props: {
 function Bash(props: ToolProps<typeof BashTool>) {
   const { theme } = useTheme()
   const sync = useSync()
+  const { dynamicDetails } = use()
   const isRunning = createMemo(() => props.part.state.status === "running")
   const output = createMemo(() => stripAnsi(props.metadata.output?.trim() ?? ""))
   const [expanded, setExpanded] = createSignal(false)
   const lines = createMemo(() => output().split("\n"))
-  const overflow = createMemo(() => lines().length > 10)
+  const overflow = createMemo(() => !dynamicDetails() && lines().length > 10)
   const limited = createMemo(() => {
     if (expanded() || !overflow()) return output()
     return [...lines().slice(0, 10), "…"].join("\n")
@@ -1919,7 +2037,7 @@ function Edit(props: ToolProps<typeof EditTool>) {
     <Switch>
       <Match when={props.metadata.diff !== undefined}>
         <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
-          <box paddingLeft={1}>
+          <box paddingLeft={1} width="100%">
             <diff
               diff={diffContent()}
               view={view()}
@@ -2041,7 +2159,7 @@ function TodoWrite(props: ToolProps<typeof TodoWriteTool>) {
   return (
     <Switch>
       <Match when={props.metadata.todos?.length}>
-        <BlockTool title="# Todos" part={props.part}>
+        <BlockTool title="# Todos" part={props.part} disableDynamic>
           <box>
             <For each={props.input.todos ?? []}>
               {(todo) => <TodoItem status={todo.status} content={todo.content} />}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -928,6 +928,16 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    dynamic_details_max_lines: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("Max visible lines before tool output becomes collapsible (default: 15)"),
+    dynamic_details_show_arrows: z
+      .boolean()
+      .optional()
+      .describe("Show arrow indicators on collapsible tool outputs (default: false)"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1641,6 +1641,14 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Max visible lines before tool output becomes collapsible (default: 15)
+     */
+    dynamic_details_max_lines?: number
+    /**
+     * Show arrow indicators on collapsible tool outputs (default: true)
+     */
+    dynamic_details_show_arrows?: boolean
   }
   server?: ServerConfig
   /**


### PR DESCRIPTION
## Summary

Keeps tool output compact and accessible with click-to-expand functionality. Tool blocks with more than 15 lines collapse by default, showing a preview with a "+N" indicator. Click anywhere on the tool block to expand/collapse, making it easier to navigate long sessions without pages of output scrolling by.

Fixes #7450
Relates to #1816

Also helps with:
- #5358 - Collapsible outputs improve tool output visibility
- #5419 - Less scrolling through verbose output improves screen real estate usage
- #6240 - Same goal of reducing visual clutter
- #3521 - Diffs are collapsed by default
- #5277 - Collapsed outputs save space on small screens

Compliments commit: https://github.com/anomalyco/opencode/commit/b3a2f9fb4

## Features

- Tool outputs collapse when exceeding configured line threshold
- Click anywhere on tool block to expand/collapse
- Shows "+N" indicator for hidden lines
- Configurable threshold via `tui.dynamic_details_max_lines` (default: 15)
- Configurable arrow indicators via `tui.dynamic_details_show_arrows` (default: true)
- Toggle via Ctrl+P -> "Enable/Disable dynamic details"
- Persisted preference in KV store (default: enabled)

## Configuration

```json
{
  "tui": {
    "dynamic_details_max_lines": 15,
    "dynamic_details_show_arrows": true
  }
}
```

## Applies To

Block-container tools (bash, write, edit, patch) when:
- Output exceeds configured line threshold
- Tool has completed (not pending/running states)

TodoWrite is excluded (always expanded) for visibility.

## Implementation

Enhances the existing `BlockTool` component with collapse/expand logic rather than introducing new abstractions. Uses:
- Data-based line counting for collapse decisions (stable, based on tool output)
- Visual line counting via `virtualLineCount` for accurate "+N" display
- `maxHeight` + `overflow: hidden` for clipping when collapsed

## Changes

- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` - Add dynamicDetails context, toggle command, and collapse logic in BlockTool
- `packages/opencode/src/config/config.ts` - Add config options for max lines and arrow indicators