### PR TITLE
fix: show toast error message on ConfigMarkdown parse error

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -19,6 +19,8 @@ import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
 import { existsSync } from "fs"
+import { Bus } from "@/bus"
+import { TuiEvent } from "@/cli/cmd/tui/event"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -218,7 +220,27 @@ export namespace Config {
       dot: true,
       cwd: dir,
     })) {
-      const md = await ConfigMarkdown.parse(item)
+      let md
+      try {
+        md = await ConfigMarkdown.parse(item)
+      } catch (err) {
+        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
+          log.error("failed to parse command frontmatter", {
+            path: err.data.path,
+            message: err.data.message,
+          })
+          const relativePath = path.relative(dir, item)
+          Bus.publish(TuiEvent.ToastShow, {
+            title: "Command Error",
+            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+            variant: "error",
+            duration: 8000,
+          })
+        } else {
+          log.error("failed to load command", { path: item, error: err })
+        }
+        continue
+      }
       if (!md.data) continue
 
       const name = (() => {
@@ -257,7 +279,27 @@ export namespace Config {
       dot: true,
       cwd: dir,
     })) {
-      const md = await ConfigMarkdown.parse(item)
+      let md
+      try {
+        md = await ConfigMarkdown.parse(item)
+      } catch (err) {
+        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
+          log.error("failed to parse agent frontmatter", {
+            path: err.data.path,
+            message: err.data.message,
+          })
+          const relativePath = path.relative(dir, item)
+          Bus.publish(TuiEvent.ToastShow, {
+            title: "Agent Error",
+            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+            variant: "error",
+            duration: 8000,
+          })
+        } else {
+          log.error("failed to load agent", { path: item, error: err })
+        }
+        continue
+      }
       if (!md.data) continue
 
       // Extract relative path from agent folder for nested agents
@@ -299,7 +341,27 @@ export namespace Config {
       dot: true,
       cwd: dir,
     })) {
-      const md = await ConfigMarkdown.parse(item)
+      let md
+      try {
+        md = await ConfigMarkdown.parse(item)
+      } catch (err) {
+        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
+          log.error("failed to parse mode frontmatter", {
+            path: err.data.path,
+            message: err.data.message,
+          })
+          const relativePath = path.relative(dir, item)
+          Bus.publish(TuiEvent.ToastShow, {
+            title: "Mode Error",
+            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+            variant: "error",
+            duration: 8000,
+          })
+        } else {
+          log.error("failed to load mode", { path: item, error: err })
+        }
+        continue
+      }
       if (!md.data) continue
 
       const config = {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -221,9 +221,10 @@ export namespace Config {
       cwd: dir,
     })) {
       const md = await ConfigMarkdown.parse(item).catch((err) => {
-        Bus.publish(Session.Event.Error, {
-          error: new NamedError.Unknown({ message: `Frontmatter failed to parse command ${item}: ${err}` }),
-        })
+        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+          ? `${err.data.path}: ${err.data.message}`
+          : `Failed to parse command ${item}`
+        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
         log.error("failed to load command", { command: item, err })
         return undefined
       })
@@ -266,9 +267,10 @@ export namespace Config {
       cwd: dir,
     })) {
       const md = await ConfigMarkdown.parse(item).catch((err) => {
-        Bus.publish(Session.Event.Error, {
-          error: new NamedError.Unknown({ message: `Frontmatter failed to parse agent ${item}: ${err}` }),
-        })
+        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+          ? `${err.data.path}: ${err.data.message}`
+          : `Failed to parse agent ${item}`
+        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
         log.error("failed to load agent", { agent: item, err })
         return undefined
       })
@@ -314,9 +316,10 @@ export namespace Config {
       cwd: dir,
     })) {
       const md = await ConfigMarkdown.parse(item).catch((err) => {
-        Bus.publish(Session.Event.Error, {
-          error: new NamedError.Unknown({ message: `Frontmatter failed to parse mode ${item}: ${err}` }),
-        })
+        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+          ? `${err.data.path}: ${err.data.message}`
+          : `Failed to parse mode ${item}`
+        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
         log.error("failed to load mode", { mode: item, err })
         return undefined
       })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -220,28 +220,25 @@ export namespace Config {
       dot: true,
       cwd: dir,
     })) {
-      let md
-      try {
-        md = await ConfigMarkdown.parse(item)
-      } catch (err) {
-        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to parse command frontmatter", {
-            path: err.data.path,
-            message: err.data.message,
-          })
-          const relativePath = path.relative(dir, item)
-          Bus.publish(TuiEvent.ToastShow, {
-            title: "Command Error",
-            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-            variant: "error",
-            duration: 8000,
-          })
-        } else {
+      const md = await ConfigMarkdown.parse(item).catch((err) => {
+        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
           log.error("failed to load command", { path: item, error: err })
+          return undefined
         }
-        continue
-      }
-      if (!md.data) continue
+        log.error("failed to parse command frontmatter", {
+          path: err.data.path,
+          message: err.data.message,
+        })
+        const relativePath = path.relative(dir, item)
+        Bus.publish(TuiEvent.ToastShow, {
+          title: "Command Error",
+          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+          variant: "error",
+          duration: 8000,
+        })
+        return undefined
+      })
+      if (!md?.data) continue
 
       const name = (() => {
         const patterns = ["/.opencode/command/", "/command/"]
@@ -279,28 +276,25 @@ export namespace Config {
       dot: true,
       cwd: dir,
     })) {
-      let md
-      try {
-        md = await ConfigMarkdown.parse(item)
-      } catch (err) {
-        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to parse agent frontmatter", {
-            path: err.data.path,
-            message: err.data.message,
-          })
-          const relativePath = path.relative(dir, item)
-          Bus.publish(TuiEvent.ToastShow, {
-            title: "Agent Error",
-            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-            variant: "error",
-            duration: 8000,
-          })
-        } else {
+      const md = await ConfigMarkdown.parse(item).catch((err) => {
+        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
           log.error("failed to load agent", { path: item, error: err })
+          return undefined
         }
-        continue
-      }
-      if (!md.data) continue
+        log.error("failed to parse agent frontmatter", {
+          path: err.data.path,
+          message: err.data.message,
+        })
+        const relativePath = path.relative(dir, item)
+        Bus.publish(TuiEvent.ToastShow, {
+          title: "Agent Error",
+          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+          variant: "error",
+          duration: 8000,
+        })
+        return undefined
+      })
+      if (!md?.data) continue
 
       // Extract relative path from agent folder for nested agents
       let agentName = path.basename(item, ".md")
