### PR TITLE
fix(sdk): add shell option for Windows spawn compatibility

### DIFF
--- a/packages/sdk/js/src/server.ts
+++ b/packages/sdk/js/src/server.ts
@@ -33,6 +33,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
 
   const proc = spawn(`opencode`, args, {
     signal: options.signal,
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}),
@@ -109,6 +110,7 @@ export function createOpencodeTui(options?: TuiOptions) {
   const proc = spawn(`opencode`, args, {
     signal: options?.signal,
     stdio: "inherit",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options?.config ?? {}),

--- a/packages/sdk/js/src/v2/server.ts
+++ b/packages/sdk/js/src/v2/server.ts
@@ -33,6 +33,7 @@ export async function createOpencodeServer(options?: ServerOptions) {
 
   const proc = spawn(`opencode`, args, {
     signal: options.signal,
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}),
@@ -109,6 +110,7 @@ export function createOpencodeTui(options?: TuiOptions) {
   const proc = spawn(`opencode`, args, {
     signal: options?.signal,
     stdio: "inherit",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify(options?.config ?? {}),


### PR DESCRIPTION
## Summary

- Adds `shell: process.platform === 'win32'` to both `spawn()` calls in SDK server module
- Fixes Windows compatibility issue where npm-installed `.cmd` wrappers aren't found

Fixes #8160

## Problem

On Windows, npm-installed packages create `.cmd` wrapper scripts (e.g., `opencode.cmd`). Node.js `spawn()` without `shell: true` cannot find these in PATH, causing:

```
ENOENT: no such file or directory, uv_spawn 'opencode'
```

## Solution

Add conditional `shell: true` on Windows:

```typescript
const proc = spawn(\, args, {
  signal: options.signal,
  shell: process.platform === 'win32',  // NEW
  env: { ... },
})
```

## Testing

Verified manually on Windows 11:
1. Before fix: `ENOENT` error when calling `createOpencodeServer()`
2. After fix: Server spawns successfully, returns URL

## Files Changed

- `packages/sdk/js/src/server.ts` - both spawn calls
- `packages/sdk/js/src/v2/server.ts` - both spawn calls