### PR TITLE
fix(bun): guard against missing keys in cache manifest

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -71,6 +71,7 @@ export namespace BunProc {
       await Bun.write(pkgjson.name!, JSON.stringify(result, null, 2))
       return result
     })
+    parsed.dependencies ??= {}
     if (parsed.dependencies[pkg] === version) return mod
 
     const proxied = !!(


### PR DESCRIPTION
Ran into this crash locally while developing a plugin and modifying dependencies/dev-dependencies.

The cached `package.json` can be valid but missing the `dependencies` key (e.g. if it only has `devDependencies`). This ensures we default to `{}` to prevent the TypeError.