### PR TITLE
chore(lander): fix spacing in desktop app banner

### DIFF
--- a/packages/console/app/src/routes/index.css
+++ b/packages/console/app/src/routes/index.css
@@ -522,7 +522,7 @@ body {
     [data-slot="content"] {
       display: flex;
       align-items: center;
-      gap: 4px;
+      gap: 1ch;
     }
 
     [data-slot="text"] {


### PR DESCRIPTION
### What does this PR do?

So I visited `opencode.ai` to download the latest version of the desktop app and was met with this banner text spacing:

<img width="1099" height="227" alt="image" src="https://github.com/user-attachments/assets/f7858cfb-e017-4e37-890f-5d45c0c8a017" />

This PR gives it a bit more consistency and room to breathe with `gap: 1ch`, to match the font size:

<img width="1098" height="225" alt="image" src="https://github.com/user-attachments/assets/5d2a0b91-d940-4952-b4de-401d551eb122" />

cc @iamdavidhill 

### How did you verify your code works?

`bun run dev`