### PR TITLE
fix(tui): handle JSON parse error on double-escape abort

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -217,7 +217,7 @@ export function Prompt(props: PromptProps) {
           if (store.interrupt >= 2) {
             sdk.client.session.abort({
               sessionID: props.sessionID,
-            })
+            }).catch(() => {})
             setStore("interrupt", 0)
           }
           dialog.clear()


### PR DESCRIPTION
## Summary
Fixes #7946

When aborting a session with double-escape (pressing Esc twice), the `session.abort()` call races with the in-flight `session.prompt()` request. If the server terminates the response mid-stream, the response body is incomplete or empty, causing the SDK's JSON parser to throw `SyntaxError: Unexpected end of JSON input`.

## Changes
- Added `.catch(() => {})` to the `session.abort()` call in the TUI prompt component to silently ignore expected errors during abort

This matches the existing pattern used in `routes/session/index.tsx:400` and `app/src/pages/session.tsx:577` for the same scenario.

## Test plan
- [x] Run `bun run typecheck` on the opencode package (passes)
- [ ] Manual test: Start a task, press Esc twice to abort mid-work
- [ ] Verify no crash occurs, session aborts cleanly

---
🤖 Generated with Claude Code