### PR TITLE
fix: allow model variants in OAuth Codex filter

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -314,9 +314,13 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         if (auth.type !== "oauth") return {}
 
         // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set(["gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-codex"])
+        // Allow base models and their variants (e.g., gpt-5.2-codex-low, gpt-5.2-codex-high)
+        const allowedBaseModels = ["gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-codex"]
         for (const modelId of Object.keys(provider.models)) {
-          if (!allowedModels.has(modelId)) {
+          const isAllowed = allowedBaseModels.some(
+            (base) => modelId === base || modelId.startsWith(base + "-"),
+          )
+          if (!isAllowed) {
             delete provider.models[modelId]
           }
         }


### PR DESCRIPTION
## Summary
- Fixed model variant filtering in Codex OAuth plugin to allow user-defined variants
- Previously only exact model IDs were allowed (e.g., `gpt-5.2-codex`)
- Now variants like `gpt-5.2-codex-low`, `gpt-5.2-codex-high`, `gpt-5.2-codex-xhigh` are also allowed

## Problem
Users who defined custom reasoning effort variants in their `opencode.json` under the `openai` provider found that these variants were being filtered out by the Codex plugin's OAuth loader.

## Solution
Changed the filter logic from exact Set matching to prefix-based matching.

Fixes #7593