### PR TITLE
fix(opencode): speed up project resolution with single root commit query

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -73,21 +73,14 @@ export namespace Project {
 
         // generate id from root commit
         if (!id) {
-          const roots = await $`git rev-list --max-parents=0 --all`
+          const root = await $`git rev-list --max-parents=0 --all --max-count=1`
             .quiet()
             .nothrow()
             .cwd(sandbox)
             .text()
-            .then((x) =>
-              x
-                .split("\n")
-                .filter(Boolean)
-                .map((x) => x.trim())
-                .toSorted(),
-            )
             .catch(() => undefined)
 
-          if (!roots) {
+          if (root === undefined) {
             return {
               id: "global",
               worktree: sandbox,
@@ -96,21 +89,18 @@ export namespace Project {
             }
           }
 
-          id = roots[0]
-          if (id) {
-            void Bun.file(path.join(git, "opencode"))
-              .write(id)
-              .catch(() => undefined)
+          id = root.trim()
+          if (!id) {
+            return {
+              id: "global",
+              worktree: sandbox,
+              sandbox: sandbox,
+              vcs: "git",
+            }
           }
-        }
-
-        if (!id) {
-          return {
-            id: "global",
-            worktree: sandbox,
-            sandbox: sandbox,
-            vcs: "git",
-          }
+          void Bun.file(path.join(git, "opencode"))
+            .write(id)
+            .catch(() => undefined)
         }
 
         const top = await $`git rev-parse --show-toplevel`


### PR DESCRIPTION
### What does this PR do?

Use `--max-count=1` to fetch only the first root commit during ID resolution rather than fetching all of them. This is significantly faster on repos with many root commits/orphan branches. In my testing on a huge repo with 170 orphaned branches, the execution time went from 10s to 1.5s on a cold cache, and 3.5s to 1.2s on a warm cache.

### How did you verify your code works?

Tested in a repo with many orphan branches, and a repo with one root branch.

The generated ID for the repo with many orphan branches was different from the previous code, so this is _not_ backwards compatible, although the cached ID should stay the same if it was stored. I'm not sure what if any impact this has on the rest of the system though.