### PR TITLE
fix: cleanly restore terminal state on fatal error exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -653,9 +653,17 @@ function ErrorComponent(props: {
   mode?: "dark" | "light"
 }) {
   const term = useTerminalDimensions()
+  const renderer = useRenderer()
+
+  const handleExit = async () => {
+    renderer.setTerminalTitle("")
+    renderer.destroy()
+    props.onExit()
+  }
+
   useKeyboard((evt) => {
     if (evt.ctrl && evt.name === "c") {
-      props.onExit()
+      handleExit()
     }
   })
   const [copied, setCopied] = createSignal(false)
@@ -708,7 +716,7 @@ function ErrorComponent(props: {
         <box onMouseUp={props.reset} backgroundColor={colors.primary} padding={1}>
           <text fg={colors.bg}>Reset TUI</text>
         </box>
-        <box onMouseUp={props.onExit} backgroundColor={colors.primary} padding={1}>
+        <box onMouseUp={handleExit} backgroundColor={colors.primary} padding={1}>
           <text fg={colors.bg}>Exit</text>
         </box>
       </box>


### PR DESCRIPTION
Restore terminal state when a fatal error occurs and user clicks "Exit". Currently, the terminal state looks a little mangled and captures escape sequences

<img width="857" height="480" alt="SCR-20260108-llqk" src="https://github.com/user-attachments/assets/920e864c-a4d8-47a2-a8aa-17ffa9c6abc0" />

With this PR, this is what it looks like

https://github.com/user-attachments/assets/f182a77d-77f2-4845-8b24-8dcbe0a789f3


