### PR TITLE
fix: prevent CLI hang on invalid config JSON syntax

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -9,6 +9,7 @@ import { Log } from "@/util/log"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
+import { Config } from "@/config/config"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -132,7 +133,21 @@ export const TuiThreadCommand = cmd({
       networkOpts.hostname !== "127.0.0.1"
 
     // Subscribe to events from worker
-    await client.call("subscribe", { directory: cwd })
+    const result = await client.call("subscribe", { directory: cwd })
+    if (!result.subscribed) {
+      // Reconstruct the appropriate error type for proper formatting
+      if (result.name === "ConfigJsonError") {
+        throw new Config.JsonError({ path: result.data?.path ?? "unknown", message: result.data?.message })
+      }
+      if (result.name === "ConfigInvalidError") {
+        throw new Config.InvalidError({
+          path: result.data?.path,
+          issues: result.data?.issues,
+          message: result.data?.message,
+        })
+      }
+      throw new Error(result.error)
+    }
 
     let url: string
     let customFetch: typeof fetch | undefined

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -59,18 +59,27 @@ export const rpc = {
     return { url: server.url.toString() }
   },
   async subscribe(input: { directory: string }) {
-    return Instance.provide({
-      directory: input.directory,
-      init: InstanceBootstrap,
-      fn: async () => {
-        Bus.subscribeAll((event) => {
-          Rpc.emit("event", event)
-        })
-        // Emit connected event
-        Rpc.emit("event", { type: "server.connected", properties: {} })
-        return { subscribed: true }
-      },
-    })
+    try {
+      return await Instance.provide({
+        directory: input.directory,
+        init: InstanceBootstrap,
+        fn: async () => {
+          Bus.subscribeAll((event) => {
+            Rpc.emit("event", event)
+          })
+          // Emit connected event
+          Rpc.emit("event", { type: "server.connected", properties: {} })
+          return { subscribed: true as const }
+        },
+      })
+    } catch (e) {
+      return {
+        subscribed: false as const,
+        error: e instanceof Error ? e.message : String(e),
+        name: e instanceof Error ? e.name : undefined,
+        data: e && typeof e === "object" && "toObject" in e ? (e as any).toObject().data : undefined,
+      }
+    }
   },
   async checkUpgrade(input: { directory: string }) {
     await Instance.provide({

--- a/packages/opencode/test/cli/config-syntax-error.test.ts
+++ b/packages/opencode/test/cli/config-syntax-error.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+// Invalid JSON config - missing comma after "type": "local"
+const INVALID_CONFIG = `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "example": {
+      "type": "local"
+      "command": ["echo", "hello"]
+    }
+  }
+}`
+
+// Package root directory for proper module resolution
+const PACKAGE_DIR = path.join(import.meta.dir, "../..")
+const ENTRY_POINT = path.join(PACKAGE_DIR, "src/index.ts")
+
+describe("CLI startup with invalid config", () => {
+  test("TUI should exit with error instead of hanging on invalid JSON syntax", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "opencode.json"), INVALID_CONFIG)
+      },
+    })
+
+    // Pass the project path as argument - TUI command accepts [project] positional
+    const proc = Bun.spawn({
+      cmd: ["bun", "run", "--conditions=browser", ENTRY_POINT, tmp.path],
+      cwd: PACKAGE_DIR,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        CI: "true",
+      },
+    })
+
+    const TIMEOUT_MS = 5000
+    const timeoutId = setTimeout(() => proc.kill(), TIMEOUT_MS)
+
+    const exitCode = await proc.exited
+    clearTimeout(timeoutId)
+
+    // If process was killed by timeout (exitCode is signal-based), it hung
+    // On SIGTERM, exit code is typically 143 (128 + 15) or null
+    const wasKilled = exitCode === null || exitCode >= 128
+    expect(wasKilled).toBe(false)
+
+    expect(exitCode).not.toBe(0)
+
+    const stderr = await new Response(proc.stderr).text()
+    expect(stderr).toContain("not valid JSON")
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Fixes #7789 

### Observations:
- `opencode run` exits with error since it runs on the main thread
- `opencode` runs the TUI on the main thread and spawns worker threads for the core business logic

### Alternatives Considered
- Fix RPC error propagation globally - Add try/catch to `Rpc.listen()` and introduce a new `rpc.error` message type. Rejected because it required changes to the RPC protocol and didn't seem like that was in scope
- Validate config syntax on main thread before spawning worker - Parse config files early in `TuiThreadCommand.handler()` before the worker starts. Rejected because config loading is tightly coupled to `Instance.state()` which requires the worker context, and duplicating the file search logic would be heavy.
- Move config loading to main thread entirely - Load config before spawning the worker. Rejected because the worker architecture exists for a reason (manages multiple instances, server, LSP, file watchers) and config is instance-specific.

### Proposed Solution
Update the subscription logic for the TUI to handle the case where the worker returns ` result.subscribed = false` instead of always returning `true`. If `result.subscribed == false`, we handle `ConfigJsonError` and `ConfigInvalidError` and propagate that error higher up the call stack. 

### How did you verify your code works?
- Added a new "unit" test (is it really unit if it spins up the whole application?) 
- Manual testing:
```
$ opencode --version                                                                                                                                                                                                          1.1.13
$ timeout 5 ./opencode-7789; [ $? -eq 124 ] && echo "Bug: OpenCode hung and was killed after 5s"
Bug: OpenCode hung and was killed after 5s
$ timeout 5 ./opencode-7789; [ $? -eq 124 ] && echo "Bug: OpenCode hung and was killed after 5s" # Locally built binary
Error: Config file at /private/tmp/oc-7789/opencode.json is not valid JSON(C):
--- JSONC Input ---
{
  "$schema": "https://opencode.ai/config.json",
  "mcp": {
    "example" : {
      "type": "local"
      "enabled": true,
      "command" : ["echo", "'Hello World'"]
    },
  }
}

--- Errors ---
CommaExpected at line 6, column 7
   Line 6:       "enabled": true,
                ^
--- End ---
```