### PR TITLE
fix: await auth.set to prevent race condition when setting API key

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-provider.tsx
@@ -225,7 +225,7 @@ function ApiMethod(props: ApiMethodProps) {
       }
       onConfirm={async (value) => {
         if (!value) return
-        sdk.client.auth.set({
+        await sdk.client.auth.set({
           providerID: props.providerID,
           auth: {
             type: "api",


### PR DESCRIPTION
## Summary

Fixes #8073

- Added `await` to the `auth.set()` call in the `/model` dialog to ensure the API key is persisted before `instance.dispose()` and `sync.bootstrap()` run

## Root Cause

The `auth.set()` call was not being awaited, causing a race condition where the bootstrap would happen before the auth data was written to disk. This resulted in the API key not being loaded after entry, requiring a restart.


## Reproduction of the bug

https://github.com/user-attachments/assets/e2285eca-bb87-4590-bcce-67c21ae00b96

## Bug fix 

https://github.com/user-attachments/assets/7ced70c2-6723-4fb9-a849-23829adcf720


