### PR TITLE
feat: pass sessionID to chat.system.transform

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -73,7 +73,7 @@ export namespace LLM {
 
     const header = system[0]
     const original = clone(system)
-    await Plugin.trigger("experimental.chat.system.transform", {}, { system })
+    await Plugin.trigger("experimental.chat.system.transform", { sessionID: input.sessionID }, { system })
     if (system.length === 0) {
       system.push(...original)
     }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -195,7 +195,7 @@ export interface Hooks {
     },
   ) => Promise<void>
   "experimental.chat.system.transform"?: (
-    input: {},
+    input: { sessionID: string },
     output: {
       system: string[]
     },


### PR DESCRIPTION
### What does this PR do?
Adds sessionID to experimental.chat.system.transform input

Allows plugins to conditionally inject into the system prompt based on session context (e.g., only inject for child sessions by checking parentID, or only main session)