### PR TITLE
docs: update permissions documentation with wildcard and rule evaluation

### DIFF
--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -71,11 +71,56 @@ Rules are evaluated by pattern match, with the **last matching rule winning**. A
 
 ### Wildcards
 
-Permission patterns use simple wildcard matching:
+Wildcards work on **both permission names and patterns**. They use simple wildcard matching:
 
 - `*` matches zero or more of any character
 - `?` matches exactly one character
 - All other characters match literally
+
+**Examples:**
+
+```json title="opencode.json"
+{
+  "permission": {
+    "*": "allow", // allow all tools by default (includes custom tools)
+    "web*": "deny", // deny all web tools
+    "websearch": "ask", // but ask for websearch
+    "bash": {
+      "git *": "allow", // allow git commands
+      "rm *": "deny" // deny rm commands
+    }
+  }
+}
+```
+
+:::note
+[Learn more](/docs/custom-tools) about creating and configuring custom tools.
+:::
+
+````
+
+---
+
+## Rule Evaluation
+
+Within each permission object, **the last matching pattern wins**. Put catch-all `"*"` rules first, then specific overrides:
+
+```json title="opencode.json"
+{
+  "permission": {
+    "bash": {
+      "*": "allow", // catch-all first
+      "rm *": "deny" // specific override after
+    }
+  }
+}
+````
+
+:::warning
+**Never place `"*": "allow"` at the end** — it would match everything and override all previous rules!
+:::
+
+Agent permissions override global permissions. [Learn more](/docs/config#precedence-order) about how multiple config files are merged together.
 
 ---
 
@@ -102,24 +147,34 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 
 ## Defaults
 
-If you don’t specify anything, OpenCode starts from permissive defaults:
+If you don't specify anything, OpenCode starts from these defaults:
 
-- Most permissions default to `"allow"`.
-- `doom_loop` and `external_directory` default to `"ask"`.
-- `read` is `"allow"`, but `.env` files are denied by default:
-
-```json title="opencode.json"
+```json
 {
   "permission": {
+    "*": "allow",
+    "doom_loop": "ask",
+    "external_directory": {
+      "*": "ask"
+    },
+    "question": "deny",
+    "plan_enter": "deny",
+    "plan_exit": "deny",
     "read": {
       "*": "allow",
-      "*.env": "deny",
-      "*.env.*": "deny",
+      "*.env": "ask",
+      "*.env.*": "ask",
       "*.env.example": "allow"
     }
   }
 }
 ```
+
+- Most tools default to `"allow"`.
+- `read` defaults to `"allow"`, but `.env` files require approval (`"ask"`).
+- `doom_loop` and `external_directory` default to `"ask"`.
+- `question`, `plan_enter`, and `plan_exit` default to `"deny"`.
+- `read` defaults to "allow", `.env` defaults to `"ask"`.
 
 ---
 

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -85,6 +85,7 @@ Wildcards work on **both permission names and patterns**. They use simple wildca
     "*": "allow", // allow all tools by default (includes custom tools)
     "web*": "deny", // deny all web tools
     "websearch": "ask", // but ask for websearch
+    "math_add": "ask",  // ask for custom tool
     "bash": {
       "git *": "allow", // allow git commands
       "rm *": "deny" // deny rm commands
@@ -96,8 +97,6 @@ Wildcards work on **both permission names and patterns**. They use simple wildca
 :::note
 [Learn more](/docs/custom-tools) about creating and configuring custom tools.
 :::
-
-````
 
 ---
 
@@ -171,10 +170,9 @@ If you don't specify anything, OpenCode starts from these defaults:
 ```
 
 - Most tools default to `"allow"`.
-- `read` defaults to `"allow"`, but `.env` files require approval (`"ask"`).
+- `read` defaults to `"allow"`, but `.env` files require approval `"ask"`.
 - `doom_loop` and `external_directory` default to `"ask"`.
 - `question`, `plan_enter`, and `plan_exit` default to `"deny"`.
-- `read` defaults to "allow", `.env` defaults to `"ask"`.
 
 ---
 

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -113,7 +113,7 @@ Within each permission object, **the last matching pattern wins**. Put catch-all
     }
   }
 }
-````
+```
 
 :::warning
 **Never place `"*": "allow"` at the end** — it would match everything and override all previous rules!
@@ -148,13 +148,14 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 
 If you don't specify anything, OpenCode starts from these defaults:
 
-```json
+```json title="opencode.json"
 {
   "permission": {
     "*": "allow",
     "doom_loop": "ask",
     "external_directory": {
-      "*": "ask"
+      "*": "ask",
+      /* tool output allow, see implementation */
     },
     "question": "deny",
     "plan_enter": "deny",
@@ -170,7 +171,7 @@ If you don't specify anything, OpenCode starts from these defaults:
 ```
 
 - Most tools default to `"allow"`.
-- `read` defaults to `"allow"`, but `.env` files require approval `"ask"`.
+- `read` defaults to `"allow"`, but `.env` default to `"ask"`.
 - `doom_loop` and `external_directory` default to `"ask"`.
 - `question`, `plan_enter`, and `plan_exit` default to `"deny"`.
 


### PR DESCRIPTION
Updated permission patterns and defaults in documentation.

### What does this PR do?
This pull request updates the documentation for configuring permissions in OpenCode.

Clarified permission configuration docs:
- Added wildcard examples for permission names and patterns
- Explained rule evaluation order (last matching rule wins) with placement warnings
- Expanded defaults section with explicit config and clearer behavior notes
### How did you verify your code works?
No code changes. I used https://mdxjs.com/playground/ and github preview for the changes to confirm formatting.

### Further Discussion (Why)
I was trying to dig into the docs to understand permissions because I felt that the doc wasn't clear enough and OpenCode felt like it was doing too much without asking.
There is actually a mistake in the docs saying that .env reads are "deny" but the code does not match and has "ask". This could be a bug, but this documentation reflects the current state of the code. Wildcard matching for tool name was also not really documented well.

Default permissions - packages/opencode/src/agent/agent.ts:47-65
Wildcard matching - packages/opencode/src/util/wildcard.ts:4-17
Rule evaluation order - packages/opencode/src/permission/next.ts:223-225