### PR TITLE
feat(app): add /thinking command to toggle reasoning visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ opencode-dev
 logs/
 *.bun-build
 tsconfig.tsbuildinfo
+.opencode/command/

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -106,6 +106,7 @@ export interface MessagePartProps {
   defaultOpen?: boolean
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
+  working?: boolean
 }
 
 export type PartComponent = Component<MessagePartProps>
@@ -385,6 +386,7 @@ export function AssistantParts(props: {
                   showAssistantCopyPartID={props.showAssistantCopyPartID}
                   turnDurationMs={props.turnDurationMs}
                   defaultOpen={partDefaultOpen(entry().part, props.shellToolDefaultOpen, props.editToolDefaultOpen)}
+                  working={props.working}
                 />
               )}
             </Show>
@@ -1204,15 +1206,32 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
 }
 
 PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
+  const i18n = useI18n()
   const part = props.part as ReasoningPart
   const text = () => part.text.trim()
   const throttledText = createThrottledValue(text)
+  const [open, setOpen] = createSignal(props.working ?? false)
+
+  // 完成后自动折叠，但用户可以手动点开
+  createEffect(() => {
+    if (!props.working) setOpen(false)
+  })
 
   return (
     <Show when={throttledText()}>
-      <div data-component="reasoning-part">
-        <Markdown text={throttledText()} cacheKey={part.id} />
-      </div>
+      <Collapsible open={open()} onOpenChange={setOpen} variant="ghost">
+        <Collapsible.Trigger>
+          <div data-component="reasoning-trigger">
+            <span>{i18n.t("ui.sessionTurn.status.thinking")}</span>
+            <Collapsible.Arrow />
+          </div>
+        </Collapsible.Trigger>
+        <Collapsible.Content>
+          <div data-component="reasoning-part">
+            <Markdown text={throttledText()} cacheKey={part.id} />
+          </div>
+        </Collapsible.Content>
+      </Collapsible>
     </Show>
   )
 }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -874,6 +874,7 @@ export function Part(props: MessagePartProps) {
         defaultOpen={props.defaultOpen}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         turnDurationMs={props.turnDurationMs}
+        working={props.working}
       />
     </Show>
   )


### PR DESCRIPTION
### What does this PR do?

Adds `/thinking` slash command to WebUI, matching TUI behavior for toggling thinking/reasoning block visibility.

- Default: visible (same as TUI)
- Command toggles show/hide state

Fixes #7866

### How did you verify your code works?

Tested locally with `bun run --cwd packages/app dev`:

- `/thinking` appears in slash command autocomplete
- Executing toggles visibility of reasoning blocks
- Behavior matches TUI `/thinking` command

<img width="546" height="335" alt="image" src="https://github.com/user-attachments/assets/084253d6-93cc-4d38-a8bb-522d96baf829" />
