### PR TITLE
feat(questions): enhance questions TUI + add full descendants support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,34 @@ This runs `bun run --cwd packages/desktop build` automatically via Tauri’s `be
 
 Please try to follow the [style guide](./STYLE_GUIDE.md)
 
+### Running Tests
+
+Run the test suite from the `packages/opencode` directory:
+
+```bash
+bun test
+```
+
+To run a specific test file:
+
+```bash
+bun test test/tool/tool.test.ts
+```
+
+#### Test Environment Variables
+
+Environment variables prefixed with `OPENCODE_TEST_` can be used to alter test behavior. When tests start, any such variables are printed to the console for visibility.
+
+| Variable                 | Description                                                                                  |
+| ------------------------ | -------------------------------------------------------------------------------------------- |
+| `OPENCODE_TEST_SKIP_GIT` | Skip git repository initialization in test fixtures (useful when commit signing is required) |
+
+Example:
+
+```bash
+OPENCODE_TEST_SKIP_GIT=1 bun test
+```
+
 ### Setting up a Debugger
 
 Bun debugging is currently rough around the edges. We hope this guide helps you get set up and avoid some pain points.

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1873,7 +1873,7 @@ function TodoWrite(props: ToolProps<typeof TodoWriteTool>) {
 }
 
 function Question(props: ToolProps<typeof QuestionTool>) {
-  const { theme } = useTheme()
+  const { theme, syntax } = useTheme()
   const count = createMemo(() => props.input.questions?.length ?? 0)
 
   return (
@@ -1908,9 +1908,13 @@ function Question(props: ToolProps<typeof QuestionTool>) {
                           border={["right"]}
                           borderColor={theme.border}
                         >
-                          <text fg={theme.textMuted} wrapMode="word">
-                            {q.question}
-                          </text>
+                          <code
+                            filetype="markdown"
+                            drawUnstyledText={false}
+                            syntaxStyle={syntax()}
+                            content={q.question}
+                            fg={theme.text}
+                          />
                         </box>
                         <box width={answerWidth()} paddingLeft={1} paddingRight={1} gap={isMulti() ? 1 : 0}>
                           <Show

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -27,7 +27,15 @@ import {
   RGBA,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
+import type {
+  AssistantMessage,
+  Part,
+  ToolPart,
+  UserMessage,
+  TextPart,
+  ReasoningPart,
+  Session as SessionType,
+} from "@opencode-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
 import { Locale } from "@/util/locale"
 import type { Tool } from "@/tool/tool"
@@ -111,6 +119,31 @@ export function Session() {
   const { theme } = useTheme()
   const promptRef = usePromptRef()
   const session = createMemo(() => sync.session.get(route.sessionID))
+  const descendants = createMemo(() => {
+    const rootID = session()?.parentID ?? session()?.id
+    if (!rootID) return []
+
+    const result: SessionType[] = []
+    const visited = new Set<string>()
+    const queue = [rootID]
+
+    while (queue.length > 0) {
+      const currentID = queue.shift()!
+      if (visited.has(currentID)) continue
+      visited.add(currentID)
+
+      const current = sync.data.session.find((x) => x.id === currentID)
+      if (current) result.push(current)
+
+      for (const s of sync.data.session) {
+        if (s.parentID === currentID && !visited.has(s.id)) {
+          queue.push(s.id)
+        }
+      }
+    }
+
+    return result.toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+  })
   const children = createMemo(() => {
     const parentID = session()?.parentID ?? session()?.id
     return sync.data.session
@@ -120,11 +153,13 @@ export function Session() {
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+    return descendants().flatMap((x) => sync.data.permission[x.id] ?? [])
   })
   const questions = createMemo(() => {
     if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.question[x.id] ?? [])
+    return descendants()
+      .flatMap((x) => sync.data.question[x.id] ?? [])
+      .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
 
   const pending = createMemo(() => {
@@ -1841,26 +1876,68 @@ function Question(props: ToolProps<typeof QuestionTool>) {
   const { theme } = useTheme()
   const count = createMemo(() => props.input.questions?.length ?? 0)
 
-  function format(answer?: string[]) {
-    if (!answer?.length) return "(no answer)"
-    return answer.join(", ")
-  }
-
   return (
     <Switch>
       <Match when={props.metadata.answers}>
-        <BlockTool title="# Questions" part={props.part}>
-          <box>
-            <For each={props.input.questions ?? []}>
-              {(q, i) => (
-                <box flexDirection="row" gap={1}>
-                  <text fg={theme.textMuted}>{q.question}</text>
-                  <text fg={theme.text}>{format(props.metadata.answers?.[i()])}</text>
-                </box>
-              )}
-            </For>
-          </box>
-        </BlockTool>
+        {(() => {
+          const ctx = use()
+          const allAnswers = () => (props.input.questions ?? []).map((_, idx) => props.metadata.answers?.[idx] ?? [])
+          const maxAnswerLen = () => Math.max(20, ...allAnswers().flatMap((answers) => answers.map((a) => a.length)))
+          const tableWidth = () => ctx.width - 6
+          const halfWidth = () => Math.floor(tableWidth() * 0.5)
+          const answerWidth = () => Math.max(20, Math.min(maxAnswerLen() + 2, halfWidth()))
+          return (
+            <BlockTool title="# Questions" part={props.part}>
+              <box width={tableWidth()} border={["top", "left", "right", "bottom"]} borderColor={theme.border}>
+                <For each={props.input.questions ?? []}>
+                  {(q, i) => {
+                    const answers = () => props.metadata.answers?.[i()] ?? []
+                    const isLast = () => i() === (props.input.questions?.length ?? 0) - 1
+                    const isMulti = () => answers().length > 1
+                    return (
+                      <box
+                        flexDirection="row"
+                        width="100%"
+                        border={isLast() ? [] : ["bottom"]}
+                        borderColor={theme.border}
+                      >
+                        <box
+                          flexGrow={1}
+                          paddingLeft={1}
+                          paddingRight={1}
+                          border={["right"]}
+                          borderColor={theme.border}
+                        >
+                          <text fg={theme.textMuted} wrapMode="word">
+                            {q.question}
+                          </text>
+                        </box>
+                        <box width={answerWidth()} paddingLeft={1} paddingRight={1} gap={isMulti() ? 1 : 0}>
+                          <Show
+                            when={answers().length > 0}
+                            fallback={
+                              <text fg={theme.textMuted} wrapMode="word">
+                                (no answer)
+                              </text>
+                            }
+                          >
+                            <For each={answers()}>
+                              {(answer) => (
+                                <text fg={theme.text} wrapMode="word">
+                                  {answer}
+                                </text>
+                              )}
+                            </For>
+                          </Show>
+                        </box>
+                      </box>
+                    )
+                  }}
+                </For>
+              </box>
+            </BlockTool>
+          )
+        })()}
       </Match>
       <Match when={true}>
         <InlineTool icon="→" pending="Asking questions..." complete={count()} part={props.part}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { createMemo, For, Show } from "solid-js"
+import { createEffect, createMemo, For, on, Show } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
@@ -40,6 +40,20 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     if (!value) return false
     return store.answers[store.tab]?.includes(value) ?? false
   })
+
+  createEffect(
+    on(
+      () => props.request.id,
+      () => {
+        setStore("tab", 0)
+        setStore("answers", [])
+        setStore("custom", [])
+        setStore("selected", 0)
+        setStore("editing", false)
+      },
+      { defer: true },
+    ),
+  )
 
   function submit() {
     const answers = questions().map((_, i) => store.answers[i] ?? [])
@@ -184,13 +198,9 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         setStore("selected", (store.selected + 1) % total)
       }
 
-      if (evt.name === "return") {
+      if (evt.name === "space" && multi()) {
         evt.preventDefault()
         if (other()) {
-          if (!multi()) {
-            setStore("editing", true)
-            return
-          }
           const value = input()
           if (value && customPicked()) {
             toggle(value)
@@ -201,10 +211,29 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         }
         const opt = opts[store.selected]
         if (!opt) return
+        toggle(opt.label)
+        return
+      }
+
+      if (evt.name === "return") {
+        evt.preventDefault()
         if (multi()) {
-          toggle(opt.label)
+          const hasSelections = (store.answers[store.tab]?.length ?? 0) > 0
+          if (!hasSelections) return
+          if (single()) {
+            submit()
+            return
+          }
+          setStore("tab", store.tab + 1)
+          setStore("selected", 0)
           return
         }
+        if (other()) {
+          setStore("editing", true)
+          return
+        }
+        const opt = opts[store.selected]
+        if (!opt) return
         pick(opt.label)
       }
 
@@ -223,6 +252,13 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       customBorderChars={SplitBorder.customBorderChars}
     >
       <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <Show when={props.request.from}>
+          <box paddingLeft={1}>
+            <text fg={theme.textMuted}>
+              Question from <span style={{ fg: theme.accent }}>{props.request.from}</span>
+            </text>
+          </box>
+        </Show>
         <Show when={!single()}>
           <box flexDirection="row" gap={1} paddingLeft={1}>
             <For each={questions()}>
@@ -253,25 +289,22 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         <Show when={!confirm()}>
           <box paddingLeft={1} gap={1}>
             <box>
-              <text fg={theme.text}>
-                {question()?.question}
-                {multi() ? " (select all that apply)" : ""}
-              </text>
+              <text fg={theme.text}>{question()?.question}</text>
             </box>
             <box>
               <For each={options()}>
                 {(opt, i) => {
                   const active = () => i() === store.selected
                   const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
+                  const checkbox = () => (multi() ? (picked() ? "■" : "☐") : "")
                   return (
                     <box>
                       <box flexDirection="row" gap={1}>
                         <box backgroundColor={active() ? theme.backgroundElement : undefined}>
                           <text fg={active() ? theme.secondary : picked() ? theme.success : theme.text}>
-                            {i() + 1}. {opt.label}
+                            {multi() ? checkbox() : `${i() + 1}.`} {opt.label}
                           </text>
                         </box>
-                        <text fg={theme.success}>{picked() ? "✓" : ""}</text>
                       </box>
                       <box paddingLeft={3}>
                         <text fg={theme.textMuted}>{opt.description}</text>
@@ -284,10 +317,9 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                 <box flexDirection="row" gap={1}>
                   <box backgroundColor={other() ? theme.backgroundElement : undefined}>
                     <text fg={other() ? theme.secondary : customPicked() ? theme.success : theme.text}>
-                      {options().length + 1}. Type your own answer
+                      {multi() ? (customPicked() ? "■" : "☐") : `${options().length + 1}.`} Type your own answer
                     </text>
                   </box>
-                  <text fg={theme.success}>{customPicked() ? "✓" : ""}</text>
                 </box>
                 <Show when={store.editing}>
                   <box paddingLeft={3}>
@@ -341,6 +373,11 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         justifyContent="space-between"
       >
         <box flexDirection="row" gap={2}>
+          <Show when={!confirm()}>
+            <box paddingLeft={1} paddingRight={1} backgroundColor={theme.backgroundElement}>
+              <text fg={theme.textMuted}>{multi() ? "Multiple" : "Single"}</text>
+            </box>
+          </Show>
           <Show when={!single()}>
             <text fg={theme.text}>
               {"⇆"} <span style={{ fg: theme.textMuted }}>tab</span>
@@ -351,10 +388,15 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               {"↑↓"} <span style={{ fg: theme.textMuted }}>select</span>
             </text>
           </Show>
+          <Show when={!confirm() && multi()}>
+            <text fg={theme.text}>
+              space <span style={{ fg: theme.textMuted }}>toggle</span>
+            </text>
+          </Show>
           <text fg={theme.text}>
             enter{" "}
             <span style={{ fg: theme.textMuted }}>
-              {confirm() ? "submit" : multi() ? "toggle" : single() ? "submit" : "confirm"}
+              {confirm() ? "submit" : multi() ? "confirm" : single() ? "submit" : "confirm"}
             </span>
           </text>
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { createEffect, createMemo, For, on, Show } from "solid-js"
-import { useKeyboard } from "@opentui/solid"
+import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
 import { useTheme } from "../../context/theme"
@@ -12,7 +12,8 @@ import { useDialog } from "../../ui/dialog"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
-  const { theme } = useTheme()
+  const { theme, syntax } = useTheme()
+  const dimensions = useTerminalDimensions()
   const keybind = useKeybind()
   const bindings = useTextareaKeybindings()
 
@@ -251,101 +252,119 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       borderColor={theme.accent}
       customBorderChars={SplitBorder.customBorderChars}
     >
-      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
-        <Show when={props.request.from}>
-          <box paddingLeft={1}>
-            <text fg={theme.textMuted}>
-              Question from <span style={{ fg: theme.accent }}>{props.request.from}</span>
-            </text>
-          </box>
-        </Show>
-        <Show when={!single()}>
-          <box flexDirection="row" gap={1} paddingLeft={1}>
-            <For each={questions()}>
-              {(q, index) => {
-                const isActive = () => index() === store.tab
-                const isAnswered = () => {
-                  return (store.answers[index()]?.length ?? 0) > 0
-                }
-                return (
-                  <box
-                    paddingLeft={1}
-                    paddingRight={1}
-                    backgroundColor={isActive() ? theme.accent : theme.backgroundElement}
-                  >
-                    <text fg={isActive() ? theme.selectedListItemText : isAnswered() ? theme.text : theme.textMuted}>
-                      {q.header}
-                    </text>
-                  </box>
-                )
-              }}
-            </For>
-            <box paddingLeft={1} paddingRight={1} backgroundColor={confirm() ? theme.accent : theme.backgroundElement}>
-              <text fg={confirm() ? theme.selectedListItemText : theme.textMuted}>Confirm</text>
+      <Show when={props.request.from || !single()}>
+        <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1} flexShrink={0}>
+          <Show when={props.request.from}>
+            <box paddingLeft={1}>
+              <text fg={theme.textMuted}>
+                Question from <span style={{ fg: theme.accent }}>{props.request.from}</span>
+              </text>
             </box>
-          </box>
-        </Show>
-
-        <Show when={!confirm()}>
-          <box paddingLeft={1} gap={1}>
-            <box>
-              <text fg={theme.text}>{question()?.question}</text>
-            </box>
-            <box>
-              <For each={options()}>
-                {(opt, i) => {
-                  const active = () => i() === store.selected
-                  const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
-                  const checkbox = () => (multi() ? (picked() ? "■" : "☐") : "")
+          </Show>
+          <Show when={!single()}>
+            <box flexDirection="row" gap={1} paddingLeft={1}>
+              <For each={questions()}>
+                {(q, index) => {
+                  const isActive = () => index() === store.tab
+                  const isAnswered = () => {
+                    return (store.answers[index()]?.length ?? 0) > 0
+                  }
                   return (
-                    <box>
-                      <box flexDirection="row" gap={1}>
-                        <box backgroundColor={active() ? theme.backgroundElement : undefined}>
-                          <text fg={active() ? theme.secondary : picked() ? theme.success : theme.text}>
-                            {multi() ? checkbox() : `${i() + 1}.`} {opt.label}
-                          </text>
-                        </box>
-                      </box>
-                      <box paddingLeft={3}>
-                        <text fg={theme.textMuted}>{opt.description}</text>
-                      </box>
+                    <box
+                      paddingLeft={1}
+                      paddingRight={1}
+                      backgroundColor={isActive() ? theme.accent : theme.backgroundElement}
+                    >
+                      <text fg={isActive() ? theme.selectedListItemText : isAnswered() ? theme.text : theme.textMuted}>
+                        {q.header}
+                      </text>
                     </box>
                   )
                 }}
               </For>
-              <box>
-                <box flexDirection="row" gap={1}>
-                  <box backgroundColor={other() ? theme.backgroundElement : undefined}>
-                    <text fg={other() ? theme.secondary : customPicked() ? theme.success : theme.text}>
-                      {multi() ? (customPicked() ? "■" : "☐") : `${options().length + 1}.`} Type your own answer
-                    </text>
-                  </box>
-                </box>
-                <Show when={store.editing}>
-                  <box paddingLeft={3}>
-                    <textarea
-                      ref={(val: TextareaRenderable) => (textarea = val)}
-                      focused
-                      initialValue={input()}
-                      placeholder="Type your own answer"
-                      textColor={theme.text}
-                      focusedTextColor={theme.text}
-                      cursorColor={theme.primary}
-                      keyBindings={bindings()}
-                    />
-                  </box>
-                </Show>
-                <Show when={!store.editing && input()}>
-                  <box paddingLeft={3}>
-                    <text fg={theme.textMuted}>{input()}</text>
-                  </box>
-                </Show>
+              <box
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={confirm() ? theme.accent : theme.backgroundElement}
+              >
+                <text fg={confirm() ? theme.selectedListItemText : theme.textMuted}>Confirm</text>
               </box>
             </box>
-          </box>
-        </Show>
+          </Show>
+        </box>
+      </Show>
 
-        <Show when={confirm() && !single()}>
+      <Show when={!confirm()}>
+        <box
+          maxHeight={Math.floor(dimensions().height * 0.5)}
+          overflow="scroll"
+          paddingLeft={2}
+          paddingRight={3}
+          backgroundColor={theme.backgroundElement}
+        >
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            syntaxStyle={syntax()}
+            content={"\n" + (question()?.question ?? "") + "\n"}
+            fg={theme.text}
+          />
+        </box>
+        <box paddingLeft={2} paddingRight={3} paddingTop={1} flexShrink={0}>
+          <For each={options()}>
+            {(opt, i) => {
+              const active = () => i() === store.selected
+              const picked = () => store.answers[store.tab]?.includes(opt.label) ?? false
+              const checkbox = () => (multi() ? (picked() ? "■" : "☐") : "")
+              return (
+                <box>
+                  <box flexDirection="row" gap={1}>
+                    <box backgroundColor={active() ? theme.backgroundElement : undefined}>
+                      <text fg={active() ? theme.secondary : picked() ? theme.success : theme.text}>
+                        {multi() ? checkbox() : `${i() + 1}.`} {opt.label}
+                      </text>
+                    </box>
+                  </box>
+                  <box paddingLeft={3}>
+                    <text fg={theme.textMuted}>{opt.description}</text>
+                  </box>
+                </box>
+              )
+            }}
+          </For>
+          <box>
+            <box flexDirection="row" gap={1}>
+              <box backgroundColor={other() ? theme.backgroundElement : undefined}>
+                <text fg={other() ? theme.secondary : customPicked() ? theme.success : theme.text}>
+                  {multi() ? (customPicked() ? "■" : "☐") : `${options().length + 1}.`} Type your own answer
+                </text>
+              </box>
+            </box>
+            <Show when={store.editing}>
+              <box paddingLeft={3}>
+                <textarea
+                  ref={(val: TextareaRenderable) => (textarea = val)}
+                  focused
+                  initialValue={input()}
+                  placeholder="Type your own answer"
+                  textColor={theme.text}
+                  focusedTextColor={theme.text}
+                  cursorColor={theme.primary}
+                  keyBindings={bindings()}
+                />
+              </box>
+            </Show>
+            <Show when={!store.editing && input()}>
+              <box paddingLeft={3}>
+                <text fg={theme.textMuted}>{input()}</text>
+              </box>
+            </Show>
+          </box>
+        </box>
+      </Show>
+
+      <Show when={confirm() && !single()}>
+        <box paddingLeft={2} paddingRight={3} flexGrow={1}>
           <box paddingLeft={1}>
             <text fg={theme.text}>Review</text>
           </box>
@@ -361,14 +380,16 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               )
             }}
           </For>
-        </Show>
-      </box>
+        </box>
+      </Show>
+
       <box
         flexDirection="row"
         flexShrink={0}
         gap={1}
         paddingLeft={2}
         paddingRight={3}
+        paddingTop={1}
         paddingBottom={1}
         justifyContent="space-between"
       >

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -35,6 +35,7 @@ export namespace Question {
       id: Identifier.schema("question"),
       sessionID: Identifier.schema("session"),
       questions: z.array(Info).describe("Questions to ask"),
+      from: z.string().optional().describe("Identifier of who is asking the question (e.g. agent name)"),
       tool: z
         .object({
           messageID: z.string(),
@@ -96,18 +97,20 @@ export namespace Question {
   export async function ask(input: {
     sessionID: string
     questions: Info[]
+    from?: string
     tool?: { messageID: string; callID: string }
   }): Promise<Answer[]> {
     const s = await state()
     const id = Identifier.ascending("question")
 
-    log.info("asking", { id, questions: input.questions.length })
+    log.info("asking", { id, questions: input.questions.length, from: input.from })
 
     return new Promise<Answer[]>((resolve, reject) => {
       const info: Request = {
         id,
         sessionID: input.sessionID,
         questions: input.questions,
+        from: input.from,
         tool: input.tool,
       }
       s.pending[id] = {

--- a/packages/opencode/src/tool/question.ts
+++ b/packages/opencode/src/tool/question.ts
@@ -7,11 +7,18 @@ export const QuestionTool = Tool.define("question", {
   description: DESCRIPTION,
   parameters: z.object({
     questions: z.array(Question.Info).describe("Questions to ask"),
+    from: z
+      .string()
+      .optional()
+      .describe(
+        "Identifier of who is asking the question (e.g. agent name). Used to inform the user which agent is asking.",
+      ),
   }),
   async execute(params, ctx) {
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
       questions: params.questions,
+      from: params.from,
       tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
     })
 

--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -8,3 +8,4 @@ Usage notes:
 - Users will always be able to select "Other" to provide custom text input
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+- Use the optional `from` parameter to identify who is asking the question (e.g. your agent name). This helps the user understand which agent is requesting input.

--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -9,3 +9,4 @@ Usage notes:
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
 - Use the optional `from` parameter to identify who is asking the question (e.g. your agent name). This helps the user understand which agent is requesting input.
+- The `question` field supports full Markdown syntax including headings, bold, italic, code blocks with syntax highlighting, lists, links, and tables. Use this to format complex questions clearly.

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -18,7 +18,7 @@ type TmpDirOptions<T> = {
 export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   const dirpath = sanitizePath(path.join(os.tmpdir(), "opencode-test-" + Math.random().toString(36).slice(2)))
   await fs.mkdir(dirpath, { recursive: true })
-  if (options?.git) {
+  if (options?.git && !process.env["OPENCODE_TEST_SKIP_GIT"]) {
     await $`git init`.cwd(dirpath).quiet()
     await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
   }

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -6,6 +6,24 @@ import fs from "fs/promises"
 import fsSync from "fs"
 import { afterAll } from "bun:test"
 
+// Print all OPENCODE_TEST_* env vars for visibility
+const testEnvVars = Object.entries(process.env)
+  .filter(([key]) => key.startsWith("OPENCODE_TEST_"))
+  .sort(([a], [b]) => a.localeCompare(b))
+
+if (testEnvVars.length > 0) {
+  const title = " Test Environment Variables "
+  const lines = testEnvVars.map(([key, value]) => `│ ${key}=${value}`)
+  const maxContentWidth = Math.max(title.length, ...lines.map((l) => l.length - 1))
+  const width = maxContentWidth + 1
+
+  console.log("\n┌" + "─" + title + "─".repeat(width - title.length - 1) + "┐")
+  for (const line of lines) {
+    console.log(line + " ".repeat(width - line.length + 1) + "│")
+  }
+  console.log("└" + "─".repeat(width) + "┘\n")
+}
+
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
 afterAll(() => {

--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -298,3 +298,54 @@ test("list - returns empty when no pending", async () => {
     },
   })
 })
+
+// from tests
+
+test("ask - includes from in request when provided", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      Question.ask({
+        sessionID: "ses_test",
+        questions: [
+          {
+            question: "What would you like to do?",
+            header: "Action",
+            options: [{ label: "Option 1", description: "First option" }],
+          },
+        ],
+        from: "test-agent",
+      })
+
+      const pending = await Question.list()
+
+      expect(pending.length).toBe(1)
+      expect(pending[0].from).toBe("test-agent")
+    },
+  })
+})
+
+test("ask - from is undefined when not provided", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      Question.ask({
+        sessionID: "ses_test",
+        questions: [
+          {
+            question: "What would you like to do?",
+            header: "Action",
+            options: [{ label: "Option 1", description: "First option" }],
+          },
+        ],
+      })
+
+      const pending = await Question.list()
+
+      expect(pending.length).toBe(1)
+      expect(pending[0].from).toBeUndefined()
+    },
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -554,6 +554,10 @@ export type QuestionRequest = {
    * Questions to ask
    */
   questions: Array<QuestionInfo>
+  /**
+   * Identifier of who is asking the question (e.g. agent name)
+   */
+  from?: string
   tool?: {
     messageID: string
     callID: string


### PR DESCRIPTION
## Summary

This PR fixes nested agent questions not appearing in the TUI and improves question tool UX.
Fixes #7654 

## Problem

When using ohmyopencode (or similar setups) with sub-agents spawning other agents via `background_task`, questions from deeply nested agents don't show up in the main session's TUI. The old code only looked at direct children sessions, missing questions from grandchildren and beyond.

**To reproduce (without this PR):**

```
Do the following:
- spawn one subagent
- from this subagent spawn 3 background_task and give them a name (one, two and three)
- in each background_task ask 3 questions (ask if I prefer python or typescript). Include both the background_task name and the question number.
Once all is done, give me a summary of all answers
```

The questions never appear in the TUI.

## Solution

### Core Fix: Nested Agent Questions

- Changed from direct children lookup to BFS traversal of all session descendants
- Questions from any depth now surface to the root session
- Added `from` parameter so users know which agent is asking ("Question from explorer-agent")

### QoL Improvements

The remaining changes are quality-of-life tweaks to improve the interview workflow:

- **Answer display**: Table layout with borders, word wrapping, multi-select answers on separate lines
- **Multi-select UX**: Checkbox prefixes (`☐`/`■`), `space` to toggle, `enter` to confirm
- **Question type indicator**: "Single"/"Multiple" tag in bottom bar
- **State reset**: Fix stale selections bleeding into new questions

### Test Infrastructure

- `OPENCODE_TEST_SKIP_GIT` env var to skip git init (for commit signing setups)
- Print `OPENCODE_TEST_*` vars at test start for visibility

## Verification

- Tested the reproduction prompt above - questions now appear
- Manually verified single/multi-select flows
- Added tests for `from` field

## Screenshots

### Short single without `from`

<img width="1394" height="249" alt="Screenshot 2026-01-10 at 23 26 22" src="https://github.com/user-attachments/assets/f0dbd2f8-b1dc-4997-b550-5278819c097c" />

### Short single with `from`

<img width="1394" height="308" alt="Screenshot 2026-01-10 at 23 26 50" src="https://github.com/user-attachments/assets/2372f262-7b1a-4601-93af-8a5abda0916f" />

### Simple Multi-select without `from`

<img width="1394" height="350" alt="Screenshot 2026-01-10 at 23 27 30" src="https://github.com/user-attachments/assets/421cae97-22b5-4ce4-9020-d52ce9255136" />

### Simple Multi-select with `from`

<img width="1394" height="389" alt="Screenshot 2026-01-10 at 23 29 29" src="https://github.com/user-attachments/assets/5137dc01-81fa-4538-a85a-797f954349b1" />

### Multi-Question

<img width="1394" height="350" alt="Screenshot 2026-01-10 at 23 28 12" src="https://github.com/user-attachments/assets/975f8477-ff32-40c3-a769-856a88653786" />

### Long Markdown question (dark zone is scrollable)

<img width="1394" height="837" alt="Screenshot 2026-01-10 at 23 19 22" src="https://github.com/user-attachments/assets/d4393e19-f3ce-4f13-9999-5096b6a32046" />

### Support for Markdown in the discussion answers

<img width="1394" height="659" alt="Screenshot 2026-01-10 at 23 12 31" src="https://github.com/user-attachments/assets/6fe64de9-9645-4445-b4fe-25511fd3d9a3" />


(this PR was mainly done by opencode with my supervision, I've been using the question workflow heavily lately with the https://github.com/paulp-o/ask-user-questions-mcp MCP. It's so great that we have questions natively in opencode now, but there descendant issue was preventing my old workflows from working properly as questions weren't bubbling up from lower than direct child agents. Also added some TUI improvements)