### PR TITLE
feat(tui): add double-click to copy word in TUI messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -25,6 +25,7 @@ import {
   type ScrollAcceleration,
   TextAttributes,
   RGBA,
+  type MouseEvent,
 } from "@opentui/core"
 import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
@@ -74,6 +75,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { useMultiClickTextCopy } from "../../util/use-multi-click-text-copy"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1101,6 +1103,11 @@ function UserMessage(props: {
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => (queued() ? theme.accent : local.agent.color(props.message.agent)))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
+  const toast = useToast()
+  const multiClick = useMultiClickTextCopy({
+    getText: () => text()?.text ?? "",
+    toast,
+  })
 
   const compaction = createMemo(() => props.parts.find((x) => x.type === "compaction"))
 
@@ -1121,7 +1128,10 @@ function UserMessage(props: {
             onMouseOut={() => {
               setHover(false)
             }}
-            onMouseUp={props.onMouseUp}
+            onMouseUp={(event) => {
+              multiClick.onMouseUp(event)
+              props.onMouseUp()
+            }}
             paddingTop={1}
             paddingBottom={1}
             paddingLeft={2}
@@ -1268,10 +1278,15 @@ const PART_MAPPING = {
 function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage }) {
   const { theme, subtleSyntax } = useTheme()
   const ctx = use()
+  const toast = useToast()
   const content = createMemo(() => {
     // Filter out redacted reasoning chunks from OpenRouter
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
     return props.part.text.replace("[REDACTED]", "").trim()
+  })
+  const multiClick = useMultiClickTextCopy({
+    getText: () => content(),
+    toast,
   })
   return (
     <Show when={content() && ctx.showThinking()}>
@@ -1283,6 +1298,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
         border={["left"]}
         customBorderChars={SplitBorder.customBorderChars}
         borderColor={theme.backgroundElement}
+        onMouseUp={multiClick.onMouseUp}
       >
         <code
           filetype="markdown"
@@ -1301,9 +1317,14 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const toast = useToast()
+  const multiClick = useMultiClickTextCopy({
+    getText: () => props.part.text.trim(),
+    toast,
+  })
   return (
     <Show when={props.part.text.trim()}>
-      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
+      <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0} onMouseUp={multiClick.onMouseUp}>
         <code
           filetype="markdown"
           drawUnstyledText={false}

--- a/packages/opencode/src/cli/cmd/tui/util/multi-click.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/multi-click.ts
@@ -1,0 +1,81 @@
+import { createSignal, type Accessor } from "solid-js"
+
+interface ClickState {
+  count: number
+  lastClickTime: number
+  x: number
+  y: number
+}
+
+export function createMultiClickDetector(
+  onDoubleClick: (x: number, y: number) => void,
+  onTripleClick: (x: number, y: number) => void,
+  clickTimeout: number = 500,
+) {
+  const [clickState, setClickState] = createSignal<ClickState>({
+    count: 0,
+    lastClickTime: 0,
+    x: 0,
+    y: 0,
+  })
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  return (x: number, y: number) => {
+    const now = Date.now()
+    const currentState = clickState() // Read state once to avoid consistency issues
+    const timeSinceLastClick = now - currentState.lastClickTime
+    const positionTolerance = 5 // pixels
+
+    // Check if this is part of a multi-click sequence
+    const isSamePosition =
+      Math.abs(x - currentState.x) < positionTolerance && Math.abs(y - currentState.y) < positionTolerance
+    const isWithinTimeout = timeSinceLastClick < clickTimeout
+
+    if (isSamePosition && isWithinTimeout) {
+      // Increment click count
+      const newCount = currentState.count + 1
+      setClickState({
+        count: newCount,
+        lastClickTime: now,
+        x,
+        y,
+      })
+
+      // Clear existing timeout
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+
+      // Trigger appropriate action
+      if (newCount === 2) {
+        onDoubleClick(x, y)
+      } else if (newCount === 3) {
+        onTripleClick(x, y)
+      }
+
+      // Set new timeout to reset count
+      timeoutId = setTimeout(() => {
+        setClickState((prev) => ({ ...prev, count: 0 }))
+        timeoutId = undefined
+      }, clickTimeout)
+    } else {
+      // Start new click sequence
+      setClickState({
+        count: 1,
+        lastClickTime: now,
+        x,
+        y,
+      })
+
+      // Set timeout to reset count if no additional clicks
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
+      timeoutId = setTimeout(() => {
+        setClickState((prev) => ({ ...prev, count: 0 }))
+        timeoutId = undefined
+      }, clickTimeout)
+    }
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/util/text-boundaries.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/text-boundaries.ts
@@ -1,0 +1,72 @@
+// Word boundary characters - characters that separate words
+const WORD_BOUNDARY_CHARS = /[\s.,;:!?'"()\[\]{}<>\/\\|`~@#$%^&*+=\-]/
+
+// Find word boundaries around a character index in a line
+export function findWordBoundaries(
+  line: string,
+  charIndex: number,
+): { start: number; end: number; word: string } | undefined {
+  if (!line || charIndex < 0 || charIndex >= line.length) return undefined
+
+  // Check if we're on a boundary character
+  if (WORD_BOUNDARY_CHARS.test(line[charIndex])) return undefined
+
+  // Find start of word by scanning backwards
+  let start = charIndex
+  while (start > 0 && !WORD_BOUNDARY_CHARS.test(line[start - 1])) {
+    start--
+  }
+
+  // Find end of word by scanning forwards
+  let end = charIndex
+  while (end + 1 < line.length && !WORD_BOUNDARY_CHARS.test(line[end + 1])) {
+    end++
+  }
+
+  const word = line.substring(start, end + 1)
+  return word.length > 0 ? { start, end: end + 1, word } : undefined
+}
+
+// Extract word at approximate screen position
+// Assumes monospace font where each character is 1 unit wide
+// x = column (0-indexed), y = line (0-indexed relative to text start)
+export function extractWordAtPosition(
+  x: number,
+  y: number,
+  text: string,
+  elementX: number,
+  elementY: number,
+): string | undefined {
+  if (!text) return undefined
+
+  const lines = text.split("\n")
+  // Calculate relative line index from click position
+  const lineIndex = y - elementY
+  if (lineIndex < 0 || lineIndex >= lines.length) return undefined
+
+  const line = lines[lineIndex]
+  if (!line) return undefined
+
+  // Calculate character index from X position (accounting for element's X offset)
+  const charIndex = x - elementX
+  if (charIndex < 0 || charIndex >= line.length) return undefined
+
+  const result = findWordBoundaries(line, charIndex)
+  return result?.word
+}
+
+// Extract line at approximate screen position
+export function extractLineAtPosition(
+  y: number,
+  text: string,
+  elementY: number,
+): string | undefined {
+  if (!text) return undefined
+
+  const lines = text.split("\n")
+  const lineIndex = y - elementY
+  if (lineIndex < 0 || lineIndex >= lines.length) return undefined
+
+  const line = lines[lineIndex]
+  return line?.trim() || undefined
+}

--- a/packages/opencode/src/cli/cmd/tui/util/use-multi-click-text-copy.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/use-multi-click-text-copy.ts
@@ -1,0 +1,74 @@
+import { useRenderer } from "@opentui/solid"
+import { type MouseEvent, type Renderable } from "@opentui/core"
+import { createMultiClickDetector } from "./multi-click"
+import { extractWordAtPosition, extractLineAtPosition } from "./text-boundaries"
+import { Clipboard } from "./clipboard"
+import { type useToast } from "../ui/toast"
+
+interface UseMultiClickTextCopyOptions {
+  getText: () => string
+  toast: ReturnType<typeof useToast>
+}
+
+export function useMultiClickTextCopy(options: UseMultiClickTextCopyOptions) {
+  const renderer = useRenderer()
+
+  const copyText = async (text: string, type: "word" | "line") => {
+    // Copy via OSC52 for terminal compatibility
+    const base64 = Buffer.from(text).toString("base64")
+    const osc52 = `\x1b]52;c;${base64}\x07`
+    const finalOsc52 = process.env["TMUX"] ? `\x1bPtmux;\x1b${osc52}\x1b\\` : osc52
+    // @ts-expect-error writeOut is not in type definitions
+    renderer.writeOut(finalOsc52)
+
+    // Copy via native clipboard
+    await Clipboard.copy(text)
+      .then(() => {
+        options.toast.show({
+          message: type === "word" ? "Word copied!" : "Line copied!",
+          variant: "info",
+          duration: 2000,
+        })
+      })
+      .catch(() => {
+        options.toast.show({
+          message: "Failed to copy",
+          variant: "error",
+          duration: 2000,
+        })
+      })
+  }
+
+  // Store the current event target for callbacks
+  // The callbacks are synchronous so this is safe
+  const state = { target: null as Renderable | null }
+
+  const detectMultiClick = createMultiClickDetector(
+    (x, y) => {
+      const text = options.getText()
+      const target = state.target
+      if (!text || !target) return
+
+      const word = extractWordAtPosition(x, y, text, target.x, target.y)
+      if (word) copyText(word, "word")
+    },
+    (x, y) => {
+      const text = options.getText()
+      const target = state.target
+      if (!text || !target) return
+
+      const line = extractLineAtPosition(y, text, target.y)
+      if (line) copyText(line, "line")
+    },
+  )
+
+  const onMouseUp = (event: MouseEvent) => {
+    // Don't interfere with text selection
+    if (renderer.getSelection()?.getSelectedText()) return
+
+    state.target = event.target
+    detectMultiClick(event.x, event.y)
+  }
+
+  return { onMouseUp }
+}

--- a/packages/opencode/test/util/multi-click.test.ts
+++ b/packages/opencode/test/util/multi-click.test.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "bun:test"
+import { createMultiClickDetector } from "../../src/cli/cmd/tui/util/multi-click"
+
+test("multi-click detector detects double click", (done) => {
+  let doubleClickTriggered = false
+  let tripleClickTriggered = false
+
+  const detector = createMultiClickDetector(
+    () => {
+      doubleClickTriggered = true
+    },
+    () => {
+      tripleClickTriggered = true
+    },
+    100, // Short timeout for testing
+  )
+
+  // Simulate double click
+  detector(10, 10)
+  detector(12, 11) // Within tolerance and timeout
+
+  // Should trigger double click
+  expect(doubleClickTriggered).toBe(true)
+  expect(tripleClickTriggered).toBe(false)
+
+  done()
+})
+
+test("multi-click detector detects triple click", (done) => {
+  let doubleClickTriggered = false
+  let tripleClickTriggered = false
+
+  const detector = createMultiClickDetector(
+    () => {
+      doubleClickTriggered = true
+    },
+    () => {
+      tripleClickTriggered = true
+    },
+    100, // Short timeout for testing
+  )
+
+  // Simulate triple click
+  detector(10, 10)
+  detector(12, 11) // Within tolerance and timeout
+  detector(11, 12) // Within tolerance and timeout
+
+  // Should trigger triple click
+  expect(tripleClickTriggered).toBe(true)
+
+  done()
+})
+
+test("multi-click detector resets after timeout", (done) => {
+  let doubleClickTriggered = false
+  let tripleClickTriggered = false
+
+  const detector = createMultiClickDetector(
+    () => {
+      doubleClickTriggered = true
+    },
+    () => {
+      tripleClickTriggered = true
+    },
+    50, // Very short timeout for testing
+  )
+
+  // First click
+  detector(10, 10)
+
+  // Wait for timeout to pass
+  setTimeout(() => {
+    // Second click after timeout should start new sequence
+    detector(15, 15)
+
+    // Give it a moment to process
+    setTimeout(() => {
+      // Should not trigger double click since timeout passed
+      expect(doubleClickTriggered).toBe(false)
+      expect(tripleClickTriggered).toBe(false)
+
+      done()
+    }, 20)
+  }, 100)
+})
+
+test("multi-click detector handles position tolerance", (done) => {
+  let doubleClickTriggered = false
+  let tripleClickTriggered = false
+
+  const detector = createMultiClickDetector(
+    () => {
+      doubleClickTriggered = true
+    },
+    () => {
+      tripleClickTriggered = true
+    },
+    100,
+  )
+
+  // Clicks too far apart should not count as multi-click
+  detector(10, 10)
+  detector(20, 20) // Outside tolerance
+
+  // Should not trigger double click
+  expect(doubleClickTriggered).toBe(false)
+  expect(tripleClickTriggered).toBe(false)
+
+  done()
+})


### PR DESCRIPTION
## Summary

**Changes**
Add multi-click text copy functionality for messages in the TUI:
- Double-click copies the word at cursor position
- Triple-click copies the entire line
- Works on both user and assistant messages

**Files:**
- multi-click.ts: Multi-click detector with timeout handling
- text-boundaries.ts: Position-to-text mapping for word extraction
- use-multi-click-text-copy.ts: Hook integrating detection and clipboard
- session/index.tsx: Integration into TextPart, ReasoningPart, UserMessage

**Closes:** #3091

---

**tldr:** Double click to copy words, triple click to copy lines.
