### PR TITLE
fix: exclude 'none' variant for gpt-5.2-codex

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -318,7 +318,10 @@ export namespace ProviderTransform {
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/openai
         if (id === "gpt-5-pro") return {}
         const openaiEfforts = iife(() => {
-          if (id.includes("codex") && !id.includes("5.2")) return WIDELY_SUPPORTED_EFFORTS
+          if (id.includes("codex")) {
+            if (id.includes("5.2")) return [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
+            return WIDELY_SUPPORTED_EFFORTS
+          }
           const arr = [...WIDELY_SUPPORTED_EFFORTS]
           if (id.includes("gpt-5-") || id === "gpt-5") {
             arr.unshift("minimal")


### PR DESCRIPTION
Fixes #7680

### What does this PR do?
adds explicit variant handling for codex models:
- `gpt-*-codex` → `["low", "medium", "high"]`
- `gpt-5.2-codex` → `["low", "medium", "high", "xhigh"]`
