### PR TITLE
fix(ui): add timeout cleanup in TextField copy handler

### DIFF
--- a/packages/ui/src/components/text-field.tsx
+++ b/packages/ui/src/components/text-field.tsx
@@ -1,5 +1,5 @@
 import { TextField as Kobalte } from "@kobalte/core/text-field"
-import { createSignal, Show, splitProps } from "solid-js"
+import { createEffect, createSignal, onCleanup, Show, splitProps } from "solid-js"
 import type { ComponentProps } from "solid-js"
 import { IconButton } from "./icon-button"
 import { Tooltip } from "./tooltip"
@@ -51,11 +51,16 @@ export function TextField(props: TextFieldProps) {
   ])
   const [copied, setCopied] = createSignal(false)
 
+  createEffect(() => {
+    if (!copied()) return
+    const timeout = setTimeout(() => setCopied(false), 2000)
+    onCleanup(() => clearTimeout(timeout))
+  })
+
   async function handleCopy() {
     const value = local.value ?? local.defaultValue ?? ""
     await navigator.clipboard.writeText(value)
     setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
   }
 
   function handleClick() {


### PR DESCRIPTION
## Summary
- Fix potential memory leak in TextField copy button
- Use reactive effect pattern for timeout management
- Auto-cleanup on rapid clicks and component unmount

## Changes
The copy feedback timeout (2s "Copied" indicator) now uses `createEffect` with `onCleanup` instead of a bare `setTimeout`. This ensures:
- Previous timeout is cleared on rapid clicks
- Timeout is cleared on component unmount
- No state updates on unmounted components