### PR TITLE
fix(github): skip git config when using GITHUB_TOKEN to prevent duplicate Authorization header

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -654,6 +654,15 @@ async function configureGit(appToken: string) {
   // Do not change git config when running locally
   if (isMock()) return
 
+  // Skip git configuration when using GITHUB_TOKEN
+  // The GitHub Actions runner already has proper authentication configured
+  if (useEnvGithubToken()) {
+    console.log("Skipping git config (using GitHub TOKEN)")
+    await $`git config --global user.name "opencode-agent[bot]"`
+    await $`git config --global user.email "opencode-agent[bot]@users.noreply.github.com"`
+    return
+  }
+
   console.log("Configuring git...")
   const config = "http.https://github.com/.extraheader"
   const ret = await $`git config --local --get ${config}`
@@ -668,6 +677,9 @@ async function configureGit(appToken: string) {
 }
 
 async function restoreGitConfig() {
+  // Skip restoration when using GITHUB_TOKEN (we didn't modify config)
+  if (useEnvGithubToken()) return
+
   if (gitConfig === undefined) return
   console.log("Restoring git config...")
   const config = "http.https://github.com/.extraheader"


### PR DESCRIPTION
## Problem

When using opencode GitHub action without the `TOKEN` parameter, the action configures git authentication by setting `http.https://github.com/.extraheader` with an `AUTHORIZATION` header. This conflicts with GitHub Actions' built-in authentication, causing the error:

``
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/.../': The requested URL returned error: 400
``

This happens when `git push` is executed.

## Root Cause

The `configureGit()` function always sets git config with custom authentication header, even when the GitHub Actions runner already has proper authentication configured via GITHUB_TOKEN (provided by GitHub Actions or passed via `TOKEN` parameter).

## Solution

Modified `configureGit()` and `restoreGitConfig()` to:
1. Check if `TOKEN` environment variable is set (via `useEnvGithubToken()`)
2. When `TOKEN` is set, skip configuring `http.https://github.com/.extraheader`
3. Only configure git user.name and git user.email
4. Also skip `restoreGitConfig()` when using GITHUB_TOKEN

This prevents the duplicate Authorization header error because:
- GitHub Actions runner already has proper credentials configured
- We don't add conflicting authentication headers
- Git operations work with the runner's existing authentication

## Testing

Users experiencing the error can either:
1. Add `token: \\` to their workflow (explicitly use GITHUB_TOKEN)
2. Update to this version of the action (automatic fix)

## Related Issue

Fixes #7325