### PR TITLE
fix(ui): allow text editing shortcuts in search dialogs on macOS

### DIFF
--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -82,6 +82,8 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
       const selected = flat()[selectedIndex]
       if (selected) props.onSelect?.(selected, selectedIndex)
     } else {
+      // Skip list navigation for text editing shortcuts (e.g., Option+Arrow, Option+Backspace on macOS)
+      if (event.altKey || event.metaKey) return
       list.onKeyDown(event)
     }
   }


### PR DESCRIPTION
## Summary
  - Skip list navigation when modifier keys (Alt/Option or Meta/Cmd) are pressed
  - Allows native text editing shortcuts like Option+Arrow (word navigation) and Option+Backspace (delete word) to work in search dialogs

  Fixes #7398