### PR TITLE
fix: handle empty JSON responses in sdk client

### DIFF
--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -5,8 +5,54 @@ process.chdir(dir)
 
 import { $ } from "bun"
 import path from "path"
+import fs from "fs/promises"
 
 import { createClient } from "@hey-api/openapi-ts"
+
+const patchClient = async (filepath: string, options?: { required?: boolean }) => {
+  const required = options?.required ?? true
+  const content = await fs.readFile(filepath, "utf8").catch(() => "")
+  if (!content) {
+    if (required) throw new Error(`patch target missing: ${filepath}`)
+    return
+  }
+
+  const oldLines = [
+    '        case "formData":',
+    '        case "json":',
+    '        case "text":',
+    "          data = await response[parseAs]()",
+    "          break",
+  ]
+  const newLines = [
+    '        case "formData":',
+    '        case "text":',
+    "          data = await response[parseAs]()",
+    "          break",
+    '        case "json": {',
+    "          const text = await response.text()",
+    "          if (!text.trim()) {",
+    "            data = {}",
+    "          } else {",
+    "            data = JSON.parse(text)",
+    "          }",
+    "          break",
+    "        }",
+  ]
+
+  const newline = content.includes("\r\n") ? "\r\n" : "\n"
+  const oldBlock = oldLines.join(newline) + newline
+  const newBlock = newLines.join(newline) + newline
+
+  if (!content.includes(oldBlock)) {
+    if (required) {
+      throw new Error(`patch pattern not found in ${filepath}`)
+    }
+    return
+  }
+
+  await fs.writeFile(filepath, content.replace(oldBlock, newBlock), "utf8")
+}
 
 await $`bun dev generate > ${dir}/openapi.json`.cwd(path.resolve(dir, "../../opencode"))
 
@@ -36,6 +82,9 @@ await createClient({
     },
   ],
 })
+
+await patchClient(path.join(dir, "src/v2/gen/client/client.gen.ts"))
+await patchClient(path.join(dir, "src/gen/client/client.gen.ts"), { required: false })
 
 await $`bun prettier --write src/gen`
 await $`bun prettier --write src/v2`

--- a/packages/sdk/js/src/gen/client/client.gen.ts
+++ b/packages/sdk/js/src/gen/client/client.gen.ts
@@ -114,10 +114,18 @@ export const createClient = (config: Config = {}): Client => {
         case "arrayBuffer":
         case "blob":
         case "formData":
-        case "json":
         case "text":
           data = await response[parseAs]()
           break
+        case "json": {
+          const text = await response.text()
+          if (!text.trim()) {
+            data = {}
+          } else {
+            data = JSON.parse(text)
+          }
+          break
+        }
         case "stream":
           return opts.responseStyle === "data"
             ? response.body

--- a/packages/sdk/js/src/v2/gen/client/client.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/client.gen.ts
@@ -162,10 +162,18 @@ export const createClient = (config: Config = {}): Client => {
         case "arrayBuffer":
         case "blob":
         case "formData":
-        case "json":
         case "text":
           data = await response[parseAs]()
           break
+        case "json": {
+          const text = await response.text()
+          if (!text.trim()) {
+            data = {}
+          } else {
+            data = JSON.parse(text)
+          }
+          break
+        }
         case "stream":
           return opts.responseStyle === "data"
             ? response.body


### PR DESCRIPTION
Issue link:
- Fixes #8014
- https://github.com/anomalyco/opencode/issues/8014

Summary:
- Handle empty JSON responses by falling back to `{}` instead of throwing.
- Apply the fix to v1/v2 generated clients and keep it via the SDK build patch.

Motivation:
- Some endpoints can return empty bodies, which currently triggers `Unexpected end of JSON input` in the desktop app.

Validation:
- `bun run typecheck` (packages/sdk/js)
