### PR TITLE
chore: remove unused debug scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
-    "random": "echo 'Random script'",
-    "hello": "echo 'Hello World!'",
     "test": "echo 'do not run tests from root' && exit 1"
   },
   "workspaces": {


### PR DESCRIPTION
Cleaned up legacy debug scripts in the root package.json. 
Why: Scripts like random and hello are placeholders used during development/testing. Removing them keeps the codebase professional and reduces noise for new contributors.
