### PR TITLE
fix(session): store api url in metadata

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -664,6 +664,7 @@ export namespace MessageV2 {
           return `${msg}: ${e.responseBody}`
         }).trim()
 
+        const metadata = e.url ? { url: e.url } : undefined
         return new MessageV2.APIError(
           {
             message,
@@ -671,6 +672,7 @@ export namespace MessageV2 {
             isRetryable: e.isRetryable,
             responseHeaders: e.responseHeaders,
             responseBody: e.responseBody,
+            metadata,
           },
           { cause: e },
         ).toObject()


### PR DESCRIPTION
If the underlying error contains a url, ensure it is included in the metadata for `APIError` to assit with debugging.

Fixes: #8088
