### PR TITLE
fix: block whitespace-only prompts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -486,6 +486,14 @@ export function Prompt(props: PromptProps) {
     if (autocomplete?.visible) return
     if (!store.prompt.input) return
     const trimmed = store.prompt.input.trim()
+    if (!trimmed) {
+      toast.show({
+        variant: "warning",
+        message: "Message cannot be empty",
+        duration: 2000,
+      })
+      return
+    }
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       exit()
       return


### PR DESCRIPTION
Issue: https://github.com/anomalyco/opencode/issues/7493

Summary:
- block whitespace-only prompt submissions
- show a warning toast instead of sending an empty message

Motivation:
- avoid backend "Text cannot be empty" errors that interrupt sessions

Validation:
- Manual testing completed