### PR TITLE
fix(ci): revert GraphQL field to closingIssuesReferences

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -105,7 +105,7 @@ jobs:
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
-                    issuesReferences(first: 1) {
+                    closingIssuesReferences(first: 1) {
                       totalCount
                     }
                   }
@@ -119,7 +119,7 @@ jobs:
               number: pr.number
             });
 
-            const linkedIssues = result.repository.pullRequest.issuesReferences.totalCount;
+            const linkedIssues = result.repository.pullRequest.closingIssuesReferences.totalCount;
 
             if (linkedIssues === 0) {
               await addLabel('needs:issue');


### PR DESCRIPTION
## Summary

Fixes the GraphQL field name in the PR standards workflow from `issuesReferences` to `closingIssuesReferences`.

## Problem

While submitting #7443, we noticed the `check-standards` job was failing:
https://github.com/anomalyco/opencode/actions/runs/20845955619/job/59889485904?pr=7443

The error:
```
Field 'issuesReferences' doesn't exist on type 'PullRequest'
```

The correct field name in GitHub's GraphQL API is `closingIssuesReferences`.

## Solution

Update the field name to match the GitHub GraphQL API schema.

Fixes #7446