### PR TITLE
docs: add opencode-mystatus plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -42,7 +42,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                      |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                          |
-
+| [opencode-mystatus](https://github.com/vbgate/opencode-mystatus)                           | Check all your AI subscription quotas in one command. Supports OpenAI (Plus/Pro/Codex, etc.), Zhipu AI, Google Antigravity, and more.
 ---
 
 ## Projects


### PR DESCRIPTION
Add opencode-mystatus plugin that checks AI subscription quotas for OpenAI (Plus/Pro/Codex), Zhipu AI, Google Antigravity, and more platforms.
- npm: https://www.npmjs.com/package/opencode-mystatus
- repo: https://github.com/vbgate/opencode-mystatus

### What does this PR do?
Add opencode-mystatus to the ecosystem plugins list.

### How did you verify your code works?
The plugin is published on npm and tested locally. Documentation and usage instructions are available in the repository README.