### PR TITLE
feat: add apiKeyCommand for dynamic API key retrieval

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -809,6 +809,12 @@ export namespace Config {
       options: z
         .object({
           apiKey: z.string().optional(),
+          apiKeyCommand: z
+            .array(z.string())
+            .optional()
+            .describe(
+              "Command to execute to get the API key dynamically. The command should output the API key to stdout. Example: ['my-auth-cli', 'get-token']",
+            ),
           baseURL: z.string().optional(),
           enterpriseUrl: z.string().optional().describe("GitHub Enterprise URL for copilot authentication"),
           setCacheKey: z.boolean().optional().describe("Enable promptCacheKey for this provider (default false)"),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -64,6 +64,30 @@ export namespace Provider {
     "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
   }
 
+  /**
+   * Executes an apiKeyCommand and returns the output as the API key.
+   * This allows dynamic API key retrieval from credential helpers or token services.
+   */
+  async function resolveApiKeyCommand(command: string[]): Promise<string | undefined> {
+    if (!command || command.length === 0) return undefined
+    try {
+      const proc = Bun.spawn(command, {
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+      const code = await proc.exited
+      if (code !== 0) {
+        log.warn("apiKeyCommand failed", { command, exitCode: code })
+        return undefined
+      }
+      const stdout = await new Response(proc.stdout).text()
+      return stdout.trim()
+    } catch (e) {
+      log.warn("apiKeyCommand execution error", { command, error: e })
+      return undefined
+    }
+  }
+
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
   type CustomLoader = (provider: Info) => Promise<{
     autoload: boolean
@@ -921,6 +945,12 @@ export namespace Provider {
 
       if (!options["baseURL"]) options["baseURL"] = model.api.url
       if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
+      // If no apiKey yet, try apiKeyCommand
+      if (options["apiKey"] === undefined && options["apiKeyCommand"]) {
+        const key = await resolveApiKeyCommand(options["apiKeyCommand"])
+        if (key) options["apiKey"] = key
+        delete options["apiKeyCommand"] // Don't pass command to SDK
+      }
       if (model.headers)
         options["headers"] = {
           ...options["headers"],


### PR DESCRIPTION
## Summary

Add support for fetching API keys dynamically by executing a command. This enables integration with credential managers, token services, or any external authentication system.

## Related Issues

This PR addresses several feature requests from the community:

- #1302 - Request to support Dynamic API keys through an apiKeyHelper (LiteLLM proxy with rotating tokens)
- #7487 - exec variable substitution (1Password CLI integration)
- #231 - add ability to load secrets from external command or environment variables
- #4318 - Allow storage of secrets in system credential store

## Motivation

Currently, API keys can be provided via:
- Static values in the config file
- Environment variables using `{env:VAR_NAME}` syntax
- The `/connect` command (stored in auth.json)

This works well for simple setups, but doesn't support:

- **Credential helpers** that fetch tokens dynamically (similar to git's `credential.helper`)
- **Token services** like LiteLLM proxy servers that require short-lived tokens
- **Secret managers** (1Password CLI, AWS Secrets Manager, HashiCorp Vault, etc.)
- **Desktop apps** that can't inherit environment variables from shell wrappers

## Usage

```json
{
  "provider": {
    "my-provider": {
      "options": {
        "apiKeyCommand": ["my-credential-helper", "get-token"]
      }
    }
  }
}
```

The command should output the API key to stdout. The output is trimmed of whitespace.

## Examples

```json
// 1Password CLI
{
  "provider": {
    "openai": {
      "options": {
        "apiKeyCommand": ["op", "read", "op://Private/OpenAI/api-key"]
      }
    }
  }
}

// Custom token service (e.g., LiteLLM with IDP auth)
{
  "provider": {
    "my-llm-proxy": {
      "options": {
        "apiKeyCommand": ["my-auth-cli", "get-token"]
      }
    }
  }
}

// AWS Secrets Manager
{
  "provider": {
    "openai": {
      "options": {
        "apiKeyCommand": ["aws", "secretsmanager", "get-secret-value", "--secret-id", "openai-key", "--query", "SecretString", "--output", "text"]
      }
    }
  }
}
```

## Design Notes

This complements the existing `{env:VAR_NAME}` syntax rather than replacing it. The `apiKeyCommand` approach is:

- **Explicit**: Only used for API keys, not arbitrary config values
- **Secure**: Command is executed at SDK initialization time, not config parse time
- **Flexible**: Supports any command that outputs a token to stdout

An alternative approach would be adding `{exec:command}` syntax similar to `{env:...}`, but `apiKeyCommand` is more targeted and follows patterns used by:
- AWS CLI: `credential_process` in `~/.aws/config`
- Git: `credential.helper` configuration
- Docker: `credHelpers` in `~/.docker/config.json`

## Changes

- Added `apiKeyCommand` field to provider options in config schema
- Added `resolveApiKeyCommand()` helper function to execute the command
- Updated `getSDK()` to check for `apiKeyCommand` when no `apiKey` is set