### PR TITLE
fix(tui): center dialog properly and prevent overflow

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -25,8 +25,8 @@ export function Dialog(
       width={dimensions().width}
       height={dimensions().height}
       alignItems="center"
+      justifyContent="center"
       position="absolute"
-      paddingTop={dimensions().height / 4}
       left={0}
       top={0}
       backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
@@ -38,6 +38,7 @@ export function Dialog(
         }}
         width={props.size === "large" ? 80 : 60}
         maxWidth={dimensions().width - 2}
+        maxHeight={dimensions().height - 4}
         backgroundColor={theme.backgroundPanel}
         paddingTop={1}
       >


### PR DESCRIPTION
## Summary
- Use `justifyContent="center"` instead of fixed `paddingTop` for true vertical centering
- Add `maxHeight` constraint to prevent dialog from overflowing when terminal is small

Fixes #7902
