### PR TITLE
docs: add opencode-remote-config plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -33,7 +33,6 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                        |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible         |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                   |
-| [opencode-remote-config](https://github.com/jgordijn/opencode-remote-config)                       | Sync skills, agents, commands, and instructions from Git repositories                          |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events            |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                           |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection        |
@@ -43,6 +42,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                      |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                          |
+| [opencode-remote-config](https://github.com/jgordijn/opencode-remote-config)                       | Sync skills, agents, commands, and instructions from Git repositories                          |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -33,6 +33,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                        |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible         |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                   |
+| [opencode-remote-config](https://github.com/jgordijn/opencode-remote-config)                       | Sync skills, agents, commands, and instructions from Git repositories                          |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events            |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                           |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection        |


### PR DESCRIPTION
Added @jgordijn's opencode-remote-config plugin to the ecosystem documentation.