### PR TITLE
feat: add --dir flag to opencode run --attach

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -83,6 +83,10 @@ export const RunCommand = cmd({
         type: "string",
         describe: "attach to a running opencode server (e.g., http://localhost:4096)",
       })
+      .option("dir", {
+        type: "string",
+        describe: "directory to run in (only used with --attach)",
+      })
       .option("port", {
         type: "number",
         describe: "port for the local server (defaults to random port if no value provided)",
@@ -276,7 +280,10 @@ export const RunCommand = cmd({
     }
 
     if (args.attach) {
-      const sdk = createOpencodeClient({ baseUrl: args.attach })
+      const sdk = createOpencodeClient({
+        baseUrl: args.attach,
+        directory: args.dir,
+      })
 
       const sessionID = await (async () => {
         if (args.continue) {

--- a/packages/opencode/test/cli/run-args.test.ts
+++ b/packages/opencode/test/cli/run-args.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
+
+describe("cli.run --dir flag", () => {
+  test("SDK adds x-opencode-directory header when directory is provided", async () => {
+    let captured: Request | undefined
+
+    const mockFetch = async (input: Request) => {
+      captured = input
+      return new Response(JSON.stringify({ data: { id: "test-session" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    const client = createOpencodeClient({
+      baseUrl: "http://localhost:4096",
+      directory: "/custom/project/path",
+      fetch: mockFetch as typeof fetch,
+    })
+
+    await client.session.create()
+
+    expect(captured).toBeDefined()
+    expect(captured!.headers.get("x-opencode-directory")).toBe("/custom/project/path")
+  })
+
+  test("SDK does not add x-opencode-directory header when directory is not provided", async () => {
+    let captured: Request | undefined
+
+    const mockFetch = async (input: Request) => {
+      captured = input
+      return new Response(JSON.stringify({ data: { id: "test-session" } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    const client = createOpencodeClient({
+      baseUrl: "http://localhost:4096",
+      fetch: mockFetch as typeof fetch,
+    })
+
+    await client.session.create()
+
+    expect(captured).toBeDefined()
+    expect(captured!.headers.get("x-opencode-directory")).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Add `--dir` flag to `opencode run` command
- When used with `--attach`, passes directory to SDK client via `x-opencode-directory` header
- Enables sessions attached to a global server to run in the correct project directory

## Use Case

When using [opencode-pilot](https://github.com/athal7/opencode-pilot) to spawn sessions that attach to a running OpenCode Desktop with worktree="/", sessions now run in the correct project directory instead of the server's home directory.

```bash
# Before: sessions run in wrong directory
opencode run --attach http://localhost:4096 "fix bug"
# Working directory: /Users/me (wrong!)

# After: sessions run in correct directory
opencode run --attach http://localhost:4096 --dir /path/to/project "fix bug"
# Working directory: /path/to/project (correct!)
```

Closes #7376