### PR TITLE
fix(opencode): gracefully handle malformed skill YAML frontmatter

### DIFF
--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -14,6 +14,74 @@ export namespace ConfigMarkdown {
     return Array.from(template.matchAll(SHELL_REGEX))
   }
 
+  function fixYamlFrontmatter(content: string): string {
+    const lines = content.split("\n")
+    const result: string[] = []
+    let inFrontmatter = false
+    let frontmatterEnd = false
+
+    for (const line of lines) {
+      if (line.trim() === "---" && !inFrontmatter) {
+        inFrontmatter = true
+        result.push(line)
+        continue
+      }
+
+      if (line.trim() === "---" && inFrontmatter && !frontmatterEnd) {
+        frontmatterEnd = true
+        inFrontmatter = false
+        result.push(line)
+        continue
+      }
+
+      if (!inFrontmatter) {
+        result.push(line)
+        continue
+      }
+
+      const colonIndex = line.indexOf(":")
+      if (colonIndex === -1) {
+        result.push(line)
+        continue
+      }
+
+      const key = line.slice(0, colonIndex).trim()
+      const value = line.slice(colonIndex + 1).trim()
+
+      if (!value || value.startsWith("#") || value.startsWith("|") || value.startsWith(">")) {
+        result.push(line)
+        continue
+      }
+
+      const alreadyQuoted =
+        (value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))
+
+      if (alreadyQuoted) {
+        result.push(line)
+        continue
+      }
+
+      const specialChars = /[:#{}\[\],>|\*&@%`]/
+      const needsQuoting = specialChars.test(value)
+
+      if (!needsQuoting) {
+        result.push(line)
+        continue
+      }
+
+      let quotedValue: string
+      if (value.includes("'")) {
+        quotedValue = `"${value.replace(/"/g, '\\"')}"`
+      } else {
+        quotedValue = `'${value}'`
+      }
+
+      result.push(`${key}: ${quotedValue}`)
+    }
+
+    return result.join("\n")
+  }
+
   export async function parse(filePath: string) {
     const template = await Bun.file(filePath).text()
 
@@ -21,13 +89,19 @@ export namespace ConfigMarkdown {
       const md = matter(template)
       return md
     } catch (err) {
-      throw new FrontmatterError(
-        {
-          path: filePath,
-          message: `Failed to parse YAML frontmatter: ${err instanceof Error ? err.message : String(err)}`,
-        },
-        { cause: err },
-      )
+      const fixed = fixYamlFrontmatter(template)
+      try {
+        const md = matter(fixed)
+        return md
+      } catch {
+        throw new FrontmatterError(
+          {
+            path: filePath,
+            message: `Failed to parse YAML frontmatter: ${err instanceof Error ? err.message : String(err)}`,
+          },
+          { cause: err },
+        )
+      }
     }
   }
 

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -43,7 +43,19 @@ export namespace Skill {
     const skills: Record<string, Info> = {}
 
     const addSkill = async (match: string) => {
-      const md = await ConfigMarkdown.parse(match)
+      let md
+      try {
+        md = await ConfigMarkdown.parse(match)
+      } catch (error) {
+        if (error instanceof ConfigMarkdown.FrontmatterError) {
+          log.warn("skipping skill with invalid YAML frontmatter", {
+            path: error.data.path,
+            message: error.data.message,
+          })
+          return
+        }
+        throw error
+      }
       if (!md) {
         return
       }

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -43,19 +43,7 @@ export namespace Skill {
     const skills: Record<string, Info> = {}
 
     const addSkill = async (match: string) => {
-      let md
-      try {
-        md = await ConfigMarkdown.parse(match)
-      } catch (error) {
-        if (error instanceof ConfigMarkdown.FrontmatterError) {
-          log.warn("skipping skill with invalid YAML frontmatter", {
-            path: error.data.path,
-            message: error.data.message,
-          })
-          return
-        }
-        throw error
-      }
+      const md = await ConfigMarkdown.parse(match)
       if (!md) {
         return
       }


### PR DESCRIPTION
Fixes #7582

When a skill file (from `~/.claude/skills/` or project `.claude/skills/`) has invalid YAML frontmatter, OpenCode crashes with `ConfigFrontmatterError` after sending a message (see #7582). As @paulp-o noted, malformed config files can cause this terminal operation error.

This change catches the error and logs a warning instead, allowing OpenCode to continue loading other skills.

**How I verified:**
1. Created a skill file with invalid YAML:
   ```yaml
   ---
   name: completion-check
   description: Completion Check: Verify Infrastructure Is Wired
   ---
(unquoted colon in description value)

2. Ran bun dev, typed a message and sent it - previously crashed with ConfigFrontmatterError, now works
3. Confirmed warning appears in ~/.local/share/opencode/log/dev.log