### PR TITLE
fix: report config errors instead of silent termination

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -99,14 +99,16 @@ const cli = yargs(hideBin(process.argv))
   .command(GithubCommand)
   .command(PrCommand)
   .command(SessionCommand)
-  .fail((msg) => {
+  .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||
       msg?.startsWith("Not enough non-option arguments") ||
       msg?.startsWith("Invalid values:")
     ) {
+      if (err) throw err
       cli.showHelp("log")
     }
+    if (err) throw err
     process.exit(1)
   })
   .strict()


### PR DESCRIPTION
The args .fail() handler was only checking for specific argument errors and silently exiting for all other errors, including invalid config keys. This change re-throws errors so they're caught by the outer error handling logic that properly formats and displays them to users.

### What does this PR do?

Instead of silently terminating when run using `bun dev`, OpenCode will report errors in the configuration file.

### How did you verify your code works?

A/B testing.
