### PR TITLE
docs: Numbered list not visible + not suitable in zen.mdx

### DIFF
--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -237,7 +237,7 @@ and you want to use that instead of the one that Zen provides.
 
 We created OpenCode Zen to:
 
-1. **Benchmark** the best models/providers for coding agents.
-2. Have access to the **highest quality** options and not downgrade performance or route to cheaper providers.
-3. Pass along any **price drops** by selling at cost; so the only markup is to cover our processing fees.
-4. Have **no lock-in** by allowing you to use it with any other coding agent. And always let you use any other provider with OpenCode as well.
+- **Benchmark** the best models/providers for coding agents.
+- Have access to the **highest quality** options and not downgrade performance or route to cheaper providers.
+- Pass along any **price drops** by selling at cost; so the only markup is to cover our processing fees.
+- Have **no lock-in** by allowing you to use it with any other coding agent. And always let you use any other provider with OpenCode as well.


### PR DESCRIPTION
The numbered list at the end of `zen.mdx` is not visible. This list works better as an unordered list, as it doesn't describe a set of actions but a list of things.

<img width="1354" height="1240" alt="open-code-pr" src="https://github.com/user-attachments/assets/6346c441-feda-496e-bd31-793c27dcfafc" />

### What does this PR do?

Small fix at the end of the `zen.mdx` documentation file, where an invisible ordered list is replaced by an unordered one.

### How did you verify your code works?

No code is involved; just a markup update to one OpenCode document.