### PR TITLE
fix: show path in external_directory permission prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -219,7 +219,10 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                 <TextBody icon="◇" title={`Exa Code Search "` + (input().query ?? "") + `"`} />
               </Match>
               <Match when={props.request.permission === "external_directory"}>
-                <TextBody icon="←" title={`Access external directory ` + normalizePath(input().path as string)} />
+                <TextBody
+                  icon="←"
+                  title={`Access external directory ` + path.resolve(props.request.metadata?.parentDir as string)}
+                />
               </Match>
               <Match when={props.request.permission === "doom_loop"}>
                 <TextBody icon="⟳" title="Continue after repeated failures" />

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -136,12 +136,15 @@ export const BashTool = Tool.define("bash", async () => {
         }
       }
 
-      if (directories.size > 0) {
+      for (const dir of directories) {
         await ctx.ask({
           permission: "external_directory",
-          patterns: Array.from(directories),
-          always: Array.from(directories).map((x) => path.dirname(x) + "*"),
-          metadata: {},
+          patterns: [dir],
+          always: [dir + "/*"],
+          metadata: {
+            filepath: dir,
+            parentDir: dir,
+          },
         })
       }
 

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -144,6 +144,7 @@ describe("tool.bash permissions", () => {
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeDefined()
         expect(extDirReq!.patterns).toContain("/tmp")
+        expect(extDirReq!.metadata.parentDir).toBe("/tmp")
       },
     })
   })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -73,6 +73,7 @@ describe("tool.read external_directory permission", () => {
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeDefined()
         expect(extDirReq!.patterns.some((p) => p.includes(outerTmp.path))).toBe(true)
+        expect(extDirReq!.metadata.parentDir).toBe(outerTmp.path)
       },
     })
   })


### PR DESCRIPTION
Without this, external_directory permissions prompts, at least for read tools, didn't show a path at all. You could figure it out by seeing which tool usages were pending, but that was annoying especially if it was a different session triggering the prompt. The "always allow" confirmation screen _did_ include the path though.

- Update bash tool to ask for each external directory individually (consistent with read/edit/patch tools)
- Populate metadata.parentDir in bash tool's external_directory request
- Display absolute path for external directories instead of relative