### PR TITLE
fix(mcp): support `resource` content type in MCP tool output

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -777,8 +777,23 @@ export namespace SessionPrompt {
               mime: contentItem.mimeType,
               url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
             })
+          } else if (contentItem.type === "resource") {
+            const { resource } = contentItem
+            if (resource.text) {
+              textParts.push(resource.text)
+            }
+            if (resource.blob) {
+              attachments.push({
+                id: Identifier.ascending("part"),
+                sessionID: input.session.id,
+                messageID: input.processor.message.id,
+                type: "file",
+                mime: resource.mimeType ?? "application/octet-stream",
+                url: `data:${resource.mimeType ?? "application/octet-stream"};base64,${resource.blob}`,
+                filename: resource.uri,
+              })
+            }
           }
-          // Add support for other types if needed
         }
 
         return {


### PR DESCRIPTION
### What does this PR do?

This PR adds support for `resource` content types in MCP tool outputs. Previously, OpenCode ignored these, causing tools like `github-mcp-server`'s `get_file_contents` to return empty results to the agent.

- Updated `MCP.tools()` in `packages/opencode/src/session/prompt.ts` to process `contentItem.type === "resource"`.
- Text resources are now appended to the tool output.
- Blob resources are attached as file parts.

Closes #7878 

### How did you verify your code works?

- Verified with `github-mcp-server` by reading a file from a repository. The agent now correctly receives the file content.
- Ran `bun typecheck`.