### PR TITLE
fix(opencode): command palette mouse hover highlights wrong item

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -255,7 +255,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                           props.onSelect?.(option)
                         }}
                         onMouseOver={() => {
-                          const index = filtered().findIndex((x) => isDeepEqual(x.value, option.value))
+                          const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
                           if (index === -1) return
                           moveTo(index)
                         }}


### PR DESCRIPTION
https://github.com/user-attachments/assets/42f2561e-c37e-43ab-aa13-6957d174c9a4

## Summary
- align hover selection index with grouped command list ordering
- keep mouse hover consistent after filtering

## Verification
- open command palette (Ctrl+P) and hover items
- optionally type a filter (e.g. press "e" a few times) and hover again

Fixes #7722