### PR TITLE
feat(terminal): implement better dynamic terminal numbering

### DIFF
--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -8,6 +8,7 @@ import { Persist, persisted } from "@/utils/persist"
 export type LocalPTY = {
   id: string
   title: string
+  titleNumber: number
   rows?: number
   cols?: number
   buffer?: string
@@ -42,8 +43,21 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, id: 
     all: createMemo(() => Object.values(store.all)),
     active: createMemo(() => store.active),
     new() {
+      const existingTitleNumbers = new Set(
+        store.all
+          .map((pty) => {
+            const match = pty.titleNumber
+            return match
+          })
+      )
+
+      let nextNumber = 1
+      while (existingTitleNumbers.has(nextNumber)) {
+        nextNumber++
+      }
+
       sdk.client.pty
-        .create({ title: `Terminal ${store.all.length + 1}` })
+      .create({ title: `Terminal ${nextNumber}` })
         .then((pty) => {
           const id = pty.data?.id
           if (!id) return
@@ -52,6 +66,7 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, id: 
             {
               id,
               title: pty.data?.title ?? "Terminal",
+              titleNumber: nextNumber,
             },
           ])
           setStore("active", id)


### PR DESCRIPTION
### What does this PR do?

Closes #8080 
Allows for better dynamic terminal numbering, by storing the titleNumbers of previous terminals, and using this in a set to determine the next number. Preventing duplicates.

### How did you verify your code works?
Tested on dev environment 


https://github.com/user-attachments/assets/7a6fe5ee-a843-4089-8dea-00af44343c54

