### PR TITLE
fix(tui): extract url from instructions when copying oauth credentials

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -112,8 +112,11 @@ function AutoMethod(props: AutoMethodProps) {
 
   useKeyboard((evt) => {
     if (evt.name === "c" && !evt.ctrl && !evt.meta) {
-      const code = props.authorization.instructions.match(/[A-Z0-9]{4}-[A-Z0-9]{4}/)?.[0] ?? props.authorization.url
-      Clipboard.copy(code)
+      const text = props.authorization.instructions
+      const token = text.match(/[A-Z0-9]{4}-[A-Z0-9]{4}/)?.[0]
+      const url = text.match(/https?:\/\/\S+/)?.[0]
+      const value = token ?? url ?? props.authorization.url
+      Clipboard.copy(value)
         .then(() => toast.show({ message: "Copied to clipboard", variant: "info" }))
         .catch(toast.error)
     }


### PR DESCRIPTION
### What does this PR do?
Since the option to login with ChatGPT Plus/pro credentials was included, this fixes the "c copy" keybind in oauth auto-method dialogs to also extract URLs from the instructions text when no device code is present.  The copy priority is now: device code token → URL in instructions → authorization URL.

### How did you verify your code works?
Tested oauth flow with providers that include URLs in their instructions text rather than device codes.

Fixes: #7838