### PR TITLE
feat(provider): add Responses API support for custom OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -62,6 +62,8 @@ export namespace Provider {
     "@ai-sdk/vercel": createVercel,
     // @ts-ignore (TODO: kill this code so we dont have to maintain it)
     "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
+    // @ts-ignore
+    "@opencode-ai/openai-compatible": createGitHubCopilotOpenAICompatible,
   }
 
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
@@ -974,9 +976,17 @@ export namespace Provider {
     const sdk = await getSDK(model)
 
     try {
-      const language = s.modelLoaders[model.providerID]
-        ? await s.modelLoaders[model.providerID](sdk, model.api.id, provider.options)
-        : sdk.languageModel(model.api.id)
+      let language
+      if (s.modelLoaders[model.providerID]) {
+        language = await s.modelLoaders[model.providerID](sdk, model.api.id, provider.options)
+      } else if (model.api.npm === "@opencode-ai/openai-compatible") {
+        language =
+          provider.options?.useResponsesApi === false
+            ? (sdk as any).chat(model.api.id)
+            : (sdk as any).responses(model.api.id)
+      } else {
+        language = sdk.languageModel(model.api.id)
+      }
       s.models.set(key, language)
       return language
     } catch (e) {

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
@@ -33,6 +33,12 @@ export interface OpenaiCompatibleProviderSettings {
    * Custom fetch implementation.
    */
   fetch?: FetchFunction
+
+  /**
+   * Omit max_output_tokens parameter from requests.
+   * Some OpenAI-compatible providers don't support this parameter.
+   */
+  omitMaxOutputTokens?: boolean
 }
 
 export interface OpenaiCompatibleProvider {
@@ -80,6 +86,7 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
       headers: getHeaders,
       url: ({ path }) => `${baseURL}${path}`,
       fetch: options.fetch,
+      omitMaxOutputTokens: options.omitMaxOutputTokens,
     })
   }
 

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-config.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-config.ts
@@ -15,4 +15,5 @@ export type OpenAIConfig = {
    * - Azure OpenAI: ['assistant-'] for IDs like 'assistant-abc123'
    */
   fileIdPrefixes?: readonly string[]
+  omitMaxOutputTokens?: boolean
 }

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-language-model.ts
@@ -256,7 +256,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
       input,
       temperature,
       top_p: topP,
-      max_output_tokens: maxOutputTokens,
+      ...(!this.config.omitMaxOutputTokens && maxOutputTokens != null && { max_output_tokens: maxOutputTokens }),
 
       ...((responseFormat?.type === "json" || openaiOptions?.textVerbosity) && {
         text: {


### PR DESCRIPTION
## Summary

- Register `@opencode-ai/openai-compatible` as bundled provider with Responses API support
- Add `omitMaxOutputTokens` option for providers that don't support `max_output_tokens` parameter
- Default to `responses()` API, with option to fallback to `chat()` via `useResponsesApi: false`

## Motivation

Many OpenAI-compatible API proxies (OpenRouter, NewAPI? etc.) now support OpenAI's `/responses` endpoint. However, `@ai-sdk/openai-compatible` only supports Chat Completions API.

This PR exposes the existing internal Responses API implementation (currently only used for GitHub Copilot) to custom providers.

Related: [vercel/ai#9723](https://github.com/vercel/ai/pull/9723) (stale, 795 commits behind)

## Usage

```json
{
  "provider": {
    "my-provider": {
      "npm": "@opencode-ai/openai-compatible",
      "api": "https://my-api.com/v1",
      "env": ["MY_API_KEY"],
      "options": {
        "omitMaxOutputTokens": true
      },
      "models": {
        "gpt-5.2": {}
      }
    }
  }
}
```

## Options

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `omitMaxOutputTokens` | boolean | false | Don't send `max_output_tokens` parameter (some proxies don't support it) |
| `useResponsesApi` | boolean | true | Use Responses API; set to `false` to use Chat Completions API |