### PR TITLE
docs: fix permission system documentation in agents section

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -436,10 +436,6 @@ permission:
 Only analyze code and suggest changes.
 ```
 
-:::tip
-Use pattern matching for commands with arguments. `"grep *"` allows `grep pattern file.txt`, while `"grep"` alone would block it. Commands like `git status` work for default behavior but require explicit permission (like `"git status*"`) when arguments are passed.
-:::
-
 You can set permissions for specific bash commands.
 
 ```json title="opencode.json" {7}

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -429,11 +429,16 @@ permission:
     "*": ask
     "git diff": allow
     "git log*": allow
+    "grep *": allow
   webfetch: deny
 ---
 
 Only analyze code and suggest changes.
 ```
+
+:::tip
+Use pattern matching for commands with arguments. `"grep *"` allows `grep pattern file.txt`, while `"grep"` alone would block it. Commands like `git status` work for default behavior but require explicit permission (like `"git status*"`) when arguments are passed.
+:::
 
 You can set permissions for specific bash commands.
 
@@ -444,7 +449,8 @@ You can set permissions for specific bash commands.
     "build": {
       "permission": {
         "bash": {
-          "git push": "ask"
+          "git push": "ask",
+          "grep *": "allow"
         }
       }
     }
@@ -480,7 +486,7 @@ Since the last matching rule takes precedence, put the `*` wildcard first and sp
       "permission": {
         "bash": {
           "*": "ask",
-          "git status": "allow"
+          "git status *": "allow"
         }
       }
     }

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -57,7 +57,8 @@ For most permissions, you can use an object to apply different actions based on 
       "*": "ask",
       "git *": "allow",
       "npm *": "allow",
-      "rm *": "deny"
+      "rm *": "deny",
+      "grep *": "allow"
     },
     "edit": {
       "*": "deny",
@@ -139,13 +140,20 @@ The set of patterns that `always` would approve is provided by the tool (for exa
 
 You can override permissions per agent. Agent permissions are merged with the global config, and agent rules take precedence. [Learn more](/docs/agents#permissions) about agent permissions.
 
+:::note
+Refer to the [Granular Rules (Object Syntax)](#granular-rules-object-syntax) section above for more detailed pattern matching examples.
+:::
+
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
   "permission": {
     "bash": {
       "*": "ask",
-      "git status": "allow"
+      "git *": "allow",
+      "git commit *": "deny",
+      "git push *": "deny",
+      "grep *": "allow"
     }
   },
   "agent": {
@@ -153,8 +161,10 @@ You can override permissions per agent. Agent permissions are merged with the gl
       "permission": {
         "bash": {
           "*": "ask",
-          "git status": "allow",
-          "git push": "allow"
+          "git *": "allow",
+          "git commit *": "ask",
+          "git push *": "deny",
+          "grep *": "allow"
         }
       }
     }
@@ -176,3 +186,7 @@ permission:
 
 Only analyze code and suggest changes.
 ```
+
+:::tip
+Use pattern matching for commands with arguments. `"grep *"` allows `grep pattern file.txt`, while `"grep"` alone would block it. Commands like `git status` work for default behavior but require explicit permission (like `"git status *"`) when arguments are passed.
+:::


### PR DESCRIPTION
### What does this PR do?

Updates the agents section in the permissions documentation to reflect the new granular rules system. The previous examples showed mismatched patterns (e.g., `"git status"` without wildcards) that didn't properly demonstrate how pattern matching works for commands with arguments. The fix adds `"grep *"` examples to clearly demonstrate when pattern matching is essential, updates the explanatory tip to show both scenarios (commands that work without arguments vs. commands that require pattern matching).

### How did you verify your code works?

Ran the docs development server locally to verify the changes render correctly and the examples are properly formatted. The documentation now accurately reflects how the granular permission system works with clear examples showing when to use pattern matching for commands that accept arguments like `grep`, versus commands that work with basic usage like `git status`.
