### PR TITLE
fix: add header length constraint to question.txt

### DIFF
--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -8,3 +8,4 @@ Usage notes:
 - When `custom` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+- Header must be 30 characters or less (maxLength: 30)


### PR DESCRIPTION
Fixes #7616 

Cause: agents sometimes violate the 12-character header limit because JSON Schema constraints like "maxLength": 12 are buried in nested parameter definitions and have lower attention weight compared to prominent natural language instructions in the tool description, causing the LLM occasionally to miss or forget the constraint during generation.

Fix: add it to description text in question.txt