### PR TITLE
fix: race condition causing prompt.set undefined error

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -275,6 +275,7 @@
         "@ai-sdk/togetherai": "1.0.30",
         "@ai-sdk/vercel": "1.0.31",
         "@ai-sdk/xai": "2.0.42",
+        "@anthropic-ai/claude-agent-sdk": "^0.1.0",
         "@clack/prompts": "1.0.0-alpha.1",
         "@hono/standard-validator": "0.1.5",
         "@hono/zod-validator": "catalog:",
@@ -583,6 +584,8 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.1.77", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.33.5", "@img/sharp-darwin-x64": "^0.33.5", "@img/sharp-linux-arm": "^0.33.5", "@img/sharp-linux-arm64": "^0.33.5", "@img/sharp-linux-x64": "^0.33.5", "@img/sharp-linuxmusl-arm64": "^0.33.5", "@img/sharp-linuxmusl-x64": "^0.33.5", "@img/sharp-win32-x64": "^0.33.5" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ZEjWQtkoB2MEY6K16DWMmF+8OhywAynH0m08V265cerbZ8xPD/2Ng2jPzbbO40mPeFSsMDJboShL+a3aObP0Jg=="],
 
     "@astrojs/cloudflare": ["@astrojs/cloudflare@12.6.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.7.1", "@astrojs/underscore-redirects": "1.0.0", "@cloudflare/workers-types": "^4.20250507.0", "tinyglobby": "^0.2.13", "vite": "^6.3.5", "wrangler": "^4.14.1" }, "peerDependencies": { "astro": "^5.0.0" } }, "sha512-xhJptF5tU2k5eo70nIMyL1Udma0CqmUEnGSlGyFflLqSY82CRQI6nWZ/xZt0ZvmXuErUjIx0YYQNfZsz5CNjLQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -69,6 +69,7 @@
     "@ai-sdk/togetherai": "1.0.30",
     "@ai-sdk/vercel": "1.0.31",
     "@ai-sdk/xai": "2.0.42",
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
     "@clack/prompts": "1.0.0-alpha.1",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import { createMemo, Match, onMount, Show, Switch } from "solid-js"
+import { createMemo, Match, createEffect, Show, Switch } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { Logo } from "../component/logo"
 import { DidYouKnow, randomizeTip } from "../component/did-you-know"
