### PR TITLE
fix(ui): use explicit light text colors for toast on dark float surface

### DIFF
--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -31,7 +31,7 @@
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-weak-base);
   background: var(--surface-float-base);
-  color: var(--text-invert-base);
+  color: var(--smoke-dark-11);
   box-shadow: var(--shadow-md);
 
   [data-slot="toast-inner"] {
@@ -80,8 +80,7 @@
     justify-content: center;
 
     [data-component="icon"] {
-      color: var(--text-invert-stronger);
-      /* color: var(--icon-invert-base); */
+      color: var(--smoke-dark-12);
     }
   }
 
@@ -94,7 +93,7 @@
   }
 
   [data-slot="toast-title"] {
-    color: var(--text-invert-strong);
+    color: var(--smoke-dark-12);
 
     /* text-14-medium */
     font-family: var(--font-family-sans);
@@ -108,7 +107,7 @@
   }
 
   [data-slot="toast-description"] {
-    color: var(--text-invert-base);
+    color: var(--smoke-dark-11);
     text-wrap-style: pretty;
 
     /* text-14-regular */
@@ -134,7 +133,7 @@
     padding: 0;
     cursor: pointer;
 
-    color: var(--text-invert-weak);
+    color: var(--smoke-dark-9);
     font-family: var(--font-family-sans);
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-medium);
@@ -146,7 +145,7 @@
     }
 
     &:first-child {
-      color: var(--text-invert-strong);
+      color: var(--smoke-dark-12);
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes #7833

Toast text is unreadable in Light mode because dark text appears on a dark background.

## Root Cause
The toast component uses `--surface-float-base` which is a dark surface in both light and dark modes. However, it was using `--text-invert-*` CSS variables for text colors. These variables don't properly resolve to light colors in light mode due to how `neutralAlpha` is calculated in the theme resolver (`resolve.ts`).

This causes:
- Light mode: Dark text on dark toast background (unreadable)
- Dark mode: Works correctly

## Changes
Replace `--text-invert-*` variables with explicit `--smoke-dark-*` colors which are always light colors suitable for dark backgrounds:

| Element | Old Variable | New Variable | Color |
|---------|--------------|--------------|-------|
| Title | `--text-invert-strong` | `--smoke-dark-12` | `#f1ecec` (near-white) |
| Description | `--text-invert-base` | `--smoke-dark-11` | `#b7b1b1` (light gray) |
| Icon | `--text-invert-stronger` | `--smoke-dark-12` | `#f1ecec` |
| Action (weak) | `--text-invert-weak` | `--smoke-dark-9` | `#716c6b` (medium gray) |
| Action (first) | `--text-invert-strong` | `--smoke-dark-12` | `#f1ecec` |

## Test plan
- [x] UI package typechecks pass
- [ ] Visual verification: Toast text is readable in both Light and Dark modes

---
🤖 Generated with Claude Code