### PR TITLE
fix(plugin): add .js extensions to ESM imports

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -9,8 +9,14 @@
     "build": "tsc"
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./tool": "./src/tool.ts"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./tool": {
+      "import": "./dist/tool.js",
+      "types": "./dist/tool.d.ts"
+    }
   },
   "files": [
     "dist"

--- a/packages/plugin/src/example.ts
+++ b/packages/plugin/src/example.ts
@@ -1,5 +1,5 @@
-import { Plugin } from "./index"
-import { tool } from "./tool"
+import { Plugin } from "./index.js"
+import { tool } from "./tool.js"
 
 export const ExamplePlugin: Plugin = async (ctx) => {
   return {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -12,10 +12,10 @@ import type {
   Config,
 } from "@opencode-ai/sdk"
 
-import type { BunShell } from "./shell"
-import { type ToolDefinition } from "./tool"
+import type { BunShell } from "./shell.js"
+import { type ToolDefinition } from "./tool.js"
 
-export * from "./tool"
+export * from "./tool.js"
 
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"


### PR DESCRIPTION
## Summary

Fixes the `@opencode-ai/plugin` package so it works when installed from npm.

## Problem

The plugin package fails to load with error:
```
Cannot find module './tool' imported from .../node_modules/@opencode-ai/plugin/dist/index.js
```

**Root causes:**
1. `package.json` exports pointed to `./src/index.ts` but only `dist/` is published to npm
2. Compiled `dist/index.js` had `export * from "./tool"` without `.js` extension, which does not resolve in Node.js ESM

## Solution

1. Updated `package.json` exports to point to `dist/*.js` files with proper ESM conditional exports
2. Added `.js` extensions to all relative imports in source files

## Testing

Tested with [opencode-shakespeare-plugin](https://github.com/derekross/opencode-shakespeare-plugin) which was unable to load until this fix was applied.

Fixes #8006