### PR TITLE
feat: add choco and scoop to opencode upgrade methods

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -83,6 +83,14 @@ export namespace Installation {
         name: "brew" as const,
         command: () => $`brew list --formula opencode`.throws(false).quiet().text(),
       },
+      {
+        name: "scoop" as const,
+        command: () => $`scoop list opencode`.throws(false).quiet().text(),
+      },
+      {
+        name: "choco" as const,
+        command: () => $`choco list --limit-output opencode`.throws(false).quiet().text(),
+      },
     ]
 
     checks.sort((a, b) => {
@@ -95,7 +103,9 @@ export namespace Installation {
 
     for (const check of checks) {
       const output = await check.command()
-      if (output.includes(check.name === "brew" ? "opencode" : "opencode-ai")) {
+      const installedName =
+        check.name === "brew" || check.name === "choco" || check.name === "scoop" ? "opencode" : "opencode-ai"
+      if (output.includes(installedName)) {
         return check.name
       }
     }
@@ -144,20 +154,28 @@ export namespace Installation {
         })
         break
       }
+      case "choco":
+        cmd = $`choco upgrade opencode --version=${target} -y -r`
+        break
+      case "scoop":
+        cmd = $`scoop install extras/opencode@${target}`
+        break
       default:
         throw new Error(`Unknown method: ${method}`)
     }
     const result = await cmd.quiet().throws(false)
+    if (result.exitCode !== 0) {
+      const stderr = method === "choco" ? "not running from an elevated command shell" : result.stderr.toString("utf8")
+      throw new UpgradeFailedError({
+        stderr: stderr,
+      })
+    }
     log.info("upgraded", {
       method,
       target,
       stdout: result.stdout.toString(),
       stderr: result.stderr.toString(),
     })
-    if (result.exitCode !== 0)
-      throw new UpgradeFailedError({
-        stderr: result.stderr.toString("utf8"),
-      })
     await $`${process.execPath} --version`.nothrow().quiet().text()
   }
 
@@ -188,6 +206,29 @@ export namespace Installation {
       })
       const channel = CHANNEL
       return fetch(`${registry}/opencode-ai/${channel}`)
+        .then((res) => {
+          if (!res.ok) throw new Error(res.statusText)
+          return res.json()
+        })
+        .then((data: any) => data.version)
+    }
+
+    if (detectedMethod === "choco") {
+      return fetch(
+        "https://community.chocolatey.org/api/v2/Packages?$filter=Id%20eq%20%27opencode%27%20and%20IsLatestVersion&$select=Version",
+        { headers: { Accept: "application/json;odata=verbose" } },
+      )
+        .then((res) => {
+          if (!res.ok) throw new Error(res.statusText)
+          return res.json()
+        })
+        .then((data: any) => data.d.results[0].Version)
+    }
+
+    if (detectedMethod === "scoop") {
+      return fetch("https://raw.githubusercontent.com/ScoopInstaller/Extras/master/bucket/opencode.json", {
+        headers: { Accept: "application/json" },
+      })
         .then((res) => {
           if (!res.ok) throw new Error(res.statusText)
           return res.json()

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -155,7 +155,7 @@ export namespace Installation {
         break
       }
       case "choco":
-        cmd = $`choco upgrade opencode --version=${target} -y -r`
+        cmd = $`echo Y | choco upgrade opencode --version=${target}`
         break
       case "scoop":
         cmd = $`scoop install extras/opencode@${target}`


### PR DESCRIPTION
### What does this PR do?

Adds support for `opencode upgrade` to work with Chocolatey and Scoop installations. This works by adding `choco` and `scoop` commands to the relevant methods in the `Installation` namespace - 

- `Installation.method`: add `choco list` and `scoop list` commands
- `Installation.upgrade`: add `choco upgrade --version=<target>` and `scoop install opencode@<target>` commands
- `Installation.latest`: fetch the latest version number of the `choco` and `scoop` opencode packages from public manifest URLs

### How did you verify your code works?

#### Chocolatey

```pwsh
PS C:\Users\Mani\repos\opencode\dev--win-auto-update> opencode -v
1.1.17
PS C:\Users\Mani\repos\opencode\dev--win-auto-update> bun dev upgrade
$ bun run --cwd packages/opencode --conditions=browser src/index.ts upgrade

                                   ▄
  █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
  █░░█ █░░█ █▀▀▀ █░░█ █░░░ █░░█ █░░█ █▀▀▀
  ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀


┌  Upgrade
│
●  Using method: choco
│
●  From v1.1.17 → 1.1.18
│
◇  Upgrade complete
│
└  Done

PS C:\Users\Mani\repos\opencode\dev--win-auto-update> opencode -v
1.1.18
```

#### Scoop

```pwsh
PS C:\Users\Mani\repos\opencode\dev--win-auto-update> opencode -v
1.1.17
PS C:\Users\Mani\repos\opencode\dev--win-auto-update> bun dev upgrade
$ bun run --cwd packages/opencode --conditions=browser src/index.ts upgrade

                                   ▄
  █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
  █░░█ █░░█ █▀▀▀ █░░█ █░░░ █░░█ █░░█ █▀▀▀
  ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀


┌  Upgrade
│
●  Using method: scoop
│
●  From v1.1.17 → 1.1.18
│
◇  Upgrade complete
│
└  Done

PS C:\Users\Mani\repos\opencode\dev--win-auto-update> opencode -v
1.1.18
```

#### Notify Update

`latest()` pulls in the right version for our chocolatey based install (`1.1.18` at the time of this PR whereas latest release is on `1.1.19`

<img width="544" height="116" alt="image" src="https://github.com/user-attachments/assets/ff79d81b-09ca-4eae-999c-a1e1fb7d8de1" />

#### Not an Elevated Command Shell

Chocolatey has an annoying issue where it doesn't allow installation or upgrading a package if you're not in an elevated command shell. This "error" also passes to `stdout` and not `stderr` so we pass a custom error message to the `UpgradeFailedError` so we can capture it in the `upgrade.ts` and communicate this to the user.

<img width="1095" height="651" alt="image" src="https://github.com/user-attachments/assets/54304f7b-2a2e-4fb2-953a-e53df576a147" />

Output of `upgrade` w/ a non-elevated command shell (this has been tested on `cmd` and non-elevated `powershell`.

```pwsh
PS C:\Users\Mani\repos\opencode\dev--win-auto-update> bun dev upgrade
$ bun run --cwd packages/opencode --conditions=browser src/index.ts upgrade

                                   ▄
  █▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█
  █░░█ █░░█ █▀▀▀ █░░█ █░░░ █░░█ █░░█ █▀▀▀
  ▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀


┌  Upgrade
│
●  Using method: choco
│
●  From v1.1.17 → 1.1.18
│
■  Upgrade failed
│
■  Please run the terminal as Administrator and try again
│
└  Done
```