### PR TITLE
fix: accept boolean values for permission config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -453,9 +453,11 @@ export namespace Config {
   export const Mcp = z.discriminatedUnion("type", [McpLocal, McpRemote])
   export type Mcp = z.infer<typeof Mcp>
 
-  export const PermissionAction = z.enum(["ask", "allow", "deny"]).meta({
-    ref: "PermissionActionConfig",
-  })
+  export const PermissionAction = z
+    .preprocess((val) => (val === true ? "allow" : val === false ? "deny" : val), z.enum(["ask", "allow", "deny"]))
+    .meta({
+      ref: "PermissionActionConfig",
+    })
   export type PermissionAction = z.infer<typeof PermissionAction>
 
   export const PermissionObject = z.record(z.string(), PermissionAction).meta({


### PR DESCRIPTION
Fixes #7810

### What does this PR do?

Users may now use boolean `true`/`false` instead of `"allow"`/`"deny"` for permissions. 
This adds a preprocess step to convert booleans automatically, consistent with how `tools` config already handles this.

### How did you verify your code works?

I created `.opencode/agent/testing.md` with the following permissions:

```
---
description: Test agent
mode: subagent
tools:
  read: true
permission:
  write: false
---
```

I then launched OpenCode in my project directory. It now launches successfully and does not hang like before.