### PR TITLE
fix(clipboard): actually escape powershell commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -32,7 +32,7 @@ export namespace Clipboard {
     if (os === "win32" || release().includes("WSL")) {
       const script =
         "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $ms = New-Object System.IO.MemoryStream; $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray()) }"
-      const base64 = await $`powershell.exe -NonInteractive -NoProfile -command "${script}"`.nothrow().text()
+      const base64 = await $`powershell.exe -NonInteractive -NoProfile -Command '${script}'`.nothrow().text()
       if (base64) {
         const imageBuffer = Buffer.from(base64.trim(), "base64")
         if (imageBuffer.length > 0) {
@@ -110,9 +110,8 @@ export namespace Clipboard {
     if (os === "win32") {
       console.log("clipboard: using powershell")
       return async (text: string) => {
-        // need to escape backticks because powershell uses them as escape code
-        const escaped = text.replace(/"/g, '""').replace(/`/g, "``")
-        await $`powershell -NonInteractive -NoProfile -Command "Set-Clipboard -Value \"${escaped}\""`.nothrow().quiet()
+        const escaped = text.replace(/"/g, '`"').replace(/'/g, "`'")
+        await $`powershell -NonInteractive -NoProfile -Command "Set-Clipboard -Value '${escaped}'"`.nothrow().quiet()
       }
     }
 


### PR DESCRIPTION
continuation of #7157, hopefully this should be the last one

resolves #8166 hopefully

### What does this PR do?
use powershell's auto-escape ability by wrapping strings in single inverted comma `'` instead of double inverted comma `"`

### How did you verify your code works?
like just copy it

Before:
<pre>
 = (Invoke-Expression "Write-Host 'Hello'")
</pre>
After:
<pre>
$output = (Invoke-Expression "Write-Host 'Hello'")
</pre>