### PR TITLE
feat(opencode): add project usage cli command

### DIFF
--- a/packages/opencode/src/cli/cmd/projects.ts
+++ b/packages/opencode/src/cli/cmd/projects.ts
@@ -4,6 +4,8 @@ import { bootstrap } from "../bootstrap"
 import { Storage } from "../../storage/storage"
 import { Project } from "../../project/project"
 import { Session } from "../../session"
+import { Locale } from "../../util/locale"
+import { UI } from "../ui"
 import { access } from "fs/promises"
 
 interface ProjectStats {
@@ -125,32 +127,50 @@ async function aggregateProjectStats(args: {
   return filtered
 }
 
-function displayProjectStats(stats: ProjectStats[], args: { limit?: number }) {
-  const width = 79
+export function displayProjectStats(
+  stats: ProjectStats[],
+  args: { limit?: number },
+  write: (...message: string[]) => void = UI.println,
+  options?: { width?: number },
+) {
+  const width = clampWidth(options?.width ?? process.stdout.columns ?? 100)
 
-  function renderRow(path: string, sessions: string, lastActive: string): string {
-    // Path: 40 chars, Sessions: 12 chars, Last Active: 20 chars
-    const pathFormatted = formatPath(path, 40).padEnd(40)
-    const sessionsFormatted = sessions.padStart(8)
-    const lastActiveFormatted = lastActive.padEnd(20)
-    return `│ ${pathFormatted}  ${sessionsFormatted}    ${lastActiveFormatted} │`
+  const sessionsWidth = Math.max("Sessions".length, ...stats.map((s) => s.sessionCount.toString().length), 1)
+  const lastActiveValues = stats.map((s) => (s.lastActive ? Locale.todayTimeOrDateTime(s.lastActive) : "never"))
+  const lastActiveWidth = Math.max("Last Active".length, ...lastActiveValues.map((v) => v.length), 1)
+  const paddingWidth = 8 // borders + inter-column spaces
+  const pathWidth = Math.max(10, width - sessionsWidth - lastActiveWidth - paddingWidth)
+
+  function renderRow(path: string, sessions: string, lastActive: string) {
+    const pathLines = wrapText(path, pathWidth)
+    const rows: string[] = []
+
+    for (let i = 0; i < pathLines.length; i++) {
+      const pathPart = pathLines[i].padEnd(pathWidth)
+      const sessionsPart = i === 0 ? sessions.padStart(sessionsWidth) : "".padStart(sessionsWidth)
+      const lastActivePart = i === 0 ? lastActive.padEnd(lastActiveWidth) : "".padEnd(lastActiveWidth)
+      rows.push(`│ ${pathPart}  ${sessionsPart}  ${lastActivePart} │`)
+    }
+
+    return rows
   }
 
   // Header
-  console.log("┌" + "─".repeat(width - 2) + "┐")
-  console.log("│" + "PROJECTS".padStart(41).padEnd(width - 2) + "│")
-  console.log("├" + "─".repeat(width - 2) + "┤")
-  console.log(renderRow("Path", "Sessions", "Last Active"))
-  console.log("├" + "─".repeat(width - 2) + "┤")
+  write("┌" + "─".repeat(width - 2) + "┐")
+  write("│" + "PROJECTS".padStart(Math.floor((width - 2 + "PROJECTS".length) / 2)).padEnd(width - 2) + "│")
+  write("├" + "─".repeat(width - 2) + "┤")
+  renderRow("Path", "Sessions", "Last Active").forEach((line) => write(line))
+  write("├" + "─".repeat(width - 2) + "┤")
 
   // Body
   if (stats.length === 0) {
     const emptyMsg = "No projects found"
-    const padding = Math.floor((width - 2 - emptyMsg.length) / 2)
-    console.log("│" + " ".repeat(padding) + emptyMsg + " ".repeat(width - 2 - padding - emptyMsg.length) + "│")
+    const padding = Math.max(0, Math.floor((width - 2 - emptyMsg.length) / 2))
+    write("│" + " ".repeat(padding) + emptyMsg + " ".repeat(width - 2 - padding - emptyMsg.length) + "│")
   } else {
     let totalSessions = 0
-    for (const stat of stats) {
+    for (let index = 0; index < stats.length; index++) {
+      const stat = stats[index]
       totalSessions += stat.sessionCount
 
       let path = stat.project.worktree
@@ -158,38 +178,35 @@ function displayProjectStats(stats: ProjectStats[], args: { limit?: number }) {
       if (!stat.worktreeExists) path += " [deleted]"
 
       const sessionsStr = stat.sessionCount.toString()
-      const lastActiveStr = stat.lastActive
-        ? new Date(stat.lastActive).toLocaleString("en-US", {
-            year: "numeric",
-            month: "2-digit",
-            day: "2-digit",
-            hour: "2-digit",
-            minute: "2-digit",
-          })
-        : "never"
+      const lastActiveStr = lastActiveValues[index] ?? "never"
 
-      console.log(renderRow(path, sessionsStr, lastActiveStr))
+      renderRow(path, sessionsStr, lastActiveStr).forEach((line) => write(line))
     }
 
     // Footer
-    console.log("└" + "─".repeat(width - 2) + "┘")
-    console.log()
-    console.log(`Total: ${stats.length} projects, ${totalSessions} sessions`)
-    console.log()
+    write("└" + "─".repeat(width - 2) + "┘")
+    write("")
+    write(`Total: ${stats.length} projects, ${totalSessions} sessions`)
+    write("")
     return
   }
 
-  console.log("└" + "─".repeat(width - 2) + "┘")
-  console.log()
+  write("└" + "─".repeat(width - 2) + "┘")
+  write("")
 }
 
-function formatPath(path: string, maxLength: number): string {
-  if (path.length <= maxLength) return path
+function clampWidth(input: number) {
+  const min = 80
+  const max = 120
+  if (!Number.isFinite(input)) return 100
+  return Math.min(max, Math.max(min, Math.floor(input)))
+}
 
-  // Truncate in middle: /Users/.../path/to/project
-  const ellipsis = "..."
-  const keepStart = Math.floor((maxLength - ellipsis.length) / 2)
-  const keepEnd = maxLength - ellipsis.length - keepStart
-
-  return path.slice(0, keepStart) + ellipsis + path.slice(-keepEnd)
+function wrapText(text: string, width: number): string[] {
+  if (width <= 0) return [text]
+  const lines: string[] = []
+  for (let i = 0; i < text.length; i += width) {
+    lines.push(text.slice(i, i + width))
+  }
+  return lines.length ? lines : [text]
 }

--- a/packages/opencode/src/cli/cmd/projects.ts
+++ b/packages/opencode/src/cli/cmd/projects.ts
@@ -1,0 +1,195 @@
+import type { Argv } from "yargs"
+import { cmd } from "./cmd"
+import { bootstrap } from "../bootstrap"
+import { Storage } from "../../storage/storage"
+import { Project } from "../../project/project"
+import { Session } from "../../session"
+import { access } from "fs/promises"
+
+interface ProjectStats {
+  project: Project.Info
+  sessionCount: number
+  lastActive: number | null
+  worktreeExists: boolean
+}
+
+export const ProjectsCommand = cmd({
+  command: "projects",
+  describe: "list all projects with conversation counts",
+  builder: (yargs: Argv) => {
+    return yargs
+      .option("sort", {
+        describe: "sort by: path, count, activity (default: activity)",
+        type: "string",
+        choices: ["path", "count", "activity"],
+        default: "activity",
+      })
+      .option("limit", {
+        describe: "limit number of projects to show",
+        type: "number",
+      })
+      .option("active-only", {
+        describe: "show only projects with sessions",
+        type: "boolean",
+        default: true,
+      })
+  },
+  handler: async (args) => {
+    await bootstrap(process.cwd(), async () => {
+      const stats = await aggregateProjectStats(args)
+      displayProjectStats(stats, args)
+    })
+  },
+})
+
+async function aggregateProjectStats(args: {
+  sort?: string
+  limit?: number
+  activeOnly?: boolean
+}): Promise<ProjectStats[]> {
+  const projects = await Project.list()
+  const stats: ProjectStats[] = []
+
+  // Show progress for large datasets
+  if (projects.length > 50) {
+    console.log(`Processing ${projects.length} projects...`)
+  }
+
+  // Process in batches for performance
+  const BATCH_SIZE = 10
+  for (let i = 0; i < projects.length; i += BATCH_SIZE) {
+    const batch = projects.slice(i, i + BATCH_SIZE)
+
+    const batchStats = await Promise.all(
+      batch.map(async (project) => {
+        if (!project) return null
+
+        // Get session keys for this project
+        const sessionKeys = await Storage.list(["session", project.id])
+
+        // Find most recent session activity
+        let lastActive: number | null = null
+        if (sessionKeys.length > 0) {
+          // Read sessions to find the latest time.updated
+          const sessions = await Promise.all(
+            sessionKeys.map((key) => Storage.read<Session.Info>(key).catch(() => null)),
+          )
+
+          for (const session of sessions) {
+            if (session && session.time.updated) {
+              lastActive = !lastActive ? session.time.updated : Math.max(lastActive, session.time.updated)
+            }
+          }
+        }
+
+        // Check if worktree still exists
+        const worktreeExists = await access(project.worktree)
+          .then(() => true)
+          .catch(() => false)
+
+        return {
+          project,
+          sessionCount: sessionKeys.length,
+          lastActive,
+          worktreeExists,
+        }
+      }),
+    )
+
+    stats.push(...(batchStats.filter((x) => x !== null) as ProjectStats[]))
+  }
+
+  // Filter based on active-only flag
+  let filtered = args.activeOnly ? stats.filter((s) => s.sessionCount > 0) : stats
+
+  // Sort
+  filtered.sort((a, b) => {
+    switch (args.sort) {
+      case "path":
+        return a.project.worktree.localeCompare(b.project.worktree)
+      case "count":
+        return b.sessionCount - a.sessionCount
+      case "activity":
+      default:
+        if (!a.lastActive) return 1
+        if (!b.lastActive) return -1
+        return b.lastActive - a.lastActive
+    }
+  })
+
+  // Apply limit
+  if (args.limit) {
+    filtered = filtered.slice(0, args.limit)
+  }
+
+  return filtered
+}
+
+function displayProjectStats(stats: ProjectStats[], args: { limit?: number }) {
+  const width = 79
+
+  function renderRow(path: string, sessions: string, lastActive: string): string {
+    // Path: 40 chars, Sessions: 12 chars, Last Active: 20 chars
+    const pathFormatted = formatPath(path, 40).padEnd(40)
+    const sessionsFormatted = sessions.padStart(8)
+    const lastActiveFormatted = lastActive.padEnd(20)
+    return `│ ${pathFormatted}  ${sessionsFormatted}    ${lastActiveFormatted} │`
+  }
+
+  // Header
+  console.log("┌" + "─".repeat(width - 2) + "┐")
+  console.log("│" + "PROJECTS".padStart(41).padEnd(width - 2) + "│")
+  console.log("├" + "─".repeat(width - 2) + "┤")
+  console.log(renderRow("Path", "Sessions", "Last Active"))
+  console.log("├" + "─".repeat(width - 2) + "┤")
+
+  // Body
+  if (stats.length === 0) {
+    const emptyMsg = "No projects found"
+    const padding = Math.floor((width - 2 - emptyMsg.length) / 2)
+    console.log("│" + " ".repeat(padding) + emptyMsg + " ".repeat(width - 2 - padding - emptyMsg.length) + "│")
+  } else {
+    let totalSessions = 0
+    for (const stat of stats) {
+      totalSessions += stat.sessionCount
+
+      let path = stat.project.worktree
+      if (path === "/") path = "/ (global)"
+      if (!stat.worktreeExists) path += " [deleted]"
+
+      const sessionsStr = stat.sessionCount.toString()
+      const lastActiveStr = stat.lastActive
+        ? new Date(stat.lastActive).toLocaleString("en-US", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : "never"
+
+      console.log(renderRow(path, sessionsStr, lastActiveStr))
+    }
+
+    // Footer
+    console.log("└" + "─".repeat(width - 2) + "┘")
+    console.log()
+    console.log(`Total: ${stats.length} projects, ${totalSessions} sessions`)
+    console.log()
+    return
+  }
+
+  console.log("└" + "─".repeat(width - 2) + "┘")
+  console.log()
+}
+
+function formatPath(path: string, maxLength: number): string {
+  if (path.length <= maxLength) return path
+
+  // Truncate in middle: /Users/.../path/to/project
+  const ellipsis = "..."
+  const keepStart = Math.floor((maxLength - ellipsis.length) / 2)
+  const keepEnd = maxLength - ellipsis.length - keepStart
+
+  return path.slice(0, keepStart) + ellipsis + path.slice(-keepEnd)
+}

--- a/packages/opencode/src/cli/cmd/projects.ts
+++ b/packages/opencode/src/cli/cmd/projects.ts
@@ -54,7 +54,7 @@ async function aggregateProjectStats(args: {
 
   // Show progress for large datasets
   if (projects.length > 50) {
-    console.log(`Processing ${projects.length} projects...`)
+    UI.println(`Processing ${projects.length} projects...`)
   }
 
   // Process in batches for performance
@@ -68,18 +68,25 @@ async function aggregateProjectStats(args: {
 
         // Get session keys for this project
         const sessionKeys = await Storage.list(["session", project.id])
+        // Read sessions in small batches to avoid overwhelming the filesystem
+        const SESSION_BATCH_SIZE = 20
+        const sessions: (Session.Info | null)[] = []
 
         // Find most recent session activity
         let lastActive: number | null = null
         if (sessionKeys.length > 0) {
           // Read sessions to find the latest time.updated
-          const sessions = await Promise.all(
-            sessionKeys.map((key) => Storage.read<Session.Info>(key).catch(() => null)),
-          )
+          for (let j = 0; j < sessionKeys.length; j += SESSION_BATCH_SIZE) {
+            const sessionBatchKeys = sessionKeys.slice(j, j + SESSION_BATCH_SIZE)
+            const sessionBatch = await Promise.all(
+              sessionBatchKeys.map((key) => Storage.read<Session.Info>(key).catch(() => null)),
+            )
+            sessions.push(...sessionBatch)
+          }
 
           for (const session of sessions) {
             if (session && session.time.updated) {
-              lastActive = !lastActive ? session.time.updated : Math.max(lastActive, session.time.updated)
+              lastActive = Math.max(lastActive ?? 0, session.time.updated)
             }
           }
         }
@@ -205,8 +212,32 @@ function clampWidth(input: number) {
 function wrapText(text: string, width: number): string[] {
   if (width <= 0) return [text]
   const lines: string[] = []
-  for (let i = 0; i < text.length; i += width) {
-    lines.push(text.slice(i, i + width))
+  let remaining = text
+
+  while (remaining.length > 0) {
+    if (remaining.length <= width) {
+      lines.push(remaining)
+      break
+    }
+
+    const candidate = remaining.slice(0, width)
+
+    // Prefer to break on path separators, then on spaces, within the width.
+    let breakIndex = candidate.lastIndexOf("/")
+    if (breakIndex <= 0) {
+      breakIndex = candidate.lastIndexOf(" ")
+    }
+
+    if (breakIndex > 0) {
+      // Include the separator/space in the current line to avoid dropping characters.
+      const line = remaining.slice(0, breakIndex + 1)
+      lines.push(line)
+      remaining = remaining.slice(breakIndex + 1)
+    } else {
+      // Fallback: hard wrap at the specified width.
+      lines.push(candidate)
+      remaining = remaining.slice(width)
+    }
   }
   return lines.length ? lines : [text]
 }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -15,6 +15,7 @@ import { FormatError } from "./cli/error"
 import { ServeCommand } from "./cli/cmd/serve"
 import { DebugCommand } from "./cli/cmd/debug"
 import { StatsCommand } from "./cli/cmd/stats"
+import { ProjectsCommand } from "./cli/cmd/projects"
 import { McpCommand } from "./cli/cmd/mcp"
 import { GithubCommand } from "./cli/cmd/github"
 import { ExportCommand } from "./cli/cmd/export"
@@ -94,6 +95,7 @@ const cli = yargs(hideBin(process.argv))
   .command(WebCommand)
   .command(ModelsCommand)
   .command(StatsCommand)
+  .command(ProjectsCommand)
   .command(ExportCommand)
   .command(ImportCommand)
   .command(GithubCommand)

--- a/packages/opencode/test/cli/projects.test.ts
+++ b/packages/opencode/test/cli/projects.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import { displayProjectStats } from "../../src/cli/cmd/projects"
+import type { Project } from "../../src/project/project"
+import { Locale } from "../../src/util/locale"
+
+describe("cli projects", () => {
+  test("renders full path with wrapping and aligned frame", () => {
+    const lines: string[] = []
+    const collect = (...message: string[]) => {
+      lines.push(...message)
+    }
+
+    const lastActive = Date.UTC(2024, 0, 1, 12, 30)
+    const longPath = "/very/long/path/to/a/project/that/should/wrap/without/ellipsis/because/we/want/full/visibility"
+    const project: Project.Info = {
+      id: "proj-1",
+      worktree: longPath,
+      vcs: "git",
+      sandboxes: [],
+      time: {
+        created: lastActive,
+        updated: lastActive,
+      },
+    }
+
+    displayProjectStats(
+      [
+        {
+          project,
+          sessionCount: 3,
+          lastActive,
+          worktreeExists: true,
+        },
+      ],
+      {},
+      collect,
+      { width: 90 },
+    )
+
+    const headerWidth = lines[0]?.length ?? 0
+    const formattedTime = Locale.todayTimeOrDateTime(lastActive)
+
+    // Frame alignment: all bordered lines share the same width
+    const borderedLines = lines.filter(
+      (line) => line.startsWith("┌") || line.startsWith("└") || line.startsWith("├") || line.startsWith("│"),
+    )
+    expect(borderedLines.every((line) => line.length === headerWidth)).toBe(true)
+
+    // No ellipsis truncation
+    expect(lines.some((line) => line.includes("..."))).toBe(false)
+
+    // Last active uses shared Locale formatting
+    expect(lines.some((line) => line.includes(formattedTime))).toBe(true)
+
+    // Path appears fully (start and end segments present across wrapped lines)
+    expect(lines.join("")).toContain(longPath.slice(0, 20))
+    expect(lines.join("")).toContain(longPath.slice(-20))
+  })
+})

--- a/packages/opencode/test/cli/projects.test.ts
+++ b/packages/opencode/test/cli/projects.test.ts
@@ -4,6 +4,20 @@ import type { Project } from "../../src/project/project"
 import { Locale } from "../../src/util/locale"
 
 describe("cli projects", () => {
+  const createProject = (id: string, worktree: string, timestamp?: number): Project.Info => {
+    const timeValue = timestamp ?? Date.UTC(2024, 0, 1, 12, 30)
+    return {
+      id,
+      worktree,
+      vcs: "git",
+      sandboxes: [],
+      time: {
+        created: timeValue,
+        updated: timeValue,
+      },
+    }
+  }
+
   test("renders full path with wrapping and aligned frame", () => {
     const lines: string[] = []
     const collect = (...message: string[]) => {
@@ -12,16 +26,7 @@ describe("cli projects", () => {
 
     const lastActive = Date.UTC(2024, 0, 1, 12, 30)
     const longPath = "/very/long/path/to/a/project/that/should/wrap/without/ellipsis/because/we/want/full/visibility"
-    const project: Project.Info = {
-      id: "proj-1",
-      worktree: longPath,
-      vcs: "git",
-      sandboxes: [],
-      time: {
-        created: lastActive,
-        updated: lastActive,
-      },
-    }
+    const project = createProject("proj-1", longPath, lastActive)
 
     displayProjectStats(
       [
@@ -37,23 +42,147 @@ describe("cli projects", () => {
       { width: 90 },
     )
 
-    const headerWidth = lines[0]?.length ?? 0
+    expect(lines.length).toBeGreaterThan(0)
+    const headerWidth = lines[0].length
     const formattedTime = Locale.todayTimeOrDateTime(lastActive)
 
-    // Frame alignment: all bordered lines share the same width
     const borderedLines = lines.filter(
       (line) => line.startsWith("┌") || line.startsWith("└") || line.startsWith("├") || line.startsWith("│"),
     )
     expect(borderedLines.every((line) => line.length === headerWidth)).toBe(true)
 
-    // No ellipsis truncation
     expect(lines.some((line) => line.includes("..."))).toBe(false)
-
-    // Last active uses shared Locale formatting
     expect(lines.some((line) => line.includes(formattedTime))).toBe(true)
-
-    // Path appears fully (start and end segments present across wrapped lines)
     expect(lines.join("")).toContain(longPath.slice(0, 20))
     expect(lines.join("")).toContain(longPath.slice(-20))
+  })
+
+  test("renders empty state when no projects", () => {
+    const lines: string[] = []
+    const collect = (...message: string[]) => {
+      lines.push(...message)
+    }
+
+    displayProjectStats([], {}, collect, { width: 90 })
+
+    const headerWidth = lines[0].length
+    const borderedLines = lines.filter(
+      (line) => line.startsWith("┌") || line.startsWith("└") || line.startsWith("├") || line.startsWith("│"),
+    )
+
+    expect(lines.some((line) => line.includes("No projects found"))).toBe(true)
+    expect(lines.some((line) => line.startsWith("Total:"))).toBe(false)
+    expect(borderedLines.every((line) => line.length === headerWidth)).toBe(true)
+  })
+
+  test("handles multiple projects with varied paths and totals", () => {
+    const lines: string[] = []
+    const collect = (...message: string[]) => {
+      lines.push(...message)
+    }
+
+    const shortPath = "/short"
+    const mediumPath = "/some/medium/path/that/stays/on_one_line"
+    const longPath =
+      "/projects/with/a/much/longer/path/that/should/wrap/to_multiple_lines/for_display/without_truncation"
+
+    const firstActive = Date.UTC(2024, 0, 2, 10, 0)
+    const secondActive = Date.UTC(2024, 0, 3, 15, 45)
+    const thirdActive = Date.UTC(2024, 0, 4, 8, 15)
+
+    displayProjectStats(
+      [
+        {
+          project: createProject("proj-1", shortPath, firstActive),
+          sessionCount: 1,
+          lastActive: firstActive,
+          worktreeExists: true,
+        },
+        {
+          project: createProject("proj-2", mediumPath, secondActive),
+          sessionCount: 5,
+          lastActive: secondActive,
+          worktreeExists: true,
+        },
+        {
+          project: createProject("proj-3", longPath, thirdActive),
+          sessionCount: 3,
+          lastActive: thirdActive,
+          worktreeExists: true,
+        },
+      ],
+      {},
+      collect,
+      { width: 90 },
+    )
+
+    const joined = lines.join("")
+    const totalLine = "Total: 3 projects, 9 sessions"
+
+    expect(joined).toContain(shortPath)
+    expect(joined).toContain(mediumPath)
+    expect(joined).toContain(longPath.slice(0, 25))
+    expect(joined).toContain(longPath.slice(-25))
+    expect(joined).toContain(totalLine)
+  })
+
+  test("shows never when last active is missing", () => {
+    const lines: string[] = []
+    const collect = (...message: string[]) => {
+      lines.push(...message)
+    }
+
+    const project = createProject("proj-4", "/no/sessions")
+
+    displayProjectStats(
+      [
+        {
+          project,
+          sessionCount: 0,
+          lastActive: null,
+          worktreeExists: true,
+        },
+      ],
+      {},
+      collect,
+      { width: 90 },
+    )
+
+    const joined = lines.join("")
+
+    expect(joined).toContain("0")
+    expect(joined).toContain("never")
+  })
+
+  test("clamps narrow widths and preserves frame", () => {
+    const lines: string[] = []
+    const collect = (...message: string[]) => {
+      lines.push(...message)
+    }
+
+    const longPath = "/a/path/that/will/wrap/when/clamped"
+
+    displayProjectStats(
+      [
+        {
+          project: createProject("proj-5", longPath),
+          sessionCount: 2,
+          lastActive: Date.UTC(2024, 0, 5, 9, 0),
+          worktreeExists: true,
+        },
+      ],
+      {},
+      collect,
+      { width: 40 },
+    )
+
+    const headerWidth = lines[0].length
+    const borderedLines = lines.filter(
+      (line) => line.startsWith("┌") || line.startsWith("└") || line.startsWith("├") || line.startsWith("│"),
+    )
+
+    expect(headerWidth).toBe(80)
+    expect(borderedLines.every((line) => line.length === headerWidth)).toBe(true)
+    expect(lines.some((line) => line.includes("..."))).toBe(false)
   })
 })


### PR DESCRIPTION
### What does this PR do?
Adds a projects CLI command that lists all known projects with session counts, last-activity timestamps, and worktree status. Output now wraps full paths (no truncation), aligns with existing CLI patterns (UI.println, Locale.todayTimeOrDateTime), supports sorting/limit/active-only flags, and keeps the table frame intact across terminal widths (clamped to 80–120, defaults to 100 when unknown).

### How did you verify your code works?
- Unit test: `bun test --cwd packages/opencode test/cli/projects.test.ts` (verifies wrapping, no ellipsis, locale time, aligned frame)
- Manual run on my machine: `bun run --cwd packages/opencode src/index.ts projects --sort activity` to see live output in the terminal.

Fixes #7545 