### PR TITLE
fix(desktop): "load more" button behavior in desktop sidebar

### DIFF
--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -38,6 +38,7 @@ type State = {
   config: Config
   path: Path
   session: Session[]
+  sessionTotal: number
   session_status: {
     [sessionID: string]: SessionStatus
   }
@@ -98,6 +99,7 @@ function createGlobalSync() {
         agent: [],
         command: [],
         session: [],
+        sessionTotal: 0,
         session_status: {},
         session_diff: {},
         todo: {},
@@ -126,6 +128,8 @@ function createGlobalSync() {
           .filter((s) => !s.time?.archived)
           .slice()
           .sort((a, b) => a.id.localeCompare(b.id))
+        // Store total session count before filtering (used for "load more" functionality)
+        setStore("sessionTotal", nonArchived.length)
         // Include up to the limit, plus any updated in the last 4 hours
         const sessions = nonArchived.filter((s, i) => {
           if (i < store.limit) return true

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -119,8 +119,10 @@ function createGlobalSync() {
 
   async function loadSessions(directory: string) {
     const [store, setStore] = child(directory)
-    globalSDK.client.session
-      .list({ directory })
+    const limit = store.limit
+
+    return globalSDK.client.session
+      .list({ directory, roots: true })
       .then((x) => {
         const fourHoursAgo = Date.now() - 4 * 60 * 60 * 1000
         const nonArchived = (x.data ?? [])
@@ -128,14 +130,14 @@ function createGlobalSync() {
           .filter((s) => !s.time?.archived)
           .slice()
           .sort((a, b) => a.id.localeCompare(b.id))
-        // Store total session count before filtering (used for "load more" functionality)
-        setStore("sessionTotal", nonArchived.length)
         // Include up to the limit, plus any updated in the last 4 hours
         const sessions = nonArchived.filter((s, i) => {
-          if (i < store.limit) return true
+          if (i < limit) return true
           const updated = new Date(s.time?.updated ?? s.time?.created).getTime()
           return updated > fourHoursAgo
         })
+        // Store total session count (used for "load more" pagination)
+        setStore("sessionTotal", nonArchived.length)
         setStore("session", reconcile(sessions, { key: "id" }))
       })
       .catch((err) => {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -944,7 +944,7 @@ export default function Layout(props: ParentProps) {
         .toSorted(sortSessions),
     )
     const rootSessions = createMemo(() => sessions().filter((s) => !s.parentID))
-    const hasMoreSessions = createMemo(() => store.session.length >= store.limit)
+    const hasMoreSessions = createMemo(() => store.sessionTotal > store.session.length)
     const loadMoreSessions = async () => {
       setProjectStore("limit", (limit) => limit + 5)
       await globalSync.project.loadSessions(props.project.worktree)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -725,6 +725,7 @@ export namespace Server {
             "query",
             z.object({
               directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
+              roots: z.coerce.boolean().optional().meta({ description: "Only return root sessions (no parentID)" }),
               start: z.coerce
                 .number()
                 .optional()
@@ -739,6 +740,7 @@ export namespace Server {
             const sessions: Session.Info[] = []
             for await (const session of Session.list()) {
               if (query.directory !== undefined && session.directory !== query.directory) continue
+              if (query.roots && session.parentID) continue
               if (query.start !== undefined && session.time.updated < query.start) continue
               if (term !== undefined && !session.title.toLowerCase().includes(term)) continue
               sessions.push(session)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -724,6 +724,7 @@ export namespace Server {
           validator(
             "query",
             z.object({
+              directory: z.string().optional().meta({ description: "Filter sessions by project directory" }),
               start: z.coerce
                 .number()
                 .optional()
@@ -737,6 +738,7 @@ export namespace Server {
             const term = query.search?.toLowerCase()
             const sessions: Session.Info[] = []
             for await (const session of Session.list()) {
+              if (query.directory !== undefined && session.directory !== query.directory) continue
               if (query.start !== undefined && session.time.updated < query.start) continue
               if (term !== undefined && !session.title.toLowerCase().includes(term)) continue
               sessions.push(session)

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { Instance } from "../../src/project/instance"
+import { Server } from "../../src/server/server"
+import { Session } from "../../src/session"
+import { Log } from "../../src/util/log"
+
+const projectRoot = path.join(__dirname, "../..")
+Log.init({ print: false })
+
+describe("session.list", () => {
+  test("filters by directory", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const app = Server.App()
+
+        const first = await Session.create({})
+
+        const otherDir = path.join(projectRoot, "..", "__session_list_other")
+        const second = await Instance.provide({
+          directory: otherDir,
+          fn: async () => Session.create({}),
+        })
+
+        const response = await app.request(`/session?directory=${encodeURIComponent(projectRoot)}`)
+        expect(response.status).toBe(200)
+
+        const body = (await response.json()) as unknown[]
+        const ids = body
+          .map((s) => (typeof s === "object" && s && "id" in s ? (s as { id: string }).id : undefined))
+          .filter((x): x is string => typeof x === "string")
+
+        expect(ids).toContain(first.id)
+        expect(ids).not.toContain(second.id)
+      },
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -781,6 +781,7 @@ export class Session extends HeyApiClient {
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
       directory?: string
+      roots?: boolean
       start?: number
       search?: string
       limit?: number
@@ -793,6 +794,7 @@ export class Session extends HeyApiClient {
         {
           args: [
             { in: "query", key: "directory" },
+            { in: "query", key: "roots" },
             { in: "query", key: "start" },
             { in: "query", key: "search" },
             { in: "query", key: "limit" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2589,7 +2589,14 @@ export type SessionListData = {
   body?: never
   path?: never
   query?: {
+    /**
+     * Filter sessions by project directory
+     */
     directory?: string
+    /**
+     * Only return root sessions (no parentID)
+     */
+    roots?: boolean
     /**
      * Filter sessions updated on or after this timestamp (milliseconds since epoch)
      */


### PR DESCRIPTION
### What does this PR do?
Fixes #8426 

This is what seemed to be happening: 

When the client fetched sessions for a given project, it used [the `/session` endpoint.](https://github.com/anomalyco/opencode/blob/76b10d85eea11a3bac51248b84daae034dec2c3a/packages/opencode/src/server/server.ts#L707-L747) This endpoint did not filter by project/directory, so it was returning sessions that were not a part of the project connected to a given "load more" button. Then, [this createMemo](https://github.com/anomalyco/opencode/blob/76b10d85eea11a3bac51248b84daae034dec2c3a/packages/app/src/pages/layout.tsx#L947) used the length of that list of sessions to determine pagination. So, even if a project only had one session, it could receive dozens of other sessions (from other projects).

Another issue was that the frontend was filtering out non-root/child sessions [here](https://github.com/anomalyco/opencode/blob/76b10d85eea11a3bac51248b84daae034dec2c3a/packages/app/src/pages/layout.tsx#L946). Because the backend did not differentiate between root/child sessions, when the frontend received them, there were sometimes child sessions that counted toward the pagination limit, but then got filtered out, resulting in what looked like a no-op when clicking the load more button.

This PR checks a project's directory when pulling in its sessions and also filters out child sessions in the backend to make pagination calculations line up with actually-rendered sessions.

I feel that there are probably better long-term solutions for this, but this is a pretty small change and has been working fine for me. Would love to hear the team's perspective/ideas. 

### Before fix:
https://github.com/user-attachments/assets/faaca941-0070-436a-ac31-b061ce6dc0dd

### After fix:
https://github.com/user-attachments/assets/3e053820-979c-4672-970b-54c535058672

### How did you verify your code works?
Ran tests and manually verified that projects in different states (e.g. fresh vs. old/complex ones) worked as expected
