### PR TITLE
feat: add configuration for open ai store option on provider level

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -778,6 +778,10 @@ export namespace Config {
             .describe(
               "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
             ),
+          store: z
+            .boolean()
+            .optional()
+            .describe("Set store option for all models of this provider (OpenAI only). Default is true."),
         })
         .catchall(z.any())
         .optional(),

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -458,6 +458,10 @@ export namespace ProviderTransform {
       result["promptCacheKey"] = sessionID
     }
 
+    if (model.providerID === "openai" && providerOptions?.store !== undefined) {
+      result["store"] = providerOptions.store
+    }
+
     if (model.api.npm === "@ai-sdk/google" || model.api.npm === "@ai-sdk/google-vertex") {
       result["thinkingConfig"] = {
         includeThoughts: true,


### PR DESCRIPTION
For organizations with ZDR enabled, currently we need to manually set the "store" option for every open ai model in configuration. This change adds support to specify it once on the provider level instead. Ref: https://github.com/anomalyco/opencode/issues/2966