### PR TITLE
feat(opencode): add auto model detection for OpenAI-compatible providers

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -872,6 +872,10 @@ export namespace Config {
             .describe(
               "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
             ),
+          autoDetectModels: z
+            .boolean()
+            .optional()
+            .describe("Enable auto-detection of models. Default is false. Currently only support local providers that use OpenAI-compatible APIs.")
         })
         .catchall(z.any())
         .optional(),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -872,10 +872,6 @@ export namespace Config {
             .describe(
               "Timeout in milliseconds for requests to this provider. Default is 300000 (5 minutes). Set to false to disable timeout.",
             ),
-          autoDetectModels: z
-            .boolean()
-            .optional()
-            .describe("Enable auto-detection of models. Default is false. Currently only support local providers that use OpenAI-compatible APIs.")
         })
         .catchall(z.any())
         .optional(),

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -140,6 +140,11 @@ export namespace ProviderModelDetection.OpenAICompatible {
       throw new Error(`unknown error: ${error}`)
     }
 
+    let npm = "@ai-sdk/openai-compatible"
+    if (provider.id === "github-copilot" || provider.id === "github-copilot-enterprise") {
+      npm = "@ai-sdk/github-copilot"
+    }
+
     return Object.fromEntries(
       parsed.data
         .filter((model) => model.id && !model.id.includes("embedding") && !model.id.includes("embed"))
@@ -151,7 +156,7 @@ export namespace ProviderModelDetection.OpenAICompatible {
             api: {
               id: model.id,
               url: baseURL,
-              npm: "@ai-sdk/openai-compatible",
+              npm,
             },
             name: model.id,
           },

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -1,0 +1,45 @@
+import z from "zod"
+import { Provider } from "./provider"
+
+export namespace ProviderModelDetection.OpenAICompatible {
+  export const ListModelResponse = z.object({
+    object: z.string(),
+    data: z.array(
+      z.object({
+        id: z.string(),
+        object: z.string().optional(),
+        created: z.number().optional(),
+        owned_by: z.string().optional(),
+      }),
+    ),
+  })
+  export type ListModelResponse = z.infer<typeof ListModelResponse>
+
+  function filterModelID(modelID: string): boolean {
+    return !(modelID.includes("embedding") || modelID.includes("embed"))
+  }
+
+  export async function getModelIDs(baseURL: string): Promise<string[]> {
+    let res: Response
+    let parsedRes: ListModelResponse
+
+    try {
+      res = await fetch(`${baseURL}/models`)
+    } catch (error) {
+      throw new Error(`failed to fetch: ${error}`)
+    }
+    if (!res.ok) {
+      throw new Error(`failed to fetch: http status ${res.status}`)
+    }
+    try {
+      parsedRes = ListModelResponse.parse(await res.json())
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`failed to parse response: ${error.message}`)
+      }
+      throw new Error(`unknown error: ${error}`)
+    }
+
+    return parsedRes.data.map((model) => model.id).filter(filterModelID)
+  }
+}

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -137,7 +137,6 @@ export namespace ProviderModelDetection.OpenAICompatible {
               url: baseURL,
               npm: "@ai-sdk/openai-compatible",
             },