@@ -341,28 +335,25 @@ export namespace Config {
       dot: true,
       cwd: dir,
     })) {
-      let md
-      try {
-        md = await ConfigMarkdown.parse(item)
-      } catch (err) {
-        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to parse mode frontmatter", {
-            path: err.data.path,
-            message: err.data.message,
-          })
-          const relativePath = path.relative(dir, item)
-          Bus.publish(TuiEvent.ToastShow, {
-            title: "Mode Error",
-            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-            variant: "error",
-            duration: 8000,
-          })
-        } else {
+      const md = await ConfigMarkdown.parse(item).catch((err) => {
+        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
           log.error("failed to load mode", { path: item, error: err })
+          return undefined
         }
-        continue
-      }
-      if (!md.data) continue
+        log.error("failed to parse mode frontmatter", {
+          path: err.data.path,
+          message: err.data.message,
+        })
+        const relativePath = path.relative(dir, item)
+        Bus.publish(TuiEvent.ToastShow, {
+          title: "Mode Error",
+          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+          variant: "error",
+          duration: 8000,
+        })
+        return undefined
+      })
+      if (!md?.data) continue
 
       const config = {
         name: path.basename(item, ".md"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -20,7 +20,7 @@ import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
 import { existsSync } from "fs"
 import { Bus } from "@/bus"
-import { TuiEvent } from "@/cli/cmd/tui/event"
+import { Session } from "@/session"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -221,24 +221,13 @@ export namespace Config {
       cwd: dir,
     })) {
       const md = await ConfigMarkdown.parse(item).catch((err) => {
-        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to load command", { path: item, error: err })
-          return undefined
-        }
-        log.error("failed to parse command frontmatter", {
-          path: err.data.path,
-          message: err.data.message,
+        Bus.publish(Session.Event.Error, {
+          error: new NamedError.Unknown({ message: `Frontmatter failed to parse command ${item}: ${err}` }),
         })
-        const relativePath = path.relative(dir, item)
-        Bus.publish(TuiEvent.ToastShow, {
-          title: "Command Error",
-          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-          variant: "error",
-          duration: 8000,
-        })
+        log.error("failed to load command", { command: item, err })
         return undefined
       })
-      if (!md?.data) continue
+      if (!md) continue
 
       const name = (() => {
         const patterns = ["/.opencode/command/", "/command/"]
@@ -277,24 +266,13 @@ export namespace Config {
       cwd: dir,
     })) {
       const md = await ConfigMarkdown.parse(item).catch((err) => {
-        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to load agent", { path: item, error: err })
-          return undefined
-        }
-        log.error("failed to parse agent frontmatter", {
-          path: err.data.path,
-          message: err.data.message,
+        Bus.publish(Session.Event.Error, {
+          error: new NamedError.Unknown({ message: `Frontmatter failed to parse agent ${item}: ${err}` }),
         })
-        const relativePath = path.relative(dir, item)
-        Bus.publish(TuiEvent.ToastShow, {
-          title: "Agent Error",
-          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-          variant: "error",
-          duration: 8000,
-        })
+        log.error("failed to load agent", { agent: item, err })
         return undefined
       })
-      if (!md?.data) continue
+      if (!md) continue
 
       // Extract relative path from agent folder for nested agents
       let agentName = path.basename(item, ".md")
@@ -336,24 +314,13 @@ export namespace Config {
       cwd: dir,
     })) {
       const md = await ConfigMarkdown.parse(item).catch((err) => {
-        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to load mode", { path: item, error: err })
-          return undefined
-        }
-        log.error("failed to parse mode frontmatter", {
-          path: err.data.path,
-          message: err.data.message,
+        Bus.publish(Session.Event.Error, {
+          error: new NamedError.Unknown({ message: `Frontmatter failed to parse mode ${item}: ${err}` }),
         })
-        const relativePath = path.relative(dir, item)
-        Bus.publish(TuiEvent.ToastShow, {
-          title: "Mode Error",
-          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-          variant: "error",
-          duration: 8000,
-        })
+        log.error("failed to load mode", { mode: item, err })
         return undefined
       })
-      if (!md?.data) continue
+      if (!md) continue
 
       const config = {
         name: path.basename(item, ".md"),

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import path from "path"
 import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { NamedError } from "@opencode-ai/util/error"
@@ -8,6 +9,8 @@ import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 import { exists } from "fs/promises"
 import { Flag } from "@/flag/flag"
+import { Bus } from "@/bus"
+import { TuiEvent } from "@/cli/cmd/tui/event"
 
 export namespace Skill {
   const log = Log.create({ service: "skill" })
@@ -43,7 +46,28 @@ export namespace Skill {
     const skills: Record<string, Info> = {}
 
     const addSkill = async (match: string) => {
-      const md = await ConfigMarkdown.parse(match)
+      let md
+      try {
+        md = await ConfigMarkdown.parse(match)
+      } catch (err) {
+        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
+          log.error("failed to parse skill frontmatter", {
+            path: err.data.path,
+            message: err.data.message,
+          })
+          const relativePath = path.relative(Instance.directory, match)
+          Bus.publish(TuiEvent.ToastShow, {
+            title: "Skill Error",
+            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+            variant: "error",
+            duration: 8000,
+          })
+        } else {
+          log.error("failed to load skill", { path: match, error: err })
+        }
+        return
+      }
+
       if (!md) {
         return
       }

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -11,6 +11,7 @@ import { exists } from "fs/promises"
 import { Flag } from "@/flag/flag"
 import { Bus } from "@/bus"
 import { TuiEvent } from "@/cli/cmd/tui/event"
+import { Session } from "@/session"
 
 export namespace Skill {
   const log = Log.create({ service: "skill" })
@@ -47,27 +48,15 @@ export namespace Skill {
 
     const addSkill = async (match: string) => {
       const md = await ConfigMarkdown.parse(match).catch((err) => {
-        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to load skill", { path: match, error: err })
-          return undefined
-        }
-        log.error("failed to parse skill frontmatter", {
-          path: err.data.path,
-          message: err.data.message,
-        })
-        const relativePath = path.relative(Instance.directory, match)
-        Bus.publish(TuiEvent.ToastShow, {
-          title: "Skill Error",
-          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-          variant: "error",
-          duration: 8000,
-        })
+        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+          ? `${err.data.path}: ${err.data.message}`
+          : `Failed to parse skill ${match}`
+        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+        log.error("failed to load skill", { skill: match, err })
         return undefined
       })
 
-      if (!md) {
-        return
-      }
+      if (!md) return
 
       const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
       if (!parsed.success) return

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -46,27 +46,24 @@ export namespace Skill {
     const skills: Record<string, Info> = {}
 
     const addSkill = async (match: string) => {
-      let md
-      try {
-        md = await ConfigMarkdown.parse(match)
-      } catch (err) {
-        if (ConfigMarkdown.FrontmatterError.isInstance(err)) {
-          log.error("failed to parse skill frontmatter", {
-            path: err.data.path,
-            message: err.data.message,
-          })
-          const relativePath = path.relative(Instance.directory, match)
-          Bus.publish(TuiEvent.ToastShow, {
-            title: "Skill Error",
-            message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
-            variant: "error",
-            duration: 8000,
-          })
-        } else {
+      const md = await ConfigMarkdown.parse(match).catch((err) => {
+        if (!ConfigMarkdown.FrontmatterError.isInstance(err)) {
           log.error("failed to load skill", { path: match, error: err })
+          return undefined
         }
-        return
-      }
+        log.error("failed to parse skill frontmatter", {
+          path: err.data.path,
+          message: err.data.message,
+        })
+        const relativePath = path.relative(Instance.directory, match)
+        Bus.publish(TuiEvent.ToastShow, {
+          title: "Skill Error",
+          message: `Failed to parse ${relativePath}: ${err.data.message.split(":")[0]}`,
+          variant: "error",
+          duration: 8000,
+        })
+        return undefined
+      })
 
       if (!md) {
         return


### PR DESCRIPTION
### What does this PR do?

Fixes #8047

This fixes issue #8047 by wrapping `ConfigMarkdown.parse()` calls in `try...catch` and displaying appropriate error messages in form of toast