### PR TITLE
fix(tui): handle undefined agent.current() to prevent fatal TypeError

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -20,7 +20,7 @@ export function DialogAgent() {
   return (
     <DialogSelect
       title="Select agent"
-      current={local.agent.current().name}
+      current={local.agent.current()?.name ?? ""}
       options={options()}
       onSelect={(option) => {
         local.agent.set(option.value)

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -534,7 +534,7 @@ export function Prompt(props: PromptProps) {
     if (store.mode === "shell") {
       sdk.client.session.shell({
         sessionID,
-        agent: local.agent.current().name,
+        agent: local.agent.current()?.name ?? "build",
         model: {
           providerID: selectedModel.providerID,
           modelID: selectedModel.modelID,
@@ -555,7 +555,7 @@ export function Prompt(props: PromptProps) {
         sessionID,
         command: command.slice(1),
         arguments: args.join(" "),
-        agent: local.agent.current().name,
+        agent: local.agent.current()?.name ?? "build",
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         messageID,
         variant,
@@ -571,7 +571,7 @@ export function Prompt(props: PromptProps) {
         sessionID,
         ...selectedModel,
         messageID,
-        agent: local.agent.current().name,
+        agent: local.agent.current()?.name ?? "build",
         model: selectedModel,
         variant,
         parts: [
@@ -691,7 +691,7 @@ export function Prompt(props: PromptProps) {
   const highlight = createMemo(() => {
     if (keybind.leader) return theme.border
     if (store.mode === "shell") return theme.primary
-    return local.agent.color(local.agent.current().name)
+    return local.agent.color(local.agent.current()?.name ?? "build")
   })
 
   const showVariant = createMemo(() => {
@@ -702,7 +702,7 @@ export function Prompt(props: PromptProps) {
   })
 
   const spinnerDef = createMemo(() => {
-    const color = local.agent.color(local.agent.current().name)
+    const color = local.agent.color(local.agent.current()?.name ?? "build")
     return {
       frames: createFrames({
         color,
@@ -933,7 +933,7 @@ export function Prompt(props: PromptProps) {
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
               <text fg={highlight()}>
-                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
+                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current()?.name ?? "build")}{" "}
               </text>
               <Show when={store.mode === "normal"}>
                 <box flexDirection="row" gap={1}>

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -38,7 +38,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       const [agentStore, setAgentStore] = createStore<{
         current: string
       }>({
-        current: agents()[0].name,
+        current: agents()[0]?.name ?? "",
       })
       const { theme } = useTheme()
       const colors = createMemo(() => [
@@ -54,7 +54,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return agents()
         },
         current() {
-          return agents().find((x) => x.name === agentStore.current)!
+          return agents().find((x) => x.name === agentStore.current)
         },
         set(name: string) {
           if (!agents().some((x) => x.name === name))
@@ -71,7 +71,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             if (next < 0) next = agents().length - 1
             if (next >= agents().length) next = 0
             const value = agents()[next]
-            setAgentStore("current", value.name)
+            if (value) setAgentStore("current", value.name)
           })
         },
         color(name: string) {
@@ -179,6 +179,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
       const currentModel = createMemo(() => {
         const a = agent.current()
+        if (!a) return undefined
         return (
           getFirstValidModel(
             () => modelStore.model[a.name],
@@ -219,6 +220,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         cycle(direction: 1 | -1) {
           const current = currentModel()
           if (!current) return
+          const currentAgent = agent.current()
+          if (!currentAgent) return
           const recent = modelStore.recent
           const index = recent.findIndex((x) => x.providerID === current.providerID && x.modelID === current.modelID)
           if (index === -1) return
@@ -227,7 +230,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (next >= recent.length) next = 0
           const val = recent[next]
           if (!val) return
-          setModelStore("model", agent.current().name, { ...val })
+          setModelStore("model", currentAgent.name, { ...val })
         },
         cycleFavorite(direction: 1 | -1) {
           const favorites = modelStore.favorite.filter((item) => isModelValid(item))
@@ -239,6 +242,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             })
             return
           }
+          const currentAgent = agent.current()
+          if (!currentAgent) return
           const current = currentModel()
           let index = -1
           if (current) {
@@ -253,7 +258,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           }
           const next = favorites[index]
           if (!next) return
-          setModelStore("model", agent.current().name, { ...next })
+          setModelStore("model", currentAgent.name, { ...next })
           const uniq = uniqueBy([next, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
           if (uniq.length > 10) uniq.pop()
           setModelStore(
@@ -264,6 +269,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         },
         set(model: { providerID: string; modelID: string }, options?: { recent?: boolean }) {
           batch(() => {
+            const currentAgent = agent.current()
+            if (!currentAgent) return
             if (!isModelValid(model)) {
               toast.show({
                 message: `Model ${model.providerID}/${model.modelID} is not valid`,
@@ -272,7 +279,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               })
               return
             }
-            setModelStore("model", agent.current().name, model)
+            setModelStore("model", currentAgent.name, model)
             if (options?.recent) {
               const uniq = uniqueBy([model, ...modelStore.recent], (x) => `${x.providerID}/${x.modelID}`)
               if (uniq.length > 10) uniq.pop()
@@ -368,6 +375,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     // Automatically update model when agent changes
     createEffect(() => {
       const value = agent.current()
+      if (!value) return
       if (value.model) {
         if (isModelValid(value.model))
           model.set({


### PR DESCRIPTION
## Summary

Fixes the fatal error: `TypeError: undefined is not an object (evaluating 'local.agent.current().name')`

## Root Cause

When the agents list is empty or the stored agent name doesn't match any available agent, `local.agent.current()` returns `undefined`. The code then crashes when accessing `.name` on `undefined`.

**Affected locations:**
- `packages/opencode/src/cli/cmd/tui/context/local.tsx` - Source of the issue
- `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx` - 6 consumer locations
- `packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx` - 1 consumer location

## Changes

### `local.tsx`
- Line 41: `agents()[0].name` → `agents()[0]?.name ?? ""` for safe initialization
- Line 57: Removed non-null assertion `!` from `current()` return
- Line 74: Added null check before setting agent store
- Lines 181-185, 230, 256, 275, 370: Added null guards before accessing `agent.current()`

### `prompt/index.tsx`
- Added optional chaining with `"build"` fallback at all 6 locations:
  - Shell handler (line 537)
  - Command handler (line 558)
  - Prompt handler (line 574)
  - Highlight memo (line 694)
  - Spinner definition (line 705)
  - JSX display (line 936)

### `dialog-agent.tsx`
- Added optional chaining with empty string fallback

## Testing

The fix adds defensive null checks that gracefully handle edge cases without changing normal behavior when agents are properly loaded.