### PR TITLE
fix: app_exit keybind ignored when using <leader> (including default <leader>q)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -247,6 +247,13 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     })
 
   useKeyboard((evt) => {
+    if (!keybind.match("app_exit", evt)) return
+    const prompt = promptRef.current?.current
+    if (prompt && prompt.input !== "") return
+    exit()
+  })
+
+  useKeyboard((evt) => {
     if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
     const sel = renderer.getSelection()
     if (!sel) return


### PR DESCRIPTION
Fixes #3851

### What does this PR do?

Summary
- Add a global app_exit handler so leader key combos reach exit even when prompt focus is blurred, while still respecting the “only exit when prompt is empty” rule in packages/opencode/src/cli/cmd/tui/app.tsx:183.
Why this fixes it
- <leader>q was being consumed while the prompt was blurred by leader mode, so the prompt-level app_exit handler never ran. The new global handler uses useKeyboard and usePromptRef to exit consistently.

### How did you verify your code works?

Built and ran locally, verified <leader>q exits the app as expected.

I was not able to find a way to add an test for this. The core issue depends on the `app.tsx` running and focus passing between the prompt an the app, so a unit test is mostly ceremonial. An e2e test would require a net test harness to mount the TUI app similar to how playwright e2e works.
