### PR TITLE
fix(cli): mcp auth duplicate radio button icon

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -21,7 +21,7 @@ function getAuthStatusIcon(status: MCP.AuthStatus): string {
     case "expired":
       return "⚠"
     case "not_authenticated":
-      return "○"
+      return "✗"
   }
 }
 


### PR DESCRIPTION
## Summary
- Change `not_authenticated` icon from `○` to `✗` to avoid visual duplication with prompts library radio button

Closes #8272

### before
<img width="1916" height="698" alt="image" src="https://github.com/user-attachments/assets/f58567ca-6820-4ae9-aa09-0a8c6291ecf4" />

### after
<img width="1938" height="842" alt="CleanShot 2026-01-13 at 14 16 24@2x" src="https://github.com/user-attachments/assets/6e968c31-bb03-4d83-9ccd-98b6c104b396" />


> [!NOTE]
> This PR was written with AI assistance.

<details><summary>AI Session Export</summary>
<p>

```json
{
  "info": {
    "title": "mcp auth radio icon fix",
    "agent": "opencode",
    "models": ["claude sonnet 4"]
  },
  "summary": [
    "user reported mcp auth cli shows duplicate radio buttons",
    "agent searched for mcp auth command implementation",
    "agent found getAuthStatusIcon returns ○ for not_authenticated",
    "agent changed icon from ○ to ✗ to avoid duplication",
    "user requested gh issue and pr",
    "agent created issue #8272 with bug details",
    "agent created branch and committed fix",
    "agent opened pr #8273 closing the issue"
  ]
}
```

</p>
</details>