### PR TITLE
fix(tui): add KeyEvent type to useKeyboard callback (#7441)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -1,7 +1,7 @@
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { batch, createContext, Show, useContext, type JSX, type ParentProps } from "solid-js"
 import { useTheme } from "@tui/context/theme"
-import { Renderable, RGBA } from "@opentui/core"
+import { Renderable, RGBA, type KeyEvent } from "@opentui/core"
 import { createStore } from "solid-js/store"
 import { Clipboard } from "@tui/util/clipboard"
 import { useToast } from "./toast"
@@ -56,7 +56,7 @@ function init() {
     size: "medium" as "medium" | "large",
   })
 
-  useKeyboard((evt) => {
+  useKeyboard((evt: KeyEvent) => {
     if (evt.name === "escape" && store.stack.length > 0) {
       const current = store.stack.at(-1)!
       current.onClose?.()


### PR DESCRIPTION
## Summary

- Add explicit `KeyEvent` type import from `@opentui/core`
- Annotate `useKeyboard` callback parameter with `KeyEvent` type to fix TypeScript error

## Problem

The `useKeyboard` callback in `dialog.tsx` uses `evt.stopPropagation()`, but TypeScript reports:

```
TS2339: Property 'stopPropagation' does not exist on type 'KeyEvent'
```

This happens because `@opentui/solid`'s `jsx-runtime.d.ts` imports from `./dist` which contains auto-generated declarations with `callback: any`, shadowing the properly-typed exports.

## Solution

Import `KeyEvent` from `@opentui/core` (which has proper type definitions) and explicitly annotate the callback parameter:

```typescript
import { Renderable, RGBA, type KeyEvent } from "@opentui/core"

useKeyboard((evt: KeyEvent) => {
  // ...
  evt.stopPropagation()  // Now properly typed
})
```

## Test Plan

- [x] `bun turbo typecheck` passes
- [x] Pre-push hooks pass

Fixes #7441