### PR TITLE
fix: relax bun version check to only error on breaking changes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,8 +2,17 @@
 # Check if bun version matches package.json
 EXPECTED_VERSION=$(grep '"packageManager"' package.json | sed 's/.*"bun@\([^"]*\)".*/\1/')
 CURRENT_VERSION=$(bun --version)
-if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
-  echo "Error: Bun version $CURRENT_VERSION does not match expected version $EXPECTED_VERSION from package.json"
+
+# Extract major.minor versions
+EXPECTED_MAJOR_MINOR=$(echo $EXPECTED_VERSION | cut -d. -f1,2)
+CURRENT_MAJOR_MINOR=$(echo $CURRENT_VERSION | cut -d. -f1,2)
+
+if [ "$CURRENT_MAJOR_MINOR" != "$EXPECTED_MAJOR_MINOR" ]; then
+  echo "Error: Bun major.minor version $CURRENT_MAJOR_MINOR does not match expected $EXPECTED_MAJOR_MINOR from package.json"
   exit 1
+fi
+
+if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
+  echo "Warning: Bun version $CURRENT_VERSION differs from expected version $EXPECTED_VERSION (patch difference only)"
 fi
 bun typecheck

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -9,8 +9,18 @@ if (!expectedBunVersion) {
   throw new Error("packageManager field not found in root package.json")
 }
 
-if (process.versions.bun !== expectedBunVersion) {
-  throw new Error(`This script requires bun@${expectedBunVersion}, but you are using bun@${process.versions.bun}`)
+const currentVersion = process.versions.bun
+const [currentMajor, currentMinor, currentPatch] = currentVersion.split(".").map(Number)
+const [expectedMajor, expectedMinor, expectedPatch] = expectedBunVersion.split(".").map(Number)
+
+if (currentMajor !== expectedMajor || currentMinor !== expectedMinor) {
+  throw new Error(`This script requires bun@${expectedBunVersion}, but you are using bun@${currentVersion}`)
+}
+
+if (currentPatch !== expectedPatch) {
+  console.warn(
+    `Warning: This script expects bun@${expectedBunVersion}, but you are using bun@${currentVersion}. Patch version difference detected.`,
+  )
 }
 
 const env = {


### PR DESCRIPTION
fixes #8469

The bun version check now only errors on major/minor version differences (breaking changes).
- Warns on patch differences (compatible).