### PR TITLE
feat(tui): allow header to always be disabled with config option

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -146,6 +146,7 @@ export function Session() {
   const [showAssistantMetadata, setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
   const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
   const [diffWrapMode, setDiffWrapMode] = createSignal<"word" | "none">("word")
+  const headerEnabled = createMemo(() => sync.data.config.tui?.header_enabled ?? true)
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
 
   const wide = createMemo(() => dimensions().width > 120)
@@ -905,7 +906,7 @@ export function Session() {
       <box flexDirection="row">
         <box flexGrow={1} paddingBottom={1} paddingTop={1} paddingLeft={2} paddingRight={2} gap={1}>
           <Show when={session()}>
-            <Show when={!sidebarVisible() || !wide()}>
+            <Show when={headerEnabled() && (!sidebarVisible() || !wide())}>
               <Header />
             </Show>
             <scrollbox

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -788,6 +788,7 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    header_enabled: z.boolean().optional().describe("Show header in session view"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1585,6 +1585,10 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Show header in session view
+     */
+    header_enabled?: boolean
   }
   server?: ServerConfig
   /**

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -350,7 +350,8 @@ You can customize TUI behavior through your OpenCode config file.
     "scroll_speed": 3,
     "scroll_acceleration": {
       "enabled": true
-    }
+    },
+    "header_enabled": true
   }
 }
 ```
@@ -359,6 +360,7 @@ You can customize TUI behavior through your OpenCode config file.
 
 - `scroll_acceleration` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `1`). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
+- `header_enabled` - Show or hide the header in the session view. Defaults to `true`.
 
 ---
 


### PR DESCRIPTION
The header is hidden when the terminal becomes wide enough, but it's useful to always have it hidden, especially on terminals that don't have much height available to them.

Fixes #7536