### PR TITLE
fix(opencode): add input limit for compaction

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -361,38 +361,6 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           }
         }
 
-        if (!provider.models["gpt-5.2-codex"]) {
-          const model = {
-            id: "gpt-5.2-codex",
-            providerID: "openai",
-            api: {
-              id: "gpt-5.2-codex",
-              url: "https://chatgpt.com/backend-api/codex",
-              npm: "@ai-sdk/openai",
-            },
-            name: "GPT-5.2 Codex",
-            capabilities: {
-              temperature: false,
-              reasoning: true,
-              attachment: true,
-              toolcall: true,
-              input: { text: true, audio: false, image: true, video: false, pdf: false },
-              output: { text: true, audio: false, image: false, video: false, pdf: false },
-              interleaved: false,
-            },
-            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-            limit: { context: 400000, output: 128000, input: 272000 },
-            status: "active" as const,
-            options: {},
-            headers: {},
-            release_date: "2025-12-18",
-            variants: {} as Record<string, Record<string, any>>,
-            family: "gpt-codex",
-          }
-          model.variants = ProviderTransform.variants(model)
-          provider.models["gpt-5.2-codex"] = model
-        }
-
         // Zero out costs for Codex (included with ChatGPT subscription)
         for (const model of Object.values(provider.models)) {
           model.cost = {

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -381,7 +381,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               interleaved: false,
             },
             cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-            limit: { context: 400000, output: 128000 },
+            limit: { context: 400000, output: 128000, input: 272000 },
             status: "active" as const,
             options: {},
             headers: {},

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -47,6 +47,7 @@ export namespace ModelsDev {
       .optional(),
     limit: z.object({
       context: z.number(),
+      input: z.number().optional(),
       output: z.number(),
     }),
     modalities: z

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -552,6 +552,7 @@ export namespace Provider {
       }),
       limit: z.object({
         context: z.number(),
+        input: z.number().optional(),
         output: z.number(),
       }),
       status: z.enum(["alpha", "beta", "deprecated", "active"]),
@@ -614,6 +615,7 @@ export namespace Provider {
       },
       limit: {
         context: model.limit.context,
+        input: model.limit.input,
         output: model.limit.output,
       },
       capabilities: {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -30,26 +30,12 @@ export namespace SessionCompaction {
   export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
     const config = await Config.get()
     if (config.compaction?.auto === false) return false
-    const inputLimit = input.model.limit.input
-    if (inputLimit && inputLimit > 0) return isOverflowWithInputLimit(input)
     const context = input.model.limit.context
     if (context === 0) return false
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output
     const output = Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
-    const usable = context - output
+    const usable = input.model.limit.input || context - output
     return count > usable
-  }
-
-  function isOverflowWithInputLimit(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
-    const inputTokens = input.tokens.input + input.tokens.cache.read
-    const outputTokens = input.tokens.output
-    const inputLimit = input.model.limit.input ?? 0
-    const outputLimit =
-      Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
-    if (inputTokens > inputLimit) return true
-    if (outputTokens > outputLimit) return true
-    if (input.model.limit.context > 0 && inputTokens + outputTokens > input.model.limit.context) return true
-    return false
   }
 
   export const PRUNE_MINIMUM = 20_000

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -30,12 +30,26 @@ export namespace SessionCompaction {
   export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
     const config = await Config.get()
     if (config.compaction?.auto === false) return false
+    const inputLimit = input.model.limit.input
+    if (inputLimit && inputLimit > 0) return isOverflowWithInputLimit(input)
     const context = input.model.limit.context
     if (context === 0) return false
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output
     const output = Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
     const usable = context - output
     return count > usable
+  }
+
+  function isOverflowWithInputLimit(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
+    const inputTokens = input.tokens.input + input.tokens.cache.read
+    const outputTokens = input.tokens.output
+    const inputLimit = input.model.limit.input ?? 0
+    const outputLimit =
+      Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
+    if (inputTokens > inputLimit) return true
+    if (outputTokens > outputLimit) return true
+    if (input.model.limit.context > 0 && inputTokens + outputTokens > input.model.limit.context) return true
+    return false
   }
 
   export const PRUNE_MINIMUM = 20_000

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -76,7 +76,7 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
-  test("respects input limit for models.dev input caps", async () => {
+  test("respects input limit for input caps", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
       directory: tmp.path,
@@ -96,18 +96,6 @@ describe("session.compaction.isOverflow", () => {
         const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
         const tokens = { input: 200_000, output: 20_000, reasoning: 0, cache: { read: 10_000, write: 0 } }
         expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(false)
-      },
-    })
-  })
-
-  test("respects output limit when input limit provided", async () => {
-    await using tmp = await tmpdir()
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const model = createModel({ context: 200_000, input: 120_000, output: 1_000 })
-        const tokens = { input: 50_000, output: 2_000, reasoning: 0, cache: { read: 0, write: 0 } }
-        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
       },
     })
   })

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -88,6 +88,18 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
+  test("returns false when input/output are within input caps", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
+        const tokens = { input: 200_000, output: 20_000, reasoning: 0, cache: { read: 10_000, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(false)
+      },
+    })
+  })
+
   test("respects output limit when input limit provided", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({
@@ -96,6 +108,18 @@ describe("session.compaction.isOverflow", () => {
         const model = createModel({ context: 200_000, input: 120_000, output: 1_000 })
         const tokens = { input: 50_000, output: 2_000, reasoning: 0, cache: { read: 0, write: 0 } }
         expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
+      },
+    })
+  })
+
+  test("returns false when output within limit with input caps", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 200_000, input: 120_000, output: 10_000 })
+        const tokens = { input: 50_000, output: 9_999, reasoning: 0, cache: { read: 0, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(false)
       },
     })
   })

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -10,13 +10,19 @@ import type { Provider } from "../../src/provider/provider"
 
 Log.init({ print: false })
 
-function createModel(opts: { context: number; output: number; cost?: Provider.Model["cost"] }): Provider.Model {
+function createModel(opts: {
+  context: number
+  output: number
+  input?: number
+  cost?: Provider.Model["cost"]
+}): Provider.Model {
   return {
     id: "test-model",
     providerID: "test",
     name: "Test",
     limit: {
       context: opts.context,
+      input: opts.input,
       output: opts.output,
     },
     cost: opts.cost ?? { input: 0, output: 0, cache: { read: 0, write: 0 } },
@@ -65,6 +71,30 @@ describe("session.compaction.isOverflow", () => {
       fn: async () => {
         const model = createModel({ context: 100_000, output: 32_000 })
         const tokens = { input: 50_000, output: 10_000, reasoning: 0, cache: { read: 10_000, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
+      },
+    })
+  })
+
+  test("respects input limit for models.dev input caps", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 400_000, input: 272_000, output: 128_000 })
+        const tokens = { input: 271_000, output: 1_000, reasoning: 0, cache: { read: 2_000, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
+      },
+    })
+  })
+
+  test("respects output limit when input limit provided", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 200_000, input: 120_000, output: 1_000 })
+        const tokens = { input: 50_000, output: 2_000, reasoning: 0, cache: { read: 0, write: 0 } }
         expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
       },
     })


### PR DESCRIPTION
### What does this PR do?

- Add support for the `input` limit from models.dev
- Adds dedicated input limit for codex 5.2
- Closes #7705
- See https://github.com/anomalyco/models.dev/pull/642
- See https://github.com/anomalyco/models.dev/pull/646, 5.2 is now upstream

### How did you verify your code works?

- Tested with several large sessions via `bun dev` to confirm compaction triggers
