### PR TITLE
fix(state): delete key from recordsByKey on instance disposal

### DIFF
--- a/packages/opencode/src/project/state.ts
+++ b/packages/opencode/src/project/state.ts
@@ -58,6 +58,7 @@ export namespace State {
       tasks.push(task)
     }
     entries.clear()
+    recordsByKey.delete(key)
     await Promise.all(tasks)
     disposalFinished = true
     log.info("state disposal completed", { key })


### PR DESCRIPTION
## Summary

Fix memory leak in `State.dispose()` where disposed instance keys remain in the parent Map forever.

Fixes #4315
Relates to #3013

## Problem

The `State` namespace uses a two-level Map structure:
- `recordsByKey: Map<string, Map<any, Entry>>` - outer Map keyed by instance
- Inner Map stores state entries for that instance

When `State.dispose(key)` is called:
1. It gets the entries Map for the key
2. Calls dispose on each entry
3. Calls `entries.clear()` to empty the inner Map
4. **Bug:** Never deletes the key from `recordsByKey`

This means every disposed instance leaves an empty `Map<any, Entry>` in `recordsByKey`, causing unbounded memory growth over the application lifetime.

## Solution

Add `recordsByKey.delete(key)` after `entries.clear()` to remove the outer Map entry entirely.

```typescript
entries.clear()
recordsByKey.delete(key)  // <-- Added
await Promise.all(tasks)
```

## Testing

- ✅ Build passes for all platforms
- ✅ Full test suite passes (652 tests, 0 failures)
- Code-review verified to follow correct cleanup pattern