@@ -76,9 +76,9 @@ export function Home() {
 
   let prompt: PromptRef
   const args = useArgs()
-  onMount(() => {
-    randomizeTip()
-    if (once) return
+  randomizeTip()
+  createEffect(() => {
+    if (once || !prompt) return
     if (route.initialPrompt) {
       prompt.set(route.initialPrompt)
       once = true

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -835,6 +835,33 @@ export namespace Config {
         })
         .catchall(z.any())
         .optional(),
+      claudeAgent: z
+        .object({
+          model: z.string().optional().describe("Model to use (e.g., 'claude-sonnet-4')"),
+          permissionMode: z
+            .enum(["default", "acceptEdits", "bypassPermissions", "plan"])
+            .optional()
+            .describe("Permission mode for SDK tool execution"),
+          allowedTools: z
+            .array(z.string())
+            .optional()
+            .describe("List of SDK built-in tools to enable"),
+          systemPrompt: z.string().optional().describe("Additional system prompt to append"),
+          cwd: z.string().optional().describe("Working directory for the agent"),
+          mcpServers: z
+            .record(
+              z.string(),
+              z.object({
+                command: z.string(),
+                args: z.array(z.string()).optional(),
+                env: z.record(z.string(), z.string()).optional(),
+              }),
+            )
+            .optional()
+            .describe("MCP servers to pass to Claude Agent SDK"),
+        })
+        .optional()
+        .describe("Claude Agent SDK specific configuration (only used when provider is 'claude-agent')"),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/provider/claude-agent/adapter.ts
+++ b/packages/opencode/src/provider/claude-agent/adapter.ts
@@ -1,0 +1,188 @@
+import { MessageV2 } from "@/session/message-v2"
+import { Identifier } from "@/id/id"
+import type { MessageContext } from "./types"
+import type {
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKResultMessage,
+} from "@anthropic-ai/claude-agent-sdk"
+
+/**
+ * Adapter for translating between opencode MessageV2 format and Claude Agent SDK format
+ */
+export namespace ClaudeAgentAdapter {
+  /**
+   * Extract the user prompt from opencode messages for SDK input
+   */
+  export function toSDKPrompt(messages: MessageV2.WithParts[]): string {
+    // Find the last user message and extract text parts
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i]
+      if (msg.info.role === "user") {
+        const textParts = msg.parts
+          .filter((p): p is MessageV2.TextPart => p.type === "text" && !p.synthetic)
+          .map((p) => p.text)
+        if (textParts.length > 0) {
+          return textParts.join("\n")
+        }
+      }
+    }
+    return ""
+  }
+
+  /**
+   * Convert SDK message to opencode Part
+   * Based on SDK message types from @anthropic-ai/claude-agent-sdk
+   */
+  export function fromSDKMessage(
+    sdkMsg: SDKMessage,
+    ctx: MessageContext,
+  ): MessageV2.Part | MessageV2.Part[] | null {
+    switch (sdkMsg.type) {
+      case "assistant":
+        return fromAssistantMessage(sdkMsg, ctx)
+      case "result":
+        return fromResultMessage(sdkMsg, ctx)
+      case "system":
+        // System messages (init) are metadata, not displayed
+        return null
+      case "user":
+        // User messages are from resume/replay, skip
+        return null
+      case "stream_event":
+        // Partial messages for streaming - handled separately
+        return null
+      default:
+        return null
+    }
+  }
+
+  function fromAssistantMessage(msg: SDKAssistantMessage, ctx: MessageContext): MessageV2.Part[] {
+    const parts: MessageV2.Part[] = []
+    const content = msg.message?.content
+
+    if (!content) return parts
+
+    for (const block of content) {
+      if ("text" in block && block.text) {
+        parts.push({
+          id: Identifier.ascending("part"),
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          type: "text",
+          text: block.text,
+        })
+      } else if ("name" in block && block.type === "tool_use") {
+        // Tool use block - SDK is calling a tool
+        parts.push({
+          id: Identifier.ascending("part"),
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          type: "tool",
+          tool: block.name,
+          callID: block.id,
+          state: {
+            status: "running",
+            input: block.input as Record<string, unknown>,
+            time: { start: Date.now() },
+          },
+        })
+      } else if (block.type === "thinking" && "thinking" in block) {
+        // Extended thinking/reasoning
+        parts.push({
+          id: Identifier.ascending("part"),
+          sessionID: ctx.sessionID,
+          messageID: ctx.messageID,
+          type: "reasoning",
+          text: block.thinking as string,
+          time: { start: Date.now() },
+        })
+      }
+    }
+
+    return parts
+  }
+
+  function fromResultMessage(msg: SDKResultMessage, ctx: MessageContext): MessageV2.Part | null {
+    // Result message contains the final text which is already included in assistant messages
+    // Returning null to avoid duplicate output
+    // Usage/cost info is extracted separately in extractUsage()
+    return null
+  }
+
+  /**
+   * Create a tool completion part from SDK tool result
+   */
+  export function toolCompleted(
+    toolCallId: string,
+    toolName: string,
+    input: Record<string, unknown>,
+    output: string,
+    ctx: MessageContext,
+  ): MessageV2.ToolPart {
+    return {
+      id: Identifier.ascending("part"),
+      sessionID: ctx.sessionID,
+      messageID: ctx.messageID,
+      type: "tool",
+      tool: toolName,
+      callID: toolCallId,
+      state: {
+        status: "completed",
+        input,
+        output,
+        title: toolName,
+        metadata: {},
+        time: { start: Date.now(), end: Date.now() },
+      },
+    }
+  }
+
+  /**
+   * Create a tool error part from SDK tool failure
+   */
+  export function toolError(
+    toolCallId: string,
+    toolName: string,
+    input: Record<string, unknown>,
+    error: string,
+    ctx: MessageContext,
+  ): MessageV2.ToolPart {
+    return {
+      id: Identifier.ascending("part"),
+      sessionID: ctx.sessionID,
+      messageID: ctx.messageID,
+      type: "tool",
+      tool: toolName,
+      callID: toolCallId,
+      state: {
+        status: "error",
+        input,
+        error,
+        time: { start: Date.now(), end: Date.now() },
+      },
+    }
+  }
+
+  /**
+   * Extract usage statistics from SDK result message
+   */
+  export function extractUsage(msg: SDKResultMessage): {
+    input: number
+    output: number
+    cache: { read: number; write: number }
+    cost: number
+  } {
+    const usage = msg.usage || { input_tokens: 0, output_tokens: 0 }
+    return {
+      input: usage.input_tokens || 0,
+      output: usage.output_tokens || 0,
+      cache: {
+        read: usage.cache_read_input_tokens || 0,
+        write: usage.cache_creation_input_tokens || 0,
+      },
+      cost: msg.total_cost_usd || 0,
+    }
+  }
+}
+

--- a/packages/opencode/src/provider/claude-agent/index.ts
+++ b/packages/opencode/src/provider/claude-agent/index.ts
@@ -1,0 +1,152 @@
+import type { Provider } from "@/provider/provider"
+import { ClaudeAgentConfig, DEFAULT_ALLOWED_TOOLS } from "./types"
+
+/**
+ * Claude Agent SDK Provider
+ *
+ * This provider uses @anthropic-ai/claude-agent-sdk for agent execution,
+ * which includes built-in tool execution and MCP server support.
+ */
+export namespace ClaudeAgentProvider {
+  export const ID = "claude-agent"
+
+  /**
+   * Check if a provider ID is the Claude Agent provider
+   */
+  export function isClaudeAgentProvider(providerID: string): boolean {
+    return providerID === ID
+  }
+
+  /**
+   * Create default model configuration
+   */
+  function createModel(
+    id: string,
+    name: string,
+    apiId: string,
+    options: Partial<{
+      context: number
+      output: number
+      costInput: number
+      costOutput: number
+    }> = {},
+  ): Provider.Model {
+    const { context = 200000, output = 16384, costInput = 3, costOutput = 15 } = options
+
+    return {
+      id,
+      providerID: ID,
+      name,
+      family: "claude",
+      api: {
+        id: apiId,
+        url: "https://api.anthropic.com/v1",
+        npm: "@anthropic-ai/claude-agent-sdk",
+      },
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: {
+          text: true,
+          audio: false,
+          image: true,
+          video: false,
+          pdf: true,
+        },
+        output: {
+          text: true,
+          audio: false,
+          image: false,
+          video: false,
+          pdf: false,
+        },
+        interleaved: {
+          field: "reasoning_content",
+        },
+      },
+      cost: {
+        input: costInput,
+        output: costOutput,
+        cache: {
+          read: costInput * 0.1,
+          write: costInput * 1.25,
+        },
+      },
+      limit: {
+        context,
+        output,
+      },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2025-01-01",
+    }
+  }
+
+  /**
+   * Provider info for Claude Agent SDK
+   */
+  export const Info: Provider.Info = {
+    id: ID,
+    name: "Claude Agent SDK",
+    source: "custom",
+    env: ["ANTHROPIC_API_KEY"],
+    options: {},
+    models: {
+      "claude-sonnet-4": createModel("claude-sonnet-4", "Claude Sonnet 4 (Agent SDK)", "claude-sonnet-4-20250514", {
+        context: 200000,
+        output: 16384,
+        costInput: 3,
+        costOutput: 15,
+      }),
+      "claude-opus-4": createModel("claude-opus-4", "Claude Opus 4 (Agent SDK)", "claude-opus-4-20250514", {
+        context: 200000,
+        output: 32768,
+        costInput: 15,
+        costOutput: 75,
+      }),
+      "claude-haiku-3.5": createModel(
+        "claude-haiku-3.5",
+        "Claude Haiku 3.5 (Agent SDK)",
+        "claude-3-5-haiku-20241022",
+        {
+          context: 200000,
+          output: 8192,
+          costInput: 0.8,
+          costOutput: 4,
+        },
+      ),
+    },
+  }
+
+  /**
+   * Get the default configuration for Claude Agent SDK
+   */
+  export function getDefaultConfig(): ClaudeAgentConfig {
+    return {
+      permissionMode: "default",
+      allowedTools: DEFAULT_ALLOWED_TOOLS,
+    }
+  }
+
+  /**
+   * Validate and merge user config with defaults
+   */
+  export function mergeConfig(userConfig?: Partial<ClaudeAgentConfig>): ClaudeAgentConfig {
+    const defaults = getDefaultConfig()
+    return {
+      ...defaults,
+      ...userConfig,
+      allowedTools: userConfig?.allowedTools ?? defaults.allowedTools,
+    }
+  }
+}
+
+export { ClaudeAgentAdapter } from "./adapter"
+export { ClaudeAgentSession } from "./session-handler"
+export { ClaudeAgentConfig, DEFAULT_ALLOWED_TOOLS } from "./types"
+export { PermissionBridge } from "./permission-bridge"
+export { QuestionBridge } from "./question-bridge"
+export { ToolMCPBridge } from "./tool-mcp-bridge"

--- a/packages/opencode/src/provider/claude-agent/permission-bridge.ts
+++ b/packages/opencode/src/provider/claude-agent/permission-bridge.ts
@@ -1,0 +1,144 @@
+import { Bus } from "@/bus"
+import { Identifier } from "@/id/id"
+import { PermissionNext } from "@/permission/next"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "claude-agent.permission-bridge" })
+
+export namespace PermissionBridge {
+  export interface PendingRequest {
+    requestID: string
+    toolName: string
+    toolInput: unknown
+    patterns: string[]
+    resolve: (reply: "once" | "always" | "reject") => void
+    reject: (error: Error) => void
+  }
+
+  export function create(sessionID: string) {
+    const pending: Map<string, PendingRequest> = new Map()
+    let isListening = false
+
+    function startListening() {
+      if (isListening) return
+      isListening = true
+
+      Bus.subscribe(PermissionNext.Event.Replied, ({ properties }) => {
+        const request = pending.get(properties.requestID)
+        if (!request) return
+
+        log.debug("permission reply received", {
+          requestID: properties.requestID,
+          reply: properties.reply,
+          toolName: request.toolName,
+        })
+
+        request.resolve(properties.reply)
+        pending.delete(properties.requestID)
+      })
+    }
+
+    startListening()
+
+    async function ask(
+      toolName: string,
+      toolInput: unknown,
+      signal: AbortSignal,
+    ): Promise<"once" | "always" | "reject"> {
+      const patterns = extractPatterns(toolName, toolInput)
+      const requestID = Identifier.ascending("permission")
+
+      log.debug("asking permission", {
+        requestID,
+        toolName,
+        patterns,
+        sessionID,
+      })
+
+      const responsePromise = new Promise<"once" | "always" | "reject">((resolve, reject) => {
+        const pendingRequest: PendingRequest = {
+          requestID,
+          toolName,
+          toolInput,
+          patterns,
+          resolve,
+          reject,
+        }
+        pending.set(requestID, pendingRequest)
+
+        signal.addEventListener("abort", () => {
+          pending.delete(requestID)
+          reject(new Error("Permission request aborted"))
+        })
+      })
+
+      await PermissionNext.ask({
+        permission: toolName,
+        patterns,
+        metadata: toolInput as Record<string, unknown>,
+        always: patterns,
+        sessionID,
+        ruleset: [],
+      })
+
+      try {
+        const result = await responsePromise
+        log.debug("permission resolved", {
+          requestID,
+          result,
+          toolName,
+        })
+        return result
+      } finally {
+        pending.delete(requestID)
+      }
+    }
+
+    return {
+      ask,
+    }
+  }
+
+  function extractPatterns(toolName: string, toolInput: unknown): string[] {
+    if (!toolInput || typeof toolInput !== "object") return ["*"]
+
+    const input = toolInput as Record<string, unknown>
+
+    switch (toolName) {
+      case "Read":
+      case "Write":
+      case "Edit": {
+        const filePath = typeof input.file_path === "string" ? input.file_path : undefined
+        return filePath ? [filePath] : ["*"]
+      }
+
+      case "Bash": {
+        const command = typeof input.command === "string" ? input.command : undefined
+        return command ? [command] : ["bash *"]
+      }
+
+      case "WebFetch": {
+        const url = typeof input.url === "string" ? input.url : undefined
+        return url ? [url] : ["webfetch *"]
+      }
+
+      case "WebSearch": {
+        const query = typeof input.query === "string" ? input.query : undefined
+        return query ? [query] : ["websearch *"]
+      }
+
+      case "Glob":
+      case "Grep": {
+        const patterns: string[] = []
+        const pattern = typeof input.pattern === "string" ? input.pattern : undefined
+        const path = typeof input.path === "string" ? input.path : undefined
+        if (path) patterns.push(path)
+        if (pattern) patterns.push(pattern)
+        return patterns.length > 0 ? patterns : ["*"]
+      }
+
+      default:
+        return ["*"]
+    }
+  }
+}

