### PR TITLE
feat: add respect_gitignore config option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1030,6 +1030,10 @@ export namespace Config {
           },
         ),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
+      respect_gitignore: z
+        .boolean()
+        .optional()
+        .describe("Respect .gitignore when searching files. Set to false to include gitignored files. Default: true"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
       tools: z.record(z.string(), z.boolean()).optional(),

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -12,6 +12,7 @@ import { Instance } from "../project/instance"
 import { Ripgrep } from "./ripgrep"
 import fuzzysort from "fuzzysort"
 import { Global } from "../global"
+import { Config } from "../config/config"
 
 export namespace File {
   const log = Log.create({ service: "file" })
@@ -167,7 +168,8 @@ export namespace File {
       }
 
       const set = new Set<string>()
-      for await (const file of Ripgrep.files({ cwd: Instance.directory })) {
+      const cfg = await Config.get()
+      for await (const file of Ripgrep.files({ cwd: Instance.directory, noIgnore: cfg.respect_gitignore === false })) {
         result.files.push(file)
         let current = file
         while (true) {

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -210,12 +210,14 @@ export namespace Ripgrep {
     follow?: boolean
     maxDepth?: number
     signal?: AbortSignal
+    noIgnore?: boolean
   }) {
     input.signal?.throwIfAborted()
 
     const args = [await filepath(), "--files", "--glob=!.git/*"]
     if (input.follow !== false) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
+    if (input.noIgnore) args.push("--no-ignore")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
     if (input.glob) {
       for (const g of input.glob) {
@@ -379,9 +381,11 @@ export namespace Ripgrep {
     glob?: string[]
     limit?: number
     follow?: boolean
+    noIgnore?: boolean
   }) {
     const args = [`${await filepath()}`, "--json", "--hidden", "--glob='!.git/*'"]
     if (input.follow !== false) args.push("--follow")
+    if (input.noIgnore) args.push("--no-ignore")
 
     if (input.glob) {
       for (const g of input.glob) {

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -5,6 +5,7 @@ import DESCRIPTION from "./glob.txt"
 import { Ripgrep } from "../file/ripgrep"
 import { Instance } from "../project/instance"
 import { assertExternalDirectory } from "./external-directory"
+import { Config } from "../config/config"
 
 export const GlobTool = Tool.define("glob", {
   description: DESCRIPTION,
@@ -32,6 +33,7 @@ export const GlobTool = Tool.define("glob", {
     search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
     await assertExternalDirectory(ctx, search, { kind: "directory" })
 
+    const cfg = await Config.get()
     const limit = 100
     const files = []
     let truncated = false
@@ -39,6 +41,7 @@ export const GlobTool = Tool.define("glob", {
       cwd: search,
       glob: [params.pattern],
       signal: ctx.abort,
+      noIgnore: cfg.respect_gitignore === false,
     })) {
       if (files.length >= limit) {
         truncated = true

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -6,6 +6,7 @@ import DESCRIPTION from "./grep.txt"
 import { Instance } from "../project/instance"
 import path from "path"
 import { assertExternalDirectory } from "./external-directory"
+import { Config } from "../config/config"
 
 const MAX_LINE_LENGTH = 2000
 
@@ -36,6 +37,7 @@ export const GrepTool = Tool.define("grep", {
     searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
+    const cfg = await Config.get()
     const rgPath = await Ripgrep.filepath()
     const args = [
       "-nH",
@@ -46,6 +48,7 @@ export const GrepTool = Tool.define("grep", {
       "--regexp",
       params.pattern,
     ]
+    if (cfg.respect_gitignore === false) args.push("--no-ignore")
     if (params.include) {
       args.push("--glob", params.include)
     }

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -5,6 +5,7 @@ import DESCRIPTION from "./ls.txt"
 import { Instance } from "../project/instance"
 import { Ripgrep } from "../file/ripgrep"
 import { assertExternalDirectory } from "./external-directory"
+import { Config } from "../config/config"
 
 export const IGNORE_PATTERNS = [
   "node_modules/",
@@ -54,9 +55,10 @@ export const ListTool = Tool.define("list", {
       },
     })
 
+    const cfg = await Config.get()
     const ignoreGlobs = IGNORE_PATTERNS.map((p) => `!${p}*`).concat(params.ignore?.map((p) => `!${p}`) || [])
     const files = []
-    for await (const file of Ripgrep.files({ cwd: searchPath, glob: ignoreGlobs, signal: ctx.abort })) {
+    for await (const file of Ripgrep.files({ cwd: searchPath, glob: ignoreGlobs, signal: ctx.abort, noIgnore: cfg.respect_gitignore === false })) {
       files.push(file)
       if (files.length >= LIMIT) break
     }


### PR DESCRIPTION
### What does this PR do?

Adds a new respect_gitignore config option that controls whether .gitignore rules are respected when searching files.

### How did you verify your code works?

- Tested with respect_gitignore: false and confirmed gitignored files (e.g., node_modules/, build artifacts) appear in glob/grep/ls results
- Tested with default config (no setting or respect_gitignore: true) and confirmed gitignored files are excluded as before

Fixed https://github.com/anomalyco/opencode/issues/7969