### PR TITLE
fix(tui): prevent crash when input is undefined in prompt set

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -466,6 +466,7 @@ export function Prompt(props: PromptProps) {
       input.blur()
     },
     set(prompt) {
+      if (!input) return;
       input.setText(prompt.input)
       setStore("prompt", prompt)
       restoreExtmarksFromParts(prompt.parts)


### PR DESCRIPTION
I added defensive checks for the input object in set() and onSelect callbacks. While this specific race condition is hard to reproduce locally, this change directly addresses the undefined error reported in #7528 by ensuring setText is only called on a valid object.