### PR TITLE
feat(tui): Ability to Toggle LSP Diagnostics

### DIFF
--- a/packages/app/src/components/session-lsp-indicator.tsx
+++ b/packages/app/src/components/session-lsp-indicator.tsx
@@ -16,7 +16,9 @@ export function SessionLspIndicator() {
   const tooltipContent = createMemo(() => {
     const lsp = sync.data.lsp ?? []
     if (lsp.length === 0) return "No LSP servers"
-    return lsp.map((s) => s.name).join(", ")
+    const servers = lsp.map((s) => s.name).join(", ")
+    const diagStatus = sync.data.lsp_diagnostics ? "enabled" : "disabled"
+    return `${servers} • Diagnostics: ${diagStatus}`
   })
 
   return (

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -52,6 +52,7 @@ type State = {
     [name: string]: McpStatus
   }
   lsp: LspStatus[]
+  lsp_diagnostics: boolean | undefined
   vcs: VcsInfo | undefined
   limit: number
   message: {
@@ -98,6 +99,7 @@ function createGlobalSync() {
         permission: {},
         mcp: {},
         lsp: [],
+        lsp_diagnostics: undefined,
         vcs: undefined,
         limit: 5,
         message: {},
@@ -172,6 +174,7 @@ function createGlobalSync() {
           loadSessions(directory),
           sdk.mcp.status().then((x) => setStore("mcp", x.data!)),
           sdk.lsp.status().then((x) => setStore("lsp", x.data!)),
+          sdk.lsp.diagnostics.status().then((x) => setStore("lsp_diagnostics", x.data?.enabled)),
           sdk.vcs.get().then((x) => setStore("vcs", x.data)),
           sdk.permission.list().then((x) => {
             const grouped: Record<string, PermissionRequest[]> = {}

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -52,7 +52,7 @@ type State = {
     [name: string]: McpStatus
   }
   lsp: LspStatus[]
-  lsp_diagnostics: boolean | undefined
+  lsp_diagnostics: boolean
   vcs: VcsInfo | undefined
   limit: number
   message: {
@@ -99,7 +99,7 @@ function createGlobalSync() {
         permission: {},
         mcp: {},
         lsp: [],
-        lsp_diagnostics: undefined,
+        lsp_diagnostics: true,
         vcs: undefined,
         limit: 5,
         message: {},
@@ -174,7 +174,7 @@ function createGlobalSync() {
           loadSessions(directory),
           sdk.mcp.status().then((x) => setStore("mcp", x.data!)),
           sdk.lsp.status().then((x) => setStore("lsp", x.data!)),
-          sdk.lsp.diagnostics.status().then((x) => setStore("lsp_diagnostics", x.data?.enabled)),
+          sdk.lsp.diagnostics.status().then((x) => setStore("lsp_diagnostics", x.data?.enabled ?? true)),
           sdk.vcs.get().then((x) => setStore("vcs", x.data)),
           sdk.permission.list().then((x) => {
             const grouped: Record<string, PermissionRequest[]> = {}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -443,11 +443,13 @@ export default function Page() {
       onSelect: async () => {
         await sdk.client.lsp.diagnostics.toggle()
         const status = await sdk.client.lsp.diagnostics.status()
-        sync.set("lsp_diagnostics", status.data?.enabled)
-        showToast({
-          title: "LSP Diagnostics",
-          description: `Diagnostics ${status.data?.enabled ? "enabled" : "disabled"}`,
-        })
+        if (status.data) {
+          sync.set("lsp_diagnostics", status.data.enabled)
+          showToast({
+            title: "LSP Diagnostics",
+            description: `Diagnostics ${status.data.enabled ? "enabled" : "disabled"}`,
+          })
+        }
       },
     },
     {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -435,6 +435,22 @@ export default function Page() {
       onSelect: () => dialog.show(() => <DialogSelectMcp />),
     },
     {
+      id: "lsp.diagnostics.toggle",
+      title: "Toggle LSP Diagnostics",
+      description: "Toggle LSP diagnostics to model",
+      category: "LSP",
+      slash: "lsp-diagnostics",
+      onSelect: async () => {
+        await sdk.client.lsp.diagnostics.toggle()
+        const status = await sdk.client.lsp.diagnostics.status()
+        sync.set("lsp_diagnostics", status.data?.enabled)
+        showToast({
+          title: "LSP Diagnostics",
+          description: `Diagnostics ${status.data?.enabled ? "enabled" : "disabled"}`,
+        })
+      },
+    },
+    {
       id: "agent.cycle",
       title: "Cycle agent",
       description: "Switch to the next agent",

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -372,12 +372,14 @@ function App() {
       onSelect: async () => {
         await sdk.client.lsp.diagnostics.toggle()
         const status = await sdk.client.lsp.diagnostics.status()
-        sync.set("lsp_diagnostics", status.data?.enabled)
-        toast.show({
-          variant: "info",
-          message: `LSP diagnostics ${status.data?.enabled ? "enabled" : "disabled"}`,
-          duration: 2000,
-        })
+        if (status.data) {
+          sync.set("lsp_diagnostics", status.data.enabled)
+          toast.show({
+            variant: "info",
+            message: `LSP diagnostics ${status.data.enabled ? "enabled" : "disabled"}`,
+            duration: 2000,
+          })
+        }
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -366,6 +366,21 @@ function App() {
       },
     },
     {
+      title: "Toggle LSP Diagnostics",
+      value: "lsp.diagnostics.toggle",
+      category: "Agent",
+      onSelect: async () => {
+        await sdk.client.lsp.diagnostics.toggle()
+        const status = await sdk.client.lsp.diagnostics.status()
+        sync.set("lsp_diagnostics", status.data?.enabled)
+        toast.show({
+          variant: "info",
+          message: `LSP diagnostics ${status.data?.enabled ? "enabled" : "disabled"}`,
+          duration: 2000,
+        })
+      },
+    },
+    {
       title: "Agent cycle",
       value: "agent.cycle",
       keybind: "agent_cycle",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -426,6 +426,11 @@ export function Autocomplete(props: {
         onSelect: () => command.trigger("mcp.list"),
       },
       {
+        display: "/diagnostics",
+        description: "toggle LSP Diagnostics",
+        onSelect: () => command.trigger("lsp.diagnostics.toggle"),
+      },
+      {
         display: "/theme",
         description: "toggle theme",
         onSelect: () => command.trigger("theme.switch"),

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -60,7 +60,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         [messageID: string]: Part[]
       }
       lsp: LspStatus[]
-      lsp_diagnostics: boolean | undefined
+      lsp_diagnostics: boolean
       mcp: {
         [key: string]: McpStatus
       }
@@ -91,7 +91,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       message: {},
       part: {},
       lsp: [],
-      lsp_diagnostics: undefined,
+      lsp_diagnostics: true,
       mcp: {},
       mcp_resource: {},
       formatter: [],
@@ -302,7 +302,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             ...(args.continue ? [] : [sessionListPromise]),
             sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
-            sdk.client.lsp.diagnostics.status().then((x) => setStore("lsp_diagnostics", x.data?.enabled)),
+            sdk.client.lsp.diagnostics.status().then((x) => setStore("lsp_diagnostics", x.data?.enabled ?? true)),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
             sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
             sdk.client.formatter.status().then((x) => setStore("formatter", reconcile(x.data!))),

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -60,6 +60,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         [messageID: string]: Part[]
       }
       lsp: LspStatus[]
+      lsp_diagnostics: boolean | undefined
       mcp: {
         [key: string]: McpStatus
       }
@@ -90,6 +91,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       message: {},
       part: {},
       lsp: [],
+      lsp_diagnostics: undefined,
       mcp: {},
       mcp_resource: {},
       formatter: [],
@@ -300,6 +302,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             ...(args.continue ? [] : [sessionListPromise]),
             sdk.client.command.list().then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status().then((x) => setStore("lsp", reconcile(x.data!))),
+            sdk.client.lsp.diagnostics.status().then((x) => setStore("lsp_diagnostics", x.data?.enabled)),
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
             sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
             sdk.client.formatter.status().then((x) => setStore("formatter", reconcile(x.data!))),

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -198,6 +198,9 @@ export function Sidebar(props: { sessionID: string }) {
                     </box>
                   )}
                 </For>
+                <text fg={theme.textMuted}>
+                  Diagnostics: {sync.data.lsp_diagnostics ? "Enabled" : "Disabled"}
+                </text>
               </Show>
             </box>
             <Show when={todo().length > 0 && todo().some((t) => t.status !== "completed")}>

--- a/packages/opencode/src/lsp/index.ts
+++ b/packages/opencode/src/lsp/index.ts
@@ -89,6 +89,7 @@ export namespace LSP {
           servers,
           clients,
           spawning: new Map<string, Promise<LSPClient.Info | undefined>>(),
+          diagnosticsEnabled: true,
         }
       }
 
@@ -136,6 +137,7 @@ export namespace LSP {
         servers,
         clients,
         spawning: new Map<string, Promise<LSPClient.Info | undefined>>(),
+        diagnosticsEnabled: true,
       }
     },
     async (state) => {
@@ -464,6 +466,25 @@ export namespace LSP {
     const clients = await getClients(file)
     const tasks = clients.map((x) => input(x))
     return Promise.all(tasks)
+  }
+
+  export const DiagnosticsStatus = z
+    .object({
+      enabled: z.boolean(),
+    })
+    .meta({ ref: "LSPDiagnosticsStatus" })
+  export type DiagnosticsStatus = z.infer<typeof DiagnosticsStatus>
+
+  export async function toggleDiagnostics(): Promise<boolean> {
+    const s = await state()
+    s.diagnosticsEnabled = !(s.diagnosticsEnabled ?? true)
+    log.info("toggled LSP diagnostics", { enabled: s.diagnosticsEnabled })
+    return s.diagnosticsEnabled
+  }
+
+  export async function diagnosticsStatus(): Promise<DiagnosticsStatus> {
+    const s = await state()
+    return { enabled: s.diagnosticsEnabled ?? true }
   }
 
   export namespace Diagnostic {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -51,6 +51,7 @@ import { PermissionNext } from "@/permission/next"
 import { Installation } from "@/installation"
 import { MDNS } from "./mdns"
 import { Worktree } from "../worktree"
+import ignore from "ignore"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -2401,49 +2402,6 @@ export namespace Server {
         }),
         async (c) => {
           return c.json(await LSP.status())
-        },
-      )
-      .get(
-        "/lsp/diagnostics/status",
-        describeRoute({
-          summary: "Get LSP diagnostics toggle status",
-          description: "Returns the current state of LSP diagnostics toggle",
-          operationId: "lsp.diagnostics.status",
-          responses: {
-            200: {
-              description: "LSP diagnostics toggle status",
-              content: {
-                "application/json": {
-                  schema: resolver(LSP.DiagnosticsStatus),
-                },
-              },
-            },
-          },
-        }),
-        async (c) => {
-          return c.json(await LSP.diagnosticsStatus())
-        },
-      )
-      .post(
-        "/lsp/diagnostics/toggle",
-        describeRoute({
-          summary: "Toggle LSP diagnostics",
-          description: "Toggle whether LSP diagnostics are sent to the model",
-          operationId: "lsp.diagnostics.toggle",
-          responses: {
-            200: {
-              description: "Updated diagnostics status",
-              content: {
-                "application/json": {
-                  schema: resolver(LSP.DiagnosticsStatus),
-                },
-              },
-            },
-          },
-        }),
-        async (c) => {
-          const enabled = await LSP.toggleDiagnostics()
-          return c.json({ enabled })
         },
       )
       .get(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2404,6 +2404,49 @@ export namespace Server {
         },
       )
       .get(
+        "/lsp/diagnostics/status",
+        describeRoute({
+          summary: "Get LSP diagnostics toggle status",
+          description: "Returns the current state of LSP diagnostics toggle",
+          operationId: "lsp.diagnostics.status",
+          responses: {
+            200: {
+              description: "LSP diagnostics toggle status",
+              content: {
+                "application/json": {
+                  schema: resolver(LSP.DiagnosticsStatus),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          return c.json(await LSP.diagnosticsStatus())
+        },
+      )
+      .post(
+        "/lsp/diagnostics/toggle",
+        describeRoute({
+          summary: "Toggle LSP diagnostics",
+          description: "Toggle whether LSP diagnostics are sent to the model",
+          operationId: "lsp.diagnostics.toggle",
+          responses: {
+            200: {
+              description: "Updated diagnostics status",
+              content: {
+                "application/json": {
+                  schema: resolver(LSP.DiagnosticsStatus),
+                },
+              },
+            },
+          },
+        }),
+        async (c) => {
+          const enabled = await LSP.toggleDiagnostics()
+          return c.json({ enabled })
+        },
+      )
+      .get(
         "/formatter",
         describeRoute({
           summary: "Get formatter status",

--- a/packages/opencode/src/server/tui.ts
+++ b/packages/opencode/src/server/tui.ts
@@ -2,6 +2,7 @@ import { Hono, type Context } from "hono"
 import { describeRoute, resolver, validator } from "hono-openapi"
 import { z } from "zod"
 import { AsyncQueue } from "../util/queue"
+import { LSP } from "@/lsp"
 
 const TuiRequest = z.object({
   path: z.string(),
@@ -67,5 +68,48 @@ export const TuiRoute = new Hono()
       const body = c.req.valid("json")
       response.push(body)
       return c.json(true)
+    },
+  )
+  .get(
+    "/lsp/diagnostics/status",
+    describeRoute({
+      summary: "Get LSP diagnostics toggle status",
+      description: "Returns the current state of LSP diagnostics toggle",
+      operationId: "lsp.diagnostics.status",
+      responses: {
+        200: {
+          description: "LSP diagnostics toggle status",
+          content: {
+            "application/json": {
+              schema: resolver(LSP.DiagnosticsStatus),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      return c.json(await LSP.diagnosticsStatus())
+    },
+  )
+  .post(
+    "/lsp/diagnostics/toggle",
+    describeRoute({
+      summary: "Toggle LSP diagnostics",
+      description: "Toggle whether LSP diagnostics are sent to the model",
+      operationId: "lsp.diagnostics.toggle",
+      responses: {
+        200: {
+          description: "Updated diagnostics status",
+          content: {
+            "application/json": {
+              schema: resolver(LSP.DiagnosticsStatus),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const enabled = await LSP.toggleDiagnostics()
+      return c.json({ enabled })
     },
   )

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -131,7 +131,7 @@ export const EditTool = Tool.define("edit", {
 
     let output = ""
     await LSP.touchFile(filePath, true)
-    const diagnostics = await LSP.diagnostics()
+    const diagnostics = ((await LSP.diagnosticsStatus()).enabled) ? await LSP.diagnostics() : {}
     const normalizedFilePath = Filesystem.normalizePath(filePath)
     const issues = diagnostics[normalizedFilePath] ?? []
     const errors = issues.filter((item) => item.severity === 1)

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -53,7 +53,7 @@ export const WriteTool = Tool.define("write", {
 
     let output = ""
     await LSP.touchFile(filepath, true)
-    const diagnostics = await LSP.diagnostics()
+    const diagnostics = ((await LSP.diagnosticsStatus()).enabled) ? await LSP.diagnostics() : {}
     const normalizedFilepath = Filesystem.normalizePath(filepath)
     let projectDiagnosticsCount = 0
     for (const [file, issues] of Object.entries(diagnostics)) {

--- a/packages/opencode/test/lsp/diagnostics.test.ts
+++ b/packages/opencode/test/lsp/diagnostics.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import path from "path"
+import { LSP } from "../../src/lsp"
+import { Instance } from "../../src/project/instance"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+import { WriteTool } from "../../src/tool/write"
+import { EditTool } from "../../src/tool/edit"
+
+const ctx = {
+  sessionID: "test",
+  messageID: "",
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  metadata: () => {},
+  ask: async () => {},
+}
+
+describe("LSP Diagnostics Toggle Integration", () => {
+  beforeEach(async () => {
+    await Log.init({ print: false })
+  })
+
+  test("Write tool respects diagnostics toggle when disabled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await LSP.init()
+
+        await LSP.toggleDiagnostics()
+        expect((await LSP.diagnosticsStatus()).enabled).toBe(false)
+
+        const write = await WriteTool.init()
+        const testFile = path.join(tmp.path, "test.ts")
+
+        const result = await write.execute(
+          {
+            filePath: testFile,
+            content: `const x: number = "hello";\nconst missing = undefinedVar;`,
+          },
+          ctx,
+        )
+
+        expect(result.output).not.toContain("<file_diagnostics>")
+        expect(result.output).not.toContain("ERROR")
+      },
+    })
+  })
+
+  test("Write tool shows diagnostics when enabled", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        // Create a tsconfig to enable TypeScript LSP
+        await Bun.write(
+          path.join(dir, "tsconfig.json"),
+          JSON.stringify({
+            compilerOptions: {
+              strict: true,
+              target: "ES2020",
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await LSP.init()
+
+        const status = await LSP.diagnosticsStatus()
+        expect(status.enabled).toBe(true)
+
+        const write = await WriteTool.init()
+        const testFile = path.join(tmp.path, "test.ts")
+
+        const result = await write.execute(
+          {
+            filePath: testFile,
+            content: `const x: number = "hello";\nconst missing = undefinedVar;`,
+          },
+          ctx,
+        )
+
+        // Wait a bit for LSP to process
+        await new Promise((r) => setTimeout(r, 500))
+
+        // Note: Actual diagnostics may not appear if LSP isn't running,
+        // but we're testing the filtering logic
+        // The tool should at least attempt to fetch diagnostics
+        expect(result).toBeDefined()
+      },
+    })
+  })
+
+  test("Edit tool respects diagnostics toggle when disabled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await LSP.init()
+        const testFile = path.join(tmp.path, "test.ts")
+        await Bun.write(testFile, `const x = 1;`)
+
+        // Read the file first (required by Edit tool)
+        const { ReadTool } = await import("../../src/tool/read")
+        const read = await ReadTool.init()
+        await read.execute({ filePath: testFile }, ctx)
+
+        await LSP.toggleDiagnostics()
+        expect((await LSP.diagnosticsStatus()).enabled).toBe(false)
+
+        const edit = await EditTool.init()
+        const result = await edit.execute(
+          {
+            filePath: testFile,
+            oldString: "const x = 1;",
+            newString: 'const x: number = "hello";',
+          },
+          ctx,
+        )
+        
+        expect(result.output).not.toContain("<file_diagnostics>")
+        expect(result.output).not.toContain("ERROR")
+      },
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -35,6 +35,8 @@ import type {
   GlobalEventResponses,
   GlobalHealthResponses,
   InstanceDisposeResponses,
+  LspDiagnosticsStatusResponses,
+  LspDiagnosticsToggleResponses,
   LspStatusResponses,
   McpAddErrors,
   McpAddResponses,
@@ -2482,6 +2484,46 @@ export class Experimental extends HeyApiClient {
   resource = new Resource({ client: this.client })
 }
 
+export class Diagnostics extends HeyApiClient {
+  /**
+   * Get LSP diagnostics toggle status
+   *
+   * Returns the current state of LSP diagnostics toggle
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<LspDiagnosticsStatusResponses, unknown, ThrowOnError>({
+      url: "/lsp/diagnostics/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Toggle LSP diagnostics
+   *
+   * Toggle whether LSP diagnostics are sent to the model
+   */
+  public toggle<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).post<LspDiagnosticsToggleResponses, unknown, ThrowOnError>({
+      url: "/lsp/diagnostics/toggle",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Lsp extends HeyApiClient {
   /**
    * Get LSP status
@@ -2501,6 +2543,8 @@ export class Lsp extends HeyApiClient {
       ...params,
     })
   }
+
+  diagnostics = new Diagnostics({ client: this.client })
 }
 
 export class Formatter extends HeyApiClient {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2498,7 +2498,7 @@ export class Diagnostics extends HeyApiClient {
   ) {
     const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
     return (options?.client ?? this.client).get<LspDiagnosticsStatusResponses, unknown, ThrowOnError>({
-      url: "/lsp/diagnostics/status",
+      url: "/tui/control/lsp/diagnostics/status",
       ...options,
       ...params,
     })
@@ -2517,7 +2517,7 @@ export class Diagnostics extends HeyApiClient {
   ) {
     const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
     return (options?.client ?? this.client).post<LspDiagnosticsToggleResponses, unknown, ThrowOnError>({
-      url: "/lsp/diagnostics/toggle",
+      url: "/tui/control/lsp/diagnostics/toggle",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1980,6 +1980,10 @@ export type LspStatus = {
   status: "connected" | "error"
 }
 
+export type LspDiagnosticsStatus = {
+  enabled: boolean
+}
+
 export type FormatterStatus = {
   name: string
   extensions: Array<string>
@@ -4233,6 +4237,42 @@ export type LspStatusResponses = {
 }
 
 export type LspStatusResponse = LspStatusResponses[keyof LspStatusResponses]
+
+export type LspDiagnosticsStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/lsp/diagnostics/status"
+}
+
+export type LspDiagnosticsStatusResponses = {
+  /**
+   * LSP diagnostics toggle status
+   */
+  200: LspDiagnosticsStatus
+}
+
+export type LspDiagnosticsStatusResponse = LspDiagnosticsStatusResponses[keyof LspDiagnosticsStatusResponses]
+
+export type LspDiagnosticsToggleData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/lsp/diagnostics/toggle"
+}
+
+export type LspDiagnosticsToggleResponses = {
+  /**
+   * Updated diagnostics status
+   */
+  200: LspDiagnosticsStatus
+}
+
+export type LspDiagnosticsToggleResponse = LspDiagnosticsToggleResponses[keyof LspDiagnosticsToggleResponses]
 
 export type FormatterStatusData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1980,13 +1980,13 @@ export type LspStatus = {
   status: "connected" | "error"
 }
 
-export type LspDiagnosticsStatus = {
-  enabled: boolean
-}
-
 export type FormatterStatus = {
   name: string
   extensions: Array<string>
+  enabled: boolean
+}
+
+export type LspDiagnosticsStatus = {
   enabled: boolean
 }
 
@@ -4238,42 +4238,6 @@ export type LspStatusResponses = {
 
 export type LspStatusResponse = LspStatusResponses[keyof LspStatusResponses]
 
-export type LspDiagnosticsStatusData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-  }
-  url: "/lsp/diagnostics/status"
-}
-
-export type LspDiagnosticsStatusResponses = {
-  /**
-   * LSP diagnostics toggle status
-   */
-  200: LspDiagnosticsStatus
-}
-
-export type LspDiagnosticsStatusResponse = LspDiagnosticsStatusResponses[keyof LspDiagnosticsStatusResponses]
-
-export type LspDiagnosticsToggleData = {
-  body?: never
-  path?: never
-  query?: {
-    directory?: string
-  }
-  url: "/lsp/diagnostics/toggle"
-}
-
-export type LspDiagnosticsToggleResponses = {
-  /**
-   * Updated diagnostics status
-   */
-  200: LspDiagnosticsStatus
-}
-
-export type LspDiagnosticsToggleResponse = LspDiagnosticsToggleResponses[keyof LspDiagnosticsToggleResponses]
-
 export type FormatterStatusData = {
   body?: never
   path?: never
@@ -4585,6 +4549,42 @@ export type TuiControlResponseResponses = {
 }
 
 export type TuiControlResponseResponse = TuiControlResponseResponses[keyof TuiControlResponseResponses]
+
+export type LspDiagnosticsStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/tui/control/lsp/diagnostics/status"
+}
+
+export type LspDiagnosticsStatusResponses = {
+  /**
+   * LSP diagnostics toggle status
+   */
+  200: LspDiagnosticsStatus
+}
+
+export type LspDiagnosticsStatusResponse = LspDiagnosticsStatusResponses[keyof LspDiagnosticsStatusResponses]
+
+export type LspDiagnosticsToggleData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/tui/control/lsp/diagnostics/toggle"
+}
+
+export type LspDiagnosticsToggleResponses = {
+  /**
+   * Updated diagnostics status
+   */
+  200: LspDiagnosticsStatus
+}
+
+export type LspDiagnosticsToggleResponse = LspDiagnosticsToggleResponses[keyof LspDiagnosticsToggleResponses]
 
 export type AuthSetData = {
   body?: Auth


### PR DESCRIPTION
Closes #6692 

- Add ability to toggle LSP Diagnostics on/off via the command palette or slash command
- When toggled off, the `edit` & `write` tools skip fetching and adding LSP diagnostics to the model
- LSP diagnostics are enabled by default and need to toggled off actively

## Screenshots

Command Palette
<img width="450" height="259" alt="SCR-20260106-mpta" src="https://github.com/user-attachments/assets/356f7d27-1d44-45c6-9b79-f8b3dd321df8" />

Slash Command
<img width="411" height="86" alt="SCR-20260106-mpxs" src="https://github.com/user-attachments/assets/748f075a-ae18-411c-b32b-09d6f99e2224" />

Toast + Sidebar
<img width="487" height="290" alt="SCR-20260106-mqxj" src="https://github.com/user-attachments/assets/9327bf63-c9bc-4006-832f-101cdd4f3303" />

## Output Comparison

```txt
# LSP Diagnostics enabled
DEBUG +0ms service=lsp fileCount=1 totalDiagnostics=158 diagnostics fetched
DEBUG +0ms service=tool.write diagnostics_enabled=true filepath=/tmp/lsp-stress-test.ts diagnosticFileCount=1 tool.write diagnostics check
This file has errors, please fix
<file_diagnostics>
ERROR [4:7] Type 'number' is not assignable to type 'string'.
ERROR [5:7] Type 'string' is not assignable to type 'number'.
ERROR [6:7] Type 'string' is not assignable to type 'boolean'.
ERROR [7:24] Type 'string' is not assignable to type 'number'.
ERROR [7:29] Type 'string' is not assignable to type 'number'.
ERROR [7:34] Type 'string' is not assignable to type 'number'.
ERROR [8:30] Type 'string' is not assignable to type 'number'.
ERROR [14:5] Argument of type 'string' is not assignable to parameter of type 'number'.
... and 67 more
</file_diagnostics>
 tool.write diagnostic output
```
vs

```txt
# LSP Diagnostics Disabled

DEBUG +0ms service=lsp enabled=false diagnosticsStatus called
DEBUG +0ms service=tool.write diagnostics_enabled=false filepath=/tmp/lsp-stress-test-common.ts diagnosticFileCount=0 tool.write diagnostics check
DEBUG +0ms service=tool.write diagnostics={} output= tool.write diagnostic output
```
