### PR TITLE
feat: add Undertale and Deltarune built-in themes

### DIFF
--- a/packages/ui/src/theme/themes/deltarune.json
+++ b/packages/ui/src/theme/themes/deltarune.json
@@ -1,0 +1,231 @@
+{
+    "$schema": "https://opencode.ai/theme.json",
+    "defs": {
+        "darkWorldBg": "#0B0B3B",
+        "darkWorldDeep": "#050520",
+        "darkWorldPanel": "#151555",
+        "krisBlue": "#6A7BC4",
+        "krisCyan": "#75FBED",
+        "krisIce": "#C7E3F2",
+        "susiePurple": "#5B209D",
+        "susieMagenta": "#A017D0",
+        "susiePink": "#F983D8",
+        "ralseiGreen": "#33A56C",
+        "ralseiTeal": "#40E4D4",
+        "noelleRose": "#DC8998",
+        "noelleRed": "#DC1510",
+        "noelleMint": "#ECFFBB",
+        "noelleCyan": "#77E0FF",
+        "noelleAqua": "#BBFFFC",
+        "gold": "#FBCE3C",
+        "orange": "#F4A731",
+        "hotPink": "#EB0095",
+        "queenPink": "#F983D8",
+        "cyberGreen": "#00FF00",
+        "white": "#FFFFFF",
+        "black": "#000000",
+        "textMuted": "#8888AA"
+    },
+    "theme": {
+        "primary": {
+            "dark": "hotPink",
+            "light": "susieMagenta"
+        },
+        "secondary": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "accent": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "error": {
+            "dark": "noelleRed",
+            "light": "noelleRed"
+        },
+        "warning": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "success": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "info": {
+            "dark": "noelleCyan",
+            "light": "krisBlue"
+        },
+        "text": {
+            "dark": "white",
+            "light": "black"
+        },
+        "textMuted": {
+            "dark": "textMuted",
+            "light": "#555577"
+        },
+        "background": {
+            "dark": "darkWorldBg",
+            "light": "white"
+        },
+        "backgroundPanel": {
+            "dark": "darkWorldDeep",
+            "light": "#F0F0F8"
+        },
+        "backgroundElement": {
+            "dark": "darkWorldPanel",
+            "light": "#E5E5F0"
+        },
+        "border": {
+            "dark": "krisBlue",
+            "light": "susiePurple"
+        },
+        "borderActive": {
+            "dark": "hotPink",
+            "light": "susieMagenta"
+        },
+        "borderSubtle": {
+            "dark": "#3A3A6A",
+            "light": "#AAAACC"
+        },
+        "diffAdded": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "diffRemoved": {
+            "dark": "hotPink",
+            "light": "noelleRed"
+        },
+        "diffContext": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "diffHunkHeader": {
+            "dark": "krisBlue",
+            "light": "susiePurple"
+        },
+        "diffHighlightAdded": {
+            "dark": "ralseiGreen",
+            "light": "ralseiTeal"
+        },
+        "diffHighlightRemoved": {
+            "dark": "noelleRed",
+            "light": "hotPink"
+        },
+        "diffAddedBg": {
+            "dark": "#0A2A2A",
+            "light": "#D4FFEE"
+        },
+        "diffRemovedBg": {
+            "dark": "#2A0A2A",
+            "light": "#FFD4E8"
+        },
+        "diffContextBg": {
+            "dark": "darkWorldDeep",
+            "light": "#F5F5FA"
+        },
+        "diffLineNumber": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "diffAddedLineNumberBg": {
+            "dark": "#082020",
+            "light": "#E0FFF0"
+        },
+        "diffRemovedLineNumberBg": {
+            "dark": "#200820",
+            "light": "#FFE0F0"
+        },
+        "markdownText": {
+            "dark": "white",
+            "light": "black"
+        },
+        "markdownHeading": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "markdownLink": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "markdownLinkText": {
+            "dark": "noelleCyan",
+            "light": "susiePurple"
+        },
+        "markdownCode": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "markdownBlockQuote": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "markdownEmph": {
+            "dark": "susiePink",
+            "light": "susieMagenta"
+        },
+        "markdownStrong": {
+            "dark": "hotPink",
+            "light": "susiePurple"
+        },
+        "markdownHorizontalRule": {
+            "dark": "krisBlue",
+            "light": "susiePurple"
+        },
+        "markdownListItem": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "markdownListEnumeration": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "markdownImage": {
+            "dark": "susieMagenta",
+            "light": "susiePurple"
+        },
+        "markdownImageText": {
+            "dark": "susiePink",
+            "light": "susieMagenta"
+        },
+        "markdownCodeBlock": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxComment": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "syntaxKeyword": {
+            "dark": "hotPink",
+            "light": "susieMagenta"
+        },
+        "syntaxFunction": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "syntaxVariable": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "syntaxString": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "syntaxNumber": {
+            "dark": "noelleRose",
+            "light": "noelleRed"
+        },
+        "syntaxType": {
+            "dark": "noelleCyan",
+            "light": "krisBlue"
+        },
+        "syntaxOperator": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxPunctuation": {
+            "dark": "krisBlue",
+            "light": "#555577"
+        }
+    }
+}

