### PR TITLE
feat(cli): add select all text functionality for input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/textarea-keybindings.ts
@@ -14,6 +14,7 @@ const TEXTAREA_ACTIONS = [
   "select-right",
   "select-up",
   "select-down",
+  "select-all",
   "line-home",
   "line-end",
   "select-line-home",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -674,6 +674,7 @@ export namespace Config {
       input_select_right: z.string().optional().default("shift+right").describe("Select right in input"),
       input_select_up: z.string().optional().default("shift+up").describe("Select up in input"),
       input_select_down: z.string().optional().default("shift+down").describe("Select down in input"),
+      input_select_all: z.string().optional().default("ctrl+shift+a").describe("Select all text in input"),
       input_line_home: z.string().optional().default("ctrl+a").describe("Move to start of line in input"),
       input_line_end: z.string().optional().default("ctrl+e").describe("Move to end of line in input"),
       input_select_line_home: z


### PR DESCRIPTION

### What does this PR do?
Feature #8504
Add Ctrl+Shift+A shortcut to select all text in the CLI input prompt. Added input_select_all keybind config and registered select-all action in textarea keybindings.

### How did you verify your code works?
