### PR TITLE
feat(desktop): Change Terminal's Cursor to Bar and Stop Blinking when not focused

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -45,6 +45,8 @@ export const Terminal = (props: TerminalProps) => {
   let serializeAddon: SerializeAddon
   let fitAddon: FitAddon
   let handleResize: () => void
+  let handleTextareaFocus: () => void
+  let handleTextareaBlur: () => void
   let reconnect: number | undefined
   let disposed = false
 
@@ -105,6 +107,7 @@ export const Terminal = (props: TerminalProps) => {
 
     const t = new mod.Terminal({
       cursorBlink: true,
+      cursorStyle: "bar",
       fontSize: 14,
       fontFamily: "IBM Plex Mono, monospace",
       allowTransparency: true,
@@ -170,6 +173,17 @@ export const Terminal = (props: TerminalProps) => {
 
     t.open(container)
     container.addEventListener("pointerdown", handlePointerDown)
+
+    handleTextareaFocus = () => {
+      t.options.cursorBlink = true
+    }
+    handleTextareaBlur = () => {
+      t.options.cursorBlink = false
+    }
+
+    t.textarea?.addEventListener("focus", handleTextareaFocus)
+    t.textarea?.addEventListener("blur", handleTextareaBlur)
+
     focusTerminal()
 
     if (local.pty.buffer) {
@@ -242,6 +256,8 @@ export const Terminal = (props: TerminalProps) => {
       window.removeEventListener("resize", handleResize)
     }
     container.removeEventListener("pointerdown", handlePointerDown)
+    term?.textarea?.removeEventListener("focus", handleTextareaFocus)
+    term?.textarea?.removeEventListener("blur", handleTextareaBlur)
 
     const t = term
     if (serializeAddon && props.onCleanup && t) {


### PR DESCRIPTION
### What does this PR do?

Currently terminal cursor keeps blinking even when not focused, this PR makes it not blink when unfocused.

I also changed the cursor to be bar instead of cursor, which is Ghostty default, and cleaner.

### How did you verify your code works?

Tested with and without focus

<img width="1423" height="518" alt="image" src="https://github.com/user-attachments/assets/c23290b3-684b-4fba-8d21-0df69cb37541" />