--- a/packages/ui/src/theme/themes/undertale.json
+++ b/packages/ui/src/theme/themes/undertale.json
@@ -1,0 +1,232 @@
+{
+    "$schema": "https://opencode.ai/theme.json",
+    "defs": {
+        "black": "#000000",
+        "white": "#FFFFFF",
+        "soulRed": "#FF0000",
+        "soulOrange": "#FF6600",
+        "soulYellow": "#FFFF00",
+        "soulGreen": "#00FF00",
+        "soulAqua": "#00FFFF",
+        "soulBlue": "#0000FF",
+        "soulPurple": "#FF00FF",
+        "ruinsPurple": "#A349A4",
+        "ruinsDark": "#380A43",
+        "snowdinBlue": "#6BA3E5",
+        "hotlandOrange": "#FF7F27",
+        "coreGray": "#3A3949",
+        "battleBg": "#0D0D1A",
+        "battlePanel": "#1A1A2E",
+        "uiYellow": "#FFC90E",
+        "textGray": "#909090",
+        "damageRed": "#FF3333",
+        "healGreen": "#00FF00",
+        "saveYellow": "#FFFF00",
+        "determinationRed": "#FF0000",
+        "mttPink": "#FF6EB4",
+        "waterfall": "#283197",
+        "waterfallGlow": "#00BFFF"
+    },
+    "theme": {
+        "primary": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "secondary": {
+            "dark": "uiYellow",
+            "light": "uiYellow"
+        },
+        "accent": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "error": {
+            "dark": "damageRed",
+            "light": "soulRed"
+        },
+        "warning": {
+            "dark": "uiYellow",
+            "light": "hotlandOrange"
+        },
+        "success": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "info": {
+            "dark": "soulAqua",
+            "light": "waterfallGlow"
+        },
+        "text": {
+            "dark": "white",
+            "light": "black"
+        },
+        "textMuted": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "background": {
+            "dark": "black",
+            "light": "white"
+        },
+        "backgroundPanel": {
+            "dark": "battleBg",
+            "light": "#F0F0F0"
+        },
+        "backgroundElement": {
+            "dark": "battlePanel",
+            "light": "#E5E5E5"
+        },
+        "border": {
+            "dark": "white",
+            "light": "black"
+        },
+        "borderActive": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "borderSubtle": {
+            "dark": "#555555",
+            "light": "#AAAAAA"
+        },
+        "diffAdded": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "diffRemoved": {
+            "dark": "damageRed",
+            "light": "soulRed"
+        },
+        "diffContext": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "diffHunkHeader": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "diffHighlightAdded": {
+            "dark": "soulGreen",
+            "light": "healGreen"
+        },
+        "diffHighlightRemoved": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "diffAddedBg": {
+            "dark": "#002200",
+            "light": "#CCFFCC"
+        },
+        "diffRemovedBg": {
+            "dark": "#220000",
+            "light": "#FFCCCC"
+        },
+        "diffContextBg": {
+            "dark": "battleBg",
+            "light": "#F5F5F5"
+        },
+        "diffLineNumber": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "diffAddedLineNumberBg": {
+            "dark": "#001A00",
+            "light": "#E0FFE0"
+        },
+        "diffRemovedLineNumberBg": {
+            "dark": "#1A0000",
+            "light": "#FFE0E0"
+        },
+        "markdownText": {
+            "dark": "white",
+            "light": "black"
+        },
+        "markdownHeading": {
+            "dark": "uiYellow",
+            "light": "hotlandOrange"
+        },
+        "markdownLink": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "markdownLinkText": {
+            "dark": "waterfallGlow",
+            "light": "waterfall"
+        },
+        "markdownCode": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "markdownBlockQuote": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "markdownEmph": {
+            "dark": "mttPink",
+            "light": "soulPurple"
+        },
+        "markdownStrong": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "markdownHorizontalRule": {
+            "dark": "white",
+            "light": "black"
+        },
+        "markdownListItem": {
+            "dark": "uiYellow",
+            "light": "uiYellow"
+        },
+        "markdownListEnumeration": {
+            "dark": "uiYellow",
+            "light": "uiYellow"
+        },
+        "markdownImage": {
+            "dark": "ruinsPurple",
+            "light": "soulPurple"
+        },
+        "markdownImageText": {
+            "dark": "mttPink",
+            "light": "ruinsPurple"
+        },
+        "markdownCodeBlock": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxComment": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "syntaxKeyword": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "syntaxFunction": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "syntaxVariable": {
+            "dark": "uiYellow",
+            "light": "hotlandOrange"
+        },
+        "syntaxString": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "syntaxNumber": {
+            "dark": "mttPink",
+            "light": "soulPurple"
+        },
+        "syntaxType": {
+            "dark": "waterfallGlow",
+            "light": "waterfall"
+        },
+        "syntaxOperator": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxPunctuation": {
+            "dark": "textGray",
+            "light": "coreGray"
+        }
+    }
+}

