### PR TITLE
fix: gracefully handle invalid json response

### DIFF
--- a/packages/sdk/js/src/v2/gen/client/client.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/client.gen.ts
@@ -162,9 +162,15 @@ export const createClient = (config: Config = {}): Client => {
         case "arrayBuffer":
         case "blob":
         case "formData":
-        case "json":
         case "text":
           data = await response[parseAs]()
+          break
+        case "json":
+          try {
+            data = await response.json()
+          } catch {
+            data = {}
+          }
           break
         case "stream":
           return opts.responseStyle === "data"


### PR DESCRIPTION
Fixes #7889 

Cause:

Aborting requests (e.g., pressing ESC during streaming responses) can result in an empty response body.
The SDK client's JSON parser fails on empty strings with "Unexpected end of JSON input" because there was no error handling.


Fix: add error handling.