### PR TITLE
docs: Add opencode-canvas plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                     |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control      |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
+| [opencode-canvas](https://github.com/mailshieldai/opencode-canvas)                                 | Interactive terminal canvases for calendars, documents, and flight booking in tmux splits      |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                      |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                          |
 


### PR DESCRIPTION
## Summary

Adds [opencode-canvas](https://github.com/mailshieldai/opencode-canvas) to the ecosystem page.

**opencode-canvas** is a plugin that gives OpenCode its own display. Instead of text-only responses, the AI can spawn interactive terminal interfaces in tmux split panes.

### Features

- **Calendar views** - Visual date pickers, event displays, and meeting time selection
- **Document editors** - Rich markdown rendering with text selection support
- **Flight booking** - Interactive flight search with seat map selection
- **IPC communication** - Real-time bidirectional updates between OpenCode and canvases

### Tools Provided

| Tool | Description |
|------|-------------|
| `canvas_spawn` | Create a new canvas (calendar, document, or flight) in a tmux split |
| `canvas_update` | Update canvas state via IPC |
| `canvas_selection` | Get current selection from canvas (dates, text, seats) |
| `canvas_close` | Close a canvas session |

### Installation

```bash
npm install @mailshieldai/opencode-canvas
```

Add to `opencode.jsonc`:
```jsonc
{
  "plugin": ["@mailshieldai/opencode-canvas"],
  "permission": {
    "canvas_*": "allow"
  }
}
```

### Requirements

- [Bun](https://bun.sh) - JavaScript runtime
- [tmux](https://github.com/tmux/tmux) - Canvases spawn in split panes
- [OpenCode](https://opencode.ai) - AI coding assistant

Based on [claude-canvas](https://github.com/dvdsgl/claude-canvas) by David Siegel, adapted for OpenCode.