### PR TITLE
fix(opencode): introduce `childrenIDs` session field to allow for fast children lookup

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -46,6 +46,7 @@ export namespace Session {
       projectID: z.string(),
       directory: z.string(),
       parentID: Identifier.schema("session").optional(),
+      childrenIDs: Identifier.schema("session").array().optional(),
       summary: z
         .object({
           additions: z.number(),
@@ -203,6 +204,7 @@ export namespace Session {
       projectID: Instance.project.id,
       directory: input.directory,
       parentID: input.parentID,
+      childrenIDs: [],
       title: input.title ?? createDefaultTitle(!!input.parentID),
       permission: input.permission,
       time: {
@@ -215,6 +217,14 @@ export namespace Session {
     Bus.publish(Event.Created, {
       info: result,
     })
+
+    if (input.parentID) {
+      await update(input.parentID, (draft) => {
+        if (!draft.childrenIDs) draft.childrenIDs = []
+        draft.childrenIDs.push(result.id)
+      })
+    }
+
     const cfg = await Config.get()
     if (!result.parentID && (Flag.OPENCODE_AUTO_SHARE || cfg.share === "auto"))
       share(result.id)
@@ -310,6 +320,21 @@ export namespace Session {
   }
 
   export const children = fn(Identifier.schema("session"), async (parentID) => {
+    const parentSession = await get(parentID)
+
+    // If the parent session has childrenIDs field initialized,
+    // use them to get the children sessions (fast)
+    if (parentSession && Array.isArray(parentSession.childrenIDs)) {
+      return await Promise.all(
+        parentSession.childrenIDs.map((childID) => get(childID).catch((err) => {
+          log.warn(`Failed to get child session ${childID} of parent ${parentID}:`, err)
+          return null
+        }))
+      ).then(sessions => sessions.filter(Boolean) as Session.Info[])
+    }
+
+    // else, fall back to scanning all sessions
+    // (slower, but ensures we get all children even if childrenIDs is missing/outdated)
     const project = Instance.project
     const result = [] as Session.Info[]
     for (const item of await Storage.list(["session", project.id])) {
@@ -327,7 +352,7 @@ export namespace Session {
       for (const child of await children(sessionID)) {
         await remove(child.id)
       }
-      await unshare(sessionID).catch(() => {})
+      await unshare(sessionID).catch(() => { })
       for (const msg of await Storage.list(["message", sessionID])) {
         for (const part of await Storage.list(["part", msg.at(-1)!])) {
           await Storage.remove(part)

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
 import path from "path"
 import { Session } from "../../src/session"
 import { Bus } from "../../src/bus"
 import { Log } from "../../src/util/log"
 import { Instance } from "../../src/project/instance"
+import { Identifier } from "../../src/id/id"
 
 const projectRoot = path.join(__dirname, "../..")
 Log.init({ print: false })
@@ -65,6 +66,211 @@ describe("session.started event", () => {
         expect(events.indexOf("started")).toBeLessThan(events.indexOf("updated"))
 
         await Session.remove(session.id)
+      },
+    })
+  })
+})
+
+describe("session creation with parent/child relationship", () => {
+  let parentSession: Session.Info | null = null
+  let childSession: Session.Info | null = null
+
+  afterEach(async () => {
+    if (childSession) {
+      await Session.remove(childSession.id).catch(() => {})
+      childSession = null
+    }
+    if (parentSession) {
+      await Session.remove(parentSession.id).catch(() => {})
+      parentSession = null
+    }
+  })
+
+  test("should create parent session with default title", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        expect(parentSession).toBeDefined()
+        expect(parentSession!.title).toStartWith("New session - ")
+        expect(parentSession!.parentID).toBeUndefined()
+        expect(parentSession!.childrenIDs).toEqual([])
+      },
+    })
+  })
+
+  test("should create child session with parentID set and child title", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        childSession = await Session.create({ parentID: parentSession!.id })
+
+        expect(childSession).toBeDefined()
+        expect(childSession!.parentID).toBe(parentSession!.id)
+        expect(childSession!.title).toStartWith("Child session - ")
+      },
+    })
+  })
+
+  test("should populate childrenIDs on parent when child is created", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        childSession = await Session.create({ parentID: parentSession!.id })
+
+        const updatedParent = await Session.get(parentSession!.id)
+        expect(updatedParent.childrenIDs).toBeDefined()
+        expect(updatedParent.childrenIDs).toContain(childSession!.id)
+        expect(updatedParent.childrenIDs!.length).toBe(1)
+      },
+    })
+  })
+
+  test("should add multiple children to parent childrenIDs", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        const child1 = await Session.create({ parentID: parentSession!.id })
+        const child2 = await Session.create({ parentID: parentSession!.id })
+        const child3 = await Session.create({ parentID: parentSession!.id })
+
+        const updatedParent = await Session.get(parentSession!.id)
+        expect(updatedParent.childrenIDs).toBeDefined()
+        expect(updatedParent.childrenIDs!.length).toBe(3)
+        expect(updatedParent.childrenIDs).toContain(child1.id)
+        expect(updatedParent.childrenIDs).toContain(child2.id)
+        expect(updatedParent.childrenIDs).toContain(child3.id)
+      },
+    })
+  })
+})
+
+describe("Session.children function", () => {
+  let parentSession: Session.Info | null = null
+  let children: Session.Info[] = []
+
+  afterEach(async () => {
+    for (const child of children) {
+      await Session.remove(child.id).catch(() => {})
+    }
+    children = []
+    if (parentSession) {
+      await Session.remove(parentSession.id).catch(() => {})
+      parentSession = null
+    }
+  })
+
+  test("children should return empty array when no children exist", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        const result = await Session.children(parentSession!.id)
+        expect(result).toEqual([])
+      },
+    })
+  })
+
+  test("children should return children using fast path (childrenIDs)", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        const child1 = await Session.create({ parentID: parentSession!.id })
+        const child2 = await Session.create({ parentID: parentSession!.id })
+        children = [child1, child2]
+
+        const result = await Session.children(parentSession!.id)
+        expect(result.length).toBe(2)
+        const childIds = result.map((c) => c.id).sort()
+        expect(childIds).toEqual([child1.id, child2.id].sort())
+      },
+    })
+  })
+
+  test("children should filter out null sessions when child is missing", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        const child1 = await Session.create({ parentID: parentSession!.id })
+        children = [child1]
+
+        const nonexistentID = Identifier.descending("session")
+        await Session.update(parentSession!.id, (draft) => {
+          draft.childrenIDs = [child1.id, nonexistentID]
+        })
+
+        const result = await Session.children(parentSession!.id)
+        expect(result.length).toBe(1)
+        expect(result[0].id).toBe(child1.id)
+      },
+    })
+  })
+
+  test("children should use fallback when childrenIDs is not set", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        parentSession = await Session.create({})
+        const child1 = await Session.create({ parentID: parentSession!.id })
+        const child2 = await Session.create({ parentID: parentSession!.id })
+        children = [child1, child2]
+
+        await Session.update(parentSession!.id, (draft) => {
+          draft.childrenIDs = undefined
+        })
+
+        const result = await Session.children(parentSession!.id)
+        expect(result.length).toBe(2)
+      },
+    })
+  })
+})
+
+describe("Session.remove with children", () => {
+  test("should recursively remove all children when removing parent", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const parent = await Session.create({})
+        const child1 = await Session.create({ parentID: parent.id })
+        const child2 = await Session.create({ parentID: parent.id })
+        const grandchild = await Session.create({ parentID: child1.id })
+
+        await Session.remove(parent.id)
+
+        const parentAfter = await Session.get(parent.id).catch(() => null)
+        const child1After = await Session.get(child1.id).catch(() => null)
+        const child2After = await Session.get(child2.id).catch(() => null)
+        const grandchildAfter = await Session.get(grandchild.id).catch(() => null)
+
+        expect(parentAfter).toBeNull()
+        expect(child1After).toBeNull()
+        expect(child2After).toBeNull()
+        expect(grandchildAfter).toBeNull()
+      },
+    })
+  })
+
+  test("children function should not return removed children", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const parent = await Session.create({})
+        const child1 = await Session.create({ parentID: parent.id })
+        const child2 = await Session.create({ parentID: parent.id })
+
+        await Session.remove(child1.id)
+
+        const children = await Session.children(parent.id)
+        expect(children.length).toBe(1)
+        expect(children[0].id).toBe(child2.id)
+
+        await Session.remove(parent.id)
       },
     })
   })


### PR DESCRIPTION
Fixes #8437 #3526 