### PR TITLE
fix(tui): copy oauth url when no device code

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -112,8 +112,7 @@ function AutoMethod(props: AutoMethodProps) {
 
   useKeyboard((evt) => {
     if (evt.name === "c" && !evt.ctrl && !evt.meta) {
-      const code =
-        props.authorization.instructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4}/)?.[0] ?? props.authorization.instructions
+      const code = props.authorization.instructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4}/)?.[0] ?? props.authorization.url
       Clipboard.copy(code)
         .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
         .catch(toast.error)


### PR DESCRIPTION
### Summary

Fixes https://github.com/anomalyco/opencode/issues/7838 by updating the `c` copy handler in the OAuth auto dialog to:

 - Copy the device code if one exists in `authorization.instructions`
 - Otherwise copy `authorization.url` (the long authorize URL)

No other behavior changes. This makes `c copy` consistently copy the thing you actually need to paste into the browser e.g. Copilot: copies the device code and ChatGPT Plus/Pro copies the full authorize URL.

### Context

When connecting providers that use the OAuth "auto" flow in the TUI, OpenCode shows a URL, an instruction line, and a `c copy` hint. Pressing `c` previously copied `authorization.instructions` unless a device code (e.g. `ABCD-EFGH`) was detected inside it. For example ...

```
Login with GitHub Copilot
https://github.com/login/device
Enter code: [REDACTED]
Waiting for authorization...
c copy 
```

This worked for device-code style flows (e.g. GitHub Copilot), but for ChatGPT Plus/Pro the instructions are a generic sentence ("Complete authorization in your browser…"), so `c` copied that sentence instead of the actual authorize URL, from this ...

```
ChatGPT Pro/Plus
https://auth.openai.com/oauth/authorize?response_type=code&client_id=[REDACTED]&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&scope=openid+profile+email+offline_access&code_challenge=[REDACTED]&code_challenge_method=S256&id_token_add_organizations=true&codex_cli_simplified_flow=true&state=[REDACTED]&originator=opencode
Complete authorization in your browser. This window will close automatically.
Waiting for authorization...
c copy 
```

### Testing

I manually tested the TUI and confirmed what I expected was in the clipboard. Verified for Copilot and ChatGPT Plus/Pro ... I don't know if the other providers have flows outside what's mentioned here (and there are too many to manually check).