### PR TITLE
feat: switch mode tool

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -16,6 +16,7 @@ import {
   type LspStatus,
   type VcsInfo,
   type PermissionRequest,
+  type ModeSwitchRequest,
   createOpencodeClient,
 } from "@opencode-ai/sdk/v2/client"
 import { createStore, produce, reconcile } from "solid-js/store"
@@ -47,6 +48,9 @@ type State = {
   }
   permission: {
     [sessionID: string]: PermissionRequest[]
+  }
+  modeswitch: {
+    [sessionID: string]: ModeSwitchRequest[]
   }
   mcp: {
     [name: string]: McpStatus
@@ -96,6 +100,7 @@ function createGlobalSync() {
         session_diff: {},
         todo: {},
         permission: {},
+        modeswitch: {},
         mcp: {},
         lsp: [],
         vcs: undefined,
@@ -197,6 +202,38 @@ function createGlobalSync() {
                   reconcile(
                     permissions
                       .filter((p) => !!p?.id)
+                      .slice()
+                      .sort((a, b) => a.id.localeCompare(b.id)),
+                    { key: "id" },
+                  ),
+                )
+              }
+            })
+          }),
+          sdk.modeswitch.list().then((x) => {
+            const grouped: Record<string, ModeSwitchRequest[]> = {}
+            for (const req of x.data ?? []) {
+              if (!req?.id || !req.sessionID) continue
+              const existing = grouped[req.sessionID]
+              if (existing) {
+                existing.push(req)
+                continue
+              }
+              grouped[req.sessionID] = [req]
+            }
+
+            batch(() => {
+              for (const sessionID of Object.keys(store.modeswitch)) {
+                if (grouped[sessionID]) continue
+                setStore("modeswitch", sessionID, [])
+              }
+              for (const [sessionID, requests] of Object.entries(grouped)) {
+                setStore(
+                  "modeswitch",
+                  sessionID,
+                  reconcile(
+                    requests
+                      .filter((r) => !!r?.id)
                       .slice()
                       .sort((a, b) => a.id.localeCompare(b.id)),
                     { key: "id" },
@@ -386,6 +423,43 @@ function createGlobalSync() {
         if (!result.found) break
         setStore(
           "permission",
+          event.properties.sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 1)
+          }),
+        )
+        break
+      }
+      case "modeswitch.asked": {
+        const sessionID = event.properties.sessionID
+        const requests = store.modeswitch[sessionID]
+        if (!requests) {
+          setStore("modeswitch", sessionID, [event.properties])
+          break
+        }
+
+        const result = Binary.search(requests, event.properties.id, (r) => r.id)
+        if (result.found) {
+          setStore("modeswitch", sessionID, result.index, reconcile(event.properties))
+          break
+        }
+
+        setStore(
+          "modeswitch",
+          sessionID,
+          produce((draft) => {
+            draft.splice(result.index, 0, event.properties)
+          }),
+        )
+        break
+      }
+      case "modeswitch.replied": {
+        const requests = store.modeswitch[event.properties.sessionID]
+        if (!requests) break
+        const result = Binary.search(requests, event.properties.requestID, (r) => r.id)
+        if (!result.found) break
+        setStore(
+          "modeswitch",
           event.properties.sessionID,
           produce((draft) => {
             draft.splice(result.index, 1)

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -2,7 +2,7 @@ import { createMemo, Show, type ParentProps } from "solid-js"
 import { useNavigate, useParams } from "@solidjs/router"
 import { SDKProvider, useSDK } from "@/context/sdk"
 import { SyncProvider, useSync } from "@/context/sync"
-import { LocalProvider } from "@/context/local"
+import { LocalProvider, useLocal } from "@/context/local"
 
 import { base64Decode } from "@opencode-ai/util/encode"
 import { DataProvider } from "@opencode-ai/ui/context"
@@ -18,30 +18,46 @@ export default function Layout(props: ParentProps) {
     <Show when={params.dir} keyed>
       <SDKProvider directory={directory()}>
         <SyncProvider>
-          {iife(() => {
-            const sync = useSync()
-            const sdk = useSDK()
-            const respond = (input: {
-              sessionID: string
-              permissionID: string
-              response: "once" | "always" | "reject"
-            }) => sdk.client.permission.respond(input)
+          <LocalProvider>
+            {iife(() => {
+              const sync = useSync()
+              const sdk = useSDK()
+              const local = useLocal()
+              const respond = (input: {
+                sessionID: string
+                permissionID: string
+                response: "once" | "always" | "reject"
+              }) => sdk.client.permission.respond(input)
 
-            const navigateToSession = (sessionID: string) => {
-              navigate(`/${params.dir}/session/${sessionID}`)
-            }
+              const respondToModeSwitch = (input: {
+                sessionID: string
+                requestID: string
+                response: "approve" | "reject"
+                targetMode?: string
+              }) => {
+                sdk.client.modeswitch.reply({ requestID: input.requestID, reply: input.response })
+                if (input.response === "approve" && input.targetMode) {
+                  local.agent.set(input.targetMode)
+                }
+              }
 
-            return (
-              <DataProvider
-                data={sync.data}
-                directory={directory()}
-                onPermissionRespond={respond}
-                onNavigateToSession={navigateToSession}
-              >
-                <LocalProvider>{props.children}</LocalProvider>
-              </DataProvider>
-            )
-          })}
+              const navigateToSession = (sessionID: string) => {
+                navigate(`/${params.dir}/session/${sessionID}`)
+              }
+
+              return (
+                <DataProvider
+                  data={sync.data}
+                  directory={directory()}
+                  onPermissionRespond={respond}
+                  onModeSwitchRespond={respondToModeSwitch}
+                  onNavigateToSession={navigateToSession}
+                >
+                  {props.children}
+                </DataProvider>
+              )
+            })}
+          </LocalProvider>
         </SyncProvider>
       </SDKProvider>
     </Show>

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -9,6 +9,7 @@ import type {
   Command,
   PermissionRequest,
   QuestionRequest,
+  ModeSwitchRequest,
   LspStatus,
   McpStatus,
   McpResource,
@@ -45,6 +46,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       }
       question: {
         [sessionID: string]: QuestionRequest[]
+      }
+      modeswitch: {
+        [sessionID: string]: ModeSwitchRequest[]
       }
       config: Config
       session: Session[]
@@ -85,6 +89,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       agent: [],
       permission: {},
       question: {},
+      modeswitch: {},
       command: [],
       provider: [],
       provider_default: {},
@@ -177,6 +182,43 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           }
           setStore(
             "question",
+            request.sessionID,
+            produce((draft) => {
+              draft.splice(match.index, 0, request)
+            }),
+          )
+          break
+        }
+
+        case "modeswitch.replied": {
+          const requests = store.modeswitch[event.properties.sessionID]
+          if (!requests) break
+          const match = Binary.search(requests, event.properties.requestID, (r) => r.id)
+          if (!match.found) break
+          setStore(
+            "modeswitch",
+            event.properties.sessionID,
+            produce((draft) => {
+              draft.splice(match.index, 1)
+            }),
+          )
+          break
+        }
+
+        case "modeswitch.asked": {
+          const request = event.properties
+          const requests = store.modeswitch[request.sessionID]
+          if (!requests) {
+            setStore("modeswitch", request.sessionID, [request])
+            break
+          }
+          const match = Binary.search(requests, request.id, (r) => r.id)
+          if (match.found) {
+            setStore("modeswitch", request.sessionID, match.index, reconcile(request))
+            break
+          }
+          setStore(
+            "modeswitch",
             request.sessionID,
             produce((draft) => {
               draft.splice(match.index, 0, request)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -71,6 +71,7 @@ import { useExit } from "../../context/exit"
 import { Filesystem } from "@/util/filesystem"
 import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
+import { ModeSwitchPrompt } from "./modeswitch"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 
@@ -125,6 +126,10 @@ export function Session() {
   const questions = createMemo(() => {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.question[x.id] ?? [])
+  })
+  const modeswitches = createMemo(() => {
+    if (session()?.parentID) return []
+    return children().flatMap((x) => sync.data.modeswitch[x.id] ?? [])
   })
 
   const pending = createMemo(() => {
@@ -1011,8 +1016,16 @@ export function Session() {
               <Show when={permissions().length === 0 && questions().length > 0}>
                 <QuestionPrompt request={questions()[0]} />
               </Show>
+              <Show when={permissions().length === 0 && questions().length === 0 && modeswitches().length > 0}>
+                <ModeSwitchPrompt request={modeswitches()[0]} />
+              </Show>
               <Prompt
-                visible={!session()?.parentID && permissions().length === 0 && questions().length === 0}
+                visible={
+                  !session()?.parentID &&
+                  permissions().length === 0 &&
+                  questions().length === 0 &&
+                  modeswitches().length === 0
+                }
                 ref={(r) => {
                   prompt = r
                   promptRef.set(r)
@@ -1021,7 +1034,7 @@ export function Session() {
                     r.set(route.initialPrompt)
                   }
                 }}
-                disabled={permissions().length > 0 || questions().length > 0}
+                disabled={permissions().length > 0 || questions().length > 0 || modeswitches().length > 0}
                 onSubmit={() => {
                   toBottom()
                 }}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/modeswitch.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/modeswitch.tsx
@@ -1,0 +1,120 @@
+import { createStore } from "solid-js/store"
+import { For } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
+import { useKeybind } from "../../context/keybind"
+import { useTheme, selectedForeground } from "../../context/theme"
+import { useSDK } from "../../context/sdk"
+import { SplitBorder } from "../../component/border"
+import { useLocal } from "../../context/local"
+import type { ModeSwitchRequest } from "@opencode-ai/sdk/v2"
+
+export function ModeSwitchPrompt(props: { request: ModeSwitchRequest }) {
+  const sdk = useSDK()
+  const local = useLocal()
+  const { theme } = useTheme()
+  const keybind = useKeybind()
+
+  const [store, setStore] = createStore({
+    selected: 0 as 0 | 1,
+  })
+
+  const options = ["Approve", "Reject"] as const
+
+  function approve() {
+    sdk.client.modeswitch.reply({
+      requestID: props.request.id,
+      reply: "approve",
+    })
+    local.agent.set(props.request.targetMode)
+  }
+
+  function reject() {
+    sdk.client.modeswitch.reply({
+      requestID: props.request.id,
+      reply: "reject",
+    })
+  }
+
+  useKeyboard((evt) => {
+    if (evt.name === "left" || evt.name === "h") {
+      evt.preventDefault()
+      setStore("selected", store.selected === 0 ? 1 : 0)
+    }
+
+    if (evt.name === "right" || evt.name === "l") {
+      evt.preventDefault()
+      setStore("selected", store.selected === 0 ? 1 : 0)
+    }
+
+    if (evt.name === "return") {
+      evt.preventDefault()
+      if (store.selected === 0) {
+        approve()
+      } else {
+        reject()
+      }
+    }
+
+    if (evt.name === "escape" || keybind.match("app_exit", evt)) {
+      evt.preventDefault()
+      reject()
+    }
+  })
+
+  return (
+    <box
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.success}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <box flexDirection="row" gap={1} paddingLeft={1}>
+          <text fg={theme.success}>{"▣"}</text>
+          <text fg={theme.text}>Switch to Build Mode?</text>
+        </box>
+        <box paddingLeft={1}>
+          <text fg={theme.textMuted}>The assistant is ready to implement the plan.</text>
+        </box>
+        <box paddingLeft={1}>
+          <text fg={theme.text}>{props.request.reason}</text>
+        </box>
+      </box>
+      <box
+        flexDirection="row"
+        flexShrink={0}
+        gap={1}
+        paddingTop={1}
+        paddingLeft={2}
+        paddingRight={3}
+        paddingBottom={1}
+        backgroundColor={theme.backgroundElement}
+        justifyContent="space-between"
+      >
+        <box flexDirection="row" gap={1}>
+          <For each={options}>
+            {(option, index) => (
+              <box
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={index() === store.selected ? theme.success : theme.backgroundMenu}
+              >
+                <text fg={index() === store.selected ? selectedForeground(theme, theme.success) : theme.textMuted}>
+                  {option}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+        <box flexDirection="row" gap={2}>
+          <text fg={theme.text}>
+            {"⇆"} <span style={{ fg: theme.textMuted }}>select</span>
+          </text>
+          <text fg={theme.text}>
+            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -7,6 +7,7 @@ export namespace Identifier {
     message: "msg",
     permission: "per",
     question: "que",
+    modeswitch: "msw",
     user: "usr",
     part: "prt",
     pty: "pty",

--- a/packages/opencode/src/mode-switch/index.ts
+++ b/packages/opencode/src/mode-switch/index.ts
@@ -1,0 +1,128 @@
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { Identifier } from "@/id/id"
+import { Instance } from "@/project/instance"
+import { Log } from "@/util/log"
+import { Session } from "@/session"
+import z from "zod"
+
+export namespace ModeSwitch {
+  const log = Log.create({ service: "mode-switch" })
+
+  export const Request = z
+    .object({
+      id: Identifier.schema("modeswitch"),
+      sessionID: Identifier.schema("session"),
+      targetMode: z.string().describe("The mode to switch to"),
+      reason: z.string().describe("Why the LLM wants to switch modes"),
+      tool: z
+        .object({
+          messageID: z.string(),
+          callID: z.string(),
+        })
+        .optional(),
+    })
+    .meta({
+      ref: "ModeSwitchRequest",
+    })
+  export type Request = z.infer<typeof Request>
+
+  export const Reply = z.enum(["approve", "reject"])
+  export type Reply = z.infer<typeof Reply>
+
+  export const Event = {
+    Asked: BusEvent.define("modeswitch.asked", Request),
+    Replied: BusEvent.define(
+      "modeswitch.replied",
+      z.object({
+        sessionID: z.string(),
+        requestID: z.string(),
+        reply: Reply,
+      }),
+    ),
+  }
+
+  const state = Instance.state(async () => {
+    const pending: Record<
+      string,
+      {
+        info: Request
+        resolve: (approved: boolean) => void
+        reject: (e: any) => void
+      }
+    > = {}
+
+    return {
+      pending,
+    }
+  })
+
+  export async function ask(input: {
+    sessionID: string
+    targetMode: string
+    reason: string
+    tool?: { messageID: string; callID: string }
+  }): Promise<boolean> {
+    const s = await state()
+    const id = Identifier.ascending("modeswitch")
+
+    log.info("asking", { id, targetMode: input.targetMode, reason: input.reason })
+
+    return new Promise<boolean>((resolve, reject) => {
+      const info: Request = {
+        id,
+        sessionID: input.sessionID,
+        targetMode: input.targetMode,
+        reason: input.reason,
+        tool: input.tool,
+      }
+      s.pending[id] = {
+        info,
+        resolve,
+        reject,
+      }
+      Bus.publish(Event.Asked, info)
+    })
+  }
+
+  export async function reply(input: { requestID: string; reply: Reply }): Promise<void> {
+    const s = await state()
+    const existing = s.pending[input.requestID]
+    if (!existing) {
+      log.warn("reply for unknown request", { requestID: input.requestID })
+      return
+    }
+    delete s.pending[input.requestID]
+
+    log.info("replied", { requestID: input.requestID, reply: input.reply })
+
+    if (input.reply === "approve") {
+      const messages = await Session.messages({ sessionID: existing.info.sessionID })
+      const lastUserMsg = messages.findLast((m) => m.info.role === "user")
+      if (lastUserMsg?.info.role === "user") {
+        await Session.updateMessage({
+          ...lastUserMsg.info,
+          agent: existing.info.targetMode,
+        })
+      }
+    }
+
+    Bus.publish(Event.Replied, {
+      sessionID: existing.info.sessionID,
+      requestID: existing.info.id,
+      reply: input.reply,
+    })
+
+    existing.resolve(input.reply === "approve")
+  }
+
+  export class RejectedError extends Error {
+    constructor() {
+      super("The user rejected the mode switch request")
+    }
+  }
+
+  export async function list() {
+    return state().then((x) => Object.values(x.pending).map((x) => x.info))
+  }
+}

--- a/packages/opencode/src/server/modeswitch.ts
+++ b/packages/opencode/src/server/modeswitch.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono"
+import { describeRoute, validator } from "hono-openapi"
+import { resolver } from "hono-openapi"
+import { ModeSwitch } from "../mode-switch"
+import z from "zod"
+import { errors } from "./error"
+
+export const ModeSwitchRoute = new Hono()
+  .get(
+    "/",
+    describeRoute({
+      summary: "List pending mode switch requests",
+      description: "Get all pending mode switch requests across all sessions.",
+      operationId: "modeswitch.list",
+      responses: {
+        200: {
+          description: "List of pending mode switch requests",
+          content: {
+            "application/json": {
+              schema: resolver(ModeSwitch.Request.array()),
+            },
+          },
+        },
+      },
+    }),
+    async (c) => {
+      const requests = await ModeSwitch.list()
+      return c.json(requests)
+    },
+  )
+  .post(
+    "/:requestID/reply",
+    describeRoute({
+      summary: "Reply to mode switch request",
+      description: "Approve or reject a mode switch request from the AI assistant.",
+      operationId: "modeswitch.reply",
+      responses: {
+        200: {
+          description: "Mode switch request handled successfully",
+          content: {
+            "application/json": {
+              schema: resolver(z.boolean()),
+            },
+          },
+        },
+        ...errors(400, 404),
+      },
+    }),
+    validator(
+      "param",
+      z.object({
+        requestID: z.string(),
+      }),
+    ),
+    validator(
+      "json",
+      z.object({
+        reply: ModeSwitch.Reply,
+      }),
+    ),
+    async (c) => {
+      const params = c.req.valid("param")
+      const json = c.req.valid("json")
+      await ModeSwitch.reply({
+        requestID: params.requestID,
+        reply: json.reply,
+      })
+      return c.json(true)
+    },
+  )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -49,6 +49,7 @@ import { errors } from "./error"
 import { Pty } from "@/pty"
 import { PermissionNext } from "@/permission/next"
 import { QuestionRoute } from "./question"
+import { ModeSwitchRoute } from "./modeswitch"
 import { Installation } from "@/installation"
 import { MDNS } from "./mdns"
 import { Worktree } from "../worktree"
@@ -1695,6 +1696,7 @@ export namespace Server {
           },
         )
         .route("/question", QuestionRoute)
+        .route("/modeswitch", ModeSwitchRoute)
         .get(
           "/command",
           describeRoute({

--- a/packages/opencode/src/session/prompt/plan.txt
+++ b/packages/opencode/src/session/prompt/plan.txt
@@ -20,6 +20,12 @@ Ask the user clarifying questions or ask for their opinion when weighing tradeof
 
 ---
 
+## Switching to Build Mode
+
+When you have finished planning, call the `modeswitch` tool. If you asked the user a question, wait for their response before calling it.
+
+---
+
 ## Important
 
 The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.

--- a/packages/opencode/src/tool/modeswitch.ts
+++ b/packages/opencode/src/tool/modeswitch.ts
@@ -1,0 +1,33 @@
+import z from "zod"
+import { Tool } from "./tool"
+import { ModeSwitch } from "../mode-switch"
+import DESCRIPTION from "./modeswitch.txt"
+
+export const ModeSwitchTool = Tool.define("modeswitch", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    reason: z.string().describe("Brief explanation of why you're ready to switch to build mode"),
+  }),
+  async execute(params, ctx) {
+    const approved = await ModeSwitch.ask({
+      sessionID: ctx.sessionID,
+      targetMode: "build",
+      reason: params.reason,
+      tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+    })
+
+    if (!approved) {
+      throw new ModeSwitch.RejectedError()
+    }
+
+    return {
+      title: "Mode switch approved",
+      output:
+        "The user has approved switching to build mode. You are now in build mode and can begin implementing the planned changes. Proceed with the implementation.",
+      metadata: {
+        approved: true,
+        targetMode: "build",
+      },
+    }
+  },
+})

--- a/packages/opencode/src/tool/modeswitch.txt
+++ b/packages/opencode/src/tool/modeswitch.txt
@@ -1,0 +1,3 @@
+Request to switch from planning mode to build mode.
+
+Call this tool when planning is complete. If you asked the user a question, wait for their response first.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -11,6 +11,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { ModeSwitchTool } from "./modeswitch"
 import type { Agent } from "../agent/agent"
 import { Tool } from "./tool"
 import { Instance } from "../project/instance"
@@ -107,6 +108,7 @@ export namespace ToolRegistry {
       WebSearchTool,
       CodeSearchTool,
       SkillTool,
+      ModeSwitchTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...custom,
@@ -125,6 +127,10 @@ export namespace ToolRegistry {
           // Enable websearch/codesearch for zen users OR via enable flag
           if (t.id === "codesearch" || t.id === "websearch") {
             return providerID === "opencode" || Flag.OPENCODE_ENABLE_EXA
+          }
+          // Only enable modeswitch tool for the plan agent
+          if (t.id === "modeswitch") {
+            return agent?.name === "plan"
           }
           return true
         })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -51,6 +51,9 @@ import type {
   McpLocalConfig,
   McpRemoteConfig,
   McpStatusResponses,
+  ModeswitchListResponses,
+  ModeswitchReplyErrors,
+  ModeswitchReplyResponses,
   Part as Part2,
   PartDeleteErrors,
   PartDeleteResponses,
@@ -1875,6 +1878,64 @@ export class Question extends HeyApiClient {
   }
 }
 
+export class Modeswitch extends HeyApiClient {
+  /**
+   * List pending mode switch requests
+   *
+   * Get all pending mode switch requests across all sessions.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<ModeswitchListResponses, unknown, ThrowOnError>({
+      url: "/modeswitch",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reply to mode switch request
+   *
+   * Approve or reject a mode switch request from the AI assistant.
+   */
+  public reply<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      reply?: "approve" | "reject"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "body", key: "reply" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ModeswitchReplyResponses, ModeswitchReplyErrors, ThrowOnError>({
+      url: "/modeswitch/{requestID}/reply",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
 export class Command extends HeyApiClient {
   /**
    * List commands
@@ -3007,6 +3068,8 @@ export class OpencodeClient extends HeyApiClient {
   permission = new Permission({ client: this.client })
 
   question = new Question({ client: this.client })
+
+  modeswitch = new Modeswitch({ client: this.client })
 
   command = new Command({ client: this.client })
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -625,6 +625,37 @@ export type EventTodoUpdated = {
   }
 }
 
+export type ModeSwitchRequest = {
+  id: string
+  sessionID: string
+  /**
+   * The mode to switch to
+   */
+  targetMode: string
+  /**
+   * Why the LLM wants to switch modes
+   */
+  reason: string
+  tool?: {
+    messageID: string
+    callID: string
+  }
+}
+
+export type EventModeswitchAsked = {
+  type: "modeswitch.asked"
+  properties: ModeSwitchRequest
+}
+
+export type EventModeswitchReplied = {
+  type: "modeswitch.replied"
+  properties: {
+    sessionID: string
+    requestID: string
+    reply: "approve" | "reject"
+  }
+}
+
 export type EventTuiPromptAppend = {
   type: "tui.prompt.append"
   properties: {
@@ -861,6 +892,8 @@ export type Event =
   | EventSessionCompacted
   | EventFileEdited
   | EventTodoUpdated
+  | EventModeswitchAsked
+  | EventModeswitchReplied
   | EventTuiPromptAppend
   | EventTuiCommandExecute
   | EventTuiToastShow
@@ -3704,6 +3737,59 @@ export type QuestionRejectResponses = {
 }
 
 export type QuestionRejectResponse = QuestionRejectResponses[keyof QuestionRejectResponses]
+
+export type ModeswitchListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/modeswitch"
+}
+
+export type ModeswitchListResponses = {
+  /**
+   * List of pending mode switch requests
+   */
+  200: Array<ModeSwitchRequest>
+}
+
+export type ModeswitchListResponse = ModeswitchListResponses[keyof ModeswitchListResponses]
+
+export type ModeswitchReplyData = {
+  body?: {
+    reply: "approve" | "reject"
+  }
+  path: {
+    requestID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/modeswitch/{requestID}/reply"
+}
+
+export type ModeswitchReplyErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ModeswitchReplyError = ModeswitchReplyErrors[keyof ModeswitchReplyErrors]
+
+export type ModeswitchReplyResponses = {
+  /**
+   * Mode switch request handled successfully
+   */
+  200: boolean
+}
+
+export type ModeswitchReplyResponse = ModeswitchReplyResponses[keyof ModeswitchReplyResponses]
 
 export type CommandListData = {
   body?: never

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -16,6 +16,7 @@ import {
   AssistantMessage,
   FilePart,
   Message as MessageType,
+  ModeSwitchRequest,
   Part as PartType,
   ReasoningPart,
   TextPart,
@@ -460,7 +461,15 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
     return next
   })
 
+  const modeswitch = createMemo(() => {
+    const next = data.store.modeswitch?.[props.message.sessionID]?.[0]
+    if (!next || !next.tool) return undefined
+    if (next.tool.callID !== part.callID) return undefined
+    return next
+  })
+
   const [showPermission, setShowPermission] = createSignal(false)
+  const [showModeSwitch, setShowModeSwitch] = createSignal(false)
 
   createEffect(() => {
     const perm = permission()
@@ -472,9 +481,19 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
     }
   })
 
+  createEffect(() => {
+    const ms = modeswitch()
+    if (ms) {
+      const timeout = setTimeout(() => setShowModeSwitch(true), 50)
+      onCleanup(() => clearTimeout(timeout))
+    } else {
+      setShowModeSwitch(false)
+    }
+  })
+
   const [forceOpen, setForceOpen] = createSignal(false)
   createEffect(() => {
-    if (permission()) setForceOpen(true)
+    if (permission() || modeswitch()) setForceOpen(true)
   })
 
   const respond = (response: "once" | "always" | "reject") => {
@@ -484,6 +503,17 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
       sessionID: perm.sessionID,
       permissionID: perm.id,
       response,
+    })
+  }
+
+  const respondModeSwitch = (response: "approve" | "reject") => {
+    const ms = modeswitch()
+    if (!ms || !data.respondToModeSwitch) return
+    data.respondToModeSwitch({
+      sessionID: ms.sessionID,
+      requestID: ms.id,
+      response,
+      targetMode: ms.targetMode,
     })
   }
 
@@ -497,7 +527,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
   const render = ToolRegistry.render(part.tool) ?? GenericTool
 
   return (
-    <div data-component="tool-part-wrapper" data-permission={showPermission()}>
+    <div data-component="tool-part-wrapper" data-permission={showPermission() || showModeSwitch()}>
       <Switch>
         <Match when={part.state.status === "error" && part.state.error}>
           {(error) => {
@@ -552,6 +582,20 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
             </Button>
           </div>
         </div>
+      </Show>
+      <Show when={showModeSwitch() && modeswitch()}>
+        {(ms) => (
+          <div data-component="permission-prompt">
+            <div data-slot="permission-actions">
+              <Button variant="ghost" size="small" onClick={() => respondModeSwitch("reject")}>
+                Reject
+              </Button>
+              <Button variant="primary" size="small" onClick={() => respondModeSwitch("approve")}>
+                Switch to {ms().targetMode}
+              </Button>
+            </div>
+          </div>
+        )}
       </Show>
     </div>
   )
@@ -1021,6 +1065,28 @@ ToolRegistry.register({
                 </Checkbox>
               )}
             </For>
+          </div>
+        </Show>
+      </BasicTool>
+    )
+  },
+})
+
+ToolRegistry.register({
+  name: "modeswitch",
+  render(props) {
+    return (
+      <BasicTool
+        {...props}
+        icon="task"
+        trigger={{
+          title: "Mode Switch",
+          subtitle: props.metadata.targetMode ? `to ${props.metadata.targetMode}` : undefined,
+        }}
+      >
+        <Show when={props.input.reason}>
+          <div data-component="tool-output">
+            <Markdown text={props.input.reason} />
           </div>
         </Show>
       </BasicTool>

--- a/packages/ui/src/context/data.tsx
+++ b/packages/ui/src/context/data.tsx
@@ -1,4 +1,12 @@
-import type { Message, Session, Part, FileDiff, SessionStatus, PermissionRequest } from "@opencode-ai/sdk/v2"
+import type {
+  Message,
+  Session,
+  Part,
+  FileDiff,
+  SessionStatus,
+  PermissionRequest,
+  ModeSwitchRequest,
+} from "@opencode-ai/sdk/v2"
 import { createSimpleContext } from "./helper"
 import { PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
 
@@ -16,6 +24,9 @@ type Data = {
   permission?: {
     [sessionID: string]: PermissionRequest[]
   }
+  modeswitch?: {
+    [sessionID: string]: ModeSwitchRequest[]
+  }
   message: {
     [sessionID: string]: Message[]
   }
@@ -30,6 +41,13 @@ export type PermissionRespondFn = (input: {
   response: "once" | "always" | "reject"
 }) => void
 
+export type ModeSwitchRespondFn = (input: {
+  sessionID: string
+  requestID: string
+  response: "approve" | "reject"
+  targetMode?: string
+}) => void
+
 export type NavigateToSessionFn = (sessionID: string) => void
 
 export const { use: useData, provider: DataProvider } = createSimpleContext({
@@ -38,6 +56,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     data: Data
     directory: string
     onPermissionRespond?: PermissionRespondFn
+    onModeSwitchRespond?: ModeSwitchRespondFn
     onNavigateToSession?: NavigateToSessionFn
   }) => {
     return {
@@ -48,6 +67,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         return props.directory
       },
       respondToPermission: props.onPermissionRespond,
+      respondToModeSwitch: props.onModeSwitchRespond,
       navigateToSession: props.onNavigateToSession,
     }
   },


### PR DESCRIPTION
### What does this PR do?

Adds a new `modeswitch` tool which allows the LLM to request the mode to be changed. So instead of the user having to switch to the build mode manually and ask the LLM to continue with the implementation, the LLM will request that itself and if approved, it will start implementing the plan.

<img width="1538" height="975" alt="image" src="https://github.com/user-attachments/assets/1726b78d-ab63-4beb-95a3-3e559f907866" />

<img width="1574" height="1041" alt="image" src="https://github.com/user-attachments/assets/81edcf2e-9897-4c39-93d2-a102e3dd70b0" />

### How did you verify your code works?

Tested it locally through the TUI and Desktop app.

Closes https://github.com/anomalyco/opencode/issues/7627