### PR TITLE
feat(desktop): Add command to /toggle-appearence

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -616,8 +616,10 @@ export default function Layout(props: ParentProps) {
 
     commands.push({
       id: "theme.scheme.cycle",
-      title: "Cycle color scheme",
+      title: "Toggle appearance",
+      description: "Cycle through system, light, and dark color schemes",
       category: "Theme",
+      slash: "toggle-appearance",
       keybind: "mod+shift+s",
       onSelect: () => cycleColorScheme(1),
     })


### PR DESCRIPTION
Add a way to use `/toggle-appearance`, while we don't have a command pallet like TUI, this is fine.

**One thing i notice is this keybind `mod+shift+s` only works on home, because when you're on a session, there is another keybind for opening a new session, which takes precedence.**
