### PR TITLE
fix(tui): move props.ref to onMount

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -317,6 +317,38 @@ export function Prompt(props: PromptProps) {
 
   onMount(() => {
     promptPartTypeId = input.extmarks.registerType("prompt-part")
+    props.ref?.({
+      get focused() {
+        return input.focused
+      },
+      get current() {
+        return store.prompt
+      },
+      focus() {
+        input.focus()
+      },
+      blur() {
+        input.blur()
+      },
+      set(prompt) {
+        input.setText(prompt.input)
+        setStore("prompt", prompt)
+        restoreExtmarksFromParts(prompt.parts)
+        input.gotoBufferEnd()
+      },
+      reset() {
+        input.clear()
+        input.extmarks.clear()
+        setStore("prompt", {
+          input: "",
+          parts: [],
+        })
+        setStore("extmarkToPartIndex", new Map())
+      },
+      submit() {
+        submit()
+      },
+    })
   })
 
   function restoreExtmarksFromParts(parts: PromptInfo["parts"]) {
@@ -451,39 +483,6 @@ export function Prompt(props: PromptProps) {
       },
     },
   ])
-
-  props.ref?.({
-    get focused() {
-      return input.focused
-    },
-    get current() {
-      return store.prompt
-    },
-    focus() {
-      input.focus()
-    },
-    blur() {
-      input.blur()
-    },
-    set(prompt) {
-      input.setText(prompt.input)
-      setStore("prompt", prompt)
-      restoreExtmarksFromParts(prompt.parts)
-      input.gotoBufferEnd()
-    },
-    reset() {
-      input.clear()
-      input.extmarks.clear()
-      setStore("prompt", {
-        input: "",
-        parts: [],
-      })
-      setStore("extmarkToPartIndex", new Map())
-    },
-    submit() {
-      submit()
-    },
-  })
 
   async function submit() {
     if (props.disabled) return


### PR DESCRIPTION
Fixes: #7633 & possibly #7634

### What does this PR do?

Currently there is an issue where forking from the first message of a session causes a fatal crash since
the session route calls `r.set(route.initialPrompt)` immediately after receiving the ref, but the`input` is not valid until the `textarea` component is ready later on-down in the component hierarchy.

This PR moves the `Prompt props.ref` logic into the `onMount` lifecycle component to ensure that the ref is only invoked when the component is fully ready.

### How did you verify your code works?

https://github.com/user-attachments/assets/180de7a3-a277-4f3f-953c-4d7931833bb8