### PR TITLE
fix(tui): defer prompt.set() to prevent crash when using --prompt flag

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -79,14 +79,18 @@ export function Home() {
   onMount(() => {
     randomizeTip()
     if (once) return
-    if (route.initialPrompt) {
-      prompt.set(route.initialPrompt)
-      once = true
-    } else if (args.prompt) {
-      prompt.set({ input: args.prompt, parts: [] })
-      once = true
-      prompt.submit()
-    }
+    // Defer to allow child Prompt component's onMount to run first
+    queueMicrotask(() => {
+      if (once || !prompt) return
+      if (route.initialPrompt) {
+        prompt.set(route.initialPrompt)
+        once = true
+      } else if (args.prompt) {
+        prompt.set({ input: args.prompt, parts: [] })
+        once = true
+        prompt.submit()
+      }
+    })
   })
   const directory = useDirectory()
 


### PR DESCRIPTION
### What does this PR do?
Fixes a regression caused by #7702 that causes a crash when using the `--prompt` flag.

Fixes #7818
Fixes #7850

### How did you verify your code works?
I ran tests with `--prompt` populated and without, as well as tested that you can still successfully fork from the first message so as to not cause any regression from the original PR.