### PR TITLE
fix: support plural directory names in command/agent name extraction

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -222,7 +222,7 @@ export namespace Config {
       if (!md.data) continue
 
       const name = (() => {
-        const patterns = ["/.opencode/command/", "/command/"]
+        const patterns = ["/.opencode/commands/", "/.opencode/command/", "/commands/", "/command/"]
         const pattern = patterns.find((p) => item.includes(p))
 
         if (pattern) {
@@ -262,11 +262,15 @@ export namespace Config {
 
       // Extract relative path from agent folder for nested agents
       let agentName = path.basename(item, ".md")
-      const agentFolderPath = item.includes("/.opencode/agent/")
-        ? item.split("/.opencode/agent/")[1]
-        : item.includes("/agent/")
-          ? item.split("/agent/")[1]
-          : agentName + ".md"
+      const agentFolderPath = item.includes("/.opencode/agents/")
+        ? item.split("/.opencode/agents/")[1]
+        : item.includes("/.opencode/agent/")
+          ? item.split("/.opencode/agent/")[1]
+          : item.includes("/agents/")
+            ? item.split("/agents/")[1]
+            : item.includes("/agent/")
+              ? item.split("/agent/")[1]
+              : agentName + ".md"
 
       // If agent is in a subfolder, include folder path in name
       if (agentFolderPath.includes("/")) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -261,16 +261,13 @@ export namespace Config {
       if (!md.data) continue
 
       // Extract relative path from agent folder for nested agents
+      const agentFolderPath = (() => {
+        const patterns = ["/.opencode/agents/", "/.opencode/agent/", "/agents/", "/agent/"]
+        const pattern = patterns.find((p) => item.includes(p))
+        if (pattern) return item.split(pattern)[1]
+        return path.basename(item, ".md") + ".md"
+      })()
       let agentName = path.basename(item, ".md")
-      const agentFolderPath = item.includes("/.opencode/agents/")
-        ? item.split("/.opencode/agents/")[1]
-        : item.includes("/.opencode/agent/")
-          ? item.split("/.opencode/agent/")[1]
-          : item.includes("/agents/")
-            ? item.split("/agents/")[1]
-            : item.includes("/agent/")
-              ? item.split("/agent/")[1]
-              : agentName + ".md"
 
       // If agent is in a subfolder, include folder path in name
       if (agentFolderPath.includes("/")) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -334,6 +334,69 @@ Test agent prompt`,
   })
 })
 
+test("loads nested commands from plural commands/ directory with prefix", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      await fs.mkdir(opencodeDir, { recursive: true })
+      const commandsDir = path.join(opencodeDir, "commands", "email")
+      await fs.mkdir(commandsDir, { recursive: true })
+
+      await Bun.write(
+        path.join(commandsDir, "digest.md"),
+        `---
+description: Generate email digest
+---
+Generate a digest of recent emails`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Should preserve the email/ prefix from nested directory
+      expect(config.command?.["email/digest"]).toEqual({
+        description: "Generate email digest",
+        template: "Generate a digest of recent emails",
+      })
+    },
+  })
+})
+
+test("loads nested agents from plural agents/ directory with prefix", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      await fs.mkdir(opencodeDir, { recursive: true })
+      const agentsDir = path.join(opencodeDir, "agents", "ml")
+      await fs.mkdir(agentsDir, { recursive: true })
+
+      await Bun.write(
+        path.join(agentsDir, "engineer.md"),
+        `---
+model: test/model
+---
+ML Engineer agent prompt`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      // Should preserve the ml/ prefix from nested directory
+      expect(config.agent?.["ml/engineer"]).toEqual(
+        expect.objectContaining({
+          name: "ml/engineer",
+          model: "test/model",
+          prompt: "ML Engineer agent prompt",
+        }),
+      )
+    },
+  })
+})
+
 test("updates config and writes to file", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({


### PR DESCRIPTION
## Summary

Fixes #7667

Commit b9ef09a0 added glob pattern support for plural directory names (`commands/`, `agents/`) but did not update the name extraction logic. This caused nested command/agent names to lose their prefix when using plural directory names.

## Changes

- Added plural patterns (`/.opencode/commands/`, `/commands/`, `/.opencode/agents/`, `/agents/`) to the name extraction logic in `loadCommand` and `loadAgent` functions
- Added test cases to verify nested commands/agents in plural directories preserve their path prefix

## Test Plan

- [x] All existing tests pass (44 tests in config.test.ts)
- [x] New test cases added for:
  - Nested commands in `commands/` directory
  - Nested agents in `agents/` directory

## Example

When using `OPENCODE_CONFIG_DIR` with structure `commands/email/digest.md`:
- Before: command name = `digest` (prefix lost)
- After: command name = `email/digest` (prefix preserved)