### PR TITLE
fix: handle prompt abort to prevent JSON parse crash

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1429,7 +1429,7 @@ export namespace Server {
             return stream(c, async (stream) => {
               const sessionID = c.req.valid("param").sessionID
               const body = c.req.valid("json")
-              const msg = await SessionPrompt.prompt({ ...body, sessionID })
+              const msg = await SessionPrompt.prompt({ ...body, sessionID }).catch(() => null)
               stream.write(JSON.stringify(msg))
             })
           },


### PR DESCRIPTION
Fixes #7946

When cancel() rejects the prompt callback, the stream closes without writing anything. SDK then crashes parsing empty body.

This catches the rejection and writes null instead.

Couldn't reproduce locally but the fix seems correct based on the code flow.