### PR TITLE
fix(tui): start server on-demand when opening WebUI from command palette

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -106,6 +106,7 @@ export function tui(input: {
   fetch?: typeof fetch
   events?: EventSource
   onExit?: () => Promise<void>
+  onStartServer?: () => Promise<string>
 }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
@@ -131,6 +132,7 @@ export function tui(input: {
                         directory={input.directory}
                         fetch={input.fetch}
                         events={input.events}
+                        onStartServer={input.onStartServer}
                       >
                         <SyncProvider>
                           <ThemeProvider mode={mode}>
@@ -464,8 +466,12 @@ function App() {
     {
       title: "Open WebUI",
       value: "webui.open",
-      onSelect: () => {
-        open(sdk.url).catch(() => {})
+      onSelect: async () => {
+        let url = sdk.url
+        if (sdk.url.includes("opencode.internal") && sdk.onStartServer) {
+          url = await sdk.onStartServer()
+        }
+        open(url).catch(() => {})
         dialog.clear()
       },
       category: "System",

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -9,7 +9,13 @@ export type EventSource = {
 
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
-  init: (props: { url: string; directory?: string; fetch?: typeof fetch; events?: EventSource }) => {
+  init: (props: {
+    url: string
+    directory?: string
+    fetch?: typeof fetch
+    events?: EventSource
+    onStartServer?: () => Promise<string>
+  }) => {
     const abort = new AbortController()
     const sdk = createOpencodeClient({
       baseUrl: props.url,
@@ -89,6 +95,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       if (timer) clearTimeout(timer)
     })
 
-    return { client: sdk, event: emitter, url: props.url }
+    return { client: sdk, event: emitter, url: props.url, onStartServer: props.onStartServer }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -154,6 +154,12 @@ export const TuiThreadCommand = cmd({
       onExit: async () => {
         await client.call("shutdown", undefined)
       },
+      onStartServer: !shouldStartServer
+        ? async () => {
+            const server = await client.call("server", networkOpts)
+            return server.url
+          }
+        : undefined,
     })
 
     setTimeout(() => {


### PR DESCRIPTION
### What does this PR do?

Fixes #8407
Fixes #7549

When using direct RPC communication (the default mode), the "Open WebUI" command in the command palette was trying to open `http://opencode.internal/` - a placeholder URL that doesn't resolve on any system. This caused DNS errors like:

```
This site can't be reached
opencode.internal's DNS address could not be found.
```

The root cause is that when OpenCode starts without explicit `--port` or network options, it uses direct RPC communication via Worker threads instead of starting an HTTP server. The `sdk.url` in this case is set to the non-routable placeholder.

### The fix

This PR adds an `onStartServer` callback that lazily starts an HTTP server when the user selects "Open WebUI" from the command palette and no server is already running. The callback:
1. Calls the worker RPC to start a real server on localhost
2. Returns the actual URL (e.g., `http://127.0.0.1:4096/`)
3. Opens that URL in the browser

This matches the behavior of `opencode web` which correctly opens localhost.

### How did you verify your code works?

- Code review of the fix logic
- Verified the pattern matches existing RPC calls in thread.ts
- Confirmed typecheck passes (the `@gitlab/gitlab-ai-provider` error is pre-existing in upstream/dev)

---
🤖 Generated with Claude Code