### PR TITLE
fix: prevent [object Object] error display in console output

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/file.ts
+++ b/packages/opencode/src/cli/cmd/debug/file.ts
@@ -78,7 +78,7 @@ const FileTreeCommand = cmd({
     }),
   async handler(args) {
     const files = await Ripgrep.tree({ cwd: args.dir, limit: 200 })
-    console.log(files)
+    console.log(JSON.stringify(files, null, 2))
   },
 })
 

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -624,7 +624,7 @@ export const GithubRunCommand = cmd({
         }
       } catch (e: any) {
         exitCode = 1
-        console.error(e)
+        console.error(e instanceof Error ? e.message : String(e))
         let msg = e
         if (e instanceof $.ShellError) {
           msg = e.stderr.toString()
@@ -915,7 +915,7 @@ export const GithubRunCommand = cmd({
 
         // result should always be assistant just satisfying type checker
         if (result.info.role === "assistant" && result.info.error) {
-          console.error(result.info)
+          console.error("Agent error:", result.info.error)
           throw new Error(
             `${result.info.error.name}: ${"message" in result.info.error ? result.info.error.message : ""}`,
           )
@@ -944,7 +944,7 @@ export const GithubRunCommand = cmd({
         })
 
         if (summary.info.role === "assistant" && summary.info.error) {
-          console.error(summary.info)
+          console.error("Summary agent error:", summary.info.error)
           throw new Error(
             `${summary.info.error.name}: ${"message" in summary.info.error ? summary.info.error.message : ""}`,
           )
@@ -962,7 +962,7 @@ export const GithubRunCommand = cmd({
         try {
           return await core.getIDToken("opencode-github-action")
         } catch (error) {
-          console.error("Failed to get OIDC token:", error)
+          console.error("Failed to get OIDC token:", error instanceof Error ? error.message : error)
           throw new Error(
             "Could not fetch an OIDC token. Make sure to add `id-token: write` to your workflow permissions.",
           )

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -147,7 +147,7 @@ try {
   if (formatted) UI.error(formatted)
   if (formatted === undefined) {
     UI.error("Unexpected error, check log file at " + Log.file() + " for more details" + EOL)
-    console.error(e)
+    console.error(e instanceof Error ? e.message : String(e))
   }
   process.exitCode = 1
 } finally {


### PR DESCRIPTION
Fix multiple locations where objects were being directly passed to
console.error/console.log, which causes [object Object] to be displayed
instead of meaningful error messages.

Changes:
- packages/opencode/src/index.ts: Properly convert error to string
- packages/opencode/src/cli/cmd/github.ts: Convert error objects to strings
- packages/opencode/src/cli/cmd/debug/file.ts: Use JSON.stringify for objects