--- a/packages/opencode/src/provider/claude-agent/question-bridge.ts
+++ b/packages/opencode/src/provider/claude-agent/question-bridge.ts
@@ -1,0 +1,33 @@
+import { Bus } from "@/bus"
+import { Identifier } from "@/id/id"
+import { Question } from "@/question"
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "claude-agent.question-bridge" })
+
+export namespace QuestionBridge {
+  export function create(sessionID: string) {
+    async function ask(questions: Question.Info[], signal: AbortSignal): Promise<Question.Answer[]> {
+      log.debug("asking questions", {
+        questionsCount: questions.length,
+        sessionID,
+      })
+
+      const result = await Question.ask({
+        sessionID,
+        questions,
+      })
+
+      log.debug("questions resolved", {
+        answersCount: result.length,
+        questionsCount: questions.length,
+      })
+
+      return result
+    }
+
+    return {
+      ask,
+    }
+  }
+}

--- a/packages/opencode/src/provider/claude-agent/session-handler.ts
+++ b/packages/opencode/src/provider/claude-agent/session-handler.ts
@@ -1,0 +1,528 @@
+import { MessageV2 } from "@/session/message-v2"
+import { Session } from "@/session"
+import { Identifier } from "@/id/id"
+import { Instance } from "@/project/instance"
+import { Config } from "@/config/config"
+import { Bus } from "@/bus"
+import { Log } from "@/util/log"
+import { BunProc } from "@/bun"
+import { ClaudeAgentAdapter } from "./adapter"
+import { ClaudeAgentProvider } from "./index"
+import type { ClaudeAgentConfig, SDKMcpServerConfig } from "./types"
+import { DEFAULT_ALLOWED_TOOLS } from "./types"
+import type { Config as ConfigNamespace } from "@/config/config"
+import { PermissionBridge } from "./permission-bridge"
+import { QuestionBridge } from "./question-bridge"
+import { Question } from "@/question"
+import { ToolMCPBridge } from "./tool-mcp-bridge"
+
+const log = Log.create({ service: "claude-agent.session" })
+
+/**
+ * Session handler for Claude Agent SDK
+ *
+ * This module handles the integration between opencode's session system
+ * and the Claude Agent SDK. When a user selects the claude-agent provider,
+ * this handler takes over the session processing.
+ */
+export namespace ClaudeAgentSession {
+  /**
+   * Process a session turn using Claude Agent SDK
+   */
+  export async function process(input: {
+    sessionID: string
+    user: MessageV2.User
+    messages: MessageV2.WithParts[]
+    config: ClaudeAgentConfig
+    abort: AbortSignal
+    session: Session.Info
+  }): Promise<MessageV2.WithParts> {
+    const { sessionID, user, messages, config, abort, session } = input
+
+    // Create assistant message
+    const assistantMessage = (await Session.updateMessage({
+      id: Identifier.ascending("message"),
+      role: "assistant",
+      parentID: user.id,
+      sessionID,
+      mode: user.agent,
+      agent: user.agent,
+      path: {
+        cwd: Instance.directory,
+        root: Instance.worktree,
+      },
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      modelID: user.model.modelID,
+      providerID: user.model.providerID,
+      time: {
+        created: Date.now(),
+      },
+    })) as MessageV2.Assistant
+
+    const parts: MessageV2.Part[] = []
+
+    try {
+      // Import Claude Agent SDK - installed at runtime for compiled binaries
+      let query: typeof import("@anthropic-ai/claude-agent-sdk")["query"]
+      try {
+        const sdkPath = await BunProc.install("@anthropic-ai/claude-agent-sdk")
+        const sdk = await import(sdkPath)
+        query = sdk.query
+      } catch (importError) {
+        log.error("failed to load claude agent sdk", { error: importError })
+        throw new Error(
+          "Failed to load Claude Agent SDK (@anthropic-ai/claude-agent-sdk). " +
+            "Error: " + (importError instanceof Error ? importError.message : String(importError)),
+        )
+      }
+
+      // Create permission and question bridges for this session
+      const permissionBridge = PermissionBridge.create(sessionID)
+      const questionBridge = QuestionBridge.create(sessionID)
+
+      // Create OpenCode tools MCP server
+      const opencodeToolsServer = await ToolMCPBridge.create(sessionID, permissionBridge)
+      log.info("opencode tools mcp server ready", {
+        serverName: opencodeToolsServer.name,
+        sessionID,
+      })
+
+      // Build SDK options
+      const sdkOptions = await buildSDKOptions(config, session, sessionID, abort, permissionBridge, questionBridge, opencodeToolsServer)
+
+      // Extract prompt from messages
+      const prompt = ClaudeAgentAdapter.toSDKPrompt(messages)
+
+      log.info("starting claude agent query", {
+        sessionID,
+        prompt: prompt.substring(0, 100),
+        model: config.model,
+        permissionMode: config.permissionMode,
+      })
+
+      // Create message context for adapter
+      const ctx = {
+        sessionID,
+        messageID: assistantMessage.id,
+        partIndex: 0,
+      }
+
+      // Track SDK session ID for resume capability
+      let sdkSessionId: string | undefined
+
+      // Call Claude Agent SDK and iterate through results
+      const queryResult = query({
+        prompt,
+        options: sdkOptions,
+      })
+
+      for await (const sdkMsg of queryResult) {
+        if (abort.aborted) {
+          log.info("query aborted", { sessionID })
+          break
+        }
+
+        // Capture SDK session ID from init message
+        if (sdkMsg.type === "system" && sdkMsg.subtype === "init") {
+          sdkSessionId = sdkMsg.session_id
+          log.info("sdk session initialized", { sdkSessionId })
+        }
+
+        // Convert SDK message to opencode parts
+        const newParts = ClaudeAgentAdapter.fromSDKMessage(sdkMsg, ctx)
+        if (newParts) {
+          const partsArray = Array.isArray(newParts) ? newParts : [newParts]
+          for (const part of partsArray) {
+            parts.push(part)
+            await Session.updatePart(part)
+            Bus.publish(MessageV2.Event.PartUpdated, { part })
+            ctx.partIndex++
+          }
+        }
+
+        // Extract usage from result messages
+        if (sdkMsg.type === "result") {
+          const usage = ClaudeAgentAdapter.extractUsage(sdkMsg)
+          assistantMessage.tokens = {
+            input: usage.input,
+            output: usage.output,
+            reasoning: 0,
+            cache: usage.cache,
+          }
+          assistantMessage.cost = usage.cost
+
+          // Determine finish reason
+          if (sdkMsg.subtype === "success") {
+            assistantMessage.finish = "stop"
+          } else {
+            assistantMessage.finish = "error"
+            // Add error info
+            if ("errors" in sdkMsg && sdkMsg.errors?.length) {
+              assistantMessage.error = {
+                name: "UnknownError",
+                data: { message: sdkMsg.errors.join(", ") },
+              }
+            }
+          }
+        }
+      }
+
+      // Store SDK session ID for potential resume
+      if (sdkSessionId) {
+        log.info("saving sdk session id", { sdkSessionId, sessionID })
+        await Session.update(sessionID, (sess) => {
+          sess.metadata = sess.metadata ?? {}
+          sess.metadata["claudeAgentSessionId"] = sdkSessionId
+        })
+      }
+    } catch (error) {
+      log.error("claude agent query failed", {
+        sessionID,
+        error: error instanceof Error ? error.message : String(error),
+      })
+
+      assistantMessage.finish = "error"
+      assistantMessage.error = MessageV2.fromError(error, { providerID: ClaudeAgentProvider.ID })
+
+      // Add error message as text part
+      parts.push({
+        id: Identifier.ascending("part"),
+        sessionID,
+        messageID: assistantMessage.id,
+        type: "text",
+        text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+      })
+      await Session.updatePart(parts[parts.length - 1])
+    }
+
+    // Mark message as completed
+    assistantMessage.time.completed = Date.now()
+    if (!assistantMessage.finish) {
+      assistantMessage.finish = abort.aborted ? "cancelled" : "stop"
+    }
+    await Session.updateMessage(assistantMessage)
+
+    return {
+      info: assistantMessage,
+      parts,
+    }
+  }
+
+  /**
+   * Build Claude Agent SDK options from opencode config
+   */
+  async function buildSDKOptions(
+    config: ClaudeAgentConfig,
+    session: Session.Info,
+    sessionID: string,
+    abort: AbortSignal,
+    permissionBridge: ReturnType<typeof PermissionBridge.create>,
+    questionBridge: ReturnType<typeof QuestionBridge.create>,
+    opencodeToolsServer: Awaited<ReturnType<typeof ToolMCPBridge.create>>,
+  ): Promise<Record<string, unknown>> {
+    const mcpServers = await getMcpServersForSDK(config)
+
+    // Add OpenCode's tools via MCP server
+    mcpServers["tools"] = opencodeToolsServer
+
+    const options: Record<string, unknown> = {
+      // Permission mode
+      permissionMode: config.permissionMode ?? "default",
+
+      // Disable SDK's built-in tools to only use OpenCode MCP tools
+      disableBuiltInTools: true,
+
+      // Allowed tools - empty since we're disabling built-in tools
+      allowedTools: [],
+
+      // Working directory
+      cwd: config.cwd ?? Instance.directory,
+
+      // System prompt
+      systemPrompt: config.systemPrompt,
+
+      // Model selection
+      model: config.model,
+
+      // MCP servers (merged from opencode config + plugin config)
+      mcpServers,
+
+      // Hooks for permission and question bridging
+      hooks: {
+        PermissionRequest: [
+          {
+            hooks: [
+              async (
+                input: {
+                  hook_event_name: string
+                  tool_name: string
+                  tool_input: unknown
+                  session_id: string
+                  transcript_path: string
+                  cwd: string
+                  permission_suggestions?: unknown[]
+                },
+                toolUseID: string | null,
+                context: { signal: AbortSignal },
+              ) => {
+                // Skip OpenCode's permission system if SDK is in bypass mode
+                if (config.permissionMode === "bypassPermissions") {
+                  return {
+                    hookSpecificOutput: {
+                      hookEventName: "PermissionRequest",
+                      permissionDecision: "allow" as const,
+                      permissionDecisionReason: "Bypass mode enabled",
+                    },
+                  }
+                }
+
+                // Handle AskUserQuestion specially - bridge to OpenCode's question system
+                if (input.tool_name === "AskUserQuestion") {
+                  const toolInput = input.tool_input as {
+                    questions: Array<{
+                      question: string
+                      header: string
+                      options: Array<{ label: string; description: string }>
+                      multiSelect: boolean
+                    }>
+                  }
+
+                  // Convert SDK format to OpenCode format
+                  const questions: Question.Info[] = toolInput.questions.map((q) => ({
+                    question: q.question,
+                    header: q.header,
+                    options: q.options.map((o) => ({
+                      label: o.label,
+                      description: o.description,
+                    })),
+                    multiple: q.multiSelect,
+                  }))
+
+                  try {
+                    // Ask OpenCode's question system
+                    const answers = await questionBridge.ask(questions, context.signal)
+
+                    // Convert answers back to SDK format (map question text to answer label)
+                    const answersMap: Record<string, string> = {}
+                    answers.forEach((answer, index) => {
+                      if (answer.length > 0 && questions[index]) {
+                        answersMap[questions[index].question] = answer.join(", ")
+                      }
+                    })
+
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: "PermissionRequest",
+                        permissionDecision: "allow" as const,
+                        permissionDecisionReason: "User answered questions",
+                        updatedInput: {
+                          ...toolInput,
+                          answers: answersMap,
+                        },
+                      },
+                    }
+                  } catch (error) {
+                    log.error("question handling failed", {
+                      error: error instanceof Error ? error.message : String(error),
+                      sessionID,
+                    })
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: "PermissionRequest",
+                        permissionDecision: "deny" as const,
+                        permissionDecisionReason: error instanceof Error ? error.message : "Question rejected",
+                      },
+                    }
+                  }
+                }
+
+                // Regular permission handling - bridge to OpenCode's permission system
+                try {
+                  const reply = await permissionBridge.ask(input.tool_name, input.tool_input, context.signal)
+
+                  if (reply === "reject") {
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: "PermissionRequest",
+                        permissionDecision: "deny" as const,
+                        permissionDecisionReason: "User rejected permission",
+                      },
+                    }
+                  } else {
+                    return {
+                      hookSpecificOutput: {
+                        hookEventName: "PermissionRequest",
+                        permissionDecision: "allow" as const,
+                        permissionDecisionReason: "User approved permission",
+                      },
+                    }
+                  }
+                } catch (error) {
+                  log.error("permission handling failed", {
+                    error: error instanceof Error ? error.message : String(error),
+                    sessionID,
+                    toolName: input.tool_name,
+                  })
+                  return {
+                    hookSpecificOutput: {
+                      hookEventName: "PermissionRequest",
+                      permissionDecision: "deny" as const,
+                      permissionDecisionReason: error instanceof Error ? error.message : "Permission error",
+                    },
+                  }
+                }
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    log.info("built sdk options", {
+      mcpServerCount: Object.keys(mcpServers).length,
+      mcpServers: Object.keys(mcpServers),
+      permissionMode: config.permissionMode,
+      hooksEnabled: Boolean(options.hooks),
+    })
+
+    // Resume previous SDK session if available
+    const sdkSessionId = session.metadata?.["claudeAgentSessionId"] as string | undefined
+    if (sdkSessionId) {
+      options.resume = sdkSessionId
+      log.info("resuming sdk session", { sdkSessionId })
+    }
+
+    // For bypassPermissions, we need to explicitly allow it
+    if (config.permissionMode === "bypassPermissions") {
+      options.allowDangerouslySkipPermissions = true
+    }
+
+    return options
+  }
+
+  /**
+   * Convert opencode MCP server configurations to Claude Agent SDK format
+   */
+  async function getMcpServersForSDK(
+    config: ClaudeAgentConfig,
+  ): Promise<Record<string, SDKMcpServerConfig>> {
+    const result: Record<string, SDKMcpServerConfig> = {}
+
+    // Add MCP servers from plugin config
+    if (config.mcpServers) {
+      for (const [name, server] of Object.entries(config.mcpServers)) {
+        result[name] = {
+          type: "stdio",
+          command: server.command,
+          args: server.args,
+          env: server.env,
+        }
+      }
+    }
+
+    // Add MCP servers from opencode's global config
+    try {
+      const appConfig = await Config.get()
+      const mcpConfig = appConfig.mcp ?? {}
+
+      for (const [name, mcp] of Object.entries(mcpConfig)) {
+        // Skip if already defined in plugin config (plugin takes precedence)
+        if (result[name]) continue
+
+        // Skip disabled servers
+        if (typeof mcp === "object" && "enabled" in mcp && mcp.enabled === false) {
+          continue
+        }
+
+        // Handle local MCP servers (stdio-based)
+        if (typeof mcp === "object" && "type" in mcp && mcp.type === "local") {
+          const [command, ...args] = mcp.command
+          result[name] = {
+            type: "stdio",
+            command,
+            args,
+            env: mcp.environment,
+          }
+          log.info("added local mcp server to SDK", { name, command, argsCount: args.length })
+        }
+        // Handle remote MCP servers (SSE/HTTP-based)
+        else if (typeof mcp === "object" && "type" in mcp && mcp.type === "remote") {
+          // Determine transport type based on URL path
+          const baseUrl = mcp.url.toLowerCase()
+          const type = baseUrl.includes("/sse") || baseUrl.endsWith("/sse") ? "sse" : "http"
+
+          result[name] = {
+            type,
+            url: mcp.url,
+            headers: mcp.headers ?? {},
+          }
+
+          // Add OAuth headers if configured
+          if (mcp.oauth && typeof mcp.oauth === "object") {
+            const oauth = mcp.oauth
+            if (oauth.clientId) {
+              result[name].headers = {
+                ...result[name].headers,
+                "X-OAuth-Client-ID": oauth.clientId,
+              }
+            }
+            if (oauth.clientSecret) {
+              result[name].headers = {
+                ...result[name].headers,
+                "X-OAuth-Client-Secret": oauth.clientSecret,
+              }
+            }
+            if (oauth.scope) {
+              result[name].headers = {
+                ...result[name].headers,
+                "X-OAuth-Scope": oauth.scope,
+              }
+            }
+          }
+
+          log.info("added remote mcp server to SDK", {
+            name,
+            type,
+            url: mcp.url,
+            hasAuth: Object.keys(result[name].headers ?? {}).length > 0,
+          })
+        }
+      }
+
+      log.info("built mcp servers config for SDK", {
+        count: Object.keys(result).length,
+        servers: Object.keys(result),
+        details: result,
+      })
+    } catch (error) {
+      log.warn("failed to get opencode mcp config", { error })
+    }
+
+    return result
+  }
+
+  /**
+   * Get Claude Agent configuration from session/config
+   */
+  export async function getConfig(session: Session.Info): Promise<ClaudeAgentConfig> {
+    const appConfig = await Config.get()
+    const providerConfig = appConfig.provider?.[ClaudeAgentProvider.ID]
+
+    // Start with defaults
+    const config = ClaudeAgentProvider.getDefaultConfig()
+
+    // Merge with provider-level config
+    if (providerConfig && "claudeAgent" in providerConfig) {
+      const claudeAgentConfig = providerConfig.claudeAgent as Partial<ClaudeAgentConfig>
+      return ClaudeAgentProvider.mergeConfig(claudeAgentConfig)
+    }
+
+    return config
+  }
+}

