### PR TITLE
fix: Add Plugin Mocks to Provider Tests

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,6 +1,4 @@
 import z from "zod"
-import path from "path"
-import os from "os"
 import fuzzysort from "fuzzysort"
 import { Config } from "../config/config"
 import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
@@ -605,13 +603,13 @@ export namespace Provider {
         },
         experimentalOver200K: model.cost?.context_over_200k
           ? {
-              cache: {
-                read: model.cost.context_over_200k.cache_read ?? 0,
-                write: model.cost.context_over_200k.cache_write ?? 0,
-              },
-              input: model.cost.context_over_200k.input,
-              output: model.cost.context_over_200k.output,
-            }
+            cache: {
+              read: model.cost.context_over_200k.cache_read ?? 0,
+              write: model.cost.context_over_200k.cache_write ?? 0,
+            },
+            input: model.cost.context_over_200k.input,
+            output: model.cost.context_over_200k.output,
+          }
           : undefined,
       },
       limit: {


### PR DESCRIPTION
## Summary

Adds missing plugin mocks to provider.test.ts to prevent test timeouts. After moving GitLab auth plugin to the BUILTIN array, all provider tests need to mock builtin plugins to prevent actual package installation attempts during test runs.

## Problem

The test "provider loaded from env variable" was timing out (5000ms) because:
- GitLab auth plugin (@gitlab/opencode-gitlab-auth@1.3.0) is now in the BUILTIN array
- Plugin loading triggers BunProc.install() for all builtin plugins  
- provider.test.ts had no mocks for BunProc or builtin plugins
- Real installation attempts caused test timeouts

## Solution

Added comprehensive mocks to provider.test.ts:
- Mock BunProc.install() to return package names without attempting real installations
- Mock all builtin plugins: opencode-copilot-auth, opencode-anthropic-auth, @gitlab/opencode-gitlab-auth
- Follow the same mocking pattern used in gitlab-duo.test.ts and amazon-bedrock.test.ts
- Remove unused imports, fix formatting