### PR TITLE
fix(homepage): Update FAQ to include desktop and web links

### DIFF
--- a/packages/console/app/src/routes/download/index.tsx
+++ b/packages/console/app/src/routes/download/index.tsx
@@ -441,7 +441,8 @@ export default function Download() {
             </li>
             <li>
               <Faq question="Can I only use OpenCode in the terminal?">
-                Not anymore! OpenCode is now available as an app for your desktop.
+                Not anymore! OpenCode is now available as an app for your <a href="/download">desktop</a> and{" "}
+                <a href="/docs/cli/#web">web</a>!
               </Faq>
             </li>
             <li>

--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -692,7 +692,8 @@ export default function Home() {
               </li>
               <li>
                 <Faq question="Can I only use OpenCode in the terminal?">
-                  Not anymore! OpenCode is now available as an app for your desktop.
+                  Not anymore! OpenCode is now available as an app for your <a href="/download">desktop</a> and{" "}
+                  <a href="/docs/cli/#web">web</a>!
                 </Faq>
               </li>
               <li>


### PR DESCRIPTION
## Summary
- Updated the FAQ answer for "Can I only use OpenCode in the terminal?" in both locations
- Added hyperlinks to `/download` for desktop and `/docs/cli/#web` for web