### PR TITLE
feat: add config setting to avoid subagents models overriding session model

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -145,8 +145,12 @@ export function Prompt(props: PromptProps) {
       if (msg.agent && isPrimaryAgent) {
         local.agent.set(msg.agent)
       }
-      if (msg.model) local.model.set(msg.model)
-      if (msg.variant) local.model.variant.set(msg.variant)
+
+      const isolateModel = sync.data.config.isolate_subagent_model
+      if (!isolateModel) {
+        if (msg.model) local.model.set(msg.model)
+        if (msg.variant) local.model.variant.set(msg.variant)
+      }
     }
   })
 

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -871,6 +871,10 @@ export namespace Config {
         .boolean()
         .optional()
         .describe("@deprecated Use 'share' field instead. Share newly created sessions automatically"),
+      isolate_subagent_model: z
+        .boolean()
+        .optional()
+        .describe("Prevent commands and subagents from persisting their model to the parent session"),
       autoupdate: z
         .union([z.boolean(), z.literal("notify")])
         .optional()

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1591,6 +1591,10 @@ export type Config = {
    */
   autoshare?: boolean
   /**
+   * Prevent commands and subagents from persisting their model to the parent session
+   */
+  isolate_subagent_model?: boolean
+  /**
    * Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications
    */
   autoupdate?: boolean | "notify"


### PR DESCRIPTION
### What does this PR do?
Adds a new config setting which, when enabled, stops models used in subagents and commands from bubbling up and overriding the main session model on completion.

I am unsure if this is a bug or intended behaviour. It seems like odd behaviour to me that running subagents would modify the parent session's model (and I'd very much not like to have to add a config setting) but I couldn't really be certain based on the comment above it.

### How did you verify your code works?
Ran it locally and confirmed behaviour was fixed. Ran tests.

Fixes #7430