### PR TITLE
Feature/base path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,30 @@ If you're interested in contributing to OpenCode, please read our [contributing 
 
 If you are working on a project that's related to OpenCode and is using "opencode" as a part of its name; for example, "opencode-dashboard" or "opencode-mobile", please add a note to your README to clarify that it is not built by the OpenCode team and is not affiliated with us in any way.
 
+### Running Behind a Reverse Proxy
+
+OpenCode supports running behind a reverse proxy with a base path prefix:
+
+```bash
+# CLI flag
+opencode web --base-path /my-prefix/
+
+# Environment variable
+OPENCODE_BASE_PATH=/my-prefix/ opencode web
+
+# Config file (opencode.json)
+{
+  "server": {
+    "basePath": "/my-prefix/"
+  }
+}
+```
+
+This is useful for:
+- Kubernetes Ingress with path-based routing
+- Kubeflow Notebooks (set `basePath` to `$NB_PREFIX`)
+- Running multiple instances behind nginx/traefik
+
 ### FAQ
 
 #### How is this different from Claude Code?

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -34,6 +34,7 @@ const Loading = () => <div class="size-full flex items-center justify-center tex
 declare global {
   interface Window {
     __OPENCODE__?: { updaterEnabled?: boolean; port?: number; serverReady?: boolean }
+    __OPENCODE_BASE_PATH__?: string
   }
 }
 
