### PR TITLE
fix(cli): add help text to debug command and subcommands

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -6,6 +6,7 @@ import { cmd } from "../cmd"
 
 export const AgentCommand = cmd({
   command: "agent <name>",
+  describe: "show agent configuration details",
   builder: (yargs) =>
     yargs.positional("name", {
       type: "string",

--- a/packages/opencode/src/cli/cmd/debug/config.ts
+++ b/packages/opencode/src/cli/cmd/debug/config.ts
@@ -5,6 +5,7 @@ import { cmd } from "../cmd"
 
 export const ConfigCommand = cmd({
   command: "config",
+  describe: "show resolved configuration",
   builder: (yargs) => yargs,
   async handler() {
     await bootstrap(process.cwd(), async () => {

--- a/packages/opencode/src/cli/cmd/debug/file.ts
+++ b/packages/opencode/src/cli/cmd/debug/file.ts
@@ -6,6 +6,7 @@ import { Ripgrep } from "@/file/ripgrep"
 
 const FileSearchCommand = cmd({
   command: "search <query>",
+  describe: "search files by query",
   builder: (yargs) =>
     yargs.positional("query", {
       type: "string",
@@ -22,6 +23,7 @@ const FileSearchCommand = cmd({
 
 const FileReadCommand = cmd({
   command: "read <path>",
+  describe: "read file contents as JSON",
   builder: (yargs) =>
     yargs.positional("path", {
       type: "string",
@@ -38,6 +40,7 @@ const FileReadCommand = cmd({
 
 const FileStatusCommand = cmd({
   command: "status",
+  describe: "show file status information",
   builder: (yargs) => yargs,
   async handler() {
     await bootstrap(process.cwd(), async () => {
@@ -49,6 +52,7 @@ const FileStatusCommand = cmd({
 
 const FileListCommand = cmd({
   command: "list <path>",
+  describe: "list files in a directory",
   builder: (yargs) =>
     yargs.positional("path", {
       type: "string",
@@ -65,6 +69,7 @@ const FileListCommand = cmd({
 
 const FileTreeCommand = cmd({
   command: "tree [dir]",
+  describe: "show directory tree",
   builder: (yargs) =>
     yargs.positional("dir", {
       type: "string",
@@ -79,6 +84,7 @@ const FileTreeCommand = cmd({
 
 export const FileCommand = cmd({
   command: "file",
+  describe: "file system debugging utilities",
   builder: (yargs) =>
     yargs
       .command(FileReadCommand)

--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -12,6 +12,7 @@ import { AgentCommand } from "./agent"
 
 export const DebugCommand = cmd({
   command: "debug",
+  describe: "debugging and troubleshooting tools",
   builder: (yargs) =>
     yargs
       .command(ConfigCommand)
@@ -25,6 +26,7 @@ export const DebugCommand = cmd({
       .command(PathsCommand)
       .command({
         command: "wait",
+        describe: "wait indefinitely (for debugging)",
         async handler() {
           await bootstrap(process.cwd(), async () => {
             await new Promise((resolve) => setTimeout(resolve, 1_000 * 60 * 60 * 24))
@@ -37,6 +39,7 @@ export const DebugCommand = cmd({
 
 const PathsCommand = cmd({
   command: "paths",
+  describe: "show global paths (data, config, cache, state)",
   handler() {
     for (const [key, value] of Object.entries(Global.Path)) {
       console.log(key.padEnd(10), value)

--- a/packages/opencode/src/cli/cmd/debug/lsp.ts
+++ b/packages/opencode/src/cli/cmd/debug/lsp.ts
@@ -6,6 +6,7 @@ import { EOL } from "os"
 
 export const LSPCommand = cmd({
   command: "lsp",
+  describe: "LSP debugging utilities",
   builder: (yargs) =>
     yargs.command(DiagnosticsCommand).command(SymbolsCommand).command(DocumentSymbolsCommand).demandCommand(),
   async handler() {},
@@ -13,6 +14,7 @@ export const LSPCommand = cmd({
 
 const DiagnosticsCommand = cmd({
   command: "diagnostics <file>",
+  describe: "get diagnostics for a file",
   builder: (yargs) => yargs.positional("file", { type: "string", demandOption: true }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
@@ -25,6 +27,7 @@ const DiagnosticsCommand = cmd({
 
 export const SymbolsCommand = cmd({
   command: "symbols <query>",
+  describe: "search workspace symbols",
   builder: (yargs) => yargs.positional("query", { type: "string", demandOption: true }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {
@@ -37,6 +40,7 @@ export const SymbolsCommand = cmd({
 
 export const DocumentSymbolsCommand = cmd({
   command: "document-symbols <uri>",
+  describe: "get symbols from a document",
   builder: (yargs) => yargs.positional("uri", { type: "string", demandOption: true }),
   async handler(args) {
     await bootstrap(process.cwd(), async () => {

--- a/packages/opencode/src/cli/cmd/debug/ripgrep.ts
+++ b/packages/opencode/src/cli/cmd/debug/ripgrep.ts
@@ -6,12 +6,14 @@ import { cmd } from "../cmd"
 
 export const RipgrepCommand = cmd({
   command: "rg",
+  describe: "ripgrep debugging utilities",
   builder: (yargs) => yargs.command(TreeCommand).command(FilesCommand).command(SearchCommand).demandCommand(),
   async handler() {},
 })
 
 const TreeCommand = cmd({
   command: "tree",
+  describe: "show file tree using ripgrep",
   builder: (yargs) =>
     yargs.option("limit", {
       type: "number",
@@ -25,6 +27,7 @@ const TreeCommand = cmd({
 
 const FilesCommand = cmd({
   command: "files",
+  describe: "list files using ripgrep",
   builder: (yargs) =>
     yargs
       .option("query", {
@@ -56,6 +59,7 @@ const FilesCommand = cmd({
 
 const SearchCommand = cmd({
   command: "search <pattern>",
+  describe: "search file contents using ripgrep",
   builder: (yargs) =>
     yargs
       .positional("pattern", {

--- a/packages/opencode/src/cli/cmd/debug/scrap.ts
+++ b/packages/opencode/src/cli/cmd/debug/scrap.ts
@@ -5,6 +5,7 @@ import { cmd } from "../cmd"
 
 export const ScrapCommand = cmd({
   command: "scrap",
+  describe: "list all known projects",
   builder: (yargs) => yargs,
   async handler() {
     const timer = Log.Default.time("scrap")

--- a/packages/opencode/src/cli/cmd/debug/skill.ts
+++ b/packages/opencode/src/cli/cmd/debug/skill.ts
@@ -5,6 +5,7 @@ import { cmd } from "../cmd"
 
 export const SkillCommand = cmd({
   command: "skill",
+  describe: "list all available skills",
   builder: (yargs) => yargs,
   async handler() {
     await bootstrap(process.cwd(), async () => {

--- a/packages/opencode/src/cli/cmd/debug/snapshot.ts
+++ b/packages/opencode/src/cli/cmd/debug/snapshot.ts
@@ -4,12 +4,14 @@ import { cmd } from "../cmd"
 
 export const SnapshotCommand = cmd({
   command: "snapshot",
+  describe: "snapshot debugging utilities",
   builder: (yargs) => yargs.command(TrackCommand).command(PatchCommand).command(DiffCommand).demandCommand(),
   async handler() {},
 })
 
 const TrackCommand = cmd({
   command: "track",
+  describe: "track current snapshot state",
   async handler() {
     await bootstrap(process.cwd(), async () => {
       console.log(await Snapshot.track())
@@ -19,6 +21,7 @@ const TrackCommand = cmd({
 
 const PatchCommand = cmd({
   command: "patch <hash>",
+  describe: "show patch for a snapshot hash",
   builder: (yargs) =>
     yargs.positional("hash", {
       type: "string",
@@ -34,6 +37,7 @@ const PatchCommand = cmd({
 
 const DiffCommand = cmd({
   command: "diff <hash>",
+  describe: "show diff for a snapshot hash",
   builder: (yargs) =>
     yargs.positional("hash", {
       type: "string",

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -30,7 +30,7 @@ function getNetworkIPs() {
 export const WebCommand = cmd({
   command: "web",
   builder: (yargs) => withNetworkOptions(yargs),
-  describe: "starts a headless opencode server",
+  describe: "start opencode server and open web interface",
   handler: async (args) => {
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -101,9 +101,9 @@ const cli = yargs(hideBin(process.argv))
   .command(SessionCommand)
   .fail((msg) => {
     if (
-      msg.startsWith("Unknown argument") ||
-      msg.startsWith("Not enough non-option arguments") ||
-      msg.startsWith("Invalid values:")
+      msg?.startsWith("Unknown argument") ||
+      msg?.startsWith("Not enough non-option arguments") ||
+      msg?.startsWith("Invalid values:")
     ) {
       cli.showHelp("log")
     }


### PR DESCRIPTION
## Summary

Add `describe` property to `debug` command and all its subcommands so they appear in `--help` output.

**Fixes:** #7330  
**Supersedes:** #1524 (stale since Aug 2025, missing newer subcommands)

## Changes

- Add help text to `debug` command and subcommands (`config`, `lsp`, `file`, `skill`, `agent`, `ripgrep`, `scrap`, `snapshot`)
- Fix `web` command description (differentiate from `serve`)
- Handle null message in yargs fail handler

## Before

```
$ opencode --help | rg "debug"
opencode --help | rg "web"
opencode debug --help 2>&1 | rg "config|lsp|file|skill|agent|rg|scrap|snapshot|paths|wait"
opencode debug lsp --help 2>&1 | rg "diagnostics|symbols|document-symbols"
opencode debug file --help 2>&1 | rg "read|status"
opencode debug rg --help 2>&1 | rg "tree|files|search"
opencode debug snapshot --help 2>&1 | rg "track|patch|diff"

  opencode web                 starts a headless opencode server
```

## After

```
$ bun run dev --help | rg "debug"
bun run dev --help | rg "web"
bun run dev debug --help 2>&1 | rg "config|lsp|file|skill|agent|rg|scrap|snapshot|paths|wait"
bun run dev debug lsp --help 2>&1 | rg "diagnostics|symbols|document-symbols"
bun run dev debug file --help 2>&1 | rg "read|status"
bun run dev debug rg --help 2>&1 | rg "tree|files|search"
bun run dev debug snapshot --help 2>&1 | rg "track|patch|diff"

  opencode debug               debugging and troubleshooting tools

  opencode web                 start opencode server and open web interface

  opencode debug config        show resolved configuration
  opencode debug lsp           LSP debugging utilities
  opencode debug rg            ripgrep debugging utilities
  opencode debug file          file system debugging utilities
  opencode debug scrap         list all known projects
  opencode debug skill         list all available skills
  opencode debug snapshot      snapshot debugging utilities
  opencode debug agent <name>  show agent configuration details
  opencode debug paths         show global paths (data, config, cache, state)
  opencode debug wait          wait indefinitely (for debugging)
  opencode debug lsp diagnostics <file>      get diagnostics for a file
  opencode debug lsp symbols <query>         search workspace symbols
  opencode debug lsp document-symbols <uri>  get symbols from a document
  opencode debug file read <path>     read file contents as JSON
  opencode debug file status          show file status information
  opencode debug rg tree              show file tree using ripgrep
  opencode debug rg files             list files using ripgrep
  opencode debug rg search <pattern>  search file contents using ripgrep
  opencode debug snapshot track         track current snapshot state
  opencode debug snapshot patch <hash>  show patch for a snapshot hash
  opencode debug snapshot diff <hash>   show diff for a snapshot hash
```