### PR TITLE
feat(tui): add mouse hover and click support to autocomplete

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -700,6 +700,8 @@ export function Autocomplete(props: {
               paddingRight={1}
               backgroundColor={index === store.selected ? theme.primary : undefined}
               flexDirection="row"
+              onMouseOver={() => moveTo(index)}
+              onMouseUp={() => select()}
             >
               <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>
                 {option().display}


### PR DESCRIPTION


https://github.com/user-attachments/assets/5ff7c157-18c1-4bcd-a89d-2e82925a618e



Fixes #7819

Add `onMouseOver` and `onMouseUp` handlers to autocomplete options, matching the behavior of the command palette (dialog-select).