### PR TITLE
fix: handle missing Instance context in Read tool

### DIFF
--- a/packages/opencode/src/tool/external-directory.ts
+++ b/packages/opencode/src/tool/external-directory.ts
@@ -14,7 +14,13 @@ export async function assertExternalDirectory(ctx: Tool.Context, target?: string
 
   if (options?.bypass) return
 
-  if (Instance.containsPath(target)) return
+  // Instance context may not be available in certain execution paths (e.g., MCP, plugins)
+  // Skip the containsPath check if context is missing - permission will still be requested
+  try {
+    if (Instance.containsPath(target)) return
+  } catch {
+    // Instance context not available - proceed to ask for permission
+  }
 
   const kind = options?.kind ?? "file"
   const parentDir = kind === "directory" ? target : path.dirname(target)

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -25,7 +25,16 @@ export const ReadTool = Tool.define("read", {
     if (!path.isAbsolute(filepath)) {
       filepath = path.join(process.cwd(), filepath)
     }
-    const title = path.relative(Instance.worktree, filepath)
+
+    // Instance context may not be available in certain execution paths (e.g., MCP, plugins)
+    // Gracefully handle missing context to avoid cryptic native binding errors
+    let worktree: string | undefined
+    try {
+      worktree = Instance.worktree
+    } catch {
+      // Instance context not available - fall back to basename for title
+    }
+    const title = worktree ? path.relative(worktree, filepath) : path.basename(filepath)
 
     await assertExternalDirectory(ctx, filepath, {
       bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),


### PR DESCRIPTION
## Summary

Fixes #8301

- Gracefully handle missing Instance context in Read tool and external-directory helper
- Prevents cryptic native binding errors when tools are executed outside normal server flow
- Falls back to `path.basename()` for title when `Instance.worktree` is unavailable

## Problem

When the Read tool is executed outside of an Instance context (e.g., via MCP, plugins), accessing `Instance.worktree` throws a `Context.NotFound` exception. However, before this propagates, `path.relative(undefined, filepath)` throws:

```
TypeError: Binding expected string, TypedArray, boolean, number, bigint or null
```

This is confusing and does not indicate the actual problem.

## Solution

Wrap `Instance.worktree` and `Instance.containsPath()` access in try-catch blocks:
- In `read.ts`: Fall back to `path.basename(filepath)` for the title
- In `external-directory.ts`: Proceed to ask for permission when containsPath check cannot run

## Verification

- All existing read tool tests pass (26 tests)
- Tested fix logic with simulated missing context