### PR TITLE
fix(ui): install toast text not visible in light mode

### DIFF
--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -30,8 +30,8 @@
 
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-weak-base);
-  background: var(--surface-raised-strong);
-  color: var(--text-base);
+  background: var(--surface-float-base);
+  color: var(--text-invert-base);
   box-shadow: var(--shadow-md);
 
   [data-slot="toast-inner"] {
@@ -80,7 +80,7 @@
     justify-content: center;
 
     [data-component="icon"] {
-      color: var(--text-strong);
+      color: var(--text-invert-stronger);
       /* color: var(--icon-invert-base); */
     }
   }
@@ -94,7 +94,7 @@
   }
 
   [data-slot="toast-title"] {
-    color: var(--text-strong);
+    color: var(--text-on-interactive-base);
 
     /* text-14-medium */
     font-family: var(--font-family-sans);
@@ -108,7 +108,7 @@
   }
 
   [data-slot="toast-description"] {
-    color: var(--text-base);
+    color: var(--text-invert-base);
     text-wrap-style: pretty;
 
     /* text-14-regular */
@@ -146,7 +146,7 @@
     }
 
     &:first-child {
-      color: var(--text-strong);
+      color: var(--text-on-interactive-base);
     }
   }
 

--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -30,8 +30,8 @@
 
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-weak-base);
-  background: var(--surface-float-base);
-  color: var(--text-invert-base);
+  background: var(--surface-raised-strong);
+  color: var(--text-base);
   box-shadow: var(--shadow-md);
 
   [data-slot="toast-inner"] {
@@ -80,7 +80,7 @@
     justify-content: center;
 
     [data-component="icon"] {
-      color: var(--text-invert-stronger);
+      color: var(--text-strong);
       /* color: var(--icon-invert-base); */
     }
   }
@@ -94,7 +94,7 @@
   }
 
   [data-slot="toast-title"] {
-    color: var(--text-invert-strong);
+    color: var(--text-strong);
 
     /* text-14-medium */
     font-family: var(--font-family-sans);
@@ -108,7 +108,7 @@
   }
 
   [data-slot="toast-description"] {
-    color: var(--text-invert-base);
+    color: var(--text-base);
     text-wrap-style: pretty;
 
     /* text-14-regular */
@@ -134,7 +134,7 @@
     padding: 0;
     cursor: pointer;
 
-    color: var(--text-invert-weak);
+    color: var(--text-weak);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-medium);
@@ -146,7 +146,7 @@
     }
 
     &:first-child {
-      color: var(--text-invert-strong);
+      color: var(--text-strong);
     }
   }
 


### PR DESCRIPTION
- Changed background from --surface-float-base to --surface-raised-strong
- Replaced all --text-invert-* tokens with --text-* tokens
- Fixed typo: --text-invert-stronger doesn't exist in theme system
- Toast now adapts to light/dark theme like rest of UI

Before: Toast always dark in light mode, light in dark mode
After: Toast follows theme - light bg in light mode, dark bg in dark mode

### What does this PR do?

Fixes #7831 

### How did you verify your code works?

First I hardcoded in `packages/app/src/pages/layout.tsx`   `updateAvailable = true` to force the toast to appear.
Then I ran:
cd packages/desktop
bun run tauri dev

<img width="1250" height="881" alt="Screenshot_20260111_143508" src="https://github.com/user-attachments/assets/f3eb6b2b-68cd-4e0d-b2a4-945a148e8e69" />
<img width="1248" height="879" alt="Screenshot_20260111_143425" src="https://github.com/user-attachments/assets/f7744116-df58-4340-9fba-bb2fb00d421c" />
