### PR TITLE
fix: add timeout to git commands to prevent Zed extension hang on Win…

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -16,6 +16,24 @@ import { existsSync } from "fs"
 
 export namespace Project {
   const log = Log.create({ service: "project" })
+
+  // Helper function to run git commands with timeout to prevent hangs
+  async function gitWithTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number = 5000,
+    fallback: T
+  ): Promise<T> {
+    return Promise.race([
+      promise,
+      new Promise<T>((resolve) => 
+        setTimeout(() => {
+          log.warn("git command timed out, falling back to non-git behavior", { timeoutMs })
+          resolve(fallback)
+        }, timeoutMs)
+      )
+    ])
+  }
+
   export const Info = z
     .object({
       id: z.string(),
@@ -73,19 +91,23 @@ export namespace Project {
 
         // generate id from root commit
         if (!id) {
-          const roots = await $`git rev-list --max-parents=0 --all`
-            .quiet()
-            .nothrow()
-            .cwd(sandbox)
-            .text()
-            .then((x) =>
-              x
-                .split("\n")
-                .filter(Boolean)
-                .map((x) => x.trim())
-                .toSorted(),
-            )
-            .catch(() => undefined)
+          const roots = await gitWithTimeout(
+            $`git rev-list --max-parents=0 --all`
+              .quiet()
+              .nothrow()
+              .cwd(sandbox)
+              .text()
+              .then((x) =>
+                x
+                  .split("\n")
+                  .filter(Boolean)
+                  .map((x) => x.trim())
+                  .toSorted(),
+              )
+              .catch(() => undefined),
+            5000,
+            undefined
+          )
 
           if (!roots) {
             return {
@@ -113,13 +135,17 @@ export namespace Project {
           }
         }
 
-        const top = await $`git rev-parse --show-toplevel`
-          .quiet()
-          .nothrow()
-          .cwd(sandbox)
-          .text()
-          .then((x) => path.resolve(sandbox, x.trim()))
-          .catch(() => undefined)
+        const top = await gitWithTimeout(
+          $`git rev-parse --show-toplevel`
+            .quiet()
+            .nothrow()
+            .cwd(sandbox)
+            .text()
+            .then((x) => path.resolve(sandbox, x.trim()))
+            .catch(() => undefined),
+          5000,
+          undefined
+        )
 
         if (!top) {
           return {
@@ -132,17 +158,21 @@ export namespace Project {
 
         sandbox = top
 
-        const worktree = await $`git rev-parse --git-common-dir`
-          .quiet()
-          .nothrow()
-          .cwd(sandbox)
-          .text()
-          .then((x) => {
-            const dirname = path.dirname(x.trim())
-            if (dirname === ".") return sandbox
-            return dirname
-          })
-          .catch(() => undefined)
+        const worktree = await gitWithTimeout(
+          $`git rev-parse --git-common-dir`
+            .quiet()
+            .nothrow()
+            .cwd(sandbox)
+            .text()
+            .then((x) => {
+              const dirname = path.dirname(x.trim())
+              if (dirname === ".") return sandbox
+              return dirname
+            })
+            .catch(() => undefined),
+          5000,
+          undefined
+        )
 
         if (!worktree) {
           return {


### PR DESCRIPTION
Summary
Fixes the OpenCode extension hanging indefinitely on "Loading..." when opening Git repositories in Zed editor on Windows.
 
 Problem
When opening a Git repository in Zed on Windows, three git commands in `Project.fromDirectory()` would hang indefinitely:
- `git rev-list --max-parents=0 --all` (project ID generation)
- `git rev-parse --show-toplevel` (repository root detection)  
- `git rev-parse --git-common-dir` (worktree detection)
This caused the Zed extension to freeze during initialization, preventing users from using the OpenCode assistant in any Git repository.
 
 Root Cause
The issue was initially reported as a Zed bug in zed-industries/zed#43335, but investigation revealed it was an OpenCode bug. The git commands were executed without any timeout mechanism, causing indefinite hangs on Windows when called through the Zed Agent Communication Protocol.
 
 Solution
Added a `gitWithTimeout()` helper function that wraps git command promises with a 5-second timeout using `Promise.race()`. When a timeout occurs:
- Logs a warning message for debugging (`log.warn`)
- Returns the fallback value (undefined)
- Triggers existing fallback logic (already in place for when git commands fail)
- Gracefully degrades to non-git behavior instead of hanging
The timeout is conservative enough (5 seconds) that it won't affect normal git operations on any platform, but prevents indefinite hangs.
 
 Testing
-  Tested on Windows 11 with Zed 0.218.6
-  Confirmed extension now loads successfully in Git repositories
- Binary built and tested locally with the patched code
- No impact on non-Windows platforms (timeout is generous for normal operations)
- Fallback behavior works correctly when timeout is triggered
 
 Related Issues
- Closes the OpenCode hang issue reported in zed-industries/zed#43335 (was initially thought to be a Zed bug, but root cause was in OpenCode)
 
 Changes
- Added `gitWithTimeout()` helper function in `packages/opencode/src/project/project.ts`
- Wrapped three git commands with timeout protection
- Added warning log when timeout occurs for debugging purposes

Fixes #7587