### PR TITLE
fix: prevent undefined values in TextNodeRenderable components

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1229,7 +1229,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           customBorderChars={SplitBorder.customBorderChars}
           borderColor={theme.error}
         >
-          <text fg={theme.textMuted}>{props.message.error?.data.message}</text>
+          <text fg={theme.textMuted}>{props.message.error?.data?.message ?? ""}</text>
         </box>
       </Show>
       <Switch>
@@ -1814,7 +1814,7 @@ function Patch(props: ToolProps<typeof PatchTool>) {
       <Match when={props.output !== undefined}>
         <BlockTool title="# Patch" part={props.part}>
           <box>
-            <text fg={theme.text}>{props.output?.trim()}</text>
+            <text fg={theme.text}>{props.output!.trim()}</text>
           </box>
         </BlockTool>
       </Match>


### PR DESCRIPTION
## Summary
- Fix fatal crash: `TextNodeRenderable only accepts strings, TextNodeRenderable instances, or StyledText instances`

## Changes
- **Line 1817** (`Patch` component): Remove optional chaining `?.` on `props.output` since the `<Match when={props.output !== undefined}>` guard already ensures it's defined. Use non-null assertion `!` instead.
- **Line 1232** (error message display): Add nullish coalescing `?? ""` for `error.data?.message` to provide empty string fallback when `data` is undefined.

## Root Cause
The `<text>` component from `@opentui/core` only accepts strings, TextNodeRenderable instances, or StyledText instances. Optional chaining (`?.`) can return `undefined` even inside guarded blocks, causing the runtime error.

## Testing
The fix ensures all `<text>` children are guaranteed to be strings:
- `props.output!.trim()` - Safe because Match guard checks `props.output !== undefined`
- `props.message.error?.data?.message ?? ""` - Falls back to empty string