### PR TITLE
fix(desktop): open external links in default browser

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -292,6 +292,23 @@ root?.addEventListener("mousewheel", (e) => {
   e.stopPropagation()
 })
 
+// Intercept all link clicks and open external links in the default browser
+root?.addEventListener("click", (e) => {
+  const target = e.target as HTMLElement
+  const anchor = target.closest("a")
+  if (!anchor) return
+
+  const href = anchor.getAttribute("href")
+  if (!href) return
+
+  // Only intercept external links (http/https)
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    e.preventDefault()
+    e.stopPropagation()
+    void shellOpen(href).catch(() => undefined)
+  }
+})
+
 render(() => {
   const [serverPassword, setServerPassword] = createSignal<string | null>(null)
   const platform = createPlatform(() => serverPassword())


### PR DESCRIPTION
## Summary

Fixes an issue where clicking links in the OpenCode desktop app would open them in the same window instead of the user's default external browser.

## Changes

- Added click event listener at root level to intercept all link clicks
- External links (http/https) now use Tauri's `shellOpen` to open in default browser
- Prevents markdown links from navigating within the app window

## Testing

1. Run the desktop app: `bun run tauri dev`
2. Prompt the AI for a response containing a link
3. Click the link - it should open in your external browser, not within the app

## Related Issue

Fixes #8361