### PR TITLE
chore(tui): clarify ChatGPT plan hint

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -294,7 +294,7 @@ export const AuthLoginCommand = cmd({
                 hint: {
                   opencode: "recommended",
                   anthropic: "Claude Max or API key",
-                  openai: "ChatGPT Plus/Pro or API key",
+                  openai: "ChatGPT plan with Codex or API key",
                 }[x.id],
               })),
             ),

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -36,7 +36,7 @@ export function createDialogProviderOptions() {
         description: {
           opencode: "(Recommended)",
           anthropic: "(Claude Max or API key)",
-          openai: "(ChatGPT Plus/Pro or API key)",
+          openai: "(ChatGPT plan with Codex or API key)",
         }[provider.id],
         category: provider.id in PROVIDER_PRIORITY ? "Popular" : "Other",
         async onSelect() {


### PR DESCRIPTION
Fixes #7941 by updating the OpenAI provider hint text to clarify that ChatGPT plans with Codex access work, without listing every plan tier i.e. if we used "ChatGPT Plus/Pro/Business/Enterprise or API key" which would wrap awkwardly in the TUI.

**Before**

<img width="1231" height="813" alt="Screenshot 2026-01-12 at 09 41 20" src="https://github.com/user-attachments/assets/77eeb779-3c6c-4c3d-a93d-76c437f853b6" />

**After**

<img width="1231" height="813" alt="Screenshot 2026-01-12 at 09 41 48" src="https://github.com/user-attachments/assets/be67e4f6-5148-46b3-b7e6-fd40e7969282" />
