### PR TITLE
docs: add OCX and opencode extension plugins to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,11 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                     |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control      |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
+| [ocx](https://github.com/kdcokenny/ocx)                                                            | A Go tool for building context for AI-assisted coding                                          |
+| [opencode-ghostwriter](https://github.com/kdcokenny/opencode-ghostwriter)                          | Context pruning and distillation using persistent memory                                       |
+| [opencode-context7](https://github.com/kdcokenny/opencode-context7)                                | MCP integration for library docs via Context7                                                  |
+| [opencode-perplexity](https://github.com/kdcokenny/opencode-perplexity)                            | Web search tool via Perplexity Sonar API                                                       |
+| [opencode-e2b](https://github.com/kdcokenny/opencode-e2b)                                          | Sandboxed code execution using E2B cloud environments                                          |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds 5 community projects to the ecosystem.

### Projects
- **[ocx](https://github.com/kdcokenny/ocx)** – The missing package manager for OpenCode extensions – ShadCN model with Ghost Mode

### Plugins
- **[opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)** – Claude Code-style background agents with async delegation and context persistence
- **[opencode-notify](https://github.com/kdcokenny/opencode-notify)** – Native OS notifications for OpenCode – know when tasks complete
- **[opencode-workspace](https://github.com/kdcokenny/opencode-workspace)** – Bundled multi-agent orchestration harness – 16 components, one install
- **[opencode-worktree](https://github.com/kdcokenny/opencode-worktree)** – Isolated branches for AI experiments – git worktrees that spawn their own terminal

All projects include the required affiliation disclaimer per README.md L97.