### PR TITLE
fix: add missing args to windows tauri cli spawn

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -155,6 +155,7 @@ pub fn create_command(app: &tauri::AppHandle, args: &str) -> Command {
         .shell()
         .sidecar("opencode-cli")
         .unwrap()
+        .args(args.split_whitespace())
         .env("OPENCODE_EXPERIMENTAL_ICON_DISCOVERY", "true")
         .env("OPENCODE_CLIENT", "desktop")
         .env("XDG_STATE_HOME", &state_dir);


### PR DESCRIPTION
Fixes #8074 

Cause: args missing in windows cli spawning
- When the desktop app tried to spawn the sidecar with: `cli::create_command(app, "serve --port 63591")`
- Expected: Run `opencode-cli.exe serve --port 63591`
- Actually ran: `opencode-cli.exe` (no arguments at all!)

Fix: add args