@@ -46,7 +47,10 @@ const defaultServerUrl = iife(() => {
   if (import.meta.env.DEV)
     return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
-  return window.location.origin
+  // Support for reverse proxy with base path (e.g., Kubeflow NB_PREFIX)
+  // The server injects window.__OPENCODE_BASE_PATH__ when serving under a base path
+  const basePath = window.__OPENCODE_BASE_PATH__ || ""
+  return window.location.origin + basePath
 })
 
 export function AppBaseProviders(props: ParentProps) {
@@ -78,12 +82,15 @@ function ServerKey(props: ParentProps) {
 }
 
 export function AppInterface() {
+  const basePath = window.__OPENCODE_BASE_PATH__ || ""
+
   return (
     <ServerProvider defaultUrl={defaultServerUrl}>
       <ServerKey>
         <GlobalSDKProvider>
           <GlobalSyncProvider>
             <Router
+              base={basePath}
               root={(props) => (
                 <PermissionProvider>
                   <LayoutProvider>

--- a/packages/opencode/Dockerfile
+++ b/packages/opencode/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine AS base
 # On ephemeral containers, the cache is not useful
 ARG BUN_RUNTIME_TRANSPILER_CACHE_PATH=0
 ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=${BUN_RUNTIME_TRANSPILER_CACHE_PATH}
-RUN apk add libgcc libstdc++ ripgrep
+RUN apk add libgcc libstdc++ ripgrep gcompat
 
 FROM base AS build-amd64
 COPY dist/opencode-linux-x64-baseline-musl/bin/opencode /usr/local/bin/opencode

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,6 +1,7 @@
 import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { normalizeBasePath } from "../../util/base-path"
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -9,7 +10,9 @@ export const ServeCommand = cmd({
   handler: async (args) => {
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    const basePath = normalizeBasePath(opts.basePath)
+    const pathSuffix = basePath ? `${basePath}/` : ""
+    console.log(`opencode server listening on http://${server.hostname}:${server.port}${pathSuffix}`)
     await new Promise(() => {})
     await server.stop()
   },

--- a/packages/opencode/src/cli/cmd/tui/spawn.ts
+++ b/packages/opencode/src/cli/cmd/tui/spawn.ts
@@ -29,7 +29,7 @@ export const TuiSpawnCommand = cmd({
       )
       cwd = new URL("../../../../", import.meta.url).pathname
     } else cmd.push(process.execPath)
-    cmd.push("attach", server.url.toString(), "--dir", args.project ? path.resolve(args.project) : process.cwd())
+    cmd.push("attach", Server.url().toString(), "--dir", args.project ? path.resolve(args.project) : process.cwd())
     const proc = Bun.spawn({
       cmd,
       cwd,

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -31,12 +31,12 @@ process.on("uncaughtException", (e) => {
 
 let server: Bun.Server<BunWebSocketData>
 export const rpc = {
-  async server(input: { port: number; hostname: string; mdns?: boolean }) {
+  async server(input: { port: number; hostname: string; mdns?: boolean; basePath?: string }) {
     if (server) await server.stop(true)
     try {
       server = Server.listen(input)
       return {
-        url: server.url.toString(),
+        url: Server.url().toString(),
       }
     } catch (e) {
       console.error(e)

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -4,6 +4,7 @@ import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import open from "open"
 import { networkInterfaces } from "os"
+import { normalizeBasePath } from "../../util/base-path"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -34,13 +35,16 @@ export const WebCommand = cmd({
   handler: async (args) => {
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
+    const basePath = normalizeBasePath(opts.basePath)
+    const pathSuffix = basePath ? `${basePath}/` : ""
+
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
+      const localhostUrl = `http://localhost:${server.port}${pathSuffix}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
 
       // Show network IPs for remote access
@@ -50,7 +54,7 @@ export const WebCommand = cmd({
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            `http://${ip}:${server.port}${pathSuffix}`,
           )
         }
       }
@@ -59,11 +63,18 @@ export const WebCommand = cmd({
         UI.println(UI.Style.TEXT_INFO_BOLD + "  mDNS:              ", UI.Style.TEXT_NORMAL, "opencode.local")
       }
 
+      if (basePath) {
+        UI.println(UI.Style.TEXT_INFO_BOLD + "  Base path:         ", UI.Style.TEXT_NORMAL, basePath)
+      }
+
       // Open localhost in browser
       open(localhostUrl.toString()).catch(() => {})
     } else {
-      const displayUrl = server.url.toString()
+      const displayUrl = Server.url().toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
+      if (basePath) {
+        UI.println(UI.Style.TEXT_INFO_BOLD + "  Base path:         ", UI.Style.TEXT_NORMAL, basePath)
+      }
       open(displayUrl).catch(() => {})
     }
 

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -12,6 +12,11 @@ const options = {
     describe: "hostname to listen on",
     default: "127.0.0.1",
   },
+  "base-path": {
+    type: "string" as const,
+    describe: "base path prefix for all routes (e.g., /notebook/ns/name/ for Kubeflow)",
+    default: "/",
+  },
   mdns: {
     type: "boolean" as const,
     describe: "enable mDNS service discovery (defaults hostname to 0.0.0.0)",
@@ -35,6 +40,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const config = await Config.global()
   const portExplicitlySet = process.argv.includes("--port")
   const hostnameExplicitlySet = process.argv.includes("--hostname")
+  const basePathExplicitlySet = process.argv.includes("--base-path")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const corsExplicitlySet = process.argv.includes("--cors")
 
@@ -49,5 +55,13 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 
-  return { hostname, port, mdns, cors }
+  // Resolve base path: CLI arg > env var > config > default
+  const envBasePath = process.env.OPENCODE_BASE_PATH
+  const basePath = basePathExplicitlySet
+    ? args["base-path"]
+    : envBasePath
+      ? envBasePath
+      : (config?.server?.basePath ?? args["base-path"])
+
+  return { hostname, port, mdns, cors, basePath }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -776,6 +776,10 @@ export namespace Config {
     .object({
       port: z.number().int().positive().optional().describe("Port to listen on"),
       hostname: z.string().optional().describe("Hostname to listen on"),
+      basePath: z
+        .string()
+        .optional()
+        .describe("Base path prefix for all routes (e.g., /notebook/ns/name/ for Kubeflow)"),
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
       cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
     })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2861,12 +2861,40 @@ export namespace Server {
             html = html.replace(/(href|src|content)="\/(?!\/)/g, `$1="${_basePath}/`)
 
             // Inject basePath as a global variable before the closing </head> tag
+            // Also override the default server URL logic to use basePath
             html = html.replace(
               "</head>",
-              `<script>window.__OPENCODE_BASE_PATH__="${_basePath}";</script></head>`,
+              `<script>
+window.__OPENCODE_BASE_PATH__="${_basePath}";
+// Override default server URL to include basePath for reverse proxy support
+(function() {
+  var origOrigin = window.location.origin;
+  Object.defineProperty(window.location, '__opencodeOriginWithBase', {
+    get: function() { return origOrigin + (window.__OPENCODE_BASE_PATH__ || ''); }
+  });
+})();
+</script></head>`,
             )
 
             return new Response(html, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
+          }
+
+          // For JavaScript files, patch window.location.origin references to include basePath
+          if (_basePath && (contentType.includes("javascript") || path.endsWith(".js"))) {
+            let js = await response.text()
+
+            // Replace the pattern where the app determines the server URL
+            // In minified code it appears as: :window.location.origin)
+            js = js.replace(
+              /:window\.location\.origin\)/g,
+              `:window.location.origin+(window.__OPENCODE_BASE_PATH__||""))`,
+            )
+
+            return new Response(js, {
               status: response.status,
               statusText: response.statusText,
               headers: response.headers,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -60,10 +60,19 @@ export namespace Server {
   const log = Log.create({ service: "server" })
 
   let _url: URL | undefined
+  let _basePath: string = ""
   let _corsWhitelist: string[] = []
 
   export function url(): URL {
-    return _url ?? new URL("http://localhost:4096")
+    const base = _url ?? new URL("http://localhost:4096")
+    if (_basePath) {
+      return new URL(_basePath + "/", base)
+    }
+    return base
+  }
+
+  export function basePath(): string {
+    return _basePath
   }
 
   export const Event = {
@@ -2845,13 +2854,37 @@ export namespace Server {
     return result
   }
 
-  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
+  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; basePath?: string }) {
     _corsWhitelist = opts.cors ?? []
+
+    // Normalize basePath: ensure leading slash, remove trailing slash
+    const rawBasePath = opts.basePath ?? "/"
+    _basePath =
+      rawBasePath === "/"
+        ? ""
+        : (rawBasePath.startsWith("/") ? rawBasePath : `/${rawBasePath}`).replace(/\/+$/, "")
+
+    // Create wrapper app for base path routing
+    const baseApp = new Hono()
+    const mainApp = App()
+
+    if (_basePath) {
+      // Mount the main app under the base path
+      baseApp.route(_basePath, mainApp)
+
+      // Redirect root to base path
+      baseApp.get("/", (c) => c.redirect(`${_basePath}/`))
+
+      // Return 404 for any other path not under base path
+      baseApp.all("/*", (c) => c.notFound())
+    }
+
+    const appToServe = _basePath ? baseApp : mainApp
 
     const args = {
       hostname: opts.hostname,
       idleTimeout: 0,
-      fetch: App().fetch,
+      fetch: appToServe.fetch,
       websocket: websocket,
     } as const
     const tryServe = (port: number) => {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2894,6 +2894,10 @@ window.__OPENCODE_BASE_PATH__="${_basePath}";
               `:window.location.origin+(window.__OPENCODE_BASE_PATH__||""))`,
             )
 
+            // Rewrite absolute asset paths in JavaScript strings
+            // Matches "/assets/..." in JS strings
+            js = js.replace(/"\/(assets\/[^"]*)"/g, `"${_basePath}/$1"`)
+
             return new Response(js, {
               status: response.status,
               statusText: response.statusText,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -150,14 +150,24 @@ export namespace Server {
                 description: "Health information",
                 content: {
                   "application/json": {
-                    schema: resolver(z.object({ healthy: z.literal(true), version: z.string() })),
+                    schema: resolver(
+                      z.object({
+                        healthy: z.literal(true),
+                        version: z.string(),
+                        basePath: z.string().optional(),
+                      }),
+                    ),
                   },
                 },
               },
             },
           }),
           async (c) => {
-            return c.json({ healthy: true, version: Installation.VERSION })
+            return c.json({
+              healthy: true,
+              version: Installation.VERSION,
+              basePath: _basePath || undefined,
+            })
           },
         )
         .get(
@@ -2835,6 +2845,23 @@ export namespace Server {
               host: "app.opencode.ai",
             },
           })
+
+          // Inject basePath into HTML responses for reverse proxy support
+          const contentType = response.headers.get("content-type") || ""
+          if (_basePath && contentType.includes("text/html")) {
+            const html = await response.text()
+            // Inject basePath as a global variable before the closing </head> tag
+            const injectedHtml = html.replace(
+              "</head>",
+              `<script>window.__OPENCODE_BASE_PATH__="${_basePath}";</script></head>`,
+            )
+            return new Response(injectedHtml, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
+          }
+
           return response
         }) as unknown as Hono,
   )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2912,13 +2912,13 @@ window.__OPENCODE_BASE_PATH__="${_basePath}";
               `:window.location.origin+(window.__OPENCODE_BASE_PATH__||""))`,
             )
 
-            // Rewrite absolute asset paths in JavaScript strings
-            // Matches "/assets/..." in JS strings
-            js = js.replace(/"\/(assets\/[^"]*)"/g, `"${_basePath}/$1"`)
-
-            // Rewrite relative asset paths in JavaScript strings (for dynamic imports)
-            // Matches "assets/..." in JS strings (without leading slash)
-            js = js.replace(/"(assets\/[^"]*)"/g, `"${_basePath}/$1"`)
+            // Patch Vite's base path function to use our basePath instead of "/"
+            // The function looks like: function(t){return"/"+t}
+            // This handles all dynamic asset loading
+            js = js.replace(
+              /function\(t\)\{return"\/"\+t\}/g,
+              `function(t){return"${_basePath}/"+t}`,
+            )
 
             return new Response(js, {
               status: response.status,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2901,6 +2901,20 @@ window.__OPENCODE_BASE_PATH__="${_basePath}";
             })
           }
 
+          // For CSS files, rewrite absolute URLs to include basePath
+          if (_basePath && (contentType.includes("text/css") || path.endsWith(".css"))) {
+            let css = await response.text()
+
+            // Rewrite url(/assets/...) to url(/basePath/assets/...)
+            css = css.replace(/url\(\/(?!\/)/g, `url(${_basePath}/`)
+
+            return new Response(css, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
+          }
+
           return response
         }) as unknown as Hono,
   )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2837,7 +2837,12 @@ export namespace Server {
           },
         )
         .all("/*", async (c) => {
-          const path = c.req.path
+          // Strip basePath from the request path before proxying
+          let path = c.req.path
+          if (_basePath && path.startsWith(_basePath)) {
+            path = path.slice(_basePath.length) || "/"
+          }
+
           const response = await proxy(`https://app.opencode.ai${path}`, {
             ...c.req,
             headers: {
@@ -2849,13 +2854,19 @@ export namespace Server {
           // Inject basePath into HTML responses for reverse proxy support
           const contentType = response.headers.get("content-type") || ""
           if (_basePath && contentType.includes("text/html")) {
-            const html = await response.text()
+            let html = await response.text()
+
+            // Rewrite absolute paths in HTML to include basePath
+            // Matches href="/...", src="/...", content="/..." but not href="//..." (protocol-relative) or href="http..."
+            html = html.replace(/(href|src|content)="\/(?!\/)/g, `$1="${_basePath}/`)
+
             // Inject basePath as a global variable before the closing </head> tag
-            const injectedHtml = html.replace(
+            html = html.replace(
               "</head>",
               `<script>window.__OPENCODE_BASE_PATH__="${_basePath}";</script></head>`,
             )
-            return new Response(injectedHtml, {
+
+            return new Response(html, {
               status: response.status,
               statusText: response.statusText,
               headers: response.headers,
@@ -2899,11 +2910,9 @@ export namespace Server {
       // Mount the main app under the base path
       baseApp.route(_basePath, mainApp)
 
-      // Redirect root to base path
-      baseApp.get("/", (c) => c.redirect(`${_basePath}/`))
-
-      // Return 404 for any other path not under base path
-      baseApp.all("/*", (c) => c.notFound())
+      // Also mount API routes at root level for backward compatibility
+      // This allows the frontend (which may not know about basePath yet) to still work
+      baseApp.route("/", mainApp)
     }
 
     const appToServe = _basePath ? baseApp : mainApp

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2866,12 +2866,30 @@ export namespace Server {
               "</head>",
               `<script>
 window.__OPENCODE_BASE_PATH__="${_basePath}";
-// Override default server URL to include basePath for reverse proxy support
+// Wrap history.pushState and replaceState to add basePath prefix
 (function() {
-  var origOrigin = window.location.origin;
-  Object.defineProperty(window.location, '__opencodeOriginWithBase', {
-    get: function() { return origOrigin + (window.__OPENCODE_BASE_PATH__ || ''); }
-  });
+  var basePath = window.__OPENCODE_BASE_PATH__ || "";
+  if (!basePath) return;
+  
+  var origPushState = history.pushState.bind(history);
+  var origReplaceState = history.replaceState.bind(history);
+  
+  function addBasePathIfNeeded(url) {
+    if (!url || typeof url !== "string") return url;
+    // If URL starts with / but not with basePath, add basePath
+    if (url.startsWith("/") && !url.startsWith(basePath)) {
+      return basePath + url;
+    }
+    return url;
+  }
+  
+  history.pushState = function(state, title, url) {
+    return origPushState(state, title, addBasePathIfNeeded(url));
+  };
+  
+  history.replaceState = function(state, title, url) {
+    return origReplaceState(state, title, addBasePathIfNeeded(url));
+  };
 })();
 </script></head>`,
             )
@@ -2897,6 +2915,10 @@ window.__OPENCODE_BASE_PATH__="${_basePath}";
             // Rewrite absolute asset paths in JavaScript strings
             // Matches "/assets/..." in JS strings
             js = js.replace(/"\/(assets\/[^"]*)"/g, `"${_basePath}/$1"`)
+
+            // Rewrite relative asset paths in JavaScript strings (for dynamic imports)
+            // Matches "assets/..." in JS strings (without leading slash)
+            js = js.replace(/"(assets\/[^"]*)"/g, `"${_basePath}/$1"`)
 
             return new Response(js, {
               status: response.status,

--- a/packages/opencode/src/util/base-path.ts
+++ b/packages/opencode/src/util/base-path.ts
@@ -2,14 +2,14 @@
  * Normalizes a base path to ensure consistent format:
  * - Returns empty string for root path or undefined
  * - Ensures leading slash
- * - Removes trailing slash
+ * - Removes trailing slashes
  */
 export function normalizeBasePath(path?: string): string {
   if (!path || path === "/") return ""
 
-  // Ensure leading slash, remove trailing slash
+  // Ensure leading slash, remove trailing slashes
   let normalized = path.startsWith("/") ? path : `/${path}`
-  normalized = normalized.endsWith("/") ? normalized.slice(0, -1) : normalized
+  normalized = normalized.replace(/\/+$/, "")
 
   return normalized
 }

--- a/packages/opencode/src/util/base-path.ts
+++ b/packages/opencode/src/util/base-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalizes a base path to ensure consistent format:
+ * - Returns empty string for root path or undefined
+ * - Ensures leading slash
+ * - Removes trailing slash
+ */
+export function normalizeBasePath(path?: string): string {
+  if (!path || path === "/") return ""
+
+  // Ensure leading slash, remove trailing slash
+  let normalized = path.startsWith("/") ? path : `/${path}`
+  normalized = normalized.endsWith("/") ? normalized.slice(0, -1) : normalized
+
+  return normalized
+}
+
+/**
+ * Joins a base path with additional path segments.
+ * Handles normalization of the base path and proper joining of segments.
+ */
+export function joinPath(basePath: string, ...segments: string[]): string {
+  const base = normalizeBasePath(basePath)
+  const path = segments.join("/").replace(/\/+/g, "/")
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`
+}

--- a/packages/opencode/test/util/base-path.test.ts
+++ b/packages/opencode/test/util/base-path.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeBasePath, joinPath } from "../../src/util/base-path"
+
+describe("util.base-path", () => {
+  describe("normalizeBasePath", () => {
+    test("returns empty string for root", () => {
+      expect(normalizeBasePath("/")).toBe("")
+      expect(normalizeBasePath(undefined)).toBe("")
+    })
+
+    test("returns empty string for empty string", () => {
+      expect(normalizeBasePath("")).toBe("")
+    })
+
+    test("normalizes paths with leading slash", () => {
+      expect(normalizeBasePath("/prefix")).toBe("/prefix")
+      expect(normalizeBasePath("/notebook/namespace/name")).toBe("/notebook/namespace/name")
+    })
+
+    test("removes trailing slash", () => {
+      expect(normalizeBasePath("/prefix/")).toBe("/prefix")
+      expect(normalizeBasePath("/notebook/namespace/name/")).toBe("/notebook/namespace/name")
+    })
+
+    test("adds leading slash if missing", () => {
+      expect(normalizeBasePath("prefix")).toBe("/prefix")
+      expect(normalizeBasePath("notebook/namespace/name")).toBe("/notebook/namespace/name")
+    })
+
+    test("handles path without leading slash and with trailing slash", () => {
+      expect(normalizeBasePath("prefix/")).toBe("/prefix")
+      expect(normalizeBasePath("notebook/namespace/name/")).toBe("/notebook/namespace/name")
+    })
+
+    test("handles multiple trailing slashes", () => {
+      expect(normalizeBasePath("/prefix///")).toBe("/prefix")
+    })
+  })
+
+  describe("joinPath", () => {
+    test("joins base path with segments", () => {
+      expect(joinPath("/prefix", "api", "v1")).toBe("/prefix/api/v1")
+      expect(joinPath("/prefix", "/api", "/v1")).toBe("/prefix/api/v1")
+    })
+
+    test("handles empty base path", () => {
+      expect(joinPath("/", "api", "v1")).toBe("/api/v1")
+      expect(joinPath("", "api", "v1")).toBe("/api/v1")
+    })
+
+    test("normalizes multiple slashes", () => {
+      expect(joinPath("/prefix", "//api//", "//v1")).toBe("/prefix/api/v1")
+    })
+
+    test("handles segments with leading slashes", () => {
+      expect(joinPath("/prefix", "/session")).toBe("/prefix/session")
+    })
+
+    test("handles trailing slash on base path", () => {
+      expect(joinPath("/prefix/", "api")).toBe("/prefix/api")
+    })
+  })
+})


### PR DESCRIPTION
## Add `--base-path` support for reverse proxy deployments

### Summary

This PR adds support for running OpenCode behind a reverse proxy with a URL path prefix (e.g., `/notebook/namespace/name/`). This is essential for environments like Kubeflow Notebooks, Kubernetes Ingress with path-based routing, or shared servers running multiple services.

### Motivation

When deploying OpenCode in Kubeflow, the application runs under a URL prefix set by `NB_PREFIX` (e.g., `/notebook/demo-user1/opencode/`). Without base-path support, all assets, API calls, and navigation fail because they use absolute paths starting with `/`.

### Usage

```bash
# CLI flag
opencode web --base-path /notebook/namespace/name/

# Environment variable
OPENCODE_BASE_PATH=/prefix opencode web

# Config file (opencode.json)
{
  "server": {
    "basePath": "/prefix"
  }
}
```

### Changes

| File | Description |
|------|-------------|
| `src/util/base-path.ts` | New utility for path normalization |
| `src/config/config.ts` | Added `basePath` to server config schema |
| `src/cli/network.ts` | Added `--base-path` CLI option |
| `src/cli/cmd/web.ts` | Display base path in startup message |
| `src/cli/cmd/serve.ts` | Display base path in startup message |
| `src/server/server.ts` | Route mounting, HTML/JS/CSS runtime patching |
| `src/cli/cmd/tui/worker.ts` | Use `Server.url()` with basePath |
| `src/cli/cmd/tui/spawn.ts` | Use `Server.url()` with basePath |
| `packages/app/src/app.tsx` | Frontend basePath support |
| `Dockerfile` | Added `gcompat` for PTY terminal support |
| `README.md` | Documentation |
| `test/util/base-path.test.ts` | Unit tests |

### Technical Details

Since the frontend is served from `app.opencode.ai`, runtime patching is required:

- **HTML**: Rewrite asset paths (`href`, `src`, `content` attributes)
- **JavaScript**: Patch Vite's base function, patch `window.location.origin` for API calls
- **CSS**: Rewrite font URLs (`url(/assets/...)`)
- **History API**: Wrap `pushState`/`replaceState` for client-side routing

### Testing

- ✅ 634 unit tests passing
- ✅ Tested locally with `bun dev`
- ✅ Tested in Kubeflow Notebooks with `NB_PREFIX`
- ✅ Docker multi-platform build (linux/amd64, linux/arm64)

### Breaking Changes

None. Default behavior (no base path) is unchanged.