--- a/themes/deltarune.json
+++ b/themes/deltarune.json
@@ -1,0 +1,231 @@
+{
+    "$schema": "https://opencode.ai/theme.json",
+    "defs": {
+        "darkWorldBg": "#0B0B3B",
+        "darkWorldDeep": "#050520",
+        "darkWorldPanel": "#151555",
+        "krisBlue": "#6A7BC4",
+        "krisCyan": "#75FBED",
+        "krisIce": "#C7E3F2",
+        "susiePurple": "#5B209D",
+        "susieMagenta": "#A017D0",
+        "susiePink": "#F983D8",
+        "ralseiGreen": "#33A56C",
+        "ralseiTeal": "#40E4D4",
+        "noelleRose": "#DC8998",
+        "noelleRed": "#DC1510",
+        "noelleMint": "#ECFFBB",
+        "noelleCyan": "#77E0FF",
+        "noelleAqua": "#BBFFFC",
+        "gold": "#FBCE3C",
+        "orange": "#F4A731",
+        "hotPink": "#EB0095",
+        "queenPink": "#F983D8",
+        "cyberGreen": "#00FF00",
+        "white": "#FFFFFF",
+        "black": "#000000",
+        "textMuted": "#8888AA"
+    },
+    "theme": {
+        "primary": {
+            "dark": "hotPink",
+            "light": "susieMagenta"
+        },
+        "secondary": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "accent": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "error": {
+            "dark": "noelleRed",
+            "light": "noelleRed"
+        },
+        "warning": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "success": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "info": {
+            "dark": "noelleCyan",
+            "light": "krisBlue"
+        },
+        "text": {
+            "dark": "white",
+            "light": "black"
+        },
+        "textMuted": {
+            "dark": "textMuted",
+            "light": "#555577"
+        },
+        "background": {
+            "dark": "darkWorldBg",
+            "light": "white"
+        },
+        "backgroundPanel": {
+            "dark": "darkWorldDeep",
+            "light": "#F0F0F8"
+        },
+        "backgroundElement": {
+            "dark": "darkWorldPanel",
+            "light": "#E5E5F0"
+        },
+        "border": {
+            "dark": "krisBlue",
+            "light": "susiePurple"
+        },
+        "borderActive": {
+            "dark": "hotPink",
+            "light": "susieMagenta"
+        },
+        "borderSubtle": {
+            "dark": "#3A3A6A",
+            "light": "#AAAACC"
+        },
+        "diffAdded": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "diffRemoved": {
+            "dark": "hotPink",
+            "light": "noelleRed"
+        },
+        "diffContext": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "diffHunkHeader": {
+            "dark": "krisBlue",
+            "light": "susiePurple"
+        },
+        "diffHighlightAdded": {
+            "dark": "ralseiGreen",
+            "light": "ralseiTeal"
+        },
+        "diffHighlightRemoved": {
+            "dark": "noelleRed",
+            "light": "hotPink"
+        },
+        "diffAddedBg": {
+            "dark": "#0A2A2A",
+            "light": "#D4FFEE"
+        },
+        "diffRemovedBg": {
+            "dark": "#2A0A2A",
+            "light": "#FFD4E8"
+        },
+        "diffContextBg": {
+            "dark": "darkWorldDeep",
+            "light": "#F5F5FA"
+        },
+        "diffLineNumber": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "diffAddedLineNumberBg": {
+            "dark": "#082020",
+            "light": "#E0FFF0"
+        },
+        "diffRemovedLineNumberBg": {
+            "dark": "#200820",
+            "light": "#FFE0F0"
+        },
+        "markdownText": {
+            "dark": "white",
+            "light": "black"
+        },
+        "markdownHeading": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "markdownLink": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "markdownLinkText": {
+            "dark": "noelleCyan",
+            "light": "susiePurple"
+        },
+        "markdownCode": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "markdownBlockQuote": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "markdownEmph": {
+            "dark": "susiePink",
+            "light": "susieMagenta"
+        },
+        "markdownStrong": {
+            "dark": "hotPink",
+            "light": "susiePurple"
+        },
+        "markdownHorizontalRule": {
+            "dark": "krisBlue",
+            "light": "susiePurple"
+        },
+        "markdownListItem": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "markdownListEnumeration": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "markdownImage": {
+            "dark": "susieMagenta",
+            "light": "susiePurple"
+        },
+        "markdownImageText": {
+            "dark": "susiePink",
+            "light": "susieMagenta"
+        },
+        "markdownCodeBlock": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxComment": {
+            "dark": "textMuted",
+            "light": "#666688"
+        },
+        "syntaxKeyword": {
+            "dark": "hotPink",
+            "light": "susieMagenta"
+        },
+        "syntaxFunction": {
+            "dark": "krisCyan",
+            "light": "krisBlue"
+        },
+        "syntaxVariable": {
+            "dark": "gold",
+            "light": "orange"
+        },
+        "syntaxString": {
+            "dark": "ralseiTeal",
+            "light": "ralseiGreen"
+        },
+        "syntaxNumber": {
+            "dark": "noelleRose",
+            "light": "noelleRed"
+        },
+        "syntaxType": {
+            "dark": "noelleCyan",
+            "light": "krisBlue"
+        },
+        "syntaxOperator": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxPunctuation": {
+            "dark": "krisBlue",
+            "light": "#555577"
+        }
+    }
+}

