### PR TITLE
fix(telemetry): restore userId and sessionId metadata in experimental_telemetry

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -219,7 +219,13 @@ export namespace LLM {
           extractReasoningMiddleware({ tagName: "think", startWithReasoning: false }),
         ],
       }),
-      experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
+      experimental_telemetry: {
+        isEnabled: cfg.experimental?.openTelemetry,
+        metadata: {
+          userId: cfg.username ?? "unknown",
+          sessionId: input.sessionID,
+        },
+      },
     })
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes #8193

Restores `userId` and `sessionId` metadata to `experimental_telemetry` in [llm.ts](cci:7://file:///Users/raviguntakala/Desktop/opencode/packages/opencode/src/session/llm.ts:0:0-0:0), which was removed during LLM refactoring.

Originally added in #5279.

### How did you verify your code works?
Tested with Langfuse - traces correctly group by session and display user attribution.
