### PR TITLE
feat(acp): track file modified

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -30,6 +30,7 @@ import { Todo } from "@/session/todo"
 import { z } from "zod"
 import { LoadAPIKeyError } from "ai"
 import type { OpencodeClient, SessionMessageResponse } from "@opencode-ai/sdk/v2"
+import { applyPatch } from "diff"
 
 export namespace ACP {
   const log = Log.create({ service: "acp-agent" })
@@ -104,6 +105,20 @@ export namespace ACP {
                     directory,
                   })
                   return
+                }
+                if (res.outcome.optionId !== "reject" && permission.permission == "edit") {
+                  const metadata = permission.metadata || {}
+                  const filepath = typeof metadata["filepath"] === "string" ? metadata["filepath"] : ""
+                  const diff = typeof metadata["diff"] === "string" ? metadata["diff"] : ""
+
+                  const content = await Bun.file(filepath).text()
+                  const newContent = getNewContent(content, diff)
+
+                  this.connection.writeTextFile({
+                    sessionId: sessionId,
+                    path: filepath,
+                    content: newContent,
+                  })
                 }
                 await this.config.sdk.permission.reply({
                   requestID: permission.id,
@@ -1094,5 +1109,13 @@ export namespace ACP {
         text: uri,
       }
     }
+  }
+
+  function getNewContent(fileOriginal: string, unifiedDiff: string): string {
+    const result = applyPatch(fileOriginal, unifiedDiff)
+    if (result === false) {
+      throw new Error("Failed to apply unified diff (context mismatch)")
+    }
+    return result
   }
 }

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -114,11 +114,13 @@ export namespace ACP {
                   const content = await Bun.file(filepath).text()
                   const newContent = getNewContent(content, diff)
 
-                  this.connection.writeTextFile({
-                    sessionId: sessionId,
-                    path: filepath,
-                    content: newContent,
-                  })
+                  if (newContent) {
+                    this.connection.writeTextFile({
+                      sessionId: sessionId,
+                      path: filepath,
+                      content: newContent,
+                    })
+                  }
                 }
                 await this.config.sdk.permission.reply({
                   requestID: permission.id,
@@ -1111,10 +1113,11 @@ export namespace ACP {
     }
   }
 
-  function getNewContent(fileOriginal: string, unifiedDiff: string): string {
+  function getNewContent(fileOriginal: string, unifiedDiff: string): string | undefined {
     const result = applyPatch(fileOriginal, unifiedDiff)
     if (result === false) {
-      throw new Error("Failed to apply unified diff (context mismatch)")
+      log.error("Failed to apply unified diff (context mismatch)")
+      return undefined
     }
     return result
   }


### PR DESCRIPTION
Fixes #7720
<img width="1644" height="972" alt="Screenshot 2026-01-11 074658" src="https://github.com/user-attachments/assets/5326c98d-1ec1-4c22-9a73-dce4682c7c24" />

I implemented https://agentclientprotocol.com/protocol/schema#fs/write-text-file in front of opencode acp, so that the user can choose which one needs to be rejected or approved.
