### PR TITLE
fix(tui): fix Shift+Enter newline on Windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
@@ -4,9 +4,26 @@ import { Keybind } from "@/util/keybind"
 import { pipe, mapValues } from "remeda"
 import type { KeybindsConfig } from "@opencode-ai/sdk/v2"
 import type { ParsedKey, Renderable } from "@opentui/core"
+import { dlopen } from "bun:ffi"
 import { createStore } from "solid-js/store"
 import { useKeyboard, useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
+
+const win = process.platform === "win32"
+const user32 = win
+  ? dlopen("user32.dll", {
+      GetAsyncKeyState: {
+        args: ["i32"],
+        returns: "i16",
+      },
+    } as const)
+  : undefined
+
+const shiftdown = () => {
+  if (!user32) return false
+  const state = user32.symbols.GetAsyncKeyState(0x10)
+  return (state & 0x8000) !== 0
+}
 
 export const { use: useKeybind, provider: KeybindProvider } = createSimpleContext({
   name: "Keybind",
@@ -50,6 +67,19 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
     }
 
     useKeyboard(async (evt) => {
+      if (
+        win &&
+        evt.name === "return" &&
+        !evt.shift &&
+        !evt.ctrl &&
+        !evt.meta &&
+        !evt.super &&
+        !evt.hyper &&
+        shiftdown()
+      ) {
+        evt.shift = true
+      }
+
       if (!store.leader && result.match("leader", evt)) {
         leader(true)
         return


### PR DESCRIPTION
### What does this PR do?
[Video](https://github.com/user-attachments/assets/35dff786-2811-474e-9a05-e9249734011b)
Fixes #8038

### Summary
Fixes Windows prompt behavior where `Shift+Enter` was treated like `Enter` (submitting) instead of inserting a newline, restoring the intended “newline vs submit” UX.

### Details
- **Observed behavior (Windows Terminal/ConPTY):** `Shift+Enter` can be delivered as an unmodified `return` key event, so it matches the textarea’s `return → submit` binding (same path as plain `Enter`).
- **Implementation:** Add a Windows-only modifier fallback in `packages/opencode/src/cli/cmd/tui/context/keybind.tsx`:
  - Load `user32.dll` via `bun:ffi` and call `GetAsyncKeyState(VK_SHIFT)` (`VK_SHIFT = 0x10`).
  - When receiving an event with:
    - `evt.name === "return"`
    - `evt.shift/ctrl/meta/super/hyper` all false
    - `GetAsyncKeyState` indicates Shift is currently down (`state & 0x8000`)
    - then set `evt.shift = true` before matching keybinds.
- **Scope control (narrow by design):** Only applies to `return` events with *no other modifiers* and only on `process.platform === "win32"`, so the change is intentionally limited to the broken case.

### How did you verify your code works?
- The attached screen capture makes the corrected behavior evident end-to-end on Windows (newline insertion with `Shift+Enter`, submit with `Enter`).
- Ran `bun run typecheck` (repo typecheck via the pre-push hook / `turbo typecheck`).