--- a/packages/opencode/src/provider/claude-agent/tool-mcp-bridge.ts
+++ b/packages/opencode/src/provider/claude-agent/tool-mcp-bridge.ts
@@ -1,0 +1,217 @@
+import type { McpSdkServerConfigWithInstance } from "@anthropic-ai/claude-agent-sdk"
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk"
+import { ToolRegistry } from "../../tool/registry"
+import { Log } from "../../util/log"
+import { PermissionNext } from "../../permission/next"
+import { PermissionBridge } from "./permission-bridge"
+import z from "zod"
+
+const log = Log.create({ service: "claude-agent.tool-mcp" })
+
+const TOOL_NAME_MAPPING: Record<string, string> = {
+  read: "opencoderead",
+  write: "opencodewrite",
+  edit: "opencodeedit",
+  bash: "opencodebash",
+  glob: "opencodeglob",
+  greptool: "opencodegrep",
+  websearch: "opencodewebsearch",
+  webfetch: "opencodewebfetch",
+  task: "opencodetask",
+  todowrite: "opencodetodowrite",
+  todoread: "opencodetodoread",
+  question: "opencodequestion",
+  lsp: "opencodelsp",
+  ls: "opencodels",
+  codesearch: "opencodecodesearch",
+  skill: "opencodeskill",
+  multiedit: "opencodemultiedit",
+  patch: "opencodepatch",
+  batch: "opencodebatch",
+}
+
+function toSDKToolName(opencodeToolId: string): string {
+  return TOOL_NAME_MAPPING[opencodeToolId] || opencodeToolId.charAt(0).toUpperCase() + opencodeToolId.slice(1)
+}
+
+export namespace ToolMCPBridge {
+  export async function create(sessionID: string, permissionBridge?: ReturnType<typeof PermissionBridge.create>): Promise<McpSdkServerConfigWithInstance> {
+    try {
+      const tools = await ToolRegistry.tools("claude-agent", undefined)
+      log.info("creating mcp server for opencode tools", {
+        toolCount: Object.keys(tools).length,
+        sessionID,
+      })
+
+      const sdkTools = []
+
+      for (const toolInfo of tools) {
+        try {
+          const sdkToolName = toSDKToolName(toolInfo.id)
+
+          log.debug("preparing tool for sdk", {
+            toolID: toolInfo.id,
+            sdkToolName,
+            sessionID,
+          })
+
+          const sdkTool = tool(
+            sdkToolName,
+            toolInfo.description,
+            convertSchema(toolInfo.parameters) as any,
+            async (args: unknown) => {
+              try {
+                log.info("sdk executing opencode tool", {
+                  toolID: sdkToolName,
+                  opencodeToolID: toolInfo.id,
+                  sessionID,
+                })
+
+                const ctx = {
+                  sessionID,
+                  messageID: "sdk-tool-call",
+                  agent: "claude-sdk",
+                  abort: new AbortController().signal,
+                  metadata: () => {},
+                  ask: async (input: Omit<PermissionNext.Request, "id" | "sessionID" | "tool"> & { ruleset?: PermissionNext.Ruleset }) => {
+                    if (permissionBridge) {
+                      const reply = await permissionBridge.ask(
+                        input.permission,
+                        input.patterns,
+                        new AbortController().signal,
+                      )
+                      if (reply === "reject") {
+                        throw new Error("Permission rejected")
+                      }
+                      return
+                    }
+                    await PermissionNext.ask({
+                      permission: input.permission,
+                      patterns: input.patterns,
+                      always: input.always,
+                      metadata: input.metadata,
+                      sessionID,
+                      ruleset: input.ruleset ?? [],
+                    })
+                  },
+                }
+
+                const result = await toolInfo.execute(args as Record<string, unknown>, ctx)
+
+                log.debug("tool execution completed", {
+                  toolID: sdkToolName,
+                  resultSize: result.output.length,
+                  sessionID,
+                })
+
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: result.output,
+                    },
+                  ],
+                }
+              } catch (error) {
+                log.error("tool execution failed", {
+                  toolID: sdkToolName,
+                  error: error instanceof Error ? error.message : String(error),
+                  sessionID,
+                })
+
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+                    },
+                  ],
+                  isError: true,
+                }
+              }
+            },
+          )
+
+          sdkTools.push(sdkTool)
+
+          log.debug("prepared tool for sdk", {
+            toolID: sdkToolName,
+            opencodeToolID: toolInfo.id,
+            totalTools: sdkTools.length,
+            sessionID,
+          })
+        } catch (error) {
+          const sdkToolName = toSDKToolName(toolInfo.id)
+          log.warn("failed to prepare tool", {
+            toolID: sdkToolName,
+            opencodeToolID: toolInfo.id,
+            error: error instanceof Error ? error.message : String(error),
+            sessionID,
+          })
+        }
+      }
+
+      const server = createSdkMcpServer({
+        name: "tools",
+        version: "1.0.0",
+        tools: sdkTools,
+      })
+
+      log.info("mcp server created successfully", {
+        toolCount: sdkTools.length,
+        sessionID,
+        tools: sdkTools.map((t) => t.name),
+      })
+
+      return server as McpSdkServerConfigWithInstance
+    } catch (error) {
+      log.error("failed to create mcp server", {
+        error: error instanceof Error ? error.message : String(error),
+        sessionID,
+      })
+      throw error
+    }
+  }
+
+  function convertSchema(zodSchema: z.ZodType): unknown {
+    try {
+      return z.toJSONSchema(zodSchema)
+    } catch {
+      log.warn("failed to convert schema to json schema", {})
+      return { type: "object" }
+    }
+  }
+
+  function extractPatterns(toolName: string, args: unknown): string[] {
+    if (!args || typeof args !== "object") return ["*"]
+
+    const input = args as Record<string, unknown>
+
+    switch (toolName) {
+      case "read":
+      case "write":
+      case "edit":
+        return typeof input.filePath === "string" ? [input.filePath] : ["*"]
+
+      case "bash":
+        return typeof input.command === "string" ? [input.command] : ["bash *"]
+
+      case "webfetch":
+        return typeof input.url === "string" ? [input.url] : ["webfetch *"]
+
+      case "websearch":
+        return typeof input.query === "string" ? [input.query] : ["websearch *"]
+
+      case "greptool":
+      case "glob": {
+        const patterns: string[] = []
+        if (typeof input.pattern === "string") patterns.push(input.pattern)
+        if (typeof input.path === "string") patterns.push(input.path)
+        return patterns.length > 0 ? patterns : ["*"]
+      }
+
+      default:
+        return ["*"]
+    }
+  }
+}

