### PR TITLE
fix: Allow ctrl+space to work as leader key

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
@@ -52,6 +52,7 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
 
     useKeyboard(async (evt) => {
       if (!store.leader && result.match("leader", evt)) {
+        evt.preventDefault()
         leader(true)
         return
       }
@@ -74,10 +75,6 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
         return store.leader
       },
       parse(evt: ParsedKey): Keybind.Info {
-        // Handle special case for Ctrl+Underscore (represented as \x1F)
-        if (evt.name === "\x1F") {
-          return Keybind.fromParsedKey({ ...evt, name: "_", ctrl: true }, store.leader)
-        }
         return Keybind.fromParsedKey(evt, store.leader)
       },
       match(key: string, evt: ParsedKey) {

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -20,15 +20,22 @@ export function match(a: Info | undefined, b: Info): boolean {
  * Convert OpenTUI's ParsedKey to our Keybind.Info format.
  * This helper ensures all required fields are present and avoids manual object creation.
  */
-export function fromParsedKey(key: ParsedKey, leader = false): Info {
-  return {
-    name: key.name === " " ? "space" : key.name,
+export function fromParsedKey(
+  key: Pick<ParsedKey, "name" | "ctrl" | "meta" | "shift" | "super">,
+  leader = false,
+): Info {
+  const info = {
+    name: key.name,
     ctrl: key.ctrl,
     meta: key.meta,
     shift: key.shift,
     super: key.super ?? false,
     leader,
   }
+  if (key.name === "\x00") return { ...info, name: "space", ctrl: true }
+  if (key.name === "\x1F") return { ...info, name: "_", ctrl: true }
+  if (key.name === " ") return { ...info, name: "space" }
+  return info
 }
 
 export function toString(info: Info | undefined): string {

--- a/packages/opencode/test/keybind.test.ts
+++ b/packages/opencode/test/keybind.test.ts
@@ -54,6 +54,17 @@ describe("Keybind.toString", () => {
     expect(Keybind.toString(info)).toBe("pgup")
   })
 
+  test("should convert space key to string", () => {
+    const info: Keybind.Info = {
+      ctrl: false,
+      meta: false,
+      shift: false,
+      leader: false,
+      name: "space",
+    }
+    expect(Keybind.toString(info)).toBe("space")
+  })
+
   test("should handle empty name", () => {
     const info: Keybind.Info = { ctrl: true, meta: false, shift: false, leader: false, name: "" }
     expect(Keybind.toString(info)).toBe("ctrl")
@@ -172,6 +183,44 @@ describe("Keybind.match", () => {
     const a: Keybind.Info = { ctrl: true, meta: true, shift: true, super: true, leader: false, name: "a" }
     const b: Keybind.Info = { ctrl: true, meta: true, shift: true, super: false, leader: false, name: "a" }
     expect(Keybind.match(a, b)).toBe(false)
+  })
+})
+
+describe("Keybind.fromParsedKey", () => {
+  test("should parse ' ' as space", () => {
+    const result = Keybind.fromParsedKey({ name: " ", ctrl: false, meta: false, shift: false, super: false })
+    expect(result).toEqual({
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+      name: "space",
+    })
+  })
+
+  test("should parse \x1F as ctrl+_", () => {
+    const result = Keybind.fromParsedKey({ name: "\x1F", ctrl: false, meta: false, shift: false, super: false })
+    expect(result).toEqual({
+      ctrl: true,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+      name: "_",
+    })
+  })
+
+  test("should parse \x00 as ctrl+space", () => {
+    const result = Keybind.fromParsedKey({ name: "\x00", ctrl: false, meta: false, shift: false, super: false })
+    expect(result).toEqual({
+      ctrl: true,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+      name: "space",
+    })
   })
 })
 


### PR DESCRIPTION
### What does this PR do?

Closes #3657 (which should have been re-opened)

Summary
- Normalize ParsedKey events so ctrl+space (NUL) and ctrl+_ map to named keys in one place.
- Add focused unit tests that fails pre-fix by asserting NUL maps to ctrl+space.

### How did you verify your code works?

Tested locally and added test for key detection. Test verified failing before src changes. 
