### PR TITLE
fix: include provider name in search for recent and favorite models

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -179,9 +179,9 @@ export function DialogModel(props: { providerID?: string }) {
 
     // Apply fuzzy filtering to each section separately, maintaining section order
     if (q) {
-      const filteredFavorites = fuzzysort.go(q, favoriteOptions, { keys: ["title"] }).map((x) => x.obj)
+      const filteredFavorites = fuzzysort.go(q, favoriteOptions, { keys: ["title", "description"] }).map((x) => x.obj)
       const filteredRecents = fuzzysort
-        .go(q, recentOptions, { keys: ["title"] })
+        .go(q, recentOptions, { keys: ["title", "description"] })
         .map((x) => x.obj)
         .slice(0, 5)
       const filteredProviders = fuzzysort.go(q, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj)


### PR DESCRIPTION
Fixes #7366

Recent and favorite models are now searchable by provider name, not just by model name. 

- Add 'description' field to search keys for favorite models
- Add 'description' field to search keys for recent models

Before 
<img width="516" height="240" alt="image" src="https://github.com/user-attachments/assets/d28715eb-3941-41eb-8725-ee416f402e2b" />

After
<img width="499" height="304" alt="image" src="https://github.com/user-attachments/assets/7b4be25e-2a77-417b-83d4-cee0d80211e9" />
