### PR TITLE
fix: add error handling to RPC system to prevent crashes on session abort

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -215,9 +215,11 @@ export function Prompt(props: PromptProps) {
           }, 5000)
 
           if (store.interrupt >= 2) {
-            sdk.client.session.abort({
-              sessionID: props.sessionID,
-            })
+            sdk.client.session
+              .abort({
+                sessionID: props.sessionID,
+              })
+              .catch(() => {})
             setStore("interrupt", 0)
           }
           dialog.clear()

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1457,7 +1457,7 @@ export namespace Server {
             void SessionPrompt.prompt({ ...body, sessionID }).catch((error) => {
               log.error("prompt_async failed", { error, sessionID })
             })
-            return c.text("", 204)
+            return c.body(null, 204)
           },
         )
         .post(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1424,14 +1424,10 @@ export namespace Server {
           ),
           validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
           async (c) => {
-            c.status(200)
-            c.header("Content-Type", "application/json")
-            return stream(c, async (stream) => {
-              const sessionID = c.req.valid("param").sessionID
-              const body = c.req.valid("json")
-              const msg = await SessionPrompt.prompt({ ...body, sessionID })
-              stream.write(JSON.stringify(msg))
-            })
+            const sessionID = c.req.valid("param").sessionID
+            const body = c.req.valid("json")
+            const msg = await SessionPrompt.prompt({ ...body, sessionID })
+            return c.json(msg)
           },
         )
         .post(
@@ -1456,13 +1452,12 @@ export namespace Server {
           ),
           validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
           async (c) => {
-            c.status(204)
-            c.header("Content-Type", "application/json")
-            return stream(c, async () => {
-              const sessionID = c.req.valid("param").sessionID
-              const body = c.req.valid("json")
-              SessionPrompt.prompt({ ...body, sessionID })
+            const sessionID = c.req.valid("param").sessionID
+            const body = c.req.valid("json")
+            void SessionPrompt.prompt({ ...body, sessionID }).catch((error) => {
+              log.error("prompt_async failed", { error, sessionID })
             })
+            return c.text("", 204)
           },
         )
         .post(

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -7,8 +7,18 @@ export namespace Rpc {
     onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.request") {
-        const result = await rpc[parsed.method](parsed.input)
-        postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+        try {
+          const result = await rpc[parsed.method](parsed.input)
+          postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+        } catch (error) {
+          postMessage(
+            JSON.stringify({
+              type: "rpc.error",
+              error: error instanceof Error ? error.message : String(error),
+              id: parsed.id,
+            }),
+          )
+        }
       }
     }
   }
@@ -21,15 +31,22 @@ export namespace Rpc {
     postMessage: (data: string) => void | null
     onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
   }) {
-    const pending = new Map<number, (result: any) => void>()
+    const pending = new Map<number, { resolve: (result: any) => void; reject: (error: Error) => void }>()
     const listeners = new Map<string, Set<(data: any) => void>>()
     let id = 0
     target.onmessage = async (evt) => {
       const parsed = JSON.parse(evt.data)
       if (parsed.type === "rpc.result") {
-        const resolve = pending.get(parsed.id)
-        if (resolve) {
-          resolve(parsed.result)
+        const callbacks = pending.get(parsed.id)
+        if (callbacks) {
+          callbacks.resolve(parsed.result)
+          pending.delete(parsed.id)
+        }
+      }
+      if (parsed.type === "rpc.error") {
+        const callbacks = pending.get(parsed.id)
+        if (callbacks) {
+          callbacks.reject(new Error(parsed.error))
           pending.delete(parsed.id)
         }
       }
@@ -45,8 +62,8 @@ export namespace Rpc {
     return {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
         const requestId = id++
-        return new Promise((resolve) => {
-          pending.set(requestId, resolve)
+        return new Promise((resolve, reject) => {
+          pending.set(requestId, { resolve, reject })
           target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
         })
       },


### PR DESCRIPTION
### What does this PR do?

Fixes a crash that occurs when aborting a session with double-escape. The app would crash with "Unexpected end of JSON input" error.

Fixes #7946

An example of error
```
error/crash [09:17:24] [LOG] 'bootstrapping'
[09:17:25] [LOG] 'resolveSystemTheme'
[09:17:25] [LOG] '{"type":"home"}'
[09:17:26] [LOG] [
      '#1d1f21', '#cc6666',
      '#b5bd68', '#f0c674',
      '#81a2be', '#b294bb',
      '#8abeb7', '#c5c8c6',
      '#666666', '#d54e53',
      '#b9ca4a', '#e7c547',
      '#7aa6da', '#c397d8',
      '#70c0b1', '#eaeaea'
    ]
[09:17:49] [LOG] 'navigate' { type: 'session', sessionID: 'ses_44eee8c1cffeyYbm3ENuvzhYkm' }
[09:17:49] [LOG] '{"type":"session","sessionID":"ses_44eee8c1cffeyYbm3ENuvzhYkm"}'
[09:17:53] [LOG] 'TSWorker:' 'Loading from local path: /$bunfs/root/tree-sitter-markdown-411r6y9b.wasm'
[09:17:53] [LOG] 'TSWorker:' 'Loading from local path: /$bunfs/root/highlights-r812a2qc.scm'
[09:17:53] [LOG] 'TSWorker:' 'Loading from local path: /$bunfs/root/injections-73j83es3.scm'
[09:17:53] [LOG] 'TSWorker:' 'Loading from local path: /$bunfs/root/tree-sitter-markdown_inline-j5349f42.wasm'
[09:17:53] [LOG] 'TSWorker:' 'Loading from local path: /$bunfs/root/highlights-x6tmsnaa.scm'
[09:25:00] [ERROR] Error: Unexpected end of JSON input
    SyntaxError: Unexpected end of JSON input
        at <parse> (:0)
        at json (unknown)
        at <anonymous> (../sdk/js/src/v2/gen/client/client.gen.ts:167:33)
        at processTicksAndRejections (native:7:39) 
```

**Changes:**
- Add try/catch in RPC listener to send error responses back to client instead of leaving promises hanging
- Handle `rpc.error` messages in client to reject promises properly
- Add `.catch()` to `session.abort` call to prevent unhandled rejections
- Return JSON from `/session/:sessionID/prompt` instead of a streaming response to avoid empty bodies on abort
- Fire-and-forget `/session/:sessionID/prompt_async` with a 204 no-content response and server-side error logging

### How did you verify your code works?

1. Started opencode TUI
2. Started an agent task
3. Pressed escape twice to abort mid-work
4. Verified the app no longer crashes with JSON parse errors

Note: I have not rerun the flow after the latest server response adjustments in this environment.
