### PR TITLE
fix(provider): add gpt-5.1-codex-max model to OpenRouter

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -900,6 +900,64 @@ export namespace Provider {
         }))
       }
 
+      // Add missing models to OpenRouter that exist in OpenRouter's API but not in models.dev
+      if (providerID === "openrouter" && !provider.models["openai/gpt-5.1-codex-max"]) {
+        const codexBase = provider.models["openai/gpt-5.1-codex"]
+        if (codexBase) {
+          const codexMaxModel: Model = {
+            id: "openai/gpt-5.1-codex-max",
+            providerID: "openrouter",
+            name: "GPT-5.1 Codex Max",
+            family: "gpt-5-codex-max",
+            api: {
+              id: "openai/gpt-5.1-codex-max",
+              url: codexBase.api.url,
+              npm: codexBase.api.npm,
+            },
+            status: "active",
+            headers: {},
+            options: {},
+            cost: {
+              input: 1.1,
+              output: 9,
+              cache: {
+                read: 0.11,
+                write: 0,
+              },
+            },
+            limit: {
+              context: 400000,
+              output: 128000,
+            },
+            capabilities: {
+              temperature: false,
+              reasoning: true,
+              attachment: true,
+              toolcall: true,
+              input: {
+                text: true,
+                audio: false,
+                image: true,
+                video: false,
+                pdf: false,
+              },
+              output: {
+                text: true,
+                audio: false,
+                image: false,
+                video: false,
+                pdf: false,
+              },
+              interleaved: false,
+            },
+            release_date: "2025-12-08",
+            variants: {},
+          }
+          codexMaxModel.variants = ProviderTransform.variants(codexMaxModel)
+          provider.models["openai/gpt-5.1-codex-max"] = codexMaxModel
+        }
+      }
+
       const configProvider = config.provider?.[providerID]
 
       for (const [modelID, model] of Object.entries(provider.models)) {


### PR DESCRIPTION
## Summary

Fixes #8291

The `openai/gpt-5.1-codex-max` model is available on OpenRouter's API but was not included in the models.dev database, making it unavailable to OpenCode users connecting via OpenRouter.

## Changes

- Added dynamic model injection for `openai/gpt-5.1-codex-max` to the OpenRouter provider
- Model is only added if the base `openai/gpt-5.1-codex` model exists (to ensure we have a valid API configuration to inherit from)
- Follows the same pattern used for GitHub Copilot model handling

### Model specifications:
- Context limit: 400,000 tokens
- Output limit: 128,000 tokens
- Supports: reasoning, tool calls, image input
- Pricing: $1.1/M input, $9/M output, $0.11/M cache read

## Test plan

- [ ] Verify model appears in `/models` when using OpenRouter provider
- [ ] Verify model is selectable and usable for chat
- [ ] Verify existing OpenRouter models continue to work

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)