### PR TITLE
fix: prevent model picker overflow with Zen in new sessions

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -76,7 +76,7 @@ export const ModelSelectorPopover: Component<{
     <Kobalte open={open()} onOpenChange={setOpen} placement="top-start" gutter={8}>
       <Kobalte.Trigger as="div">{props.children}</Kobalte.Trigger>
       <Kobalte.Portal>
-        <Kobalte.Content class="w-72 h-80 flex flex-col rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none">
+        <Kobalte.Content class="w-72 h-80 flex flex-col rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden">
           <Kobalte.Title class="sr-only">Select model</Kobalte.Title>
           <ModelList provider={props.provider} onSelect={() => setOpen(false)} class="p-1" />
         </Kobalte.Content>


### PR DESCRIPTION
fixes issue #7494 

Adding Zen as a provider caused the model picker to overflow in new sessions, rendering a black bar at the bottom. This was due to the picker having a fixed height while the model list grew.

Fix:
Clamp overflow in ModelSelectorPopover by adding overflow-hidden to Kobalte.Content, ensuring content stays within the fixed 320px height while remaining scrollable.

Change:

```
- <Kobalte.Content class="w-72 h-80 flex flex-col ... outline-none">
+ <Kobalte.Content class="w-72 h-80 flex flex-col ... outline-none overflow-hidden">
```

Tested:

Add Zen provider

Open model picker in a new session

Confirm no black bar and models scroll correctly