### PR TITLE
fix(sdk): improve JSON parsing error handling with contextual messages

### DIFF
--- a/packages/sdk/js/src/gen/client/client.gen.ts
+++ b/packages/sdk/js/src/gen/client/client.gen.ts
@@ -114,9 +114,40 @@ export const createClient = (config: Config = {}): Client => {
         case "arrayBuffer":
         case "blob":
         case "formData":
-        case "json":
         case "text":
           data = await response[parseAs]()
+          break
+        case "json":
+          try {
+            data = await response.json()
+          } catch (parseError) {
+            // Handle JSON parsing errors with more context
+            const errorMessage = parseError instanceof Error ? parseError.message : String(parseError)
+            const enhancedError = new Error(
+              `Failed to parse JSON response: ${errorMessage}. ` +
+                `Status: ${response.status}, URL: ${response.url}`
+            )
+            ;(enhancedError as any).cause = parseError
+            ;(enhancedError as any).response = response
+
+            let finalError: unknown = enhancedError
+            for (const fn of interceptors.error._fns) {
+              if (fn) {
+                finalError = await fn(enhancedError, response, request, opts)
+              }
+            }
+
+            if (opts.throwOnError) {
+              throw finalError
+            }
+
+            return opts.responseStyle === "data"
+              ? undefined
+              : {
+                  error: finalError,
+                  ...result,
+                }
+          }
           break
         case "stream":
           return opts.responseStyle === "data"

--- a/packages/sdk/js/src/v2/gen/client/client.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/client.gen.ts
@@ -162,9 +162,40 @@ export const createClient = (config: Config = {}): Client => {
         case "arrayBuffer":
         case "blob":
         case "formData":
-        case "json":
         case "text":
           data = await response[parseAs]()
+          break
+        case "json":
+          try {
+            data = await response.json()
+          } catch (parseError) {
+            // Handle JSON parsing errors with more context
+            const errorMessage = parseError instanceof Error ? parseError.message : String(parseError)
+            const enhancedError = new Error(
+              `Failed to parse JSON response: ${errorMessage}. ` +
+                `Status: ${response.status}, URL: ${response.url}`
+            )
+            ;(enhancedError as any).cause = parseError
+            ;(enhancedError as any).response = response
+
+            let finalError: unknown = enhancedError
+            for (const fn of interceptors.error.fns) {
+              if (fn) {
+                finalError = await fn(enhancedError, response, request, opts)
+              }
+            }
+
+            if (opts.throwOnError) {
+              throw finalError
+            }
+
+            return opts.responseStyle === "data"
+              ? undefined
+              : {
+                  error: finalError,
+                  ...result,
+                }
+          }
           break
         case "stream":
           return opts.responseStyle === "data"


### PR DESCRIPTION
## Summary

When API responses return empty or malformed JSON (e.g., network interruption, API timeout, truncated response), the SDK now provides actionable error messages instead of cryptic `SyntaxError: Unexpected end of JSON input`.

## Problem

The current implementation calls `response.json()` directly without error handling:

```typescript
case "json":
  data = await response[parseAs]()  // Throws unhelpful error on malformed JSON
  break
```

When the API returns an incomplete response, users see:
```
SyntaxError: Unexpected end of JSON input
    at json (unknown)
    at <anonymous> (../sdk/js/src/v2/gen/client/client.gen.ts:167:33)
```

This provides no context about what went wrong or how to debug it.

## Solution

Wrap `response.json()` in try-catch and provide enhanced error messages:

- Include HTTP status code
- Include request URL
- Preserve original error as `cause` for debugging
- Route errors through interceptors for custom handling

**After this fix:**
```
Error: Failed to parse JSON response: Unexpected end of JSON input. Status: 200, URL: https://api.example.com/v1/chat
```

## Changes

- `packages/sdk/js/src/v2/gen/client/client.gen.ts` - v2 client
- `packages/sdk/js/src/gen/client/client.gen.ts` - v1 client

## Note

These files are auto-generated by `@hey-api/openapi-ts`. This is a temporary fix until upstream handles JSON parsing errors gracefully. The fix will need to be reapplied after regeneration, or ideally contributed upstream to `@hey-api/client-fetch`.