--- a/themes/undertale.json
+++ b/themes/undertale.json
@@ -1,0 +1,232 @@
+{
+    "$schema": "https://opencode.ai/theme.json",
+    "defs": {
+        "black": "#000000",
+        "white": "#FFFFFF",
+        "soulRed": "#FF0000",
+        "soulOrange": "#FF6600",
+        "soulYellow": "#FFFF00",
+        "soulGreen": "#00FF00",
+        "soulAqua": "#00FFFF",
+        "soulBlue": "#0000FF",
+        "soulPurple": "#FF00FF",
+        "ruinsPurple": "#A349A4",
+        "ruinsDark": "#380A43",
+        "snowdinBlue": "#6BA3E5",
+        "hotlandOrange": "#FF7F27",
+        "coreGray": "#3A3949",
+        "battleBg": "#0D0D1A",
+        "battlePanel": "#1A1A2E",
+        "uiYellow": "#FFC90E",
+        "textGray": "#909090",
+        "damageRed": "#FF3333",
+        "healGreen": "#00FF00",
+        "saveYellow": "#FFFF00",
+        "determinationRed": "#FF0000",
+        "mttPink": "#FF6EB4",
+        "waterfall": "#283197",
+        "waterfallGlow": "#00BFFF"
+    },
+    "theme": {
+        "primary": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "secondary": {
+            "dark": "uiYellow",
+            "light": "uiYellow"
+        },
+        "accent": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "error": {
+            "dark": "damageRed",
+            "light": "soulRed"
+        },
+        "warning": {
+            "dark": "uiYellow",
+            "light": "hotlandOrange"
+        },
+        "success": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "info": {
+            "dark": "soulAqua",
+            "light": "waterfallGlow"
+        },
+        "text": {
+            "dark": "white",
+            "light": "black"
+        },
+        "textMuted": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "background": {
+            "dark": "black",
+            "light": "white"
+        },
+        "backgroundPanel": {
+            "dark": "battleBg",
+            "light": "#F0F0F0"
+        },
+        "backgroundElement": {
+            "dark": "battlePanel",
+            "light": "#E5E5E5"
+        },
+        "border": {
+            "dark": "white",
+            "light": "black"
+        },
+        "borderActive": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "borderSubtle": {
+            "dark": "#555555",
+            "light": "#AAAAAA"
+        },
+        "diffAdded": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "diffRemoved": {
+            "dark": "damageRed",
+            "light": "soulRed"
+        },
+        "diffContext": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "diffHunkHeader": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "diffHighlightAdded": {
+            "dark": "soulGreen",
+            "light": "healGreen"
+        },
+        "diffHighlightRemoved": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "diffAddedBg": {
+            "dark": "#002200",
+            "light": "#CCFFCC"
+        },
+        "diffRemovedBg": {
+            "dark": "#220000",
+            "light": "#FFCCCC"
+        },
+        "diffContextBg": {
+            "dark": "battleBg",
+            "light": "#F5F5F5"
+        },
+        "diffLineNumber": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "diffAddedLineNumberBg": {
+            "dark": "#001A00",
+            "light": "#E0FFE0"
+        },
+        "diffRemovedLineNumberBg": {
+            "dark": "#1A0000",
+            "light": "#FFE0E0"
+        },
+        "markdownText": {
+            "dark": "white",
+            "light": "black"
+        },
+        "markdownHeading": {
+            "dark": "uiYellow",
+            "light": "hotlandOrange"
+        },
+        "markdownLink": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "markdownLinkText": {
+            "dark": "waterfallGlow",
+            "light": "waterfall"
+        },
+        "markdownCode": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "markdownBlockQuote": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "markdownEmph": {
+            "dark": "mttPink",
+            "light": "soulPurple"
+        },
+        "markdownStrong": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "markdownHorizontalRule": {
+            "dark": "white",
+            "light": "black"
+        },
+        "markdownListItem": {
+            "dark": "uiYellow",
+            "light": "uiYellow"
+        },
+        "markdownListEnumeration": {
+            "dark": "uiYellow",
+            "light": "uiYellow"
+        },
+        "markdownImage": {
+            "dark": "ruinsPurple",
+            "light": "soulPurple"
+        },
+        "markdownImageText": {
+            "dark": "mttPink",
+            "light": "ruinsPurple"
+        },
+        "markdownCodeBlock": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxComment": {
+            "dark": "textGray",
+            "light": "coreGray"
+        },
+        "syntaxKeyword": {
+            "dark": "soulRed",
+            "light": "determinationRed"
+        },
+        "syntaxFunction": {
+            "dark": "soulAqua",
+            "light": "soulBlue"
+        },
+        "syntaxVariable": {
+            "dark": "uiYellow",
+            "light": "hotlandOrange"
+        },
+        "syntaxString": {
+            "dark": "healGreen",
+            "light": "soulGreen"
+        },
+        "syntaxNumber": {
+            "dark": "mttPink",
+            "light": "soulPurple"
+        },
+        "syntaxType": {
+            "dark": "waterfallGlow",
+            "light": "waterfall"
+        },
+        "syntaxOperator": {
+            "dark": "white",
+            "light": "black"
+        },
+        "syntaxPunctuation": {
+            "dark": "textGray",
+            "light": "coreGray"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new built-in themes inspired by Undertale and Deltarune. Both themes feature game-accurate color palettes, iconic SOUL colors (Undertale), and Dark World neon aesthetics (Deltarune).

Closes #8244