--- a/packages/opencode/src/provider/claude-agent/types.ts
+++ b/packages/opencode/src/provider/claude-agent/types.ts
@@ -1,0 +1,98 @@
+import z from "zod"
+
+/**
+ * Configuration for the Claude Agent SDK provider
+ */
+export const ClaudeAgentConfig = z
+  .object({
+    /** Model to use (e.g., "claude-sonnet-4") */
+    model: z.string().optional(),
+    /** Permission mode for SDK tool execution */
+    permissionMode: z
+      .enum(["default", "acceptEdits", "bypassPermissions", "plan"])
+      .optional()
+      .default("default"),
+    /** List of SDK built-in tools to enable - set to empty array to disable all built-in tools */
+    allowedTools: z.array(z.string()).optional(),
+    /** Additional system prompt to append */
+    systemPrompt: z.string().optional(),
+    /** Working directory for the agent */
+    cwd: z.string().optional(),
+    /** Disable SDK's built-in tools entirely to only use MCP tools */
+    disableBuiltInTools: z.boolean().optional(),
+    /** MCP servers to pass to SDK (in addition to opencode's configured MCP servers) */
+    mcpServers: z
+      .record(
+        z.string(),
+        z.object({
+          command: z.string(),
+          args: z.array(z.string()).optional(),
+          env: z.record(z.string(), z.string()).optional(),
+        }),
+      )
+      .optional(),
+  })
+  .strict()
+
+export type ClaudeAgentConfig = z.infer<typeof ClaudeAgentConfig>
+
+/**
+ * MCP server configuration in Claude Agent SDK format
+ */
+export interface SDKMcpServerConfig {
+  type?: "stdio" | "sse" | "http" | "sdk"
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+  name?: string
+  instance?: unknown
+}
+
+/**
+ * State stored for Claude Agent SDK sessions
+ */
+export interface ClaudeAgentSessionState {
+  /** SDK's internal session ID for resume capability */
+  sdkSessionId?: string
+}
+
+/**
+ * Context for message translation
+ */
+export interface MessageContext {
+  sessionID: string
+  messageID: string
+  partIndex: number
+}
+
+/**
+ * SDK Permission modes
+ */
+export type SDKPermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan"
+
+/**
+ * Default allowed tools for Claude Agent SDK
+ * These map to OpenCode's tools via MCP server
+ */
+export const DEFAULT_ALLOWED_TOOLS = [
+  "opencoderead",
+  "opencodewrite",
+  "opencodeedit",
+  "opencodebash",
+  "opencodeglob",
+  "opencodegrep",
+  "opencodewebsearch",
+  "opencodewebfetch",
+  "opencodetask",
+  "opencodetodowrite",
+  "opencodetodoread",
+  "opencodequestion",
+  "opencodelsp",
+  "opencodels",
+  "opencodecodesearch",
+  "opencodeskill",
+  "opencodemultiedit",
+  "opencodepatch",
+]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -72,6 +72,25 @@ export namespace Provider {
   }>
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
+    /**
+     * Claude Agent SDK provider
+     * Uses @anthropic-ai/claude-agent-sdk for agent execution with built-in tools
+     */
+    async "claude-agent"() {
+      const hasKey = await (async () => {
+        const env = Env.all()
+        if (env.ANTHROPIC_API_KEY) return true
+        if (await Auth.get("anthropic")) return true
+        const config = await Config.get()
+        if (config.provider?.["claude-agent"]?.options?.apiKey) return true
+        return false
+      })()
+
+      return {
+        autoload: hasKey,
+        options: {},
+      }
+    },
     async anthropic() {
       return {
         autoload: false,
@@ -602,6 +621,48 @@ export namespace Provider {
     }
   }
 
+  /**
+   * Create a model definition for Claude Agent SDK provider
+   */
+  function createClaudeAgentModel(
+    id: string,
+    name: string,
+    apiId: string,
+    options: { context: number; output: number; costInput: number; costOutput: number },
+  ): Model {
+    return {
+      id,
+      providerID: "claude-agent",
+      name,
+      family: "claude",
+      api: {
+        id: apiId,
+        url: "https://api.anthropic.com/v1",
+        npm: "@anthropic-ai/claude-agent-sdk",
+      },
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: true },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: { field: "reasoning_content" },
+      },
+      cost: {
+        input: options.costInput,
+        output: options.costOutput,
+        cache: { read: options.costInput * 0.1, write: options.costInput * 1.25 },
+      },
+      limit: { context: options.context, output: options.output },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2025-01-01",
+      variants: {},
+    }
+  }
+
   const state = Instance.state(async () => {
     using _ = log.time("state")
     const config = await Config.get()
@@ -640,6 +701,36 @@ export namespace Provider {
           providerID: "github-copilot-enterprise",
         })),
       }
