### PR TITLE
feat(opencode): enhance TUI Thread Init & RPC error handling

### DIFF
--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -3,12 +3,41 @@ export namespace Rpc {
     [method: string]: (input: any) => any
   }
 
+  interface SerializedError {
+    name: string
+    message: string
+    stack?: string
+    data?: Record<string, unknown>
+  }
+
+  function serializeError(err: unknown): SerializedError {
+    if (err instanceof Error) {
+      const serialized: SerializedError = {
+        name: err.name,
+        message: err.message,
+        stack: err.stack,
+      }
+      if ("toObject" in err && typeof err.toObject === "function") {
+        serialized.data = err.toObject().data
+      }
+      return serialized
+    }
+    return {
+      name: "Error",
+      message: String(err),
+    }
+  }
+
   export function listen(rpc: Definition) {
     onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.request") {
-        const result = await rpc[parsed.method](parsed.input)
-        postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+        try {
+          const result = await rpc[parsed.method](parsed.input)
+          postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+        } catch (err) {
+          postMessage(JSON.stringify({ type: "rpc.error", error: serializeError(err), id: parsed.id }))
+        }
       }
     }
   }
@@ -17,19 +46,42 @@ export namespace Rpc {
     postMessage(JSON.stringify({ type: "rpc.event", event, data }))
   }
 
+  /**
+   * Error class that reconstructs a remote error in a way that is compatible
+   * with NamedError.isInstance checks. The `name` and `data` properties match
+   * the original error, allowing FormatError to handle it correctly.
+   */
+  export class RemoteError extends Error {
+    readonly data?: Record<string, unknown>
+
+    constructor(error: SerializedError) {
+      super(error.message)
+      this.name = error.name
+      this.stack = error.stack
+      this.data = error.data
+    }
+  }
+
   export function client<T extends Definition>(target: {
     postMessage: (data: string) => void | null
     onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
   }) {
-    const pending = new Map<number, (result: any) => void>()
+    const pending = new Map<number, { resolve: (result: any) => void; reject: (error: Error) => void }>()
     const listeners = new Map<string, Set<(data: any) => void>>()
     let id = 0
     target.onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.result") {
-        const resolve = pending.get(parsed.id)
-        if (resolve) {
-          resolve(parsed.result)
+        const handler = pending.get(parsed.id)
+        if (handler) {
+          handler.resolve(parsed.result)
+          pending.delete(parsed.id)
+        }
+      }
+      if (parsed.type === "rpc.error") {
+        const handler = pending.get(parsed.id)
+        if (handler) {
+          handler.reject(new RemoteError(parsed.error))
           pending.delete(parsed.id)
         }
       }
@@ -45,8 +97,8 @@ export namespace Rpc {
     return {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
         const requestId = id++
-        return new Promise((resolve) => {
-          pending.set(requestId, resolve)
+        return new Promise((resolve, reject) => {
+          pending.set(requestId, { resolve, reject })
           target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
         })
       },


### PR DESCRIPTION
### What does this PR do?

Closes #7693 

When starting the TUI, `thread.ts` creates a worker and calls client.call("subscribe", { directory: cwd }). This triggers `rpc.subscribe` in the worker, which calls Instance.provide() → InstanceBootstrap() → Plugin.init() → Config.get() → Config.state() → loadAgent().

If loadAgent() throws an error due to a bad markdown:

**Previously**: Rpc.listen had no try/catch, so the error became an unhandled rejection caught only by the worker's process.on("uncaughtException"). No response was ever sent back. The client's promise from client.call() was never resolved or rejected, so it hung forever.

**With PR**: Rpc.listen catches the error, serializes it, and sends an rpc.error message back. The client receives this, rejects the promise, and the error propagates up to the catch block in index.ts where FormatError() displays it to the user.

### How did you verify your code works?

Tested it with an agent MD file similar to the one the user had an error with in #7693 just adding an invalid trailing comma. Now the error is logged and the TUI is exited, rather than hanging previously. Ideally this should fix any other error that gets thrown on startup.

<img width="798" height="197" alt="Screenshot 2026-01-11 at 03 33 28" src="https://github.com/user-attachments/assets/e82b90e4-1ec3-4886-aa90-5bf73ffe132d" />

