### PR TITLE
fix(session): use directory instead of root for plan mode paths

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -233,7 +233,10 @@ export namespace Session {
   }
 
   export function plan(input: { slug: string; time: { created: number } }) {
-    return path.join(Instance.worktree, ".opencode", "plans", [input.time.created, input.slug].join("-") + ".md")
+    // Use Instance.directory when worktree is "/" (non-git project) to avoid
+    // creating files at root directory (e.g., /.opencode/plans/...)
+    const base = Instance.worktree === "/" ? Instance.directory : Instance.worktree
+    return path.join(base, ".opencode", "plans", [input.time.created, input.slug].join("-") + ".md")
   }
 
   export const get = fn(Identifier.schema("session"), async (id) => {


### PR DESCRIPTION
### What does this PR do?

Fixes #8389

When `Instance.worktree` is "/" (non-git projects), the `Session.plan()` function was creating paths like `/.opencode/plans/...` at the system root, which fails with `EACCES: permission denied, mkdir /.opencode`.

This PR fixes the issue by using `Instance.directory` (the actual working directory) when `worktree` is "/" to create plan files in the correct location.

### How did you verify your code works?

- Code review of the fix logic
- Verified the pattern matches similar handling in `cli/cmd/agent.ts` for global vs project scopes
- Confirmed the typecheck error on `@gitlab/gitlab-ai-provider` is pre-existing in upstream/dev (unrelated to this change)

---
🤖 Generated with Claude Code