+    }
+
+    // Add Claude Agent SDK provider (uses @anthropic-ai/claude-agent-sdk)
+    // This provider bypasses normal processing and uses the SDK's built-in agent runtime
+    database["claude-agent"] = {
+      id: "claude-agent",
+      name: "Claude Agent SDK",
+      source: "custom",
+      env: ["ANTHROPIC_API_KEY"],
+      options: {},
+      models: {
+        "claude-sonnet-4": createClaudeAgentModel("claude-sonnet-4", "Claude Sonnet 4 (Agent SDK)", "claude-sonnet-4-20250514", {
+          context: 200000,
+          output: 16384,
+          costInput: 3,
+          costOutput: 15,
+        }),
+        "claude-opus-4": createClaudeAgentModel("claude-opus-4", "Claude Opus 4 (Agent SDK)", "claude-opus-4-20250514", {
+          context: 200000,
+          output: 32768,
+          costInput: 15,
+          costOutput: 75,
+        }),
+        "claude-haiku-3.5": createClaudeAgentModel("claude-haiku-3.5", "Claude Haiku 3.5 (Agent SDK)", "claude-3-5-haiku-20241022", {
+          context: 200000,
+          output: 8192,
+          costInput: 0.8,
+          costOutput: 4,
+        }),
+      },
     }
 
     function mergeProvider(providerID: string, provider: Partial<Info>) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -10,6 +10,7 @@ import { proxy } from "hono/proxy"
 import { Session } from "../session"
 import z from "zod"
 import { Provider } from "../provider/provider"
