### PR TITLE
feat: plugin: add plugin tool execution for PTC

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -30,6 +30,7 @@ import { ProviderAuth } from "../provider/auth"
 import { Global } from "../global"
 import { ProjectRoute } from "./project"
 import { ToolRegistry } from "../tool/registry"
+import { Tool } from "../tool/tool"
 import { zodToJsonSchema } from "zod-to-json-schema"
 import { SessionPrompt } from "../session/prompt"
 import { SessionCompaction } from "../session/compaction"
@@ -558,6 +559,90 @@ export namespace Server {
                 parameters: (t.parameters as any)?._def ? zodToJsonSchema(t.parameters as any) : t.parameters,
               })),
             )
+          },
+        )
+        .post(
+          "/experimental/tool/execute",
+          describeRoute({
+            summary: "Execute tool",
+            description:
+              "Execute a specific tool with the provided arguments. Returns the tool output.",
+            operationId: "tool.execute",
+            responses: {
+              200: {
+                description: "Tool execution result",
+                content: {
+                  "application/json": {
+                    schema: resolver(
+                      z
+                        .object({
+                          title: z.string(),
+                          output: z.string(),
+                          metadata: z.record(z.string(), z.any()).optional(),
+                        })
+                        .meta({ ref: "ToolExecuteResult" }),
+                    ),
+                  },
+                },
+              },
+              ...errors(400, 404),
+            },
+          }),
+          validator(
+            "json",
+            z.object({
+              sessionID: z.string().meta({ description: "Session ID for context" }),
+              messageID: z.string().meta({ description: "Message ID for context" }),
+              providerID: z.string().meta({ description: "Provider ID for tool filtering" }),
+              toolID: z.string().meta({ description: "Tool ID to execute" }),
+              args: z.record(z.string(), z.any()).meta({ description: "Tool arguments" }),
+              agent: z.string().optional().meta({ description: "Agent name (optional)" }),
+              callID: z.string().optional().meta({ description: "Tool call ID (optional)" }),
+            }),
+          ),
+          async (c) => {
+            const body = c.req.valid("json")
+            const session = await Session.get(body.sessionID)
+            const agentName = body.agent ?? (await Agent.defaultAgent())
+            const agent = await Agent.get(agentName)
+            if (!agent) {
+              throw new Storage.NotFoundError({ message: `Agent not found: ${agentName}` })
+            }
+
+            const tools = await ToolRegistry.tools(body.providerID, agent)
+            const tool = tools.find((t) => t.id === body.toolID)
+            if (!tool) {
+              throw new Storage.NotFoundError({ message: `Tool not found: ${body.toolID}` })
+            }
+
+            const abortController = new AbortController()
+            let currentMetadata: { title?: string; metadata?: Record<string, any> } = {}
+
+            const ctx: Tool.Context = {
+              sessionID: body.sessionID,
+              messageID: body.messageID,
+              agent: agentName,
+              abort: abortController.signal,
+              callID: body.callID,
+              metadata: (input) => {
+                currentMetadata = input
+              },
+              ask: async (req) => {
+                await PermissionNext.ask({
+                  ...req,
+                  sessionID: session.id,
+                  tool: body.callID ? { messageID: body.messageID, callID: body.callID } : undefined,
+                  ruleset: PermissionNext.merge(agent.permission, session.permission ?? []),
+                })
+              },
+            }
+
+            const result = await tool.execute(body.args, ctx)
+            return c.json({
+              title: result.title || currentMetadata.title || "",
+              output: result.output,
+              metadata: result.metadata,
+            })
           },
         )
         .post(

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -36,6 +36,9 @@ import type {
   ToolListData,
   ToolListResponses,
   ToolListErrors,
+  ToolExecuteData,
+  ToolExecuteResponses,
+  ToolExecuteErrors,
   InstanceDisposeData,
   InstanceDisposeResponses,
   PathGetData,
@@ -388,6 +391,17 @@ class Tool extends _HeyApiClient {
     return (options.client ?? this._client).get<ToolListResponses, ToolListErrors, ThrowOnError>({
       url: "/experimental/tool",
       ...options,
+    })
+  }
+
+  public execute<ThrowOnError extends boolean = false>(options?: Options<ToolExecuteData, ThrowOnError>) {
+    return (options?.client ?? this._client).post<ToolExecuteResponses, ToolExecuteErrors, ThrowOnError>({
+      url: "/experimental/tool/execute",
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
     })
   }
 }

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1996,6 +1996,52 @@ export type ToolListResponses = {
 
 export type ToolListResponse = ToolListResponses[keyof ToolListResponses]
 
+export type ToolExecuteData = {
+  body?: {
+    agent?: string
+    args?: {
+      [key: string]: unknown
+    }
+    messageID?: string
+    providerID?: string
+    sessionID?: string
+    toolID?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/experimental/tool/execute"
+}
+
+export type ToolExecuteErrors = {
+  /**
+   * Bad request
+   */
+  400: string
+  /**
+   * Tool not found
+   */
+  404: string
+  /**
+   * Tool execution failed
+   */
+  500: string
+}
+
+export type ToolExecuteError = ToolExecuteErrors[keyof ToolExecuteErrors]
+
+export type ToolExecuteResponses = {
+  /**
+   * Tool execution result
+   */
+  200: {
+    output?: string
+  }
+}
+
+export type ToolExecuteResponse = ToolExecuteResponses[keyof ToolExecuteResponses]
+
 export type InstanceDisposeData = {
   body?: never
   path?: never

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -136,6 +136,8 @@ import type {
   SessionUpdateResponses,
   SubtaskPartInput,
   TextPartInput,
+  ToolExecuteErrors,
+  ToolExecuteResponses,
   ToolIdsErrors,
   ToolIdsResponses,
   ToolListErrors,
@@ -649,6 +651,55 @@ export class Tool extends HeyApiClient {
       url: "/experimental/tool",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Execute tool
+   *
+   * Execute a specific tool with the provided arguments. Returns the tool output.
+   */
+  public execute<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      sessionID?: string
+      messageID?: string
+      providerID?: string
+      toolID?: string
+      args?: {
+        [key: string]: unknown
+      }
+      agent?: string
+      callID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "sessionID" },
+            { in: "body", key: "messageID" },
+            { in: "body", key: "providerID" },
+            { in: "body", key: "toolID" },
+            { in: "body", key: "args" },
+            { in: "body", key: "agent" },
+            { in: "body", key: "callID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ToolExecuteResponses, ToolExecuteErrors, ThrowOnError>({
+      url: "/experimental/tool/execute",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1767,6 +1767,14 @@ export type ToolListItem = {
 
 export type ToolList = Array<ToolListItem>
 
+export type ToolExecuteResult = {
+  title: string
+  output: string
+  metadata?: {
+    [key: string]: unknown
+  }
+}
+
 export type Path = {
   home: string
   state: string
@@ -2480,6 +2488,68 @@ export type ToolListResponses = {
 }
 
 export type ToolListResponse = ToolListResponses[keyof ToolListResponses]
+
+export type ToolExecuteData = {
+  body?: {
+    /**
+     * Session ID for context
+     */
+    sessionID: string
+    /**
+     * Message ID for context
+     */
+    messageID: string
+    /**
+     * Provider ID for tool filtering
+     */
+    providerID: string
+    /**
+     * Tool ID to execute
+     */
+    toolID: string
+    /**
+     * Tool arguments
+     */
+    args: {
+      [key: string]: unknown
+    }
+    /**
+     * Agent name (optional)
+     */
+    agent?: string
+    /**
+     * Tool call ID (optional)
+     */
+    callID?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/experimental/tool/execute"
+}
+
+export type ToolExecuteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type ToolExecuteError = ToolExecuteErrors[keyof ToolExecuteErrors]
+
+export type ToolExecuteResponses = {
+  /**
+   * Tool execution result
+   */
+  200: ToolExecuteResult
+}
+
+export type ToolExecuteResponse = ToolExecuteResponses[keyof ToolExecuteResponses]
 
 export type InstanceDisposeData = {
   body?: never


### PR DESCRIPTION
### What does this PR do?
Programmatic Tool Calling (PTC)[1] lets code invoke tools directly in the execution environment, cutting model round-trips, latency, and tokens. Without an execution API, models could not programmatically invoke tools and had to fall back to provider-native tool calling, which blocks PTC on other models.

Introduce a tool execution API to run a tool by id with session/message context, provider/agent filtering, and permission gating, returning title/output/metadata.

Regenerate the JS SDK (v1/v2) to expose the new execute API and types so plugins can implement PTC regardless of the underlying model provider.

[1] https://platform.claude.com/cookbook/tool-use-programmatic-tool-calling-ptc

### How did you verify your code works?
I've writing a POC plugin to wrap the tools into async javascript functions, and the model is able to create 10k TODOs with the new interface.

Because it currently depends on a local SDK version, it has not been released yet. I will complete it as soon as possible and open-source it under the MIT license.

<img width="1585" height="871" alt="image" src="https://github.com/user-attachments/assets/f4d92257-af1f-4efa-b381-4468b32171b2" />

