### PR TITLE
feat(install): respect ZDOTDIR for zsh config detection

### DIFF
--- a/install
+++ b/install
@@ -369,7 +369,7 @@ case $current_shell in
         config_files="$HOME/.config/fish/config.fish"
     ;;
     zsh)
-        config_files="$HOME/.zshrc $HOME/.zshenv $XDG_CONFIG_HOME/zsh/.zshrc $XDG_CONFIG_HOME/zsh/.zshenv"
+        config_files="${ZDOTDIR:-$HOME}/.zshrc ${ZDOTDIR:-$HOME}/.zshenv $XDG_CONFIG_HOME/zsh/.zshrc $XDG_CONFIG_HOME/zsh/.zshenv"
     ;;
     bash)
         config_files="$HOME/.bashrc $HOME/.bash_profile $HOME/.profile $XDG_CONFIG_HOME/bash/.bashrc $XDG_CONFIG_HOME/bash/.bash_profile"


### PR DESCRIPTION
### What does this PR do?
- Closes #8512
- Respect `ZDOTDIR` environment variable when detecting zsh config files
- Falls back to `HOME` when unset, matching zsh's native behavior

_Per the zsh manual: "If $ZDOTDIR is unset, $HOME is used instead."_

### How did you verify your code works?
- I ran the script and it installed correctly, respecting ZDOTDIR.
- Tested with ZDOTDIR unset, set, and empty - all expand correctly
- Confirmed users without ZDOTDIR get identical paths as before (no breaking change)
- Tested file selection loop with temp files - correctly prioritizes ZDOTDIR over HOME