### PR TITLE
fix(desktop): open external links in system browser instead of webview

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -266,6 +266,15 @@ root?.addEventListener("mousewheel", (e) => {
   e.stopPropagation()
 })
 
+// Handle external links - open in system browser instead of webview
+document.addEventListener("click", (e) => {
+  const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
+  if (link?.href) {
+    e.preventDefault()
+    platform.openLink(link.href)
+  }
+})
+
 render(() => {
   return (
     <PlatformProvider value={platform}>

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -383,7 +383,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
         renderer: {
           link({ href, title, text }) {
             const titleAttr = title ? ` title="${title}"` : ""
-            return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer">${text}</a>`
+            return `<a href="${href}"${titleAttr} class="external-link" target="_blank" rel="noopener noreferrer">${text}</a>`
           },
         },
       },


### PR DESCRIPTION
## Summary

- External links in markdown content (AI responses) now open in the system's default browser instead of inside the Tauri webview

## Problem

When clicking links in AI-generated markdown output in the desktop app, such as GitHub PR links, they were opening inside the Tauri webview rather than in the system's default browser. This happened because `target="_blank"` links bypass Tauri's `on_navigation` handler.

## Solution

- Changed the markdown link renderer to use `class="external-link"`
- Added a global click listener in the desktop entry point that intercepts clicks on `.external-link` anchors and opens them via `platform.openLink()` (which uses Tauri's shell plugin)

This keeps the fix isolated to the desktop package while reusing the existing `openLink` platform API.