### PR TITLE
fix(desktop): remove split operation in serverDisplayName function

### DIFF
--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -19,7 +19,6 @@ export function serverDisplayName(url: string) {
   return url
     .replace(/^https?:\/\//, "")
     .replace(/\/+$/, "")
-    .split("/")[0]
 }
 
 function projectsKey(url: string) {


### PR DESCRIPTION
### What does this PR do?

It removes the split from the `serverDisplayName` function, this allows the path of the server url to also be shown and Closes #7396. Preventing issues when there are server urls with the same domains.

### How did you verify your code works?

Tested the app locally and have these results.
<img width="870" height="476" alt="Screenshot 2026-01-09 at 01 21 26" src="https://github.com/user-attachments/assets/59ff9fe5-37c1-4d71-85a4-ef925eab0e44" />
<img width="763" height="218" alt="Screenshot 2026-01-09 at 01 24 04" src="https://github.com/user-attachments/assets/f77546fa-25c2-4fa5-9623-00158dc44813" />
<img width="777" height="380" alt="Screenshot 2026-01-09 at 01 24 11" src="https://github.com/user-attachments/assets/03a65608-5580-4809-abf8-7aeb01b287e4" />
