### PR TITLE
fix(web): open project dialog not showing directories

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -70,7 +70,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   }
 
   const directories = async (filter: string) => {
-    const query = normalizeQuery(filter.trim())
+    const query = normalizeQuery((filter ?? "").trim())
     return fetchDirs(query)
   }
 

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1962,20 +1962,56 @@ export namespace Server {
           validator(
             "query",
             z.object({
-              query: z.string(),
+              directory: z.string().optional(),
+              query: z.string().optional().default(""),
               dirs: z.enum(["true", "false"]).optional(),
               type: z.enum(["file", "directory"]).optional(),
               limit: z.coerce.number().int().min(1).max(200).optional(),
             }),
           ),
           async (c) => {
-            const query = c.req.valid("query").query
+            const directory = c.req.valid("query").directory
+            const query = c.req.valid("query").query ?? ""
             const dirs = c.req.valid("query").dirs
             const type = c.req.valid("query").type
-            const limit = c.req.valid("query").limit
+            const limit = c.req.valid("query").limit ?? 10
+
+            if (directory && type === "directory") {
+              const fs = await import("fs")
+              const path = await import("path")
+              const fuzzysort = await import("fuzzysort")
+
+              const scanDirs = async (base: string, depth: number = 0): Promise<string[]> => {
+                if (depth > 2) return []
+                const results: string[] = []
+                try {
+                  const entries = await fs.promises.readdir(base, { withFileTypes: true })
+                  for (const entry of entries) {
+                    if (!entry.isDirectory()) continue
+                    if (entry.name.startsWith(".")) continue
+                    if (["node_modules", "dist", "build", ".git"].includes(entry.name)) continue
+                    const rel = path.relative(directory, path.join(base, entry.name))
+                    results.push(rel + "/")
+                    if (depth < 1) {
+                      const children = await scanDirs(path.join(base, entry.name), depth + 1)
+                      results.push(...children)
+                    }
+                  }
+                } catch {}
+                return results
+              }
+
+              const allDirs = await scanDirs(directory)
+              if (!query) {
+                return c.json(allDirs.slice(0, limit))
+              }
+              const sorted = fuzzysort.go(query, allDirs, { limit }).map((r) => r.target)
+              return c.json(sorted)
+            }
+
             const results = await File.search({
               query,
-              limit: limit ?? 10,
+              limit,
               dirs: dirs !== "false",
               type,
             })

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -23,20 +23,21 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
 
   const [grouped, { refetch }] = createResource(
     () => {
-      // When items is a function (not async filter function), call it to track changes
-      const itemsValue =
-        typeof props.items === "function"
-          ? (props.items as () => T[])() // Call synchronous function to track it
-          : props.items
-
       return {
         filter: store.filter,
-        items: itemsValue,
+        items: Array.isArray(props.items) ? props.items : undefined,
       }
     },
     async ({ filter, items }) => {
       const needle = filter?.toLowerCase()
-      const all = (items ?? (await (props.items as (filter: string) => T[] | Promise<T[]>)(needle))) || []
+      let all: T[]
+      if (items !== undefined) {
+        all = items
+      } else if (typeof props.items === "function") {
+        all = (await props.items(needle ?? "")) || []
+      } else {
+        all = []
+      }
       const result = pipe(
         all,
         (x) => {


### PR DESCRIPTION
## Summary
- Fix "Open project" dialog showing "No folders found" in web mode
- Related to #6307 (closed but fix was incomplete)

## Problem
Three issues prevented the Open Project dialog from working:

1. **Server**: `query` parameter was required but SDK sends empty string as `undefined`, causing 400 Bad Request
2. **Server**: `directory` parameter was ignored, always searching current project directory instead of home
3. **UI**: `useFilteredList` hook didn't properly handle async items function, causing Promise to be used as array

## Changes

### `packages/opencode/src/server/server.ts`
- Make `query` parameter optional with default empty string
- Add `directory` parameter support to `/find/file` endpoint
- Implement directory scanning when `directory` param is provided (2 levels deep)

### `packages/ui/src/hooks/use-filtered-list.tsx`
- Fix `createResource` source function to not call async functions synchronously
- Properly await async items function in fetcher

### `packages/app/src/components/dialog-select-directory.tsx`
- Add null-safety to `filter.trim()` call

## Testing
Tested locally with `opencode web` - dialog now shows home directories and search works correctly.