### PR TITLE
docs: document ~/.claude/CLAUDE.md compatibility behavior

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -6,7 +6,7 @@ description: Using any LLM provider in OpenCode.
 import config from "../../../config.mjs"
 export const console = config.console
 
-OpenCode uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support for **75+ LLM providers** and it supports running local models.
+OpenCode uses the [AI SDK](https://ai-sdk.dev/) and [Models.dev](https://models.dev) to support **75+ LLM providers** and it supports running local models.
 
 To add a provider you need to:
 
@@ -80,8 +80,7 @@ If you are new, we recommend starting with OpenCode Zen.
    /models
    ```
 
-It works like any other provider in OpenCode. And is completely optional to use
-it.
+It works like any other provider in OpenCode and is completely optional to use.
 
 ---
 
@@ -226,7 +225,7 @@ We recommend signing up for [Claude Pro](https://www.anthropic.com/news/claude-p
    └
    ```
 
-3. Now all the the Anthropic models should be available when you use the `/models` command.
+3. Now all the Anthropic models should be available when you use the `/models` command.
 
    ```txt
    /models

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -68,10 +68,10 @@ Since this isn't committed to Git or shared with your team, we recommend using t
 
 ### Claude Code Compatibility
 
-For users migrating from or using both Claude Code and OpenCode, OpenCode supports Claude Code's file conventions:
+For users migrating from Claude Code, OpenCode supports Claude Code's file conventions as fallbacks:
 
-- **Project rules**: `CLAUDE.md` in your project directory (works the same as `AGENTS.md`)
-- **Global rules**: `~/.claude/CLAUDE.md`
+- **Project rules**: `CLAUDE.md` in your project directory (used if no `AGENTS.md` exists)
+- **Global rules**: `~/.claude/CLAUDE.md` (used if no `~/.config/opencode/AGENTS.md` exists)
 - **Skills**: `~/.claude/skills/` — see [Agent Skills](/docs/skills/) for details
 
 To disable Claude Code compatibility, set one of these environment variables:
@@ -92,7 +92,7 @@ When opencode starts, it looks for rule files in this order:
 2. **Global file** at `~/.config/opencode/AGENTS.md`
 3. **Claude Code file** at `~/.claude/CLAUDE.md` (unless disabled)
 
-The first matching local file wins (checked in the order listed above). Global and Claude Code files are combined with local rules.
+The first matching file wins in each category. For example, if you have both `AGENTS.md` and `CLAUDE.md`, only `AGENTS.md` is used. Similarly, `~/.config/opencode/AGENTS.md` takes precedence over `~/.claude/CLAUDE.md`.
 
 ---
 

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -3,7 +3,7 @@ title: Rules
 description: Set custom instructions for opencode.
 ---
 
-You can provide custom instructions to opencode by creating an `AGENTS.md` file. This is similar to `CLAUDE.md` or Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
+You can provide custom instructions to opencode by creating an `AGENTS.md` file (or `CLAUDE.md` for Claude Code compatibility). This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
 
 ---
 
@@ -58,7 +58,7 @@ opencode also supports reading the `AGENTS.md` file from multiple locations. And
 
 ### Project
 
-The ones we have seen above, where the `AGENTS.md` is placed in the project root, are project-specific rules. These only apply when you are working in this directory or its sub-directories.
+Place an `AGENTS.md` (or `CLAUDE.md`) in your project root for project-specific rules. These only apply when you are working in this directory or its sub-directories.
 
 ### Global
 
@@ -66,16 +66,33 @@ You can also have global rules in a `~/.config/opencode/AGENTS.md` file. This ge
 
 Since this isn't committed to Git or shared with your team, we recommend using this to specify any personal rules that the LLM should follow.
 
+### Claude Code Compatibility
+
+For users migrating from or using both Claude Code and OpenCode, OpenCode supports Claude Code's file conventions:
+
+- **Project rules**: `CLAUDE.md` in your project directory (works the same as `AGENTS.md`)
+- **Global rules**: `~/.claude/CLAUDE.md`
+- **Skills**: `~/.claude/skills/` — see [Agent Skills](/docs/skills/) for details
+
+To disable Claude Code compatibility, set one of these environment variables:
+
+```bash
+export OPENCODE_DISABLE_CLAUDE_CODE=1        # Disable all .claude support
+export OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=1 # Disable only ~/.claude/CLAUDE.md
+export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # Disable only .claude/skills
+```
+
 ---
 
 ## Precedence
 
-So when opencode starts, it looks for:
+When opencode starts, it looks for rule files in this order:
 
-1. **Local files** by traversing up from the current directory
-2. **Global file** by checking `~/.config/opencode/AGENTS.md`
+1. **Local files** by traversing up from the current directory (`AGENTS.md`, `CLAUDE.md`, or `CONTEXT.md`)
+2. **Global file** at `~/.config/opencode/AGENTS.md`
+3. **Claude Code file** at `~/.claude/CLAUDE.md` (unless disabled)
 
-If you have both global and project-specific rules, opencode will combine them together.
+The first matching local file wins (checked in the order listed above). Global and Claude Code files are combined with local rules.
 
 ---
 

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -3,7 +3,7 @@ title: Rules
 description: Set custom instructions for opencode.
 ---
 
-You can provide custom instructions to opencode by creating an `AGENTS.md` file (or `CLAUDE.md` for Claude Code compatibility). This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
+You can provide custom instructions to opencode by creating an `AGENTS.md` file. This is similar to Cursor's rules. It contains instructions that will be included in the LLM's context to customize its behavior for your specific project.
 
 ---
 
@@ -58,7 +58,7 @@ opencode also supports reading the `AGENTS.md` file from multiple locations. And
 
 ### Project
 
-Place an `AGENTS.md` (or `CLAUDE.md`) in your project root for project-specific rules. These only apply when you are working in this directory or its sub-directories.
+Place an `AGENTS.md` in your project root for project-specific rules. These only apply when you are working in this directory or its sub-directories.
 
 ### Global
 


### PR DESCRIPTION
This PR documents Claude Code compatibility features in the Rules documentation.

## Changes

- Update intro to mention `CLAUDE.md` as alternative to `AGENTS.md`
- Update Project section to mention `CLAUDE.md` support
- Add "Claude Code Compatibility" section covering:
  - Project-level `CLAUDE.md`
  - Global `~/.claude/CLAUDE.md`
  - Cross-reference to Skills docs for `~/.claude/skills/`
- Document all three `OPENCODE_DISABLE_CLAUDE_CODE*` environment variables
- Update Precedence section to list all local file types (`AGENTS.md`, `CLAUDE.md`, `CONTEXT.md`)

Closes #8265

## Testing locally

```bash
gh repo clone anomalyco/opencode
cd opencode
gh pr checkout 8268
# Review changes in packages/web/src/content/docs/rules.mdx
```