### PR TITLE
feat(tui): add approval command dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -18,6 +18,7 @@ import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
+import { DialogApproval } from "@tui/component/dialog-approval"
 import { KeybindProvider } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
@@ -312,6 +313,23 @@ function App() {
           initialPrompt: currentPrompt,
         })
         dialog.clear()
+      },
+    },
+    {
+      title: "Approval mode",
+      value: "session.approval",
+      category: "Permissions",
+      disabled: route.data.type !== "session",
+      onSelect: () => {
+        const sessionID = route.data.type === "session" ? route.data.sessionID : undefined
+        if (!sessionID) {
+          toast.show({
+            variant: "warning",
+            message: "Open a session to update approvals",
+          })
+          return
+        }
+        dialog.replace(() => <DialogApproval sessionID={sessionID} />)
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-approval.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-approval.tsx
@@ -1,0 +1,60 @@
+import { DialogSelect } from "@tui/ui/dialog-select"
+import { useDialog } from "@tui/ui/dialog"
+import { useSDK } from "@tui/context/sdk"
+import { useToast } from "@tui/ui/toast"
+
+type ApprovalMode = "allow" | "ask" | "reject"
+
+type ApprovalOption = {
+  title: string
+  value: ApprovalMode
+  description: string
+}
+
+const options: ApprovalOption[] = [
+  {
+    title: "Allow",
+    value: "allow",
+    description: "Auto-approve tools",
+  },
+  {
+    title: "Ask",
+    value: "ask",
+    description: "Ask for each tool",
+  },
+  {
+    title: "Reject",
+    value: "reject",
+    description: "Deny all tools",
+  },
+]
+
+export function DialogApproval(props: { sessionID: string }) {
+  const sdk = useSDK()
+  const dialog = useDialog()
+  const toast = useToast()
+
+  const apply = (mode: ApprovalMode) => {
+    const action = mode === "reject" ? "deny" : mode
+    sdk.client.session
+      .update({
+        sessionID: props.sessionID,
+        permission: [{ permission: "*", pattern: "*", action }],
+      })
+      .then(() => {
+        dialog.clear()
+        toast.show({
+          variant: "success",
+          message: `Approval mode: ${mode}`,
+        })
+      })
+      .catch(() => {
+        toast.show({
+          variant: "error",
+          message: "Failed to update approvals",
+        })
+      })
+  }
+
+  return <DialogSelect title="Approval mode" options={options} onSelect={(option) => apply(option.value)} />
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -404,6 +404,11 @@ export function Autocomplete(props: {
         onSelect: () => command.trigger("session.new"),
       },
       {
+        display: "/approval",
+        description: "set approval mode",
+        onSelect: () => command.trigger("session.approval"),
+      },
+      {
         display: "/models",
         description: "list models",
         onSelect: () => command.trigger("model.list"),

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -27,6 +27,7 @@ import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
 import { DialogAlert } from "../../ui/dialog-alert"
+import { DialogApproval } from "../dialog-approval"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
@@ -495,6 +496,19 @@ export function Prompt(props: PromptProps) {
       promptModelWarning()
       return
     }
+    let inputText = store.prompt.input
+    const isApproval = inputText.startsWith("/approval")
+    if (isApproval && !props.sessionID) {
+      toast.show({
+        variant: "warning",
+        message: "Open a session to update approvals",
+      })
+      input.extmarks.clear()
+      input.clear()
+      setStore("prompt", { input: "", parts: [] })
+      setStore("extmarkToPartIndex", new Map())
+      return
+    }
     const sessionID = props.sessionID
       ? props.sessionID
       : await (async () => {
@@ -502,7 +516,6 @@ export function Prompt(props: PromptProps) {
           return sessionID
         })()
     const messageID = Identifier.ascending("message")
-    let inputText = store.prompt.input
 
     // Expand pasted text inline before submitting
     const allExtmarks = input.extmarks.getAllForTypeId(promptPartTypeId)
@@ -527,7 +540,8 @@ export function Prompt(props: PromptProps) {
     const currentMode = store.mode
     const variant = local.model.variant.current()
 
-    if (store.mode === "shell") {
+    const isShell = store.mode === "shell"
+    if (isShell) {
       sdk.client.session.shell({
         sessionID,
         agent: local.agent.current().name,
@@ -538,50 +552,63 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
-    } else if (
-      inputText.startsWith("/") &&
-      iife(() => {
-        const command = inputText.split(" ")[0].slice(1)
-        console.log(command)
-        return sync.data.command.some((x) => x.name === command)
-      })
-    ) {
-      let [command, ...args] = inputText.split(" ")
-      sdk.client.session.command({
-        sessionID,
-        command: command.slice(1),
-        arguments: args.join(" "),
-        agent: local.agent.current().name,
-        model: `${selectedModel.providerID}/${selectedModel.modelID}`,
-        messageID,
-        variant,
-        parts: nonTextParts
-          .filter((x) => x.type === "file")
-          .map((x) => ({
-            id: Identifier.ascending("part"),
-            ...x,
-          })),
-      })
-    } else {
-      sdk.client.session.prompt({
-        sessionID,
-        ...selectedModel,
-        messageID,
-        agent: local.agent.current().name,
-        model: selectedModel,
-        variant,
-        parts: [
-          {
-            id: Identifier.ascending("part"),
-            type: "text",
-            text: inputText,
-          },
-          ...nonTextParts.map((x) => ({
-            id: Identifier.ascending("part"),
-            ...x,
-          })),
-        ],
-      })
+    }
+
+    if (!isShell) {
+      if (inputText.startsWith("/approval")) {
+        dialog.replace(() => <DialogApproval sessionID={sessionID} />)
+        input.extmarks.clear()
+        setStore("prompt", { input: "", parts: [] })
+        setStore("extmarkToPartIndex", new Map())
+        input.clear()
+        return
+      }
+
+      if (
+        inputText.startsWith("/") &&
+        iife(() => {
+          const command = inputText.split(" ")[0].slice(1)
+          console.log(command)
+          return sync.data.command.some((x) => x.name === command)
+        })
+      ) {
+        const [command, ...args] = inputText.split(" ")
+        sdk.client.session.command({
+          sessionID,
+          command: command.slice(1),
+          arguments: args.join(" "),
+          agent: local.agent.current().name,
+          model: `${selectedModel.providerID}/${selectedModel.modelID}`,
+          messageID,
+          variant,
+          parts: nonTextParts
+            .filter((x) => x.type === "file")
+            .map((x) => ({
+              id: Identifier.ascending("part"),
+              ...x,
+            })),
+        })
+      } else {
+        sdk.client.session.prompt({
+          sessionID,
+          ...selectedModel,
+          messageID,
+          agent: local.agent.current().name,
+          model: selectedModel,
+          variant,
+          parts: [
+            {
+              id: Identifier.ascending("part"),
+              type: "text",
+              text: inputText,
+            },
+            ...nonTextParts.map((x) => ({
+              id: Identifier.ascending("part"),
+              ...x,
+            })),
+          ],
+        })
+      }
     }
     history.append({
       ...store.prompt,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -939,6 +939,7 @@ export namespace Server {
                   archived: z.number().optional(),
                 })
                 .optional(),
+              permission: PermissionNext.Ruleset.optional(),
             }),
           ),
           async (c) => {
@@ -950,6 +951,7 @@ export namespace Server {
                 session.title = updates.title
               }
               if (updates.time?.archived !== undefined) session.time.archived = updates.time.archived
+              if (updates.permission !== undefined) session.permission = updates.permission
             })
 
             return c.json(updatedSession)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -938,6 +938,7 @@ export class Session extends HeyApiClient {
       time?: {
         archived?: number
       }
+      permission?: PermissionRuleset
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -950,6 +951,7 @@ export class Session extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "body", key: "title" },
             { in: "body", key: "time" },
+            { in: "body", key: "permission" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2742,6 +2742,7 @@ export type SessionUpdateData = {
     time?: {
       archived?: number
     }
+    permission?: PermissionRuleset
   }
   path: {
     sessionID: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1339,6 +1339,9 @@
                         "type": "number"
                       }
                     }
+                  },
+                  "permission": {
+                    "$ref": "#/components/schemas/PermissionRuleset"
                   }
                 }
               }


### PR DESCRIPTION
### What does this PR do?
Fixes #7726
- Adds a /approval command in the TUI with an allow/ask/reject dialog.
- Surfaces the command in / autocomplete and the command palette.
- Stores the session-level approval rule via session.update (SDK/OpenAPI synced).
- For longer flows, repeated “ask” prompts can break the rhythm and waste time; /approval lets users adjust permissions on the fly to keep work moving.

  
### How did you verify your code works?
- Built and ran the TUI locally.

<img width="370" height="162" alt="image" src="https://github.com/user-attachments/assets/7cdbcfe5-604c-4c67-84ca-b30effd86032" />

Allow:

<img width="380" height="120" alt="image" src="https://github.com/user-attachments/assets/b557d356-b126-4195-b6e5-1708148ce85c" />


Ask:
<img width="374" height="243" alt="image" src="https://github.com/user-attachments/assets/1ab70360-d861-4f29-b572-3135a47f6bca" />

