### PR TITLE
fix(desktop): Allow Selecting Card Errors

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -387,7 +387,8 @@
 [data-component="edit-content"],
 [data-component="write-content"],
 [data-component="todos"],
-[data-component="diagnostics"] {
+[data-component="diagnostics"],
+.error-card {
   -webkit-user-select: text;
   user-select: text;
 }


### PR DESCRIPTION
### What does this PR do?

Currently we can't select to copy from errors, like this one, i had to type this URL...

### How did you verify your code works?

<img width="1855" height="447" alt="image" src="https://github.com/user-attachments/assets/fc62873d-f02f-45ea-b5a0-bfa9761debd0" />
