### PR TITLE
fix(tui): prevent layout jump when toggling tips visibility

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -94,6 +94,7 @@ export function Home() {
   return (
     <>
       <box flexGrow={1} justifyContent="center" alignItems="center" paddingLeft={2} paddingRight={2} gap={1}>
+        <box height={3} />
         <Logo />
         <box width="100%" maxWidth={75} zIndex={1000} paddingTop={1}>
           <Prompt
@@ -104,11 +105,11 @@ export function Home() {
             hint={Hint}
           />
         </box>
-        <Show when={showTips()}>
-          <box width="100%" maxWidth={75} paddingTop={2} alignItems="center">
+        <box height={3} width="100%" maxWidth={75} alignItems="center" paddingTop={2}>
+          <Show when={showTips()}>
             <Tips />
-          </box>
-        </Show>
+          </Show>
+        </box>
         <Toast />
       </box>
       <box paddingTop={1} paddingBottom={1} paddingLeft={2} paddingRight={2} flexDirection="row" flexShrink={0} gap={2}>


### PR DESCRIPTION
## Summary

- Use balanced spacers (height=3) above and below the centered content to reserve space for tips
- Tips container always occupies the same space regardless of visibility
- Eliminates the layout jump when showing/hiding tips on the home screen

## Before
https://github.com/user-attachments/assets/a0faeff8-667b-4c0c-ac1a-e38ebdce2c28
When toggling tips, the prompt box would shift up/down as the centered content recalculated.

## After
https://github.com/user-attachments/assets/c03d03aa-a66c-4a3f-b85f-3a278c93dab5
Prompt box stays in place because the space for tips is always reserved with a matching spacer above for balance.




