### PR TITLE
fix(formatter): use biome `check` instead of `format` to include import sorting

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -96,7 +96,7 @@ export const oxfmt: Info = {
 
 export const biome: Info = {
   name: "biome",
-  command: [BunProc.which(), "x", "@biomejs/biome", "format", "--write", "$FILE"],
+  command: [BunProc.which(), "x", "@biomejs/biome", "check", "--write", "$FILE"],
   environment: {
     BUN_BE_BUN: "1",
   },


### PR DESCRIPTION
### What does this PR do?

Changes the biome formatter command from `format` to `check`. The `check` command includes formatting AND import sorting, which prevents edit tool from errors like `The imports and exports are not sorted.`

### How did you verify your code works?

- The change is a simple command substitution from `format` to `check`
- biome `check` is documented at: https://biomejs.dev/reference/cli/#biome-check

Fixes #8061
