### PR TITLE
fix: don't ask for permission for cd within project

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -89,6 +89,9 @@ export const BashTool = Tool.define("bash", async () => {
       const patterns = new Set<string>()
       const always = new Set<string>()
 
+      // track effective working directory as cd commands change it
+      let effectiveCwd = cwd
+
       for (const node of tree.rootNode.descendantsOfType("command")) {
         if (!node) continue
         const command = []
@@ -112,12 +115,12 @@ export const BashTool = Tool.define("bash", async () => {
           for (const arg of command.slice(1)) {
             if (arg.startsWith("-") || (command[0] === "chmod" && arg.startsWith("+"))) continue
             const resolved = await $`realpath ${arg}`
-              .cwd(cwd)
+              .cwd(effectiveCwd)
               .quiet()
               .nothrow()
               .text()
               .then((x) => x.trim())
-            log.info("resolved path", { arg, resolved })
+            log.info("resolved path", { arg, resolved, effectiveCwd })
             if (resolved) {
               // Git Bash on Windows returns Unix-style paths like /c/Users/...
               const normalized =
@@ -125,6 +128,9 @@ export const BashTool = Tool.define("bash", async () => {
                   ? resolved.replace(/^\/([a-z])\//, (_, drive) => `${drive.toUpperCase()}:\\`).replace(/\//g, "\\")
                   : resolved
               if (!Instance.containsPath(normalized)) directories.add(normalized)
+
+              // update effective cwd after cd command
+              if (command[0] === "cd") effectiveCwd = normalized
             }
           }
         }

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -230,6 +230,93 @@ describe("tool.bash permissions", () => {
       },
     })
   })
+
+  test("does not ask for external_directory permission when cd into subdir then cd back", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const subdir = path.join(tmp.path, "subdir")
+    await Bun.write(path.join(subdir, ".keep"), "")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: "cd subdir && ls && cd ..",
+            description: "cd into subdir and back",
+          },
+          testCtx,
+        )
+        const extDirReq = requests.find((r) => r.permission === "external_directory")
+        expect(extDirReq).toBeUndefined()
+      },
+    })
+  })
+
+  test("does not ask for external_directory when multiple cd commands stay within project", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const nested = path.join(tmp.path, "a", "b", "c")
+    await Bun.write(path.join(nested, ".keep"), "")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: "cd a && cd b && cd c && cd .. && cd .. && cd ..",
+            description: "navigate through nested dirs and back to root",
+          },
+          testCtx,
+        )
+        const extDirReq = requests.find((r) => r.permission === "external_directory")
+        expect(extDirReq).toBeUndefined()
+      },
+    })
+  })
+
+  test("asks for external_directory when cd actually leaves project", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const subdir = path.join(tmp.path, "subdir")
+    await Bun.write(path.join(subdir, ".keep"), "")
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+        const testCtx = {
+          ...ctx,
+          ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+            requests.push(req)
+          },
+        }
+        await bash.execute(
+          {
+            command: "cd subdir && cd ../.. && ls",
+            description: "cd into subdir then escape project",
+          },
+          testCtx,
+        )
+        const extDirReq = requests.find((r) => r.permission === "external_directory")
+        expect(extDirReq).toBeDefined()
+      },
+    })
+  })
 })
 
 describe("tool.bash truncation", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #8192.

Fixes false permission requests when chained `cd` commands navigate within the project directory. Previously, commands like `cd subdir && do something && cd ..` would incorrectly trigger an `external_directory` permission request because all paths were resolved relative to the initial working directory rather than tracking the effective directory after each `cd`.

<img width="386" height="242" alt="image" src="https://github.com/user-attachments/assets/05e04a77-8ede-416b-a5bf-abd3c1c65f5a" />

The fix tracks an `effectiveCwd` variable that updates after each `cd` command, so subsequent path resolutions use the correct context.

### How did you verify your code works?

Added three tests in `test/tool/bash.test.ts`:
- `cd subdir && ls && cd ..` does not request external_directory permission
- `cd a && cd b && cd c && cd .. && cd .. && cd ..` (nested navigation) does not request permission
- `cd subdir && cd ../..` (actually escapes project) still correctly requests permission

Verified tests fail before the fix and pass after.

---

**WIP:** Not all combinations of commands are `&&`s, so `cd` shouldn't always change the effective working directory of the next command. We should instead use the AST provided by the tree-sitter and track the working directory along its paths.