### PR TITLE
fix(desktop): correct health check endpoint URL to /global/health

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -198,7 +198,7 @@ fn spawn_sidecar(app: &AppHandle, port: u32, password: &str) -> CommandChild {
 }
 
 async fn check_server_health(url: &str, password: Option<&str>) -> bool {
-    let health_url = format!("{}/health", url.trim_end_matches('/'));
+    let health_url = format!("{}/global/health", url.trim_end_matches('/'));
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(3))
         .build();


### PR DESCRIPTION
## Summary

Fixes the desktop app failing to start with "Failed to spawn OpenCode Server" even though the server is running and listening.

**Root cause**: The Tauri desktop app was checking `/health` for server readiness, but the actual endpoint in `server.ts` is `/global/health`.

## Changes

- Updated `check_server_health()` in `lib.rs` to use `/global/health` instead of `/health`

## Fixes

- #8149 - Desktop App Failing to Start server on Windows
- #8200 - window install error Failed to spawn OpenCode Server
- #8206 - Error: Failed to spawn OpenCode Server

## Error Message (before fix)

```
Error: Failed to spawn OpenCode Server. Logs:
[STDOUT] opencode server listening on http://127.0.0.1:2731

    at castError (http://tauri.localhost/assets/index-DT7g4zby.js:2:11968)
    at http://tauri.localhost/assets/index-DT7g4zby.js:2:4662
```

The logs show the server **is** listening, but the health check was hitting the wrong endpoint, causing a 30-second timeout and the error.