### PR TITLE
feat(plugin): show both configured & installed version of plugins in `DialogStatus`

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -11,30 +11,7 @@ export function DialogStatus() {
 
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
 
-  const plugins = createMemo(() => {
-    const list = sync.data.config.plugin ?? []
-    const result = list.map((value) => {
-      if (value.startsWith("file://")) {
-        const path = value.substring("file://".length)
-        const parts = path.split("/")
-        const filename = parts.pop() || path
-        if (!filename.includes(".")) return { name: filename }
-        const basename = filename.split(".")[0]
-        if (basename === "index") {
-          const dirname = parts.pop()
-          const name = dirname || basename
-          return { name }
-        }
-        return { name: basename }
-      }
-      const index = value.lastIndexOf("@")
-      if (index <= 0) return { name: value, version: "latest" }
-      const name = value.substring(0, index)
-      const version = value.substring(index + 1)
-      return { name, version }
-    })
-    return result.toSorted((a, b) => a.name.localeCompare(b.name))
-  })
+  const plugins = createMemo(() => sync.data.plugin)
 
   return (
     <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
@@ -150,7 +127,8 @@ export function DialogStatus() {
                 </text>
                 <text wrapMode="word" fg={theme.text}>
                   <b>{item.name}</b>
-                  {item.version && <span style={{ fg: theme.textMuted }}> @{item.version}</span>}
+                  {item.configuredVersion && <span style={{ fg: theme.textMuted }}>@{item.configuredVersion}</span>}
+                  {item.installedVersion && <span style={{ fg: theme.textMuted }}> v{item.installedVersion}</span>}
                 </text>
               </box>
             )}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -13,6 +13,7 @@ import type {
   McpStatus,
   McpResource,
   FormatterStatus,
+  PluginStatus,
   SessionStatus,
   ProviderListResponse,
   ProviderAuthMethod,
@@ -71,6 +72,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
         [key: string]: McpResource
       }
       formatter: FormatterStatus[]
+      plugin: PluginStatus[]
       vcs: VcsInfo | undefined
       path: Path
     }>({
@@ -98,6 +100,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       mcp: {},
       mcp_resource: {},
       formatter: [],
+      plugin: [],
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
     })
@@ -346,6 +349,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
             sdk.client.mcp.status().then((x) => setStore("mcp", reconcile(x.data!))),
             sdk.client.experimental.resource.list().then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
             sdk.client.formatter.status().then((x) => setStore("formatter", reconcile(x.data!))),
+            sdk.client.plugin.status().then((x) => setStore("plugin", reconcile(x.data!))),
             sdk.client.session.status().then((x) => {
               setStore("session_status", reconcile(x.data!))
             }),

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -10,9 +10,24 @@ import { Flag } from "../flag/flag"
 import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
+import path from "path"
+import { Global } from "../global"
+import z from "zod"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
+
+  export const Status = z
+    .object({
+      name: z.string(),
+      configuredVersion: z.string().optional(),
+      installedVersion: z.string().optional(),
+      path: z.string().optional(),
+    })
+    .meta({
+      ref: "PluginStatus",
+    })
+  export type Status = z.infer<typeof Status>
 
   const BUILTIN = ["opencode-copilot-auth@0.0.12", "opencode-anthropic-auth@0.0.8"]
 
@@ -129,5 +144,32 @@ export namespace Plugin {
         })
       }
     })
