### PR TITLE
feat(tui): add config option to disable syntax highlighting in diffs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1757,7 +1757,7 @@ function Edit(props: ToolProps<typeof EditTool>) {
               diff={diffContent()}
               view={view()}
               filetype={ft()}
-              syntaxStyle={syntax()}
+              syntaxStyle={ctx.sync.data.config.tui?.diff_syntax !== false ? syntax() : undefined}
               showLineNumbers={true}
               width="100%"
               wrapMode={ctx.diffWrapMode()}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -59,7 +59,7 @@ function EditBody(props: { request: PermissionRequest }) {
             diff={diff()}
             view={view()}
             filetype={ft()}
-            syntaxStyle={syntax()}
+            syntaxStyle={sync.data.config.tui?.diff_syntax !== false ? syntax() : undefined}
             showLineNumbers={true}
             width="100%"
             wrapMode="word"

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -770,6 +770,7 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    diff_syntax: z.boolean().optional().describe("Enable syntax highlighting in diffs"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1563,6 +1563,10 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Enable syntax highlighting in diffs
+     */
+    diff_syntax?: boolean
   }
   server?: ServerConfig
   /**


### PR DESCRIPTION
for #7853

## Summary

Adds `tui.diff_syntax` config option to disable syntax highlighting in diffs.

```json
{
  "tui": {
    "diff_syntax": false
  }
}
```

Default is `true` (syntax highlighting enabled). When set to `false`, diffs render without syntax highlighting.

## Changes

- Added `diff_syntax` boolean option to TUI config schema
- Updated `Edit` component and permission dialog to respect the config
- Regenerated SDK types