### PR TITLE
fix(grep): follow symlinks by default in ripgrep searches

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -367,8 +367,15 @@ export namespace Ripgrep {
     return lines.join("\n")
   }
 
-  export async function search(input: { cwd: string; pattern: string; glob?: string[]; limit?: number }) {
+  export async function search(input: {
+    cwd: string
+    pattern: string
+    glob?: string[]
+    limit?: number
+    follow?: boolean
+  }) {
     const args = [`${await filepath()}`, "--json", "--hidden", "--glob='!.git/*'"]
+    if (input.follow !== false) args.push("--follow")
 
     if (input.glob) {
       for (const g of input.glob) {

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -33,7 +33,7 @@ export const GrepTool = Tool.define("grep", {
     const searchPath = params.path || Instance.directory
 
     const rgPath = await Ripgrep.filepath()
-    const args = ["-nH", "--field-match-separator=|", "--regexp", params.pattern]
+    const args = ["-nH", "--hidden", "--follow", "--field-match-separator=|", "--regexp", params.pattern]
     if (params.include) {
       args.push("--glob", params.include)
     }


### PR DESCRIPTION
## Summary
Fixes #7498 - Grep fails on symlinked directories

## Changes
- Add `--follow` flag to grep tool for consistent symlink traversal
- Add `--hidden` flag to grep tool for parity with `Ripgrep.search()`
- Add `follow?: boolean` parameter to `Ripgrep.search()` with default `true` for API consistency with `Ripgrep.files()`

## Design Decision
Following VS Code's approach, symlinks are now followed by default since OpenCode is an IDE-like tool where users expect to find all their code regardless of filesystem structure. The `follow` parameter provides an escape hatch for users who need stricter behavior.

## Compliance
- Atomic Predictability: Both `files()` and `search()` now have consistent API for the `follow` parameter
- Intentional Naming: The `follow` parameter explicitly communicates symlink-following behavior

---

### Note for Maintainers
During review, we noticed that `grep.ts` does not include `--glob='!.git/*'` while `Ripgrep.search()` does. This is a pre-existing inconsistency (not related to this PR). If you'd like us to add this for consistency, we're happy to update the PR.