### PR TITLE
fix: validate version exists before upgrade

### DIFF
--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -50,18 +50,40 @@ export const UpgradeCommand = {
       return
     }
 
+    // Validate version exists before attempting upgrade
+    if (args.target) {
+      const spinner = prompts.spinner()
+      spinner.start("Checking version availability...")
+      const exists = await Installation.versionExists(target, method)
+      if (!exists) {
+        spinner.stop("Version not found", 1)
+        if (method === "brew") {
+          prompts.log.error(`Version ${target} is not available via brew. Only the latest version can be installed.`)
+          const latestVersion = await Installation.latest(method).catch(() => null)
+          if (latestVersion) {
+            prompts.log.info(`Available version: ${latestVersion}`)
+          }
+        } else {
+          prompts.log.error(`Version ${target} was not found. Please check the version number and try again.`)
+        }
+        prompts.outro("Done")
+        return
+      }
+      spinner.stop("Version available")
+    }
+
     prompts.log.info(`From ${Installation.VERSION} → ${target}`)
-    const spinner = prompts.spinner()
-    spinner.start("Upgrading...")
+    const upgradeSpinner = prompts.spinner()
+    upgradeSpinner.start("Upgrading...")
     const err = await Installation.upgrade(method, target).catch((err) => err)
     if (err) {
-      spinner.stop("Upgrade failed", 1)
+      upgradeSpinner.stop("Upgrade failed", 1)
       if (err instanceof Installation.UpgradeFailedError) prompts.log.error(err.data.stderr)
       else if (err instanceof Error) prompts.log.error(err.message)
       prompts.outro("Done")
       return
     }
-    spinner.stop("Upgrade complete")
+    upgradeSpinner.stop("Upgrade complete")
     prompts.outro("Done")
   },
 }

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -202,4 +202,38 @@ export namespace Installation {
       })
       .then((data: any) => data.tag_name.replace(/^v/, ""))
   }
+
+  export const VersionNotFoundError = NamedError.create(
+    "VersionNotFoundError",
+    z.object({
+      version: z.string(),
+      method: z.string(),
+    }),
+  )
+
+  export async function versionExists(version: string, installMethod?: Method): Promise<boolean> {
+    const detectedMethod = installMethod || (await method())
+
+    if (detectedMethod === "brew") {
+      // Brew doesn't support installing specific versions easily
+      // Only the current formula version is available
+      const latestVersion = await latest(detectedMethod).catch(() => null)
+      return version === latestVersion
+    }
+
+    if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {
+      const registry = await iife(async () => {
+        const r = (await $`npm config get registry`.quiet().nothrow().text()).trim()
+        const reg = r || "https://registry.npmjs.org"
+        return reg.endsWith("/") ? reg.slice(0, -1) : reg
+      })
+      // Check if the specific version exists
+      const res = await fetch(`${registry}/opencode-ai/${version}`)
+      return res.ok
+    }
+
+    // For curl method, check GitHub releases
+    const res = await fetch(`https://api.github.com/repos/anomalyco/opencode/releases/tags/v${version}`)
+    return res.ok
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #8422

When upgrading to a specific version with `opencode upgrade <version>`, the command now validates that the version exists before attempting the upgrade. Previously, the command would always report "Upgrade complete" even when specifying non-existent versions like `1.1.1534543` or `0.0.0`.

## Changes

- Added `versionExists()` function to `Installation` namespace to check if a version is available
- Modified upgrade command to validate the target version before proceeding
- Added clear error messages when version is not found:
  - For brew: Explains that only the latest version is available
  - For npm/pnpm/bun: Reports that the version was not found
  - For curl: Checks GitHub releases for the version

## Before

```
$ opencode upgrade 1.1.1534543
┌  Upgrade
│
●  Using method: brew
│
●  From 1.1.10 → 1.1.1534543
│
◇  Upgrade complete   ← FALSE SUCCESS
│
└  Done
```

## After

```
$ opencode upgrade 1.1.1534543
┌  Upgrade
│
●  Using method: brew
│
◇  Checking version availability...
│
✖  Version not found
│
▲  Version 1.1.1534543 is not available via brew. Only the latest version can be installed.
│
●  Available version: 1.1.20
│
└  Done
```

---
🤖 Generated with Claude Code