### PR TITLE
docs: Add Scaleway to provider docs

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1271,6 +1271,35 @@ SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon
 
 ---
 
+### Scaleway
+
+To use [Scaleway Generative APIs](https://www.scaleway.com/en/docs/generative-apis/) with Opencode:
+
+1. Head over to the [Scaleway Console IAM settings](https://console.scaleway.com/iam/api-keys) to generate a new API key.
+
+2. Run the `/connect` command and search for **Scaleway**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Scaleway API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _devstral-2-123b-instruct-2512_ or _gpt-oss-120b_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Together AI
 
 1. Head over to the [Together AI console](https://api.together.ai), create an account, and click **Add Key**.


### PR DESCRIPTION
Scaleway models were already added to [models.dev](https://models.dev/?search=scaleway), this PR update the documentation about selecting Scaleway as a provider:
- Added Scaleway to providers.mdx
- Included basic setup instructions
