### PR TITLE
fix(grep): return lines even in the presence of warnings

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -60,7 +60,10 @@ export const GrepTool = Tool.define("grep", {
       }
     }
 
-    if (exitCode !== 0) {
+    // Non-zero exit code means an error occurred, but ripgrep might have
+    // returned some data regardless. In that case, the error was likely a soft
+    // error (like a broken symlink), rather than something fatal.
+    if (exitCode !== 0 && !output.trim()) {
       throw new Error(`ripgrep failed: ${errorOutput}`)
     }
 

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { GrepTool } from "../../src/tool/grep"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
@@ -55,6 +56,55 @@ describe("tool.grep", () => {
         )
         expect(result.metadata.matches).toBe(0)
         expect(result.output).toBe("No files found")
+      },
+    })
+  })
+
+  test("returns results when broken symlink exists", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "valid.txt"), "hello world")
+        const subdir = path.join(dir, "subdir")
+        await fs.mkdir(subdir)
+        await fs.symlink(path.join(dir, "/nonexistent/path"), path.join(subdir, "broken"))
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const grep = await GrepTool.init()
+        const result = await grep.execute(
+          {
+            pattern: "hello",
+            path: tmp.path,
+          },
+          ctx,
+        )
+        expect(result.metadata.matches).toBe(1)
+        expect(result.output).toContain("valid.txt")
+      },
+    })
+  })
+
+  test("throws on ripgrep error without stdout", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "test.txt"), "hello world")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const grep = await GrepTool.init()
+        expect(
+          grep.execute(
+            {
+              pattern: "[invalid",
+              path: tmp.path,
+            },
+            ctx,
+          ),
+        ).rejects.toThrow("ripgrep failed")
       },
     })
   })


### PR DESCRIPTION
### What does this PR do?

Fixes #8307 by modifying the `Grep` tool so that an error is only returned if `ripgrep`'s stdout is empty, in addition to checking the status code.

This might not be the solution you all want, since it doesn't enable the model to get the potentially useful warning messages out of the tool call.

### How did you verify your code works?

Added some unit tests, and recreated the scenario here: https://opncd.ai/share/9YARWprF. Create a broken symlink, and then ask the model to grep in the root of the repo.
