### PR TITLE
feat(desktop): open external links in system browser instead of webview

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -33,7 +33,7 @@ const Loading = () => <div class="size-full flex items-center justify-center tex
 
 declare global {
   interface Window {
-    __OPENCODE__?: { updaterEnabled?: boolean; serverPassword?: string }
+    __OPENCODE__?: { updaterEnabled?: boolean; serverPassword?: string; openLinksExternally?: boolean }
   }
 }
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -68,6 +68,9 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
         sessionTabs: {} as Record<string, SessionTabs>,
         sessionView: {} as Record<string, SessionView>,
+        links: {
+          openExternally: true,
+        },
       }),
     )
 
@@ -266,6 +269,13 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       )
     })
 
+    // Sync openLinksExternally setting to window.__OPENCODE__ for desktop app
+    createEffect(() => {
+      const value = store.links?.openExternally ?? true
+      window.__OPENCODE__ ??= {}
+      window.__OPENCODE__.openLinksExternally = value
+    })
+
     return {
       ready,
       projects: {
@@ -341,6 +351,24 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
         toggle() {
           setStore("mobileSidebar", "opened", (x) => !x)
+        },
+      },
+      links: {
+        openExternally: createMemo(() => store.links?.openExternally ?? true),
+        setOpenExternally(value: boolean) {
+          if (!store.links) {
+            setStore("links", { openExternally: value })
+            return
+          }
+          setStore("links", "openExternally", value)
+        },
+        toggle() {
+          const current = store.links?.openExternally ?? true
+          if (!store.links) {
+            setStore("links", { openExternally: !current })
+            return
+          }
+          setStore("links", "openExternally", !current)
         },
       },
       view(sessionKey: string) {

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -599,6 +599,12 @@ export default function Layout(props: ParentProps) {
         keybind: "mod+shift+t",
         onSelect: () => cycleTheme(1),
       },
+      {
+        id: "links.toggle-external",
+        title: layout.links.openExternally() ? "Open links in app" : "Open links in browser",
+        category: "Settings",
+        onSelect: () => layout.links.toggle(),
+      },
     ]
 
     for (const [id, definition] of availableThemeEntries()) {
@@ -1236,6 +1242,23 @@ export default function Layout(props: ParentProps) {
               <Show when={expanded()}>Share feedback</Show>
             </Button>
           </Tooltip>
+          <Show when={platform.platform === "desktop"}>
+            <Tooltip
+              placement="right"
+              value={layout.links.openExternally() ? "Links open in browser" : "Links open in app"}
+              inactive={expanded()}
+            >
+              <Button
+                class="flex w-full text-left justify-start text-text-base stroke-[1.5px] rounded-lg px-2"
+                variant="ghost"
+                size="large"
+                icon={layout.links.openExternally() ? "square-arrow-top-right" : "window-cursor"}
+                onClick={() => layout.links.toggle()}
+              >
+                <Show when={expanded()}>{layout.links.openExternally() ? "Links: Browser" : "Links: In-app"}</Show>
+              </Button>
+            </Tooltip>
+          </Show>
         </div>
       </div>
     )

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -292,12 +292,23 @@ root?.addEventListener("mousewheel", (e) => {
   e.stopPropagation()
 })
 
-// Handle external links - open in system browser instead of webview
-document.addEventListener("click", (e) => {
-  const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
-  if (link?.href) {
+// Intercept all link clicks and open external URLs in system browser
+root?.addEventListener("click", (e) => {
+  const anchor = (e.target as HTMLElement).closest("a")
+  if (!anchor) return
+
+  const href = anchor.getAttribute("href")
+  if (!href) return
+
+  // Only intercept external URLs (http/https)
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    // Check if user wants to open links externally (default: true)
+    const openExternally = window.__OPENCODE__?.openLinksExternally ?? true
+    if (!openExternally) return
+
     e.preventDefault()
-    platform.openLink(link.href)
+    e.stopPropagation()
+    void shellOpen(href).catch(() => undefined)
   }
 })
 


### PR DESCRIPTION
## Summary

Fixes #8361

This PR fixes the issue where clicking links in AI responses navigates inside the Tauri webview instead of opening in the system browser.

**What makes this PR different from #8520 and #7360:**
- ✅ **User toggle setting** - Users can choose between external browser or in-app navigation
- ✅ **Command palette integration** - Quick toggle via Mod+Shift+P
- ✅ **UI toggle button** - Visible in sidebar footer (desktop only)
- ✅ **Persisted preference** - Setting survives app restarts

## Changes

- **Global click handler**: Intercepts all `<a>` tag clicks with `http://` or `https://` URLs and opens them via `shellOpen()` in the system browser
- **User setting**: Added `links.openExternally` to Layout context (persisted) so users can toggle between external browser and in-app navigation
- **Command palette**: Added "Open links in browser/app" command for quick toggling
- **UI toggle**: Added a toggle button in the sidebar footer (only visible on desktop)

## Problem

In Tauri webview, `target="_blank"` on `<a>` tags does NOT automatically open links in the system browser. When users click links from:
- Markdown rendered AI responses
- Native `<a>` tags (like the feedback button)

...the webview navigates to that URL, and users get "stuck" with no obvious way to return.

## Solution

Added a global click handler that:
1. Intercepts clicks on `<a>` tags with external URLs
2. Checks user preference (`window.__OPENCODE__.openLinksExternally`)
3. If enabled (default: true), prevents default navigation and opens via `shellOpen()`

## Testing

1. Run `bun dev` in `packages/opencode`
2. Open desktop app
3. Ask the AI to respond with a link (e.g., "give me a link to github")
4. Click the link → should open in system browser
5. Toggle the setting in sidebar → links should now navigate in-app

## Files Changed

| File | Change |
|------|--------|
| `packages/desktop/src/index.tsx` | Global click handler |
| `packages/app/src/context/layout.tsx` | Persisted setting + sync to `window.__OPENCODE__` |
| `packages/app/src/app.tsx` | Type definition for `window.__OPENCODE__` |
| `packages/app/src/pages/layout.tsx` | Command palette + UI toggle button |

## Default Behavior

**Opens links in external browser** (most users expect this behavior)

Users who prefer in-app browsing can toggle the setting.

---

> **Note:** This PR is aware of #8520 and #7360 which address the same core issue. This PR adds additional user-facing features (toggle setting, command palette, UI button) that those PRs don't include. Happy to collaborate or consolidate if needed!