### PR TITLE
fix: restore persisted model/agent when loading ACP session

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -440,7 +440,7 @@ export namespace ACP {
 
         log.info("load_session", { sessionId, mcpServers: params.mcpServers.length })
 
-        const mode = await this.loadSessionMode({
+        const result = await this.loadSessionMode({
           cwd: directory,
           mcpServers: params.mcpServers,
           sessionId,
@@ -463,12 +463,20 @@ export namespace ACP {
             return undefined
           })
 
+        const lastUser = messages?.findLast((m) => m.info.role === "user")?.info
+        if (lastUser?.role === "user") {
+          result.models.currentModelId = `${lastUser.model.providerID}/${lastUser.model.modelID}`
+          if (result.modes.availableModes.some((m) => m.id === lastUser.agent)) {
+            result.modes.currentModeId = lastUser.agent
+          }
+        }
+
         for (const msg of messages ?? []) {
           log.debug("replay message", msg)
           await this.processMessage(msg)
         }
 
-        return mode
+        return result
       } catch (e) {
         const error = MessageV2.fromError(e, {
           providerID: this.config.defaultModel?.providerID ?? "unknown",


### PR DESCRIPTION
Fixes https://github.com/anomalyco/opencode/issues/7804

Read model and agent from last user message in loadSession(), matching TUI behavior (prompt/index.tsx:145-148).
