### PR TITLE
fix: add missing metadata() and ask() defintions to ToolContext type

### DIFF
--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -5,6 +5,7 @@ export type ToolContext = {
   messageID: string
   agent: string
   abort: AbortSignal
+  metadata(input: { title?: string, metadata?: { [key: string]: any } }): void
 }
 
 export function tool<Args extends z.ZodRawShape>(input: {

--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -5,7 +5,15 @@ export type ToolContext = {
   messageID: string
   agent: string
   abort: AbortSignal
-  metadata(input: { title?: string, metadata?: { [key: string]: any } }): void
+  metadata(input: { title?: string; metadata?: { [key: string]: any } }): void
+  ask(input: AskInput): Promise<void>
+}
+
+type AskInput = {
+  permission: string
+  patterns: string[]
+  always: string[]
+  metadata: { [key: string]: any }
 }
 
 export function tool<Args extends z.ZodRawShape>(input: {


### PR DESCRIPTION
### What does this PR do?
Fixes #8219.

Adds missing `metadata()` definition to the `ToolContext` type. I got the definition from `packages/opencode/src/tool/tool.ts`.

Should other properties like `callID` and `ask()` be exposed as well?

### How did you verify your code works?

Created a custom tool and didn't get any Typescript errors.
