### PR TITLE
feat(formatters): add laravel pint as a `.php` formatter

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -357,3 +357,18 @@ export const cargofmt: Info = {
     return found.length > 0
   },
 }
+
+export const pint: Info = {
+  name: "pint",
+  command: ["./vendor/bin/pint", "$FILE"],
+  extensions: [".php"],
+  async enabled() {
+    const items = await Filesystem.findUp("composer.json", Instance.directory, Instance.worktree)
+    for (const item of items) {
+      const json = await Bun.file(item).json()
+      if (json.require?.["laravel/pint"]) return true
+      if (json["require-dev"]?.["laravel/pint"]) return true
+    }
+    return false
+  },
+}

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -33,6 +33,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | gleam                | .gleam                                                                                                   | `gleam` command available                                                                             |
 | nixfmt               | .nix                                                                                                     | `nixfmt` command available                                                                            |
 | shfmt                | .sh, .bash                                                                                               | `shfmt` command available                                                                             |
+| pint                 | .php                                                                                                     | `laravel/pint` dependency in `composer.json`                                                          |
 | oxfmt (Experimental) | .js, .jsx, .ts, .tsx                                                                                     | `oxfmt` dependency in `package.json` and an [experimental env variable flag](/docs/cli/#experimental) |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.


### PR DESCRIPTION
yo, this pull request adds laravel pint as a `.php` formatter, and it only runs if it’s explicitly specified in `composer.json`, as expected.

note: although pint is under the laravel organization, it’s framework-agnostic and works with any php project.