### PR TITLE
feat: Add `--variant` flag to root opencode command

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/args.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/args.tsx
@@ -2,6 +2,7 @@ import { createSimpleContext } from "./helper"
 
 export interface Args {
   model?: string
+  variant?: string
   agent?: string
   prompt?: string
   continue?: boolean

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -383,6 +383,16 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       }
     })
 
+    // Initialize variant from CLI args
+    const args = useArgs()
+    let variantInitialized = false
+    createEffect(() => {
+      if (variantInitialized) return
+      if (!model.ready || !args.variant || !model.current()) return
+      variantInitialized = true
+      model.variant.set(args.variant)
+    })
+
     const result = {
       model,
       agent,

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -77,6 +77,10 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      .option("variant", {
+        type: "string",
+        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
       }),
   handler: async (args) => {
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
@@ -158,6 +162,7 @@ export const TuiThreadCommand = cmd({
         sessionID: args.session,
         agent: args.agent,
         model: args.model,
+        variant: args.variant,
         prompt,
       },
       onExit: async () => {

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -29,15 +29,16 @@ opencode [project]
 
 #### Flags
 
-| Flag         | Short | Description                                |
-| ------------ | ----- | ------------------------------------------ |
-| `--continue` | `-c`  | Continue the last session                  |
-| `--session`  | `-s`  | Session ID to continue                     |
-| `--prompt`   |       | Prompt to use                              |
-| `--model`    | `-m`  | Model to use in the form of provider/model |
-| `--agent`    |       | Agent to use                               |
-| `--port`     |       | Port to listen on                          |
-| `--hostname` |       | Hostname to listen on                      |
+| Flag         | Short | Description                                                    |
+| ------------ | ----- | -------------------------------------------------------------- |
+| `--continue` | `-c`  | Continue the last session                                      |
+| `--session`  | `-s`  | Session ID to continue                                         |
+| `--prompt`   |       | Prompt to use                                                  |
+| `--model`    | `-m`  | Model to use in the form of provider/model                     |
+| `--variant`  |       | Model variant (provider-specific reasoning effort, e.g., high) |
+| `--agent`    |       | Agent to use                                                   |
+| `--port`     |       | Port to listen on                                              |
+| `--hostname` |       | Hostname to listen on                                          |
 
 ---
 
@@ -341,6 +342,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | `--session`  | `-s`  | Session ID to continue                                             |
 | `--share`    |       | Share the session                                                  |
 | `--model`    | `-m`  | Model to use in the form of provider/model                         |
+| `--variant`  |       | Model variant (provider-specific reasoning effort, e.g., high)     |
 | `--agent`    |       | Agent to use                                                       |
 | `--file`     | `-f`  | File(s) to attach to message                                       |
 | `--format`   |       | Format: default (formatted) or json (raw JSON events)              |


### PR DESCRIPTION
Closes #7354

## Summary

Adds `--variant` flag to root `opencode` command, matching existing support in `opencode run`.

## Changes

- `thread.ts`: Add `--variant` option to yargs builder, pass to tui args
- `args.tsx`: Add `variant` to Args interface
- `local.tsx`: Initialize variant from CLI arg using `model.variant.set()`

---

This is my first contribution here, so please let me know if I've missed something! I didn't see any existing test coverage for the CLI args or the TUI local context, but I'm happy to add tests if desired.