### PR TITLE
feat(tui): add auto_scroll configuration setting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -521,6 +521,21 @@ export function Session() {
       },
     },
     {
+      title: (sync.data.config.tui as any)?.auto_scroll !== false ? "Disable auto-scroll" : "Enable auto-scroll",
+      value: "session.toggle.autoscroll",
+      category: "Session",
+      onSelect: (dialog) => {
+        const current = (sync.data.config.tui as any)?.auto_scroll ?? true
+        sdk.client.config.update({
+          tui: {
+            ...sync.data.config.tui,
+            auto_scroll: !current,
+          },
+        })
+        dialog.clear()
+      },
+    },
+    {
       title: animationsEnabled() ? "Disable animations" : "Enable animations",
       value: "session.toggle.animations",
       category: "Session",
@@ -903,7 +918,7 @@ export function Session() {
                   foregroundColor: theme.border,
                 },
               }}
-              stickyScroll={true}
+              stickyScroll={(sync.data.config.tui as any)?.auto_scroll ?? true}
               stickyStart="bottom"
               flexGrow={1}
               scrollAcceleration={scrollAcceleration()}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -766,6 +766,7 @@ export namespace Config {
       })
       .optional()
       .describe("Scroll acceleration settings"),
+    auto_scroll: z.boolean().optional().describe("Automatically scroll to bottom when new messages arrive"),
     diff_style: z
       .enum(["auto", "stacked"])
       .optional()

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -160,7 +160,8 @@ You can configure TUI-specific settings through the `tui` option.
     "scroll_acceleration": {
       "enabled": true
     },
-    "diff_style": "auto"
+    "diff_style": "auto",
+    "auto_scroll": true
   }
 }
 ```
@@ -170,6 +171,7 @@ Available options:
 - `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration. **Takes precedence over `scroll_speed`.**
 - `scroll_speed` - Custom scroll speed multiplier (default: `1`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
 - `diff_style` - Control diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows single column.
+- `auto_scroll` - Automatically scroll to bottom when new messages arrive (default: `true`).
 
 [Learn more about using the TUI here](/docs/tui).
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -368,6 +368,13 @@ You can customize various aspects of the TUI view using the command palette (`ct
 
 ---
 
+#### Auto-scroll
+
+Toggle automatic scrolling to the bottom when new messages arrive.
+
+- Command palette: Search for "scroll" or "auto-scroll"
+- The setting persists automatically and will be remembered across TUI sessions
+
 #### Username display
 
 Toggle whether your username appears in chat messages. Access this through:


### PR DESCRIPTION
## Summary
Adds a new `tui.auto_scroll` configuration option to control the sticky scrolling behavior in the TUI session view. This addresses the request to prevent auto-scrolling when new messages arrive.

## Changes
- Added `auto_scroll` boolean to `TUI` config schema in `packages/opencode/src/config/config.ts`
- Updated `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` to respect the `auto_scroll` setting (defaults to `true`).

Fixes #7648