### PR TITLE
fix(desktop): enable store auto-save to persist data

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -207,7 +207,7 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
-        .plugin(tauri_plugin_store::Builder::new().build())
+        .plugin(tauri_plugin_store::Builder::new().auto_save(std::time::Duration::from_millis(100)).build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_process::init())


### PR DESCRIPTION
Fixes #7637

## 问题
Desktop app 中使用 Tauri Store 时,数据无法持久化,导致错误:
"Item with id 'xxx' not found. Items are not persisted when 'store' is set to false."

## 修复
在 Tauri Store 插件初始化时添加 `auto_save` 配置,每 100ms 自动保存一次。

## 变更
- 修改 `packages/desktop/src-tauri/src/lib.rs` 中的 Store 初始化配置
- 添加 `auto_save(Duration::from_millis(100))` 参数