-            name: model.id,
           },
         ])
     )

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -66,7 +66,7 @@ export namespace ProviderModelDetection {
     provider: Provider.Info,
     configProvider?: Config.Provider,
     modelsDevProvider?: ModelsDev.Provider,
-  ): Promise<undefined> {
+  ): Promise<void> {
     const providerNPM = configProvider?.npm ?? modelsDevProvider?.npm ?? "@ai-sdk/openai-compatible"
     const providerBaseURL = configProvider?.options?.baseURL ?? configProvider?.api ?? modelsDevProvider?.api
 
@@ -123,26 +123,21 @@ export namespace ProviderModelDetection.OpenAICompatible {
     try {
       res = await fetchFn(`${baseURL}/models`, {
         headers,
-        signal: AbortSignal.timeout(5 * 1000),
+        signal: AbortSignal.timeout(3 * 1000),
       })
     } catch (error) {
-      throw new Error(`failed to fetch: ${error}`)
+      throw new Error(`failed to fetch ${baseURL}/models\n${error}`)
     }
     if (!res.ok) {
-      throw new Error(`failed to fetch: http status ${res.status}`)
+      throw new Error(`bad http status ${res.status}`)
     }
     try {
       parsed = OpenAICompatibleResponse.parse(await res.json())
     } catch (error) {
       if (error instanceof z.ZodError) {
-        throw new Error(`failed to parse response: ${error.message}`)
+        throw new Error(`bad data structure\n${error}`)
       }
-      throw new Error(`unknown error: ${error}`)
-    }
-
-    let npm = "@ai-sdk/openai-compatible"
-    if (provider.id === "github-copilot" || provider.id === "github-copilot-enterprise") {
-      npm = "@ai-sdk/github-copilot"
+      throw new Error(`unknown error\n${error}`)
     }
 
     return Object.fromEntries(
@@ -156,7 +151,7 @@ export namespace ProviderModelDetection.OpenAICompatible {
             api: {
               id: model.id,
               url: baseURL,
-              npm,
+              npm: "@ai-sdk/openai-compatible",
             },
             name: model.id,
           },

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -1,4 +1,5 @@
 import z from "zod"
+import { iife } from "@/util/iife"
 import { Config } from "../config/config"
 import { ModelsDev } from "./models"
 import { Provider } from "./provider"
@@ -70,13 +71,12 @@ export namespace ProviderModelDetection {
     const providerNPM = configProvider?.npm ?? modelsDevProvider?.npm ?? "@ai-sdk/openai-compatible"
     const providerBaseURL = configProvider?.options?.baseURL ?? configProvider?.api ?? modelsDevProvider?.api
 
-    let detectedModels: Record<string, Partial<Provider.Model>> | undefined = undefined
-    if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
-      detectedModels = await ProviderModelDetection.OpenAICompatible.listModels(providerBaseURL, provider)
-    } else {
-      return
-    }
-    if (detectedModels === undefined) return
+    const detectedModels = await iife(async () => {
+      if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
+        return await ProviderModelDetection.OpenAICompatible.listModels(providerBaseURL, provider)
+      }
+    })
+    if (!detectedModels) return
 
     // Models detected from provider and config are kept
     const modelIDs = Array.from(new Set([
@@ -90,7 +90,7 @@ export namespace ProviderModelDetection {
         detectedModels[modelID],
         provider.models[modelID],
         provider.id,
-        providerBaseURL,
+        providerBaseURL!,
         modelID,
       ),
     ]))
@@ -112,33 +112,17 @@ export namespace ProviderModelDetection.OpenAICompatible {
   type OpenAICompatibleResponse = z.infer<typeof OpenAICompatibleResponse>
 
   export async function listModels(baseURL: string, provider: Provider.Info): Promise<Record<string, Partial<Provider.Model>>> {
-    let res: Response
-    let parsed: OpenAICompatibleResponse
-
     const fetchFn = provider.options["fetch"] ?? fetch
     const apiKey = provider.options["apiKey"] ?? provider.key ?? ""
     const headers = new Headers()
     if (apiKey) headers.append("Authorization", `Bearer ${apiKey}`)
 
-    try {
-      res = await fetchFn(`${baseURL}/models`, {
-        headers,
-        signal: AbortSignal.timeout(3 * 1000),
-      })
-    } catch (error) {
-      throw new Error(`failed to fetch ${baseURL}/models\n${error}`)
-    }
-    if (!res.ok) {
-      throw new Error(`bad http status ${res.status}`)
-    }
-    try {
-      parsed = OpenAICompatibleResponse.parse(await res.json())
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        throw new Error(`bad data structure\n${error}`)
-      }
-      throw new Error(`unknown error\n${error}`)
-    }
+    const res = await fetchFn(`${baseURL}/models`, {
+      headers,
+      signal: AbortSignal.timeout(3 * 1000),
+    })
+    if (!res.ok) throw new Error(`bad http status ${res.status}`)
+    const parsed = OpenAICompatibleResponse.parse(await res.json())
 
     return Object.fromEntries(
       parsed.data

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -24,7 +24,9 @@ export namespace ProviderModelDetection.OpenAICompatible {
     let parsedRes: ListModelResponse
 
     try {
-      res = await fetch(`${baseURL}/models`)
+      res = await fetch(`${baseURL}/models`, {
+        signal: AbortSignal.timeout(5 * 1000),
+      })
     } catch (error) {
       throw new Error(`failed to fetch: ${error}`)
     }

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -1,8 +1,104 @@
 import z from "zod"
+import { Config } from "../config/config"
+import { ModelsDev } from "./models"
 import { Provider } from "./provider"
 
+export namespace ProviderModelDetection {
+  function mergeModel(
+    detectedModel: Partial<Provider.Model> | undefined,
+    providerModel: Provider.Model | undefined,
+    providerID: string,
+    providerBaseURL: string,
+    modelID: string,
+  ): Provider.Model {
+    return {
+      id: detectedModel?.id ?? providerModel?.id ?? modelID,
+      providerID: detectedModel?.providerID ?? providerModel?.providerID ?? providerID,
+      api: {
+        id: modelID,
+        url: detectedModel?.api?.url ?? providerModel?.api?.url ?? providerBaseURL,
+        npm: detectedModel?.api?.npm ?? providerModel?.api?.npm ?? "@ai-sdk/openai-compatible",
+      },
+      name: detectedModel?.name ?? providerModel?.name ?? modelID,
+      family: detectedModel?.family ?? providerModel?.family ?? "",
+      capabilities: {
+        temperature: detectedModel?.capabilities?.temperature ?? providerModel?.capabilities?.temperature ?? false,
+        reasoning: detectedModel?.capabilities?.reasoning ?? providerModel?.capabilities?.reasoning ?? false,
+        attachment: detectedModel?.capabilities?.attachment ?? providerModel?.capabilities?.attachment ?? false,
+        toolcall: detectedModel?.capabilities?.toolcall ?? providerModel?.capabilities?.toolcall ?? true,
+        input: {
+          text: detectedModel?.capabilities?.input?.text ?? providerModel?.capabilities?.input?.text ?? true,
+          audio: detectedModel?.capabilities?.input?.audio ?? providerModel?.capabilities?.input?.audio ?? false,
+          image: detectedModel?.capabilities?.input?.image ?? providerModel?.capabilities?.input?.image ?? false,
+          video: detectedModel?.capabilities?.input?.video ?? providerModel?.capabilities?.input?.video ?? false,
+          pdf: detectedModel?.capabilities?.input?.pdf ?? providerModel?.capabilities?.input?.pdf ?? false,
+        },
+        output: {
+          text: detectedModel?.capabilities?.output?.text ?? providerModel?.capabilities?.output?.text ?? true,
+          audio: detectedModel?.capabilities?.output?.audio ?? providerModel?.capabilities?.output?.audio ?? false,
+          image: detectedModel?.capabilities?.output?.image ?? providerModel?.capabilities?.output?.image ?? false,
+          video: detectedModel?.capabilities?.output?.video ?? providerModel?.capabilities?.output?.video ?? false,
+          pdf: detectedModel?.capabilities?.output?.pdf ?? providerModel?.capabilities?.output?.pdf ?? false,
+        },
+        interleaved: detectedModel?.capabilities?.interleaved ?? providerModel?.capabilities?.interleaved ?? false,
+      },
+      cost: {
+        input: detectedModel?.cost?.input ?? providerModel?.cost?.input ?? 0,
+        output: detectedModel?.cost?.output ?? providerModel?.cost?.output ?? 0,
+        cache: {
+          read: detectedModel?.cost?.cache?.read ?? providerModel?.cost?.cache?.read ?? 0,
+          write: detectedModel?.cost?.cache?.write ?? providerModel?.cost?.cache?.write ?? 0,
+        },
+      },
+      limit: {
+        context: detectedModel?.limit?.context ?? providerModel?.limit?.context ?? 0,
+        output: detectedModel?.limit?.output ?? providerModel?.limit?.output ?? 0,
+      },
+      status: detectedModel?.status ?? providerModel?.status ?? "active",
+      options: detectedModel?.options ?? providerModel?.options ?? {},
+      headers: detectedModel?.headers ?? providerModel?.headers ?? {},
+      release_date: detectedModel?.release_date ?? providerModel?.release_date ?? "",
+      variants: detectedModel?.variants ?? providerModel?.variants ?? {},
+    }
+  }
+
+  export async function populateModels(
+    provider: Provider.Info,
+    configProvider?: Config.Provider,
+    modelsDevProvider?: ModelsDev.Provider,
+  ): Promise<undefined> {
+    const providerNPM = configProvider?.npm ?? modelsDevProvider?.npm ?? "@ai-sdk/openai-compatible"
+    const providerBaseURL = configProvider?.options?.baseURL ?? configProvider?.api ?? modelsDevProvider?.api
+
+    let detectedModels: Record<string, Partial<Provider.Model>> | undefined = undefined
+    if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
+      detectedModels = await ProviderModelDetection.OpenAICompatible.listModels(providerBaseURL, provider)
+    } else {
+      return
+    }
+    if (detectedModels === undefined) return
+
+    // Models detected from provider and config are kept
+    const modelIDs = Array.from(new Set([
+      ...Object.keys(detectedModels),
+      ...Object.keys(configProvider?.models ?? {}),
+    ]))
+    // Use detected metadata -> config metadata (-> Models.dev metadata)
+    provider.models = Object.fromEntries(modelIDs.map((modelID) => [
+      modelID,
+      mergeModel(
+        detectedModels[modelID],
+        provider.models[modelID],
+        provider.id,
+        providerBaseURL,
+        modelID,
+      ),
+    ]))
+  }
+}
+
 export namespace ProviderModelDetection.OpenAICompatible {
-  export const ListModelResponse = z.object({
+  const OpenAICompatibleResponse = z.object({
     object: z.string(),
     data: z.array(
       z.object({
@@ -13,18 +109,20 @@ export namespace ProviderModelDetection.OpenAICompatible {
       }),
     ),
   })
-  export type ListModelResponse = z.infer<typeof ListModelResponse>
+  type OpenAICompatibleResponse = z.infer<typeof OpenAICompatibleResponse>
 
-  function filterModelID(modelID: string): boolean {
-    return !(modelID.includes("embedding") || modelID.includes("embed"))
-  }
-
-  export async function getModelIDs(baseURL: string): Promise<string[]> {
+  export async function listModels(baseURL: string, provider: Provider.Info): Promise<Record<string, Partial<Provider.Model>>> {
     let res: Response
-    let parsedRes: ListModelResponse
+    let parsed: OpenAICompatibleResponse
+
+    const fetchFn = provider.options["fetch"] ?? fetch
+    const apiKey = provider.options["apiKey"] ?? provider.key ?? ""
+    const headers = new Headers()
+    if (apiKey) headers.append("Authorization", `Bearer ${apiKey}`)
 
     try {
-      res = await fetch(`${baseURL}/models`, {
+      res = await fetchFn(`${baseURL}/models`, {
+        headers,
         signal: AbortSignal.timeout(5 * 1000),
       })
     } catch (error) {
@@ -34,7 +132,7 @@ export namespace ProviderModelDetection.OpenAICompatible {
       throw new Error(`failed to fetch: http status ${res.status}`)
     }
     try {
-      parsedRes = ListModelResponse.parse(await res.json())
+      parsed = OpenAICompatibleResponse.parse(await res.json())
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new Error(`failed to parse response: ${error.message}`)
@@ -42,6 +140,22 @@ export namespace ProviderModelDetection.OpenAICompatible {
       throw new Error(`unknown error: ${error}`)
     }
 
-    return parsedRes.data.map((model) => model.id).filter(filterModelID)
+    return Object.fromEntries(
+      parsed.data
+        .filter((model) => model.id && !model.id.includes("embedding") && !model.id.includes("embed"))
+        .map((model) => [
+          model.id,
+          {
+            id: model.id,
+            providerID: provider.id,
+            api: {
+              id: model.id,
+              url: baseURL,
+              npm: "@ai-sdk/openai-compatible",
+            },
+            name: model.id,
+          },
+        ])
+    )
   }
 }

--- a/packages/opencode/src/provider/model-detection.ts
+++ b/packages/opencode/src/provider/model-detection.ts
@@ -1,65 +1,68 @@
 import z from "zod"
 import { iife } from "@/util/iife"
+import { Log } from "@/util/log"
 import { Config } from "../config/config"
 import { ModelsDev } from "./models"
 import { Provider } from "./provider"
 
 export namespace ProviderModelDetection {
   function mergeModel(
-    detectedModel: Partial<Provider.Model> | undefined,
+    detectedModel: Partial<Provider.Model>,
     providerModel: Provider.Model | undefined,
+    modelID: string,
     providerID: string,
     providerBaseURL: string,
-    modelID: string,
   ): Provider.Model {
     return {
-      id: detectedModel?.id ?? providerModel?.id ?? modelID,
-      providerID: detectedModel?.providerID ?? providerModel?.providerID ?? providerID,
+      id: modelID,
+      providerID: detectedModel.providerID ?? providerModel?.providerID ?? providerID,
       api: {
         id: modelID,
-        url: detectedModel?.api?.url ?? providerModel?.api?.url ?? providerBaseURL,
-        npm: detectedModel?.api?.npm ?? providerModel?.api?.npm ?? "@ai-sdk/openai-compatible",
+        url: detectedModel.api?.url ?? providerModel?.api?.url ?? providerBaseURL,
+        npm: detectedModel.api?.npm ?? providerModel?.api?.npm ?? "@ai-sdk/openai-compatible",
       },
-      name: detectedModel?.name ?? providerModel?.name ?? modelID,
-      family: detectedModel?.family ?? providerModel?.family ?? "",
+      name: detectedModel.name ?? providerModel?.name ?? modelID,
+      family: detectedModel.family ?? providerModel?.family ?? "",
       capabilities: {
-        temperature: detectedModel?.capabilities?.temperature ?? providerModel?.capabilities?.temperature ?? false,
-        reasoning: detectedModel?.capabilities?.reasoning ?? providerModel?.capabilities?.reasoning ?? false,
-        attachment: detectedModel?.capabilities?.attachment ?? providerModel?.capabilities?.attachment ?? false,
-        toolcall: detectedModel?.capabilities?.toolcall ?? providerModel?.capabilities?.toolcall ?? true,
+        temperature: detectedModel.capabilities?.temperature ?? providerModel?.capabilities?.temperature ?? false,
+        reasoning: detectedModel.capabilities?.reasoning ?? providerModel?.capabilities?.reasoning ?? false,
+        attachment: detectedModel.capabilities?.attachment ?? providerModel?.capabilities?.attachment ?? false,
+        toolcall: detectedModel.capabilities?.toolcall ?? providerModel?.capabilities?.toolcall ?? true,
         input: {
-          text: detectedModel?.capabilities?.input?.text ?? providerModel?.capabilities?.input?.text ?? true,
-          audio: detectedModel?.capabilities?.input?.audio ?? providerModel?.capabilities?.input?.audio ?? false,
-          image: detectedModel?.capabilities?.input?.image ?? providerModel?.capabilities?.input?.image ?? false,
-          video: detectedModel?.capabilities?.input?.video ?? providerModel?.capabilities?.input?.video ?? false,
-          pdf: detectedModel?.capabilities?.input?.pdf ?? providerModel?.capabilities?.input?.pdf ?? false,
+          text: detectedModel.capabilities?.input?.text ?? providerModel?.capabilities?.input?.text ?? true,
+          audio: detectedModel.capabilities?.input?.audio ?? providerModel?.capabilities?.input?.audio ?? false,
+          image: detectedModel.capabilities?.input?.image ?? providerModel?.capabilities?.input?.image ?? false,
+          video: detectedModel.capabilities?.input?.video ?? providerModel?.capabilities?.input?.video ?? false,
+          pdf: detectedModel.capabilities?.input?.pdf ?? providerModel?.capabilities?.input?.pdf ?? false,
         },
         output: {
-          text: detectedModel?.capabilities?.output?.text ?? providerModel?.capabilities?.output?.text ?? true,
-          audio: detectedModel?.capabilities?.output?.audio ?? providerModel?.capabilities?.output?.audio ?? false,
-          image: detectedModel?.capabilities?.output?.image ?? providerModel?.capabilities?.output?.image ?? false,
-          video: detectedModel?.capabilities?.output?.video ?? providerModel?.capabilities?.output?.video ?? false,
-          pdf: detectedModel?.capabilities?.output?.pdf ?? providerModel?.capabilities?.output?.pdf ?? false,
+          text: detectedModel.capabilities?.output?.text ?? providerModel?.capabilities?.output?.text ?? true,
+          audio: detectedModel.capabilities?.output?.audio ?? providerModel?.capabilities?.output?.audio ?? false,
+          image: detectedModel.capabilities?.output?.image ?? providerModel?.capabilities?.output?.image ?? false,
+          video: detectedModel.capabilities?.output?.video ?? providerModel?.capabilities?.output?.video ?? false,
+          pdf: detectedModel.capabilities?.output?.pdf ?? providerModel?.capabilities?.output?.pdf ?? false,
         },
-        interleaved: detectedModel?.capabilities?.interleaved ?? providerModel?.capabilities?.interleaved ?? false,
+        interleaved: detectedModel.capabilities?.interleaved ?? providerModel?.capabilities?.interleaved ?? false,
       },
       cost: {
-        input: detectedModel?.cost?.input ?? providerModel?.cost?.input ?? 0,
-        output: detectedModel?.cost?.output ?? providerModel?.cost?.output ?? 0,
+        input: detectedModel.cost?.input ?? providerModel?.cost?.input ?? 0,
+        output: detectedModel.cost?.output ?? providerModel?.cost?.output ?? 0,
         cache: {
-          read: detectedModel?.cost?.cache?.read ?? providerModel?.cost?.cache?.read ?? 0,
-          write: detectedModel?.cost?.cache?.write ?? providerModel?.cost?.cache?.write ?? 0,
+          read: detectedModel.cost?.cache?.read ?? providerModel?.cost?.cache?.read ?? 0,
+          write: detectedModel.cost?.cache?.write ?? providerModel?.cost?.cache?.write ?? 0,
         },
+        experimentalOver200K: detectedModel.cost?.experimentalOver200K ?? providerModel?.cost?.experimentalOver200K,
       },
       limit: {
-        context: detectedModel?.limit?.context ?? providerModel?.limit?.context ?? 0,
-        output: detectedModel?.limit?.output ?? providerModel?.limit?.output ?? 0,
+        context: detectedModel.limit?.context ?? providerModel?.limit?.context ?? 0,
+        input: detectedModel.limit?.input ?? providerModel?.limit?.input ?? 0,
+        output: detectedModel.limit?.output ?? providerModel?.limit?.output ?? 0,
       },
-      status: detectedModel?.status ?? providerModel?.status ?? "active",
-      options: detectedModel?.options ?? providerModel?.options ?? {},
-      headers: detectedModel?.headers ?? providerModel?.headers ?? {},
-      release_date: detectedModel?.release_date ?? providerModel?.release_date ?? "",
-      variants: detectedModel?.variants ?? providerModel?.variants ?? {},
+      status: detectedModel.status ?? providerModel?.status ?? "active",
+      options: detectedModel.options ?? providerModel?.options ?? {},
+      headers: detectedModel.headers ?? providerModel?.headers ?? {},
+      release_date: detectedModel.release_date ?? providerModel?.release_date ?? "",
+      variants: detectedModel.variants ?? providerModel?.variants ?? {},
     }
   }
 
@@ -68,32 +71,47 @@ export namespace ProviderModelDetection {
     configProvider?: Config.Provider,
     modelsDevProvider?: ModelsDev.Provider,
   ): Promise<void> {
+    const log = Log.create({ service: "provider.model-detection" })
+
     const providerNPM = configProvider?.npm ?? modelsDevProvider?.npm ?? "@ai-sdk/openai-compatible"
-    const providerBaseURL = configProvider?.options?.baseURL ?? configProvider?.api ?? modelsDevProvider?.api
+    const providerBaseURL = configProvider?.options?.baseURL ?? configProvider?.api ?? modelsDevProvider?.api ?? ""
 
     const detectedModels = await iife(async () => {
-      if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
-        return await ProviderModelDetection.OpenAICompatible.listModels(providerBaseURL, provider)
+      if (provider.id === "opencode") return
+
+      try {
+        if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
+          log.info("using OpenAI-compatible method", { providerID: provider.id })
+          return await ProviderModelDetection.OpenAICompatible.listModels(providerBaseURL, provider)
+        }
+      } catch (error) {
+        log.warn(`failed to populate models\n${error}`, { providerID: provider.id })
       }
     })
-    if (!detectedModels) return
+    if (!detectedModels || Object.entries(detectedModels).length === 0) return
 
-    // Models detected from provider and config are kept
+    // Only keep models detected and models specified in config
     const modelIDs = Array.from(new Set([
       ...Object.keys(detectedModels),
       ...Object.keys(configProvider?.models ?? {}),
     ]))
-    // Use detected metadata -> config metadata (-> Models.dev metadata)
-    provider.models = Object.fromEntries(modelIDs.map((modelID) => [
-      modelID,
-      mergeModel(
+    // Provider models are merged from config and Models.dev, delete models only from Models.dev
+    for (const [modelID] of Object.entries(provider.models)) {
+      if (!modelIDs.includes(modelID)) delete provider.models[modelID]
+    }
+    // Add detected models, and take precedence over provider models (which are from config and Models.dev)
+    for (const modelID of modelIDs) {
+      if (!(modelID in detectedModels)) continue
+      provider.models[modelID] = mergeModel(
         detectedModels[modelID],
         provider.models[modelID],
-        provider.id,
-        providerBaseURL!,
         modelID,
-      ),
-    ]))
+        provider.id,
+        providerBaseURL,
+      )
+    }
+
+    log.info("populated models", { providerID: provider.id })
   }
 }
 
@@ -127,18 +145,7 @@ export namespace ProviderModelDetection.OpenAICompatible {
     return Object.fromEntries(
       parsed.data
         .filter((model) => model.id && !model.id.includes("embedding") && !model.id.includes("embed"))
-        .map((model) => [
-          model.id,
-          {
-            id: model.id,
-            providerID: provider.id,
-            api: {
-              id: model.id,
-              url: baseURL,
-              npm: "@ai-sdk/openai-compatible",
-            },
-          },
-        ])
+        .map((model) => [model.id, {}])
     )
   }
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -739,25 +739,6 @@ export namespace Provider {
         models: existing?.models ?? {},
       }
 
-      // (local providers only) auto-detect models and extend config
-      if (provider.options?.autoDetectModels) {
-        const providerNPM = provider.npm ?? modelsDev[providerID]?.npm ?? "@ai-sdk/openai-compatible"
-        const providerBaseURL = provider.options?.baseURL ?? provider.api ?? modelsDev[providerID]?.api
-        if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
-          try {
-            const modelIDs = await ProviderModelDetection.OpenAICompatible.getModelIDs(providerBaseURL)
-            const providerModels = provider.models ?? {}
-            modelIDs.forEach((modelID) => {
-              if (!(modelID in providerModels)) providerModels[modelID] = {}
-            })
-            provider.models = providerModels
-            parsed.models = {}
-          } catch (error) {
-            log.warn("failed to auto-detect models", { providerID, error })
-          }
-        }
-      }
-
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {
         const existingModel = parsed.models[model.id ?? modelID]
         const name = iife(() => {
@@ -962,6 +943,14 @@ export namespace Provider {
       }
 
       log.info("found", { providerID })
+    }
+
+    for (const [providerID, provider] of Object.entries(providers)) {
+      try {
+        await ProviderModelDetection.populateModels(provider, config.provider?.[providerID], modelsDev[providerID])
+      } catch (error) {
+        log.warn("failed to autodetect models", { providerID, error })
+      }
     }
 
     return {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -914,7 +914,7 @@ export namespace Provider {
           log.info("detect models", { providerID })
         }
         catch (error) {
-          log.warn(`detect models ${error}`, { providerID })
+          log.warn(`failed to detect models\n${error}`, { providerID })
         }
       })
     )

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -909,13 +909,7 @@ export namespace Provider {
     // detect and populate models
     await Promise.all(
       Object.entries(providers).map(async ([providerID, provider]) => {
-        try {
-          await ProviderModelDetection.populateModels(provider, config.provider?.[providerID], modelsDev[providerID])
-          log.info("detect models", { providerID })
-        }
-        catch (error) {
-          log.warn(`failed to detect models\n${error}`, { providerID })
-        }
+        await ProviderModelDetection.populateModels(provider, config.provider?.[providerID], modelsDev[providerID])
       })
     )
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -37,6 +37,7 @@ import { createPerplexity } from "@ai-sdk/perplexity"
 import { createVercel } from "@ai-sdk/vercel"
 import { createGitLab } from "@gitlab/gitlab-ai-provider"
 import { ProviderTransform } from "./transform"
+import { ProviderModelDetection } from "./model-detection"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
@@ -736,6 +737,25 @@ export namespace Provider {
         options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
         source: "config",
         models: existing?.models ?? {},
+      }
+
+      // (local providers only) auto-detect models and extend config
+      if (provider.options?.autoDetectModels) {
+        const providerNPM = provider.npm ?? modelsDev[providerID]?.npm ?? "@ai-sdk/openai-compatible"
+        const providerBaseURL = provider.options?.baseURL ?? provider.api ?? modelsDev[providerID]?.api
+        if (providerNPM === "@ai-sdk/openai-compatible" && providerBaseURL) {
+          try {
+            const modelIDs = await ProviderModelDetection.OpenAICompatible.getModelIDs(providerBaseURL)
+            const providerModels = provider.models ?? {}
+            modelIDs.forEach((modelID) => {
+              if (!(modelID in providerModels)) providerModels[modelID] = {}
+            })
+            provider.models = providerModels
+            parsed.models = {}
+          } catch (error) {
+            log.warn("failed to auto-detect models", { providerID, error })
+          }
+        }
       }
 
       for (const [modelID, model] of Object.entries(provider.models ?? {})) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -945,11 +945,12 @@ export namespace Provider {
       log.info("found", { providerID })
     }
 
+    // auto-detect models
     for (const [providerID, provider] of Object.entries(providers)) {
       try {
         await ProviderModelDetection.populateModels(provider, config.provider?.[providerID], modelsDev[providerID])
       } catch (error) {
-        log.warn("failed to autodetect models", { providerID, error })
+        log.warn("failed to auto-detect models", { providerID, error })
       }
     }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -906,6 +906,19 @@ export namespace Provider {
       mergeProvider(providerID, partial)
     }
 
+    // detect and populate models
+    await Promise.all(
+      Object.entries(providers).map(async ([providerID, provider]) => {
+        try {
+          await ProviderModelDetection.populateModels(provider, config.provider?.[providerID], modelsDev[providerID])
+          log.info("detect models", { providerID })
+        }
+        catch (error) {
+          log.warn(`detect models ${error}`, { providerID })
+        }
+      })
+    )
+
     for (const [providerID, provider] of Object.entries(providers)) {
       if (!isProviderAllowed(providerID)) {
         delete providers[providerID]
@@ -943,15 +956,6 @@ export namespace Provider {
       }
 
       log.info("found", { providerID })
-    }
-
-    // auto-detect models
-    for (const [providerID, provider] of Object.entries(providers)) {
-      try {
-        await ProviderModelDetection.populateModels(provider, config.provider?.[providerID], modelsDev[providerID])
-      } catch (error) {
-        log.warn("failed to auto-detect models", { providerID, error })
-      }
     }
 
     return {


### PR DESCRIPTION
### What does this PR do?

This PR adds automatic model detection/discovery for providers that use `npm: @ai-sdk/openai-compatible`. It allows OpenCode to utilize the `GET /v1/models` API to populate the model list.

Models may come from 3 sources now: Models.dev, config file, and detected via API. The "filtering" logic is: the model will be visible, if it's detected via API or declared in config file; if it is visible, its metadata will be merged from API -> config -> Models.dev (with prescedence from high to low).

Fixes #6231
Fixes #4232
Fixes #2456

Note: I understand it may be by design to rely entirely on `Models.dev` for providers and models, but having OpenCode core automatically populate the model list would be a major improvement for users running LM Studio or other local providers.

### How did you verify your code works?

1. I ran an LM Studio server locally and downloaded two models (`openai/gpt-oss-20b` and `zai-org/glm-4.6v-flash`).
2. I configured my `~/.config/opencode/opencode.json` with two LM Studio providers and two models. One of the models does not exist in LM Studio, but should still appear later. (File attached: [opencode.json](https://github.com/user-attachments/files/24605320/opencode.json)).
3. I used a debugger and breakpoints to inspect the `providers` value at `packages/opencode/src/provider/provider.ts#958`, and it looked correct to me.
4. I ran `bun dev -- models`, and the output looked correct.
5. I launched the TUI with `bun dev`, ran `/models`, and the output also looked correct.
6. From the TUI, I was able to use both local models in LM Studio and cloud models I had previously configured.
7. I shut down the LM Studio server and repeated steps 3–6; everything behaved as expected.