### PR TITLE
docs: Update plan mode restrictions

### DIFF
--- a/packages/web/src/content/docs/modes.mdx
+++ b/packages/web/src/content/docs/modes.mdx
@@ -34,7 +34,7 @@ Build is the **default** mode with all tools enabled. This is the standard mode 
 A restricted mode designed for planning and analysis. In plan mode, the following tools are disabled by default:
 
 - `write` - Cannot create new files
-- `edit` - Cannot modify existing files
+- `edit` - Cannot modify existing files, except for files located at `.opencode/plans/*.md` to detail the plan itself
 - `patch` - Cannot apply patches
 - `bash` - Cannot execute shell commands
 


### PR DESCRIPTION
Clarified restrictions in plan mode regarding file editing.

### What does this PR do?

Properly corrects documentation on plan mode where opencode agent can write files to `.opencode/plans/*.md`. As per the source files: https://github.com/anomalyco/opencode/blob/dev/packages/opencode/src/agent/agent.ts#L83-L100

