### PR TITLE
fix: Clarify to tools the limit of the header size

### DIFF
--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -8,3 +8,4 @@ Usage notes:
 - Users will always be able to select "Other" to provide custom text input
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+- The `header` propery accepts a maximum of 12 characters per header


### PR DESCRIPTION
Tool calls to the `question` tool repeatedly becuase the agent doesnt realise that the title must be 12 or less characters. This fix should (hopefully) inform the agents on how to avoid this error in the future
** I am not a prompt engineer, this is just a rough edit**

partially Fixes #8432 