### PR TITLE
fix(config): handle write errors when updating schema in opencode config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1159,7 +1159,7 @@ export namespace Config {
     if (parsed.success) {
       if (!parsed.data.$schema) {
         parsed.data.$schema = "https://opencode.ai/config.json"
-        await Bun.write(configFilepath, JSON.stringify(parsed.data, null, 2))
+        await Bun.write(configFilepath, JSON.stringify(parsed.data, null, 2)).catch(() => {})
       }
       const data = parsed.data
       if (data.plugin) {


### PR DESCRIPTION
### What does this PR do?
fixes https://github.com/anomalyco/opencode/issues/8126

when opencode launches it will try to add `"$schema": "https://opencode.ai/config.json"` if it is not already there

If opencode is unable to write to config it crashes with this error 

ran into this since my config is syslinked from nix-store and you cant write to nix-store
```
❯ opencode
EACCES: permission denied, open '/Users/usr/.config/opencode/opencode.jsonc'
    path: "/Users/usr/.config/opencode/opencode.jsonc",
 syscall: "open",
   errno: -13,
    code: "EACCES"

      at write (unknown:1:1)
      at load (src/config/config.ts:1167:19)
      at load (src/config/config.ts:1097:23)
      at src/config/config.ts:1064:23
      at resolveNetworkOptions (src/cli/network.ts:35:31)
      at src/cli/cmd/tui/thread.ts:119:31
      at processTicksAndRejections (unknown:7:39)
```

Could add logging to this, but since i don't think its a big issue it's best to just ignore.

alternatively instead of the error above you could show a nicer warning saying `failed to add "$schema": "https://opencode.ai/config.json"` to prompt the user to update their config manually

### How did you verify your code works?

I looked at it

... fine i'll test it... , ran bun dev; launches fine with misconfigured config
