### PR TITLE
fix: disable telemetry in the php lsp server

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1528,7 +1528,11 @@ export namespace LSPServer {
       })
       return {
         process: proc,
-        initialization: {},
+        initialization: {
+          telemetry: {
+            enabled: false,
+          },
+        },
       }
     },
   }


### PR DESCRIPTION
### What does this PR do?

* Turns off sending telemetry data when using the PHP lsp server
* Fixes https://github.com/anomalyco/opencode/issues/6099

### How did you verify your code works?

* I tested it with "Http Toolkit" before and after the turned off telemetry.
