### PR TITLE
fix: Add kind, title, rawInput to ACP tool_call_update events

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -167,6 +167,8 @@ export namespace ACP {
                             sessionUpdate: "tool_call_update",
                             toolCallId: part.callID,
                             status: "in_progress",
+                            kind: toToolKind(part.tool),
+                            title: part.tool,
                             locations: toLocations(part.tool, part.state.input),
                             rawInput: part.state.input,
                           },
@@ -242,6 +244,7 @@ export namespace ACP {
                             kind,
                             content,
                             title: part.state.title,
+                            rawInput: part.state.input,
                             rawOutput: {
                               output: part.state.output,
                               metadata: part.state.metadata,
@@ -260,6 +263,9 @@ export namespace ACP {
                             sessionUpdate: "tool_call_update",
                             toolCallId: part.callID,
                             status: "failed",
+                            kind: toToolKind(part.tool),
+                            title: part.tool,
+                            rawInput: part.state.input,
                             content: [
                               {
                                 type: "content",
@@ -491,6 +497,8 @@ export namespace ACP {
                     sessionUpdate: "tool_call_update",
                     toolCallId: part.callID,
                     status: "in_progress",
+                    kind: toToolKind(part.tool),
+                    title: part.tool,
                     locations: toLocations(part.tool, part.state.input),
                     rawInput: part.state.input,
                   },
@@ -566,6 +574,7 @@ export namespace ACP {
                     kind,
                     content,
                     title: part.state.title,
+                    rawInput: part.state.input,
                     rawOutput: {
                       output: part.state.output,
                       metadata: part.state.metadata,
@@ -584,6 +593,9 @@ export namespace ACP {
                     sessionUpdate: "tool_call_update",
                     toolCallId: part.callID,
                     status: "failed",
+                    kind: toToolKind(part.tool),
+                    title: part.tool,
+                    rawInput: part.state.input,
                     content: [
                       {
                         type: "content",


### PR DESCRIPTION
Ensures ACP clients can identify MCP tools during running/error states and access tool arguments for completed tools.

Fixes https://github.com/anomalyco/opencode/issues/7356