### PR TITLE
fix(mcp): close existing client before reassignment to prevent leaks

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -266,6 +266,13 @@ export namespace MCP {
         status: s.status,
       }
     }
+    // Close existing client if present to prevent memory leaks
+    const existingClient = s.clients[name]
+    if (existingClient) {
+      await existingClient.close().catch((error) => {
+        log.error("Failed to close existing MCP client", { name, error })
+      })
+    }
     s.clients[name] = result.mcpClient
     s.status[name] = result.status
 
@@ -523,6 +530,13 @@ export namespace MCP {
     const s = await state()
     s.status[name] = result.status
     if (result.mcpClient) {
+      // Close existing client if present to prevent memory leaks
+      const existingClient = s.clients[name]
+      if (existingClient) {
+        await existingClient.close().catch((error) => {
+          log.error("Failed to close existing MCP client", { name, error })
+        })
+      }
       s.clients[name] = result.mcpClient
     }
   }


### PR DESCRIPTION
## Summary

Fix memory leak in MCP client management where existing clients are orphaned when replaced.

Fixes #8257
Relates to #7261
Relates to #3013

## Problem

In `MCP.add()` and the OAuth `finishAuth()` flow, when a new MCP client is created and assigned to `s.clients[name]`, any existing client at that key is silently overwritten:

```typescript
// Before (leaks existing client)
s.clients[name] = result.mcpClient
```

The old client is never closed, leaving:
- Open connections/sockets
- Active event listeners
- Unreleased resources

This happens when:
- Reconnecting to an MCP server
- Completing OAuth flow for an already-connected server
- Re-initializing MCP configuration

## Solution

Check for and close existing clients before reassignment in both locations:

```typescript
// Close existing client if present to prevent memory leaks
const existingClient = s.clients[name]
if (existingClient) {
  await existingClient.close().catch((error) => {
    log.error("Failed to close existing MCP client", { name, error })
  })
}
s.clients[name] = result.mcpClient
```

## Changes

- `packages/opencode/src/mcp/index.ts`: Added client cleanup in `add()` function
- `packages/opencode/src/mcp/index.ts`: Added client cleanup in `finishAuth()` flow

## Testing

- ✅ Build passes for all platforms
- ✅ Full test suite passes (652 tests, 0 failures)
- Code-review verified to follow correct resource cleanup pattern