### PR TITLE
fix(tui): handle empty paste fallback

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -30,6 +30,7 @@ import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
+import { resolvePastedContent } from "./paste"
 
 export type PromptProps = {
   sessionID?: string
@@ -861,12 +862,14 @@ export function Prompt(props: PromptProps) {
                 // Normalize line endings at the boundary
                 // Windows ConPTY/Terminal often sends CR-only newlines in bracketed paste
                 // Replace CRLF first, then any remaining CR
-                const normalizedText = event.text.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
-                const pastedContent = normalizedText.trim()
-                if (!pastedContent) {
+                const resolvedContent = await resolvePastedContent(event.text, Clipboard.read)
+
+                if (!resolvedContent) {
                   command.trigger("prompt.paste")
                   return
                 }
+
+                const pastedContent = resolvedContent
 
                 // trim ' from the beginning and end of the pasted content. just
                 // ' and nothing else

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/paste.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/paste.ts
@@ -1,0 +1,17 @@
+import { Clipboard } from "../../util/clipboard"
+
+export async function resolvePastedContent(
+  eventText: string,
+  readClipboard: () => Promise<Clipboard.Content | undefined>,
+): Promise<string | undefined> {
+  // Normalize and use paste payload when terminals supply text directly
+  const normalized = eventText.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+  const text = normalized.trim()
+  if (text) return text
+
+  // Finder copy often yields empty paste events; fallback to clipboard text
+  const clipboardContent = await readClipboard()
+  const clipboardText = clipboardContent?.mime.startsWith("text/") ? clipboardContent.data : undefined
+  if (!clipboardText) return
+  return clipboardText.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim()
+}

--- a/packages/opencode/test/cli/tui/paste.test.ts
+++ b/packages/opencode/test/cli/tui/paste.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, mock, test } from "bun:test"
+import { resolvePastedContent } from "../../../src/cli/cmd/tui/component/prompt/paste"
+
+describe("resolvePastedContent", () => {
+  test("returns normalized event text when present", async () => {
+    const readClipboard = mock(async () => undefined)
+    const result = await resolvePastedContent("  Hello\r\nWorld  ", readClipboard)
+    expect(result).toBe("Hello\nWorld")
+    expect(readClipboard.mock.calls.length).toBe(0)
+  })
+
+  test("falls back to clipboard text when event text is empty", async () => {
+    const readClipboard = mock(async () => ({ data: "  clipboard text  ", mime: "text/plain" }))
+    const result = await resolvePastedContent("", readClipboard)
+    expect(result).toBe("clipboard text")
+    expect(readClipboard.mock.calls.length).toBe(1)
+  })
+
+  test("returns undefined when clipboard lacks text content", async () => {
+    const readClipboard = mock(async () => ({ data: "ignored", mime: "image/png" }))
+    const result = await resolvePastedContent("", readClipboard)
+    expect(result).toBeUndefined()
+  })
+})


### PR DESCRIPTION
I have noticed that when I copy a filename in MacOS finder, then attempt to paste it into opencode, nothing is pasted. 

This PR resolves that!

Here's a demo of the fix in action:

https://github.com/user-attachments/assets/e1465aad-9b65-416f-9c24-08a847daf84a



Fixes #7897