### PR TITLE
fix: stop changing main model/agent from subtasks invocation

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -75,6 +75,7 @@ export namespace Command {
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+        agent: "plan"
       },
     }
 

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -75,7 +75,6 @@ export namespace Command {
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
-        agent: "plan"
       },
     }
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -168,6 +168,12 @@ export namespace MessageV2 {
     prompt: z.string(),
     description: z.string(),
     agent: z.string(),
+    model: z
+      .object({
+        providerID: z.string(),
+        modelID: z.string(),
+      })
+      .optional(),
     command: z.string().optional(),
   })
   export type SubtaskPart = z.infer<typeof SubtaskPart>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1545,25 +1545,27 @@ export namespace SessionPrompt {
     }
 
     const templateParts = await resolvePromptParts(template)
-    const parts =
-      (agent.mode === "subagent" && command.subtask !== false) || command.subtask === true
-        ? [
-            {
-              type: "subtask" as const,
-              agent: agent.name,
-              description: command.description ?? "",
-              command: input.command,
-              // TODO: how can we make task tool accept a more complex input?
-              prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
-            },
-          ]
-        : [...templateParts, ...(input.parts ?? [])]
+    const isSubtask = (agent.mode === "subagent" && command.subtask !== false) || command.subtask === true
+    const parts = isSubtask
+      ? [
+          {
+            type: "subtask" as const,
+            agent: agent.name,
+            description: command.description ?? "",
+            command: input.command,
+            // TODO: how can we make task tool accept a more complex input?
+            prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
+          },
+        ]
+      : [...templateParts, ...(input.parts ?? [])]
+
+    const userAgent = isSubtask ? (input.agent ?? (await Agent.defaultAgent())) : agentName
 
     const result = (await prompt({
       sessionID: input.sessionID,
       messageID: input.messageID,
       model,
-      agent: agentName,
+      agent: userAgent,
       parts,
       variant: input.variant,
     })) as MessageV2.WithParts

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -316,6 +316,9 @@ export namespace SessionPrompt {
       // TODO: centralize "invoke tool" logic
       if (task?.type === "subtask") {
         const taskTool = await TaskTool.init()
+        const taskModel = task.model
+          ? await Provider.getModel(task.model.providerID, task.model.modelID)
+          : model
         const assistantMessage = (await Session.updateMessage({
           id: Identifier.ascending("message"),
           role: "assistant",
@@ -334,8 +337,8 @@ export namespace SessionPrompt {
             reasoning: 0,
             cache: { read: 0, write: 0 },
           },
-          modelID: model.id,
-          providerID: model.providerID,
+          modelID: taskModel.id,
+          providerID: taskModel.providerID,
           time: {
             created: Date.now(),
           },
@@ -1505,7 +1508,7 @@ export namespace SessionPrompt {
     }
     template = template.trim()
 
-    const model = await (async () => {
+    const taskModel = await (async () => {
       if (command.model) {
         return Provider.parseModel(command.model)
       }
@@ -1520,7 +1523,7 @@ export namespace SessionPrompt {
     })()
 
     try {
-      await Provider.getModel(model.providerID, model.modelID)
+      await Provider.getModel(taskModel.providerID, taskModel.modelID)
     } catch (e) {
       if (Provider.ModelNotFoundError.isInstance(e)) {
         const { providerID, modelID, suggestions } = e.data
@@ -1553,6 +1556,10 @@ export namespace SessionPrompt {
             agent: agent.name,
             description: command.description ?? "",
             command: input.command,
+            model: {
+              providerID: taskModel.providerID,
+              modelID: taskModel.modelID,
+            },
             // TODO: how can we make task tool accept a more complex input?
             prompt: templateParts.find((y) => y.type === "text")?.text ?? "",
           },
@@ -1560,11 +1567,12 @@ export namespace SessionPrompt {
       : [...templateParts, ...(input.parts ?? [])]
 
     const userAgent = isSubtask ? (input.agent ?? (await Agent.defaultAgent())) : agentName
+    const userModel = isSubtask ? await lastModel(input.sessionID) : taskModel
 
     const result = (await prompt({
       sessionID: input.sessionID,
       messageID: input.messageID,
-      model,
+      model: userModel,
       agent: userAgent,
       parts,
       variant: input.variant,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -316,9 +316,7 @@ export namespace SessionPrompt {
       // TODO: centralize "invoke tool" logic
       if (task?.type === "subtask") {
         const taskTool = await TaskTool.init()
-        const taskModel = task.model
-          ? await Provider.getModel(task.model.providerID, task.model.modelID)
-          : model
+        const taskModel = task.model ? await Provider.getModel(task.model.providerID, task.model.modelID) : model
         const assistantMessage = (await Session.updateMessage({
           id: Identifier.ascending("message"),
           role: "assistant",
@@ -1567,7 +1565,11 @@ export namespace SessionPrompt {
       : [...templateParts, ...(input.parts ?? [])]
 
     const userAgent = isSubtask ? (input.agent ?? (await Agent.defaultAgent())) : agentName
-    const userModel = isSubtask ? await lastModel(input.sessionID) : taskModel
+    const userModel = isSubtask
+      ? input.model
+        ? Provider.parseModel(input.model)
+        : await lastModel(input.sessionID)
+      : taskModel
 
     const result = (await prompt({
       sessionID: input.sessionID,


### PR DESCRIPTION
### What does this PR do?

Currently `/review`, even having in the prompt to not make changes, very often it decides to go ahead and do the changes.

<img width="877" height="728" alt="image" src="https://github.com/user-attachments/assets/3287520f-2ef7-4322-8b56-bcd568870083" />

This PR changes to use plan agent.

Also, i noticed that currently even with subtasks, when you run a command with a different agent, it's changing the main session agent to that, this PR also fixes it.

### How did you verify your code works?

<img width="1551" height="1004" alt="image" src="https://github.com/user-attachments/assets/2c8ffb70-b829-488c-a2ab-322f244499d4" />
