### PR TITLE
fix(desktop): Remove Cursor Unfocused Prompt Input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -252,8 +252,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   // tauri/wkwebview doesn't always remove cursor when focus moves to another element
   createEffect(() => {
-    if (!isFocused() && document.hasFocus()) {
-      window.getSelection()?.removeAllRanges()
+    if (!isFocused() && document.activeElement !== editorRef) {
+      const selection = window.getSelection()
+      if (selection && editorRef.contains(selection.anchorNode)) {
+        selection.removeAllRanges()
+      }
     }
   })
 

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -250,6 +250,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   const isFocused = createFocusSignal(() => editorRef)
 
+  // tauri/wkwebview doesn't always remove cursor when focus moves to another element
+  createEffect(() => {
+    if (!isFocused() && document.hasFocus()) {
+      window.getSelection()?.removeAllRanges()
+    }
+  })
+
   createEffect(() => {
     params.id
     editorRef.focus()


### PR DESCRIPTION
### What does this PR do?  

Remove the cursor from the prompt input when focus moves to another element, addressing an issue with cursor visibility in certain environments.  

### How did you verify your code works?  

Currently if you click some elements, or sometimes when you cmd + tab, the focus leaves the prompt input, but the cursor is still there, for example, focus the prompt input, and click on session breadcrumb that opens sessions:

<img width="1970" height="1043" alt="image" src="https://github.com/user-attachments/assets/033ccf5f-8f27-458d-be19-6eab2c6b82b3" />

This works on web version, but on tauri version of mac has weird behaviors.

So if you focus prompt, click there, and paste an image from the clipboard, this still happens:

<img width="1667" height="1020" alt="image" src="https://github.com/user-attachments/assets/87f92c0c-6118-4c0c-b119-58c20c27a158" />

Also tested moving cursor to a new input like terminal, works fine.



