### PR TITLE
feat(tui): add contextual labels for some toggle commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -211,6 +211,8 @@ function App() {
     renderer.clearSelection()
   }
   const [terminalTitleEnabled, setTerminalTitleEnabled] = createSignal(kv.get("terminal_title_enabled", true))
+  const [showConsole, setShowConsole] = createSignal(false)
+  const [showDebugPanel, setShowDebugPanel] = createSignal(false)
 
   createEffect(() => {
     console.log(JSON.stringify(route.data))
@@ -477,20 +479,22 @@ function App() {
       category: "System",
     },
     {
-      title: "Toggle debug panel",
+      title: showDebugPanel() ? "Hide debug panel" : "Show debug panel",
       category: "System",
       value: "app.debug",
       onSelect: (dialog) => {
         renderer.toggleDebugOverlay()
+        setShowDebugPanel((prev) => !prev)
         dialog.clear()
       },
     },
     {
-      title: "Toggle console",
+      title: showConsole() ? "Hide console" : "Show console",
       category: "System",
       value: "app.console",
       onSelect: (dialog) => {
         renderer.console.toggle()
+        setShowConsole((prev) => !prev)
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -492,7 +492,7 @@ export function Session() {
       },
     },
     {
-      title: "Toggle diff wrapping",
+      title: diffWrapMode() === "word" ? "Hide diff wrapping" : "Show diff wrapping",
       value: "session.toggle.diffwrap",
       category: "Session",
       onSelect: (dialog) => {
@@ -511,7 +511,7 @@ export function Session() {
       },
     },
     {
-      title: "Toggle session scrollbar",
+      title: showScrollbar() ? "Hide session scrollbar" : "Show session scrollbar",
       value: "session.toggle.scrollbar",
       keybind: "scrollbar_toggle",
       category: "Session",


### PR DESCRIPTION
### What does this PR do?

Brings the UI for `Toggle debug panel`, `Toggle console`, `Toggle diff wrapping` and `Toggle session scrollbar` commands in line with other toggle commands by enabling contextual labels about their current state.

### How did you verify your code works?

Manual testing. Screenshots attached below

<img width="454" height="181" alt="SCR-20260110-egyx" src="https://github.com/user-attachments/assets/9486837d-9430-48a8-bb0f-df13f996087a" />
<img width="857" height="468" alt="SCR-20260110-ehdp" src="https://github.com/user-attachments/assets/d0cbcb6d-62c5-4083-b2b1-af57b75eb3f1" />
<img width="859" height="748" alt="SCR-20260110-ehiu" src="https://github.com/user-attachments/assets/759e8580-c9d3-4c3e-b0ad-698b7bfe17d9" />