### PR TITLE
fix(bedrock): use reasoningConfig for Anthropic models on Bedrock

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -364,6 +364,25 @@ export namespace ProviderTransform {
 
       case "@ai-sdk/amazon-bedrock":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
+        // For Anthropic models on Bedrock, use reasoningConfig with budgetTokens
+        if (/^(us\.|global\.)?anthropic\./.test(model.api.id)) {
+          return {
+            high: {
+              reasoningConfig: {
+                type: "enabled",
+                budgetTokens: 16000,
+              },
+            },
+            max: {
+              reasoningConfig: {
+                type: "enabled",
+                budgetTokens: 31999,
+              },
+            },
+          }
+        }
+
+        // For Amazon Nova models, use reasoningConfig with maxReasoningEffort
         return Object.fromEntries(
           WIDELY_SUPPORTED_EFFORTS.map((effort) => [
             effort,

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -365,7 +365,7 @@ export namespace ProviderTransform {
       case "@ai-sdk/amazon-bedrock":
         // https://v5.ai-sdk.dev/providers/ai-sdk-providers/amazon-bedrock
         // For Anthropic models on Bedrock, use reasoningConfig with budgetTokens
-        if (/^(us\.|global\.)?anthropic\./.test(model.api.id)) {
+        if (model.api.id.includes("anthropic")) {
           return {
             high: {
               reasoningConfig: {


### PR DESCRIPTION
### What does this PR do?

Added Regex Check for anthropic models to add reasoning for variants.

Bedrocks Model id's can be set as:
- Global (For Global Inference) `global.` prefix
- US (Cross Region) `us.` prefix.
- Region based (No prefix)

### How did you verify your code works?

Tested locally with bun run dev with Bedrock Provider with variants set:
- Before Change - no thinking tokens
- After change - thinking tokens

Fixes #7357