### PR TITLE
fix(app): show custom models without valid release_date in web UI mod…

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -276,7 +276,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         visible(model: ModelKey) {
           const key = `${model.providerID}:${model.modelID}`
           const visibility = userVisibilityMap().get(key)
-          return visibility !== "hide" && (latestSet().has(key) || visibility === "show")
+          if (visibility === "hide") return false
+          if (visibility === "show") return true
+          if (latestSet().has(key)) return true
+          // For models without valid release_date (e.g. custom models), show by default
+          const m = find(model)
+          if (!m?.release_date || !DateTime.fromISO(m.release_date).isValid) return true
+          return false
         },
         setVisibility(model: ModelKey, visible: boolean) {
           updateVisibility(model, visible ? "show" : "hide")


### PR DESCRIPTION
## Summary

Fix custom models not appearing in the web UI model selector.

## Problem

Users who configure custom models (e.g., DeepSeek, OpenRouter, Aliyun) in their `opencode.json` can see and use all models in the TUI, but only a subset appears in the web UI. This inconsistency creates confusion and limits the web UI's usefulness.

## Root Cause

The web UI model visibility logic filters models based on whether they belong to a "latest" set, which relies on `release_date` metadata. Custom models typically don't have a valid `release_date`, causing them to be filtered out by default.

## Solution

Update the `visible()` function in `packages/app/src/context/local.tsx` to show models without a valid `release_date` by default. This ensures custom models are visible in the web UI while preserving the existing behavior for official models with proper metadata.

**Before:** Models without `release_date` → hidden by default  
**After:** Models without `release_date` → shown by default

## Testing

- Configured custom models now appear in web UI model selector
- Official models with `release_date` maintain their existing visibility behavior
- User visibility preferences (`show`/`hide`) still take precedence

Fixes #6798