### PR TITLE
fix(ui): handle async items function in useFilteredList hook

### DIFF
--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -24,6 +24,7 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
   const [grouped, { refetch }] = createResource(
     () => {
       // When items is a function (not async filter function), call it to track changes
+      // Don't call async functions here - they'll be called in the fetcher with the filter
       const itemsValue =
         typeof props.items === "function"
           ? (props.items as () => T[])() // Call synchronous function to track it
@@ -36,7 +37,13 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
     },
     async ({ filter, items }) => {
       const needle = filter?.toLowerCase()
-      const all = (items ?? (await (props.items as (filter: string) => T[] | Promise<T[]>)(needle))) || []
+      // Handle case where items is a Promise (from async function called without filter)
+      // In that case, we need to call the function again with the proper filter
+      const resolvedItems =
+        items instanceof Promise || !Array.isArray(items)
+          ? await (props.items as (filter: string) => T[] | Promise<T[]>)(needle ?? "")
+          : items
+      const all = resolvedItems || []
       const result = pipe(
         all,
         (x) => {


### PR DESCRIPTION
### What does this PR do?

Fixes the empty file list issue when trying to tag files/folders in chat via the `@` mention autocomplete (issue #8148).

**Root Cause:**
When `props.items` is an async function (like in the `@` autocomplete which calls `files.searchFilesAndDirectories`), the `useFilteredList` hook's source function calls it without arguments. This returns a Promise, which is then passed to the fetcher as `items`. Since Promise is truthy, the fallback logic `items ?? await props.items(needle)` didn't trigger, causing the code to iterate over a Promise object instead of an array.

**Fix:**
Check if `items` is a Promise or not an array, and if so, properly call the async function with the filter parameter.

### How did you verify your code works?

- Ran `npm run typecheck` - passes
- Analyzed the code flow to confirm the fix handles the async case properly

Fixes #8148

---
🤖 Generated with Claude Code