### PR TITLE
chore: update GitHub stars count to 60K

### DIFF
--- a/packages/console/app/src/config.ts
+++ b/packages/console/app/src/config.ts
@@ -9,8 +9,8 @@ export const config = {
   github: {
     repoUrl: "https://github.com/anomalyco/opencode",
     starsFormatted: {
-      compact: "50K",
-      full: "50,000",
+      compact: "60K",
+      full: "60,000",
     },
   },
 


### PR DESCRIPTION
### What does this PR do?

Updates the constant to reflect github stars count properly
