### PR TITLE
feat: allow provider-level store option

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -816,6 +816,7 @@ export namespace Config {
           apiKey: z.string().optional(),
           baseURL: z.string().optional(),
           enterpriseUrl: z.string().optional().describe("GitHub Enterprise URL for copilot authentication"),
+          store: z.boolean().optional().describe("Set the OpenAI Responses store flag for this provider"),
           setCacheKey: z.boolean().optional().describe("Enable promptCacheKey for this provider (default false)"),
           timeout: z
             .union([

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -460,6 +460,9 @@ export namespace ProviderTransform {
     if (model.providerID === "openai" || providerOptions?.setCacheKey) {
       result["promptCacheKey"] = sessionID
     }
+    if (typeof providerOptions?.store === "boolean") {
+      result["store"] = providerOptions.store
+    }
 
     if (model.api.npm === "@ai-sdk/google" || model.api.npm === "@ai-sdk/google-vertex") {
       result["thinkingConfig"] = {


### PR DESCRIPTION
## Background
Provider options currently support baseURL/apiKey and setCacheKey, but there is no way to set the OpenAI Responses store flag at the provider level. This makes users repeat store=false for every model.

## Changes
- Read provider.options.store in ProviderTransform.options and emit it into request options.
- Add store to the provider options schema so it is documented and validated.

## Verification
- bun test test/config/config.test.ts
