### PR TITLE
fix(app): listing files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode",

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode",

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -23,10 +23,11 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
 
   const [grouped, { refetch }] = createResource(
     () => {
-      // When items is a function (not async filter function), call it to track changes
       const itemsValue =
         typeof props.items === "function"
-          ? (props.items as () => T[])() // Call synchronous function to track it
+          ? props.items.length === 0
+            ? (props.items as () => T[])()
+            : undefined
           : props.items
 
       return {


### PR DESCRIPTION
### What does this PR do?

Listing files when using "@filename" was not working.
It was passing undefined to searchFiles 

### How did you verify your code works?

Open dekstop app, prompt @filename 

I guess "duplicate" of #8164 and #8186 although I do not think their fixes are appropiate especailly those inline imports

Here's a really quick fix for listing files when using cmd + p or @filename in for prompt 