### PR TITLE
fix(github): add persist-credentials: false to workflow templates

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -81,12 +81,13 @@ This will walk you through installing the GitHub app, creating the workflow, and
        permissions:
          id-token: write
        steps:
-         - name: Checkout repository
-           uses: actions/checkout@v6
-           with:
-             fetch-depth: 1
+          - name: Checkout repository
+            uses: actions/checkout@v6
+            with:
+              fetch-depth: 1
+              persist-credentials: false
 
-         - name: Run opencode
+          - name: Run opencode
            uses: anomalyco/opencode/github@latest
            env:
              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -394,6 +394,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run opencode
         uses: anomalyco/opencode/github@latest${envStr}

--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -57,12 +57,13 @@ Or you can set it up manually.
        permissions:
          id-token: write
        steps:
-         - name: Checkout repository
-           uses: actions/checkout@v6
-           with:
-             fetch-depth: 1
+          - name: Checkout repository
+            uses: actions/checkout@v6
+            with:
+              fetch-depth: 1
+              persist-credentials: false
 
-         - name: Run OpenCode
+          - name: Run OpenCode
            uses: anomalyco/opencode/github@latest
            env:
              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -135,6 +136,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
@@ -172,6 +175,8 @@ jobs:
       issues: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: anomalyco/opencode/github@latest
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -223,6 +228,8 @@ jobs:
 
       - uses: actions/checkout@v6
         if: steps.check.outputs.result == 'true'
+        with:
+          persist-credentials: false
 
       - uses: anomalyco/opencode/github@latest
         if: steps.check.outputs.result == 'true'


### PR DESCRIPTION
## Summary

Adds `persist-credentials: false` to all `actions/checkout@v6` steps in workflow templates to prevent the "Duplicate Authorization header" error.

## Problem

When using `actions/checkout@v6` with the OpenCode GitHub action, users encounter:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/...': The requested URL returned error: 400
```

### Root Cause

1. `actions/checkout@v6` persists the GitHub token to git config via `http.extraheader`
2. The `anomalyco/opencode/github@latest` action adds its own authentication
3. Both Authorization headers get sent to GitHub → 400 error

## Solution

Add `persist-credentials: false` to the checkout step in all workflow templates:

```yaml
- uses: actions/checkout@v6
  with:
    persist-credentials: false
```

This prevents the checkout action from persisting credentials, allowing the OpenCode action to handle authentication without conflicts.

## Changes

- `packages/opencode/src/cli/cmd/github.ts` - CLI-generated workflow template
- `packages/web/src/content/docs/github.mdx` - Documentation examples (4 workflows)
- `github/README.md` - Manual setup example

## Related Issues

- Fixes #7325 - "Github plugin having duplicate Authorization header"
- Related to #5827 - "GitHub action incompatible with actions/checkout@v6" (closed, different fix approach)
- Builds on #6969 - "docs: update GHA examples to use actions/checkout@v6" (merged, but didn't add persist-credentials)

## Testing

Users experiencing the error can update their workflows to include `persist-credentials: false` in the checkout step. New users following the setup instructions will get the correct configuration automatically.