### PR TITLE
feat: add configurable reminder field for agents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -11,6 +11,7 @@ import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import PROMPT_PLAN from "../session/prompt/plan.txt"
 import { PermissionNext } from "@/permission/next"
 import { mergeDeep, pipe, sortBy, values } from "remeda"
 
@@ -35,6 +36,7 @@ export namespace Agent {
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
+      reminder: z.union([z.string(), z.literal(false)]).optional(),
     })
     .meta({
       ref: "Agent",
@@ -79,6 +81,8 @@ export namespace Agent {
       plan: {
         name: "plan",
         options: {},
+        // TODO (for mr dax): update to use the anthropic full fledged one (see plan-reminder-anthropic.txt)
+        reminder: PROMPT_PLAN,
         permission: PermissionNext.merge(
           defaults,
           PermissionNext.fromConfig({
@@ -208,6 +212,7 @@ export namespace Agent {
       item.steps = value.steps ?? item.steps
       item.options = mergeDeep(item.options, value.options ?? {})
       item.permission = PermissionNext.merge(item.permission, PermissionNext.fromConfig(value.permission ?? {}))
+      item.reminder = value.reminder ?? item.reminder
     }
 
     // Ensure Truncate.DIR is allowed unless explicitly configured

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -557,6 +557,12 @@ export namespace Config {
         .describe("Maximum number of agentic iterations before forcing text-only response"),
       maxSteps: z.number().int().positive().optional().describe("@deprecated Use 'steps' field instead."),
       permission: Permission.optional(),
+      reminder: z
+        .union([z.string(), z.literal(false)])
+        .optional()
+        .describe(
+          "Custom reminder text injected into user messages for this agent. Set to false to disable the default reminder.",
+        ),
     })
     .catchall(z.any())
     .transform((agent, ctx) => {
@@ -576,6 +582,7 @@ export namespace Config {
         "permission",
         "disable",
         "tools",
+        "reminder",
       ])
 
       // Extract unknown properties into options

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -16,7 +16,6 @@ import { Bus } from "../bus"
 import { ProviderTransform } from "../provider/transform"
 import { SystemPrompt } from "./system"
 import { Plugin } from "../plugin"
-import PROMPT_PLAN from "../session/prompt/plan.txt"
 import BUILD_SWITCH from "../session/prompt/build-switch.txt"
 import MAX_STEPS from "../session/prompt/max-steps.txt"
 import { defer } from "../util/defer"
@@ -1173,17 +1172,21 @@ export namespace SessionPrompt {
   function insertReminders(input: { messages: MessageV2.WithParts[]; agent: Agent.Info }) {
     const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
     if (!userMessage) return input.messages
-    if (input.agent.name === "plan") {
+
+    // If agent has a reminder configured (string), inject it
+    // If reminder is false or undefined, skip injection
+    if (typeof input.agent.reminder === "string") {
       userMessage.parts.push({
         id: Identifier.ascending("part"),
         messageID: userMessage.info.id,
         sessionID: userMessage.info.sessionID,
         type: "text",
-        // TODO (for mr dax): update to use the anthropic full fledged one (see plan-reminder-anthropic.txt)
-        text: PROMPT_PLAN,
+        text: input.agent.reminder,
         synthetic: true,
       })
     }
+
+    // Notify build agent when switching from plan mode
     const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
     if (wasPlan && input.agent.name === "build") {
       userMessage.parts.push({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1350,6 +1350,10 @@ export type AgentConfig = {
    */
   maxSteps?: number
   permission?: PermissionConfig
+  /**
+   * Custom reminder text injected into user messages for this agent. Set to false to disable the default reminder.
+   */
+  reminder?: string | false
   [key: string]:
     | unknown
     | string
@@ -1367,6 +1371,8 @@ export type AgentConfig = {
     | string
     | number
     | PermissionConfig
+    | string
+    | false
     | undefined
 }
 
@@ -2005,6 +2011,7 @@ export type Agent = {
     [key: string]: unknown
   }
   steps?: number
+  reminder?: string | false
 }
 
 export type McpStatusConnected = {


### PR DESCRIPTION
## Summary
- Add `reminder` field to agent configuration allowing custom reminder text or disabling reminders entirely
- Move plan reminder logic from hardcoded check to configurable agent property
- Keep existing build-switch behavior (notifies build agent when switching from plan mode)

## Motivation
The plan agent's reminder was previously hardcoded and injected unconditionally based on agent name, preventing plugins from customizing agent behavior. This change makes reminders configurable per-agent while preserving backward compatibility.

## Changes
- **Config schema**: Add `reminder: string | false` field to `Config.Agent`
- **Agent schema**: Add `reminder` field to `Agent.Info`, set `PROMPT_PLAN` as default for plan agent
- **Prompt handling**: Check `agent.reminder` instead of hardcoded agent name

## Usage

Replace default reminder with custom text:
```jsonc
{
  "agent": {
    "plan": {
      "reminder": "You are in planning mode. You may edit .opencode/plan/*.md files."
    }
  }
}
```

Disable reminder entirely:
```jsonc
{
  "agent": {
    "plan": {
      "reminder": false
    }
  }
}
```

## Backward Compatibility
- If `reminder` is not specified, plan agent uses the existing default (`PROMPT_PLAN`)
- Build-switch reminder behavior unchanged
- No breaking changes to existing configs

resolves #7656
