### PR TITLE
docs(ecosystem): add micode and octto plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                     |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control      |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
+| [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                      |
+| [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                          |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add [micode](https://github.com/vtemian/micode) - Structured Brainstorm → Plan → Implement workflow with session continuity
- Add [octto](https://github.com/vtemian/octto) - Interactive browser UI for AI brainstorming with multi-question forms