+  }
+
+  export async function status(): Promise<Status[]> {
+    const config = await Config.get()
+    const plugins = config.plugin ?? []
+    const result: Status[] = []
+
+    for (const plugin of plugins) {
+      if (plugin.startsWith("file://")) {
+        const name = Config.getPluginName(plugin)
+        result.push({ name, path: plugin })
+      } else {
+        const lastAtIndex = plugin.lastIndexOf("@")
+        const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
+        const configuredVersion = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : undefined
+
+        const pkgPath = path.join(Global.Path.cache, "node_modules", pkg, "package.json")
+        const pkgJson = await Bun.file(pkgPath)
+          .json()
+          .catch(() => null)
+        const installedVersion = pkgJson?.version
+
+        result.push({ name: pkg, configuredVersion, installedVersion })
+      }
+    }
+
+    return result.toSorted((a, b) => a.name.localeCompare(b.name))
   }
 }

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -19,6 +19,7 @@ import { Config } from "../config/config"
 import { File } from "../file"
 import { LSP } from "../lsp"
 import { Format } from "../format"
+import { Plugin } from "../plugin"
 import { MessageV2 } from "../session/message-v2"
 import { TuiRoute } from "./tui"
 import { Instance } from "../project/instance"
@@ -2443,6 +2444,27 @@ export namespace Server {
           }),
           async (c) => {
             return c.json(await Format.status())
+          },
+        )
+        .get(
+          "/plugin",
+          describeRoute({
+            summary: "Get plugin status",
+            description: "Get plugin status",
+            operationId: "plugin.status",
+            responses: {
+              200: {
+                description: "Plugin status",
+                content: {
+                  "application/json": {
+                    schema: resolver(Plugin.Status.array()),
+                  },
+                },
+              },
+            },
+          }),
+          async (c) => {
+            return c.json(await Plugin.status())
           },
         )
         .post(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -63,6 +63,7 @@ import type {
   PermissionRespondErrors,
   PermissionRespondResponses,
   PermissionRuleset,
+  PluginStatusResponses,
   ProjectCurrentResponses,
   ProjectListResponses,
   ProjectUpdateErrors,
@@ -2618,6 +2619,27 @@ export class Formatter extends HeyApiClient {
   }
 }
 
+export class Plugin extends HeyApiClient {
+  /**
+   * Get plugin status
+   *
+   * Get plugin status
+   */
+  public status<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<PluginStatusResponses, unknown, ThrowOnError>({
+      url: "/plugin",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Control extends HeyApiClient {
   /**
    * Get next TUI request
@@ -3025,6 +3047,8 @@ export class OpencodeClient extends HeyApiClient {
   lsp = new Lsp({ client: this.client })
 
   formatter = new Formatter({ client: this.client })
+
+  plugin = new Plugin({ client: this.client })
 
   tui = new Tui({ client: this.client })
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2057,6 +2057,13 @@ export type FormatterStatus = {
   enabled: boolean
 }
 
+export type PluginStatus = {
+  name: string
+  configuredVersion?: string
+  installedVersion?: string
+  path?: string
+}
+
 export type OAuth = {
   type: "oauth"
   refresh: string
@@ -4412,6 +4419,24 @@ export type FormatterStatusResponses = {
 }
 
 export type FormatterStatusResponse = FormatterStatusResponses[keyof FormatterStatusResponses]
+
+export type PluginStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/plugin"
+}
+
+export type PluginStatusResponses = {
+  /**
+   * Plugin status
+   */
+  200: Array<PluginStatus>
+}
+
+export type PluginStatusResponse = PluginStatusResponses[keyof PluginStatusResponses]
 
 export type TuiAppendPromptData = {
   body?: {


### PR DESCRIPTION
Closes #8280

### What does this PR do?

This PR implements `GET /plugin` API to retrieve plugins' status (similar to LSP/MCP/Formatter status endpoints). Then it shows both configured version and actually installed version in 
`DialogStatus` (triggered via `/status` command)

### How did you verify your code works?

BEFORE:
<img width="1076" height="892" alt="Screenshot 2026-01-14 at 03 37 38" src="https://github.com/user-attachments/assets/9abc5fd9-b32d-4468-a869-7cc859d54227" />


AFTER:
<img width="1076" height="892" alt="Screenshot 2026-01-14 at 03 37 05" src="https://github.com/user-attachments/assets/e3500b5b-726d-4074-95dc-35865cf0a85b" />

