### PR TITLE
fix(cli): skip local agent validation in attach mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -231,6 +231,8 @@ export const RunCommand = cmd({
       // Validate agent if specified
       const resolvedAgent = await (async () => {
         if (!args.agent) return undefined
+        // Skip local agent validation in attach mode - the remote server handles it
+        if (args.attach) return args.agent
         const agent = await Agent.get(args.agent)
         if (!agent) {
           UI.println(


### PR DESCRIPTION
## Summary
Fixes #6489 #8094

When using `opencode run --attach <server> --agent <agent>`, the CLI crashes with:
```
instance: No context found for instance
    at use (src/util/context.ts:16:21)
    at directory (src/project/instance.ts:42:20)
    ...
```

## Problem
The `Agent.get()` function requires `Instance` context that is established by `bootstrap()`. In attach mode, `bootstrap()` is never called since we connect to a remote server. This causes the crash when trying to validate the agent locally.

## Solution
Skip local agent validation when in attach mode by adding an early return. The remote server handles agent validation instead.

```typescript
if (args.attach) return args.agent
```

### What does this PR do?

Adds a check to skip local agent validation when the `--attach` flag is used, allowing the remote server to handle agent validation.

### How did you verify your code works?

Reviewed the code logic and confirmed the fix aligns with the root cause analysis from #6489. The change is minimal and focused - it only adds an early return for the attach mode case.

---
🤖 Generated with Claude Code