### PR TITLE
fix(mcp): abort hanging connections to non-standard servers

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -318,38 +318,59 @@ export namespace MCP {
         )
       }
 
-      const transports: Array<{ name: string; transport: TransportWithAuth }> = [
+      const streamableAbort = new AbortController()
+      const sseAbort = new AbortController()
+
+      const transports: Array<{ name: string; transport: TransportWithAuth; abort: AbortController }> = [
         {
           name: "StreamableHTTP",
+          abort: streamableAbort,
           transport: new StreamableHTTPClientTransport(new URL(mcp.url), {
             authProvider,
-            requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
+            requestInit: mcp.headers
+              ? { headers: mcp.headers, signal: streamableAbort.signal }
+              : { signal: streamableAbort.signal },
           }),
         },
         {
           name: "SSE",
+          abort: sseAbort,
           transport: new SSEClientTransport(new URL(mcp.url), {
             authProvider,
-            requestInit: mcp.headers ? { headers: mcp.headers } : undefined,
+            requestInit: mcp.headers
+              ? { headers: mcp.headers, signal: sseAbort.signal }
+              : { signal: sseAbort.signal },
           }),
         },
       ]
 
       let lastError: Error | undefined
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
-      for (const { name, transport } of transports) {
+      for (const { name, transport, abort } of transports) {
         try {
           const client = new Client({
             name: "opencode",
             version: Installation.VERSION,
           })
+          const timer = setTimeout(() => {
+            log.debug("connection timeout, aborting transport", { key, transport: name })
+            abort.abort()
+          }, connectTimeout)
+
           await withTimeout(client.connect(transport), connectTimeout)
+            .then(() => clearTimeout(timer))
+            .catch((error) => {
+              clearTimeout(timer)
+              abort.abort()
+              throw error
+            })
           registerNotificationHandlers(client, key)
           mcpClient = client
           log.info("connected", { key, transport: name })
           status = { status: "connected" }
           break
         } catch (error) {
+          abort.abort()
           lastError = error instanceof Error ? error : new Error(String(error))
 
           // Handle OAuth-specific errors


### PR DESCRIPTION
  ## Issue
  Fixes #8406

  ## Problem
  When connecting to non-standard MCP servers, OpenCode can hang indefinitely if the server returns HTTP 200 but:
  - Sends malformed SSE stream
  - Never completes MCP initialize handshake
  - Stalls during message exchange

  The existing `withTimeout` wrapper rejects the promise but doesn't cancel the underlying network request, leaving connections hanging.

  ## Solution
  Add `AbortController` support to remote MCP transports using native Web APIs:

  1. **Created AbortController instances** for each transport (StreamableHTTP, SSE)
  2. **Passed `signal` to `requestInit`** - uses native fetch abort mechanism
  3. **Abort on timeout** - `setTimeout` calls `abort()` at configured timeout
  4. **Cleanup in all paths** - ensures `abort()` called on error/timeout

  ## Changes
  - Modified `packages/opencode/src/mcp/index.ts`:
    - Added `AbortController` instances for each transport
    - Passed `signal` to transport `requestInit`
    - Added timeout handler that calls `abort()`
    - Added cleanup in `.catch()` and error paths



  **Before:** OpenCode hung indefinitely
  **After:** Connection aborted after 30s timeout, clean error message

  ## Implementation Notes
  - Follows team style: uses `.catch()` over try/catch
  - Minimal changes: ~27 lines added
  - Uses native Web APIs (AbortController/AbortSignal)
  - No new abstractions or files
  - Matches existing cleanup patterns (see #8253)