### PR TITLE
docs: fix typos on the providers page

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -6,7 +6,7 @@ description: Using any LLM provider in OpenCode.
 import config from "../../../config.mjs"
 export const console = config.console
 
-OpenCode uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support for **75+ LLM providers** and it supports running local models.
+OpenCode uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support **75+ LLM providers** and it supports running local models.
 
 To add a provider you need to:
 
@@ -80,8 +80,7 @@ If you are new, we recommend starting with OpenCode Zen.
    /models
    ```
 
-It works like any other provider in OpenCode. And is completely optional to use
-it.
+It works like any other provider in OpenCode and is completely optional to use.
 
 ---
 
@@ -226,7 +225,7 @@ We recommend signing up for [Claude Pro](https://www.anthropic.com/news/claude-p
    └
    ```
 
-3. Now all the the Anthropic models should be available when you use the `/models` command.
+3. Now all the Anthropic models should be available when you use the `/models` command.
 
    ```txt
    /models


### PR DESCRIPTION
Hello! I love this project. Thanks for open-sourcing it.

This PR fixes a few little typos on the https://opencode.ai/docs/providers page.

(Note: Starting with a tiny PR to test the contribution waters. If this lands I'll make an effort to fix typos more broadly.)