### PR TITLE
fix: Respect platform directory conventions

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -114,7 +114,7 @@
     "ulid": "catalog:",
     "vscode-jsonrpc": "8.2.1",
     "web-tree-sitter": "0.25.10",
-    "xdg-basedir": "5.1.0",
+    "env-paths": "3.0.0",
     "yargs": "18.0.0",
     "zod": "catalog:",
     "zod-to-json-schema": "3.24.5"

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -1,14 +1,14 @@
 import fs from "fs/promises"
-import { xdgData, xdgCache, xdgConfig, xdgState } from "xdg-basedir"
+import envPaths from "env-paths"
 import path from "path"
 import os from "os"
 
-const app = "opencode"
+const paths = envPaths("opencode", { suffix: "" })
 
-const data = path.join(xdgData!, app)
-const cache = path.join(xdgCache!, app)
-const config = path.join(xdgConfig!, app)
-const state = path.join(xdgState!, app)
+const data = paths.data
+const cache = paths.cache
+const config = paths.config
+const state = paths.log
 
 export namespace Global {
   export const Path = {


### PR DESCRIPTION
fixes #8235 

xdg-basedir respects only the linux xdg standard. This commit replaces it with env-paths which respects the conventions on mac os and windows

### What does this PR do?
Replaces "xdg-basedir" with "env-paths" which respects platform specific directory conventions.

### How did you verify your code works?
Compiled and ran on windows and verified connecting to a provider stored the "auth.json" in the correct directory.