### PR TITLE
fix: add metadata.user_id to Anthropic API requests

### DIFF
--- a/infra/console.ts
+++ b/infra/console.ts
@@ -53,6 +53,7 @@ new sst.x.DevCommand("Studio", {
 // AUTH
 ////////////////
 
+const ZEN_SESSION_SECRET = new sst.Secret("ZEN_SESSION_SECRET")
 const GITHUB_CLIENT_ID_CONSOLE = new sst.Secret("GITHUB_CLIENT_ID_CONSOLE")
 const GITHUB_CLIENT_SECRET_CONSOLE = new sst.Secret("GITHUB_CLIENT_SECRET_CONSOLE")
 const GOOGLE_CLIENT_ID = new sst.Secret("GOOGLE_CLIENT_ID")
@@ -61,7 +62,14 @@ export const auth = new sst.cloudflare.Worker("AuthApi", {
   domain: `auth.${domain}`,
   handler: "packages/console/function/src/auth.ts",
   url: true,
-  link: [database, authStorage, GITHUB_CLIENT_ID_CONSOLE, GITHUB_CLIENT_SECRET_CONSOLE, GOOGLE_CLIENT_ID],
+  link: [
+    database,
+    authStorage,
+    GITHUB_CLIENT_ID_CONSOLE,
+    GITHUB_CLIENT_SECRET_CONSOLE,
+    GOOGLE_CLIENT_ID,
+    ZEN_SESSION_SECRET,
+  ],
 })
 
 ////////////////
@@ -149,7 +157,6 @@ if ($app.stage === "production" || $app.stage === "frank") {
   })
 }
 
-const ZEN_SESSION_SECRET = new sst.Secret("ZEN_SESSION_SECRET")
 new sst.cloudflare.x.SolidStart("Console", {
   domain,
   path: "packages/console/app",

--- a/infra/console.ts
+++ b/infra/console.ts
@@ -149,6 +149,7 @@ if ($app.stage === "production" || $app.stage === "frank") {
   })
 }
 
+const ZEN_SESSION_SECRET = new sst.Secret("ZEN_SESSION_SECRET")
 new sst.cloudflare.x.SolidStart("Console", {
   domain,
   path: "packages/console/app",
@@ -163,6 +164,7 @@ new sst.cloudflare.x.SolidStart("Console", {
     AWS_SES_ACCESS_KEY_ID,
     AWS_SES_SECRET_ACCESS_KEY,
     ZEN_BLACK,
+    ZEN_SESSION_SECRET,
     ...ZEN_MODELS,
     ...($dev
       ? [

--- a/packages/console/app/src/context/auth.session.ts
+++ b/packages/console/app/src/context/auth.session.ts
@@ -1,4 +1,5 @@
 import { useSession } from "@solidjs/start/http"
+import { Resource } from "sst"
 
 export interface AuthSession {
   account?: Record<
@@ -13,7 +14,7 @@ export interface AuthSession {
 
 export function useAuthSession() {
   return useSession<AuthSession>({
-    password: "0".repeat(32),
+    password: Resource.ZEN_SESSION_SECRET.value,
     name: "auth",
     maxAge: 60 * 60 * 24 * 365,
     cookie: {

--- a/packages/console/core/sst-env.d.ts
+++ b/packages/console/core/sst-env.d.ts
@@ -130,6 +130,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "ZEN_SESSION_SECRET": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
   }
 }
 // cloudflare 

--- a/packages/console/function/sst-env.d.ts
+++ b/packages/console/function/sst-env.d.ts
@@ -130,6 +130,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "ZEN_SESSION_SECRET": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
   }
 }
 // cloudflare 

--- a/packages/console/resource/sst-env.d.ts
+++ b/packages/console/resource/sst-env.d.ts
@@ -130,6 +130,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "ZEN_SESSION_SECRET": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
   }
 }
 // cloudflare 

--- a/packages/enterprise/sst-env.d.ts
+++ b/packages/enterprise/sst-env.d.ts
@@ -130,6 +130,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "ZEN_SESSION_SECRET": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
   }
 }
 // cloudflare 

--- a/packages/function/sst-env.d.ts
+++ b/packages/function/sst-env.d.ts
@@ -130,6 +130,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "ZEN_SESSION_SECRET": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
   }
 }
 // cloudflare 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -80,6 +80,29 @@ export namespace Provider {
             "anthropic-beta":
               "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
           },
+          fetch: async (url: RequestInfo | URL, init?: RequestInit) => {
+            if (init?.body && typeof init.body === "string") {
+              try {
+                const body = JSON.parse(init.body)
+                const sessionId = init.headers instanceof Headers
+                  ? init.headers.get("x-opencode-session")
+                  : (init.headers as Record<string, string>)?.["x-opencode-session"]
+                const projectId = Instance.project?.id ?? "unknown"
+                body.metadata = {
+                  user_id: `user_${projectId}_account__session_${sessionId ?? "unknown"}`,
+                }
+                init = { ...init, body: JSON.stringify(body) }
+                // Remove internal header before sending to Anthropic
+                if (init.headers instanceof Headers) {
+                  init.headers.delete("x-opencode-session")
+                } else if (init.headers) {
+                  const { "x-opencode-session": _, ...rest } = init.headers as Record<string, string>
+                  init.headers = rest
+                }
+              } catch {}
+            }
+            return fetch(url, init)
+          },
         },
       }
     },

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -170,6 +170,7 @@ export namespace LLM {
       maxOutputTokens,
       abortSignal: input.abort,
       headers: {
+        "x-opencode-session": input.sessionID,
         ...(isCodex
           ? {
               originator: "opencode",
@@ -180,7 +181,6 @@ export namespace LLM {
         ...(input.model.providerID.startsWith("opencode")
           ? {
               "x-opencode-project": Instance.project.id,
-              "x-opencode-session": input.sessionID,
               "x-opencode-request": input.user.id,
               "x-opencode-client": Flag.OPENCODE_CLIENT,
             }

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -156,6 +156,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "ZEN_SESSION_SECRET": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
     "ZenData": {
       "name": string
       "type": "sst.cloudflare.Bucket"


### PR DESCRIPTION
## Summary
- Add metadata.user_id field to Anthropic API requests to enable proper caching
- The user_id format: `user_{projectId}_account__session_{sessionId}`

## Changes
- `provider.ts`: Add custom fetch to inject metadata into request body
- `llm.ts`: Add x-opencode-session header (removed before sending to API)