### PR TITLE
fix: opencode Remove the symlinkBinary function call that replaces the wrapper script (fixes #7911)

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -106,8 +106,11 @@ async function main() {
       return
     }
 
-    const { binaryPath, binaryName } = findBinary()
-    symlinkBinary(binaryPath, binaryName)
+    // On non-Windows platforms, just verify the binary package exists  
+    // Don't replace the wrapper script - it handles binary execution  
+    const { binaryPath } = findBinary()  
+    console.log(`Platform binary verified at: ${binaryPath}`)  
+    console.log("Wrapper script will handle binary execution") 
   } catch (error) {
     console.error("Failed to setup opencode binary:", error.message)
     process.exit(1)


### PR DESCRIPTION
The wrapper script in `bin/opencode` already has robust logic to find the correct platform-specific binary by searching through `node_modules`, so we don't need to replace it with a symlink. The postinstall script should only ensure the binary package is installed, not modify the wrapper script.

### What does this PR do?

It fixes #7911

### How did you verify your code works?

The release package is tested in local.