+import { ClaudeAgentProvider } from "../provider/claude-agent"
 import { filter, mapValues, sortBy, pipe } from "remeda"
 import { NamedError } from "@opencode-ai/util/error"
 import { ModelsDev } from "../provider/models"
@@ -939,6 +940,7 @@ export namespace Server {
                   archived: z.number().optional(),
                 })
                 .optional(),
+              metadata: z.record(z.string(), z.any()).optional(),
             }),
           ),
           async (c) => {
@@ -950,6 +952,9 @@ export namespace Server {
                 session.title = updates.title
               }
               if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
+              if (updates.metadata !== undefined) {
+                session.metadata = { ...session.metadata, ...updates.metadata }
+              }
             })
 
             return c.json(updatedSession)

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -72,6 +72,7 @@ export namespace Session {
           diff: z.string().optional(),
         })
         .optional(),
+      metadata: z.record(z.string(), z.any()).optional(),
     })
     .meta({
       ref: "Session",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -44,6 +44,7 @@ import { SessionStatus } from "./status"
 import { LLM } from "./llm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
+import { ClaudeAgentProvider, ClaudeAgentSession } from "@/provider/claude-agent"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -291,7 +292,12 @@ export namespace SessionPrompt {
       }
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
-      if (
+
+      // Check for pending compaction/subtask tasks before exiting
+      // These need to be processed even after SDK agent finishes
+      if (tasks.length > 0) {
+        log.info("has pending tasks, skipping exit check", { sessionID, taskCount: tasks.length })
+      } else if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
         lastUser.id < lastAssistant.id
@@ -313,8 +319,8 @@ export namespace SessionPrompt {
       const task = tasks.pop()
 
       // pending subtask
-      // TODO: centralize "invoke tool" logic
-      if (task?.type === "subtask") {
+      // Skip subtask processing when using SDK agent - SDK handles it via Task v2 tool
+      if (task?.type === "subtask" && !ClaudeAgentProvider.isClaudeAgentProvider(lastUser.model.providerID)) {
         const taskTool = await TaskTool.init()
         const assistantMessage = (await Session.updateMessage({
           id: Identifier.ascending("message"),
@@ -479,7 +485,8 @@ export namespace SessionPrompt {
       }
 
       // pending compaction
-      if (task?.type === "compaction") {
+      // Skip compaction processing when using SDK agent - SDK handles it internally
+      if (task?.type === "compaction" && !ClaudeAgentProvider.isClaudeAgentProvider(lastUser.model.providerID)) {
         const result = await SessionCompaction.process({
           messages: msgs,
           parentID: lastUser.id,
@@ -503,6 +510,28 @@ export namespace SessionPrompt {
           model: lastUser.model,
           auto: true,
         })
+        continue
+      }
+
+      // Claude Agent SDK provider handling
+      // When using claude-agent provider, delegate to the SDK's agent runtime
+      if (ClaudeAgentProvider.isClaudeAgentProvider(lastUser.model.providerID)) {
+        const claudeAgentConfig = await ClaudeAgentSession.getConfig(session)
+        const result = await ClaudeAgentSession.process({
+          sessionID,
+          user: lastUser,
+          messages: msgs,
+          config: claudeAgentConfig,
+          abort,
+          session,
+        })
+
+        // Claude Agent SDK handles its own tool loop internally
+        // The SDK processes everything in one call, so we always break after
+        if (result.info.role === "assistant") {
+          // SDK completed - exit loop
+          break
+        }
         continue
       }
 


### PR DESCRIPTION
## Summary
Fixes a race condition where `onMount()` was called before the `prompt` ref was initialized, causing a "undefined is not an object (evaluating 'prompt.set')" error when starting a new session from inside an existing session.

## Root Cause
In `packages/opencode/src/cli/cmd/tui/routes/home.tsx:79-90`, the `onMount()` hook attempted to call `prompt.set()` before the ref had been assigned by the `<Prompt ref={(r) => { prompt = r }} />` component. This resulted in `prompt` being undefined during execution.

## Fix
- Changed from `onMount()` to `createEffect()` which re-evaluates when reactive dependencies change
- Added a guard `if (once || !prompt) return` to check if the prompt ref exists
- Moved `randomizeTip()` outside the effect (previously called in onMount)
- Matches the safer pattern already used in `session/index.tsx:191-196`

Fixes #7870