### PR TITLE
feat: Implement MCP server instruction fetching and integration

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -116,6 +116,7 @@ interface CreateResult {
   mcpClient?: MCPClient
   status: Status
   defs?: MCPToolDef[]
+  instructions?: string
 }
 
 interface AuthResult {
@@ -131,11 +132,13 @@ interface State {
   status: Record<string, Status>
   clients: Record<string, MCPClient>
   defs: Record<string, MCPToolDef[]>
+  serverInstructions: Record<string, string>
 }
 
 export interface Interface {
   readonly status: () => Effect.Effect<Record<string, Status>>
   readonly clients: () => Effect.Effect<Record<string, MCPClient>>
+  readonly serverInstructions: () => Effect.Effect<Record<string, string>>
   readonly tools: () => Effect.Effect<Record<string, Tool>>
   readonly prompts: () => Effect.Effect<Record<string, PromptInfo & { client: string }>>
   readonly resources: () => Effect.Effect<Record<string, ResourceInfo & { client: string }>>
@@ -353,7 +356,10 @@ export const layer = Layer.effect(
           if (!listed) {
             return yield* Effect.fail(new Error("Failed to get tools"))
           }
-          return { mcpClient, status, defs: listed } satisfies CreateResult
+          const instructions =
+            (mcpClient as MCPClient & { getInstructions?: () => string | undefined }).getInstructions?.()?.trim() ||
+            undefined
+          return { mcpClient, status, defs: listed, instructions } satisfies CreateResult
         }).pipe(
           Effect.catchCause((cause) =>
             Effect.tryPromise(() => mcpClient.close()).pipe(Effect.ignore, Effect.andThen(Effect.failCause(cause))),
@@ -441,6 +447,7 @@ export const layer = Layer.effect(
           status: {},
           clients: {},
           defs: {},
+          serverInstructions: {},
         }
 
         yield* Effect.forEach(
@@ -462,6 +469,7 @@ export const layer = Layer.effect(
               if (result.mcpClient) {
                 s.clients[key] = result.mcpClient
                 s.defs[key] = result.defs!
+                if (result.instructions) s.serverInstructions[key] = result.instructions
                 watch(s, key, result.mcpClient, bridge, mcp.timeout)
               }
             }),
@@ -498,6 +506,7 @@ export const layer = Layer.effect(
     function closeClient(s: State, name: string) {
       const client = s.clients[name]
       delete s.defs[name]
+      delete s.serverInstructions[name]
       if (!client) return Effect.void
       return Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
     }
@@ -507,6 +516,7 @@ export const layer = Layer.effect(
       name: string,
       client: MCPClient,
       listed: MCPToolDef[],
+      instructions?: string,
       timeout?: number,
     ) {
       const bridge = yield* EffectBridge.make()
@@ -514,6 +524,7 @@ export const layer = Layer.effect(
       s.status[name] = { status: "connected" }
       s.clients[name] = client
       s.defs[name] = listed
+      if (instructions) s.serverInstructions[name] = instructions
       watch(s, name, client, bridge, timeout)
       return s.status[name]
     })
@@ -542,6 +553,11 @@ export const layer = Layer.effect(
       return s.clients
     })
 
+    const serverInstructions = Effect.fn("MCP.serverInstructions")(function* () {
+      const s = yield* InstanceState.get(state)
+      return s.serverInstructions
+    })
+
     const createAndStore = Effect.fn("MCP.createAndStore")(function* (name: string, mcp: ConfigMCPV1.Info) {
       const s = yield* InstanceState.get(state)
       const result = yield* create(name, mcp)
@@ -553,7 +569,7 @@ export const layer = Layer.effect(
         return result.status
       }
 
-      return yield* storeClient(s, name, result.mcpClient, result.defs!, mcp.timeout)
+      return yield* storeClient(s, name, result.mcpClient, result.defs!, result.instructions, mcp.timeout)
     })
 
     const add = Effect.fn("MCP.add")(function* (name: string, mcp: ConfigMCPV1.Info) {
@@ -780,9 +796,12 @@ export const layer = Layer.effect(
           return { status: "failed", error: "Failed to get tools" } satisfies Status
         }
 
+        const instructions =
+          (client as MCPClient & { getInstructions?: () => string | undefined }).getInstructions?.()?.trim() ||
+          undefined
         const s = yield* InstanceState.get(state)
         yield* auth.clearOAuthState(mcpName)
-        return yield* storeClient(s, mcpName, client, listed, mcpConfig.timeout)
+        return yield* storeClient(s, mcpName, client, listed, instructions, mcpConfig.timeout)
       }
 
       const callbackPromise = McpOAuthCallback.waitForCallback(result.oauthState, mcpName)
@@ -869,6 +888,7 @@ export const layer = Layer.effect(
     return Service.of({
       status,
       clients,
+      serverInstructions,
       tools,
       prompts,
       resources,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -21,6 +21,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Wildcard } from "@/util/wildcard"
 import { SessionID } from "@/session/schema"
+import { MCP } from "@/mcp"
 import { Auth } from "@/auth"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -64,6 +65,7 @@ const live: Layer.Layer<
   never,
   | Auth.Service
   | Config.Service
+  | MCP.Service
   | Provider.Service
   | Plugin.Service
   | Permission.Service
@@ -75,6 +77,7 @@ const live: Layer.Layer<
   Effect.gen(function* () {
     const auth = yield* Auth.Service
     const config = yield* Config.Service
+    const mcp = yield* MCP.Service
     const provider = yield* Provider.Service
     const plugin = yield* Plugin.Service
     const perm = yield* Permission.Service
@@ -107,6 +110,7 @@ const live: Layer.Layer<
         ...input,
         provider: item,
         auth: info,
+        mcp,
         plugin,
         flags,
         isWorkflow,
@@ -390,6 +394,7 @@ export const defaultLayer = Layer.suspend(() =>
   layer.pipe(
     Layer.provide(Auth.defaultLayer),
     Layer.provide(Config.defaultLayer),
+    Layer.provide(MCP.defaultLayer),
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
     Layer.provide(
@@ -404,6 +409,7 @@ export const hasToolCalls = LLMRequestPrep.hasToolCalls
 export const node = LayerNode.make(layer, [
   Auth.node,
   Config.node,
+  MCP.node,
   Provider.node,
   Plugin.node,
   Permission.node,

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -1,6 +1,7 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import type { Auth } from "@/auth"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
+import type { Interface as MCPInterface } from "@/mcp"
 import type { RuntimeFlags } from "@/effect/runtime-flags"
 import { InstanceState } from "@/effect/instance-state"
 import { Permission } from "@/permission"
@@ -30,6 +31,7 @@ type PrepareInput = {
   readonly tools: Record<string, Tool>
   readonly provider: Provider.Info
   readonly auth: Auth.Info | undefined
+  readonly mcp: MCPInterface
   readonly plugin: Plugin.Interface
   readonly flags: RuntimeFlags.Info
   readonly isWorkflow: boolean
@@ -55,11 +57,22 @@ const mergeOptions = (target: Record<string, any>, source: Record<string, any> |
 
 export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: PrepareInput) {
   const isOpenaiOauth = input.provider.id === "openai" && input.auth?.type === "oauth"
+  const extra = yield* Effect.all([input.mcp.status(), input.mcp.serverInstructions()], { concurrency: "unbounded" }).pipe(
+    Effect.map(([status, instructions]) =>
+      Object.entries(status).flatMap(([name, item]) => {
+        const text = instructions[name]?.trim()
+        if (item.status !== "connected" || !text) return []
+        return [`<mcp-server name="${name}"><![CDATA[\n${text}\n]]></mcp-server>`]
+      }),
+    ),
+    Effect.orElseSucceed((): string[] => []),
+  )
   const system = [
     [
       ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
       ...input.system,
       ...(input.user.system ? [input.user.system] : []),
+      ...extra,
     ]
       .filter((x) => x)
       .join("\n"),

--- a/packages/opencode/test/session/llm-native-recorded.test.ts
+++ b/packages/opencode/test/session/llm-native-recorded.test.ts
@@ -11,6 +11,7 @@ import path from "node:path"
 import z from "zod"
 import { Auth } from "@/auth"
 import { Config } from "@/config/config"
+import { MCP } from "@/mcp"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
 
@@ -260,6 +261,30 @@ const modelsFixture = Filesystem.readJson<Record<string, ModelsDev.Provider>>(
   path.join(import.meta.dir, "../tool/fixtures/models-api.json"),
 )
 
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    serverInstructions: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in recorded LLM tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in recorded LLM tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in recorded LLM tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
 function recordedNativeLLMLayer(scenario: RecordedScenario) {
   const auth = authLayer(scenario)
   const provider = Provider.layer.pipe(
@@ -299,6 +324,7 @@ function recordedNativeLLMLayer(scenario: RecordedScenario) {
     LLM.layer.pipe(
       Layer.provide(auth),
       Layer.provide(Config.defaultLayer),
+      Layer.provide(mcp),
       Layer.provide(provider),
       Layer.provide(Plugin.defaultLayer),
       Layer.provide(recordedClient),

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -16,7 +16,7 @@ import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { Plugin } from "@/plugin"
-
+import { MCP } from "@/mcp"
 import { testEffect } from "../lib/effect"
 import type { Agent } from "../../src/agent/agent"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -53,6 +53,29 @@ const openAIConfig = (model: ModelsDev.Provider["models"][string], baseURL: stri
 }
 
 const it = testEffect(Layer.mergeAll(LLM.defaultLayer, Provider.defaultLayer))
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    serverInstructions: () => Effect.succeed({}),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in LLM tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in LLM tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in LLM tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
 
 // LLM.stream returns a Stream, not an Effect, so we can't use the serviceUse proxy.
 const drain = (input: LLM.StreamInput) => LLM.Service.use((svc) => svc.stream(input).pipe(Stream.runDrain))
@@ -79,6 +102,7 @@ function llmLayerWithExecutor(executor: Layer.Layer<RequestExecutor.Service>, fl
   return LLM.layer.pipe(
     Layer.provide(Auth.defaultLayer),
     Layer.provide(Config.defaultLayer),
+    Layer.provide(mcp),
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
     Layer.provide(LLMClient.layer.pipe(Layer.provide(Layer.mergeAll(executor, WebSocketExecutor.layer)))),
@@ -1132,6 +1156,7 @@ describe("session.llm.stream", () => {
           LLM.layer.pipe(
             Layer.provide(Auth.defaultLayer),
             Layer.provide(Config.defaultLayer),
+            Layer.provide(mcp),
             Layer.provide(Provider.defaultLayer),
             Layer.provide(Plugin.defaultLayer),
             Layer.provide(failingNativeClient),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -113,6 +113,7 @@ const mcp = Layer.succeed(
   MCP.Service.of({
     status: () => Effect.succeed({}),
     clients: () => Effect.succeed({}),
+    serverInstructions: () => Effect.succeed({}),
     tools: () => Effect.succeed({}),
     prompts: () => Effect.succeed({}),
     resources: () => Effect.succeed({}),

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -66,6 +66,7 @@ const mcp = Layer.succeed(
   MCP.Service.of({
     status: () => Effect.succeed({}),
     clients: () => Effect.succeed({}),
+    serverInstructions: () => Effect.succeed({}),
     tools: () => Effect.succeed({}),
     prompts: () => Effect.succeed({}),
     resources: () => Effect.succeed({}),


### PR DESCRIPTION
Now the LLM can see the instructions that that the server emit at initialisation.

The data was where, just not used.

Fixes #7373