### PR TITLE
chore(ci): add format check workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,21 @@
+name: format
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  format:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Check formatting
+        run: ./script/format.ts --check
+        env:
+          CI: true

--- a/script/format.ts
+++ b/script/format.ts
@@ -2,4 +2,6 @@
 
 import { $ } from "bun"
 
-await $`bun run prettier --ignore-unknown --write .`
+const check = Bun.argv.includes("--check")
+
+await $`bun run prettier --ignore-unknown ${check ? "--check" : "--write"} .`


### PR DESCRIPTION
Fixes #7710\n\n- Add `--check` mode to `./script/format.ts`\n- Add a PR CI workflow that runs Prettier in check mode\n\nHow to verify:\n- CI "format" job passes\n- Run locally: `./script/format.ts --check`