### PR TITLE
fix(tui): prevent question tool keybindings when dialog is open

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -121,6 +121,9 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   const dialog = useDialog()
 
   useKeyboard((evt) => {
+    // Skip processing if a dialog (e.g., command palette) is open
+    if (dialog.stack.length > 0) return
+
     // When editing "Other" textarea
     if (store.editing && !confirm()) {
       if (evt.name === "escape") {


### PR DESCRIPTION
### What does this PR do?

Fixes the keyboard binding conflict where the Question tool's H/L navigation keys interfere with typing in the command palette.

When the Question tool is active and the user opens the command palette (Ctrl+P), pressing `h` or `l` would navigate the question tabs instead of typing in the command palette's search input.

This change adds a guard at the start of the `useKeyboard` handler to skip event processing when a dialog is open, following the established pattern used in `dialog-command.tsx` (lines 48 and 103).

Fixes #8118

### How did you verify your code works?

- Verified the fix follows the exact pattern established in `dialog-command.tsx`
- The change uses the already-imported and instantiated `dialog` context from `useDialog()`
- Minimal change: adds only 3 lines to check `dialog.stack.length > 0` before processing

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)