### PR TITLE
feat(app): add tab cycling for modes in the prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -52,7 +52,7 @@ import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
 import { useGlobalSync } from "@/context/global-sync"
 import { usePlatform } from "@/context/platform"
-import { createOpencodeClient, type Message, type Part } from "@opencode-ai/sdk/v2/client"
+import { Agent, createOpencodeClient, type Message, type Part } from "@opencode-ai/sdk/v2/client"
 import { Binary } from "@opencode-ai/util/binary"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
@@ -979,6 +979,33 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       } else if (working()) {
         abort()
       }
+    }
+
+    if (event.key === "Tab") {
+      const agentName = local.agent.current()?.name
+      const agentNames = local.agent.list().map((agent) => agent.name)
+
+      if (!agentName || !agentNames.length || agentNames.length === 1) {
+        return
+      }
+
+      const agentNameIndex = agentNames.indexOf(agentName)
+
+      let nextAgentName: Agent["name"]
+
+      if (event.shiftKey) {
+        nextAgentName = agentNames[agentNameIndex === 0 ? agentNames.length - 1 : agentNameIndex - 1]
+      } else {
+        nextAgentName = agentNames[agentNameIndex === agentNames.length - 1 ? 0 : agentNameIndex + 1]
+      }
+
+      if (!nextAgentName) {
+        return
+      }
+
+      event.preventDefault()
+
+      local.agent.set(nextAgentName)
     }
   }
 


### PR DESCRIPTION
Closes #7224 

### What does this PR do?

- This PR adds support for cycling through your different agents/modes in the prompt input using tab and shift-tab. I know this maybe isn't the absolute best solution. For example, what if you wanna indent pasted code or something. But, maybe we can think about that later. This could be fine for now, so you don't have to reach down to the select menu every time you wanna change the agent?

### How did you verify your code works?

I tried hitting `Tab` and `Shift-Tab` in the prompt input, and it works as expected.

### Demo


https://github.com/user-attachments/assets/8ebcbd50-b99c-408b-a3f2-a5154eeae0c7

