### PR TITLE
fix(cli): enable API key prompt for Bedrock in auth login

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -341,8 +341,6 @@ export const AuthLoginCommand = cmd({
               "Configure via opencode.json options (profile, region, endpoint) or\n" +
               "AWS environment variables (AWS_PROFILE, AWS_REGION, AWS_ACCESS_KEY_ID).",
           )
-          prompts.outro("Done")
-          return
         }
 
         if (provider === "opencode") {


### PR DESCRIPTION
CLI `auth login` now prompts for API key when Bedrock is selected, matching `/connect` behavior.

Previously, it only displayed an info message and exited early.