### PR TITLE
fix: publish session.error event for invalid model selection

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -309,7 +309,18 @@ export namespace SessionPrompt {
           history: msgs,
         })
 
-      const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID)
+      const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID).catch((e) => {
+        if (Provider.ModelNotFoundError.isInstance(e)) {
+          const hint = e.data.suggestions?.length ? ` Did you mean: ${e.data.suggestions.join(", ")}?` : ""
+          Bus.publish(Session.Event.Error, {
+            sessionID,
+            error: new NamedError.Unknown({
+              message: `Model not found: ${e.data.providerID}/${e.data.modelID}.${hint}`,
+            }).toObject(),
+          })
+        }
+        throw e
+      })
       const task = tasks.pop()
 
       // pending subtask


### PR DESCRIPTION
# Fix: Publish session.error event for invalid model selection

## Problem

When sending a message via the API with an invalid provider or model ID, the error was silently swallowed. API consumers had no way to know something went wrong.

**What happened:**

1. POST to `/session/{id}/message` with `{ model: { providerID: "invalid", ... } }`
2. HTTP response returns 200 immediately (before validation)
3. User message is created successfully
4. Session goes `busy` → `idle` with no error indication
5. No `session.error` event is published to `/event`

**Root cause:** The `Provider.getModel()` call happens inside `loop()` after the HTTP response has already started streaming. When it throws `ModelNotFoundError`, the error propagates up but is never converted to a `session.error` event.

## Solution

Added error handling around `Provider.getModel()` in `loop()` to publish a `session.error` event before re-throwing. This matches the existing pattern used in the `command()` function.

**After this fix:**

```
data: {"type":"session.error","properties":{"sessionID":"ses_...","error":{"name":"UnknownError","data":{"message":"Model not found: invalid/some-model. Did you mean: anthropic, openai, ...?"}}}}
```

## Changes

- `packages/opencode/src/session/prompt.ts`: Wrap `Provider.getModel()` in try-catch, publish `session.error` on `ModelNotFoundError`

Fixes #8460