### PR TITLE
feat(tui): add mouse hover and click support to permission prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -394,6 +394,8 @@ function Prompt<const T extends Record<string, string>>(props: {
                 paddingLeft={1}
                 paddingRight={1}
                 backgroundColor={option === store.selected ? theme.warning : theme.backgroundMenu}
+                onMouseOver={() => setStore("selected", option)}
+                onMouseUp={() => props.onSelect(store.selected)}
               >
                 <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
                   {props.options[option]}


### PR DESCRIPTION
Adds mouse interaction support to the permission prompt (Allow once / Allow always / Reject) for consistency with other interactive elements like slash command selection.

Previously, users could only navigate permission options using keyboard (arrow keys + enter). This makes it inconsistent with other UI elements that support mouse interaction.

- Add `onMouseOver` handler to highlight option on hover
- Add `onMouseUp` handler to select option on click

Follows the same pattern used in `autocomplete.tsx` for slash command selection.

Fixes #7966