### PR TITLE
Fix: TUI single-line paste cursor position

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -916,7 +916,6 @@ export function Prompt(props: PromptProps) {
                 // Force layout update and render for the pasted content
                 setTimeout(() => {
                   input.getLayoutNode().markDirty()
-                  input.gotoBufferEnd()
                   renderer.requestRender()
                 }, 0)
               }}


### PR DESCRIPTION
# Fix: TUI single-line paste cursor position

## Description
This PR fixes a bug where pasting single-line text in the TUI prompt would incorrectly move the cursor to the end of the input buffer, instead of placing it immediately after the pasted text.

## Issue
Fixes #7210

## Changes
- Removed `input.gotoBufferEnd()` from the `onPaste` handler in `opencode/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`.

## Verification
- Verified that `input.gotoBufferEnd()` was the cause of the cursor jump.
- The default behavior of the textarea component handles cursor positioning correctly for pasted text.
- Retained `markDirty()` and `requestRender()` to ensure UI updates correctly after paste.