### PR TITLE
fix(opencode): improve tool robustness and session loop stability

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -274,13 +274,13 @@ export namespace SessionPrompt {
       let msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
 
       let lastUser: MessageV2.User | undefined
-      let lastAssistant: MessageV2.Assistant | undefined
+      let lastAssistant: MessageV2.WithParts | undefined
       let lastFinished: MessageV2.Assistant | undefined
       let tasks: (MessageV2.CompactionPart | MessageV2.SubtaskPart)[] = []
       for (let i = msgs.length - 1; i >= 0; i--) {
         const msg = msgs[i]
         if (!lastUser && msg.info.role === "user") lastUser = msg.info as MessageV2.User
-        if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg.info as MessageV2.Assistant
+        if (!lastAssistant && msg.info.role === "assistant") lastAssistant = msg
         if (!lastFinished && msg.info.role === "assistant" && msg.info.finish)
           lastFinished = msg.info as MessageV2.Assistant
         if (lastUser && lastFinished) break
@@ -292,12 +292,33 @@ export namespace SessionPrompt {
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
       if (
-        lastAssistant?.finish &&
-        !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
-        lastUser.id < lastAssistant.id
+        lastAssistant?.info.role === "assistant" &&
+        lastAssistant.info.finish &&
+        !["tool-calls", "unknown"].includes(lastAssistant.info.finish) &&
+        lastUser.id < lastAssistant.info.id
       ) {
-        log.info("exiting loop", { sessionID })
-        break
+        // Only exit if the last assistant message actually has text content or no tool calls
+        const hasText = lastAssistant.parts.some((p) => p.type === "text" && !p.synthetic)
+        const hasToolCalls = lastAssistant.parts.some((p) => p.type === "tool")
+
+        if (hasText || !hasToolCalls) {
+          log.info("exiting loop", {
+            sessionID,
+            finish: lastAssistant.info.finish,
+            lastUserID: lastUser.id,
+            lastAssistantID: lastAssistant.info.id,
+            hasText,
+            hasToolCalls,
+          })
+          break
+        }
+
+        log.info("continuing loop despite finish reason", {
+          sessionID,
+          finish: lastAssistant.info.finish,
+          hasText,
+          hasToolCalls,
+        })
       }
 
       step++

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -77,7 +77,7 @@ export const BashTool = Tool.define("bash", async () => {
     }),
     formatValidationError(error) {
       if (error instanceof z.ZodError) {
-        return `Invalid parameters for tool 'bash':\n${error.errors
+        return `Invalid parameters for tool 'bash':\n${(error as z.ZodError).errors
           .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
           .join("\n")}\n\nMake sure to provide 'command' and a concise 'description' of what the command does.`
       }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -77,7 +77,7 @@ export const BashTool = Tool.define("bash", async () => {
     }),
     formatValidationError(error) {
       if (error instanceof z.ZodError) {
-        return `Invalid parameters for tool 'bash':\n${(error as z.ZodError).errors
+        return `Invalid parameters for tool 'bash':\n${(error as z.ZodError<any>).errors
           .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
           .join("\n")}\n\nMake sure to provide 'command' and a concise 'description' of what the command does.`
       }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -72,10 +72,17 @@ export const BashTool = Tool.define("bash", async () => {
         .string()
         .describe(
           "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-        ),
+        )
+        .optional(),
     }),
+    formatValidationError(error) {
+      return `Invalid parameters for tool 'bash':\n${error.errors
+        .map((e) => `- ${e.path.join(".")}: ${e.message}`)
+        .join("\n")}\n\nMake sure to provide 'command' and a concise 'description' of what the command does.`
+    },
     async execute(params, ctx) {
       const cwd = params.workdir || Instance.directory
+      const description = params.description || params.command
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
@@ -170,7 +177,7 @@ export const BashTool = Tool.define("bash", async () => {
       ctx.metadata({
         metadata: {
           output: "",
-          description: params.description,
+          description,
         },
       })
 
@@ -180,7 +187,7 @@ export const BashTool = Tool.define("bash", async () => {
           metadata: {
             // truncate the metadata to avoid GIANT blobs of data (has nothing to do w/ what agent can access)
             output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
-            description: params.description,
+            description,
           },
         })
       }
@@ -244,14 +251,16 @@ export const BashTool = Tool.define("bash", async () => {
         output += "\n\n<bash_metadata>\n" + resultMetadata.join("\n") + "\n</bash_metadata>"
       }
 
+      const finalOutput = output.trim() || "(Command executed successfully with no output)"
+
       return {
-        title: params.description,
+        title: description,
         metadata: {
           output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
           exit: proc.exitCode,
-          description: params.description,
+          description,
         },
-        output,
+        output: finalOutput,
       }
     },
   }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -77,7 +77,7 @@ export const BashTool = Tool.define("bash", async () => {
     }),
     formatValidationError(error) {
       if (error instanceof z.ZodError) {
-        return `Invalid parameters for tool 'bash':\n${(error as z.ZodError<any>).errors
+        return `Invalid parameters for tool 'bash':\n${(error as any).errors
           .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
           .join("\n")}\n\nMake sure to provide 'command' and a concise 'description' of what the command does.`
       }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -76,9 +76,12 @@ export const BashTool = Tool.define("bash", async () => {
         .optional(),
     }),
     formatValidationError(error) {
-      return `Invalid parameters for tool 'bash':\n${error.errors
-        .map((e) => `- ${e.path.join(".")}: ${e.message}`)
-        .join("\n")}\n\nMake sure to provide 'command' and a concise 'description' of what the command does.`
+      if (error instanceof z.ZodError) {
+        return `Invalid parameters for tool 'bash':\n${error.errors
+          .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
+          .join("\n")}\n\nMake sure to provide 'command' and a concise 'description' of what the command does.`
+      }
+      return `Invalid parameters for tool 'bash': ${error}`
     },
     async execute(params, ctx) {
       const cwd = params.workdir || Instance.directory

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -107,7 +107,8 @@ export const ListTool = Tool.define("list", {
       return output
     }
 
-    const output = `${searchPath}/\n` + renderDir(".", 0)
+    const output =
+      files.length > 0 ? `${searchPath}/\n` + renderDir(".", 0) : `(No files found in directory: ${searchPath})`
 
     return {
       title: path.relative(Instance.worktree, searchPath),

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -40,7 +40,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     parameters,
     formatValidationError(error) {
       if (error instanceof z.ZodError) {
-        return `Invalid parameters for tool 'task':\n${error.errors
+        return `Invalid parameters for tool 'task':\n${(error as z.ZodError).errors
           .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
           .join("\n")}\n\nMake sure to provide 'prompt', 'subagent_type' and a concise 'description'.`
       }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -39,9 +39,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     description,
     parameters,
     formatValidationError(error) {
-      return `Invalid parameters for tool 'task':\n${error.errors
-        .map((e) => `- ${e.path.join(".")}: ${e.message}`)
-        .join("\n")}\n\nMake sure to provide 'prompt', 'subagent_type' and a concise 'description'.`
+      if (error instanceof z.ZodError) {
+        return `Invalid parameters for tool 'task':\n${error.errors
+          .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
+          .join("\n")}\n\nMake sure to provide 'prompt', 'subagent_type' and a concise 'description'.`
+      }
+      return `Invalid parameters for tool 'task': ${error}`
     },
     async execute(params: z.infer<typeof parameters>, ctx) {
       const config = await Config.get()

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -13,7 +13,7 @@ import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
 
 const parameters = z.object({
-  description: z.string().describe("A short (3-5 words) description of the task"),
+  description: z.string().describe("A short (3-5 words) description of the task").optional(),
   prompt: z.string().describe("The task for the agent to perform"),
   subagent_type: z.string().describe("The type of specialized agent to use for this task"),
   session_id: z.string().describe("Existing Task session to continue").optional(),
@@ -38,8 +38,14 @@ export const TaskTool = Tool.define("task", async (ctx) => {
   return {
     description,
     parameters,
+    formatValidationError(error) {
+      return `Invalid parameters for tool 'task':\n${error.errors
+        .map((e) => `- ${e.path.join(".")}: ${e.message}`)
+        .join("\n")}\n\nMake sure to provide 'prompt', 'subagent_type' and a concise 'description'.`
+    },
     async execute(params: z.infer<typeof parameters>, ctx) {
       const config = await Config.get()
+      const taskDescription = params.description || "Task"
 
       // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
@@ -48,7 +54,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           patterns: [params.subagent_type],
           always: ["*"],
           metadata: {
-            description: params.description,
+            description: taskDescription,
             subagent_type: params.subagent_type,
           },
         })
@@ -67,7 +73,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
         return await Session.create({
           parentID: ctx.sessionID,
-          title: params.description + ` (@${agent.name} subagent)`,
+          title: taskDescription + ` (@${agent.name} subagent)`,
           permission: [
             {
               permission: "todowrite",
@@ -100,7 +106,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
 
       ctx.metadata({
-        title: params.description,
+        title: taskDescription,
         metadata: {
           sessionId: session.id,
         },
@@ -122,7 +128,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           },
         }
         ctx.metadata({
-          title: params.description,
+          title: taskDescription,
           metadata: {
             summary: Object.values(parts).sort((a, b) => a.id.localeCompare(b.id)),
             sessionId: session.id,
@@ -176,7 +182,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       const output = text + "\n\n" + ["<task_metadata>", `session_id: ${session.id}`, "</task_metadata>"].join("\n")
 
       return {
-        title: params.description,
+        title: taskDescription,
         metadata: {
           summary,
           sessionId: session.id,

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -40,7 +40,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     parameters,
     formatValidationError(error) {
       if (error instanceof z.ZodError) {
-        return `Invalid parameters for tool 'task':\n${(error as z.ZodError).errors
+        return `Invalid parameters for tool 'task':\n${(error as z.ZodError<any>).errors
           .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
           .join("\n")}\n\nMake sure to provide 'prompt', 'subagent_type' and a concise 'description'.`
       }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -40,7 +40,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     parameters,
     formatValidationError(error) {
       if (error instanceof z.ZodError) {
-        return `Invalid parameters for tool 'task':\n${(error as z.ZodError<any>).errors
+        return `Invalid parameters for tool 'task':\n${(error as any).errors
           .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
           .join("\n")}\n\nMake sure to provide 'prompt', 'subagent_type' and a concise 'description'.`
       }

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -21,6 +21,14 @@ export const WriteTool = Tool.define("write", {
     content: z.string().describe("The content to write to the file"),
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
+  formatValidationError(error) {
+    if (error instanceof z.ZodError) {
+      return `Invalid parameters for tool 'write':\n${(error as any).errors
+        .map((e: z.ZodIssue) => `- ${e.path.join(".")}: ${e.message}`)
+        .join("\n")}\n\nMake sure to provide 'content' and 'filePath'.`
+    }
+    return `Invalid parameters for tool 'write': ${error}`
+  },
   async execute(params, ctx) {
     const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
     await assertExternalDirectory(ctx, filepath)


### PR DESCRIPTION
  This PR significantly improves the reliability and robustness of the AI agent execution loop by addressing three common failure modes where the agent appears to get "stuck" or "idle" without completing its task:

   1. Robust Tool Parameter Handling: Makes the description field optional in the bash and task tools. Many models (especially in fast or direct modes - **gemini**) omit this field, previously triggering Zod validation errors
      that halted execution. Added smart fallbacks (using the command string or "Task") and improved error formatting for tool validation.
   2. Explicit Feedback for Empty Results: Modifies the bash and list tools to return clear strings like (Command executed successfully with no output) or (No files found in directory) instead of empty results. This
      prevents models from interpreting silence as an environment failure or a signal to stop.
   3. Refined Session Loop Exit Logic: Updates SessionPrompt.ts to prevent premature loop exits. The loop now only terminates if the assistant has provided a real text response to the user or if no tool calls were
      made in the turn. Previously, the loop would exit purely based on the provider's finishReason: "stop", which often occurs after tool-only turns before the model has a chance to summarize or reply.


  How did you verify your code works?

   1. Replication & Log Analysis: Reproduced the "stuck" behavior in a live environment and analyzed the dev.log to confirm that the session was exiting with finish=stop while the message content was still empty
      (tool-only turns).
   2. Live Testing: Applied the fixes and verified that opencode successfully continued the loop to provide final summaries after multiple turns of tool calls (e.g., after running ls or git remote -v).
   3. Schema Validation: Confirmed that omitting the description parameter in bash tool calls no longer triggers a validation error and uses the command string as a fallback.
   4. Build Verification: Built a single native binary using bun run build --single and verified the versioned binary functions correctly on Linux x64.
   5. Type Safety: Ran bun turbo typecheck across the monorepo and resolved strict TypeScript errors related to ZodError property access in the new validation logic.                                                  █

Fixes https://github.com/anomalyco/opencode/issues/6244
Fixes https://github.com/anomalyco/opencode/issues/6838
