### PR TITLE
fix: race condition causing prompt.set undefined error

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import { createMemo, Match, onMount, Show, Switch } from "solid-js"
+import { createMemo, Match, createEffect, Show, Switch, onMount } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { Logo } from "../component/logo"
 import { DidYouKnow, randomizeTip } from "../component/did-you-know"
@@ -76,9 +76,9 @@ export function Home() {
 
   let prompt: PromptRef
   const args = useArgs()
-  onMount(() => {
-    randomizeTip()
-    if (once) return
+  onMount(() => randomizeTip())
+  createEffect(() => {
+    if (once || !prompt) return
     if (route.initialPrompt) {
       prompt.set(route.initialPrompt)
       once = true


### PR DESCRIPTION
## Summary
Fixes a race condition where `onMount()` was called before the `prompt` ref was initialized, causing a "undefined is not an object (evaluating 'prompt.set')" error when starting a new session from inside an existing session.

## Root Cause
In `packages/opencode/src/cli/cmd/tui/routes/home.tsx:79-90`, the `onMount()` hook attempted to call `prompt.set()` before the ref had been assigned by the `<Prompt ref={(r) => { prompt = r }} />` component. This resulted in `prompt` being undefined during execution.

## Fix
- Changed from `onMount()` to `createEffect()` which re-evaluates when reactive dependencies change
- Added a guard `if (once || !prompt) return` to check if the prompt ref exists

Fixes #7870