### PR TITLE
fix(app): ensure file search query param

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -384,10 +384,14 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       setScrollLeft,
       selectedLines,
       setSelectedLines,
-      searchFiles: (query: string) =>
-        sdk.client.find.files({ query, dirs: "false" }).then((x) => (x.data ?? []).map(normalize)),
-      searchFilesAndDirectories: (query: string) =>
-        sdk.client.find.files({ query, dirs: "true" }).then((x) => (x.data ?? []).map(normalize)),
+      searchFiles: (query: string | undefined) => {
+        const safeQuery = query ?? ""
+        return sdk.client.find.files({ query: safeQuery, dirs: "false" }).then((x) => (x.data ?? []).map(normalize))
+      },
+      searchFilesAndDirectories: (query: string | undefined) => {
+        const safeQuery = query ?? ""
+        return sdk.client.find.files({ query: safeQuery, dirs: "true" }).then((x) => (x.data ?? []).map(normalize))
+      },
     }
   },
 })

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -467,9 +467,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           .catch(() => {})
       }
 
-      const searchFiles = (query: string) => sdk.client.find.files({ query, dirs: "false" }).then((x) => x.data!)
-      const searchFilesAndDirectories = (query: string) =>
-        sdk.client.find.files({ query, dirs: "true" }).then((x) => x.data!)
+      const searchFiles = (query: string | undefined) => {
+        const safeQuery = query ?? ""
+        return sdk.client.find.files({ query: safeQuery, dirs: "false" }).then((x) => x.data!)
+      }
+      const searchFilesAndDirectories = (query: string | undefined) => {
+        const safeQuery = query ?? ""
+        return sdk.client.find.files({ query: safeQuery, dirs: "true" }).then((x) => x.data!)
+      }
 
       const unsub = sdk.event.listen((e) => {
         const event = e.details


### PR DESCRIPTION
Fixes #8148

Default query to "" for file search calls so the request always includes the query parameter.

Tested: local web UI @ autocomplete; request includes query=.

Thanks for taking a look.