### PR TITLE
fix(nix): initialize hashes.json with per-system format

### DIFF
--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,7 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-8nur5CuUCSV/SzD16hNXVoIlKsiPBXDzCnoITK0IhC4=",
-    "aarch64-darwin": "sha256-vD1g9dviI2nMBTTPwI87sK01hSZ+cdnmb1V72AdJYq4="
+    "x86_64-linux": "sha256-UCPTTk4b7d2bets7KgCeYBHWAUwUAPUyKm+xDYkSexE=",
+    "aarch64-darwin": "sha256-vD1g9dviI2nMBTTPwI87sK01hSZ+cdnmb1V72AdJYq4=",
+    "x86_64-darwin": "sha256-Y3o6lovahSWoG9un/l1qxu7hCmIlZXm2LxOLKNiPQfQ="
   }
 }

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,7 +1,6 @@
 {
   "nodeModules": {
     "x86_64-linux": "sha256-UCPTTk4b7d2bets7KgCeYBHWAUwUAPUyKm+xDYkSexE=",
-    "aarch64-darwin": "sha256-vD1g9dviI2nMBTTPwI87sK01hSZ+cdnmb1V72AdJYq4=",
-    "x86_64-darwin": "sha256-Y3o6lovahSWoG9un/l1qxu7hCmIlZXm2LxOLKNiPQfQ="
+    "aarch64-darwin": "sha256-Y3o6lovahSWoG9un/l1qxu7hCmIlZXm2LxOLKNiPQfQ="
   }
 }

--- a/nix/scripts/update-hashes.sh
+++ b/nix/scripts/update-hashes.sh
@@ -10,7 +10,7 @@ HASH_FILE=${HASH_FILE:-$DEFAULT_HASH_FILE}
 if [ ! -f "$HASH_FILE" ]; then
   cat >"$HASH_FILE" <<EOF
 {
-  "nodeModules": "$DUMMY"
+  "nodeModules": {}
 }
 EOF
 fi
@@ -111,7 +111,7 @@ fi
 
 write_node_modules_hash "$CORRECT_HASH"
 
-jq -e --arg hash "$CORRECT_HASH" '.nodeModules == $hash' "$HASH_FILE" >/dev/null
+jq -e --arg system "$SYSTEM" --arg hash "$CORRECT_HASH" '.nodeModules[$system] == $hash' "$HASH_FILE" >/dev/null
 
 echo "node_modules hash updated for ${SYSTEM}: $CORRECT_HASH"
 


### PR DESCRIPTION
Fixes a bug in the `update-hashes.sh` script introduced in PR #8033.

## Problem
The script was initializing `hashes.json` with legacy string format:
```json
{"nodeModules": "sha256-AAA..."}
```

But the `write_node_modules_hash` function expects per-system object format:
```json
{"nodeModules": {}}
```

This caused the `update-nix-hashes` workflow to fail when trying to write system-specific hashes.

## Solution
1. Initialize with empty object `{}` instead of dummy string
2. Fix validation check to match per-system format

## Changes
- `nix/scripts/update-hashes.sh` line 13: Change init from string to object
- `nix/scripts/update-hashes.sh` line 114: Update validation to check per-system hash

Related: #8029, #8033