### PR TITLE
feat(opencode): add keybind for /thinking toggle

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -485,6 +485,7 @@ export function Session() {
     {
       title: showThinking() ? "Hide thinking" : "Show thinking",
       value: "session.toggle.thinking",
+      keybind: "thinking_toggle",
       category: "Session",
       onSelect: (dialog) => {
         setShowThinking((prev) => !prev)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -648,6 +648,7 @@ export namespace Config {
         .default("<leader>h")
         .describe("Toggle code block concealment in messages"),
       tool_details: z.string().optional().default("none").describe("Toggle tool details visibility"),
+      thinking_toggle: z.string().optional().default("ctrl+o").describe("Toggle thinking visibility"),
       model_list: z.string().optional().default("<leader>m").describe("List available models"),
       model_cycle_recent: z.string().optional().default("f2").describe("Next recently used model"),
       model_cycle_recent_reverse: z.string().optional().default("shift+f2").describe("Previous recently used model"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1034,6 +1034,10 @@ export type KeybindsConfig = {
    */
   tool_details?: string
   /**
+   * Toggle thinking visibility
+   */
+  thinking_toggle?: string
+  /**
    * List available models
    */
   model_list?: string

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -18,6 +18,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "username_toggle": "none",
     "status_view": "<leader>s",
     "tool_details": "none",
+    "thinking_toggle": "ctrl+o",
     "session_export": "<leader>x",
     "session_new": "<leader>n",
     "session_list": "<leader>l",


### PR DESCRIPTION
closes #8167 

Adds a configurable keybind to toggle thinking visibility (same behavior as `/thinking`).