### PR TITLE
feat: add query parameter support for OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/openai-compatible-provider.ts
@@ -30,6 +30,11 @@ export interface OpenaiCompatibleProviderSettings {
   headers?: Record<string, string>
 
   /**
+   * Custom query parameter to append to the requests
+   */
+  queryParams?: Record<string, string>
+
+  /**
    * Custom fetch implementation.
    */
   fetch?: FetchFunction
@@ -65,11 +70,21 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
 
   const getHeaders = () => withUserAgentSuffix(headers, `ai-sdk/openai-compatible/${VERSION}`)
 
+  const getUrl = ({ path }: { path: string }) => {
+    const url = new URL(`${baseURL}${path}`)
+    if (options.queryParams) {
+      for (const [key, value] of Object.entries(options.queryParams)) {
+        url.searchParams.set(key, value)
+      }
+    }
+    return url.toString()
+  }
+
   const createChatModel = (modelId: OpenaiCompatibleModelId) => {
     return new OpenAICompatibleChatLanguageModel(modelId, {
       provider: `${options.name ?? "openai-compatible"}.chat`,
       headers: getHeaders,
-      url: ({ path }) => `${baseURL}${path}`,
+      url: getUrl,
       fetch: options.fetch,
     })
   }
@@ -78,7 +93,7 @@ export function createOpenaiCompatible(options: OpenaiCompatibleProviderSettings
     return new OpenAIResponsesLanguageModel(modelId, {
       provider: `${options.name ?? "openai-compatible"}.responses`,
       headers: getHeaders,
-      url: ({ path }) => `${baseURL}${path}`,
+      url: getUrl,
       fetch: options.fetch,
     })
   }

--- a/packages/opencode/test/provider/openai-compatible.test.ts
+++ b/packages/opencode/test/provider/openai-compatible.test.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "bun:test"
+import path from "path"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+
+test("provider with queryParams in config", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-openai": {
+              name: "Custom OpenAI with Query Params",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "gpt-4": {
+                  name: "GPT-4",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://api.example.com/v1",
+                queryParams: {
+                  "api-version": "2024-01-01",
+                  tenant: "my-org",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["custom-openai"]).toBeDefined()
+      expect(providers["custom-openai"].name).toBe("Custom OpenAI with Query Params")
+      expect(providers["custom-openai"].options.queryParams).toEqual({
+        "api-version": "2024-01-01",
+        tenant: "my-org",
+      })
+    },
+  })
+})
+
+test("provider without queryParams still works", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-openai": {
+              name: "Custom OpenAI",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "gpt-4": {
+                  name: "GPT-4",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://api.example.com/v1",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["custom-openai"]).toBeDefined()
+      expect(providers["custom-openai"].name).toBe("Custom OpenAI")
+      expect(providers["custom-openai"].options.queryParams).toBeUndefined()
+    },
+  })
+})
+
+test("provider with empty queryParams", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "custom-openai": {
+              name: "Custom OpenAI Empty Params",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              models: {
+                "gpt-4": {
+                  name: "GPT-4",
+                  tool_call: true,
+                  limit: { context: 128000, output: 4096 },
+                },
+              },
+              options: {
+                apiKey: "test-key",
+                baseURL: "https://api.example.com/v1",
+                queryParams: {},
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["custom-openai"]).toBeDefined()
+      expect(providers["custom-openai"].options.queryParams).toEqual({})
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `queryParams` option to `OpenaiCompatibleProviderSettings` that appends query parameters to all API requests.

- Added `queryParams?: Record<string, string>` to provider settings
- Created `getUrl` helper to construct URLs with query params
- Added integration tests for the new functionality

Fixes #7198

## Test plan

- [x] Added integration tests for providers with queryParams
- [x] Verified providers without queryParams still work
- [x] Ran `bun test test/provider/openai-compatible.test.ts` - all pass