### PR TITLE
fix: escape data-key values for querySelector compatibility

### DIFF
--- a/packages/ui/src/components/list.test.tsx
+++ b/packages/ui/src/components/list.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest"
+import { List } from "./list"
+import { render, screen } from "@testing-library/solid"
+import { createSignal } from "solid-js"
+
+describe("List Component", () => {
+  it("handles special characters in keys without querySelector errors", () => {
+    const items = [
+      { id: "file name with spaces.md", name: "File with Spaces" },
+      { id: "file'with'quotes.md", name: "File with Quotes" },
+      { id: "file#with#hashes.md", name: "File with Hashes" },
+      { id: "file@with@ats.md", name: "File with @ Symbols" },
+      { id: "file$with$dollars.md", name: "File with $ Symbols" },
+      { id: "file^with^carets.md", name: "File with ^ Symbols" },
+      { id: "file&with&amps.md", name: "File with & Symbols" },
+      { id: "中国文件名.md", name: "Chinese File Name" },
+    ]
+
+    const [current, setCurrent] = createSignal(items[0])
+    const [active, setActive] = createSignal(items[0].id)
+
+    render(() => (
+      <List
+        items={items}
+        key={(item) => item.id}
+        current={current()}
+        active={active()}
+        onSelect={(item) => setCurrent(item!)}
+      >
+        {(item) => <div>{item.name}</div>}
+      </List>
+    ))
+
+    // Verify all items are rendered
+    items.forEach((item) => {
+      expect(screen.getByText(item.name)).toBeInTheDocument()
+    })
+
+    // Simulate selecting different items to trigger scrollIntoView
+    items.forEach((item) => {
+      setCurrent(item)
+      setActive(item.id)
+      // The component should handle these without throwing errors
+    })
+  })
+})

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -67,7 +67,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
     if (!props.current) return
     const key = props.key(props.current)
     requestAnimationFrame(() => {
-      const element = scrollRef()?.querySelector(`[data-key="${key}"]`)
+      const element = scrollRef()?.querySelector(`[data-key="${CSS.escape(key)}"]`)
       element?.scrollIntoView({ block: "center" })
     })
   })
@@ -79,7 +79,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
       scrollRef()?.scrollTo(0, 0)
       return
     }
-    const element = scrollRef()?.querySelector(`[data-key="${active()}"]`)
+    const element = scrollRef()?.querySelector(`[data-key="${CSS.escape(active() || "")}"]`)
     element?.scrollIntoView({ block: "center", behavior: "smooth" })
   })
 


### PR DESCRIPTION
### What does this PR do?

Fix #7408 #7670 

Fixes a critical syntax error in the List component when using querySelector with data-key attributes containing special characters, spaces, quotes, or non-ASCII characters (like Chinese). The issue occurred because raw key values were being inserted directly into CSS selector strings without proper escaping.

### How did you verify your code works?

1. **Added comprehensive unit tests**: Created `list.test.tsx` with test cases covering:
   - File names with spaces
   - File names with single quotes
   - File names with special symbols (#, @, $, ^, &)
   - Non-ASCII Chinese file names
2. **Manual testing**: Verified component functionality with various edge case key values
3. **Type safety**: Ensured TypeScript compatibility with CSS.escape() usage
4. **Regression testing**: Confirmed existing List component behavior remains unchanged