### PR TITLE
feat(session): bi-directional cursor-based pagination (#6548)

### DIFF
--- a/packages/app/e2e/performance/unit/mock-server.test.ts
+++ b/packages/app/e2e/performance/unit/mock-server.test.ts
@@ -44,3 +44,49 @@ test("applies message latency after a list response gate is released", async () 
   expect(performance.now() - released).toBeGreaterThanOrEqual(20)
   expect(events).toEqual(["start", "before", "page", "end", "fulfill"])
 })
+
+test("serves current message list and lookup response contracts", async () => {
+  let handler: ((route: Route) => Promise<void>) | undefined
+  const responses: unknown[] = []
+  const message = {
+    info: { id: "message", role: "user" as const, time: { created: 1 } },
+    parts: [{ type: "text", text: "hello" }],
+  }
+  const page = {
+    route: (_url: string, callback: (route: Route) => Promise<void>) => {
+      handler = callback
+      return Promise.resolve()
+    },
+  } as unknown as Page
+  await mockOpenCodeServer(page, {
+    protocol: "v2",
+    provider: {},
+    directory: "C:/OpenCode",
+    project: {},
+    sessions: [{ id: "session" }],
+    pageMessages: () => ({ items: [message] }),
+    message: () => message,
+  })
+
+  const route = (url: string) =>
+    ({
+      request: () => ({ url: () => url, method: () => "GET" }),
+      fulfill: (input: { body?: string }) => {
+        responses.push(JSON.parse(input.body ?? "null"))
+        return Promise.resolve()
+      },
+      fallback: () => Promise.resolve(),
+    }) as unknown as Route
+
+  await handler!(route("http://127.0.0.1:4096/api/session/session/message"))
+  await handler!(route("http://127.0.0.1:4096/api/session/session/message/message"))
+
+  expect(responses).toEqual([
+    {
+      data: [{ id: "message", type: "user", time: { created: 1 }, text: "hello" }],
+      context: [],
+      cursor: {},
+    },
+    { data: { id: "message", type: "user", time: { created: 1 }, text: "hello" } },
+  ])
+})

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -261,6 +261,15 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
     const projectMatch = path.match(/^\/project\/([^/]+)$/)
     if (projectMatch) return json(route, config.project)
 
+    const currentMessageMatch = path.match(/^\/api\/session\/([^/]+)\/message\/([^/]+)$/)
+    if (currentMessageMatch) {
+      config.onMessage?.({ sessionID: currentMessageMatch[1]!, messageID: currentMessageMatch[2]! })
+      if (config.messageDelay !== undefined) await new Promise((resolve) => setTimeout(resolve, config.messageDelay))
+      const message = config.message?.(currentMessageMatch[1]!, currentMessageMatch[2]!)
+      if (message === undefined) return json(route, { error: "Message not found" }, undefined, 404)
+      return json(route, { data: currentMessage(message) })
+    }
+
     const messageMatch = path.match(/^\/session\/([^/]+)\/message\/([^/]+)$/)
     if (messageMatch) {
       config.onMessage?.({ sessionID: messageMatch[1]!, messageID: messageMatch[2]! })
@@ -288,6 +297,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       if (cursor) cursors.set(cursor, pageData.cursor!)
       return json(route, {
         data: pageData.items.map(currentMessage).reverse(),
+        context: [],
         cursor: { next: cursor },
       })
     }
@@ -306,7 +316,12 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       if (!pageData.cursor) return json(route, pageData.items)
       const cursor = `cursor_${++nextCursor}`
       cursors.set(cursor, pageData.cursor)
-      return json(route, pageData.items, { "x-next-cursor": cursor })
+      const next = new URL(url)
+      next.searchParams.delete("after")
+      next.searchParams.delete("oldest")
+      next.searchParams.set("limit", limit.toString())
+      next.searchParams.set("before", cursor)
+      return json(route, pageData.items, { "x-next-cursor": cursor, Link: `<${next.toString()}>; rel="next"` })
     }
 
     if (url.port === targetPort && targetPort !== appPort) return json(route, {})
@@ -429,7 +444,7 @@ function json(route: Route, body: unknown, headers?: Record<string, string>, sta
     contentType: "application/json",
     headers: {
       "access-control-allow-origin": "*",
-      "access-control-expose-headers": "x-next-cursor",
+      "access-control-expose-headers": "Link, X-Next-Cursor",
       ...headers,
     },
     body: JSON.stringify(body ?? null),

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -18,6 +18,7 @@ import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
+import { selectVisibleUserMessages } from "@/pages/session/timeline/model"
 import { getSessionContext } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
@@ -113,19 +114,8 @@ export function SessionContextTab() {
     { equals: same },
   )
 
-  const userMessages = createMemo(
-    () => messages().filter((m) => m.role === "user") as UserMessage[],
-    emptyUserMessages,
-    { equals: same },
-  )
-
   const visibleUserMessages = createMemo(
-    () => {
-      const revert = info()?.revert?.messageID
-      if (!revert) return userMessages()
-      const boundary = userMessages().findIndex((message) => message.id === revert)
-      return boundary < 0 ? userMessages() : userMessages().slice(0, boundary)
-    },
+    () => selectVisibleUserMessages(messages(), info()?.revert),
     emptyUserMessages,
     { equals: same },
   )

--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -17,6 +17,7 @@ const sessionFields = new Set([
   "question",
   "message",
   "session_message",
+  "revert_preview",
   "part",
   "part_text_accum_delta",
 ])

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -70,6 +70,7 @@ function directoryState() {
     limit: 5,
     message: {},
     session_message: {},
+    revert_preview: {},
     part: {},
     part_text_accum_delta: {},
   })

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -256,6 +256,7 @@ export function createChildStoreManager(input: {
             limit: 5,
             message: {},
             session_message: {},
+            revert_preview: {},
             part: {},
             part_text_accum_delta: {},
           })

--- a/packages/app/src/context/global-sync/event-reducer.test.ts
+++ b/packages/app/src/context/global-sync/event-reducer.test.ts
@@ -81,6 +81,7 @@ const baseState = (input: Partial<State> = {}) =>
     limit: 10,
     message: {},
     session_message: {},
+    revert_preview: {},
     part: {},
     part_text_accum_delta: {},
     ...input,

--- a/packages/app/src/context/global-sync/session-cache.test.ts
+++ b/packages/app/src/context/global-sync/session-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import type { Message, Part, PermissionRequest, QuestionRequest, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import { dropSessionCaches, pickSessionCacheEvictions } from "./session-cache"
+import type { RevertPreview } from "./types"
 
 const msg = (id: string, sessionID: string) =>
   ({
@@ -30,6 +31,7 @@ describe("app session cache", () => {
       todo: Record<string, Todo[] | undefined>
       message: Record<string, Message[] | undefined>
       session_message: Record<string, never[] | undefined>
+      revert_preview: Record<string, RevertPreview | undefined>
       part: Record<string, Part[] | undefined>
       permission: Record<string, PermissionRequest[] | undefined>
       question: Record<string, QuestionRequest[] | undefined>
@@ -40,6 +42,7 @@ describe("app session cache", () => {
       todo: { ses_1: [] as Todo[] },
       message: {},
       session_message: {},
+      revert_preview: { ses_1: { messageID: "msg_1", userCount: 0, hasMore: false, items: [] } },
       part: { msg_1: [part("prt_1", "ses_1", "msg_1")] },
       permission: { ses_1: [] as PermissionRequest[] },
       question: { ses_1: [] as QuestionRequest[] },
@@ -56,6 +59,7 @@ describe("app session cache", () => {
     expect(store.session_status.ses_1).toBeUndefined()
     expect(store.permission.ses_1).toBeUndefined()
     expect(store.question.ses_1).toBeUndefined()
+    expect(store.revert_preview.ses_1).toBeUndefined()
   })
 
   test("dropSessionCaches clears message-backed parts", () => {
@@ -66,6 +70,7 @@ describe("app session cache", () => {
       todo: Record<string, Todo[] | undefined>
       message: Record<string, Message[] | undefined>
       session_message: Record<string, never[] | undefined>
+      revert_preview: Record<string, RevertPreview | undefined>
       part: Record<string, Part[] | undefined>
       permission: Record<string, PermissionRequest[] | undefined>
       question: Record<string, QuestionRequest[] | undefined>
@@ -76,6 +81,7 @@ describe("app session cache", () => {
       todo: {},
       message: { ses_1: [m] },
       session_message: {},
+      revert_preview: {},
       part: { [m.id]: [part("prt_1", "ses_1", m.id)] },
       permission: {},
       question: {},

--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -1,6 +1,7 @@
 import type { Message, Part, PermissionRequest, QuestionRequest, SessionStatus, Todo } from "@opencode-ai/sdk/v2/client"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import type { SessionMessageInfo } from "@opencode-ai/client/promise"
+import type { RevertPreview } from "./types"
 
 export const SESSION_CACHE_LIMIT = 40
 
@@ -10,6 +11,7 @@ type SessionCache = {
   todo: Record<string, Todo[] | undefined>
   message: Record<string, Message[] | undefined>
   session_message: Record<string, SessionMessageInfo[] | undefined>
+  revert_preview: Record<string, RevertPreview | undefined>
   part: Record<string, Part[] | undefined>
   permission: Record<string, PermissionRequest[] | undefined>
   question: Record<string, QuestionRequest[] | undefined>
@@ -33,6 +35,7 @@ export function dropSessionCaches(store: SessionCache, sessionIDs: Iterable<stri
     delete store.message[sessionID]
     delete store.todo[sessionID]
     delete store.session_message[sessionID]
+    delete store.revert_preview[sessionID]
     delete store.session_diff[sessionID]
     delete store.session_status[sessionID]
     delete store.permission[sessionID]

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -30,6 +30,15 @@ export type ProjectMeta = {
   }
 }
 
+export type RevertPreview = {
+  messageID: string
+  userCount: number
+  hasMore: boolean
+  nextMessageID?: string
+  continuationMessageID?: string
+  items: { id: string; text: string }[]
+}
+
 export type State = {
   status: "loading" | "partial" | "complete"
   agent: Agent[]
@@ -76,6 +85,9 @@ export type State = {
   }
   session_message: {
     [sessionID: string]: SessionMessageInfo[]
+  }
+  revert_preview: {
+    [sessionID: string]: RevertPreview | undefined
   }
   part: {
     [messageID: string]: Part[]

--- a/packages/app/src/context/revert-page.test.ts
+++ b/packages/app/src/context/revert-page.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from "bun:test"
+import type { Message, Part } from "@opencode-ai/sdk/v2/client"
+import { boundaryFromMessageResponse } from "@opencode-ai/core/util/revert-boundary"
+import { hasVisibleUserBeforeRevert, loadRevertAwareLatestPage } from "./revert-page"
+
+const message = (id: string, role: Message["role"]): Message =>
+  role === "assistant"
+    ? ({
+        id,
+        sessionID: "ses_1",
+        role: "assistant",
+        agent: "default",
+        model: { providerID: "openai", modelID: "gpt-4" },
+        time: { created: Number(id.slice(2)) },
+      } as unknown as Message)
+    : ({
+        id,
+        sessionID: "ses_1",
+        role: "user",
+        agent: "default",
+        model: { providerID: "openai", modelID: "gpt-4" },
+        time: { created: Number(id.slice(2)) },
+      } as unknown as Message)
+
+const textPart = (id: string, messageID: string): Extract<Part, { type: "text" }> => ({
+  id,
+  sessionID: "ses_1",
+  messageID,
+  type: "text",
+  text: id,
+})
+
+describe("revert page helpers", () => {
+  test("only treats 404 boundary fetch responses as missing boundaries", () => {
+    const found = { info: message("m6", "user"), parts: [textPart("p6", "m6")], cursor: "boundary" }
+    expect(boundaryFromMessageResponse({ data: found, error: undefined, response: { status: 200 } })).toBe(found)
+    expect(
+      boundaryFromMessageResponse({ data: undefined, error: { message: "missing" }, response: { status: 404 } }),
+    ).toBeUndefined()
+    expect(() =>
+      boundaryFromMessageResponse({ data: undefined, error: new Error("server failed"), response: { status: 500 } }),
+    ).toThrow("server failed")
+    expect(() => boundaryFromMessageResponse({ data: undefined, error: new Error("network failed") })).toThrow(
+      "network failed",
+    )
+    expect(() => boundaryFromMessageResponse({ data: undefined, error: undefined, response: { status: 200 } })).toThrow(
+      "missing revert boundary message",
+    )
+  })
+
+  test("detects when the loaded page has no visible user before revert", () => {
+    expect(hasVisibleUserBeforeRevert([message("m6", "user"), message("m7", "assistant")], { messageID: "m6" })).toBe(
+      false,
+    )
+    expect(
+      hasVisibleUserBeforeRevert(
+        [message("m5", "user"), message("m6", "user")],
+        { messageID: "m6" },
+        message("m6", "user"),
+      ),
+    ).toBe(true)
+  })
+
+  test("treats a user boundary as visible for part-level reverts", () => {
+    const messages = [message("m6", "user"), message("m7", "assistant")]
+    expect(hasVisibleUserBeforeRevert(messages, { messageID: "m6", partID: "p6" })).toBe(true)
+    expect(hasVisibleUserBeforeRevert(messages, { messageID: "m6" })).toBe(false)
+  })
+
+  test("does not walk older history for a part-level revert at the first user", async () => {
+    const boundaryPart = textPart("p6", "m6")
+    let olderCalls = 0
+
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m6", "user"), message("m7", "assistant")],
+        part: [
+          { id: "m6", part: [boundaryPart] },
+          { id: "m7", part: [] },
+        ],
+        cursor: undefined,
+        complete: true,
+      },
+      revert: { messageID: "m6", partID: "p6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [boundaryPart], cursor: "boundary" }),
+      fetchPage: async () => {
+        olderCalls += 1
+        return { session: [], part: [], cursor: undefined, complete: true }
+      },
+    })
+
+    expect(olderCalls).toBe(0)
+    expect(result.session.map((item) => item.id)).toEqual(["m6", "m7"])
+  })
+
+  test("loads and merges an older boundary window when latest page is fully reverted", async () => {
+    const olderPart = textPart("p5", "m5")
+    const boundaryPart = textPart("p6", "m6")
+
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m6", "user"), message("m7", "assistant"), message("m8", "user")],
+        part: [
+          { id: "m6", part: [boundaryPart] },
+          { id: "m7", part: [] },
+          { id: "m8", part: [] },
+        ],
+        cursor: undefined,
+        complete: true,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [boundaryPart], cursor: "boundary" }),
+      fetchPage: async (before) => {
+        expect(before).toBe("boundary")
+        return {
+          session: [message("m4", "assistant"), message("m5", "user")],
+          part: [
+            { id: "m4", part: [] },
+            { id: "m5", part: [olderPart] },
+          ],
+          cursor: "older",
+          complete: false,
+        }
+      },
+    })
+
+    expect(result.session.map((item) => item.id)).toEqual(["m4", "m5", "m6", "m7", "m8"])
+    expect(result.part.find((item) => item.id === "m5")?.part).toEqual([olderPart])
+    expect(result.part.find((item) => item.id === "m6")?.part).toEqual([boundaryPart])
+    expect(result.cursor).toBe("older")
+    expect(result.complete).toBe(false)
+  })
+
+  test("merges the fetched boundary when the current page already has a visible prior user", async () => {
+    const boundaryPart = textPart("p6", "m6")
+    let olderCalls = 0
+
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m5", "user"), message("m7", "assistant")],
+        part: [
+          { id: "m5", part: [] },
+          { id: "m7", part: [] },
+        ],
+        cursor: undefined,
+        complete: true,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [boundaryPart], cursor: "boundary" }),
+      fetchPage: async () => {
+        olderCalls += 1
+        return { session: [], part: [], cursor: undefined, complete: true }
+      },
+    })
+
+    expect(olderCalls).toBe(0)
+    expect(result.session.map((item) => item.id)).toEqual(["m5", "m6", "m7"])
+    expect(result.part.find((item) => item.id === "m6")?.part).toEqual([boundaryPart])
+  })
+
+  test("merges the fetched boundary when no older boundary cursor exists", async () => {
+    const boundaryPart = textPart("p6", "m6")
+
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m7", "assistant")],
+        part: [{ id: "m7", part: [] }],
+        cursor: undefined,
+        complete: true,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [boundaryPart] }),
+      fetchPage: async () => ({ session: [], part: [], cursor: undefined, complete: true }),
+    })
+
+    expect(result.session.map((item) => item.id)).toEqual(["m6", "m7"])
+    expect(result.part.find((item) => item.id === "m6")?.part).toEqual([boundaryPart])
+  })
+
+  test("walks the latest cursor when an older server omits the boundary cursor", async () => {
+    let before: string | undefined
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m7", "assistant")],
+        part: [{ id: "m7", part: [] }],
+        cursor: "raw-hidden-older",
+        complete: false,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [] }),
+      fetchPage: async (cursor) => {
+        before = cursor
+        return { session: [message("m5", "user")], part: [], cursor: undefined, complete: true }
+      },
+    })
+
+    expect(before).toBe("raw-hidden-older")
+    expect(result.session.map((item) => item.id)).toEqual(["m5", "m6", "m7"])
+    expect(result.cursor).toBeUndefined()
+    expect(result.complete).toBe(true)
+  })
+
+  test("keeps loading older pages until a visible user exists before revert", async () => {
+    const boundaryPart = textPart("p6", "m6")
+    const olderPart = textPart("p3", "m3")
+    let call = 0
+
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m6", "user"), message("m7", "assistant"), message("m8", "user")],
+        part: [
+          { id: "m6", part: [boundaryPart] },
+          { id: "m7", part: [] },
+          { id: "m8", part: [] },
+        ],
+        cursor: undefined,
+        complete: true,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [boundaryPart], cursor: "boundary" }),
+      fetchPage: async () => {
+        call += 1
+        if (call === 1) {
+          return {
+            session: [message("m4", "assistant"), message("m5", "assistant")],
+            part: [
+              { id: "m4", part: [] },
+              { id: "m5", part: [] },
+            ],
+            cursor: "older-2",
+            complete: false,
+          }
+        }
+        return {
+          session: [message("m3", "user")],
+          part: [{ id: "m3", part: [olderPart] }],
+          cursor: undefined,
+          complete: true,
+        }
+      },
+    })
+
+    expect(call).toBe(2)
+    expect(result.session.map((item) => item.id)).toEqual(["m3", "m4", "m5", "m6", "m7", "m8"])
+    expect(result.part.find((item) => item.id === "m3")?.part).toEqual([olderPart])
+    expect(result.cursor).toBeUndefined()
+    expect(result.complete).toBe(true)
+  })
+
+  test("rejects a repeated older page instead of looping", async () => {
+    let calls = 0
+    const current = {
+      session: [message("m6", "user"), message("m7", "assistant")],
+      part: [],
+      cursor: "repeat",
+      complete: false,
+    }
+
+    await expect(
+      loadRevertAwareLatestPage({
+        current,
+        revert: { messageID: "m6" },
+        fetchMessage: async () => ({ info: message("m6", "user"), parts: [], cursor: "repeat" }),
+        fetchPage: async () => {
+          calls += 1
+          if (calls > 1) throw new Error("pagination did not stop")
+          return current
+        },
+      }),
+    ).rejects.toThrow("Message pagination returned no new messages")
+    expect(calls).toBe(1)
+  })
+
+  test("keeps an unseen page that completes revert repair even when its cursor repeats", async () => {
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m6", "user"), message("m7", "assistant")],
+        part: [],
+        cursor: "repeat",
+        complete: false,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => ({ info: message("m6", "user"), parts: [], cursor: "repeat" }),
+      fetchPage: async () => ({
+        session: [message("m5", "user")],
+        part: [],
+        cursor: "repeat",
+        complete: false,
+      }),
+    })
+
+    expect(result.session.map((message) => message.id)).toEqual(["m5", "m6", "m7"])
+  })
+
+  test("marks stale revert boundaries for clearing when the boundary message is missing", async () => {
+    const result = await loadRevertAwareLatestPage({
+      current: {
+        session: [message("m7", "assistant"), message("m8", "user")],
+        part: [
+          { id: "m7", part: [] },
+          { id: "m8", part: [] },
+        ],
+        cursor: undefined,
+        complete: true,
+      },
+      revert: { messageID: "m6" },
+      fetchMessage: async () => undefined,
+      fetchPage: async () => ({
+        session: [],
+        part: [],
+        cursor: undefined,
+        complete: true,
+      }),
+    })
+
+    expect(result.clearedRevert).toBe(true)
+    expect(result.session.map((item) => item.id)).toEqual(["m7", "m8"])
+  })
+})

--- a/packages/app/src/context/revert-page.ts
+++ b/packages/app/src/context/revert-page.ts
@@ -1,0 +1,104 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2/client"
+
+type MessagePage = {
+  session: Message[]
+  part: { id: string; part: Part[] }[]
+  cursor?: string
+  complete: boolean
+  clearedRevert?: boolean
+}
+
+type MessageWithParts = {
+  info: Message
+  parts: Part[]
+  cursor?: string
+}
+
+export type RevertTarget = {
+  messageID: string
+  partID?: string
+}
+
+const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+export const compareMessages = (a: Message, b: Message) => a.time.created - b.time.created || cmp(a.id, b.id)
+export const messageBefore = (message: Message, boundary: Message) => compareMessages(message, boundary) < 0
+
+const sortParts = (parts: Part[]) => parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
+
+// A part-level revert keeps the boundary message itself visible (with trimmed parts), so a
+// user boundary counts as the visible user and no older history is required to render it.
+export function hasVisibleUserBeforeRevert(messages: readonly Message[], revert?: RevertTarget, boundary?: Message) {
+  if (!revert?.messageID) return true
+  const resolved = boundary ?? messages.find((message) => message.id === revert.messageID)
+  if (!resolved) return false
+  return messages.some(
+    (message) =>
+      message.role === "user" && (messageBefore(message, resolved) || (message.id === resolved.id && !!revert.partID)),
+  )
+}
+
+function mergeMessages(current: Message[], older: Message[], boundary: Message) {
+  const merged = new Map(current.filter((message) => !!message?.id).map((message) => [message.id, message] as const))
+  for (const message of older) {
+    if (!message?.id) continue
+    merged.set(message.id, message)
+  }
+  merged.set(boundary.id, boundary)
+  return [...merged.values()].sort(compareMessages)
+}
+
+function mergeParts(current: MessagePage["part"], older: MessagePage["part"], boundary: MessageWithParts) {
+  const merged = new Map(current.filter((item) => !!item?.id).map((item) => [item.id, sortParts(item.part)] as const))
+  for (const item of older) {
+    if (!item?.id) continue
+    merged.set(item.id, sortParts(item.part))
+  }
+  merged.set(boundary.info.id, sortParts(boundary.parts))
+  return [...merged.entries()].sort((a, b) => cmp(a[0], b[0])).map(([id, part]) => ({ id, part }))
+}
+
+export async function loadRevertAwareLatestPage(input: {
+  current: MessagePage
+  revert?: RevertTarget
+  fetchMessage: (messageID: string) => Promise<MessageWithParts | undefined>
+  fetchPage: (before: string) => Promise<MessagePage>
+}) {
+  if (!input.revert?.messageID) return input.current
+
+  const boundary = await input.fetchMessage(input.revert.messageID)
+  if (!boundary) return { ...input.current, clearedRevert: true }
+  const current = {
+    ...input.current,
+    session: mergeMessages(input.current.session, [], boundary.info),
+    part: mergeParts(input.current.part, [], boundary),
+    cursor: boundary.cursor ?? input.current.cursor,
+    complete: !boundary.cursor && !input.current.cursor,
+  }
+  if (hasVisibleUserBeforeRevert(current.session, input.revert, boundary.info)) return current
+  if (!current.cursor) return current
+
+  const cursors = new Set<string>()
+  const ids = new Set(current.session.map((message) => message.id))
+  let older: MessagePage = current
+  let session = current.session
+  let part = current.part
+  let cursor: string | undefined = current.cursor
+  while (!hasVisibleUserBeforeRevert(session, input.revert, boundary.info) && cursor) {
+    if (cursors.has(cursor)) throw new Error("Message pagination cursor did not advance")
+    cursors.add(cursor)
+    older = await input.fetchPage(cursor)
+    const unseen = older.session.filter((message) => !ids.has(message.id))
+    unseen.forEach((message) => ids.add(message.id))
+    session = mergeMessages(session, older.session, boundary.info)
+    part = mergeParts(part, older.part, boundary)
+    cursor = older.cursor
+    if (!hasVisibleUserBeforeRevert(session, input.revert, boundary.info) && cursor && unseen.length === 0)
+      throw new Error("Message pagination returned no new messages")
+  }
+  return {
+    session,
+    part,
+    cursor: older.cursor,
+    complete: older.complete,
+  }
+}

--- a/packages/app/src/context/server-session-v2-reducer.test.ts
+++ b/packages/app/src/context/server-session-v2-reducer.test.ts
@@ -153,4 +153,66 @@ describe("v2 session reducer", () => {
 
     expect(result).toMatchObject({ sessionID: "ses_1", missing: "msg_user", touched: [] })
   })
+
+  test("continues canonical hydrated shell and pending tool messages", () => {
+    const reducer = createV2SessionReducer()
+    let messages = [
+      {
+        id: "msg_shell",
+        type: "shell",
+        callID: "shell_1",
+        command: "pwd",
+        output: "",
+        time: { created: 1 },
+      },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_1",
+            name: "read",
+            state: { status: "pending", input: '{"filePath":"REA' },
+            time: { created: 1 },
+          },
+        ],
+        time: { created: 1 },
+      },
+    ] as unknown as SessionMessageInfo[]
+    const apply = (input: object) => {
+      const result = reducer.reduce(messages, event(input))
+      if (result) messages = result.messages
+    }
+
+    apply({
+      ...base,
+      id: "evt_shell_end",
+      type: "session.shell.ended",
+      data: {
+        sessionID: "ses_1",
+        shell: { id: "shell_1", status: "exited", exit: 0 },
+        output: { output: "/repo", cursor: 5, size: 5, truncated: false },
+      },
+    })
+    apply({
+      ...base,
+      id: "evt_tool_delta",
+      type: "session.tool.input.delta",
+      data: { sessionID: "ses_1", assistantMessageID: "msg_assistant", callID: "call_1", delta: 'DME.md"}' },
+    })
+
+    expect(messages[0]).toMatchObject({
+      type: "shell",
+      status: "exited",
+      output: { output: "/repo" },
+      time: { completed: 1 },
+    })
+    expect(messages[1]).toMatchObject({
+      type: "assistant",
+      content: [{ type: "tool", state: { input: '{"filePath":"README.md"}' } }],
+    })
+  })
 })

--- a/packages/app/src/context/server-session-v2-reducer.ts
+++ b/packages/app/src/context/server-session-v2-reducer.ts
@@ -105,7 +105,9 @@ export function createV2SessionReducer() {
       case "session.shell.ended":
         return updateMessage<Shell>(
           source,
-          (item): item is Shell => item.type === "shell" && item.shellID === event.data.shell.id,
+          (item): item is Shell =>
+            item.type === "shell" &&
+            (("callID" in item && item.callID === event.data.shell.id) || item.shellID === event.data.shell.id),
           (item) => ({
             ...item,
             status: event.data.shell.status,
@@ -255,15 +257,15 @@ export function createV2SessionReducer() {
               ],
         }))
       case "session.tool.input.delta":
-        return updateTool(source, event.data.assistantMessageID, event.data.callID, sessionID, (tool) =>
-          tool.state.status === "streaming"
-            ? { ...tool, state: { ...tool.state, input: tool.state.input + event.data.delta } }
-            : tool,
-        )
+        return updateTool(source, event.data.assistantMessageID, event.data.callID, sessionID, (tool) => {
+          if (!["streaming", "pending"].includes(tool.state.status) || typeof tool.state.input !== "string") return tool
+          return { ...tool, state: { status: "streaming", input: tool.state.input + event.data.delta } }
+        })
       case "session.tool.input.ended":
-        return updateTool(source, event.data.assistantMessageID, event.data.callID, sessionID, (tool) =>
-          tool.state.status === "streaming" ? { ...tool, state: { ...tool.state, input: event.data.text } } : tool,
-        )
+        return updateTool(source, event.data.assistantMessageID, event.data.callID, sessionID, (tool) => {
+          if (!["streaming", "pending"].includes(tool.state.status) || typeof tool.state.input !== "string") return tool
+          return { ...tool, state: { status: "streaming", input: event.data.text } }
+        })
       case "session.tool.called":
         return updateTool(source, event.data.assistantMessageID, event.data.callID, sessionID, (tool) => ({
           ...tool,
@@ -303,7 +305,7 @@ export function createV2SessionReducer() {
         })
       case "session.tool.failed":
         return updateTool(source, event.data.assistantMessageID, event.data.callID, sessionID, (tool) => {
-          if (tool.state.status !== "streaming" && tool.state.status !== "running") return tool
+          if (typeof tool.state.input !== "string" && tool.state.status !== "running") return tool
           return {
             ...tool,
             executed: event.data.executed || tool.executed === true,

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -140,9 +140,12 @@ const retryImmediately: typeof retry = async (task, options = {}) => {
   }
 }
 
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 function setup(sessions: Record<string, Session>) {
   const get: unknown[] = []
   const messages: unknown[] = []
+  const message: unknown[] = []
   const client = {
     session: {
       get: async (input: unknown) => {
@@ -154,11 +157,39 @@ function setup(sessions: Record<string, Session>) {
         messages.push(input)
         return response()
       },
+      message: async (input: unknown) => {
+        message.push(input)
+        return { data: { info: userMessage("boundary", { sessionID: "root", time: { created: 2 } }), parts: [] } }
+      },
       diff: async () => ({ data: [] }),
       todo: async () => ({ data: [] }),
     },
   } as unknown as OpencodeClient
-  return { get, messages, store: createServerSession(client) }
+  return { get, message, messages, store: createServerSession(client) }
+}
+
+function revertClient(
+  pages: MessageResponse[],
+  boundary = userMessage("boundary", { sessionID: "root", time: { created: 2 } }),
+  info: Session = session("root"),
+) {
+  let index = 0
+  const messages: unknown[] = []
+  const message: unknown[] = []
+  const client = {
+    session: {
+      get: async () => ({ data: info }),
+      messages: async (input: unknown) => {
+        messages.push(input)
+        return pages[index++] ?? response()
+      },
+      message: async (input: unknown) => {
+        message.push(input)
+        return { data: { info: boundary, parts: [] } }
+      },
+    },
+  } as unknown as OpencodeClient
+  return { client, message, messages }
 }
 
 describe("server session", () => {
@@ -242,7 +273,7 @@ describe("server session", () => {
       agent: "build",
       model: { id: "model", providerID: "provider" },
       content: [{ type: "text", text: "hi" }],
-      time: { created: 2, completed: 3 },
+      time: { created: 1, completed: 3 },
     }
     const client = {
       session: {
@@ -263,6 +294,16 @@ describe("server session", () => {
     await store.sync("root")
 
     expect(requests).toEqual([{ sessionID: "root", limit: 20, order: "desc" }])
+    expect(store.data.session_message.root.map((message) => message.id)).toEqual([user.id, assistant.id])
+
+    store.applyV2({
+      id: "evt_text_delta",
+      created: 4,
+      type: "session.text.delta",
+      location: { directory: "/repo" },
+      data: { sessionID: "root", assistantMessageID: assistant.id, ordinal: 0, delta: " again" },
+    })
+
     expect(store.data.session_message.root.map((message) => message.id)).toEqual([user.id, assistant.id])
     expect(store.data.message.root.map((message) => message.id)).toEqual([user.id, assistant.id])
   })
@@ -309,9 +350,225 @@ describe("server session", () => {
     expect(assistants.map((item) => store.data.part[item.id]?.[0]?.type)).toEqual(["text", "text", "text"])
   })
 
+  test("walks current pages until a whole-message revert has a visible user", async () => {
+    const older = { id: "msg_1_user", type: "user", text: "older", time: { created: 1 } } as const
+    const boundary = { id: "msg_2_user", type: "user", text: "boundary", time: { created: 2 } } as const
+    const pages = [
+      { data: [boundary], cursor: { previous: null, next: "older" } },
+      { data: [older], cursor: { previous: null, next: null } },
+    ]
+    const requests: unknown[] = []
+    const messageApi = {
+      list: async (input: unknown) => {
+        requests.push(input)
+        return pages.shift()!
+      },
+    } as unknown as MessageApi
+    const store = createServerSession({} as OpencodeClient, {} as SessionApi, messageApi)
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+
+    await store.sync("root")
+
+    expect(requests).toEqual([
+      { sessionID: "root", limit: 20, order: "desc" },
+      { sessionID: "root", limit: 20, cursor: "older" },
+    ])
+    expect(store.data.message.root.map((message) => message.id)).toEqual([older.id, boundary.id])
+    expect(store.data.info.root?.revert).toEqual({ messageID: boundary.id })
+  })
+
+  test("rejects repeated current pages during revert repair", async () => {
+    const boundary = { id: "msg_boundary", type: "user", text: "boundary", time: { created: 2 } } as const
+    let requests = 0
+    const messageApi = {
+      list: async () => {
+        requests += 1
+        if (requests > 2) throw new Error("pagination did not stop")
+        return { data: [boundary], cursor: { previous: null, next: "repeat" } }
+      },
+    } as unknown as MessageApi
+    const store = createServerSession({} as OpencodeClient, {} as SessionApi, messageApi)
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+
+    await expect(store.sync("root")).rejects.toThrow("Message pagination returned no new messages")
+    expect(requests).toBe(2)
+  })
+
+  test("rejects current revert pages that contain no unseen messages", async () => {
+    const boundary = { id: "msg_boundary", type: "user", text: "boundary", time: { created: 2 } } as const
+    let requests = 0
+    const messageApi = {
+      list: async () => {
+        requests += 1
+        return { data: [boundary], cursor: { previous: null, next: `older-${requests}` } }
+      },
+    } as unknown as MessageApi
+    const store = createServerSession({} as OpencodeClient, {} as SessionApi, messageApi)
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+
+    await expect(store.sync("root")).rejects.toThrow("Message pagination returned no new messages")
+    expect(requests).toBe(2)
+  })
+
+  test("keeps an unseen current page that completes revert repair when its cursor repeats", async () => {
+    const older = { id: "msg_older", type: "user", text: "older", time: { created: 1 } } as const
+    const boundary = { id: "msg_boundary", type: "user", text: "boundary", time: { created: 2 } } as const
+    const pages = [
+      { data: [boundary], cursor: { previous: null, next: "repeat" } },
+      { data: [older], cursor: { previous: null, next: "repeat" } },
+    ]
+    const store = createServerSession(
+      {} as OpencodeClient,
+      {} as SessionApi,
+      {
+        list: async () => pages.shift()!,
+      } as unknown as MessageApi,
+    )
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+
+    await store.sync("root")
+
+    expect(store.data.message.root.map((message) => message.id)).toEqual([older.id, boundary.id])
+  })
+
+  test("uses current page context and revert preview without walking older pages", async () => {
+    const older = { id: "msg_z_older", type: "user", text: "older", time: { created: 1 } } as const
+    const boundary = { id: "msg_a_boundary", type: "user", text: "boundary", time: { created: 1 } } as const
+    const requests: unknown[] = []
+    const messageApi = {
+      list: async (input: unknown) => {
+        requests.push(input)
+        return {
+          data: [boundary],
+          context: [older],
+          contextCursor: "visible-older",
+          revert: {
+            messageID: boundary.id,
+            userCount: 1,
+            hasMore: false,
+            items: [{ id: boundary.id, text: boundary.text }],
+          },
+          cursor: { previous: null, next: "raw-older" },
+        }
+      },
+    } as unknown as MessageApi
+    const store = createServerSession({} as OpencodeClient, {} as SessionApi, messageApi)
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+
+    await store.sync("root")
+
+    expect(requests).toEqual([{ sessionID: "root", limit: 20, order: "desc" }])
+    expect(store.data.message.root.map((message) => message.id)).toEqual([older.id, boundary.id])
+    expect(store.data.revert_preview.root).toEqual({
+      messageID: boundary.id,
+      userCount: 1,
+      hasMore: false,
+      items: [{ id: boundary.id, text: boundary.text }],
+    })
+    expect(store.history.more("root")).toBe(true)
+
+    await store.history.loadMore("root")
+    expect(requests[1]).toEqual({ sessionID: "root", limit: 200, cursor: "visible-older" })
+  })
+
+  test("clears a cached current preview when the revert boundary changes", () => {
+    const store = createServerSession({} as OpencodeClient)
+    store.remember({ ...session("root"), revert: { messageID: "msg_a" } })
+    store.set("revert_preview", "root", {
+      messageID: "msg_a",
+      userCount: 1,
+      hasMore: false,
+      items: [{ id: "msg_a", text: "a" }],
+    })
+
+    store.remember({ ...session("root"), revert: { messageID: "msg_b" } })
+
+    expect(store.data.revert_preview.root).toBeUndefined()
+  })
+
+  test("keeps the committed current prefix when refresh fails", async () => {
+    const boundary = { id: "msg_boundary", type: "user", text: "keep", time: { created: 1 } } as const
+    const removed = { id: "msg_removed", type: "user", text: "remove", time: { created: 2 } } as const
+    const gets: unknown[] = []
+    const requests: unknown[] = []
+    const sessionApi = {
+      get: async (input: unknown) => {
+        gets.push(input)
+        return session("root")
+      },
+    } as unknown as SessionApi
+    const messageApi = {
+      list: async (input: unknown) => {
+        requests.push(input)
+        throw new Error("refresh failed")
+      },
+    } as unknown as MessageApi
+    const store = createServerSession({} as OpencodeClient, sessionApi, messageApi)
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+    store.set("message", "root", [
+      userMessage(boundary.id, { sessionID: "root", time: boundary.time }),
+      userMessage(removed.id, { sessionID: "root", time: removed.time }),
+    ])
+    store.set("session_message", "root", [boundary, removed])
+
+    store.applyV2({
+      id: "evt_commit",
+      created: 3,
+      type: "session.next.revert.committed",
+      durable: { aggregateID: "root", seq: 3, version: 1 },
+      data: { sessionID: "root", messageID: boundary.id, timestamp: 3 },
+    } as unknown as OpenCodeEvent)
+    await tick()
+    await tick()
+
+    expect(gets).toEqual([{ sessionID: "root" }])
+    expect(requests).toEqual([{ sessionID: "root", limit: 20, order: "desc" }])
+    expect(store.data.session_message.root.map((message) => message.id)).toEqual([boundary.id])
+    expect(store.data.message.root.map((message) => message.id)).toEqual([boundary.id])
+  })
+
+  test("clears committed revert state when the session refresh fails", async () => {
+    const boundary = { id: "msg_boundary", type: "user", text: "keep", time: { created: 1 } } as const
+    const removed = { id: "msg_removed", type: "user", text: "remove", time: { created: 2 } } as const
+    const requests: unknown[] = []
+    const sessionApi = {
+      get: async () => {
+        throw new Error("session refresh failed")
+      },
+    } as unknown as SessionApi
+    const messageApi = {
+      list: async (input: unknown) => {
+        requests.push(input)
+        return { data: [boundary], context: [], cursor: { previous: null, next: null } }
+      },
+    } as unknown as MessageApi
+    const store = createServerSession({} as OpencodeClient, sessionApi, messageApi)
+    store.remember({ ...session("root"), revert: { messageID: boundary.id } })
+    store.set("message", "root", [
+      userMessage(boundary.id, { sessionID: "root", time: boundary.time }),
+      userMessage(removed.id, { sessionID: "root", time: removed.time }),
+    ])
+    store.set("session_message", "root", [boundary, removed])
+
+    store.applyV2({
+      id: "evt_commit",
+      created: 3,
+      type: "session.next.revert.committed",
+      durable: { aggregateID: "root", seq: 3, version: 1 },
+      data: { sessionID: "root", messageID: boundary.id, timestamp: 3 },
+    } as unknown as OpenCodeEvent)
+    await tick()
+
+    expect(store.data.info.root?.revert).toBeUndefined()
+    expect(store.data.message.root.map((message) => message.id)).toEqual([boundary.id])
+
+    await store.sync("root")
+    expect(requests).toEqual([{ sessionID: "root", limit: 20, order: "desc" }])
+  })
+
   test("indexes V1 messages for the current timeline projection", async () => {
-    const user = userMessage("message-1", { sessionID: "root" })
-    const assistant = assistantMessage("message-2", user.id, { sessionID: "root" })
+    const user = userMessage("message-z", { sessionID: "root", time: { created: 1 } })
+    const assistant = assistantMessage("message-a", user.id, { sessionID: "root", time: { created: 2, completed: 2 } })
     const client = messageClient(
       response([
         { info: user, parts: [textPart(user.id, { sessionID: "root" })] },
@@ -336,9 +593,9 @@ describe("server session", () => {
       { id: assistant.id, type: "assistant" },
     ])
 
-    const next = userMessage("message-3", { sessionID: "root" })
+    const next = userMessage("message-0", { sessionID: "root", time: { created: 0 } })
     store.apply({ type: "message.updated", properties: { info: next } })
-    expect(store.data.session_message.root.map((message) => message.id)).toEqual([user.id, assistant.id, next.id])
+    expect(store.data.session_message.root.map((message) => message.id)).toEqual([next.id, user.id, assistant.id])
 
     store.apply({ type: "message.removed", properties: { sessionID: "root", messageID: next.id } })
     expect(store.data.session_message.root.map((message) => message.id)).toEqual([user.id, assistant.id])
@@ -619,6 +876,149 @@ describe("server session", () => {
     expect(store.data.part[assistant.id]).toEqual([live])
   })
 
+  test("keeps fetched messages in chronological order", async () => {
+    const first = userMessage("msg_9", { time: { created: 1 } })
+    const second = userMessage("msg_2", { time: { created: 2 } })
+    const third = userMessage("msg_1", { time: { created: 3 } })
+    const store = createServerSession(
+      messageClient(
+        response([
+          { info: third, parts: [] },
+          { info: first, parts: [] },
+          { info: second, parts: [] },
+        ]),
+      ),
+    )
+
+    await store.sync("child")
+
+    expect(store.data.message.child.map((message) => message.id)).toEqual(["msg_9", "msg_2", "msg_1"])
+  })
+
+  test("reloads cached messages when remembered revert boundary changes", async () => {
+    const ctx = setup({})
+    ctx.store.remember(session("root"))
+    ctx.store.optimistic.add({ sessionID: "root", message: userMessage("cached", { sessionID: "root" }), parts: [] })
+
+    ctx.store.remember({ ...session("root"), revert: { messageID: "boundary", partID: "part" } })
+    await tick()
+
+    expect(ctx.messages).toEqual([{ sessionID: "root", limit: 20, before: undefined }])
+    expect(ctx.message).toEqual([{ sessionID: "root", messageID: "boundary" }])
+  })
+
+  test("repairs cached revert sessions that do not contain a visible user before the boundary", async () => {
+    const cached = userMessage("cached", { sessionID: "root", time: { created: 3 } })
+    const older = userMessage("older", { sessionID: "root", time: { created: 1 } })
+    const { client, message, messages } = revertClient([
+      response([{ info: cached, parts: [] }]),
+      response([{ info: older, parts: [] }]),
+    ])
+    const store = createServerSession(client)
+    await store.sync("root")
+
+    store.set("info", "root", { ...session("root"), revert: { messageID: "boundary", partID: "part" } })
+    await store.sync("root")
+
+    expect(messages).toEqual([
+      { sessionID: "root", limit: 20, before: undefined },
+      { sessionID: "root", limit: 1, before: undefined },
+    ])
+    expect(message).toEqual([{ sessionID: "root", messageID: "boundary" }])
+  })
+
+  test("does not repair a complete part-level revert cache when the boundary user is visible", async () => {
+    const boundary = userMessage("boundary", { sessionID: "root", time: { created: 2 } })
+    const { client, message, messages } = revertClient([response([{ info: boundary, parts: [] }])], boundary)
+    const store = createServerSession(client)
+    await store.sync("root")
+
+    store.set("info", "root", { ...session("root"), revert: { messageID: "boundary", partID: "part" } })
+    await store.sync("root")
+
+    expect(messages).toEqual([{ sessionID: "root", limit: 20, before: undefined }])
+    expect(message).toEqual([])
+  })
+
+  test("does not repeatedly repair a complete whole-message revert at the first user", async () => {
+    const boundary = userMessage("boundary", { sessionID: "root", time: { created: 2 } })
+    const { client, message, messages } = revertClient([response([{ info: boundary, parts: [] }])], boundary)
+    const store = createServerSession(client)
+    await store.sync("root")
+
+    store.set("info", "root", { ...session("root"), revert: { messageID: "boundary" } })
+    await store.sync("root")
+
+    expect(messages).toEqual([{ sessionID: "root", limit: 20, before: undefined }])
+    expect(message).toEqual([])
+  })
+
+  test("repairs uncached sessions when resolve discovers a revert boundary after the first load", async () => {
+    const cached = userMessage("cached", { sessionID: "root", time: { created: 3 } })
+    const older = userMessage("older", { sessionID: "root", time: { created: 1 } })
+    const { client, message, messages } = revertClient(
+      [response([{ info: cached, parts: [] }]), response([{ info: older, parts: [] }])],
+      undefined,
+      { ...session("root"), revert: { messageID: "boundary" } },
+    )
+    const store = createServerSession(client)
+
+    await store.sync("root")
+
+    expect(messages).toEqual([
+      { sessionID: "root", limit: 20, before: undefined },
+      { sessionID: "root", limit: 1, before: undefined },
+    ])
+    expect(message).toEqual([{ sessionID: "root", messageID: "boundary" }])
+  })
+
+  test("does not expose raw hidden cursors after terminal revert repair", async () => {
+    const newer = userMessage("newer", { sessionID: "root", time: { created: 3 } })
+    const { client, message, messages } = revertClient(
+      [response([{ info: newer, parts: [] }], "raw-hidden-older")],
+      undefined,
+      { ...session("root"), revert: { messageID: "boundary" } },
+    )
+    const store = createServerSession(client)
+
+    await store.sync("root")
+
+    expect(messages).toEqual([
+      { sessionID: "root", limit: 20, before: undefined },
+      { sessionID: "root", limit: 1, before: undefined },
+    ])
+    expect(message).toEqual([{ sessionID: "root", messageID: "boundary" }])
+    expect(store.history.more("root")).toBe(false)
+  })
+
+  test("uses a nonzero page size when repairing an empty cached revert session", async () => {
+    const ctx = setup({ root: session("root") })
+    await ctx.store.sync("root")
+
+    ctx.store.set("info", "root", { ...session("root"), revert: { messageID: "boundary" } })
+    await ctx.store.sync("root")
+
+    expect(ctx.messages).toEqual([
+      { sessionID: "root", limit: 20, before: undefined },
+      { sessionID: "root", limit: 20, before: undefined },
+    ])
+    expect(ctx.message).toEqual([{ sessionID: "root", messageID: "boundary" }])
+  })
+
+  test("uses a nonzero page size when remember reloads an empty cached revert session", async () => {
+    const ctx = setup({ root: session("root") })
+    await ctx.store.sync("root")
+
+    ctx.store.remember({ ...session("root"), revert: { messageID: "boundary" } })
+    await tick()
+
+    expect(ctx.messages).toEqual([
+      { sessionID: "root", limit: 20, before: undefined },
+      { sessionID: "root", limit: 20, before: undefined },
+    ])
+    expect(ctx.message).toEqual([{ sessionID: "root", messageID: "boundary" }])
+  })
+
   test("merges live events into the initial page", async () => {
     const pending = deferredResponse()
     const user = userMessage("message-1")
@@ -634,6 +1034,26 @@ describe("server session", () => {
 
     expect(store.data.message.child).toEqual([user, live])
     expect(store.data.part[live.id]).toEqual([livePart])
+  })
+
+  test("merges live events by chronology, not ID", async () => {
+    const pending = deferredResponse()
+    const first = userMessage("msg_9", { time: { created: 1 } })
+    const live = userMessage("msg_2", { time: { created: 2 } })
+    const third = userMessage("msg_1", { time: { created: 3 } })
+    const store = createServerSession(messageClient(pending.promise))
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.updated", properties: { info: live } })
+    pending.resolve(
+      response([
+        { info: first, parts: [] },
+        { info: third, parts: [] },
+      ]),
+    )
+    await loading
+
+    expect(store.data.message.child.map((message) => message.id)).toEqual(["msg_9", "msg_2", "msg_1"])
   })
 
   test("preserves same-ID live updates over the initial page", async () => {
@@ -1418,6 +1838,22 @@ describe("server session", () => {
     await store.history.loadMore("child")
 
     expect(store.data.message.child).toEqual([older, latest])
+  })
+
+  test("stops history pagination when a page makes no progress", async () => {
+    const latest = userMessage("message-2", { time: { created: 2 } })
+    const store = createServerSession(
+      messageClient(
+        response([{ info: latest, parts: [] }], "repeat"),
+        response([{ info: latest, parts: [] }], "repeat"),
+      ),
+    )
+    await store.sync("child")
+
+    await store.history.loadMore("child")
+
+    expect(store.data.message.child).toEqual([latest])
+    expect(store.history.more("child")).toBe(false)
   })
 
   test("preserves loaded history during an incomplete refresh", async () => {

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -1,4 +1,5 @@
 import { Binary } from "@opencode-ai/core/util/binary"
+import { linkParam, parseLinkHeader } from "@opencode-ai/core/util/link-header"
 import { retry } from "@opencode-ai/core/util/retry"
 import type { OpenCodeEvent, SessionApi, SessionMessageInfo } from "@opencode-ai/client/promise"
 import type {
@@ -19,11 +20,26 @@ import { sessionNotFoundError } from "@/utils/server-errors"
 import { rootSession } from "@/utils/session-route"
 import { normalizeSessionInfo } from "@/utils/session"
 import { compareMessages, messageKey, normalizeSessionMessages } from "@/utils/session-message"
+import { boundaryFromMessageResponse } from "@opencode-ai/core/util/revert-boundary"
 import { dropSessionCaches, pickSessionCacheEvictions, SESSION_CACHE_LIMIT } from "./global-sync/session-cache"
 import { createV2SessionReducer, type V2SessionReduction } from "./server-session-v2-reducer"
 import type { ServerApi } from "@/utils/server"
+import { hasVisibleUserBeforeRevert, loadRevertAwareLatestPage } from "./revert-page"
+import type { RevertPreview } from "./global-sync/types"
 
-type MessageApi = ServerApi["message"]
+// The vendored client snapshot predates the pagination fields on SessionMessagesResponse
+// (context, contextCursor, revert). This widens the pinned types to the current wire
+// contract; delete it when the vendor snapshot is refreshed.
+type MessageList = ServerApi["message"]["list"]
+type MessageApi = {
+  list: (...input: Parameters<MessageList>) => Promise<
+    Awaited<ReturnType<MessageList>> & {
+      context?: SessionMessageInfo[]
+      contextCursor?: string
+      revert?: RevertPreview
+    }
+  >
+}
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
@@ -38,9 +54,23 @@ function needsOlderTurnRoot(source: readonly SessionMessageInfo[]) {
       message.type === "user" ||
       message.type === "shell" ||
       message.type === "assistant" ||
-      (message.type === "synthetic" && message.description?.trim()),
+      (message.type === "synthetic" && (message.description?.trim() || message.text.trim())),
   )
   return boundary?.type === "assistant"
+}
+
+function nextBefore(link: string | null, fallback?: string | null) {
+  const links = parseLinkHeader(link ?? "")
+  return linkParam(links.next, "before") ?? linkParam(links.prev, "before") ?? fallback ?? undefined
+}
+
+function messageIndex(messages: readonly Message[] | undefined, id: string) {
+  return messages?.findIndex((message) => message.id === id) ?? -1
+}
+
+function insertMessage(messages: Message[], message: Message) {
+  const result = Binary.search(messages, messageKey(message), messageKey)
+  if (!result.found) messages.splice(result.index, 0, message)
 }
 
 type OptimisticItem = {
@@ -48,6 +78,11 @@ type OptimisticItem = {
   parts: Part[]
   confirmedParts?: Part[]
   confirmedMessage?: boolean
+}
+
+type OptimisticStore = {
+  message: Record<string, Message[] | undefined>
+  part: Record<string, Part[] | undefined>
 }
 
 type MessagePage = {
@@ -58,6 +93,8 @@ type MessagePage = {
   projectSource?: boolean
   cursor?: string
   complete: boolean
+  clearedRevert?: boolean
+  revertPreview?: RevertPreview
 }
 
 function legacyMessageSource(items: { info: Message; parts: Part[] }[]): SessionMessageInfo[] {
@@ -104,23 +141,35 @@ type MessageLoadBaseline = Pick<
   "touchedMessages" | "retainedMessages" | "touchedParts" | "clearedMessageParts"
 >
 
-function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) {
-  if (items.length === 0) return { ...page, observed: [] as { messageID: string; parts: Part[] }[] }
+const hasParts = (parts: Part[] | undefined, want: Part[]) => {
+  if (!parts) return want.length === 0
+  return want.every((part) => Binary.search(parts, part.id, (item) => item.id).found)
+}
+
+export function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) {
+  if (items.length === 0)
+    return { ...page, observed: [] as { messageID: string; parts: Part[] }[], confirmed: [] as string[] }
   const session = [...page.session]
   const part = new Map(page.part.map((item) => [item.id, item.part]))
   const observed: { messageID: string; parts: Part[] }[] = []
+  const confirmed: string[] = []
   for (const item of items) {
-    const result = Binary.search(session, messageKey(item.message), messageKey)
-    const found = result.found
-    if (!found) session.splice(result.index, 0, item.message)
+    const found = messageIndex(session, item.message.id) !== -1
+    if (!found) {
+      if (page.projectSource) session.push(item.message)
+      if (!page.projectSource) insertMessage(session, item.message)
+    }
     const current = part.get(item.message.id)
-    const confirmed = found ? item.parts.filter((part) => current?.some((value) => value.id === part.id)) : []
-    if (found) observed.push({ messageID: item.message.id, parts: confirmed })
+    if (found && hasParts(current, item.parts)) confirmed.push(item.message.id)
+    const confirmedParts = found
+      ? item.parts.filter((part) => Binary.search(current ?? [], part.id, (value) => value.id).found)
+      : []
+    if (found) observed.push({ messageID: item.message.id, parts: confirmedParts })
     part.set(
       item.message.id,
       merge(
         found ? (current ?? []) : merge(item.confirmedParts ?? [], current ?? []),
-        item.parts.filter((part) => !confirmed.includes(part)),
+        item.parts.filter((part) => !confirmedParts.includes(part)),
       ),
     )
   }
@@ -129,7 +178,27 @@ function mergeOptimisticPage(page: MessagePage, items: OptimisticItem[]) {
     session,
     part: [...part.entries()].sort((a, b) => cmp(a[0], b[0])).map(([id, parts]) => ({ id, part: parts })),
     observed,
+    confirmed,
   }
+}
+
+export function applyOptimisticAdd(draft: OptimisticStore, input: OptimisticItem & { sessionID: string }) {
+  const messages = draft.message[input.sessionID]
+  if (messages) {
+    if (messageIndex(messages, input.message.id) === -1) insertMessage(messages, input.message)
+  } else {
+    draft.message[input.sessionID] = [input.message]
+  }
+  draft.part[input.message.id] = input.parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id))
+}
+
+export function applyOptimisticRemove(draft: OptimisticStore, input: { sessionID: string; messageID: string }) {
+  const messages = draft.message[input.sessionID]
+  if (messages) {
+    const index = messageIndex(messages, input.messageID)
+    if (index !== -1) messages.splice(index, 1)
+  }
+  delete draft.part[input.messageID]
 }
 
 function runInflight(map: Map<string, Promise<void>>, key: string, task: () => Promise<void>) {
@@ -148,6 +217,32 @@ function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
   return [...items.values()].sort((x, y) => cmp(x.id, y.id))
 }
 
+function mergeMessages(a: readonly Message[], b: readonly Message[]) {
+  const items = new Map(a.map((item) => [item.id, item] as const))
+  for (const item of b) items.set(item.id, item)
+  return [...items.values()].sort(compareMessages)
+}
+
+function mergeProjectedMessages(
+  current: readonly Message[],
+  updated: readonly Message[],
+  source?: SessionMessageInfo[],
+) {
+  if (!source) return mergeMessages(current, updated)
+  const items = new Map(current.map((message) => [message.id, message] as const))
+  updated.forEach((message) => items.set(message.id, message))
+  const order = normalizeSessionMessages(updated[0]?.sessionID ?? current[0]?.sessionID ?? "", source).messages
+  return [
+    ...order.flatMap((message) => {
+      const item = items.get(message.id)
+      if (!item) return []
+      items.delete(message.id)
+      return [item]
+    }),
+    ...items.values(),
+  ]
+}
+
 function reconcileFetched<T extends { id: string }>(
   fetched: T[],
   current: readonly T[],
@@ -157,6 +252,7 @@ function reconcileFetched<T extends { id: string }>(
     removed?: ReadonlySet<string>
     preserveUnfetched?: boolean | ((item: T) => boolean)
     compare?: (a: T, b: T) => number
+    preserveOrder?: boolean
   } = {},
 ) {
   const result = new Map(fetched.map((item) => [item.id, item]))
@@ -179,8 +275,8 @@ function reconcileFetched<T extends { id: string }>(
     if (!item) result.delete(id)
   }
   for (const id of options.removed ?? emptyIDs) result.delete(id)
-  const items = [...result.values()]
-  return options.compare ? items.sort(options.compare) : items
+  const values = [...result.values()]
+  return options.preserveOrder ? values : values.sort(options.compare ?? ((a, b) => cmp(a.id, b.id)))
 }
 
 type ServerSessionOptions = { retry?: typeof retry; protocol?: Promise<"v1" | "v2"> }
@@ -202,6 +298,7 @@ export function createServerSession(
     question: {} as Record<string, QuestionRequest[]>,
     message: {} as Record<string, Message[]>,
     session_message: {} as Record<string, SessionMessageInfo[]>,
+    revert_preview: {} as Record<string, RevertPreview | undefined>,
     part: {} as Record<string, Part[]>,
     part_text_accum_delta: {} as Record<string, string>,
     session_working(id: string) {
@@ -253,12 +350,20 @@ export function createServerSession(
     setData(
       "session_message",
       message.sessionID,
-      reconcile([...current, ...legacyMessageSource([{ info: message, parts: [] }])]),
+      reconcile([...current, ...legacyMessageSource([{ info: message, parts: [] }])].sort(compareMessages)),
     )
   }
 
   const remember = (session: Session) => {
+    const previous = data.info[session.id]
+    const reloadMessages =
+      !!previous &&
+      data.message[session.id] !== undefined &&
+      !session.time.archived &&
+      (previous?.revert?.messageID !== session.revert?.messageID || previous?.revert?.partID !== session.revert?.partID)
     setData("info", session.id, reconcile(session))
+    if (data.revert_preview[session.id]?.messageID !== session.revert?.messageID)
+      setData("revert_preview", session.id, undefined)
     infoSeen.delete(session.id)
     infoSeen.add(session.id)
     if (infoSeen.size > sessionInfoLimit) {
@@ -297,6 +402,21 @@ export function createServerSession(
         "info",
         produce((draft) => stale.forEach((sessionID) => delete draft[sessionID])),
       )
+    }
+    if (reloadMessages) {
+      generations.set(session.id, {})
+      inflight.delete(session.id)
+      setMeta("loading", session.id, false)
+      const limit = meta.limit[session.id] ?? initialMessagePageSize
+      // Fire-and-forget reload: on failure the cached window stays visible and the next
+      // sync() detects the unrepaired revert boundary and retries.
+      void loadMessages(
+        session.id,
+        limit === 0 ? initialMessagePageSize : limit,
+        undefined,
+        undefined,
+        session.revert,
+      ).catch(() => {})
     }
     return session
   }
@@ -534,7 +654,13 @@ export function createServerSession(
       pickSessionCacheEvictions({ seen, keep: sessionID, limit: SESSION_CACHE_LIMIT, preserve: protectedSessions() }),
     )
 
-  const fetchMessages = async (sessionID: string, limit: number, before?: string, onAttempt?: () => void) => {
+  const fetchMessages = async (
+    sessionID: string,
+    limit: number,
+    before?: string,
+    onAttempt?: () => void,
+    revert?: Session["revert"],
+  ) => {
     if (messageApi && (await options?.protocol) !== "v1") {
       const request = (cursor?: string) =>
         (options?.retry ?? retry)(() => {
@@ -543,41 +669,115 @@ export function createServerSession(
         })
       const first = await request(before)
       const pages = [first]
-      while (pages.at(-1)?.cursor.next && needsOlderTurnRoot(pages.flatMap((page) => page.data).toReversed())) {
-        const response = await request(pages.at(-1)!.cursor.next ?? undefined)
+      const project = () => {
+        const seen = new Set<string>()
+        const source = pages.toReversed().flatMap((page) =>
+          [...(page.context ?? []), ...page.data.toReversed()].filter((message) => {
+            if (seen.has(message.id)) return false
+            seen.add(message.id)
+            return true
+          }),
+        )
+        return { source, normalized: normalizeSessionMessages(sessionID, source) }
+      }
+      const cursors = new Set<string>()
+      const seen = new Set(first.data.map((message) => message.id))
+      let progressed = true
+      while (pages.at(-1)?.cursor.next) {
+        const current = project()
+        const hasContext = "context" in first
+        const hasPreview = "revert" in first
+        if (
+          (hasContext || !needsOlderTurnRoot(current.source)) &&
+          (hasPreview || hasVisibleUserBeforeRevert(current.normalized.messages, revert))
+        )
+          break
+        if (!progressed) throw new Error("Message pagination returned no new messages")
+        const cursor = pages.at(-1)!.cursor.next!
+        if (cursors.has(cursor)) throw new Error("Message pagination cursor did not advance")
+        cursors.add(cursor)
+        const response = await request(cursor)
+        const unseen = response.data.filter((message) => !seen.has(message.id))
+        unseen.forEach((message) => seen.add(message.id))
+        progressed = unseen.length > 0
         pages.push(response)
         if (!response.data.length) break
       }
       const response = pages.at(-1)!
-      const source = pages.flatMap((page) => page.data).toReversed()
-      const normalized = normalizeSessionMessages(sessionID, source)
+      const current = project()
+      const complete = !response.cursor.next
       return {
-        session: normalized.messages.sort(compareMessages),
-        part: [...normalized.parts.entries()]
+        session: current.normalized.messages,
+        part: [...current.normalized.parts.entries()]
           .map(([id, part]) => ({ id, part: part.sort((a, b) => cmp(a.id, b.id)) }))
           .sort((a, b) => cmp(a.id, b.id)),
-        source,
+        source: current.source,
         sourceMode: before ? ("older" as const) : ("latest" as const),
         projectSource: true,
-        cursor: response.cursor.next ?? undefined,
-        complete: response.data.length === 0,
+        cursor: first.contextCursor ?? response.cursor.next ?? undefined,
+        complete,
+        revertPreview: "revert" in first ? first.revert : undefined,
+        clearedRevert:
+          !!revert?.messageID &&
+          !("revert" in first) &&
+          complete &&
+          !current.normalized.messages.some((message) => message.id === revert.messageID)
+            ? true
+            : undefined,
       }
     }
+    const toPage = (response: Awaited<ReturnType<typeof client.session.messages>>) => {
+      const items = (response.data ?? []).filter((item) => !!item?.info?.id)
+      const cursor = nextBefore(
+        response.response.headers.get("Link"),
+        response.response.headers.get("X-Next-Cursor") ?? response.response.headers.get("x-next-cursor"),
+      )
+      return {
+        session: items.map((item) => cleanMessage(item.info)).sort(compareMessages),
+        part: items.map((item) => ({
+          id: item.info.id,
+          part: item.parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id)),
+        })),
+        cursor,
+        complete: !cursor,
+      }
+    }
+
     const response = await (options?.retry ?? retry)(() => {
       onAttempt?.()
       return client.session.messages({ sessionID, limit, before })
     })
-    const items = (response.data ?? []).filter((item) => !!item?.info?.id)
+    const page = toPage(response)
+    const result = before
+      ? page
+      : await loadRevertAwareLatestPage({
+          current: page,
+          revert,
+          fetchMessage: (messageID) =>
+            (options?.retry ?? retry)(() =>
+              client.session.message({ sessionID, messageID }, { throwOnError: false }),
+            ).then((result) => {
+              const boundary = boundaryFromMessageResponse(result)
+              if (!boundary) return undefined
+              const cursor = "cursor" in boundary ? boundary.cursor : undefined
+              return {
+                info: cleanMessage(boundary.info),
+                parts: boundary.parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id)),
+                cursor: typeof cursor === "string" ? cursor : undefined,
+              }
+            }),
+          // Boundary repair walks assistant-heavy stretches; the sync limit (often the tiny
+          // initial page size) would turn that walk into dozens of sequential requests.
+          fetchPage: (cursor) =>
+            (options?.retry ?? retry)(() =>
+              client.session.messages({ sessionID, limit: Math.max(limit, historyMessagePageSize), before: cursor }),
+            ).then(toPage),
+        })
+    const parts = new Map(result.part.map((item) => [item.id, item.part]))
     return {
-      session: items.map((item) => cleanMessage(item.info)).sort(compareMessages),
-      part: items.map((item) => ({
-        id: item.info.id,
-        part: item.parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id)),
-      })),
-      source: legacyMessageSource(items),
+      ...result,
+      source: legacyMessageSource(result.session.map((info) => ({ info, parts: parts.get(info.id) ?? [] }))),
       sourceMode: before ? ("older" as const) : ("latest" as const),
-      cursor: response.response.headers.get("x-next-cursor") ?? undefined,
-      complete: !response.response.headers.get("x-next-cursor"),
     }
   }
 
@@ -682,8 +882,14 @@ export function createServerSession(
           const existing = data.session_message[sessionID] ?? []
           const current = existing.filter((message) => !incoming.has(message.id))
           const live = new Map(existing.map((message) => [message.id, message]))
-          return (page.sourceMode === "older" ? [...page.source, ...current] : [...current, ...page.source]).map(
-            (message) => (load?.touchedSource.has(message.id) ? (live.get(message.id) ?? message) : message),
+          const messages = (() => {
+            if (page.sourceMode === "older") return [...page.source, ...current]
+            const before = current.filter((message) => !load?.touchedSource.has(message.id))
+            const after = current.filter((message) => load?.touchedSource.has(message.id))
+            return [...before, ...page.source, ...after]
+          })()
+          return messages.map((message) =>
+            load?.touchedSource.has(message.id) ? (live.get(message.id) ?? message) : message,
           )
         })()
       : undefined
@@ -693,7 +899,7 @@ export function createServerSession(
             const normalized = normalizeSessionMessages(sessionID, source)
             return {
               ...page,
-              session: normalized.messages.sort(compareMessages),
+              session: normalized.messages,
               part: [...normalized.parts.entries()]
                 .map(([id, part]) => ({ id, part: part.sort((a, b) => cmp(a.id, b.id)) }))
                 .sort((a, b) => cmp(a.id, b.id)),
@@ -710,12 +916,15 @@ export function createServerSession(
       retained: load?.retainedMessages,
       removed: load?.removedMessages,
       preserveUnfetched,
-      compare: compareMessages,
+      compare: page.projectSource ? undefined : compareMessages,
+      preserveOrder: page.projectSource,
     })
     batch(() => {
       if (source) setData("session_message", sessionID, reconcile(source))
+      if (merged.revertPreview !== undefined) setData("revert_preview", sessionID, merged.revertPreview)
       const messageIDs = replaceMessages(sessionID, messages)
       replaceParts(sessionID, merged.part, messageIDs, load)
+      if (merged.clearedRevert) setData("info", sessionID, (info) => (info ? { ...info, revert: undefined } : info))
       const orphans = orphanParts.get(sessionID)
       if (cleanupOrphans && page.complete && orphans) {
         for (const messageID of orphans) {
@@ -730,7 +939,13 @@ export function createServerSession(
     })
   }
 
-  const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
+  const loadMessages = async (
+    sessionID: string,
+    limit: number,
+    before?: string,
+    mode?: "replace" | "prepend",
+    revert?: Session["revert"],
+  ) => {
     if (meta.loading[sessionID]) return
     const active = generation(sessionID)
     const load: MessageLoadState = {
@@ -750,11 +965,25 @@ export function createServerSession(
     setMeta("loading", sessionID, true)
     let applied = false
     try {
-      const page = await fetchMessages(sessionID, limit, before, () => resetMessageLoad(sessionID, load))
-      const first = page.session.reduce<Message | undefined>(
-        (oldest, message) => (!oldest || compareMessages(message, oldest) < 0 ? message : oldest),
-        undefined,
+      const fetched = await fetchMessages(sessionID, limit, before, () => resetMessageLoad(sessionID, load), revert)
+      const incoming = fetched.projectSource ? (fetched.source ?? []) : fetched.session
+      const existing = new Set(
+        (fetched.projectSource ? (data.session_message[sessionID] ?? []) : (data.message[sessionID] ?? [])).map(
+          (message) => message.id,
+        ),
       )
+      const page =
+        mode === "prepend" &&
+        before &&
+        (fetched.cursor === before || (!!fetched.cursor && !incoming.some((message) => !existing.has(message.id))))
+          ? { ...fetched, cursor: undefined, complete: true }
+          : fetched
+      const first = page.projectSource
+        ? page.session[0]
+        : page.session.reduce<Message | undefined>(
+            (oldest, message) => (!oldest || compareMessages(message, oldest) < 0 ? message : oldest),
+            undefined,
+          )
       if (generations.get(sessionID) !== active) return
 
       const parents = [] as Awaited<ReturnType<typeof fetchMessage>>[]
@@ -799,10 +1028,10 @@ export function createServerSession(
           ? page
           : {
               ...page,
-              session: merge(
+              session: mergeMessages(
                 page.session,
                 parents.map((parent) => parent.message),
-              ).sort(compareMessages),
+              ),
               part: merge(
                 page.part,
                 parents.map((parent) => ({ id: parent.message.id, part: parent.parts })),
@@ -836,14 +1065,38 @@ export function createServerSession(
   const sync = (sessionID: string, options?: { force?: boolean; messageLimit?: number }) => {
     touch(sessionID)
     return runInflight(inflight, sessionID, async () => {
+      const sessionInfo = data.info[sessionID]
       const cached = data.message[sessionID] !== undefined && meta.limit[sessionID] !== undefined
-      if (cached && data.info[sessionID] && !options?.force) return
-      await Promise.all([
-        resolve(sessionID, options),
-        cached && !options?.force
+      const needsRevertRepair = (revert?: Session["revert"]) => {
+        if (!revert?.messageID || data.message[sessionID] === undefined || meta.limit[sessionID] === undefined)
+          return false
+        const messages = data.message[sessionID] ?? []
+        const boundaryLoaded = messages.some((message) => message.id === revert.messageID)
+        return !hasVisibleUserBeforeRevert(messages, revert) && !(meta.complete[sessionID] && boundaryLoaded)
+      }
+      const needsExistingRevertRepair = needsRevertRepair(sessionInfo?.revert)
+      const canReuseCached = !!(cached && sessionInfo && !needsExistingRevertRepair)
+      const messageLimit = () => options?.messageLimit ?? meta.limit[sessionID] ?? initialMessagePageSize
+      const repairMessageLimit = () => {
+        const limit = messageLimit()
+        return limit === 0 ? initialMessagePageSize : limit
+      }
+      if (canReuseCached && !options?.force) return
+      const resolving = sessionInfo && !options?.force ? Promise.resolve(sessionInfo) : resolve(sessionID, options)
+      const loading =
+        cached && !options?.force && !needsExistingRevertRepair
           ? Promise.resolve()
-          : loadMessages(sessionID, options?.messageLimit ?? meta.limit[sessionID] ?? initialMessagePageSize),
-      ])
+          : loadMessages(
+              sessionID,
+              needsExistingRevertRepair ? repairMessageLimit() : messageLimit(),
+              undefined,
+              undefined,
+              sessionInfo?.revert,
+            )
+      const nextSession = await resolving
+      await loading
+      if (!sessionInfo?.revert?.messageID && nextSession.revert?.messageID && needsRevertRepair(nextSession.revert))
+        await loadMessages(sessionID, repairMessageLimit(), undefined, undefined, nextSession.revert)
     })
   }
 
@@ -855,7 +1108,9 @@ export function createServerSession(
       (meta.complete[sessionID] || (data.message[sessionID]?.length ?? 0) >= limit)
     )
       return
-    await runInflight(inflight, sessionID, () => loadMessages(sessionID, limit))
+    await runInflight(inflight, sessionID, () =>
+      loadMessages(sessionID, limit, undefined, undefined, data.info[sessionID]?.revert),
+    )
   }
 
   const eventSessionID = (event: { type: string; properties?: unknown }) => {
@@ -888,7 +1143,10 @@ export function createServerSession(
     const touched = new Set(reduction.touched)
     let parentID: string | undefined
     for (const message of reduction.messages) {
-      if (message.type === "user" || (message.type === "synthetic" && message.description?.trim()))
+      if (
+        message.type === "user" ||
+        (message.type === "synthetic" && (message.description?.trim() || message.text.trim()))
+      )
         parentID = message.id
       if (message.type === "shell") {
         if (touched.has(message.id)) touched.add(`${message.id}:assistant`)
@@ -921,16 +1179,15 @@ export function createServerSession(
     })
   }
 
-  const hydrateV2Message = (sessionID: string, messageID: string) => {
-    if (!sessionApi) return
-    void sessionApi
-      .message({ sessionID, messageID })
-      .then((message) => {
-        const current = data.session_message[sessionID] ?? []
-        const messages = [...current.filter((item) => item.id !== message.id), message].sort(compareMessages)
-        projectV2({ sessionID, messages, touched: [message.id] })
-      })
-      .catch(() => {})
+  const hydrateV2Message = (sessionID: string, _messageID: string) => {
+    if (!sessionApi || !messageApi) return
+    const refresh = () => sync(sessionID, { force: true })
+    const pending = inflight.get(sessionID)
+    if (pending) {
+      void pending.finally(refresh).catch(() => {})
+      return
+    }
+    void refresh().catch(() => {})
   }
 
   const applyV2 = (event: OpenCodeEvent) => {
@@ -975,11 +1232,45 @@ export function createServerSession(
         next: event.data.at,
       })
     if (event.type === "session.forked") void resolve(sessionID, { force: true }).catch(() => {})
-    if (
-      event.type === "session.revert.staged" ||
-      event.type === "session.revert.cleared" ||
-      event.type === "session.revert.committed"
-    )
+    const eventType: string = event.type
+    if (eventType === "session.next.revert.committed") {
+      const messageID =
+        "messageID" in event.data && typeof event.data.messageID === "string" ? event.data.messageID : undefined
+      const source = data.session_message[sessionID] ?? []
+      const boundary = messageID ? source.findIndex((message) => message.id === messageID) : -1
+      if (boundary !== -1) {
+        const committed = source.slice(0, boundary + 1)
+        const normalized = normalizeSessionMessages(sessionID, committed)
+        const messageIDs = new Set(normalized.messages.map((message) => message.id))
+        const dropped = (data.message[sessionID] ?? []).filter((message) => !messageIDs.has(message.id))
+        batch(() => {
+          setData(
+            "session_message",
+            sessionID,
+            produce((draft) => draft.splice(0, draft.length, ...committed)),
+          )
+          setData(
+            "message",
+            sessionID,
+            produce((draft) => draft.splice(0, draft.length, ...normalized.messages)),
+          )
+          setData(produce((draft) => dropped.forEach((message) => deleteMessageParts(draft, message.id))))
+          replaceParts(
+            sessionID,
+            [...normalized.parts].map(([id, part]) => ({ id, part })),
+            messageIDs,
+          )
+        })
+      }
+      setData("revert_preview", sessionID, undefined)
+      setData("info", sessionID, (info) => (info ? { ...info, revert: undefined } : info))
+      setMeta("limit", sessionID, undefined)
+      setMeta("cursor", sessionID, undefined)
+      setMeta("complete", sessionID, undefined)
+      setMeta("at", sessionID, undefined)
+    }
+    if (eventType === "session.next.revert.committed") void sync(sessionID, { force: true }).catch(() => {})
+    if (eventType === "session.next.revert.staged" || eventType === "session.next.revert.cleared")
       void resolve(sessionID, { force: true }).catch(() => {})
   }
 
@@ -1050,14 +1341,13 @@ export function createServerSession(
           setData("message", info.sessionID, [info])
           return
         }
-        const result = Binary.search(messages, messageKey(info), messageKey)
-        if (result.found) setData("message", info.sessionID, result.index, reconcile(info))
-        if (!result.found)
-          setData("message", info.sessionID, (value = []) => {
-            const next = value.slice()
-            next.splice(result.index, 0, info)
-            return next
-          })
+        setData("message", info.sessionID, (value = []) =>
+          mergeProjectedMessages(
+            value.filter((message) => message.id !== info.id),
+            [info],
+            data.session_message[info.sessionID],
+          ),
+        )
         return
       }
       case "message.removed": {
@@ -1340,7 +1630,9 @@ export function createServerSession(
         if (items) items.set(input.message.id, { ...input, parts, confirmedParts: [] })
         if (!items)
           optimistic.set(input.sessionID, new Map([[input.message.id, { ...input, parts, confirmedParts: [] }]]))
-        setData("message", input.sessionID, (messages = []) => merge(messages, [input.message]).sort(compareMessages))
+        setData("message", input.sessionID, (messages = []) =>
+          mergeProjectedMessages(messages, [input.message], data.session_message[input.sessionID]),
+        )
         setData(
           "part_text_accum_delta",
           produce((draft) => {

--- a/packages/app/src/context/sync-optimistic.test.ts
+++ b/packages/app/src/context/sync-optimistic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Message, Part } from "@opencode-ai/sdk/v2/client"
-import { applyOptimisticAdd, applyOptimisticRemove, mergeOptimisticPage } from "./sync"
+import { applyOptimisticAdd, applyOptimisticRemove, mergeOptimisticPage } from "./server-session"
 
 type Text = Extract<Part, { type: "text" }>
 
@@ -85,6 +85,24 @@ describe("sync optimistic reducers", () => {
     )
 
     expect(page.session.map((message) => message.id)).toEqual(["msg_a", "msg_z"])
+  })
+
+  test("mergeOptimisticPage appends pending messages after current protocol source order", () => {
+    const sessionID = "ses_1"
+    const durable = userMessage("msg_z_durable", sessionID)
+    const optimistic = userMessage("msg_a_optimistic", sessionID)
+    const page = mergeOptimisticPage(
+      {
+        session: [durable],
+        part: [{ id: durable.id, part: [] }],
+        source: [{ id: durable.id, type: "user", text: "durable", time: { created: 1 } }],
+        projectSource: true,
+        complete: true,
+      },
+      [{ message: optimistic, parts: [] }],
+    )
+
+    expect(page.session.map((message) => message.id)).toEqual([durable.id, optimistic.id])
   })
 
   test("mergeOptimisticPage keeps missing optimistic parts until the server has them", () => {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -3,7 +3,6 @@ import { getFilename } from "@opencode-ai/core/util/path"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createQuery, skipToken, useMutation, useQueryClient } from "@tanstack/solid-query"
 import {
-  batch,
   ErrorBoundary,
   onCleanup,
   Suspense,
@@ -76,6 +75,7 @@ import { createTimelineModel } from "@/pages/session/timeline/model"
 import { type DiffStyle, SessionReviewTab, type SessionReviewTabProps } from "@/pages/session/review-tab"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { restorePromptModel, syncPromptModel, syncSessionModel } from "@/pages/session/session-model-helpers"
+import { runPromptRollbackMutation } from "@/pages/session/session-prompt-rollback"
 import {
   clampSessionPanelWidth,
   SESSION_PANEL_WIDTH_MIN,
@@ -100,12 +100,21 @@ import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { formatServerError, isLocalSessionNotFoundError, isSessionNotFoundError } from "@/utils/server-errors"
 import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/session-route"
+import { normalizeSessionMessages } from "@/utils/session-message"
+import { restoreTarget, type RevertPreviewState } from "@/pages/session/timeline/revert"
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
 import { createSessionOwnership } from "./session/session-ownership"
 import { createSessionLineage } from "./session/session-lineage"
 
 type FollowupItem = FollowupDraft & { id: string }
 type FollowupEdit = Pick<FollowupItem, "id" | "prompt" | "context">
+type RevertPreview = {
+  userCount: number
+  nextMessageID?: string
+  hasMore?: boolean
+  continuationMessageID?: string
+  items: { id: string; text: string }[]
+}
 const emptyFollowups: FollowupItem[] = []
 
 type ChangeMode = "git" | "branch" | "turn"
@@ -119,29 +128,6 @@ const sessionViewState = () => ({
 function isCurrentSessionNotFoundError(error: unknown, sessionID: string | undefined) {
   if (!sessionID) return false
   return isSessionNotFoundError(error, sessionID) || isLocalSessionNotFoundError(error, sessionID)
-}
-
-async function runPromptRollbackMutation<T, R>(input: {
-  capturePrompt: () => { current: () => T[]; set: (value: T[]) => void; reset: () => void }
-  optimistic: (prompt: { set: (value: T[]) => void; reset: () => void }) => void
-  request: () => Promise<R>
-  complete: (result: R) => void
-  rollback: () => void
-  fail: (error: unknown) => void
-}) {
-  const prompt = input.capturePrompt()
-  const previous = prompt.current().slice()
-  batch(() => input.optimistic(prompt))
-  await input
-    .request()
-    .then(input.complete)
-    .catch((error) => {
-      batch(() => {
-        input.rollback()
-        prompt.set(previous)
-      })
-      input.fail(error)
-    })
 }
 
 export function SessionPage() {
@@ -544,8 +530,9 @@ export default function Page() {
   })
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
-  const revertMessageID = createMemo(() => info()?.revert?.messageID)
-  const timeline = createTimelineModel({ sessionID: () => params.id, revertMessageID })
+  const revertInfo = createMemo(() => info()?.revert)
+  const revertMessageID = createMemo(() => revertInfo()?.messageID)
+  const timeline = createTimelineModel({ sessionID: () => params.id, revert: revertInfo })
   const historyLoading = timeline.history.loading
   const historyMore = timeline.history.more
   const lastUserMessage = timeline.lastUserMessage
@@ -554,6 +541,11 @@ export default function Page() {
   const sessionSync = timeline.resource
   const userMessages = timeline.userMessages
   const visibleUserMessages = timeline.visibleUserMessages
+  const currentRevertPreview = createMemo(() => {
+    const id = params.id
+    if (!id) return
+    return sync().data.revert_preview[id]
+  })
 
   createEffect(() => {
     const tab = activeFileTab()
@@ -891,6 +883,34 @@ export default function Page() {
 
   const hasScrollGesture = () => Date.now() - ui.scrollGesture < scrollGestureWindowMs
 
+  const [revertPreview, setRevertPreview] = createSignal<RevertPreview>()
+  let revertPreviewEpoch = 0
+  const loadV1RevertPreview = async (sessionID: string) => {
+    if (!info()?.revert) return
+    const preview = await sdk().client.session.revertPreview({ sessionID }, { throwOnError: false })
+    if (preview.response.status === 404 || preview.response.status === 405) return
+    if (preview.error) throw preview.error
+    return preview.data ?? undefined
+  }
+  createEffect(
+    on(
+      () => [params.id, revertMessageID(), serverSDK().protocolKind()] as const,
+      ([sessionID, revert, protocol]) => {
+        const epoch = ++revertPreviewEpoch
+        setRevertPreview(undefined)
+        if (!sessionID || !revert || protocol !== "v1") return
+        void loadV1RevertPreview(sessionID)
+          .then((result) => {
+            if (epoch !== revertPreviewEpoch) return
+            setRevertPreview(result)
+          })
+          .catch(() => {
+            if (epoch !== revertPreviewEpoch) return
+            setRevertPreview(undefined)
+          })
+      },
+    ),
+  )
   createEffect(
     on(
       () => {
@@ -1137,12 +1157,26 @@ export default function Page() {
   }
 
   useComposerCommands()
+  const redoPreview = createMemo<RevertPreviewState>(() => {
+    const protocol = serverSDK().protocolKind()
+    if (!protocol) return { ready: false }
+    if (protocol === "v1") {
+      const preview = revertPreview()
+      if (!preview) return { ready: false }
+      return { ready: true, nextMessageID: preview.nextMessageID }
+    }
+    const preview = currentRevertPreview()
+    if (!preview) return { ready: false }
+    return { ready: true, nextMessageID: preview.nextMessageID }
+  })
+
   useSessionCommands({
     navigateMessageByOffset,
     setActiveMessage,
     focusInput,
     review: reviewTab,
     fileBrowser: () => newSessionDesign() && isDesktop() && !!params.id,
+    revertPreview: redoPreview,
   })
   command.register("session-palette", () => [
     {
@@ -1668,22 +1702,6 @@ export default function Page() {
     ),
   )
 
-  const draft = (id: string) =>
-    extractPromptFromParts(sync().data.part[id] ?? [], {
-      directory: sdk().directory,
-      attachmentName: language.t("common.attachment"),
-    })
-
-  const line = (id: string) => {
-    const text = draft(id)
-      .map((part) => (part.type === "image" ? `[image:${part.filename}]` : part.content))
-      .join("")
-      .replace(/\s+/g, " ")
-      .trim()
-    if (text) return text
-    return `[${language.t("common.attachment")}]`
-  }
-
   const fail = (err: unknown) => {
     showToast({
       variant: "error",
@@ -1692,15 +1710,15 @@ export default function Page() {
     })
   }
 
-  const merge = (next: NonNullable<ReturnType<typeof info>>, target = sync()) => target.session.remember(next)
-
-  const roll = (sessionID: string, next: NonNullable<ReturnType<typeof info>>["revert"], target = sync()) => {
-    const session = target.session.get(sessionID)
-    if (!session) return
-    target.session.remember({ ...session, revert: next })
-  }
-
   const busy = (sessionID: string) => sync().data.session_working(sessionID)
+  const rememberRevert = (
+    state: ReturnType<typeof sync>,
+    sessionID: string,
+    revert: NonNullable<ReturnType<typeof info>>["revert"],
+  ) => {
+    const current = state.session.get(sessionID)
+    if (current) state.session.remember({ ...current, revert })
+  }
 
   const queuedFollowups = createMemo(() => {
     const id = params.id
@@ -1817,87 +1835,144 @@ export default function Page() {
     setFollowup("edit", id, undefined)
   }
 
-  const halt = (sessionID: string) =>
-    busy(sessionID)
-      ? sdk()
-          .api.session.interrupt({ sessionID })
-          .catch(() => {})
-      : Promise.resolve()
+  const captureRollbackPrompt = () => {
+    const target = prompt.capture()
+    return {
+      current: target.current,
+      cursor: target.cursor,
+      set: target.set,
+      reset: target.reset,
+      setCursor: (cursor: number | undefined) => target.store[1]("cursor", cursor),
+    }
+  }
+
+  const captureRevert = (input: { sessionID: string; messageID: string }) => {
+    const client = sdk()
+    const state = sync()
+    return {
+      ...input,
+      state,
+      session: client.api.session,
+      prompt: captureRollbackPrompt(),
+      draft: extractPromptFromParts(state.data.part[input.messageID] ?? [], {
+        directory: client.directory,
+        attachmentName: language.t("common.attachment"),
+      }),
+    }
+  }
+
+  const captureRestore = (sessionID: string, id: string) => {
+    const client = sdk()
+    return {
+      id,
+      sessionID,
+      client,
+      currentApi: serverSDK().currentApi,
+      state: sync(),
+      session: client.api.session,
+      legacyPreview: revertPreview(),
+      currentPreview: currentRevertPreview(),
+      directory: client.directory,
+      attachmentName: language.t("common.attachment"),
+      prompt: captureRollbackPrompt(),
+    }
+  }
 
   const revertMutation = useMutation(() => ({
-    mutationFn: async (input: { sessionID: string; messageID: string }) => {
-      const session = sdk().api.session
-      const target = sync()
-      const last = target.session.get(input.sessionID)?.revert
-      const value = draft(input.messageID)
+    mutationFn: async (input: ReturnType<typeof captureRevert>) => {
       await runPromptRollbackMutation({
-        capturePrompt: prompt.capture,
-        optimistic: (prompt) => {
-          roll(input.sessionID, { messageID: input.messageID }, target)
-          prompt.set(value)
+        prompt: input.prompt,
+        prepare: () => input.draft,
+        optimistic: (prompt, value) => prompt.set(value),
+        request: async () => {
+          if (input.state.data.session_working(input.sessionID)) {
+            await input.session.interrupt({ sessionID: input.sessionID }).catch(() => {})
+          }
+          return input.session.revert.stage({ sessionID: input.sessionID, messageID: input.messageID })
         },
-        request: () => halt(input.sessionID).then(() => session.revert.stage(input)),
-        complete: () => undefined,
-        rollback: () => roll(input.sessionID, last, target),
+        complete: (revert) => rememberRevert(input.state, input.sessionID, revert),
+        rollback: () => {},
         fail,
       })
     },
   }))
 
   const restoreMutation = useMutation(() => ({
-    mutationFn: async (id: string) => {
-      const sessionID = params.id
-      if (!sessionID) return
-
-      const session = sdk().api.session
-      const target = sync()
-      const index = userMessages().findIndex((item) => item.id === id)
-      if (index < 0) return
-      const next = userMessages()[index + 1]
-      const last = target.session.get(sessionID)?.revert
-
+    mutationFn: async (input: ReturnType<typeof captureRestore>) => {
       await runPromptRollbackMutation({
-        capturePrompt: prompt.capture,
-        optimistic: (promptSession) => {
-          roll(sessionID, next ? { messageID: next.id } : undefined, target)
-          if (next) {
-            promptSession.set(draft(next.id))
-            return
-          }
-          promptSession.reset()
+        prompt: input.prompt,
+        prepare: async () => {
+          const protocol = await input.client.protocol
+          const preview = protocol === "v1" ? input.legacyPreview : input.currentPreview
+          if (!preview?.items.length) throw new Error("Failed to load revert preview")
+          const next = restoreTarget(preview, input.id)
+          if (next === undefined) throw new Error("Restore target missing from revert preview")
+          if (!next) return { next, draft: undefined }
+          const draft = await (async () => {
+            const parts = input.state.data.part[next]
+            if (parts)
+              return extractPromptFromParts(parts, {
+                directory: input.directory,
+                attachmentName: input.attachmentName,
+              })
+            if (protocol !== "v1") {
+              const message = await input.currentApi.session.message({
+                sessionID: input.sessionID,
+                messageID: next,
+              })
+              const normalized = normalizeSessionMessages(input.sessionID, [message])
+              return extractPromptFromParts(normalized.parts.get(next) ?? [], {
+                directory: input.directory,
+                attachmentName: input.attachmentName,
+              })
+            }
+            const result = await input.client.client.session.message({ sessionID: input.sessionID, messageID: next })
+            return extractPromptFromParts(result.data?.parts ?? [], {
+              directory: input.directory,
+              attachmentName: input.attachmentName,
+            })
+          })().catch(() => undefined)
+          if (!draft) throw new Error("Failed to load next restore draft")
+          return { next, draft }
         },
-        request: () =>
-          !next
-            ? halt(sessionID).then(() => session.revert.clear({ sessionID }))
-            : halt(sessionID).then(() => session.revert.stage({ sessionID, messageID: next.id }).then(() => undefined)),
-        complete: () => undefined,
-        rollback: () => roll(sessionID, last, target),
+        optimistic: (promptSession, prepared) => {
+          if (prepared.next) promptSession.set(prepared.draft ?? [])
+          else promptSession.reset()
+        },
+        request: async (prepared) => {
+          if (input.state.data.session_working(input.sessionID)) {
+            await input.session.interrupt({ sessionID: input.sessionID }).catch(() => {})
+          }
+          if (!prepared.next) {
+            await input.session.revert.clear({ sessionID: input.sessionID })
+            return undefined
+          }
+          return input.session.revert.stage({ sessionID: input.sessionID, messageID: prepared.next })
+        },
+        complete: (revert) => rememberRevert(input.state, input.sessionID, revert),
+        rollback: () => {},
         fail,
       })
     },
   }))
 
   const reverting = createMemo(() => revertMutation.isPending || restoreMutation.isPending)
-  const restoring = createMemo(() => (restoreMutation.isPending ? restoreMutation.variables : undefined))
+  const restoring = createMemo(() => (restoreMutation.isPending ? restoreMutation.variables?.id : undefined))
 
   const revert = (input: { sessionID: string; messageID: string }) => {
     if (reverting()) return
-    return revertMutation.mutateAsync(input)
+    return revertMutation.mutateAsync(captureRevert(input))
   }
 
   const restore = (id: string) => {
-    if (!params.id || reverting()) return
-    return restoreMutation.mutateAsync(id)
+    const sessionID = params.id
+    if (!sessionID || reverting()) return
+    return restoreMutation.mutateAsync(captureRestore(sessionID, id))
   }
 
   const rolled = createMemo(() => {
-    const id = revertMessageID()
-    if (!id) return []
-    const index = userMessages().findIndex((item) => item.id === id)
-    if (index < 0) return []
-    return userMessages()
-      .slice(index)
-      .map((item) => ({ id: item.id, text: line(item.id) }))
+    if (serverSDK().protocolKind() === "v1") return revertPreview()?.items ?? []
+    return currentRevertPreview()?.items ?? []
   })
 
   // attachment bytes are embedded as a data URL, so downloading always works;

--- a/packages/app/src/pages/session/session-prompt-rollback.test.ts
+++ b/packages/app/src/pages/session/session-prompt-rollback.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from "bun:test"
+import { runPromptRollbackMutation } from "./session-prompt-rollback"
+
+const prompt = (initial: string[], initialCursor?: number) => {
+  let value = initial
+  let cursor = initialCursor
+  return {
+    current: () => value,
+    cursor: () => cursor,
+    set: (next: string[], nextCursor?: number) => {
+      value = next
+      if (nextCursor !== undefined) cursor = nextCursor
+    },
+    setCursor: (next: number | undefined) => {
+      cursor = next
+    },
+    reset: () => {
+      value = []
+      cursor = 0
+    },
+  }
+}
+
+test("captures the initiating prompt before asynchronous restore preparation", async () => {
+  const first = prompt(["first draft"])
+  const second = prompt(["second draft"])
+  const prepared = Promise.withResolvers<string[]>()
+  let active = first
+  const rollback = active
+
+  const mutation = runPromptRollbackMutation({
+    prompt: rollback,
+    prepare: () => prepared.promise,
+    optimistic: (target, draft) => target.set(draft),
+    request: async () => {},
+    complete: () => {},
+    rollback: () => {},
+    fail: () => {},
+  })
+
+  active = second
+  second.set(["edited second draft"])
+  prepared.resolve(["restored first draft"])
+  await mutation
+
+  expect(first.current()).toEqual(["restored first draft"])
+  expect(second.current()).toEqual(["edited second draft"])
+})
+
+test("restores the initiating prompt cursor when the request fails", async () => {
+  const target = prompt(["original draft"], 7)
+
+  await runPromptRollbackMutation({
+    prompt: target,
+    prepare: () => undefined,
+    optimistic: (prompt) => prompt.reset(),
+    request: async () => {
+      throw new Error("request failed")
+    },
+    complete: () => {},
+    rollback: () => {},
+    fail: () => {},
+  })
+
+  expect(target.current()).toEqual(["original draft"])
+  expect(target.cursor()).toBe(7)
+})
+
+test("rolls back prompt edits made while restore preparation is pending", async () => {
+  const target = prompt(["original draft"], 7)
+  const prepared = Promise.withResolvers<void>()
+  const mutation = runPromptRollbackMutation({
+    prompt: target,
+    prepare: () => prepared.promise,
+    optimistic: (prompt) => prompt.reset(),
+    request: async () => {
+      throw new Error("request failed")
+    },
+    complete: () => {},
+    rollback: () => {},
+    fail: () => {},
+  })
+
+  target.set(["edited during preparation"], 9)
+  prepared.resolve()
+  await mutation
+
+  expect(target.current()).toEqual(["edited during preparation"])
+  expect(target.cursor()).toBe(9)
+})
+
+test("reports preparation failures without changing the prompt", async () => {
+  const target = prompt(["original draft"], 7)
+  const error = new Error("prepare failed")
+  let failed: unknown
+  let optimistic = false
+
+  await runPromptRollbackMutation({
+    prompt: target,
+    prepare: async () => {
+      throw error
+    },
+    optimistic: () => {
+      optimistic = true
+    },
+    request: async () => {},
+    complete: () => {},
+    rollback: () => {},
+    fail: (cause) => {
+      failed = cause
+    },
+  })
+
+  expect(failed).toBe(error)
+  expect(optimistic).toBe(false)
+  expect(target.current()).toEqual(["original draft"])
+  expect(target.cursor()).toBe(7)
+})

--- a/packages/app/src/pages/session/session-prompt-rollback.ts
+++ b/packages/app/src/pages/session/session-prompt-rollback.ts
@@ -1,0 +1,41 @@
+import { batch } from "solid-js"
+
+type PromptTarget<T> = {
+  current: () => T[]
+  cursor: () => number | undefined
+  set: (value: T[]) => void
+  setCursor: (value: number | undefined) => void
+  reset: () => void
+}
+
+export async function runPromptRollbackMutation<T, P, R>(input: {
+  prompt: PromptTarget<T>
+  prepare: () => P | Promise<P>
+  optimistic: (prompt: PromptTarget<T>, prepared: P) => void
+  request: (prepared: P) => Promise<R>
+  complete: (result: R) => void
+  rollback: () => void
+  fail: (error: unknown) => void
+}) {
+  const prepared = await Promise.resolve()
+    .then(input.prepare)
+    .then(
+      (value) => ({ ok: true as const, value }),
+      (error) => ({ ok: false as const, error }),
+    )
+  if (!prepared.ok) return input.fail(prepared.error)
+  const previous = input.prompt.current().slice()
+  const cursor = input.prompt.cursor()
+  batch(() => input.optimistic(input.prompt, prepared.value))
+  await input
+    .request(prepared.value)
+    .then(input.complete)
+    .catch((error) => {
+      batch(() => {
+        input.rollback()
+        input.prompt.set(previous)
+        input.prompt.setCursor(cursor)
+      })
+      input.fail(error)
+    })
+}

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -75,7 +75,8 @@ import { sessionTitle } from "@/utils/session-title"
 import { scheduleConnectedMeasure } from "./measure"
 import { observeElementOffsetReconnectAware } from "./observe-element-offset"
 import { createTimelineProjection } from "./projection"
-import { MessageComment, SummaryDiff, TimelineRow, TimelineRowMap } from "./rows"
+import { visiblePartsForMessage } from "./revert"
+import { MessageComment, SummaryDiff, TimelineRow, TimelineRowMap, visibleUserMessageContent } from "./rows"
 import { filterVirtualIndexes } from "./virtual-items"
 
 const emptyMessages: MessageType[] = []
@@ -287,9 +288,8 @@ export function MessageTimeline(props: {
     const visible = new Set(props.userMessages.map((message) => message.id))
     const boundary = sessionMessages().find((message) => message.role === "user" && !visible.has(message.id))?.id
     const messages = sync().data.session_message[id] ?? []
-    if (!boundary) return messages
-    const index = messages.findIndex((message) => message.id === boundary)
-    return index < 0 ? messages : messages.slice(0, index)
+    const index = boundary ? messages.findIndex((message) => message.id === boundary) : -1
+    return index === -1 ? messages : messages.slice(0, index)
   })
   const info = createMemo(() => {
     const id = sessionID()
@@ -313,6 +313,8 @@ export function MessageTimeline(props: {
   })
   const parentTitle = createMemo(() => sessionTitle(parent()?.title) ?? language.t("command.session.new"))
   const getMsgParts = (msgId: string) => sync().data.part[msgId] ?? emptyParts
+  const getVisibleMsgParts = (messageID: string) =>
+    visiblePartsForMessage(messageID, getMsgParts(messageID), info()?.revert)
   const getMsgPart = (messageID: string, partID: string) => getMsgParts(messageID).find((part) => part.id === partID)
   const childTaskDescription = createMemo(() => {
     const id = sessionID()
@@ -338,6 +340,7 @@ export function MessageTimeline(props: {
     status: sessionStatus,
     showReasoningSummaries: settings.general.showReasoningSummaries,
     inlineComments: settings.general.newLayoutDesigns,
+    revert: () => info()?.revert,
   })
   const activeMessageID = projection.activeMessageID
   const assistantMessagesByParent = projection.assistantMessagesByParent
@@ -1011,7 +1014,7 @@ export function MessageTimeline(props: {
       const message = messages[i]
       if (!message) continue
 
-      const parts = getMsgParts(message.id)
+      const parts = getVisibleMsgParts(message.id)
       for (let j = parts.length - 1; j >= 0; j--) {
         const part = parts[j]
         if (!part || part.type !== "text" || !part.text?.trim()) continue
@@ -1123,8 +1126,13 @@ export function MessageTimeline(props: {
         return <div data-timeline-row="TurnGap" aria-hidden="true" class="h-6" />
       case "CommentStrip": {
         const commentStripRow = row as Accessor<TimelineRowByTag<"CommentStrip">>
-        const comments = createMemo(() =>
-          getMsgParts(commentStripRow().userMessageID).flatMap((part) => MessageComment.fromPart(part) ?? []),
+        const comments = createMemo(
+          () =>
+            visibleUserMessageContent(
+              commentStripRow().userMessageID,
+              getMsgParts(commentStripRow().userMessageID),
+              info()?.revert,
+            ).comments,
         )
         return (
           <TimelineRowFrame row={commentStripRow}>
@@ -1173,7 +1181,11 @@ export function MessageTimeline(props: {
         })
         const messageComments = createMemo(() => {
           if (!settings.general.newLayoutDesigns()) return []
-          return getMsgParts(userMessageRow().userMessageID).flatMap((part) => MessageComment.fromPart(part) ?? [])
+          return visibleUserMessageContent(
+            userMessageRow().userMessageID,
+            getMsgParts(userMessageRow().userMessageID),
+            info()?.revert,
+          ).comments
         })
         return (
           <TimelineRowFrame row={userMessageRow}>
@@ -1183,7 +1195,13 @@ export function MessageTimeline(props: {
                   <div data-slot="session-turn-message-content" aria-live="off">
                     <Message
                       message={message()}
-                      parts={getMsgParts(userMessageRow().userMessageID)}
+                      parts={
+                        visibleUserMessageContent(
+                          userMessageRow().userMessageID,
+                          getMsgParts(userMessageRow().userMessageID),
+                          info()?.revert,
+                        ).parts
+                      }
                       actions={props.actions}
                       useV2Actions={settings.general.newLayoutDesigns()}
                       comments={messageComments()}

--- a/packages/app/src/pages/session/timeline/model.test.ts
+++ b/packages/app/src/pages/session/timeline/model.test.ts
@@ -2,22 +2,41 @@ import { describe, expect, test } from "bun:test"
 import type { AssistantMessage, Message, UserMessage } from "@opencode-ai/sdk/v2"
 import { isTimelineReady, loadOlderTimeline, selectUserMessages, selectVisibleUserMessages } from "./model"
 
-const user = (id: string) => ({ id, role: "user" }) as UserMessage
-const assistant = (id: string) => ({ id, role: "assistant" }) as AssistantMessage
+const user = (id: string, created: number) => ({ id, role: "user", time: { created } }) as UserMessage
+const assistant = (id: string, created: number) => ({ id, role: "assistant", time: { created } }) as AssistantMessage
 
 describe("timeline model", () => {
   test("selects users and applies the revert boundary", () => {
-    const messages: Message[] = [user("msg_z"), assistant("msg_a"), user("msg_b"), user("msg_c")]
+    const messages: Message[] = [user("msg_1", 1), assistant("msg_2", 2), user("msg_3", 3), user("msg_5", 5)]
     const users = selectUserMessages(messages)
 
-    expect(users.map((message) => message.id)).toEqual(["msg_z", "msg_b", "msg_c"])
-    expect(selectVisibleUserMessages(users, "msg_b").map((message) => message.id)).toEqual(["msg_z"])
-    expect(selectVisibleUserMessages(users)).toBe(users)
+    expect(users.map((message) => message.id)).toEqual(["msg_1", "msg_3", "msg_5"])
+    expect(selectVisibleUserMessages(messages, { messageID: "msg_5" }).map((message) => message.id)).toEqual([
+      "msg_1",
+      "msg_3",
+    ])
+    expect(selectVisibleUserMessages(messages).map((message) => message.id)).toEqual(["msg_1", "msg_3", "msg_5"])
+  })
+
+  test("uses message ordering, not ID ordering, for revert boundaries", () => {
+    const messages: Message[] = [user("msg_9", 1), assistant("msg_2", 2), user("msg_1", 3)]
+
+    expect(selectVisibleUserMessages(messages, { messageID: "msg_2" }).map((message) => message.id)).toEqual(["msg_9"])
+  })
+
+  test("keeps the boundary user visible for part-level revert boundaries", () => {
+    const messages: Message[] = [user("msg_1", 1), user("msg_2", 2), assistant("msg_3", 3)]
+
+    expect(
+      selectVisibleUserMessages(messages, { messageID: "msg_2", partID: "prt_2" }).map((message) => message.id),
+    ).toEqual(["msg_1", "msg_2"])
   })
 
   test("waits for an assistant-only load to hydrate its user root", () => {
-    expect(isTimelineReady([assistant("msg_2")], true)).toBe(false)
-    expect(isTimelineReady([user("msg_1"), assistant("msg_2")], true)).toBe(true)
+    expect(isTimelineReady([assistant("msg_2", 2)], true)).toBe(false)
+    expect(isTimelineReady([user("msg_1", 1), assistant("msg_2", 2)], true)).toBe(true)
+    expect(isTimelineReady([user("msg_2", 2)], true, { messageID: "msg_2" })).toBe(false)
+    expect(isTimelineReady([user("msg_1", 1), user("msg_2", 2)], true, { messageID: "msg_2" })).toBe(true)
     expect(isTimelineReady([], false)).toBe(true)
   })
 

--- a/packages/app/src/pages/session/timeline/model.ts
+++ b/packages/app/src/pages/session/timeline/model.ts
@@ -3,13 +3,14 @@ import { createMemo, createResource, onCleanup, untrack, type Accessor } from "s
 import { useServerSync } from "@/context/server-sync"
 import { useSync } from "@/context/sync"
 import { same } from "@/utils/same"
+import { selectVisibleMessages, type RevertBoundary } from "./revert"
 
 const emptyUserMessages: UserMessage[] = []
 const sessionFreshness = 15_000
 
 export function createTimelineModel(input: {
   sessionID: Accessor<string | undefined>
-  revertMessageID: Accessor<string | undefined>
+  revert: Accessor<RevertBoundary | undefined>
 }) {
   const serverSync = useServerSync()
   const sync = useSync()
@@ -45,12 +46,12 @@ export function createTimelineModel(input: {
   })
   const ready = createMemo(() => {
     const id = input.sessionID()
-    return !id || isTimelineReady(sync().data.message[id], serverSync().session.history.loading(id))
+    return !id || isTimelineReady(sync().data.message[id], serverSync().session.history.loading(id), input.revert())
   })
   const userMessages = createMemo(() => selectUserMessages(messages()), emptyUserMessages, { equals: same })
   const visibleUserMessages = createMemo(
     () => {
-      return selectVisibleUserMessages(userMessages(), input.revertMessageID())
+      return selectVisibleUserMessages(messages(), input.revert())
     },
     emptyUserMessages,
     { equals: same },
@@ -98,14 +99,12 @@ export function selectUserMessages(messages: Message[]) {
   return messages.filter((message): message is UserMessage => message.role === "user")
 }
 
-export function isTimelineReady(messages: Message[] | undefined, loading: boolean) {
-  return messages !== undefined && (messages.some((message) => message.role === "user") || !loading)
+export function isTimelineReady(messages: Message[] | undefined, loading: boolean, revert?: RevertBoundary) {
+  return messages !== undefined && (selectVisibleUserMessages(messages, revert).length > 0 || !loading)
 }
 
-export function selectVisibleUserMessages(messages: UserMessage[], revertMessageID?: string) {
-  if (!revertMessageID) return messages
-  const boundary = messages.findIndex((message) => message.id === revertMessageID)
-  return boundary < 0 ? messages : messages.slice(0, boundary)
+export function selectVisibleUserMessages(messages: Message[], revert?: RevertBoundary) {
+  return selectUserMessages(selectVisibleMessages(messages, revert))
 }
 
 export async function loadOlderTimeline(input: {

--- a/packages/app/src/pages/session/timeline/projection.test.ts
+++ b/packages/app/src/pages/session/timeline/projection.test.ts
@@ -1,7 +1,29 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
+import type { SessionMessageInfo } from "@opencode-ai/client/promise"
 import type { PartGroup } from "@opencode-ai/session-ui/message-part"
+import type { AssistantMessage, Message, Part, SessionStatus, UserMessage } from "@opencode-ai/sdk/v2"
+import { createRoot } from "solid-js"
+import {
+  redoTarget,
+  restoreTarget,
+  selectRevertedMessages,
+  selectVisibleMessages,
+  visiblePartsForMessage,
+} from "./revert"
 import { reuseTimelineRows } from "./row-reconciliation"
 import { TimelineRow } from "./timeline-row"
+
+mock.module("@opencode-ai/session-ui/message-part", () => ({
+  renderable: () => true,
+  groupParts: (refs: Array<{ messageID: string; part: { id: string } }>) =>
+    refs.map((ref) => ({
+      type: "part" as const,
+      key: ref.part.id,
+      ref: { messageID: ref.messageID, partID: ref.part.id },
+    })),
+}))
+
+const { createTimelineProjection } = await import("./projection")
 
 const context = (key: string, partIDs: string[], userMessageID = "user-1") =>
   new TimelineRow.AssistantPart({
@@ -16,6 +38,12 @@ const context = (key: string, partIDs: string[], userMessageID = "user-1") =>
 
 const user = (userMessageID = "user-1") => new TimelineRow.UserMessage({ userMessageID, anchor: true })
 const keys = (rows: TimelineRow.TimelineRow[]) => rows.map(TimelineRow.key)
+const userMessage = (id: string, created: number) =>
+  ({ id, sessionID: "ses_test", role: "user", time: { created } }) as UserMessage
+const assistantMessage = (id: string, parentID: string, created: number) =>
+  ({ id, parentID, sessionID: "ses_test", role: "assistant", time: { created } }) as AssistantMessage
+const textPart = (id: string, messageID: string) =>
+  ({ id, messageID, sessionID: "ses_test", type: "text", text: id }) as Extract<Part, { type: "text" }>
 
 describe("reuseTimelineRows", () => {
   test.each([
@@ -92,5 +120,129 @@ describe("reuseTimelineRows", () => {
     expect(keys(result)).toEqual([...expected])
     expect(new Set(keys(result)).size).toBe(result.length)
     reused.forEach(([resultIndex, previousIndex]) => expect(result[resultIndex]).toBe(previous[previousIndex]))
+  })
+})
+
+describe("timeline projection", () => {
+  test("does not re-add current-protocol turns after a whole-message revert", () => {
+    const u1 = userMessage("u1", 1)
+    const a1 = assistantMessage("a1", u1.id, 2)
+    const u2 = userMessage("u2", 3)
+    const a2 = assistantMessage("a2", u2.id, 4)
+    const source = [
+      { id: u1.id, type: "user", text: "first", time: { created: 1 } },
+      {
+        id: a1.id,
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [],
+        time: { created: 2, completed: 2 },
+      },
+      { id: u2.id, type: "user", text: "second", time: { created: 3 } },
+      {
+        id: a2.id,
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [],
+        time: { created: 4, completed: 4 },
+      },
+    ] satisfies SessionMessageInfo[]
+    const rows = createRoot((dispose) => {
+      const projection = createTimelineProjection({
+        messages: () => [u1, a1, u2, a2],
+        userMessages: () => [u1, u2],
+        sessionMessages: () => source,
+        parts: () => [],
+        status: () => ({ type: "idle" }) as SessionStatus,
+        showReasoningSummaries: () => true,
+        inlineComments: () => true,
+        revert: () => ({ messageID: u2.id }),
+      })
+      const result = projection.rows().map(TimelineRow.key)
+      dispose()
+      return result
+    })
+
+    expect(rows).toEqual(["user-message:u1"])
+  })
+
+  test("keeps only the boundary assistant for part-level reverts", () => {
+    const messages: Message[] = [
+      userMessage("u1", 1),
+      assistantMessage("a1", "u1", 2),
+      assistantMessage("a2", "u1", 3),
+      userMessage("u2", 4),
+    ]
+
+    expect(selectVisibleMessages(messages, { messageID: "a1", partID: "p2" }).map((message) => message.id)).toEqual([
+      "u1",
+      "a1",
+    ])
+  })
+
+  test("does not guess visibility from IDs when the boundary is not loaded", () => {
+    const messages: Message[] = [userMessage("u1", 1), assistantMessage("a1", "u1", 2), userMessage("u3", 4)]
+
+    expect(selectVisibleMessages(messages, { messageID: "u2" })).toEqual([])
+  })
+
+  test("uses authoritative array order for equal-timestamp reverse IDs", () => {
+    const messages: Message[] = [userMessage("z-user", 1), userMessage("a-user", 1)]
+
+    expect(selectVisibleMessages(messages, { messageID: "a-user" }).map((message) => message.id)).toEqual(["z-user"])
+    expect(selectRevertedMessages(messages, { messageID: "a-user" }).map((message) => message.id)).toEqual(["a-user"])
+  })
+
+  test("selects redo order from a part-level assistant boundary", () => {
+    const messages: Message[] = [
+      userMessage("u1", 1),
+      assistantMessage("a1", "u1", 2),
+      userMessage("u2", 3),
+      assistantMessage("a2", "u2", 4),
+      userMessage("u3", 5),
+    ]
+
+    expect(selectRevertedMessages(messages, { messageID: "a1", partID: "p2" }).map((message) => message.id)).toEqual([
+      "a1",
+      "u2",
+      "u3",
+    ])
+    expect(selectRevertedMessages(messages, { messageID: "a1" }).map((message) => message.id)).toEqual([
+      "a1",
+      "u2",
+      "u3",
+    ])
+    expect(selectRevertedMessages(messages, { messageID: "missing" })).toEqual([])
+  })
+
+  test("distinguishes unavailable redo state from a terminal clear", () => {
+    expect(redoTarget({ ready: false })).toBeUndefined()
+    expect(redoTarget({ ready: true, nextMessageID: "u2" })).toBe("u2")
+    expect(redoTarget({ ready: true })).toBeNull()
+  })
+
+  test("continues a restore from the end of a truncated preview", () => {
+    expect(
+      restoreTarget(
+        {
+          items: [{ id: "u1" }, { id: "u2" }],
+          continuationMessageID: "u3",
+        },
+        "u2",
+      ),
+    ).toBe("u3")
+    expect(restoreTarget({ items: [{ id: "u1" }, { id: "u2" }] }, "u2")).toBeNull()
+    expect(restoreTarget({ items: [{ id: "u1" }] }, "missing")).toBeUndefined()
+  })
+
+  test("trims boundary assistant parts before part-level revert", () => {
+    const parts = [textPart("p1", "a1"), textPart("p2", "a1"), textPart("p3", "a1")]
+
+    expect(visiblePartsForMessage("a1", parts, { messageID: "a1", partID: "p2" }).map((part) => part.id)).toEqual([
+      "p1",
+    ])
+    expect(visiblePartsForMessage("a2", parts, { messageID: "a1", partID: "p2" })).toBe(parts)
   })
 })

--- a/packages/app/src/pages/session/timeline/projection.ts
+++ b/packages/app/src/pages/session/timeline/projection.ts
@@ -3,6 +3,7 @@ import type { AssistantMessage, Message, Part, SessionStatus, UserMessage } from
 import { createMemo, type Accessor } from "solid-js"
 import { reuseTimelineRows } from "./row-reconciliation"
 import { Timeline, TimelineRow } from "./rows"
+import { selectVisibleMessages, visiblePartsForMessage, type RevertBoundary } from "./revert"
 
 export { reuseTimelineRows } from "./row-reconciliation"
 
@@ -14,11 +15,14 @@ export function createTimelineProjection(input: {
   status: Accessor<SessionStatus>
   showReasoningSummaries: Accessor<boolean>
   inlineComments: Accessor<boolean>
+  revert?: Accessor<RevertBoundary | undefined>
 }) {
-  const messageByID = createMemo(() => new Map(input.messages().map((message) => [message.id, message] as const)))
+  const visibleMessages = createMemo(() => selectVisibleMessages(input.messages(), input.revert?.()))
+  const messageByID = createMemo(() => new Map(visibleMessages().map((message) => [message.id, message] as const)))
+  const parts = (messageID: string) => visiblePartsForMessage(messageID, input.parts(messageID), input.revert?.())
   const assistantMessagesByParent = createMemo(() => {
     const result = new Map<string, AssistantMessage[]>()
-    input.messages().forEach((message) => {
+    visibleMessages().forEach((message) => {
       if (message.role !== "assistant") return
       const messages = result.get(message.parentID)
       if (messages) {
@@ -29,15 +33,16 @@ export function createTimelineProjection(input: {
     })
     return result
   })
+  const visibleUserMessages = createMemo(() => input.userMessages().filter((message) => messageByID().has(message.id)))
   const projection = createMemo(() =>
     Timeline.constructSessionMessageRows(
       input.sessionMessages(),
       (messageID) => messageByID().get(messageID) as UserMessage | AssistantMessage | undefined,
-      input.parts,
+      parts,
       input.showReasoningSummaries(),
       input.status().type,
       input.inlineComments(),
-      input.userMessages(),
+      visibleUserMessages(),
     ),
   )
   const activeMessageID = createMemo(() => projection().activeMessageID)

--- a/packages/app/src/pages/session/timeline/revert.ts
+++ b/packages/app/src/pages/session/timeline/revert.ts
@@ -1,0 +1,50 @@
+import type { Message, Part } from "@opencode-ai/sdk/v2"
+
+export type RevertBoundary = {
+  messageID: string
+  partID?: string
+}
+
+export type RevertPreviewState = { ready: false } | { ready: true; nextMessageID?: string }
+
+export function redoTarget(preview: RevertPreviewState) {
+  if (!preview.ready) return undefined
+  return preview.nextMessageID ?? null
+}
+
+export function restoreTarget(
+  preview: { items: readonly { id: string }[]; hasMore?: boolean; continuationMessageID?: string },
+  messageID: string,
+) {
+  const index = preview.items.findIndex((item) => item.id === messageID)
+  if (index === -1) return undefined
+  const next = preview.items[index + 1]?.id
+  if (next) return next
+  if (preview.continuationMessageID) return preview.continuationMessageID
+  if (preview.hasMore) return undefined
+  return null
+}
+
+export function selectVisibleMessages(messages: Message[], revert?: RevertBoundary) {
+  if (!revert) return messages
+  const boundary = messages.findIndex((message) => message.id === revert.messageID)
+  if (boundary === -1) return []
+  return messages.slice(0, boundary + (revert.partID ? 1 : 0))
+}
+
+export function selectRevertedMessages(messages: Message[], revert?: RevertBoundary) {
+  if (!revert) return []
+  const boundary = messages.findIndex((message) => message.id === revert.messageID)
+  if (boundary === -1) return []
+  const message = messages[boundary]!
+  const users = messages.slice(boundary).filter((item) => item.role === "user")
+  if (!revert.partID && message.role === "user") return users
+  return [message, ...users.filter((item) => item.id !== message.id)]
+}
+
+export function visiblePartsForMessage(messageID: string, parts: Part[], revert?: RevertBoundary) {
+  if (!revert?.partID || messageID !== revert.messageID) return parts
+  const index = parts.findIndex((part) => part.id === revert.partID)
+  if (index === -1) return []
+  return parts.slice(0, index)
+}

--- a/packages/app/src/pages/session/timeline/rows-current.test.ts
+++ b/packages/app/src/pages/session/timeline/rows-current.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, mock, test } from "bun:test"
 import type { SessionMessageInfo } from "@opencode-ai/client/promise"
+import type { Part } from "@opencode-ai/sdk/v2"
+import { createCommentMetadata } from "@/utils/comment-note"
 import { normalizeSessionMessages } from "@/utils/session-message"
 
 mock.module("@opencode-ai/session-ui/message-part", () => ({
@@ -12,9 +14,45 @@ mock.module("@opencode-ai/session-ui/message-part", () => ({
     })),
 }))
 
-const { Timeline, TimelineRow } = await import("./rows")
+const { Timeline, TimelineRow, visibleUserMessageContent } = await import("./rows")
 
 describe("current session timeline rows", () => {
+  test("trims user parts and comments at a part-level revert boundary", () => {
+    const part = (id: string, text: string): Part => ({
+      id,
+      sessionID: "ses_1",
+      messageID: "msg_user",
+      type: "text",
+      text,
+    })
+    const parts = [
+      part("text_before", "before"),
+      {
+        ...part("comment_before", "before comment"),
+        synthetic: true,
+        metadata: createCommentMetadata({ path: "src/before.ts", comment: "before" }),
+      },
+      part("boundary", "boundary"),
+      {
+        ...part("comment_after", "after comment"),
+        synthetic: true,
+        metadata: createCommentMetadata({ path: "src/after.ts", comment: "after" }),
+      },
+      part("text_after", "after"),
+    ]
+
+    const content = visibleUserMessageContent("msg_user", parts, {
+      messageID: "msg_user",
+      partID: "boundary",
+    })
+
+    expect(content.parts.map((item) => item.id)).toEqual(["text_before", "comment_before"])
+    expect(content.comments).toEqual([{ path: "src/before.ts", comment: "before", selection: undefined }])
+    expect(visibleUserMessageContent("msg_other", parts, { messageID: "msg_user", partID: "boundary" }).parts).toBe(
+      parts,
+    )
+  })
+
   test("derives turns and tagged rows from chronological current messages", () => {
     const source = [
       { id: "msg_1", type: "user", text: "first", time: { created: 1 } },

--- a/packages/app/src/pages/session/timeline/rows.ts
+++ b/packages/app/src/pages/session/timeline/rows.ts
@@ -5,6 +5,7 @@ import { groupParts, renderable, type PartGroup } from "@opencode-ai/session-ui/
 import { TimelineRow, type SummaryDiff } from "./timeline-row"
 import { uniqueSummaryDiffs } from "./summary-diffs"
 import { compareMessages } from "@/utils/session-message"
+import { visiblePartsForMessage, type RevertBoundary } from "./revert"
 
 export { TimelineRow, type SummaryDiff } from "./timeline-row"
 
@@ -30,6 +31,14 @@ export type TimelineRowMap = {
   Retry: { userMessageID: string }
   DiffSummary: { userMessageID: string; diffs: SummaryDiff[] }
   Error: { userMessageID: string; text: string }
+}
+
+export function visibleUserMessageContent(messageID: string, parts: Part[], revert?: RevertBoundary) {
+  const visible = visiblePartsForMessage(messageID, parts, revert)
+  return {
+    parts: visible,
+    comments: visible.flatMap((part) => MessageComment.fromPart(part) ?? []),
+  }
 }
 
 export namespace Timeline {

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -15,6 +15,7 @@ import { showToast } from "@/utils/toast"
 import { downloadSessionExport, fetchSessionExport, sessionExportFilename } from "@/utils/session-export"
 import { findLast } from "@opencode-ai/core/util/array"
 import { createSessionTabs } from "@/pages/session/helpers"
+import { redoTarget, selectVisibleMessages, type RevertPreviewState } from "@/pages/session/timeline/revert"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { Message, Part, UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -27,6 +28,7 @@ export type SessionCommandContext = {
   focusInput: () => void
   review?: () => boolean
   fileBrowser?: () => boolean
+  revertPreview: () => RevertPreviewState
 }
 
 const withCategory = (category: string) => {
@@ -97,11 +99,14 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     return sync().data.message[id] ?? []
   }
   const userMessages = () => messages().filter((m) => m.role === "user") as UserMessage[]
+  const beforeMessage = (message: UserMessage, boundaryID: string) => {
+    const source = messages()
+    const index = source.findIndex((item) => item.id === message.id)
+    const boundary = source.findIndex((item) => item.id === boundaryID)
+    return index !== -1 && boundary !== -1 && index < boundary
+  }
   const visibleUserMessages = () => {
-    const revert = info()?.revert?.messageID
-    if (!revert) return userMessages()
-    const boundary = userMessages().findIndex((message) => message.id === revert)
-    return boundary < 0 ? userMessages() : userMessages().slice(0, boundary)
+    return selectVisibleMessages(messages(), info()?.revert).filter((m): m is UserMessage => m.role === "user")
   }
 
   const showAllFiles = () => {
@@ -338,9 +343,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     const promptSession = prompt.capture()
     const revert = info()?.revert?.messageID
     const messages = userMessages()
-    const boundary = revert ? messages.findIndex((message) => message.id === revert) : messages.length
-    if (boundary < 0) return
-    const message = messages[boundary - 1]
+    const message = findLast(messages, (x) => !revert || beforeMessage(x, revert))
     if (!message) return
     const parts = sync().data.part[message.id]
 
@@ -351,11 +354,15 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     await runCommand({
       owner,
       prompt: promptSession,
-      request: () => session.revert.stage({ sessionID, messageID: message.id }),
+      request: async () => {
+        const revert = await session.revert.stage({ sessionID, messageID: message.id })
+        const current = sync().session.get(sessionID)
+        if (current) sync().session.remember({ ...current, revert })
+      },
       updatePrompt: (promptSession) => {
         if (parts) promptSession.set(extractPromptFromParts(parts, { directory }))
       },
-      updateViewport: () => setActiveMessage(messages[boundary - 2]),
+      updateViewport: () => setActiveMessage(findLast(messages, (x) => beforeMessage(x, message.id))),
     })
   }
 
@@ -370,16 +377,19 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     const revertMessageID = info()?.revert?.messageID
     if (!revertMessageID) return
 
-    const boundary = messages.findIndex((message) => message.id === revertMessageID)
-    if (boundary < 0) return
-    const next = messages[boundary + 1]
-    if (!next) {
+    const target = redoTarget(actions.revertPreview())
+    if (target === undefined) return
+    if (target === null) {
       await runCommand({
         owner,
         prompt: promptSession,
-        request: () => session.revert.clear({ sessionID }),
+        request: async () => {
+          await session.revert.clear({ sessionID })
+          const current = sync().session.get(sessionID)
+          if (current) sync().session.remember({ ...current, revert: undefined })
+        },
         updatePrompt: (promptSession) => promptSession.reset(),
-        updateViewport: () => setActiveMessage(messages.at(-1)),
+        updateViewport: () => setActiveMessage(findLast(messages, (x) => !beforeMessage(x, revertMessageID))),
       })
       return
     }
@@ -387,9 +397,13 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     await runCommand({
       owner,
       prompt: promptSession,
-      request: () => session.revert.stage({ sessionID, messageID: next.id }),
+      request: async () => {
+        const revert = await session.revert.stage({ sessionID, messageID: target })
+        const current = sync().session.get(sessionID)
+        if (current) sync().session.remember({ ...current, revert })
+      },
       updatePrompt: () => undefined,
-      updateViewport: () => setActiveMessage(messages[boundary]),
+      updateViewport: () => setActiveMessage(findLast(messages, (x) => beforeMessage(x, target))),
     })
   }
 
@@ -470,7 +484,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       title: language.t("command.session.redo"),
       description: language.t("command.session.redo.description"),
       slash: "redo",
-      disabled: !params.id || !info()?.revert?.messageID,
+      disabled: !params.id || !info()?.revert?.messageID || !actions.revertPreview().ready,
       onSelect: redo,
     }),
     sessionCommand({

--- a/packages/app/src/utils/server-compat.test.ts
+++ b/packages/app/src/utils/server-compat.test.ts
@@ -4,7 +4,10 @@ import { createCompatibleApi } from "./server-compat"
 
 function setup(
   protocol: "v1" | "v2" | Promise<"v1" | "v2">,
-  responses?: { vcs?: { branch: string; default_branch: string } },
+  responses?: {
+    vcs?: { branch: string; default_branch: string }
+    revert?: { messageID: string; partID?: string; snapshot?: string }
+  },
 ) {
   const requests: Request[] = []
   const fetcher = Object.assign(
@@ -35,6 +38,17 @@ function setup(
           delivery: "steer",
         })
       }
+      if (request.method === "POST" && request.url.endsWith("/revert"))
+        return Response.json({
+          id: "ses_1",
+          slug: "ses_1",
+          projectID: "project",
+          directory: "/repo",
+          title: "Session",
+          version: "1",
+          time: { created: 1, updated: 1 },
+          revert: responses?.revert,
+        })
       if (request.method === "GET" && new URL(request.url).pathname === "/vcs")
         return Response.json(responses?.vcs ?? {})
       if (request.method === "GET") return Response.json([])
@@ -127,6 +141,13 @@ describe("createCompatibleApi", () => {
       { id: "prt_text", type: "text", text: "look" },
       { id: "prt_image", type: "file", mime: "image/png", url: "data:image/png;base64,AAAA", filename: "image.png" },
     ])
+  })
+
+  test("returns the canonical V1 revert boundary", async () => {
+    const revert = { messageID: "msg_user", partID: "prt_2", snapshot: "snapshot" }
+    const { api } = setup("v1", { revert })
+
+    expect(await api.session.revert.stage({ sessionID: "ses_1", messageID: "msg_assistant" })).toEqual(revert)
   })
 
   test("resolves protocol detection once across implementation methods", async () => {

--- a/packages/app/src/utils/server-compat.ts
+++ b/packages/app/src/utils/server-compat.ts
@@ -289,8 +289,10 @@ function createV1Api(input: CompatibleInput): CompatibleApi {
       },
       revert: {
         stage: async (value: Parameters<ServerApi["session"]["revert"]["stage"]>[0]) => {
-          await legacy().session.revert(value)
-          return { messageID: value.messageID }
+          const result = await legacy().session.revert(value)
+          const revert = result.data?.revert
+          if (!revert) throw new Error("V1 revert did not return a revert boundary")
+          return revert
         },
         clear: async (value: Parameters<ServerApi["session"]["revert"]["clear"]>[0]) => {
           await legacy().session.unrevert(value)

--- a/packages/app/src/utils/session-message.test.ts
+++ b/packages/app/src/utils/session-message.test.ts
@@ -118,6 +118,27 @@ describe("normalizeSessionMessages", () => {
     expect(normalizeSessionMessages("ses_1", source).messages).toEqual([])
   })
 
+  test("uses current synthetic text as the assistant turn root", () => {
+    const source = [
+      { id: "msg_synthetic", type: "synthetic", text: "Synthetic context", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [{ type: "text", text: "Result" }],
+        time: { created: 2, completed: 3 },
+      },
+    ] satisfies SessionMessageInfo[]
+
+    const result = normalizeSessionMessages("ses_1", source)
+
+    expect(result.messages.map((message) => message.id)).toEqual(["msg_synthetic", "msg_assistant"])
+    expect(result.parts.get("msg_synthetic")).toEqual([
+      expect.objectContaining({ type: "text", text: "Synthetic context", synthetic: true }),
+    ])
+  })
+
   test("projects a current shell message into a renderable standalone turn", () => {
     const source = [
       {
@@ -149,6 +170,59 @@ describe("normalizeSessionMessages", () => {
           output: "hello",
           title: "Shell",
         }),
+      }),
+    ])
+  })
+
+  test("adapts the canonical current shell wire shape", () => {
+    const source = [
+      {
+        id: "msg_shell",
+        type: "shell",
+        callID: "shell_1",
+        command: "printf hello",
+        output: "hello",
+        time: { created: 1, completed: 2 },
+      },
+    ] as unknown as SessionMessageInfo[]
+
+    const result = normalizeSessionMessages("ses_1", source)
+
+    expect(result.parts.get("msg_shell:assistant")).toEqual([
+      expect.objectContaining({
+        callID: "shell_1",
+        state: expect.objectContaining({ status: "completed", output: "hello" }),
+      }),
+    ])
+  })
+
+  test("adapts canonical pending tool state without reading completed content", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "read it", time: { created: 1 } },
+      {
+        id: "msg_assistant",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_read",
+            name: "read",
+            state: { status: "pending", input: '{"filePath":"README.md"}' },
+            time: { created: 2 },
+          },
+        ],
+        time: { created: 2 },
+      },
+    ] as unknown as SessionMessageInfo[]
+
+    const result = normalizeSessionMessages("ses_1", source)
+
+    expect(result.parts.get("msg_assistant")).toEqual([
+      expect.objectContaining({
+        type: "tool",
+        state: expect.objectContaining({ status: "pending", input: { filePath: "README.md" } }),
       }),
     ])
   })

--- a/packages/app/src/utils/session-message.ts
+++ b/packages/app/src/utils/session-message.ts
@@ -5,8 +5,16 @@ import type {
   SessionMessageShell,
   SessionMessageUser,
 } from "@opencode-ai/client/promise"
+import { SessionMessage } from "@opencode-ai/schema/session-message"
 import type { AssistantMessage, FilePart, Message, Part, ToolPart, UserMessage } from "@opencode-ai/sdk/v2"
 import { Option, Schema } from "effect"
+
+type CurrentMessage = Schema.Codec.Encoded<typeof SessionMessage.Message>
+type SourceMessage = SessionMessageInfo | CurrentMessage
+type SourceAssistant = SessionMessageAssistant | Extract<CurrentMessage, { type: "assistant" }>
+type SourceAssistantTool = SessionMessageAssistantTool | Extract<SourceAssistant["content"][number], { type: "tool" }>
+type SourceShell = SessionMessageShell | Extract<CurrentMessage, { type: "shell" }>
+type SourceUser = SessionMessageUser | Extract<CurrentMessage, { type: "user" }>
 
 const emptyTokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
 const emptyModel: { id: string; providerID: string; variant?: string } = { id: "", providerID: "" }
@@ -45,7 +53,7 @@ function normalizeToolMetadata(name: string, metadata: Record<string, unknown>) 
   }
 }
 
-export function normalizeSessionMessages(sessionID: string, source: readonly SessionMessageInfo[]) {
+export function normalizeSessionMessages(sessionID: string, source: readonly SourceMessage[]) {
   const messages: Message[] = []
   const parts = new Map<string, Part[]>()
   let agent = ""
@@ -67,7 +75,11 @@ export function normalizeSessionMessages(sessionID: string, source: readonly Ses
       parts.set(message.id, userParts(sessionID, message))
       return
     }
-    if (message.type === "synthetic" && message.description?.trim()) {
+    const synthetic =
+      message.type === "synthetic"
+        ? ("description" in message ? message.description?.trim() : undefined) || message.text.trim()
+        : undefined
+    if (message.type === "synthetic" && synthetic) {
       parentID = message.id
       messages.push({
         id: message.id,
@@ -77,7 +89,7 @@ export function normalizeSessionMessages(sessionID: string, source: readonly Ses
         agent,
         model: { providerID: model.providerID, modelID: model.id, variant: model.variant },
       })
-      parts.set(message.id, [textPart(sessionID, message.id, 0, message.description, true)])
+      parts.set(message.id, [textPart(sessionID, message.id, 0, synthetic, true)])
       return
     }
     if (message.type === "shell") {
@@ -122,7 +134,7 @@ export function normalizeSessionMessages(sessionID: string, source: readonly Ses
 
 function shellMessages(
   sessionID: string,
-  message: SessionMessageShell,
+  message: SourceShell,
   agent: string,
   model: { id: string; providerID: string; variant?: string },
 ): [UserMessage, AssistantMessage] {
@@ -153,30 +165,29 @@ function shellMessages(
   ]
 }
 
-function shellPart(sessionID: string, message: SessionMessageShell): ToolPart {
+function shellPart(sessionID: string, message: SourceShell): ToolPart {
   const input = { command: message.command }
   const start = message.time.created
-  const state: ToolPart["state"] =
-    message.status === "running"
-      ? { status: "running", input, time: { start } }
-      : {
-          status: "completed",
-          input,
-          output: message.output?.output ?? "",
-          title: "Shell",
-          metadata: {
-            status: message.status,
-            exit: message.exit,
-            truncated: message.output?.truncated,
-          },
-          time: { start, end: message.time.completed ?? start },
-        }
+  const running = "status" in message ? message.status === "running" : message.time.completed === undefined
+  const state: ToolPart["state"] = running
+    ? { status: "running", input, time: { start } }
+    : {
+        status: "completed",
+        input,
+        output: typeof message.output === "string" ? message.output : (message.output?.output ?? ""),
+        title: "Shell",
+        metadata:
+          "status" in message
+            ? { status: message.status, exit: message.exit, truncated: message.output?.truncated }
+            : {},
+        time: { start, end: message.time.completed ?? start },
+      }
   return {
     id: `${message.id}:tool`,
     sessionID,
     messageID: `${message.id}:assistant`,
     type: "tool",
-    callID: message.shellID,
+    callID: "callID" in message ? message.callID : message.shellID,
     tool: "bash",
     state,
   }
@@ -188,7 +199,7 @@ export function sessionMessagePartID(messageID: string, type: "text" | "reasonin
 
 function userMessage(
   sessionID: string,
-  message: SessionMessageUser,
+  message: SourceUser,
   agent: string,
   model: { id: string; providerID: string; variant?: string },
 ): UserMessage {
@@ -202,43 +213,48 @@ function userMessage(
   }
 }
 
-function userParts(sessionID: string, message: SessionMessageUser): Part[] {
+function userParts(sessionID: string, message: SourceUser): Part[] {
   return [
     textPart(sessionID, message.id, 0, message.text),
-    ...(message.files ?? []).map(
-      (file, index): FilePart => ({
+    ...(message.files ?? []).map((file, index): FilePart => {
+      const source = "uri" in file ? file.source : file.mention
+      return {
         id: `${message.id}:file:${index}`,
         sessionID,
         messageID: message.id,
         type: "file",
         mime: file.mime,
         filename: file.name,
-        url: file.source.type === "uri" ? file.source.uri : `data:${file.mime};base64,${file.data}`,
-        source: file.mention
+        url:
+          "uri" in file
+            ? file.uri
+            : file.source.type === "uri"
+              ? file.source.uri
+              : `data:${file.mime};base64,${file.data}`,
+        source: source
           ? {
               type: "file",
-              text: { value: file.mention.text, start: file.mention.start, end: file.mention.end },
-              path: file.mention.text.startsWith("@") ? file.mention.text.slice(1) : (file.name ?? file.mention.text),
+              text: { value: source.text, start: source.start, end: source.end },
+              path: source.text.startsWith("@") ? source.text.slice(1) : (file.name ?? source.text),
             }
           : undefined,
-      }),
-    ),
-    ...(message.agents ?? []).map(
-      (item, index): Part => ({
+      }
+    }),
+    ...(message.agents ?? []).map((item, index): Part => {
+      const source = "source" in item ? item.source : "mention" in item ? item.mention : undefined
+      return {
         id: `${message.id}:agent:${index}`,
         sessionID,
         messageID: message.id,
         type: "agent",
         name: item.name,
-        source: item.mention
-          ? { value: item.mention.text, start: item.mention.start, end: item.mention.end }
-          : undefined,
-      }),
-    ),
+        source: source ? { value: source.text, start: source.start, end: source.end } : undefined,
+      }
+    }),
   ]
 }
 
-function assistantMessage(sessionID: string, parentID: string, message: SessionMessageAssistant): AssistantMessage {
+function assistantMessage(sessionID: string, parentID: string, message: SourceAssistant): AssistantMessage {
   const error = message.error
     ? message.error.type.toLowerCase().includes("abort") || message.error.type.toLowerCase().includes("interrupt")
       ? { name: "MessageAbortedError" as const, data: { message: message.error.message } }
@@ -263,7 +279,7 @@ function assistantMessage(sessionID: string, parentID: string, message: SessionM
   }
 }
 
-function assistantParts(sessionID: string, message: SessionMessageAssistant): Part[] {
+function assistantParts(sessionID: string, message: SourceAssistant): Part[] {
   const ordinals = { text: 0, reasoning: 0 }
   return message.content.flatMap((content): Part[] => {
     if (content.type === "text") {
@@ -277,7 +293,8 @@ function assistantParts(sessionID: string, message: SessionMessageAssistant): Pa
         messageID: message.id,
         type: "reasoning",
         text: content.text,
-        metadata: content.state,
+        metadata:
+          "state" in content ? content.state : "providerMetadata" in content ? content.providerMetadata : undefined,
         time: {
           start: content.time?.created ?? message.time.created,
           end: content.time?.completed,
@@ -300,10 +317,16 @@ function textPart(sessionID: string, messageID: string, ordinal: number, text: s
   }
 }
 
-function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssistantTool): ToolPart {
+function toolStateMetadata(state: SourceAssistantTool["state"]) {
+  if ("metadata" in state && record(state.metadata)) return state.metadata
+  if ("structured" in state && record(state.structured)) return state.structured
+  return {}
+}
+
+function toolPart(sessionID: string, messageID: string, tool: SourceAssistantTool): ToolPart {
   const start = tool.time.ran ?? tool.time.created
   const state = (() => {
-    if (tool.state.status === "streaming") {
+    if (tool.state.status === "streaming" || tool.state.status === "pending") {
       const value = Option.getOrUndefined(decodeToolInput(tool.state.input))
       const input = normalizeToolInput(tool.name, record(value) ? value : {})
       return { status: "pending" as const, input, raw: tool.state.input }
@@ -313,7 +336,7 @@ function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssi
         status: "running" as const,
         input: normalizeToolInput(tool.name, tool.state.input),
         // metadata: normalizeToolMetadata(tool.name, tool.state.structured),
-        metadata: normalizeToolMetadata(tool.name, tool.state.metadata ?? {}),
+        metadata: normalizeToolMetadata(tool.name, toolStateMetadata(tool.state)),
         time: { start },
       }
     }
@@ -323,7 +346,7 @@ function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssi
         input: normalizeToolInput(tool.name, tool.state.input),
         error: tool.state.error.message,
         // metadata: normalizeToolMetadata(tool.name, tool.state.structured),
-        metadata: normalizeToolMetadata(tool.name, tool.state.metadata ?? {}),
+        metadata: normalizeToolMetadata(tool.name, toolStateMetadata(tool.state)),
         time: { start, end: tool.time.completed ?? start },
       }
     }
@@ -348,7 +371,7 @@ function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssi
       output: tool.state.content.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n"),
       title: tool.name,
       // metadata: normalizeToolMetadata(tool.name, tool.state.structured),
-      metadata: normalizeToolMetadata(tool.name, tool.state.metadata ?? {}),
+      metadata: normalizeToolMetadata(tool.name, toolStateMetadata(tool.state)),
       time: { start, end: tool.time.completed ?? start },
       attachments: attachments.length ? attachments : undefined,
     }
@@ -361,6 +384,15 @@ function toolPart(sessionID: string, messageID: string, tool: SessionMessageAssi
     callID: tool.id,
     tool: tool.name,
     state,
-    metadata: { providerState: tool.providerState, providerResultState: tool.providerResultState },
+    metadata: {
+      providerState:
+        "providerState" in tool ? tool.providerState : "provider" in tool ? tool.provider?.metadata : undefined,
+      providerResultState:
+        "providerResultState" in tool
+          ? tool.providerResultState
+          : "provider" in tool
+            ? tool.provider?.resultMetadata
+            : undefined,
+    },
   }
 }

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -1924,7 +1924,167 @@ export type MessagesListOutput = {
         readonly time: { readonly created: number }
       }
   >
-  readonly cursor: { readonly previous?: string | null; readonly next?: string | null }
+  readonly context: ReadonlyArray<
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly type: "agent-switched"
+        readonly agent: string
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly type: "model-switched"
+        readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly text: string
+        readonly files?: ReadonlyArray<{
+          readonly uri: string
+          readonly mime: string
+          readonly name?: string
+          readonly description?: string
+          readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+        }>
+        readonly agents?: ReadonlyArray<{
+          readonly name: string
+          readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+        }>
+        readonly type: "user"
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly sessionID: string
+        readonly text: string
+        readonly type: "synthetic"
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly type: "system"
+        readonly text: string
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number; readonly completed?: number }
+        readonly type: "shell"
+        readonly callID: string
+        readonly command: string
+        readonly output: string
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number; readonly completed?: number }
+        readonly type: "assistant"
+        readonly agent: string
+        readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly content: ReadonlyArray<
+          | { readonly type: "text"; readonly id: string; readonly text: string }
+          | {
+              readonly type: "reasoning"
+              readonly id: string
+              readonly text: string
+              readonly providerMetadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+              readonly time?: { readonly created: number; readonly completed?: number }
+            }
+          | {
+              readonly type: "tool"
+              readonly id: string
+              readonly name: string
+              readonly provider?: {
+                readonly executed: boolean
+                readonly metadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+                readonly resultMetadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+              }
+              readonly state:
+                | { readonly status: "pending"; readonly input: string }
+                | {
+                    readonly status: "running"
+                    readonly input: { readonly [x: string]: JsonValue }
+                    readonly structured: { readonly [x: string]: JsonValue }
+                    readonly content: ReadonlyArray<
+                      | { readonly type: "text"; readonly text: string }
+                      | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+                    >
+                  }
+                | {
+                    readonly status: "completed"
+                    readonly input: { readonly [x: string]: JsonValue }
+                    readonly attachments?: ReadonlyArray<{
+                      readonly uri: string
+                      readonly mime: string
+                      readonly name?: string
+                      readonly description?: string
+                      readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+                    }>
+                    readonly content: ReadonlyArray<
+                      | { readonly type: "text"; readonly text: string }
+                      | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+                    >
+                    readonly outputPaths?: ReadonlyArray<string>
+                    readonly structured: { readonly [x: string]: JsonValue }
+                    readonly result?: JsonValue
+                  }
+                | {
+                    readonly status: "error"
+                    readonly input: { readonly [x: string]: JsonValue }
+                    readonly content: ReadonlyArray<
+                      | { readonly type: "text"; readonly text: string }
+                      | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+                    >
+                    readonly structured: { readonly [x: string]: JsonValue }
+                    readonly error: { readonly type: "unknown"; readonly message: string }
+                    readonly result?: JsonValue
+                  }
+              readonly time: {
+                readonly created: number
+                readonly ran?: number
+                readonly completed?: number
+                readonly pruned?: number
+              }
+            }
+        >
+        readonly snapshot?: { readonly start?: string; readonly end?: string; readonly files?: ReadonlyArray<string> }
+        readonly finish?: string
+        readonly cost?: number
+        readonly tokens?: {
+          readonly input: number
+          readonly output: number
+          readonly reasoning: number
+          readonly cache: { readonly read: number; readonly write: number }
+        }
+        readonly error?: { readonly type: "unknown"; readonly message: string }
+      }
+    | {
+        readonly type: "compaction"
+        readonly reason: "auto" | "manual"
+        readonly summary: string
+        readonly recent: string
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+      }
+  >
+  readonly contextCursor?: string
+  readonly revert?: {
+    readonly messageID: string
+    readonly userCount: number
+    readonly hasMore: boolean
+    readonly nextMessageID?: string
+    readonly continuationMessageID?: string
+    readonly items: ReadonlyArray<{ readonly id: string; readonly text: string }>
+  }
+  readonly cursor: { readonly previous?: string; readonly next?: string }
 }
 
 export type ModelsListInput = {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,7 +3,7 @@ export * from "./session/schema"
 
 import { DateTime, Effect, Layer, Schema, Context, Stream } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
-import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, like, lt, lte, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -88,6 +88,13 @@ type CompactInput = {
   prompt?: Prompt
 }
 
+type MessagesInput = {
+  sessionID: SessionSchema.ID
+  limit?: number
+  order?: "asc" | "desc"
+  cursor?: ({ seq: number } | { id: SessionMessage.ID }) & { direction: "previous" | "next" }
+}
+
 export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("Session.NotFoundError", {
   sessionID: SessionSchema.ID,
 }) {}
@@ -114,15 +121,22 @@ export interface Interface {
   readonly list: (input?: ListInput) => Effect.Effect<SessionSchema.Info[]>
   readonly create: (input: CreateInput) => Effect.Effect<SessionSchema.Info>
   readonly get: (sessionID: SessionSchema.ID) => Effect.Effect<SessionSchema.Info, NotFoundError>
-  readonly messages: (input: {
-    sessionID: SessionSchema.ID
-    limit?: number
-    order?: "asc" | "desc"
-    cursor?: {
-      id: SessionMessage.ID
-      direction: "previous" | "next"
-    }
-  }) => Effect.Effect<SessionMessage.Message[], NotFoundError | MessageDecodeError>
+  readonly messages: (
+    input: MessagesInput,
+  ) => Effect.Effect<SessionMessage.Message[], NotFoundError | MessageNotFoundError | MessageDecodeError>
+  readonly messagePage: (input: MessagesInput & { includeRevert?: boolean }) => Effect.Effect<
+    {
+      data: SessionMessage.Message[]
+      context: SessionMessage.Message[]
+      sequence: Map<string, number>
+      cursor: {
+        previous?: number
+        next?: number
+      }
+      revert?: Revert.Preview
+    },
+    NotFoundError | MessageNotFoundError | MessageDecodeError
+  >
   readonly message: (input: {
     sessionID: SessionSchema.ID
     messageID: SessionMessage.ID
@@ -203,6 +217,175 @@ const layer = Layer.effect(
             }),
         ),
       )
+    const messageRows = Effect.fn("V2Session.messages.rows")(function* (input: MessagesInput) {
+      const direction = input.cursor?.direction ?? "next"
+      const requestedOrder = input.order ?? "desc"
+      const order = direction === "previous" ? (requestedOrder === "asc" ? "desc" : "asc") : requestedOrder
+      const anchor = input.cursor
+        ? "seq" in input.cursor
+          ? { seq: input.cursor.seq }
+          : yield* db
+              .select({ seq: SessionMessageTable.seq })
+              .from(SessionMessageTable)
+              .where(
+                and(eq(SessionMessageTable.session_id, input.sessionID), eq(SessionMessageTable.id, input.cursor.id)),
+              )
+              .get()
+              .pipe(Effect.orDie)
+        : undefined
+      if (input.cursor && "id" in input.cursor && !anchor)
+        return yield* new MessageNotFoundError({ sessionID: input.sessionID, messageID: input.cursor.id })
+      const boundary = anchor
+        ? order === "asc"
+          ? gt(SessionMessageTable.seq, anchor.seq)
+          : lt(SessionMessageTable.seq, anchor.seq)
+        : undefined
+      const query = db
+        .select()
+        .from(SessionMessageTable)
+        .where(
+          boundary
+            ? and(eq(SessionMessageTable.session_id, input.sessionID), boundary)
+            : eq(SessionMessageTable.session_id, input.sessionID),
+        )
+        .orderBy(order === "asc" ? asc(SessionMessageTable.seq) : desc(SessionMessageTable.seq))
+      const rows = yield* (input.limit === undefined ? query.all() : query.limit(input.limit + 1).all()).pipe(
+        Effect.orDie,
+      )
+      const overflow = input.limit !== undefined && rows.length > input.limit
+      const page = overflow ? rows.slice(0, input.limit) : rows
+      const ordered = direction === "previous" ? page.toReversed() : page
+      const oppositeEdge = input.cursor
+        ? ((direction === "previous" ? ordered.at(-1)?.seq : ordered[0]?.seq) ?? anchor?.seq)
+        : undefined
+      const oppositeBoundary =
+        oppositeEdge !== undefined
+          ? direction === "previous"
+            ? requestedOrder === "asc"
+              ? gt(SessionMessageTable.seq, oppositeEdge)
+              : lt(SessionMessageTable.seq, oppositeEdge)
+            : requestedOrder === "asc"
+              ? lt(SessionMessageTable.seq, oppositeEdge)
+              : gt(SessionMessageTable.seq, oppositeEdge)
+          : undefined
+      const opposite = oppositeBoundary
+        ? yield* db
+            .select({ seq: SessionMessageTable.seq })
+            .from(SessionMessageTable)
+            .where(and(eq(SessionMessageTable.session_id, input.sessionID), oppositeBoundary))
+            .limit(1)
+            .get()
+            .pipe(Effect.orDie)
+        : undefined
+      return {
+        rows: ordered,
+        cursor: {
+          previous:
+            direction === "previous" ? (overflow ? ordered[0]?.seq : undefined) : opposite ? oppositeEdge : undefined,
+          next:
+            direction === "previous"
+              ? opposite
+                ? oppositeEdge
+                : undefined
+              : overflow
+                ? ordered.at(-1)?.seq
+                : undefined,
+        },
+      }
+    })
+    const messagePageContext = Effect.fn("V2Session.messagePage.context")(function* (input: {
+      sessionID: SessionSchema.ID
+      data: SessionMessage.Message[]
+      rows: (typeof SessionMessageTable.$inferSelect)[]
+      order: "asc" | "desc"
+      revert?: Revert.State
+    }) {
+      const chronological = input.order === "asc" ? input.data : input.data.toReversed()
+      const chronologicalRows = input.order === "asc" ? input.rows : input.rows.toReversed()
+      const anchor = chronologicalRows[0]
+      if (!anchor) return { messages: [], rows: [] }
+      const rows = new Map<SessionMessage.ID, typeof SessionMessageTable.$inferSelect>()
+      const add = (row: typeof SessionMessageTable.$inferSelect | undefined) => {
+        if (row) rows.set(row.id, row)
+      }
+      const latest = (condition: SQL) =>
+        db
+          .select()
+          .from(SessionMessageTable)
+          .where(
+            and(
+              eq(SessionMessageTable.session_id, input.sessionID),
+              lt(SessionMessageTable.seq, anchor.seq),
+              condition,
+            ),
+          )
+          .orderBy(desc(SessionMessageTable.seq))
+          .limit(1)
+          .get()
+          .pipe(Effect.orDie)
+
+      add(yield* latest(eq(SessionMessageTable.type, "agent-switched")))
+      add(yield* latest(eq(SessionMessageTable.type, "model-switched")))
+      const boundary = chronological.find((message) => {
+        if (message.type === "agent-switched" || message.type === "model-switched" || message.type === "system")
+          return false
+        if (message.type === "synthetic") return !!message.text.trim()
+        return true
+      })
+      if (boundary?.type === "assistant" || boundary?.type === "compaction") {
+        add(yield* latest(or(eq(SessionMessageTable.type, "user"), eq(SessionMessageTable.type, "synthetic"))!))
+      }
+
+      if (input.revert) {
+        const revert = yield* db
+          .select({ seq: SessionMessageTable.seq })
+          .from(SessionMessageTable)
+          .where(
+            and(
+              eq(SessionMessageTable.session_id, input.sessionID),
+              eq(SessionMessageTable.id, input.revert.messageID),
+            ),
+          )
+          .get()
+          .pipe(Effect.orDie)
+        if (revert) {
+          const recent = yield* db
+            .select()
+            .from(SessionMessageTable)
+            .where(
+              and(
+                eq(SessionMessageTable.session_id, input.sessionID),
+                revert.seq < anchor.seq
+                  ? lte(SessionMessageTable.seq, revert.seq)
+                  : lt(SessionMessageTable.seq, anchor.seq),
+              ),
+            )
+            .orderBy(desc(SessionMessageTable.seq))
+            .limit(20)
+            .all()
+            .pipe(Effect.orDie)
+          recent.forEach(add)
+          const prior = yield* db
+            .select()
+            .from(SessionMessageTable)
+            .where(
+              and(
+                eq(SessionMessageTable.session_id, input.sessionID),
+                lt(SessionMessageTable.seq, revert.seq),
+                or(eq(SessionMessageTable.type, "user"), eq(SessionMessageTable.type, "synthetic")),
+              ),
+            )
+            .orderBy(desc(SessionMessageTable.seq))
+            .limit(1)
+            .get()
+            .pipe(Effect.orDie)
+          if (prior && prior.seq < anchor.seq) add(prior)
+        }
+      }
+
+      const sorted = [...rows.values()].sort((a, b) => a.seq - b.seq)
+      return { messages: yield* Effect.forEach(sorted, decode), rows: sorted }
+    })
 
     const result = Service.of({
       create: Effect.fn("V2Session.create")(function* (input) {
@@ -303,37 +486,31 @@ const layer = Layer.effect(
       }),
       messages: Effect.fn("V2Session.messages")(function* (input) {
         yield* result.get(input.sessionID)
-        const direction = input.cursor?.direction ?? "next"
-        const requestedOrder = input.order ?? "desc"
-        const order = direction === "previous" ? (requestedOrder === "asc" ? "desc" : "asc") : requestedOrder
-        const anchor = input.cursor
-          ? yield* db
-              .select({ seq: SessionMessageTable.seq })
-              .from(SessionMessageTable)
-              .where(
-                and(eq(SessionMessageTable.session_id, input.sessionID), eq(SessionMessageTable.id, input.cursor.id)),
-              )
-              .get()
-              .pipe(Effect.orDie)
-          : undefined
-        if (input.cursor && !anchor) return []
-        const boundary = anchor
-          ? order === "asc"
-            ? gt(SessionMessageTable.seq, anchor.seq)
-            : lt(SessionMessageTable.seq, anchor.seq)
-          : undefined
-        const where = boundary
-          ? and(eq(SessionMessageTable.session_id, input.sessionID), boundary)
-          : eq(SessionMessageTable.session_id, input.sessionID)
-        const query = db
-          .select()
-          .from(SessionMessageTable)
-          .where(where)
-          .orderBy(order === "asc" ? asc(SessionMessageTable.seq) : desc(SessionMessageTable.seq))
-        const rows = yield* (input.limit === undefined ? query.all() : query.limit(input.limit).all()).pipe(
-          Effect.orDie,
-        )
-        return yield* Effect.forEach(direction === "previous" ? rows.toReversed() : rows, decode)
+        return yield* Effect.forEach((yield* messageRows(input)).rows, decode)
+      }),
+      messagePage: Effect.fn("V2Session.messagePage")(function* (input) {
+        const session = yield* result.get(input.sessionID)
+        const page = yield* messageRows(input)
+        const rows = page.rows
+        const data = yield* Effect.forEach(rows, decode)
+        const order = input.order ?? "desc"
+        const context = yield* messagePageContext({
+          sessionID: input.sessionID,
+          data,
+          rows,
+          order,
+          revert: input.includeRevert ? session.revert : undefined,
+        })
+        const sequence = new Map([...rows, ...context.rows].map((row) => [row.id, row.seq] as const))
+        return {
+          data,
+          context: context.messages,
+          sequence,
+          cursor: page.cursor,
+          revert: input.includeRevert
+            ? yield* SessionRevert.preview(session).pipe(Effect.provideService(Database.Service, database))
+            : undefined,
+        }
       }),
       message: Effect.fn("V2Session.message")(function* (input) {
         const stored = yield* store.message(input.messageID)

--- a/packages/core/src/session/revert.ts
+++ b/packages/core/src/session/revert.ts
@@ -1,6 +1,6 @@
 export * as SessionRevert from "./revert"
 
-import { and, asc, eq, gt } from "drizzle-orm"
+import { and, asc, count, eq, gt, gte, or, sql } from "drizzle-orm"
 import { DateTime, Effect, Schema } from "effect"
 import { Database } from "../database/database"
 import { EventV2 } from "../event"
@@ -10,6 +10,7 @@ import { SessionEvent } from "./event"
 import { SessionMessage } from "./message"
 import { SessionSchema } from "./schema"
 import { SessionMessageTable } from "./sql"
+import { Revert } from "@opencode-ai/schema/revert"
 
 export class MessageNotFoundError extends Schema.TaggedErrorClass<MessageNotFoundError>()(
   "Session.MessageNotFoundError",
@@ -23,6 +24,10 @@ interface BoundaryInput {
   readonly sessionID: SessionSchema.ID
   readonly messageID: SessionMessage.ID
 }
+
+const PreviewItemLimit = 100
+const EcmaScriptWhitespace =
+  "\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF"
 
 const plan = Effect.fn("SessionRevert.plan")(function* (input: BoundaryInput) {
   const db = (yield* Database.Service).db
@@ -55,6 +60,62 @@ const plan = Effect.fn("SessionRevert.plan")(function* (input: BoundaryInput) {
       if (!files.has(file)) files.set(file, Snapshot.ID.make(message.snapshot.start))
   }
   return files
+})
+
+export const preview = Effect.fn("SessionRevert.preview")(function* (session: SessionSchema.Info) {
+  if (!session.revert) return
+  const db = (yield* Database.Service).db
+  const boundary = yield* db
+    .select({ seq: SessionMessageTable.seq })
+    .from(SessionMessageTable)
+    .where(and(eq(SessionMessageTable.session_id, session.id), eq(SessionMessageTable.id, session.revert.messageID)))
+    .get()
+    .pipe(Effect.orDie)
+  if (!boundary) return yield* new MessageNotFoundError({ sessionID: session.id, messageID: session.revert.messageID })
+  const visibleSynthetic = sql<boolean>`trim(coalesce(json_extract(${SessionMessageTable.data}, '$.text'), ''), ${EcmaScriptWhitespace}) <> ''`
+  const root = or(
+    eq(SessionMessageTable.type, "user"),
+    eq(SessionMessageTable.type, "shell"),
+    and(eq(SessionMessageTable.type, "synthetic"), visibleSynthetic),
+  )!
+  const where = and(eq(SessionMessageTable.session_id, session.id), root, gte(SessionMessageTable.seq, boundary.seq))
+  const userCount =
+    (yield* db.select({ value: count() }).from(SessionMessageTable).where(where).get().pipe(Effect.orDie))?.value ?? 0
+  const rows = yield* db
+    .select()
+    .from(SessionMessageTable)
+    .where(where)
+    .orderBy(asc(SessionMessageTable.seq))
+    .limit(PreviewItemLimit + 1)
+    .all()
+    .pipe(Effect.orDie)
+  const decode = Schema.decodeUnknownEffect(SessionMessage.Message)
+  const messages = yield* Effect.forEach(rows, (row) =>
+    decode({ ...row.data, id: row.id, type: row.type }).pipe(Effect.orDie),
+  )
+  const preview = messages.flatMap((message): Revert.PreviewItem[] => {
+    if (message.type === "synthetic") return [{ id: message.id, text: message.text.trim() }]
+    if (message.type === "shell") return [{ id: message.id, text: message.command.trim() }]
+    if (message.type !== "user") return []
+    const text = message.text.trim()
+    return [
+      {
+        id: message.id,
+        text:
+          text || (message.files ?? []).flatMap((file) => (file.name ? [`[attachment:${file.name}]`] : [])).join(" "),
+      },
+    ]
+  })
+  const items = preview.slice(0, PreviewItemLimit)
+  const boundaryIndex = preview.findIndex((item) => item.id === session.revert?.messageID)
+  return Revert.Preview.make({
+    messageID: session.revert.messageID,
+    userCount,
+    hasMore: userCount > items.length,
+    nextMessageID: preview[boundaryIndex === -1 ? 0 : boundaryIndex + 1]?.id,
+    continuationMessageID: preview[PreviewItemLimit]?.id,
+    items,
+  })
 })
 
 export const stage = Effect.fn("SessionRevert.stage")(function* (input: {

--- a/packages/core/src/util/link-header.ts
+++ b/packages/core/src/util/link-header.ts
@@ -1,0 +1,30 @@
+export function parseLinkHeader(header: string): Record<string, string> {
+  if (!header) return {}
+  const links: Record<string, string> = {}
+  const parts = header.split(/,(?=\s*<)/)
+  for (const part of parts) {
+    const section = part.split(";")
+    if (section.length < 2) continue
+    const url = section[0].replace(/<(.*?)>/, "$1").trim()
+
+    for (const attr of section.slice(1)) {
+      const match = attr.match(/rel=["']?(?<rel>[^"']+)["']?/)
+      if (match?.groups?.rel) {
+        links[match.groups.rel.trim()] = url
+        break
+      }
+    }
+  }
+  return links
+}
+
+export function linkParam(url: string | undefined, key: string) {
+  if (!url || !URL.canParse(url)) return undefined
+  return new URL(url).searchParams.get(key) ?? undefined
+}
+
+export function stripLinkCredentials(url: URL) {
+  const next = new URL(url)
+  next.searchParams.delete("auth_token")
+  return next
+}

--- a/packages/core/src/util/revert-boundary.ts
+++ b/packages/core/src/util/revert-boundary.ts
@@ -1,0 +1,10 @@
+export function boundaryFromMessageResponse<T extends { info?: { id?: string } }>(input: {
+  data?: T
+  error?: unknown
+  response?: { status: number }
+}) {
+  if (input.response?.status === 404) return undefined
+  if (input.error) throw input.error
+  if (!input.data?.info?.id) throw new Error("missing revert boundary message")
+  return input.data
+}

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -31,18 +31,23 @@ const created = DateTime.makeUnsafe(0)
 const model = { id: ModelV2.ID.make("model"), providerID: ProviderV2.ID.make("provider") }
 const encodeMessage = Schema.encodeSync(SessionMessage.Message)
 
+const messageRow = (message: SessionMessage.Message, seq: number) => {
+  const { id: _, type, ...data } = encodeMessage(message)
+  return {
+    id: message.id,
+    session_id: sessionID,
+    type,
+    seq,
+    time_created: DateTime.toEpochMillis(message.time.created),
+    data,
+  }
+}
+
 const assistantRow = (
   id: SessionMessage.ID,
   seq: number,
   time: { created: DateTime.Utc; completed?: DateTime.Utc } = { created },
-) => {
-  const {
-    id: _,
-    type,
-    ...data
-  } = encodeMessage(SessionMessage.Assistant.make({ id, type: "assistant", agent: "build", model, content: [], time }))
-  return { id, session_id: sessionID, type, seq, time_created: DateTime.toEpochMillis(time.created), data }
-}
+) => messageRow(SessionMessage.Assistant.make({ id, type: "assistant", agent: "build", model, content: [], time }), seq)
 
 describe("SessionProjector", () => {
   it.effect("projects moved sessions without the transitional context epoch table", () =>
@@ -196,6 +201,288 @@ describe("SessionProjector", () => {
       expect(
         (yield* sessions.context(sessionID)).map((message) => (message.type === "user" ? message.text : message.type)),
       ).toEqual(["first", "second"])
+    }).pipe(Effect.provide(sessionsLayer)),
+  )
+
+  it.effect("checks page availability against returned edges when a sequence cursor row is gone", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+        })
+        .run()
+      const first = SessionMessage.ID.make("msg_first")
+      const second = SessionMessage.ID.make("msg_second")
+      const third = SessionMessage.ID.make("msg_third")
+      yield* db
+        .insert(SessionMessageTable)
+        .values([assistantRow(first, 1), assistantRow(second, 2), assistantRow(third, 3)])
+        .run()
+
+      const sessions = yield* SessionV2.Service
+      yield* db.delete(SessionMessageTable).where(eq(SessionMessageTable.id, third)).run()
+      const next = yield* sessions.messagePage({
+        sessionID,
+        limit: 1,
+        order: "desc",
+        cursor: { seq: 3, direction: "next" },
+      })
+      expect(next.data.map((message) => message.id)).toEqual([second])
+      expect(next.cursor).toEqual({ next: 2 })
+
+      yield* db.insert(SessionMessageTable).values(assistantRow(third, 3)).run()
+      yield* db.delete(SessionMessageTable).where(eq(SessionMessageTable.id, first)).run()
+      const previous = yield* sessions.messagePage({
+        sessionID,
+        limit: 1,
+        order: "desc",
+        cursor: { seq: 1, direction: "previous" },
+      })
+      expect(previous.data.map((message) => message.id)).toEqual([second])
+      expect(previous.cursor).toEqual({ previous: 2 })
+    }).pipe(Effect.provide(sessionsLayer)),
+  )
+
+  it.effect("preserves reverse navigation when a deleted sequence anchor returns an empty page", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+        })
+        .run()
+      const survivor = SessionMessage.ID.make("msg_survivor")
+      yield* db.insert(SessionMessageTable).values(assistantRow(survivor, 2)).run()
+
+      const sessions = yield* SessionV2.Service
+      const cases = [
+        { order: "asc" as const, direction: "next" as const, seq: 3, cursor: { previous: 3 } },
+        { order: "asc" as const, direction: "previous" as const, seq: 1, cursor: { next: 1 } },
+        { order: "desc" as const, direction: "next" as const, seq: 1, cursor: { previous: 1 } },
+        { order: "desc" as const, direction: "previous" as const, seq: 3, cursor: { next: 3 } },
+      ]
+
+      yield* Effect.forEach(cases, (input) =>
+        Effect.gen(function* () {
+          const empty = yield* sessions.messagePage({
+            sessionID,
+            limit: 1,
+            order: input.order,
+            cursor: { seq: input.seq, direction: input.direction },
+          })
+          expect(empty.data).toEqual([])
+          expect(empty.cursor).toEqual(input.cursor)
+          const direction = empty.cursor.previous === undefined ? "next" : "previous"
+          const seq = empty.cursor.previous ?? empty.cursor.next
+          const recovered = yield* sessions.messagePage({
+            sessionID,
+            limit: 1,
+            order: input.order,
+            cursor: { seq: seq!, direction },
+          })
+          expect(recovered.data.map((message) => message.id)).toEqual([survivor])
+        }),
+      )
+    }).pipe(Effect.provide(sessionsLayer)),
+  )
+
+  it.effect("returns bounded page context and revert preview in durable sequence order", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const events = yield* EventV2.Service
+      const first = SessionMessage.ID.make("msg_z_first")
+      const assistant = SessionMessage.ID.make("msg_a_assistant")
+      const second = SessionMessage.ID.make("msg_0_second")
+      const later = Array.from({ length: 100 }, (_, index) =>
+        SessionMessage.ID.make(`msg_later_${index.toString().padStart(3, "0")}`),
+      )
+
+      yield* events.publish(SessionEvent.Prompted, {
+        sessionID,
+        messageID: first,
+        timestamp: created,
+        prompt: Prompt.make({ text: "first" }),
+        delivery: "steer",
+      })
+      yield* events.publish(SessionEvent.Step.Started, {
+        sessionID,
+        assistantMessageID: assistant,
+        timestamp: created,
+        agent: "build",
+        model,
+      })
+      yield* events.publish(SessionEvent.Prompted, {
+        sessionID,
+        messageID: second,
+        timestamp: created,
+        prompt: Prompt.make({ text: "second" }),
+        delivery: "steer",
+      })
+      yield* Effect.forEach(later, (messageID, index) =>
+        events.publish(SessionEvent.Prompted, {
+          sessionID,
+          messageID,
+          timestamp: created,
+          prompt: Prompt.make({ text: `later ${index}` }),
+          delivery: "steer",
+        }),
+      )
+      yield* events.publish(SessionEvent.RevertEvent.Staged, {
+        sessionID,
+        timestamp: created,
+        revert: { messageID: first, files: [] },
+      })
+
+      const sessions = yield* SessionV2.Service
+      const page = yield* sessions.messagePage({ sessionID, limit: 1, order: "desc", includeRevert: true })
+
+      expect(page.data.map((message) => message.id)).toEqual([later.at(-1)!])
+      expect(page.context.map((message) => message.id)).toEqual([first])
+      expect(page.revert).toMatchObject({
+        messageID: first,
+        userCount: 102,
+        nextMessageID: second,
+        continuationMessageID: later[98],
+        hasMore: true,
+      })
+      expect(page.revert?.items.map((item) => item.id)).toEqual([first, second, ...later.slice(0, 98)])
+
+      yield* db.delete(SessionMessageTable).where(eq(SessionMessageTable.id, first)).run().pipe(Effect.orDie)
+      const error = yield* sessions
+        .messagePage({ sessionID, limit: 1, order: "desc", includeRevert: true })
+        .pipe(Effect.flip)
+      expect(error).toMatchObject({
+        _tag: "Session.MessageNotFoundError",
+        sessionID,
+        messageID: first,
+      })
+    }).pipe(Effect.provide(sessionsLayer)),
+  )
+
+  it.effect("uses projected user turn roots for revert previews", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "test",
+          directory: "/project",
+          title: "test",
+          version: "test",
+        })
+        .run()
+      const first = SessionMessage.ID.make("msg_first")
+      const blank = SessionMessage.ID.make("msg_blank_synthetic")
+      const synthetic = SessionMessage.ID.make("msg_visible_synthetic")
+      const shell = SessionMessage.ID.make("msg_shell")
+      const last = SessionMessage.ID.make("msg_last")
+      yield* db
+        .insert(SessionMessageTable)
+        .values([
+          messageRow(SessionMessage.User.make({ id: first, type: "user", text: "first", time: { created } }), 1),
+          messageRow(
+            SessionMessage.Synthetic.make({
+              id: blank,
+              sessionID,
+              type: "synthetic",
+              text: " \u00A0 ",
+              time: { created },
+            }),
+            2,
+          ),
+          messageRow(
+            SessionMessage.Synthetic.make({
+              id: synthetic,
+              sessionID,
+              type: "synthetic",
+              text: "  generated context  ",
+              time: { created },
+            }),
+            3,
+          ),
+          messageRow(
+            SessionMessage.Shell.make({
+              id: shell,
+              type: "shell",
+              callID: "call_1",
+              command: "  pwd  ",
+              output: "/project",
+              time: { created },
+            }),
+            4,
+          ),
+          messageRow(SessionMessage.User.make({ id: last, type: "user", text: "last", time: { created } }), 5),
+        ])
+        .run()
+      const events = yield* EventV2.Service
+      yield* events.publish(SessionEvent.RevertEvent.Staged, {
+        sessionID,
+        timestamp: created,
+        revert: { messageID: first, files: [] },
+      })
+
+      const sessions = yield* SessionV2.Service
+      const page = yield* sessions.messagePage({
+        sessionID,
+        limit: 1,
+        order: "desc",
+        includeRevert: true,
+      })
+      expect(page.revert).toMatchObject({
+        userCount: 4,
+        nextMessageID: synthetic,
+        hasMore: false,
+        items: [
+          { id: first, text: "first" },
+          { id: synthetic, text: "generated context" },
+          { id: shell, text: "pwd" },
+          { id: last, text: "last" },
+        ],
+      })
     }).pipe(Effect.provide(sessionsLayer)),
   )
 

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -43,7 +43,9 @@ export const DiffQuery = Schema.Struct({
 export const MessagesQuery = Schema.Struct({
   ...WorkspaceRoutingQueryFields,
   limit: Schema.optional(Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
-  before: Schema.optional(Schema.String),
+  before: Schema.optional(Schema.NonEmptyString),
+  after: Schema.optional(Schema.NonEmptyString),
+  oldest: Schema.optional(QueryBoolean),
 })
 export const StatusMap = Schema.Record(Schema.String, SessionStatus.Info)
 export const UpdatePayload = Schema.Struct({
@@ -185,7 +187,11 @@ export const SessionApi = HttpApi.make("session")
           OpenApi.annotations({
             identifier: "session.messages",
             summary: "Get session messages",
-            description: "Retrieve all messages in a session, including user prompts and AI responses.",
+            description:
+              "Retrieve messages in a session, including user prompts and AI responses. " +
+              "Without pagination parameters (or with limit=0) the full history is returned. " +
+              "With `limit`, a page is returned anchored at the latest messages, or at the opaque `before`/`after` cursors, or at the `oldest` messages. " +
+              'Link headers use a fixed chronological convention: `rel="next"` always continues into older history (`before` cursor, also exposed as `X-Next-Cursor`), and `rel="prev"` continues into newer history (`after` cursor).',
           }),
         ),
         HttpApiEndpoint.get("message", SessionPaths.message, {
@@ -364,6 +370,18 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.shell",
             summary: "Run shell command",
             description: "Execute a shell command within the session context and return the AI's response.",
+          }),
+        ),
+        HttpApiEndpoint.get("revertPreview", SessionPaths.revert, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.NullOr(SessionRevert.Preview), "Revert preview"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.revertPreview",
+            summary: "Get revert preview",
+            description: "Return the reverted user messages and next restore boundary for a reverted session.",
           }),
         ),
         HttpApiEndpoint.post("revert", SessionPaths.revert, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -22,6 +22,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
+import { stripLinkCredentials } from "@opencode-ai/core/util/link-header"
 import {
   CommandPayload,
   DiffQuery,
@@ -107,40 +108,62 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID }
       query: typeof MessagesQuery.Type
     }) {
-      if (ctx.query.before && ctx.query.limit === undefined) return yield* new HttpApiError.BadRequest({})
-      if (ctx.query.before) {
-        const before = ctx.query.before
+      const oldest = ctx.query.oldest === true
+      if (ctx.query.before && ctx.query.after) return yield* new HttpApiError.BadRequest({})
+      if (oldest && (ctx.query.before || ctx.query.after)) return yield* new HttpApiError.BadRequest({})
+      for (const cursor of [ctx.query.before, ctx.query.after]) {
+        if (!cursor) continue
         yield* Effect.try({
-          try: () => MessageV2.cursor.decode(before),
+          try: () => MessageV2.cursor.decode(cursor),
           catch: () => new HttpApiError.BadRequest({}),
         })
       }
       yield* requireSession(ctx.params.sessionID)
-      if (ctx.query.limit === undefined || ctx.query.limit === 0) {
+      const paged = ctx.query.before !== undefined || ctx.query.after !== undefined || oldest
+      // Back-compat: without pagination params, limit=0 has always meant "full history".
+      if (!paged && (ctx.query.limit === undefined || ctx.query.limit === 0)) {
         return yield* SessionError.mapStorageNotFound(session.messages({ sessionID: ctx.params.sessionID }))
       }
+      if (ctx.query.limit === 0) return yield* new HttpApiError.BadRequest({})
 
+      const pageLimit = ctx.query.limit ?? 100
       const page = yield* SessionError.mapStorageNotFound(
         MessageV2.page({
           sessionID: ctx.params.sessionID,
-          limit: ctx.query.limit,
+          limit: pageLimit,
           before: ctx.query.before,
+          after: ctx.query.after,
+          oldest,
         }),
       )
-      if (!page.cursor) return page.items
 
       const request = yield* HttpServerRequest.HttpServerRequest
-      // toURL() honors the Host + x-forwarded-proto headers, so the Link
-      // header echoes the real origin instead of a hard-coded localhost.
       const url = Option.getOrElse(HttpServerRequest.toURL(request), () => new URL(request.url, "http://localhost"))
-      url.searchParams.set("limit", ctx.query.limit.toString())
-      url.searchParams.set("before", page.cursor)
+      const links: string[] = []
+      if (page.before) {
+        const older = stripLinkCredentials(url)
+        older.searchParams.delete("after")
+        older.searchParams.delete("oldest")
+        older.searchParams.set("limit", pageLimit.toString())
+        older.searchParams.set("before", page.before)
+        links.push(`<${older.toString()}>; rel="next"`)
+      }
+      if (page.after) {
+        const newer = stripLinkCredentials(url)
+        newer.searchParams.delete("before")
+        newer.searchParams.delete("oldest")
+        newer.searchParams.set("limit", pageLimit.toString())
+        newer.searchParams.set("after", page.after)
+        links.push(`<${newer.toString()}>; rel="prev"`)
+      }
+      if (links.length === 0) return page.items
+      const headers: Record<string, string> = {
+        "Access-Control-Expose-Headers": page.before ? "Link, X-Next-Cursor" : "Link",
+        Link: links.join(", "),
+      }
+      if (page.before) headers["X-Next-Cursor"] = page.before
       return HttpServerResponse.jsonUnsafe(page.items, {
-        headers: {
-          "Access-Control-Expose-Headers": "Link, X-Next-Cursor",
-          Link: `<${url.toString()}>; rel="next"`,
-          "X-Next-Cursor": page.cursor,
-        },
+        headers,
       })
     })
 
@@ -346,6 +369,14 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return yield* SessionError.mapBusy(promptSvc.shell({ ...ctx.payload, sessionID: ctx.params.sessionID }))
     })
 
+    const revertPreview = Effect.fn("SessionHttpApi.revertPreview")(function* (ctx: {
+      params: { sessionID: SessionID }
+    }) {
+      return yield* SessionError.mapStorageNotFound(
+        revertSvc.preview({ sessionID: ctx.params.sessionID }).pipe(Effect.map((preview) => preview ?? null)),
+      )
+    })
+
     const revert = Effect.fn("SessionHttpApi.revert")(function* (ctx: {
       params: { sessionID: SessionID }
       payload: typeof RevertPayload.Type
@@ -432,6 +463,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("promptAsync", promptAsync)
       .handle("command", command)
       .handle("shell", shell)
+      .handle("revertPreview", revertPreview)
       .handle("revert", revert)
       .handle("unrevert", unrevert)
       .handle("permissionRespond", permissionRespond)

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -66,6 +66,7 @@ const QueryParameterSchemas: Record<string, OpenApiSchema> = {
   "GET /session roots": QueryBooleanOpenApi,
   "GET /session limit": { type: "number" },
   "GET /session/{sessionID}/message limit": { type: "integer", minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+  "GET /session/{sessionID}/message oldest": QueryBooleanOpenApi,
   "GET /vcs/diff context": { type: "integer", minimum: 0 },
   "GET /api/session limit": { type: "number" },
   "GET /api/session start": { type: "number" },
@@ -374,6 +375,10 @@ function referencesComponent(input: unknown, name: string): boolean {
 
 function normalizeLegacyOperation(operation: OpenApiOperation, path: string, method: string) {
   if (path === "/experimental/console/switch" && method === "post") delete operation.responses?.["400"]
+  if (path === "/session/{sessionID}/revert" && method === "get") {
+    const response = operation.responses?.["200"]?.content?.["application/json"]
+    if (response?.schema) response.schema = nullable(response.schema)
+  }
   if ((path !== "/session/{sessionID}/message" && path !== "/session/{sessionID}/command") || method !== "post") return
   const response = operation.responses?.["200"]?.content?.["application/json"]
   if (!response) return

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -21,9 +21,11 @@ import { APICallError, convertToModelMessages, LoadAPIKeyError, type ModelMessag
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { NotFoundError } from "@/storage/storage"
+import { asc } from "drizzle-orm"
 import { and } from "drizzle-orm"
 import { desc } from "drizzle-orm"
 import { eq } from "drizzle-orm"
+import { gt } from "drizzle-orm"
 import { inArray } from "drizzle-orm"
 import { lt } from "drizzle-orm"
 import { or } from "drizzle-orm"
@@ -95,6 +97,9 @@ const part = (row: typeof PartTable.$inferSelect) =>
 const older = (row: Cursor) =>
   or(lt(MessageTable.time_created, row.time), and(eq(MessageTable.time_created, row.time), lt(MessageTable.id, row.id)))
 
+const newer = (row: Cursor) =>
+  or(gt(MessageTable.time_created, row.time), and(eq(MessageTable.time_created, row.time), gt(MessageTable.id, row.id)))
+
 function hydrate(db: Database.Interface["db"], rows: (typeof MessageTable.$inferSelect)[]) {
   const ids = rows.map((row) => row.id)
   const partByMessage = new Map<string, Part[]>()
@@ -118,6 +123,7 @@ function hydrate(db: Database.Interface["db"], rows: (typeof MessageTable.$infer
     return rows.map((row) => ({
       info: info(row),
       parts: partByMessage.get(row.id) ?? [],
+      cursor: cursor.encode({ id: row.id, time: row.time_created }),
     }))
   })
 }
@@ -426,17 +432,36 @@ export const page = Effect.fn("MessageV2.page")(function* (input: {
   sessionID: SessionID
   limit: number
   before?: string
+  after?: string
+  oldest?: boolean
 }) {
   const { db } = yield* Database.Service
-  const before = input.before ? cursor.decode(input.before) : undefined
-  const where = before
-    ? and(eq(MessageTable.session_id, input.sessionID), older(before))
-    : eq(MessageTable.session_id, input.sessionID)
+  if (input.limit < 1) throw new Error("Page limit must be at least 1")
+  if (input.before && input.after) throw new Error("Cannot specify both 'before' and 'after' cursors")
+  if (input.oldest && (input.before || input.after)) throw new Error("Cannot use 'oldest' with cursors")
+  const anchor = input.oldest
+    ? ({ type: "oldest" } as const)
+    : input.after
+      ? ({ type: "after", cursor: cursor.decode(input.after) } as const)
+      : input.before
+        ? ({ type: "before", cursor: cursor.decode(input.before) } as const)
+        : ({ type: "latest" } as const)
+  const ascending = anchor.type === "oldest" || anchor.type === "after"
+  const scope = eq(MessageTable.session_id, input.sessionID)
+  const where =
+    anchor.type === "before"
+      ? and(scope, older(anchor.cursor))
+      : anchor.type === "after"
+        ? and(scope, newer(anchor.cursor))
+        : scope
+  const order = ascending
+    ? [asc(MessageTable.time_created), asc(MessageTable.id)]
+    : [desc(MessageTable.time_created), desc(MessageTable.id)]
   const rows = yield* db
     .select()
     .from(MessageTable)
     .where(where)
-    .orderBy(desc(MessageTable.time_created), desc(MessageTable.id))
+    .orderBy(...order)
     .limit(input.limit + 1)
     .all()
     .pipe(Effect.orDie)
@@ -448,21 +473,56 @@ export const page = Effect.fn("MessageV2.page")(function* (input: {
       .get()
       .pipe(Effect.orDie)
     if (!row) return yield* new NotFoundError({ message: `Session not found: ${input.sessionID}` })
-    return {
-      items: [] as WithParts[],
-      more: false,
-    }
   }
 
-  const more = rows.length > input.limit
-  const slice = more ? rows.slice(0, input.limit) : rows
+  const overflow = rows.length > input.limit
+  const slice = overflow ? rows.slice(0, input.limit) : rows
   const items = yield* hydrate(db, slice)
-  items.reverse()
-  const tail = slice.at(-1)
+  if (!ascending) items.reverse()
+  const oldestRow = ascending ? slice.at(0) : slice.at(-1)
+  const newestRow = ascending ? slice.at(-1) : slice.at(0)
+  const oldestEdge = oldestRow
+    ? { id: oldestRow.id, time: oldestRow.time_created }
+    : anchor.type === "before" || anchor.type === "after"
+      ? anchor.cursor
+      : undefined
+  const newestEdge = newestRow
+    ? { id: newestRow.id, time: newestRow.time_created }
+    : anchor.type === "before" || anchor.type === "after"
+      ? anchor.cursor
+      : undefined
+  const exists = (condition: ReturnType<typeof older> | ReturnType<typeof newer>) =>
+    db
+      .select({ id: MessageTable.id })
+      .from(MessageTable)
+      .where(and(scope, condition))
+      .limit(1)
+      .get()
+      .pipe(
+        Effect.orDie,
+        Effect.map((row) => row !== undefined),
+      )
+  const hasOlder =
+    anchor.type === "oldest"
+      ? false
+      : anchor.type === "after"
+        ? oldestEdge
+          ? yield* exists(older(oldestEdge))
+          : false
+        : overflow
+  const hasNewer =
+    anchor.type === "latest"
+      ? false
+      : anchor.type === "before"
+        ? newestEdge
+          ? yield* exists(newer(newestEdge))
+          : false
+        : overflow
+  const encode = (row: typeof MessageTable.$inferSelect) => cursor.encode({ id: row.id, time: row.time_created })
   return {
     items,
-    more,
-    cursor: more && tail ? cursor.encode({ id: tail.id, time: tail.time_created }) : undefined,
+    before: hasOlder && oldestEdge ? (oldestRow ? encode(oldestRow) : cursor.encode(oldestEdge)) : undefined,
+    after: hasNewer && newestEdge ? (newestRow ? encode(newestRow) : cursor.encode(newestEdge)) : undefined,
   }
 })
 
@@ -474,7 +534,11 @@ export function stream(sessionID: SessionID) {
     while (true) {
       const next = yield* page({ sessionID, limit: size, before }).pipe(
         Effect.catchIf(NotFoundError.isInstance, () =>
-          Effect.succeed({ items: [] as WithParts[], more: false, cursor: undefined }),
+          Effect.succeed({
+            items: [] as WithParts[],
+            before: undefined,
+            after: undefined,
+          }),
         ),
       )
       if (next.items.length === 0) break
@@ -482,8 +546,8 @@ export function stream(sessionID: SessionID) {
         const item = next.items[i]
         if (item) result.push(item)
       }
-      if (!next.more || !next.cursor) break
-      before = next.cursor
+      if (!next.before) break
+      before = next.before
     }
     return result
   })
@@ -515,7 +579,30 @@ export const get = Effect.fn("MessageV2.get")(function* (input: { sessionID: Ses
   return {
     info: info(row),
     parts: yield* parts(input.messageID),
+    cursor: cursor.encode({ id: row.id, time: row.time_created }),
   }
+})
+
+export const getMany = Effect.fn("MessageV2.getMany")(function* (input: {
+  sessionID: SessionID
+  messageIDs: readonly MessageID[]
+}) {
+  if (input.messageIDs.length === 0) return []
+  const { db } = yield* Database.Service
+  const rows = yield* db
+    .select()
+    .from(MessageTable)
+    .where(and(eq(MessageTable.session_id, input.sessionID), inArray(MessageTable.id, input.messageIDs)))
+    .all()
+    .pipe(Effect.orDie)
+  const messages = new Map((yield* hydrate(db, rows)).map((message) => [message.info.id, message]))
+  return yield* Effect.forEach(input.messageIDs, (messageID) =>
+    Effect.gen(function* () {
+      const message = messages.get(messageID)
+      if (!message) return yield* new NotFoundError({ message: `Message not found: ${messageID}` })
+      return message
+    }),
+  )
 })
 
 export function filterCompacted(msgs: Iterable<WithParts>) {

--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -5,10 +5,14 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { Snapshot } from "../snapshot"
 import { Storage } from "@/storage/storage"
 import { Session } from "./session"
-import { MessageV2 } from "./message-v2"
+import { optional } from "@opencode-ai/core/schema"
 import { SessionID, MessageID, PartID } from "./schema"
 import { SessionRunState } from "./run-state"
 import { SessionSummary } from "./summary"
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageTable } from "@opencode-ai/core/session/sql"
+import { and, asc, count, eq, gt, gte, or, sql } from "drizzle-orm"
+import { MessageV2 } from "./message-v2"
 
 export const RevertInput = Schema.Struct({
   sessionID: SessionID,
@@ -17,10 +21,27 @@ export const RevertInput = Schema.Struct({
 })
 export type RevertInput = Schema.Schema.Type<typeof RevertInput>
 
+export const PreviewItem = Schema.Struct({
+  id: MessageID,
+  text: Schema.String,
+})
+export type PreviewItem = Schema.Schema.Type<typeof PreviewItem>
+
+export const Preview = Schema.Struct({
+  userCount: Schema.Finite,
+  hasMore: Schema.Boolean,
+  nextMessageID: optional(MessageID),
+  continuationMessageID: optional(MessageID),
+  partID: optional(PartID),
+  items: Schema.Array(PreviewItem),
+})
+export type Preview = Schema.Schema.Type<typeof Preview>
+
 export interface Interface {
   readonly revert: (input: RevertInput) => Effect.Effect<Session.Info, Session.BusyError>
   readonly unrevert: (input: { sessionID: SessionID }) => Effect.Effect<Session.Info, Session.BusyError>
   readonly cleanup: (session: Session.Info) => Effect.Effect<void>
+  readonly preview: (input: { sessionID: SessionID }) => Effect.Effect<Preview | undefined, Session.NotFound>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionRevert") {}
@@ -34,6 +55,72 @@ const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const summary = yield* SessionSummary.Service
     const state = yield* SessionRunState.Service
+    const database = yield* Database.Service
+    const PreviewItemLimit = 100
+
+    const previewText = (message: SessionV1.WithParts) => {
+      const text = message.parts
+        .flatMap((part) => (part.type === "text" && !part.synthetic && part.text.trim() ? [part.text.trim()] : []))
+        .join("\n\n")
+      if (text) return text
+      const attachments = message.parts.flatMap((part) => (part.type === "file" ? [part.filename] : []))
+      if (attachments.length === 0) return ""
+      return attachments.map((name) => `[attachment:${name}]`).join(" ")
+    }
+
+    const preview = Effect.fn("SessionRevert.preview")(function* (input: { sessionID: SessionID }) {
+      const session = yield* sessions.get(input.sessionID)
+      const revert = session.revert
+      if (!revert) return undefined
+      const load = Effect.gen(function* () {
+        const boundaryRow = yield* database.db
+          .select()
+          .from(MessageTable)
+          .where(and(eq(MessageTable.session_id, input.sessionID), eq(MessageTable.id, revert.messageID)))
+          .get()
+          .pipe(Effect.orDie)
+        if (!boundaryRow) return undefined
+        const user = sql`json_extract(${MessageTable.data}, '$.role') = 'user'`
+        const afterBoundary = or(
+          gt(MessageTable.time_created, boundaryRow.time_created),
+          and(eq(MessageTable.time_created, boundaryRow.time_created), gte(MessageTable.id, boundaryRow.id)),
+        )
+        const where = and(eq(MessageTable.session_id, input.sessionID), user, afterBoundary)
+        const userCount =
+          (yield* database.db.select({ value: count() }).from(MessageTable).where(where).get().pipe(Effect.orDie))
+            ?.value ?? 0
+        const rows = yield* database.db
+          .select({ id: MessageTable.id })
+          .from(MessageTable)
+          .where(where)
+          .orderBy(asc(MessageTable.time_created), asc(MessageTable.id))
+          .limit(PreviewItemLimit + 1)
+          .all()
+          .pipe(Effect.orDie)
+        const candidateIDs = revert.partID
+          ? [revert.messageID, ...rows.flatMap((row) => (row.id === revert.messageID ? [] : [row.id]))]
+          : rows.map((row) => row.id)
+        const continuationMessageID = candidateIDs[PreviewItemLimit]
+        const candidates = yield* MessageV2.getMany({
+          sessionID: input.sessionID,
+          messageIDs: candidateIDs.slice(0, PreviewItemLimit),
+        }).pipe(Effect.provideService(Database.Service, database))
+        const items = candidates.map((message) => ({ id: message.info.id, text: previewText(message) }))
+        return {
+          userCount,
+          hasMore: continuationMessageID !== undefined,
+          nextMessageID: items[items.findIndex((item) => item.id === revert.messageID) + 1]?.id,
+          continuationMessageID,
+          partID: revert.partID,
+          items,
+        }
+      })
+      return yield* load.pipe(
+        Effect.catchIf(Storage.NotFoundError.isInstance, () =>
+          load.pipe(Effect.catchIf(Storage.NotFoundError.isInstance, () => Effect.succeed(undefined))),
+        ),
+      )
+    })
 
     const revert = Effect.fn("SessionRevert.revert")(function* (input: RevertInput) {
       yield* state.assertNotBusy(input.sessionID)
@@ -123,14 +210,22 @@ const layer = Layer.effect(
       yield* sessions.clearRevert(sessionID)
     })
 
-    return Service.of({ revert, unrevert, cleanup })
+    return Service.of({ revert, unrevert, cleanup, preview })
   }),
 )
 
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [Session.node, Snapshot.node, Storage.node, EventV2Bridge.node, SessionSummary.node, SessionRunState.node],
+  deps: [
+    Session.node,
+    Snapshot.node,
+    Storage.node,
+    EventV2Bridge.node,
+    SessionSummary.node,
+    SessionRunState.node,
+    Database.node,
+  ],
 })
 
 export * as SessionRevert from "./revert"

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -630,7 +630,11 @@ const layer: Layer.Layer<
 
     const updateMessage = <T extends SessionV1.Info>(msg: T): Effect.Effect<T> =>
       Effect.gen(function* () {
-        yield* events.publish(SessionV1.Event.MessageUpdated, { sessionID: msg.sessionID, info: msg })
+        yield* events.publish(SessionV1.Event.MessageUpdated, {
+          sessionID: msg.sessionID,
+          info: msg,
+          cursor: MessageV2.cursor.encode({ id: msg.id, time: msg.time.created }),
+        })
         return msg
       }).pipe(Effect.withSpan("Session.updateMessage"))
 
@@ -828,6 +832,7 @@ const layer: Layer.Layer<
     })
 
     const messages: Interface["messages"] = Effect.fn("Session.messages")(function* (input) {
+      // limit=0 means "no limit" and walks the full history below.
       if (input.limit) {
         return (yield* MessageV2.page({ sessionID: input.sessionID, limit: input.limit }).pipe(
           Effect.provideService(Database.Service, database),
@@ -846,8 +851,8 @@ const layer: Layer.Layer<
           const item = page.items[i]
           if (item) result.push(item)
         }
-        if (!page.more || !page.cursor) break
-        before = page.cursor
+        if (!page.before) break
+        before = page.before
       }
       return result.reverse()
     })
@@ -899,8 +904,8 @@ const layer: Layer.Layer<
           const item = page.items[i]
           if (item && predicate(item)) return Option.some(item)
         }
-        if (!page.more || !page.cursor) break
-        before = page.cursor
+        if (!page.before) break
+        before = page.before
       }
       return Option.none<SessionV1.WithParts>()
     })

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1051,7 +1051,7 @@ const scenarios: Scenario[] = [
       path: `${route("/api/session/{sessionID}/message", { sessionID: "ses_httpapi_missing" })}?${new URLSearchParams({
         limit: "2",
         directory: ctx.directory ?? "",
-        cursor: cursor({ id: "msg_httpapi_missing", time: 0, order: "desc", direction: "next" }),
+        cursor: cursor({ seq: 0, order: "desc", direction: "next" }),
       })}`,
       headers: ctx.headers(),
     }))
@@ -1061,7 +1061,7 @@ const scenarios: Scenario[] = [
     .seeded((ctx) => ctx.session({ title: "Invalid message cursor owner" }))
     .at((ctx) => ({
       path: `${route("/api/session/{sessionID}/message", { sessionID: ctx.state.id })}?${new URLSearchParams({
-        cursor: cursor({ id: "msg_httpapi_missing", time: 0, order: "desc", direction: "next" }),
+        cursor: cursor({ seq: 0, order: "desc", direction: "next" }),
         order: "asc",
       })}`,
       headers: ctx.headers(),

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -359,11 +359,14 @@ describe("session HttpApi", () => {
         expect(nextCursor).toBeTruthy()
         expect(messagePage[0]?.parts[0]).toMatchObject({ type: "text" })
 
-        expect(
-          (yield* request(`${pathFor(SessionPaths.messages, { sessionID: parent.id })}?before=${nextCursor}`, {
-            headers,
-          })).status,
-        ).toBe(400)
+        const previousMessages = yield* request(
+          `${pathFor(SessionPaths.messages, { sessionID: parent.id })}?before=${nextCursor}`,
+          { headers },
+        )
+        expect(previousMessages.status).toBe(200)
+        expect((yield* json<SessionV1.WithParts[]>(previousMessages)).map((item) => item.info.id)).toEqual([
+          message.info.id,
+        ])
         expect(
           (yield* request(`${pathFor(SessionPaths.messages, { sessionID: parent.id })}?limit=1&before=invalid`, {
             headers,
@@ -474,12 +477,21 @@ describe("session HttpApi", () => {
         })
 
         const messagePage = yield* request(`/api/session/${session.id}/message?limit=1`, { headers })
-        const messageBody = yield* json<{ data: SessionMessage.Message[]; cursor: { next?: string } }>(messagePage)
+        const messageBody = yield* json<{
+          data: SessionMessage.Message[]
+          context: SessionMessage.Message[]
+          revert?: unknown
+          cursor: { next?: string }
+        }>(messagePage)
         const messageCursor = messageBody.cursor.next
         expect(messageCursor).toBeTruthy()
         expect(messageBody.data.map((message) => message.id)).toEqual([secondMessage.id])
-        expect(JSON.parse(Buffer.from(messageCursor!, "base64url").toString("utf8"))).toEqual({
-          id: secondMessage.id,
+        expect(messageBody.context).toEqual([])
+        expect(messageBody).not.toHaveProperty("revert")
+        expect(JSON.parse(Buffer.from(messageCursor!, "base64url").toString("utf8"))).toMatchObject({
+          v: 1,
+          sessionID: session.id,
+          seq: expect.any(Number),
           order: "desc",
           direction: "next",
         })
@@ -487,9 +499,86 @@ describe("session HttpApi", () => {
         const nextMessagePage = yield* request(`/api/session/${session.id}/message?cursor=${messageCursor}`, {
           headers,
         })
+        const nextMessageBody = yield* json<{
+          data: SessionMessage.Message[]
+          cursor: { previous?: string; next?: string }
+        }>(nextMessagePage)
+        expect(nextMessageBody.data.map((message) => message.id)).toEqual([firstMessage.id])
+        expect(nextMessageBody.cursor.previous).toBeTruthy()
+        expect(nextMessageBody.cursor).not.toHaveProperty("next")
+
+        const previousMessagePage = yield* request(
+          `/api/session/${session.id}/message?cursor=${nextMessageBody.cursor.previous}`,
+          { headers },
+        )
+        const previousMessageBody = yield* json<{
+          data: SessionMessage.Message[]
+          cursor: { previous?: string; next?: string }
+        }>(previousMessagePage)
+        expect(previousMessageBody.data.map((message) => message.id)).toEqual([secondMessage.id])
+        expect(previousMessageBody.cursor).not.toHaveProperty("previous")
+        expect(previousMessageBody.cursor.next).toBeTruthy()
+
+        const completeMessagePage = yield* request(`/api/session/${session.id}/message?limit=10`, { headers })
+        expect((yield* json<{ cursor: { previous?: string; next?: string } }>(completeMessagePage)).cursor).toEqual({})
+
+        const mutationHeaders = { ...headers, "content-type": "application/json" }
+        const staged = yield* request(`/api/session/${session.id}/revert/stage`, {
+          method: "POST",
+          headers: mutationHeaders,
+          body: JSON.stringify({ messageID: firstMessage.id }),
+        })
+        expect(staged.status).toBe(200)
+        const committed = yield* request(`/api/session/${session.id}/revert/commit`, {
+          method: "POST",
+          headers: mutationHeaders,
+        })
+        expect(committed.status).toBe(204)
+
+        const stableCursorPage = yield* request(`/api/session/${session.id}/message?cursor=${messageCursor}`, {
+          headers,
+        })
+        const stableBody = yield* json<{
+          data: SessionMessage.Message[]
+          cursor: { previous?: string; next?: string }
+        }>(stableCursorPage)
+        expect(stableBody.data.map((message) => message.id)).toEqual([firstMessage.id])
+        expect(stableBody.cursor.previous).toBeUndefined()
+
+        const emptyCursor = Buffer.from(
+          JSON.stringify({ v: 1, sessionID: session.id, seq: 0, order: "desc", direction: "next" }),
+        ).toString("base64url")
+        const emptyPage = yield* request(`/api/session/${session.id}/message?cursor=${emptyCursor}`, { headers })
+        const emptyBody = yield* json<{
+          data: SessionMessage.Message[]
+          cursor: { previous?: string; next?: string }
+        }>(emptyPage)
+        expect(emptyBody.data).toEqual([])
+        expect(emptyBody.cursor.previous).toBeTruthy()
+        expect(emptyBody.cursor.next).toBeUndefined()
+        const recoveredPage = yield* request(`/api/session/${session.id}/message?cursor=${emptyBody.cursor.previous}`, {
+          headers,
+        })
         expect(
-          (yield* json<{ data: SessionMessage.Message[] }>(nextMessagePage)).data.map((message) => message.id),
+          (yield* json<{ data: SessionMessage.Message[] }>(recoveredPage)).data.map((message) => message.id),
         ).toEqual([firstMessage.id])
+
+        const foreignCursor = Buffer.from(
+          JSON.stringify({ v: 1, sessionID: "ses_other", seq: 1, order: "desc", direction: "next" }),
+        ).toString("base64url")
+        const foreignPage = yield* request(`/api/session/${session.id}/message?cursor=${foreignCursor}`, { headers })
+        expect(foreignPage.status).toBe(400)
+        expect(yield* responseJson(foreignPage)).toMatchObject({
+          _tag: "InvalidCursorError",
+          message: "Cursor belongs to another session",
+        })
+
+        const negativeCursor = Buffer.from(
+          JSON.stringify({ v: 1, sessionID: session.id, seq: -1, order: "desc", direction: "next" }),
+        ).toString("base64url")
+        const negativePage = yield* request(`/api/session/${session.id}/message?cursor=${negativeCursor}`, { headers })
+        expect(negativePage.status).toBe(400)
+        expect(yield* responseJson(negativePage)).toMatchObject({ _tag: "InvalidCursorError" })
 
         const legacyMessageCursor = Buffer.from(
           JSON.stringify({ id: secondMessage.id, time: 1, order: "desc", direction: "next" }),
@@ -497,9 +586,11 @@ describe("session HttpApi", () => {
         const legacyMessagePage = yield* request(`/api/session/${session.id}/message?cursor=${legacyMessageCursor}`, {
           headers,
         })
-        expect(
-          (yield* json<{ data: SessionMessage.Message[] }>(legacyMessagePage)).data.map((message) => message.id),
-        ).toEqual([firstMessage.id])
+        expect(legacyMessagePage.status).toBe(404)
+        expect(yield* responseJson(legacyMessagePage)).toMatchObject({
+          _tag: "MessageNotFoundError",
+          messageID: secondMessage.id,
+        })
 
         const messageCursorWithOrder = yield* request(
           `/api/session/${session.id}/message?cursor=${messageCursor}&order=asc`,
@@ -517,6 +608,9 @@ describe("session HttpApi", () => {
           _tag: "InvalidCursorError",
           message: "Invalid cursor",
         })
+
+        const emptyMessageCursor = yield* request(`/api/session/${session.id}/message?cursor=`, { headers })
+        expect(emptyMessageCursor.status).toBe(400)
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )
@@ -557,6 +651,38 @@ describe("session HttpApi", () => {
         })
         expect(prompt.status).toBe(404)
         expect(yield* responseJson(prompt)).toEqual(expected)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "returns a typed error for a stale v2 revert boundary",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const session = yield* createSession({ title: "stale revert boundary" })
+        const messageID = SessionMessage.ID.create()
+        const { db } = yield* Database.Service
+
+        // Persist an invalid boundary to exercise the public recovery/error path independently of staging.
+        yield* db
+          .update(SessionTable)
+          .set({ revert: { messageID, files: [] } })
+          .where(eq(SessionTable.id, session.id))
+          .run()
+          .pipe(Effect.orDie)
+
+        const response = yield* request(`/api/session/${session.id}/message`, {
+          headers: { "x-opencode-directory": test.directory },
+        })
+
+        expect(response.status).toBe(404)
+        expect(yield* responseJson(response)).toEqual({
+          _tag: "MessageNotFoundError",
+          sessionID: session.id,
+          messageID,
+          message: `Message not found: ${messageID}`,
+        })
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -85,9 +85,15 @@ function json<T>(response: HttpClientResponse.HttpClientResponse) {
   return response.json.pipe(Effect.map((body) => body as T))
 }
 
+function linkParam(link: string | undefined, rel: "prev" | "next", name: string) {
+  const match = new RegExp(`<([^>]+)>;\\s*rel="${rel}"`).exec(link ?? "")
+  if (!match) return undefined
+  return new URL(match[1]).searchParams.get(name) ?? undefined
+}
+
 describe("session messages endpoint", () => {
   it.instance(
-    "returns cursor headers for older pages",
+    "returns bidirectional cursor headers",
     withoutWatcher(
       Effect.gen(function* () {
         const session = yield* sessionScoped
@@ -105,6 +111,21 @@ describe("session messages endpoint", () => {
         expect(b.status).toBe(200)
         const bBody = yield* json<SessionV1.WithParts[]>(b)
         expect(bBody.map((item) => item.info.id)).toEqual(ids.slice(-4, -2))
+        expect(b.headers["link"]).toContain('rel="next"')
+        expect(b.headers["link"]).toContain('rel="prev"')
+
+        const after = linkParam(b.headers["link"], "prev", "after")
+        expect(after).toBeTruthy()
+        const c = yield* request(`/session/${session.id}/message?limit=2&after=${encodeURIComponent(after!)}`)
+        expect(c.status).toBe(200)
+        const cBody = yield* json<SessionV1.WithParts[]>(c)
+        expect(cBody.map((item) => item.info.id)).toEqual(ids.slice(-2))
+
+        const oldest = yield* request(`/session/${session.id}/message?limit=2&oldest=true`)
+        expect(oldest.status).toBe(200)
+        const oldestBody = yield* json<SessionV1.WithParts[]>(oldest)
+        expect(oldestBody.map((item) => item.info.id)).toEqual(ids.slice(0, 2))
+        expect(oldest.headers["link"]).toContain('rel="prev"')
       }),
     ),
     { git: true },
@@ -127,6 +148,31 @@ describe("session messages endpoint", () => {
   )
 
   it.instance(
+    "keeps the legacy limit=0 full-history contract and rejects limit=0 pages",
+    withoutWatcher(
+      Effect.gen(function* () {
+        const session = yield* sessionScoped
+        const ids = yield* fill(session.id, 3)
+
+        const res = yield* request(`/session/${session.id}/message?limit=0`)
+        expect(res.status).toBe(200)
+        const body = yield* json<SessionV1.WithParts[]>(res)
+        expect(body.map((item) => item.info.id)).toEqual(ids)
+
+        const page = yield* request(`/session/${session.id}/message?limit=2`)
+        const cursor = page.headers["x-next-cursor"]
+        expect(cursor).toBeTruthy()
+        const paged = yield* request(`/session/${session.id}/message?limit=0&before=${encodeURIComponent(cursor!)}`)
+        expect(paged.status).toBe(400)
+
+        const oldest = yield* request(`/session/${session.id}/message?limit=0&oldest=true`)
+        expect(oldest.status).toBe(400)
+      }),
+    ),
+    { git: true },
+  )
+
+  it.instance(
     "rejects invalid cursors and missing sessions",
     withoutWatcher(
       Effect.gen(function* () {
@@ -134,6 +180,12 @@ describe("session messages endpoint", () => {
 
         const bad = yield* request(`/session/${session.id}/message?limit=2&before=bad`)
         expect(bad.status).toBe(400)
+
+        const emptyBefore = yield* request(`/session/${session.id}/message?limit=2&before=`)
+        expect(emptyBefore.status).toBe(400)
+
+        const emptyAfter = yield* request(`/session/${session.id}/message?limit=2&after=`)
+        expect(emptyAfter.status).toBe(400)
 
         const miss = yield* request(`/session/ses_missing/message?limit=2`)
         expect(miss.status).toBe(404)

--- a/packages/opencode/test/session/messages-pagination.test.ts
+++ b/packages/opencode/test/session/messages-pagination.test.ts
@@ -148,18 +148,52 @@ describe("MessageV2.page", () => {
         const a = yield* MessageV2.page({ sessionID, limit: 2 })
         expect(a.items.map((item) => item.info.id)).toEqual(ids.slice(-2))
         expect(a.items.every((item) => item.parts.length === 1)).toBe(true)
-        expect(a.more).toBe(true)
-        expect(a.cursor).toBeTruthy()
+        expect(a.before).toBeTruthy()
 
-        const b = yield* MessageV2.page({ sessionID, limit: 2, before: a.cursor! })
+        const b = yield* MessageV2.page({ sessionID, limit: 2, before: a.before! })
         expect(b.items.map((item) => item.info.id)).toEqual(ids.slice(-4, -2))
-        expect(b.more).toBe(true)
-        expect(b.cursor).toBeTruthy()
+        expect(b.before).toBeTruthy()
 
-        const c = yield* MessageV2.page({ sessionID, limit: 2, before: b.cursor! })
+        const c = yield* MessageV2.page({ sessionID, limit: 2, before: b.before! })
         expect(c.items.map((item) => item.info.id)).toEqual(ids.slice(0, 2))
-        expect(c.more).toBe(false)
-        expect(c.cursor).toBeUndefined()
+        expect(c.before).toBeUndefined()
+        expect(c.after).toBeTruthy()
+      }),
+    ),
+  )
+
+  it.instance("pages forward from an older page", () =>
+    withSession(({ sessionID }) =>
+      Effect.gen(function* () {
+        const ids = yield* fill(sessionID, 6)
+
+        const latest = yield* MessageV2.page({ sessionID, limit: 2 })
+        const older = yield* MessageV2.page({ sessionID, limit: 2, before: latest.before! })
+        expect(older.items.map((item) => item.info.id)).toEqual(ids.slice(-4, -2))
+        expect(older.after).toBeTruthy()
+
+        const newer = yield* MessageV2.page({ sessionID, limit: 2, after: older.after! })
+        expect(newer.items.map((item) => item.info.id)).toEqual(ids.slice(-2))
+        expect(newer.before).toBeTruthy()
+        expect(newer.after).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.instance("pages from the oldest edge", () =>
+    withSession(({ sessionID }) =>
+      Effect.gen(function* () {
+        const ids = yield* fill(sessionID, 5)
+
+        const oldest = yield* MessageV2.page({ sessionID, limit: 2, oldest: true })
+        expect(oldest.items.map((item) => item.info.id)).toEqual(ids.slice(0, 2))
+        expect(oldest.before).toBeUndefined()
+        expect(oldest.after).toBeTruthy()
+
+        const next = yield* MessageV2.page({ sessionID, limit: 2, after: oldest.after! })
+        expect(next.items.map((item) => item.info.id)).toEqual(ids.slice(2, 4))
+        expect(next.before).toBeTruthy()
+        expect(next.after).toBeTruthy()
       }),
     ),
   )
@@ -180,8 +214,8 @@ describe("MessageV2.page", () => {
       Effect.gen(function* () {
         const result = yield* MessageV2.page({ sessionID, limit: 10 })
         expect(result.items).toEqual([])
-        expect(result.more).toBe(false)
-        expect(result.cursor).toBeUndefined()
+        expect(result.before).toBeUndefined()
+        expect(result.after).toBeUndefined()
       }),
     ),
   )
@@ -202,8 +236,41 @@ describe("MessageV2.page", () => {
 
         const result = yield* MessageV2.page({ sessionID, limit: 3 })
         expect(result.items.map((item) => item.info.id)).toEqual(ids)
-        expect(result.more).toBe(false)
-        expect(result.cursor).toBeUndefined()
+        expect(result.before).toBeUndefined()
+        expect(result.after).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.instance("preserves reverse navigation around deleted cursor anchors", () =>
+    withSession(({ session, sessionID }) =>
+      Effect.gen(function* () {
+        const ids = yield* fill(sessionID, 4, (index: number) => 1_000 + index)
+        const oldest = yield* MessageV2.page({ sessionID, limit: 1, oldest: true })
+        const oldestCursor = oldest.after!
+        yield* session.removeMessage({ sessionID, messageID: ids[0]! })
+
+        const beforeOldest = yield* MessageV2.page({ sessionID, limit: 1, before: oldestCursor })
+        expect(beforeOldest.items).toEqual([])
+        expect(beforeOldest.before).toBeUndefined()
+        expect(beforeOldest.after).toBe(oldestCursor)
+        expect(
+          (yield* MessageV2.page({ sessionID, limit: 1, after: beforeOldest.after })).items.map((item) => item.info.id),
+        ).toEqual([ids[1]])
+
+        const latest = yield* MessageV2.page({ sessionID, limit: 1 })
+        const newestCursor = latest.before!
+        yield* session.removeMessage({ sessionID, messageID: ids.at(-1)! })
+
+        const afterNewest = yield* MessageV2.page({ sessionID, limit: 1, after: newestCursor })
+        expect(afterNewest.items).toEqual([])
+        expect(afterNewest.before).toBe(newestCursor)
+        expect(afterNewest.after).toBeUndefined()
+        expect(
+          (yield* MessageV2.page({ sessionID, limit: 1, before: afterNewest.before })).items.map(
+            (item) => item.info.id,
+          ),
+        ).toEqual([ids[2]])
       }),
     ),
   )
@@ -216,7 +283,7 @@ describe("MessageV2.page", () => {
         const result = yield* MessageV2.page({ sessionID, limit: 1 })
         expect(result.items).toHaveLength(1)
         expect(result.items[0].info.id).toBe(ids[ids.length - 1])
-        expect(result.more).toBe(true)
+        expect(result.before).toBeTruthy()
       }),
     ),
   )
@@ -247,7 +314,7 @@ describe("MessageV2.page", () => {
         const ids = yield* fill(sessionID, 4, (i: number) => 1000.5 + i)
 
         const a = yield* MessageV2.page({ sessionID, limit: 2 })
-        const b = yield* MessageV2.page({ sessionID, limit: 2, before: a.cursor! })
+        const b = yield* MessageV2.page({ sessionID, limit: 2, before: a.before! })
 
         expect(a.items.map((item) => item.info.id)).toEqual(ids.slice(-2))
         expect(b.items.map((item) => item.info.id)).toEqual(ids.slice(0, 2))
@@ -262,11 +329,11 @@ describe("MessageV2.page", () => {
 
         const a = yield* MessageV2.page({ sessionID, limit: 2 })
         expect(a.items.map((item) => item.info.id)).toEqual(ids.slice(-2))
-        expect(a.more).toBe(true)
+        expect(a.before).toBeTruthy()
 
-        const b = yield* MessageV2.page({ sessionID, limit: 2, before: a.cursor! })
+        const b = yield* MessageV2.page({ sessionID, limit: 2, before: a.before! })
         expect(b.items.map((item) => item.info.id)).toEqual(ids.slice(0, 2))
-        expect(b.more).toBe(false)
+        expect(b.before).toBeUndefined()
       }),
     ),
   )
@@ -299,8 +366,8 @@ describe("MessageV2.page", () => {
         const result = yield* MessageV2.page({ sessionID, limit: 100 })
         expect(result.items).toHaveLength(10)
         expect(result.items.map((item) => item.info.id)).toEqual(ids)
-        expect(result.more).toBe(false)
-        expect(result.cursor).toBeUndefined()
+        expect(result.before).toBeUndefined()
+        expect(result.after).toBeUndefined()
       }),
     ),
   )
@@ -549,6 +616,44 @@ describe("MessageV2.get", () => {
         expect(result.parts).toEqual([])
       }),
     ),
+  )
+
+  it.instance("returns requested messages with hydrated parts in input order", () =>
+    withSession(({ sessionID }) =>
+      Effect.gen(function* () {
+        const ids = yield* fill(sessionID, 3)
+        const first = ids.at(0)
+        const third = ids.at(2)
+        expect(first).toBeDefined()
+        expect(third).toBeDefined()
+        if (!first || !third) return
+        const messages = yield* MessageV2.getMany({
+          sessionID,
+          messageIDs: [third, first],
+        })
+
+        expect(messages.map((message) => message.info.id)).toEqual([third, first])
+        expect(messages.map((message) => (message.parts[0] as SessionV1.TextPart).text)).toEqual(["m2", "m0"])
+      }),
+    ),
+  )
+
+  it.instance("fails when a requested message is missing from the session", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const source = yield* session.create({})
+      const target = yield* session.create({})
+      const [messageID] = yield* fill(source.id, 1)
+      const missingID = MessageID.ascending()
+
+      const crossSession = yield* Effect.flip(MessageV2.getMany({ sessionID: target.id, messageIDs: [messageID] }))
+      expect(crossSession).toBeInstanceOf(NotFoundError)
+      const missing = yield* Effect.flip(MessageV2.getMany({ sessionID: source.id, messageIDs: [missingID] }))
+      expect(missing).toBeInstanceOf(NotFoundError)
+
+      yield* session.remove(source.id)
+      yield* session.remove(target.id)
+    }),
   )
 })
 
@@ -1032,8 +1137,8 @@ describe("MessageV2 consistency", () => {
           for (let i = result.items.length - 1; i >= 0; i--) {
             paged.push(result.items[i])
           }
-          if (!result.more || !result.cursor) break
-          cursor = result.cursor
+          if (!result.before) break
+          cursor = result.before
         }
 
         expect(streamed.map((m) => m.info.id)).toEqual(paged.map((m) => m.info.id))

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -16,10 +16,19 @@ import { provideTmpdirInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { Database } from "@opencode-ai/core/database/database"
+import { sql } from "drizzle-orm"
 
 const it = testEffect(
   LayerNode.compile(
-    LayerNode.group([Session.node, SessionRevert.node, Snapshot.node, SessionProjector.node, CrossSpawnSpawner.node]),
+    LayerNode.group([
+      Session.node,
+      SessionRevert.node,
+      Snapshot.node,
+      SessionProjector.node,
+      CrossSpawnSpawner.node,
+      Database.node,
+    ]),
   ),
 )
 
@@ -392,6 +401,115 @@ describe("revert + compact workflow", () => {
 
           const cleared = yield* session.get(sid)
           expect(cleared.revert).toBeUndefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
+    "preview for partID includes the next user restore boundary",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+
+          const info = yield* session.create({})
+          const sid = info.id
+
+          const u1 = yield* user(sid)
+          const a1 = yield* assistant(sid, u1.id, dir)
+          yield* text(sid, a1.id, "kept answer")
+          const p2 = yield* tool(sid, a1.id)
+          const u2 = yield* user(sid)
+          yield* text(sid, u2.id, "second question")
+          const u3 = yield* user(sid)
+          yield* text(sid, u3.id, "third question")
+
+          yield* session.setRevert({
+            sessionID: sid,
+            revert: { messageID: a1.id, partID: p2.id },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          const preview = yield* revert.preview({ sessionID: sid })
+          expect(preview?.partID).toBe(p2.id)
+          expect(preview?.userCount).toBe(2)
+          expect(preview?.nextMessageID).toBe(u2.id)
+          expect(preview?.hasMore).toBe(false)
+          expect(preview?.continuationMessageID).toBeUndefined()
+          expect(preview?.items.map((item) => item.id)).toEqual([a1.id, u2.id, u3.id])
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
+    "preview after an assistant boundary restores the first following user",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+
+          const info = yield* session.create({})
+          const first = yield* user(info.id)
+          const boundary = yield* assistant(info.id, first.id, dir)
+          const second = yield* user(info.id)
+          const third = yield* user(info.id)
+
+          yield* session.setRevert({
+            sessionID: info.id,
+            revert: { messageID: boundary.id },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+
+          const preview = yield* revert.preview({ sessionID: info.id })
+          expect(preview?.nextMessageID).toBe(second.id)
+          expect(preview?.items.map((item) => item.id)).toEqual([second.id, third.id])
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live(
+    "bounds revert previews and exposes a continuation message",
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+          const info = yield* session.create({})
+          const records = yield* Effect.forEach(Array.from({ length: 102 }), (_, index) =>
+            Effect.gen(function* () {
+              const message = yield* user(info.id)
+              const part = yield* text(info.id, message.id, `question ${index}`)
+              return { message, part }
+            }),
+          )
+          const first = records.at(0)
+          const overflow = records.at(100)
+          expect(first).toBeDefined()
+          expect(overflow).toBeDefined()
+          if (!first || !overflow) return
+
+          yield* session.setRevert({
+            sessionID: info.id,
+            revert: { messageID: first.message.id },
+            summary: { additions: 0, deletions: 0, files: 0 },
+          })
+          const database = yield* Database.Service
+          yield* database.db.run(
+            sql`UPDATE part SET data = ${JSON.stringify({ type: "text" })} WHERE id = ${overflow.part.id}`,
+          )
+
+          const preview = yield* revert.preview({ sessionID: info.id })
+          expect(preview?.userCount).toBe(102)
+          expect(preview?.items).toHaveLength(100)
+          expect(preview?.items.at(0)?.id).toBe(first.message.id)
+          expect(preview?.items.at(-1)?.id).toBe(records[99]?.message.id)
+          expect(preview?.hasMore).toBe(true)
+          expect(preview?.continuationMessageID).toBe(overflow.message.id)
         }),
       { git: true },
     ),

--- a/packages/opencode/test/util/parse-link-header.test.ts
+++ b/packages/opencode/test/util/parse-link-header.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+import { linkParam, parseLinkHeader } from "@opencode-ai/core/util/link-header"
+
+describe("util.parseLinkHeader", () => {
+  test("returns empty object for empty string", () => {
+    expect(parseLinkHeader("")).toEqual({})
+  })
+
+  test("parses single link with rel", () => {
+    const header = '<https://api.example.com/items?page=2>; rel="next"'
+    expect(parseLinkHeader(header)).toEqual({
+      next: "https://api.example.com/items?page=2",
+    })
+  })
+
+  test("parses multiple links", () => {
+    const header =
+      '<https://api.example.com/items?page=1>; rel="prev", <https://api.example.com/items?page=3>; rel="next"'
+    expect(parseLinkHeader(header)).toEqual({
+      prev: "https://api.example.com/items?page=1",
+      next: "https://api.example.com/items?page=3",
+    })
+  })
+
+  test("handles unquoted rel values", () => {
+    const header = "<https://example.com>; rel=next"
+    expect(parseLinkHeader(header)).toEqual({
+      next: "https://example.com",
+    })
+  })
+
+  test("handles single-quoted rel values", () => {
+    const header = "<https://example.com>; rel='next'"
+    expect(parseLinkHeader(header)).toEqual({
+      next: "https://example.com",
+    })
+  })
+
+  test("ignores links without rel attribute", () => {
+    const header = "<https://example.com>; type=text/html"
+    expect(parseLinkHeader(header)).toEqual({})
+  })
+
+  test("handles malformed input gracefully", () => {
+    expect(parseLinkHeader("not a valid header")).toEqual({})
+    expect(parseLinkHeader("<<>>;;")).toEqual({})
+  })
+
+  test("handles extra whitespace", () => {
+    const header = '  <https://example.com>  ;  rel="next"  '
+    expect(parseLinkHeader(header)).toEqual({
+      next: "https://example.com",
+    })
+  })
+
+  test("extracts query params from parsed link urls", () => {
+    const links = parseLinkHeader('<https://example.com/items?before=abc&limit=100>; rel="prev"')
+    expect(linkParam(links.prev, "before")).toBe("abc")
+    expect(linkParam(links.prev, "limit")).toBe("100")
+  })
+
+  test("returns undefined for invalid link param url", () => {
+    expect(linkParam("not a url", "before")).toBeUndefined()
+  })
+})

--- a/packages/protocol/src/groups/message.ts
+++ b/packages/protocol/src/groups/message.ts
@@ -1,8 +1,10 @@
 import { Session } from "@opencode-ai/schema/session"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
+import { Revert } from "@opencode-ai/schema/revert"
+import { optional } from "@opencode-ai/schema/schema"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { InvalidCursorError, SessionNotFoundError, UnknownError } from "../errors"
+import { InvalidCursorError, MessageNotFoundError, SessionNotFoundError, UnknownError } from "../errors"
 
 export const SessionMessagesQuery = Schema.Struct({
   limit: Schema.optional(
@@ -14,7 +16,7 @@ export const SessionMessagesQuery = Schema.Struct({
     description: "Message order for the first page. Use desc for newest first or asc for oldest first.",
   }),
   cursor: Schema.optional(
-    Schema.String.annotate({
+    Schema.NonEmptyString.annotate({
       description:
         "Opaque pagination cursor returned as cursor.previous or cursor.next in the previous response. Do not combine with order.",
     }),
@@ -28,18 +30,21 @@ export const MessageGroup = HttpApiGroup.make("server.message")
       query: SessionMessagesQuery,
       success: Schema.Struct({
         data: Schema.Array(SessionMessage.Message),
+        context: Schema.Array(SessionMessage.Message),
+        contextCursor: Schema.NonEmptyString.pipe(optional),
+        revert: Revert.Preview.pipe(optional),
         cursor: Schema.Struct({
-          previous: Schema.String.pipe(Schema.optional),
-          next: Schema.String.pipe(Schema.optional),
+          previous: Schema.String.pipe(optional),
+          next: Schema.String.pipe(optional),
         }),
       }).annotate({ identifier: "SessionMessagesResponse" }),
-      error: [InvalidCursorError, SessionNotFoundError, UnknownError],
+      error: [InvalidCursorError, MessageNotFoundError, SessionNotFoundError, UnknownError],
     }).annotateMerge(
       OpenApi.annotations({
         identifier: "v2.session.messages",
         summary: "Get session messages",
         description:
-          "Retrieve projected messages for a session. Items keep the requested order across pages; use cursor.next or cursor.previous to move through the ordered timeline.",
+          "Retrieve projected messages for a session. Items keep the requested order across pages; context contains bounded earlier messages needed to project the page, and revert is included on unanchored requests. Use cursor.next or cursor.previous to move through the ordered timeline.",
       }),
     ),
   )

--- a/packages/schema/src/revert.ts
+++ b/packages/schema/src/revert.ts
@@ -22,3 +22,19 @@ export const State = Schema.Struct({
   files: Schema.Array(FileDiff).pipe(optional),
 }).annotate({ identifier: "Revert.State" })
 export interface State extends Schema.Schema.Type<typeof State> {}
+
+export const PreviewItem = Schema.Struct({
+  id: SessionMessage.ID,
+  text: Schema.String,
+}).annotate({ identifier: "Revert.Preview.Item" })
+export interface PreviewItem extends Schema.Schema.Type<typeof PreviewItem> {}
+
+export const Preview = Schema.Struct({
+  messageID: SessionMessage.ID,
+  userCount: NonNegativeInt,
+  hasMore: Schema.Boolean,
+  nextMessageID: SessionMessage.ID.pipe(optional),
+  continuationMessageID: SessionMessage.ID.pipe(optional),
+  items: Schema.Array(PreviewItem),
+}).annotate({ identifier: "Revert.Preview" })
+export interface Preview extends Schema.Schema.Type<typeof Preview> {}

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -493,10 +493,12 @@ export type Info = User | Assistant
 export const WithParts = Schema.Struct({
   info: Info,
   parts: Schema.Array(Part),
+  cursor: optional(Schema.String),
 })
 export type WithParts = {
   info: Info
   parts: Part[]
+  cursor?: string
 }
 
 const options = {
@@ -599,6 +601,7 @@ const events = {
     schema: {
       sessionID: SessionID,
       info: Info,
+      cursor: optional(Schema.String),
     },
   }),
   MessageRemoved: define({

--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -103,6 +103,9 @@ import type {
   SessionShellData,
   SessionShellResponses,
   SessionShellErrors,
+  SessionRevertPreviewData,
+  SessionRevertPreviewResponses,
+  SessionRevertPreviewErrors,
   SessionRevertData,
   SessionRevertResponses,
   SessionRevertErrors,
@@ -672,6 +675,20 @@ class Session extends _HeyApiClient {
         "Content-Type": "application/json",
         ...options.headers,
       },
+    })
+  }
+
+  /**
+   * Get revert preview
+   */
+  public revertPreview<ThrowOnError extends boolean = false>(options: Options<SessionRevertPreviewData, ThrowOnError>) {
+    return (options.client ?? this._client).get<
+      SessionRevertPreviewResponses,
+      SessionRevertPreviewErrors,
+      ThrowOnError
+    >({
+      url: "/session/{id}/revert",
+      ...options,
     })
   }
 

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -146,6 +146,7 @@ export type EventMessageUpdated = {
   type: "message.updated"
   properties: {
     info: Message
+    cursor?: string
   }
 }
 
@@ -2555,7 +2556,11 @@ export type SessionMessagesData = {
   }
   query?: {
     directory?: string
+    workspace?: string
     limit?: number
+    before?: string
+    after?: string
+    oldest?: boolean | "true" | "false"
   }
   url: "/session/{id}/message"
 }
@@ -2580,6 +2585,7 @@ export type SessionMessagesResponses = {
   200: Array<{
     info: Message
     parts: Array<Part>
+    cursor?: string
   }>
 }
 
@@ -2651,6 +2657,7 @@ export type SessionMessageData = {
   }
   query?: {
     directory?: string
+    workspace?: string
   }
   url: "/session/{id}/message/{messageID}"
 }
@@ -2675,6 +2682,7 @@ export type SessionMessageResponses = {
   200: {
     info: Message
     parts: Array<Part>
+    cursor?: string
   }
 }
 
@@ -2816,6 +2824,50 @@ export type SessionShellResponses = {
 }
 
 export type SessionShellResponse = SessionShellResponses[keyof SessionShellResponses]
+
+export type SessionRevertPreviewData = {
+  body?: never
+  path: {
+    id: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{id}/revert"
+}
+
+export type SessionRevertPreviewErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionRevertPreviewError = SessionRevertPreviewErrors[keyof SessionRevertPreviewErrors]
+
+export type SessionRevertPreviewResponses = {
+  /**
+   * Revert preview
+   */
+  200: {
+    userCount: number
+    hasMore: boolean
+    nextMessageID?: string
+    continuationMessageID?: string
+    partID?: string
+    items: Array<{
+      id: string
+      text: string
+    }>
+  } | null
+}
+
+export type SessionRevertPreviewResponse = SessionRevertPreviewResponses[keyof SessionRevertPreviewResponses]
 
 export type SessionRevertData = {
   body?: {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -206,6 +206,8 @@ import type {
   SessionPromptErrors,
   SessionPromptResponses,
   SessionRevertErrors,
+  SessionRevertPreviewErrors,
+  SessionRevertPreviewResponses,
   SessionRevertResponses,
   SessionShareErrors,
   SessionShareResponses,
@@ -3701,7 +3703,7 @@ export class Session2 extends HeyApiClient {
   /**
    * Get session messages
    *
-   * Retrieve all messages in a session, including user prompts and AI responses.
+   * Retrieve messages in a session, including user prompts and AI responses. Without pagination parameters (or with limit=0) the full history is returned. With `limit`, a page is returned anchored at the latest messages, or at the opaque `before`/`after` cursors, or at the `oldest` messages. Link headers use a fixed chronological convention: `rel="next"` always continues into older history (`before` cursor, also exposed as `X-Next-Cursor`), and `rel="prev"` continues into newer history (`after` cursor).
    */
   public messages<ThrowOnError extends boolean = false>(
     parameters: {
@@ -3710,6 +3712,8 @@ export class Session2 extends HeyApiClient {
       workspace?: string
       limit?: number
       before?: string
+      after?: string
+      oldest?: boolean | "true" | "false"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3723,6 +3727,8 @@ export class Session2 extends HeyApiClient {
             { in: "query", key: "workspace" },
             { in: "query", key: "limit" },
             { in: "query", key: "before" },
+            { in: "query", key: "after" },
+            { in: "query", key: "oldest" },
           ],
         },
       ],
@@ -4250,6 +4256,42 @@ export class Session2 extends HeyApiClient {
         ...options?.headers,
         ...params.headers,
       },
+    })
+  }
+
+  /**
+   * Get revert preview
+   *
+   * Return the reverted user messages and next restore boundary for a reverted session.
+   */
+  public revertPreview<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<
+      SessionRevertPreviewResponses,
+      SessionRevertPreviewErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/revert",
+      ...options,
+      ...params,
     })
   }
 
@@ -5826,7 +5868,7 @@ export class Session3 extends HeyApiClient {
   /**
    * Get session messages
    *
-   * Retrieve projected messages for a session. Items keep the requested order across pages; use cursor.next or cursor.previous to move through the ordered timeline.
+   * Retrieve projected messages for a session. Items keep the requested order across pages; context contains bounded earlier messages needed to project the page, and revert is included on unanchored requests. Use cursor.next or cursor.previous to move through the ordered timeline.
    */
   public messages<ThrowOnError extends boolean = false>(
     parameters: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -790,6 +790,7 @@ export type GlobalEvent = {
         properties: {
           sessionID: string
           info: Message
+          cursor?: string
         }
       }
     | {
@@ -2775,6 +2776,9 @@ export type SessionDurableEventStream = string
 
 export type SessionMessagesResponse = {
   data: Array<SessionMessage>
+  context: Array<SessionMessage>
+  contextCursor?: string
+  revert?: RevertPreview
   cursor: {
     previous?: string
     next?: string
@@ -3247,6 +3251,7 @@ export type SyncEventMessageUpdated = {
     data: {
       sessionID: string
       info: Message
+      cursor?: string
     }
   }
 }
@@ -4771,6 +4776,20 @@ export type SessionNextRevertCommitted = {
   }
 }
 
+export type RevertPreviewItem = {
+  id: string
+  text: string
+}
+
+export type RevertPreview = {
+  messageID: string
+  userCount: number
+  hasMore: boolean
+  nextMessageID?: string
+  continuationMessageID?: string
+  items: Array<RevertPreviewItem>
+}
+
 export type ModelApi =
   | {
       id: string
@@ -5158,6 +5177,7 @@ export type MessageUpdated = {
   data: {
     sessionID: string
     info: Message
+    cursor?: string
   }
 }
 
@@ -6216,6 +6236,7 @@ export type EventMessageUpdated = {
   properties: {
     sessionID: string
     info: Message
+    cursor?: string
   }
 }
 
@@ -9762,6 +9783,8 @@ export type SessionMessagesData = {
     workspace?: string
     limit?: number
     before?: string
+    after?: string
+    oldest?: boolean | "true" | "false"
   }
   url: "/session/{sessionID}/message"
 }
@@ -9786,6 +9809,7 @@ export type SessionMessagesResponses = {
   200: Array<{
     info: Message
     parts: Array<Part>
+    cursor?: string
   }>
 }
 
@@ -9915,6 +9939,7 @@ export type SessionMessageResponses = {
   200: {
     info: Message
     parts: Array<Part>
+    cursor?: string
   }
 }
 
@@ -10283,10 +10308,55 @@ export type SessionShellResponses = {
   200: {
     info: Message
     parts: Array<Part>
+    cursor?: string
   }
 }
 
 export type SessionShellResponse = SessionShellResponses[keyof SessionShellResponses]
+
+export type SessionRevertPreviewData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/revert"
+}
+
+export type SessionRevertPreviewErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionRevertPreviewError = SessionRevertPreviewErrors[keyof SessionRevertPreviewErrors]
+
+export type SessionRevertPreviewResponses = {
+  /**
+   * Revert preview
+   */
+  200: {
+    userCount: number
+    hasMore: boolean
+    nextMessageID?: string
+    continuationMessageID?: string
+    partID?: string
+    items: Array<{
+      id: string
+      text: string
+    }>
+  } | null
+}
+
+export type SessionRevertPreviewResponse = SessionRevertPreviewResponses[keyof SessionRevertPreviewResponses]
 
 export type SessionRevertData = {
   body?: {
@@ -12011,9 +12081,9 @@ export type V2SessionMessagesErrors = {
    */
   401: UnauthorizedError
   /**
-   * SessionNotFoundError
+   * MessageNotFoundError | SessionNotFoundError
    */
-  404: SessionNotFoundError
+  404: MessageNotFoundError | SessionNotFoundError
   /**
    * UnknownError
    */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -6129,7 +6129,33 @@
             "name": "before",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": false
+          },
+          {
+            "name": "oldest",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string",
+                  "enum": ["true", "false"]
+                }
+              ]
             },
             "required": false
           }
@@ -6152,6 +6178,9 @@
                         "items": {
                           "$ref": "#/components/schemas/Part"
                         }
+                      },
+                      "cursor": {
+                        "type": "string"
                       }
                     },
                     "required": ["info", "parts"],
@@ -6190,7 +6219,7 @@
             }
           }
         },
-        "description": "Retrieve all messages in a session, including user prompts and AI responses.",
+        "description": "Retrieve messages in a session, including user prompts and AI responses. Without pagination parameters (or with limit=0) the full history is returned. With `limit`, a page is returned anchored at the latest messages, or at the opaque `before`/`after` cursors, or at the `oldest` messages. Link headers use a fixed chronological convention: `rel=\"next\"` always continues into older history (`before` cursor, also exposed as `X-Next-Cursor`), and `rel=\"prev\"` continues into newer history (`after` cursor).",
         "summary": "Get session messages",
         "x-codeSamples": [
           {
@@ -6416,6 +6445,9 @@
                       "items": {
                         "$ref": "#/components/schemas/Part"
                       }
+                    },
+                    "cursor": {
+                      "type": "string"
                     }
                   },
                   "required": ["info", "parts"],
@@ -7443,6 +7475,9 @@
                       "items": {
                         "$ref": "#/components/schemas/Part"
                       }
+                    },
+                    "cursor": {
+                      "type": "string"
                     }
                   },
                   "required": ["info", "parts"],
@@ -7537,6 +7572,130 @@
       }
     },
     "/session/{sessionID}/revert": {
+      "get": {
+        "tags": ["session"],
+        "operationId": "session.revertPreview",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revert preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "userCount": {
+                          "type": "number"
+                        },
+                        "hasMore": {
+                          "type": "boolean"
+                        },
+                        "nextMessageID": {
+                          "type": "string",
+                          "pattern": "^msg"
+                        },
+                        "continuationMessageID": {
+                          "type": "string",
+                          "pattern": "^msg"
+                        },
+                        "partID": {
+                          "type": "string",
+                          "pattern": "^prt"
+                        },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "pattern": "^msg"
+                              },
+                              "text": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["id", "text"],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": ["userCount", "hasMore", "items"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Return the reverted user messages and next restore boundary for a reverted session.",
+        "summary": "Get revert preview",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.revertPreview({\n  ...\n})"
+          }
+        ]
+      },
       "post": {
         "tags": ["session"],
         "operationId": "session.revert",
@@ -11576,6 +11735,7 @@
             "in": "query",
             "schema": {
               "type": "string",
+              "minLength": 1,
               "description": "Opaque pagination cursor returned as cursor.previous or cursor.next in the previous response. Do not combine with order."
             },
             "required": false
@@ -11621,11 +11781,14 @@
             }
           },
           "404": {
-            "description": "SessionNotFoundError",
+            "description": "MessageNotFoundError | SessionNotFoundError",
             "content": {
               "application/json": {
                 "schema": {
                   "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/MessageNotFoundError"
+                    },
                     {
                       "$ref": "#/components/schemas/SessionNotFoundError"
                     },
@@ -11648,7 +11811,7 @@
             }
           }
         },
-        "description": "Retrieve projected messages for a session. Items keep the requested order across pages; use cursor.next or cursor.previous to move through the ordered timeline.",
+        "description": "Retrieve projected messages for a session. Items keep the requested order across pages; context contains bounded earlier messages needed to project the page, and revert is included on unanchored requests. Use cursor.next or cursor.previous to move through the ordered timeline.",
         "summary": "Get session messages",
         "x-codeSamples": [
           {
@@ -17602,6 +17765,9 @@
                       },
                       "info": {
                         "$ref": "#/components/schemas/Message"
+                      },
+                      "cursor": {
+                        "type": "string"
                       }
                     },
                     "required": ["sessionID", "info"],
@@ -23773,6 +23939,19 @@
               "$ref": "#/components/schemas/SessionMessage"
             }
           },
+          "context": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SessionMessage"
+            }
+          },
+          "contextCursor": {
+            "type": "string",
+            "minLength": 1
+          },
+          "revert": {
+            "$ref": "#/components/schemas/RevertPreview"
+          },
           "cursor": {
             "type": "object",
             "properties": {
@@ -23786,7 +23965,7 @@
             "additionalProperties": false
           }
         },
-        "required": ["data", "cursor"],
+        "required": ["data", "context", "cursor"],
         "additionalProperties": false
       },
       "ProviderNotFoundError": {
@@ -25096,6 +25275,9 @@
                   },
                   "info": {
                     "$ref": "#/components/schemas/Message"
+                  },
+                  "cursor": {
+                    "type": "string"
                   }
                 },
                 "required": ["sessionID", "info"],
@@ -29739,6 +29921,52 @@
         "required": ["id", "type", "data"],
         "additionalProperties": false
       },
+      "RevertPreviewItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^msg_"
+          },
+          "text": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "text"],
+        "additionalProperties": false
+      },
+      "RevertPreview": {
+        "type": "object",
+        "properties": {
+          "messageID": {
+            "type": "string",
+            "pattern": "^msg_"
+          },
+          "userCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextMessageID": {
+            "type": "string",
+            "pattern": "^msg_"
+          },
+          "continuationMessageID": {
+            "type": "string",
+            "pattern": "^msg_"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RevertPreviewItem"
+            }
+          }
+        },
+        "required": ["messageID", "userCount", "hasMore", "items"],
+        "additionalProperties": false
+      },
       "ModelApi": {
         "anyOf": [
           {
@@ -31061,6 +31289,9 @@
               },
               "info": {
                 "$ref": "#/components/schemas/Message"
+              },
+              "cursor": {
+                "type": "string"
               }
             },
             "required": ["sessionID", "info"],
@@ -34013,6 +34244,9 @@
               },
               "info": {
                 "$ref": "#/components/schemas/Message"
+              },
+              "cursor": {
+                "type": "string"
               }
             },
             "required": ["sessionID", "info"],

--- a/packages/server/src/handlers/message.ts
+++ b/packages/server/src/handlers/message.ts
@@ -3,21 +3,35 @@ import { SessionV2 } from "@opencode-ai/core/session"
 import { Effect, Schema } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
-import { InvalidCursorError, SessionNotFoundError, UnknownError } from "@opencode-ai/protocol/errors"
+import {
+  InvalidCursorError,
+  MessageNotFoundError,
+  SessionNotFoundError,
+  UnknownError,
+} from "@opencode-ai/protocol/errors"
 
 const DefaultMessagesLimit = 50
 
-const Cursor = Schema.Struct({
+const LegacyCursor = Schema.Struct({
   id: SessionMessage.ID,
   order: Schema.Union([Schema.Literal("asc"), Schema.Literal("desc")]),
   direction: Schema.Union([Schema.Literal("previous"), Schema.Literal("next")]),
 })
 
+const SequenceCursor = Schema.Struct({
+  v: Schema.Literal(1),
+  sessionID: SessionV2.ID,
+  seq: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  order: Schema.Union([Schema.Literal("asc"), Schema.Literal("desc")]),
+  direction: Schema.Union([Schema.Literal("previous"), Schema.Literal("next")]),
+})
+
+const Cursor = Schema.Union([SequenceCursor, LegacyCursor])
 const decodeCursor = Schema.decodeUnknownSync(Cursor)
 
 const cursor = {
-  encode(message: SessionMessage.Message, order: "asc" | "desc", direction: "previous" | "next") {
-    return Buffer.from(JSON.stringify({ id: message.id, order, direction })).toString("base64url")
+  encode(sessionID: SessionV2.ID, seq: number, order: "asc" | "desc", direction: "previous" | "next") {
+    return Buffer.from(JSON.stringify({ v: 1, sessionID, seq, order, direction })).toString("base64url")
   },
   decode(input: string) {
     return decodeCursor(JSON.parse(Buffer.from(input, "base64url").toString("utf8")))
@@ -37,13 +51,18 @@ export const MessageHandler = HttpApiBuilder.group(Api, "server.message", (handl
           try: () => (ctx.query.cursor ? cursor.decode(ctx.query.cursor) : undefined),
           catch: () => new InvalidCursorError({ message: "Invalid cursor" }),
         })
+        if (decoded && "seq" in decoded && decoded.sessionID !== ctx.params.sessionID)
+          return yield* new InvalidCursorError({ message: "Cursor belongs to another session" })
         const order = decoded?.order ?? ctx.query.order ?? "desc"
-        const messages = yield* session
-          .messages({
+        const page = yield* session
+          .messagePage({
             sessionID: ctx.params.sessionID,
             limit: ctx.query.limit ?? DefaultMessagesLimit,
             order,
-            cursor: decoded ? { id: decoded.id, direction: decoded.direction } : undefined,
+            cursor: decoded
+              ? { ...("seq" in decoded ? { seq: decoded.seq } : { id: decoded.id }), direction: decoded.direction }
+              : undefined,
+            includeRevert: !decoded,
           })
           .pipe(
             Effect.catchTag("Session.NotFoundError", (error) =>
@@ -51,6 +70,15 @@ export const MessageHandler = HttpApiBuilder.group(Api, "server.message", (handl
                 new SessionNotFoundError({
                   sessionID: error.sessionID,
                   message: `Session not found: ${error.sessionID}`,
+                }),
+              ),
+            ),
+            Effect.catchTag("Session.MessageNotFoundError", (error) =>
+              Effect.fail(
+                new MessageNotFoundError({
+                  sessionID: error.sessionID,
+                  messageID: error.messageID,
+                  message: `Message not found: ${error.messageID}`,
                 }),
               ),
             ),
@@ -66,13 +94,34 @@ export const MessageHandler = HttpApiBuilder.group(Api, "server.message", (handl
               )
             }),
           )
-        const first = messages[0]
-        const last = messages.at(-1)
+        const revertBoundary = page.revert
+          ? [...page.context, ...page.data].find((message) => message.id === page.revert?.messageID)
+          : undefined
+        const revertSeq = revertBoundary ? page.sequence.get(revertBoundary.id) : undefined
+        if (revertBoundary && revertSeq === undefined) {
+          const ref = `err_${crypto.randomUUID().slice(0, 8)}`
+          yield* Effect.logError("missing session message sequence for pagination cursor").pipe(
+            Effect.annotateLogs({ ref, sessionID: ctx.params.sessionID }),
+          )
+          return yield* new UnknownError({ message: "Unexpected server error. Check server logs for details.", ref })
+        }
         return {
-          data: messages,
+          data: page.data,
+          context: page.context,
+          contextCursor:
+            order === "desc" && revertSeq !== undefined
+              ? cursor.encode(ctx.params.sessionID, revertSeq, order, "next")
+              : undefined,
+          revert: page.revert,
           cursor: {
-            previous: first ? cursor.encode(first, order, "previous") : undefined,
-            next: last ? cursor.encode(last, order, "next") : undefined,
+            previous:
+              page.cursor.previous === undefined
+                ? undefined
+                : cursor.encode(ctx.params.sessionID, page.cursor.previous, order, "previous"),
+            next:
+              page.cursor.next === undefined
+                ? undefined
+                : cursor.encode(ctx.params.sessionID, page.cursor.next, order, "next"),
           },
         }
       }),

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -51,7 +51,14 @@ import { createFadeIn } from "../../util/signal"
 import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "../../context/args"
-import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap } from "../../keymap"
+import {
+  OPENCODE_BASE_MODE,
+  useBindings,
+  useCommandShortcut,
+  useLeaderActive,
+  useOpencodeKeymap,
+  useOpencodeModeStack,
+} from "../../keymap"
 import { useTuiConfig } from "../../config"
 import { usePromptWorkspace } from "./workspace"
 import { usePromptMove } from "./move"
@@ -144,6 +151,7 @@ export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
   const [inputTarget, setInputTarget] = createSignal<TextareaRenderable | undefined>()
+  const [submitting, setSubmitting] = createSignal(false)
 
   const leader = useLeaderActive()
   const local = useLocal()
@@ -164,6 +172,7 @@ export function Prompt(props: PromptProps) {
   const history = usePromptHistory()
   const stash = usePromptStash()
   const keymap = useOpencodeKeymap()
+  const modeStack = useOpencodeModeStack()
   const agentShortcut = useCommandShortcut("agent.cycle")
   const paletteShortcut = useCommandShortcut("command.palette.show")
   const renderer = useRenderer()
@@ -340,6 +349,7 @@ export function Prompt(props: PromptProps) {
         category: "Prompt",
         hidden: true,
         run: () => {
+          if (submitting()) return
           clearPrompt()
           dialog.clear()
         },
@@ -375,6 +385,7 @@ export function Prompt(props: PromptProps) {
         run: async (ctx: CommandContext<Renderable, KeyEvent>) => {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
+          if (submitting()) return
           const content = await clipboard.read?.()
           if (content?.mime.startsWith("image/")) {
             await pasteAttachment({
@@ -800,7 +811,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => {
     return {
       target: inputTarget,
-      enabled: inputTarget() !== undefined && !props.disabled,
+      enabled: inputTarget() !== undefined && !props.disabled && !submitting(),
       bindings: tuiConfig.keybinds.get("prompt.paste"),
     }
   })
@@ -808,7 +819,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => {
     return {
       target: inputTarget,
-      enabled: inputTarget() !== undefined && !props.disabled && store.prompt.input !== "",
+      enabled: inputTarget() !== undefined && !props.disabled && !submitting() && store.prompt.input !== "",
       bindings: tuiConfig.keybinds.get("prompt.clear"),
     }
   })
@@ -821,6 +832,7 @@ export function Prompt(props: PromptProps) {
         return (
           inputTarget() !== undefined &&
           !props.disabled &&
+          !submitting() &&
           store.mode === "normal" &&
           !auto()?.visible &&
           input?.visualCursor.offset === 0
@@ -843,7 +855,7 @@ export function Prompt(props: PromptProps) {
   useBindings(() => {
     return {
       target: inputTarget,
-      enabled: inputTarget() !== undefined && store.mode === "shell",
+      enabled: inputTarget() !== undefined && !submitting() && store.mode === "shell",
       bindings: [{ key: "escape", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
     }
   })
@@ -853,7 +865,9 @@ export function Prompt(props: PromptProps) {
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
-        return inputTarget() !== undefined && store.mode === "shell" && input?.visualCursor.offset === 0
+        return (
+          inputTarget() !== undefined && !submitting() && store.mode === "shell" && input?.visualCursor.offset === 0
+        )
       })(),
       bindings: [{ key: "backspace", desc: "Exit shell mode", group: "Prompt", cmd: () => setStore("mode", "normal") }],
     }
@@ -864,7 +878,9 @@ export function Prompt(props: PromptProps) {
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
-        return inputTarget() !== undefined && !props.disabled && !auto()?.visible && input !== undefined
+        return (
+          inputTarget() !== undefined && !props.disabled && !submitting() && !auto()?.visible && input !== undefined
+        )
       })(),
       commands: [
         {
@@ -896,7 +912,9 @@ export function Prompt(props: PromptProps) {
       target: inputTarget,
       enabled: (() => {
         cursorVersion()
-        return inputTarget() !== undefined && !props.disabled && !auto()?.visible && input !== undefined
+        return (
+          inputTarget() !== undefined && !props.disabled && !submitting() && !auto()?.visible && input !== undefined
+        )
       })(),
       commands: [
         {
@@ -927,7 +945,6 @@ export function Prompt(props: PromptProps) {
     }
   })
 
-  let submitting = false
   async function submit() {
     // Prevent overlapping invocations (e.g. a double-pressed Enter, or the
     // input's native onSubmit racing another dispatch). Without this guard,
@@ -935,12 +952,17 @@ export function Prompt(props: PromptProps) {
     // clears `store.prompt.input`, then awaits its own `session.create` and
     // ultimately reads the now-empty store — sending a phantom empty prompt
     // to a freshly created session.
-    if (submitting) return false
-    submitting = true
+    if (submitting()) return false
+    setSubmitting(true)
+    const unlock = modeStack.push("prompt-submitting")
+    const focused = input.focused
+    if (focused) input.blur()
     try {
       return await submitInner()
     } finally {
-      submitting = false
+      unlock()
+      setSubmitting(false)
+      if (focused && !input.isDestroyed) input.focus()
     }
   }
 
@@ -1023,40 +1045,40 @@ export function Prompt(props: PromptProps) {
       sessionID = res.data.id
     }
 
-    const inputText = expandTrackedPastedText(
-      store.prompt.input,
-      input.extmarks.getAllForTypeId(promptPartTypeId).flatMap((extmark) => {
-        const partIndex = store.extmarkToPartIndex.get(extmark.id)
-        const part = partIndex === undefined ? undefined : store.prompt.parts[partIndex]
-        if (part?.type !== "text") return []
-        return [{ start: extmark.start, end: extmark.end, text: part.text }]
-      }),
-    )
-
-    // Filter out text parts (pasted content) since they're now expanded inline
-    const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
-
-    // Capture mode before it gets reset
-    const currentMode = store.mode
     const editorSelection = editorContext()
-    const editorParts =
-      editorSelection && editor.labelState() === "pending"
-        ? [
-            {
-              type: "text" as const,
-              text: formatEditorContext(editorSelection),
-              synthetic: true,
-              metadata: {
-                kind: "editor_context",
-                source: editorSelection.source ?? "editor",
-                filePath: editorSelection.filePath,
-                ranges: editorSelection.ranges,
+    const submission = {
+      prompt: { input: store.prompt.input, parts: [...store.prompt.parts] },
+      inputText: expandTrackedPastedText(
+        store.prompt.input,
+        input.extmarks.getAllForTypeId(promptPartTypeId).flatMap((extmark) => {
+          const partIndex = store.extmarkToPartIndex.get(extmark.id)
+          const part = partIndex === undefined ? undefined : store.prompt.parts[partIndex]
+          if (part?.type !== "text") return []
+          return [{ start: extmark.start, end: extmark.end, text: part.text }]
+        }),
+      ),
+      nonTextParts: store.prompt.parts.filter((part) => part.type !== "text"),
+      currentMode: store.mode,
+      editorParts:
+        editorSelection && editor.labelState() === "pending"
+          ? [
+              {
+                type: "text" as const,
+                text: formatEditorContext(editorSelection),
+                synthetic: true,
+                metadata: {
+                  kind: "editor_context",
+                  source: editorSelection.source ?? "editor",
+                  filePath: editorSelection.filePath,
+                  ranges: editorSelection.ranges,
+                },
               },
-            },
-          ]
-        : []
+            ]
+          : [],
+    }
+    if (!submission.inputText) return false
 
-    if (store.mode === "shell") {
+    if (submission.currentMode === "shell") {
       move.startSubmit()
       void sdk.client.session.shell({
         sessionID,
@@ -1065,19 +1087,19 @@ export function Prompt(props: PromptProps) {
           providerID: selectedModel.providerID,
           modelID: selectedModel.modelID,
         },
-        command: inputText,
+        command: submission.inputText,
       })
       setStore("mode", "normal")
     } else if (
-      inputText.startsWith("/") &&
-      sync.data.command.some((x) => x.name === inputText.split("\n")[0].split(" ")[0].slice(1))
+      submission.inputText.startsWith("/") &&
+      sync.data.command.some((x) => x.name === submission.inputText.split("\n")[0].split(" ")[0].slice(1))
     ) {
       move.startSubmit()
       // Parse command from first line, preserve multi-line content in arguments
-      const firstLineEnd = inputText.indexOf("\n")
-      const firstLine = firstLineEnd === -1 ? inputText : inputText.slice(0, firstLineEnd)
+      const firstLineEnd = submission.inputText.indexOf("\n")
+      const firstLine = firstLineEnd === -1 ? submission.inputText : submission.inputText.slice(0, firstLineEnd)
       const [command, ...firstLineArgs] = firstLine.split(" ")
-      const restOfInput = firstLineEnd === -1 ? "" : inputText.slice(firstLineEnd + 1)
+      const restOfInput = firstLineEnd === -1 ? "" : submission.inputText.slice(firstLineEnd + 1)
       const args = firstLineArgs.join(" ") + (restOfInput ? "\n" + restOfInput : "")
 
       void sdk.client.session.command({
@@ -1087,7 +1109,7 @@ export function Prompt(props: PromptProps) {
         agent: agent.name,
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         variant,
-        parts: nonTextParts.filter((x) => x.type === "file"),
+        parts: submission.nonTextParts.filter((x) => x.type === "file"),
       })
     } else {
       move.startSubmit()
@@ -1100,12 +1122,12 @@ export function Prompt(props: PromptProps) {
             model: selectedModel,
             variant,
             parts: [
-              ...editorParts,
+              ...submission.editorParts,
               {
                 type: "text",
-                text: inputText,
+                text: submission.inputText,
               },
-              ...nonTextParts,
+              ...submission.nonTextParts,
             ],
           },
           { throwOnError: true },
@@ -1117,11 +1139,11 @@ export function Prompt(props: PromptProps) {
             variant: "error",
           })
         })
-      if (editorParts.length > 0) editor.markSelectionSent()
+      if (submission.editorParts.length > 0) editor.markSelectionSent()
     }
     history.append({
-      ...store.prompt,
-      mode: currentMode,
+      ...submission.prompt,
+      mode: submission.currentMode,
     })
     input.extmarks.clear()
     setStore("prompt", {
@@ -1133,7 +1155,7 @@ export function Prompt(props: PromptProps) {
 
     // temporary hack to make sure the message is sent
     if (!props.sessionID) {
-      if (editorParts.length > 0) editor.preserveSelectionFromNewSession()
+      if (submission.editorParts.length > 0) editor.preserveSelectionFromNewSession()
       setTimeout(() => {
         route.navigate({
           type: "session",
@@ -1383,7 +1405,7 @@ export function Prompt(props: PromptProps) {
               }}
               onCursorChange={() => setCursorVersion((value) => value + 1)}
               onKeyDown={(e: { preventDefault(): void }) => {
-                if (props.disabled) {
+                if (props.disabled || submitting()) {
                   e.preventDefault()
                   return
                 }
@@ -1394,7 +1416,7 @@ export function Prompt(props: PromptProps) {
                 setTimeout(() => setTimeout(() => submit(), 0), 0)
               }}
               onPaste={async (event: PasteEvent) => {
-                if (props.disabled) {
+                if (props.disabled || submitting()) {
                   event.preventDefault()
                   return
                 }

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -30,8 +30,25 @@ import { useExit } from "./exit"
 import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import path from "path"
+import { linkParam, parseLinkHeader } from "@opencode-ai/core/util/link-header"
 import { useKV } from "./kv"
 import { usePermission } from "./permission"
+import { boundaryFromMessageResponse } from "@opencode-ai/core/util/revert-boundary"
+import {
+  evictFromEnd,
+  evictFromStart,
+  messageBefore,
+  messageInsert,
+  paginationError,
+  windowNewest,
+  windowOldest,
+} from "../util/pagination"
+
+/** Maximum messages kept in memory per session */
+export const MAX_LOADED_MESSAGES = 500
+export const MESSAGE_PAGE_SIZE = 100
+
+type SessionOwner = { epoch: number; generation: number }
 
 const emptyConsoleState: ConsoleState = {
   consoleManagedProviders: [],
@@ -50,12 +67,6 @@ function search<T>(items: T[], target: string, key: (item: T) => string) {
   }
   return { found: false, index: left }
 }
-
-function compareMessage(a: Message, b: Message) {
-  return a.time.created - b.time.created || a.id.localeCompare(b.id)
-}
-
-const messageKey = (message: Message) => message.time.created + message.id
 
 export const {
   context: SyncContext,
@@ -87,6 +98,19 @@ export const {
       }
       config: Config
       session: Session[]
+      message_page: {
+        [sessionID: string]: {
+          hasOlder: boolean
+          hasNewer: boolean
+          loading: boolean
+          loadingDirection?: "older" | "newer"
+          oldest?: string
+          newest?: string
+          olderCursor?: string
+          newerCursor?: string
+          error?: string
+        }
+      }
       session_status: {
         [sessionID: string]: SessionStatus
       }
@@ -98,6 +122,9 @@ export const {
       }
       message: {
         [sessionID: string]: Message[]
+      }
+      message_cursor: {
+        [messageID: string]: string | undefined
       }
       part: {
         [messageID: string]: Part[]
@@ -131,10 +158,12 @@ export const {
       provider: [],
       provider_default: {},
       session: [],
+      message_page: {},
       session_status: {},
       session_diff: {},
       todo: {},
       message: {},
+      message_cursor: {},
       part: {},
       lsp: [],
       mcp: {},
@@ -147,14 +176,353 @@ export const {
     const project = useProject()
     const sdk = useSDK()
 
+    const getRevertMarker = (sessionID: string) => {
+      const match = search(store.session, sessionID, (s) => s.id)
+      if (!match.found) return undefined
+      return store.session[match.index].revert?.messageID
+    }
+
+    const pageInfo = (link: string) => {
+      const links = parseLinkHeader(link)
+      return {
+        hasOlder: links.next !== undefined,
+        hasNewer: links.prev !== undefined,
+        olderCursor: linkParam(links.next, "before"),
+        newerCursor: linkParam(links.prev, "after"),
+      }
+    }
+
+    const edgeCursor = (cursors: Record<string, string | undefined>, id: string | undefined) =>
+      id ? cursors[id] : undefined
+
+    const clearRevert = (sessionID: string, expected: { messageID: string; partID?: string }) => {
+      setStore(
+        "session",
+        produce((draft) => {
+          const match = search(draft, sessionID, (s) => s.id)
+          if (!match.found) return
+          const current = draft[match.index]?.revert
+          if (current?.messageID !== expected.messageID || current?.partID !== expected.partID) return
+          draft[match.index] = { ...draft[match.index], revert: undefined }
+        }),
+      )
+    }
+
+    const messageIndex = (messages: Message[] | undefined, id: string) =>
+      messages?.findIndex((item) => item.id === id) ?? -1
+
+    type LoadedMessage = {
+      info: Message
+      parts: Part[]
+      cursor?: string
+    }
+
+    type LoadedPage = ReturnType<typeof pageInfo> & {
+      items: LoadedMessage[]
+      oldest?: string
+      newest?: string
+    }
+
+    type HydrationTracker = {
+      messages: Set<string>
+      addedMessages: Set<string>
+      removedMessages: Set<string>
+      clearedMessageParts: Set<string>
+      parts: Set<string>
+      removedParts: Set<string>
+      sessionUpdated: boolean
+      revertUpdated: boolean
+    }
+
+    const createHydrationTracker = (): HydrationTracker => ({
+      messages: new Set(),
+      addedMessages: new Set(),
+      removedMessages: new Set(),
+      clearedMessageParts: new Set(),
+      parts: new Set(),
+      removedParts: new Set(),
+      sessionUpdated: false,
+      revertUpdated: false,
+    })
+
+    const mergeHydratedItems = (
+      incoming: LoadedMessage[],
+      messages: Message[],
+      parts: Record<string, Part[] | undefined>,
+      cursors: Record<string, string | undefined>,
+      tracker: HydrationTracker,
+    ) => {
+      const currentByID = new Map(messages.map((message) => [message.id, message]))
+      const merged = incoming.flatMap((message): LoadedMessage[] => {
+        if (tracker.removedMessages.has(message.info.id)) return []
+        const currentInfo = currentByID.get(message.info.id)
+        const currentParts = parts[message.info.id] ?? []
+        const nextParts = tracker.clearedMessageParts.has(message.info.id)
+          ? []
+          : message.parts.flatMap((part) => {
+              if (tracker.removedParts.has(part.id)) return []
+              const current = currentParts.find((item) => item.id === part.id)
+              if (tracker.parts.has(part.id) && current) return [current]
+              if (
+                current &&
+                (part.type === "text" || part.type === "reasoning") &&
+                (current.type === "text" || current.type === "reasoning") &&
+                part.text.length === 0 &&
+                current.text.length > 0
+              )
+                return [current]
+              return [part]
+            })
+        nextParts.push(
+          ...currentParts.filter(
+            (part) =>
+              tracker.parts.has(part.id) &&
+              !tracker.removedParts.has(part.id) &&
+              !nextParts.some((item) => item.id === part.id),
+          ),
+        )
+        return [
+          {
+            info: tracker.messages.has(message.info.id) && currentInfo ? currentInfo : message.info,
+            parts: nextParts,
+            cursor: tracker.messages.has(message.info.id)
+              ? (cursors[message.info.id] ?? message.cursor)
+              : message.cursor,
+          },
+        ]
+      })
+      return merged
+    }
+
+    const hasUnmatchedAdditions = (incoming: LoadedMessage[], messages: Message[], tracker: HydrationTracker) => {
+      const incomingIDs = new Set(incoming.map((message) => message.info.id))
+      const currentIDs = new Set(messages.map((message) => message.id))
+      return [...tracker.addedMessages].some(
+        (id) => currentIDs.has(id) && !tracker.removedMessages.has(id) && !incomingIDs.has(id),
+      )
+    }
+
+    const requireNewMessages = (continuationCursor: string | undefined, incoming: number, unseen: number) => {
+      if (continuationCursor && (incoming === 0 || unseen === 0))
+        throw new Error("Message pagination returned no new messages")
+    }
+
+    const walkOlderPages = async (input: {
+      sessionID: string
+      cursor: string
+      items: LoadedMessage[]
+      terminalOnly?: boolean
+      retain?: { limit: number; pinned?: string }
+      stop?: (items: LoadedMessage[]) => boolean
+    }) => {
+      const cursors = new Set<string>()
+      const ids = new Set(input.items.map((item) => item.info.id))
+      let items = input.items
+      let removedNewer = false
+      let info: ReturnType<typeof pageInfo> = {
+        hasOlder: true,
+        hasNewer: false,
+        olderCursor: input.cursor,
+        newerCursor: undefined,
+      }
+      let cursor: string | undefined = input.cursor
+      while (cursor) {
+        if (cursors.has(cursor)) throw new Error("Message pagination cursor did not advance")
+        cursors.add(cursor)
+        const page = await sdk.client.session.messages(
+          { sessionID: input.sessionID, before: cursor, limit: MESSAGE_PAGE_SIZE },
+          { throwOnError: true },
+        )
+        const incoming = page.data ?? []
+        info = pageInfo(page.response.headers.get("link") ?? "")
+        const unseen = incoming.filter((item) => !ids.has(item.info.id))
+        incoming.forEach((item) => ids.add(item.info.id))
+        items = input.terminalOnly ? incoming : [...incoming, ...items]
+        if (input.retain && items.length > input.retain.limit) {
+          const retained = items.map((item) => item.info)
+          const removed = evictFromEnd(retained, retained.length - input.retain.limit, input.retain.pinned)
+          if (removed.length > 0) removedNewer = true
+          const retainedIDs = new Set(retained.map((message) => message.id))
+          items = items.filter((item) => retainedIDs.has(item.info.id))
+        }
+        if (input.stop?.(items)) break
+        requireNewMessages(info.olderCursor, incoming.length, unseen.length)
+        if (info.olderCursor === cursor) throw new Error("Message pagination cursor did not advance")
+        cursor = info.olderCursor
+      }
+      return { items, info, removedNewer }
+    }
+
+    const insertLoadedMessage = (items: LoadedMessage[], message: LoadedMessage) => {
+      let left = 0
+      let right = items.length
+      while (left < right) {
+        const middle = Math.floor((left + right) / 2)
+        const current = items[middle]
+        if (!current) break
+        if (messageBefore(current.info, message.info)) left = middle + 1
+        else right = middle
+      }
+      const found = left < items.length && items[left]?.info.id === message.info.id
+      if (!found) items.splice(left, 0, message)
+    }
+
+    // A part-level revert keeps the boundary message itself visible (with trimmed parts), so
+    // a user boundary counts as the visible user and no older history is required to render it.
+    const hasUserBeforeLoadedBoundary = (items: LoadedMessage[], boundary: Message, partID?: string) =>
+      items.some(
+        (item) =>
+          item.info.role === "user" &&
+          (messageBefore(item.info, boundary) || (item.info.id === boundary.id && !!partID)),
+      )
+
+    const loadLatestPage = async (
+      sessionID: string,
+      revert?: { messageID: string; partID?: string },
+    ): Promise<LoadedPage> => {
+      const latest = await sdk.client.session.messages({ sessionID, limit: MESSAGE_PAGE_SIZE }, { throwOnError: true })
+      const latestItems = [...(latest.data ?? [])]
+      const latestPage = pageInfo(latest.response.headers.get("link") ?? "")
+      const latestOldest = latestItems.at(0)?.info.id
+      const latestNewest = latestItems.at(-1)?.info.id
+      if (!revert?.messageID) {
+        return {
+          items: latestItems,
+          oldest: latestOldest,
+          newest: latestNewest,
+          ...latestPage,
+        }
+      }
+
+      try {
+        const response = await sdk.client.session.message(
+          { sessionID, messageID: revert.messageID },
+          { throwOnError: false },
+        )
+        const boundary = boundaryFromMessageResponse(response)
+        if (!boundary) {
+          clearRevert(sessionID, revert)
+          return {
+            items: latestItems,
+            oldest: latestOldest,
+            newest: latestNewest,
+            ...latestPage,
+          }
+        }
+
+        insertLoadedMessage(latestItems, boundary)
+        const boundaryCursor = boundary.cursor ?? latestPage.olderCursor
+        if (hasUserBeforeLoadedBoundary(latestItems, boundary.info, revert.partID)) {
+          return {
+            items: latestItems,
+            oldest: latestItems.at(0)?.info.id,
+            newest: latestNewest ?? latestItems.at(-1)?.info.id,
+            hasOlder: !!boundaryCursor,
+            hasNewer: false,
+            olderCursor: boundaryCursor,
+            newerCursor: undefined,
+          }
+        }
+
+        if (!boundaryCursor)
+          return {
+            items: latestItems,
+            oldest: latestItems.at(0)?.info.id,
+            newest: latestNewest,
+            hasOlder: false,
+            hasNewer: false,
+            olderCursor: undefined,
+            newerCursor: undefined,
+          }
+        const older = await walkOlderPages({
+          sessionID,
+          cursor: boundaryCursor,
+          items: latestItems,
+          retain: { limit: MESSAGE_PAGE_SIZE, pinned: boundary.info.id },
+          stop: (items) => hasUserBeforeLoadedBoundary(items, boundary.info, revert.partID),
+        })
+        const newest = windowNewest(
+          older.items.map((item) => item.info),
+          boundary.info.id,
+        )
+        const newerCursor = older.removedNewer
+          ? (older.items.find((item) => item.info.id === newest)?.cursor ?? older.info.newerCursor)
+          : undefined
+        return {
+          items: older.items,
+          hasOlder: older.info.hasOlder,
+          hasNewer: newerCursor !== undefined,
+          olderCursor: older.info.olderCursor,
+          newerCursor,
+          oldest: older.items.at(0)?.info.id,
+          newest: latestNewest ?? older.items.at(-1)?.info.id,
+        }
+      } catch (e) {
+        console.error("Revert marker fetch failed during latest-page load", {
+          messageID: revert.messageID,
+          error: paginationError(e),
+        })
+        throw e
+      }
+    }
+
     const fullSyncedSessions = new Set<string>()
     const syncingSessions = new Map<string, Promise<void>>()
-    const hydratingSessions = new Map<string, { messages: Set<string>; parts: Set<string> }>()
-    const touchMessage = (sessionID: string, messageID: string) => {
-      hydratingSessions.get(sessionID)?.messages.add(messageID)
+    const hydratingSessions = new Map<string, HydrationTracker>()
+    const touchMessage = (sessionID: string, messageID: string, added = false) => {
+      const tracker = hydratingSessions.get(sessionID)
+      if (!tracker) return
+      tracker.messages.add(messageID)
+      tracker.removedMessages.delete(messageID)
+      if (added) tracker.addedMessages.add(messageID)
+    }
+    const removeMessage = (sessionID: string, messageID: string) => {
+      const tracker = hydratingSessions.get(sessionID)
+      if (!tracker) return
+      tracker.messages.delete(messageID)
+      tracker.addedMessages.delete(messageID)
+      tracker.removedMessages.add(messageID)
+      tracker.clearedMessageParts.add(messageID)
     }
     const touchPart = (sessionID: string, partID: string) => {
-      hydratingSessions.get(sessionID)?.parts.add(partID)
+      const tracker = hydratingSessions.get(sessionID)
+      if (!tracker) return
+      tracker.parts.add(partID)
+      tracker.removedParts.delete(partID)
+    }
+    const removePart = (sessionID: string, partID: string) => {
+      const tracker = hydratingSessions.get(sessionID)
+      if (!tracker) return
+      tracker.parts.delete(partID)
+      tracker.removedParts.add(partID)
+    }
+    const loadingGuard = new Map<string, SessionOwner>()
+    const pendingLatest = new Map<string, SessionOwner>()
+    const deletedSessions = new Map<string, number>()
+    const sessionGenerations = new Map<string, number>()
+    let syncEpoch = 0
+    const sessionGeneration = (sessionID: string) => sessionGenerations.get(sessionID) ?? 0
+    const advanceSessionGeneration = (sessionID: string) =>
+      sessionGenerations.set(sessionID, sessionGeneration(sessionID) + 1)
+    const sessionOwner = (sessionID: string) => ({ epoch: syncEpoch, generation: sessionGeneration(sessionID) })
+    const ownsSession = (sessionID: string, owner: SessionOwner) =>
+      owner.epoch === syncEpoch && owner.generation === sessionGeneration(sessionID)
+    const staleSession = (sessionID: string, owner: SessionOwner) =>
+      !ownsSession(sessionID, owner) || deletedSessions.has(sessionID)
+    const queueLatest = (sessionID: string) => pendingLatest.set(sessionID, sessionOwner(sessionID))
+    const consumeLatest = (sessionID: string, owner: SessionOwner) => {
+      const pending = pendingLatest.get(sessionID)
+      if (!pending || pending.epoch !== owner.epoch || pending.generation !== owner.generation) return false
+      pendingLatest.delete(sessionID)
+      return true
+    }
+    const acceptSession = (session: Session) => {
+      const deleted = deletedSessions.get(session.id)
+      if (deleted === undefined) return true
+      if (session.time.created <= deleted) return false
+      advanceSessionGeneration(session.id)
+      deletedSessions.delete(session.id)
+      return true
     }
 
     function sessionListQuery(): { scope?: "project"; path?: string } {
@@ -174,9 +542,43 @@ export const {
     }
 
     event.subscribe((event, { directory, workspace }) => {
+      const eventSessionID =
+        "sessionID" in event.properties && typeof event.properties.sessionID === "string"
+          ? event.properties.sessionID
+          : undefined
+      if (
+        eventSessionID &&
+        deletedSessions.has(eventSessionID) &&
+        event.type !== "session.created" &&
+        event.type !== "session.deleted"
+      )
+        return
       switch (event.type) {
         case "server.instance.disposed":
-          void bootstrap()
+          const synced = [
+            ...new Set([...fullSyncedSessions, ...Object.keys(store.message), ...Object.keys(store.message_page)]),
+          ]
+          syncEpoch += 1
+          fullSyncedSessions.clear()
+          syncingSessions.clear()
+          hydratingSessions.clear()
+          loadingGuard.clear()
+          pendingLatest.clear()
+          sessionGenerations.clear()
+          setStore(
+            produce((draft) => {
+              draft.message = {}
+              draft.message_page = {}
+              draft.message_cursor = {}
+              draft.part = {}
+              draft.todo = {}
+              draft.session_diff = {}
+              draft.session_status = {}
+              draft.permission = {}
+              draft.question = {}
+            }),
+          )
+          void bootstrap().then(() => Promise.allSettled(synced.map((sessionID) => result.session.sync(sessionID))))
           break
         case "permission.replied": {
           const requests = store.permission[event.properties.sessionID]
@@ -271,7 +673,15 @@ export const {
           break
 
         case "session.deleted": {
-          const result = search(store.session, event.properties.info.id, (s) => s.id)
+          const sessionID = event.properties.info.id
+          advanceSessionGeneration(sessionID)
+          deletedSessions.set(sessionID, event.properties.info.time.created)
+          fullSyncedSessions.delete(sessionID)
+          syncingSessions.delete(sessionID)
+          hydratingSessions.delete(sessionID)
+          loadingGuard.delete(sessionID)
+          pendingLatest.delete(sessionID)
+          const result = search(store.session, sessionID, (s) => s.id)
           if (result.found) {
             setStore(
               "session",
@@ -280,18 +690,67 @@ export const {
               }),
             )
           }
+          setStore(
+            produce((draft) => {
+              for (const message of draft.message[sessionID] ?? []) {
+                delete draft.part[message.id]
+                delete draft.message_cursor[message.id]
+              }
+              delete draft.message[sessionID]
+              delete draft.message_page[sessionID]
+              delete draft.todo[sessionID]
+              delete draft.session_diff[sessionID]
+              delete draft.session_status[sessionID]
+              delete draft.permission[sessionID]
+              delete draft.question[sessionID]
+            }),
+          )
           break
         }
-        case "session.updated": {
-          const result = search(store.session, event.properties.info.id, (s) => s.id)
-          if (result.found) {
-            setStore("session", result.index, reconcile(event.properties.info))
+        case "session.created": {
+          const info = event.properties.info
+          const deleted = deletedSessions.has(info.id)
+          const match = search(store.session, info.id, (session) => session.id)
+          const recreated = deleted || (match.found && store.session[match.index].time.created !== info.time.created)
+          if (recreated) advanceSessionGeneration(info.id)
+          deletedSessions.delete(info.id)
+          if (match.found) {
+            setStore("session", match.index, reconcile(info))
             break
           }
           setStore(
             "session",
             produce((draft) => {
-              draft.splice(result.index, 0, event.properties.info)
+              draft.splice(match.index, 0, info)
+            }),
+          )
+          break
+        }
+        case "session.updated": {
+          const info = event.properties.info
+          if (deletedSessions.has(info.id)) break
+          const match = search(store.session, info.id, (s) => s.id)
+          const previous = match.found ? store.session[match.index] : undefined
+          const revertChanged =
+            previous?.revert?.messageID !== info.revert?.messageID || previous?.revert?.partID !== info.revert?.partID
+          const tracker = hydratingSessions.get(info.id)
+          if (tracker) {
+            tracker.sessionUpdated = true
+            if (revertChanged) {
+              tracker.revertUpdated = true
+              queueLatest(info.id)
+            }
+          }
+          if (match.found) {
+            setStore("session", match.index, reconcile(info))
+            if (revertChanged && !tracker && store.message[info.id])
+              void result.session.jumpToLatest(info.id, { force: true })
+            break
+          }
+          setStore(
+            "session",
+            produce((draft) => {
+              draft.splice(match.index, 0, info)
             }),
           )
           break
@@ -319,72 +778,157 @@ export const {
         }
 
         case "message.updated": {
-          touchMessage(event.properties.info.sessionID, event.properties.info.id)
-          const messages = store.message[event.properties.info.sessionID]
+          const sessionID = event.properties.info.sessionID
+          const page = store.message_page[sessionID]
+          const messages = store.message[sessionID]
+          const pinned = getRevertMarker(sessionID)
           if (!messages) {
-            setStore("message", event.properties.info.sessionID, [event.properties.info])
+            touchMessage(sessionID, event.properties.info.id, true)
+            setStore("message", sessionID, [event.properties.info])
+            if (event.properties.cursor) setStore("message_cursor", event.properties.info.id, event.properties.cursor)
             break
           }
-          const result = search(messages, messageKey(event.properties.info), messageKey)
-          if (result.found) {
-            setStore("message", event.properties.info.sessionID, result.index, reconcile(event.properties.info))
+          const current = messageIndex(messages, event.properties.info.id)
+          if (current !== -1) {
+            touchMessage(sessionID, event.properties.info.id)
+            setStore("message", sessionID, current, reconcile(event.properties.info))
+            if (event.properties.cursor) setStore("message_cursor", event.properties.info.id, event.properties.cursor)
             break
           }
+          const loadingNewer = page?.loading && page.loadingDirection === "newer"
+          const loadingOlder = page?.loading && page.loadingDirection === "older"
+          if (page?.hasNewer && !loadingNewer) {
+            break
+          }
+          const oldest = page?.oldest ? messages.find((item) => item.id === page.oldest) : undefined
+          if (oldest && messageBefore(event.properties.info, oldest) && !loadingOlder) {
+            break
+          }
+          touchMessage(sessionID, event.properties.info.id, true)
+          const result = messageInsert(messages, event.properties.info)
+          const preview = [...messages]
+          preview.splice(result.index, 0, event.properties.info)
           setStore(
             "message",
-            event.properties.info.sessionID,
+            sessionID,
             produce((draft) => {
               draft.splice(result.index, 0, event.properties.info)
             }),
           )
-          const updated = store.message[event.properties.info.sessionID]
-          if (updated.length > 100) {
-            const oldest = updated[0]
+          if (event.properties.cursor) setStore("message_cursor", event.properties.info.id, event.properties.cursor)
+          if (page) {
+            const nextOldest = windowOldest(preview, pinned) ?? page.oldest
+            const nextNewest = windowNewest(preview, pinned) ?? page.newest
+            setStore("message_page", event.properties.info.sessionID, {
+              ...page,
+              newest: nextNewest,
+              oldest: nextOldest,
+            })
+          }
+          if (preview.length > MAX_LOADED_MESSAGES) {
+            const evictCount = preview.length - MAX_LOADED_MESSAGES
+            const trimmed = [...preview]
+            const evicted = evictFromStart(trimmed, evictCount, pinned)
+            const nextOldest = windowOldest(trimmed, pinned) ?? page?.oldest
+            const nextNewest = windowNewest(trimmed, pinned) ?? page?.newest
             batch(() => {
               setStore(
                 "message",
                 event.properties.info.sessionID,
                 produce((draft) => {
-                  draft.shift()
+                  evictFromStart(draft, evictCount, pinned)
                 }),
               )
               setStore(
                 "part",
                 produce((draft) => {
-                  delete draft[oldest.id]
+                  for (const msg of evicted) {
+                    delete draft[msg.id]
+                  }
                 }),
               )
+              setStore(
+                "message_cursor",
+                produce((draft) => {
+                  for (const msg of evicted) {
+                    delete draft[msg.id]
+                  }
+                }),
+              )
+              if (page) {
+                setStore("message_page", event.properties.info.sessionID, {
+                  ...page,
+                  hasOlder: true,
+                  oldest: nextOldest,
+                  newest: nextNewest,
+                  olderCursor: edgeCursor(store.message_cursor, nextOldest) ?? page.olderCursor,
+                })
+              }
             })
           }
           break
         }
         case "message.removed": {
-          touchMessage(event.properties.sessionID, event.properties.messageID)
+          removeMessage(event.properties.sessionID, event.properties.messageID)
           const messages = store.message[event.properties.sessionID]
-          const index = messages.findIndex((message) => message.id === event.properties.messageID)
+          const page = store.message_page[event.properties.sessionID]
+          const pinned = getRevertMarker(event.properties.sessionID)
+          const index = messageIndex(messages, event.properties.messageID)
           if (index !== -1) {
+            const preview = [...messages]
+            preview.splice(index, 1)
+            const nextOldest = windowOldest(preview, pinned) ?? preview.at(0)?.id
+            const nextNewest = windowNewest(preview, pinned) ?? preview.at(-1)?.id
+            const onlyPinned = preview.length === 1 && preview[0]?.id === pinned
             setStore(
-              "message",
-              event.properties.sessionID,
               produce((draft) => {
-                draft.splice(index, 1)
+                draft.message[event.properties.sessionID]?.splice(index, 1)
+                delete draft.part[event.properties.messageID]
+                delete draft.message_cursor[event.properties.messageID]
+                if (page) {
+                  draft.message_page[event.properties.sessionID] = {
+                    ...page,
+                    oldest: nextOldest,
+                    newest: nextNewest,
+                    olderCursor: page.hasOlder
+                      ? preview.length > 0 && !onlyPinned
+                        ? edgeCursor(draft.message_cursor, nextOldest)
+                        : page.olderCursor
+                      : undefined,
+                    newerCursor: page.hasNewer
+                      ? preview.length > 0 && !onlyPinned
+                        ? edgeCursor(draft.message_cursor, nextNewest)
+                        : page.newerCursor
+                      : undefined,
+                  }
+                }
               }),
             )
           }
           break
         }
         case "message.part.updated": {
-          touchPart(event.properties.part.sessionID, event.properties.part.id)
+          const sessionID = event.properties.part.sessionID
+          const page = store.message_page[sessionID]
+          const messages = store.message[sessionID]
+          const messageExists = messages?.some((m) => m.id === event.properties.part.messageID)
+          const loadingNewer = page?.loading && page.loadingDirection === "newer"
+          if (!messageExists && !loadingNewer) {
+            break
+          }
           const parts = store.part[event.properties.part.messageID]
           if (!parts) {
+            touchPart(sessionID, event.properties.part.id)
             setStore("part", event.properties.part.messageID, [event.properties.part])
             break
           }
           const result = search(parts, event.properties.part.id, (part) => part.id)
           if (result.found) {
+            touchPart(sessionID, event.properties.part.id)
             setStore("part", event.properties.part.messageID, result.index, reconcile(event.properties.part))
             break
           }
+          touchPart(sessionID, event.properties.part.id)
           setStore(
             "part",
             event.properties.part.messageID,
@@ -415,8 +959,9 @@ export const {
         }
 
         case "message.part.removed": {
-          touchPart(event.properties.sessionID, event.properties.partID)
+          removePart(event.properties.sessionID, event.properties.partID)
           const parts = store.part[event.properties.messageID]
+          if (!parts) break
           const result = search(parts, event.properties.partID, (part) => part.id)
           if (result.found) {
             setStore(
@@ -510,7 +1055,7 @@ export const {
               setStore("console_state", reconcile(consoleState))
               setStore("agent", reconcile(agents))
               setStore("config", reconcile(config))
-              if (sessions !== undefined) setStore("session", reconcile(sessions))
+              if (sessions !== undefined) setStore("session", reconcile(sessions.filter(acceptSession)))
             })
           })
         })
@@ -518,7 +1063,11 @@ export const {
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
+            ...(args.continue
+              ? []
+              : [
+                  sessionListPromise.then((sessions) => setStore("session", reconcile(sessions.filter(acceptSession)))),
+                ]),
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
@@ -528,7 +1077,14 @@ export const {
               .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
             sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data ?? []))),
             sdk.client.session.status({ workspace }).then((x) => {
-              setStore("session_status", reconcile(x.data ?? {}))
+              setStore(
+                "session_status",
+                reconcile(
+                  Object.fromEntries(
+                    Object.entries(x.data ?? {}).filter(([sessionID]) => !deletedSessions.has(sessionID)),
+                  ),
+                ),
+              )
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
@@ -539,7 +1095,7 @@ export const {
         })
         .catch(async (e) => {
           console.error("tui bootstrap failed", {
-            error: e instanceof Error ? e.message : String(e),
+            error: paginationError(e),
             name: e instanceof Error ? e.name : undefined,
             stack: e instanceof Error ? e.stack : undefined,
           })
@@ -579,7 +1135,7 @@ export const {
         },
         async refresh() {
           const list = await listSessions()
-          setStore("session", reconcile(list))
+          setStore("session", reconcile(list.filter(acceptSession)))
         },
         status(sessionID: string) {
           const session = result.session.get(sessionID)
@@ -595,75 +1151,550 @@ export const {
           if (fullSyncedSessions.has(sessionID)) return
           const syncing = syncingSessions.get(sessionID)
           if (syncing) return syncing
-          const tracker = { messages: new Set<string>(), parts: new Set<string>() }
+          const owner = sessionOwner(sessionID)
+          const tracker = createHydrationTracker()
           hydratingSessions.set(sessionID, tracker)
           const task = (async () => {
-            const [session, messages, todo, diff] = await Promise.all([
+            const [session, todo, diff] = await Promise.all([
               sdk.client.session.get({ sessionID }, { throwOnError: true }),
-              sdk.client.session.messages({ sessionID, limit: 100 }),
               sdk.client.session.todo({ sessionID }),
               sdk.client.session.diff({ sessionID }),
             ])
+            if (staleSession(sessionID, owner)) return
+            const sessionInfo = session.data!
             setStore(
               produce((draft) => {
-                const match = search(draft.session, sessionID, (s) => s.id)
-                if (match.found) draft.session[match.index] = session.data!
-                if (!match.found) draft.session.splice(match.index, 0, session.data!)
-                draft.todo[sessionID] = todo.data ?? []
-                const currentMessages = draft.message[sessionID] ?? []
-                const infos = (messages.data ?? []).flatMap((message) => {
-                  if (!tracker.messages.has(message.info.id)) return [message.info]
-                  const current = currentMessages.find((item) => item.id === message.info.id)
-                  return current ? [current] : []
-                })
-                infos.push(
-                  ...currentMessages.filter(
-                    (message) => tracker.messages.has(message.id) && !infos.some((item) => item.id === message.id),
-                  ),
-                )
-                infos.sort(compareMessage)
-                const removed = infos.slice(0, -100)
-                const visible = infos.slice(-100)
-                const visibleIDs = new Set(visible.map((message) => message.id))
-                for (const message of messages.data ?? []) {
-                  if (!visibleIDs.has(message.info.id)) {
-                    delete draft.part[message.info.id]
-                    continue
-                  }
-                  const currentParts = draft.part[message.info.id] ?? []
-                  const parts = message.parts.flatMap((part) => {
-                    const current = currentParts.find((item) => item.id === part.id)
-                    if (tracker.parts.has(part.id)) return current ? [current] : []
-                    if (
-                      current &&
-                      (part.type === "text" || part.type === "reasoning") &&
-                      (current.type === "text" || current.type === "reasoning") &&
-                      part.text.length === 0 &&
-                      current.text.length > 0
-                    ) {
-                      return [current]
-                    }
-                    return [part]
-                  })
-                  parts.push(
-                    ...currentParts.filter(
-                      (part) => tracker.parts.has(part.id) && !parts.some((item) => item.id === part.id),
-                    ),
-                  )
-                  draft.part[message.info.id] = parts
+                if (!tracker.sessionUpdated) {
+                  const match = search(draft.session, sessionID, (item) => item.id)
+                  if (match.found) draft.session[match.index] = sessionInfo
+                  if (!match.found) draft.session.splice(match.index, 0, sessionInfo)
                 }
-                for (const message of removed) delete draft.part[message.id]
-                draft.message[sessionID] = visible
+                draft.todo[sessionID] = todo.data ?? []
                 draft.session_diff[sessionID] = diff.data ?? []
               }),
             )
+            const page = await loadLatestPage(sessionID, result.session.get(sessionID)?.revert).catch((error) => {
+              if (staleSession(sessionID, owner)) return
+              setStore(
+                "message_page",
+                sessionID,
+                store.message_page[sessionID]
+                  ? { ...store.message_page[sessionID], loading: false, error: paginationError(error) }
+                  : {
+                      hasOlder: false,
+                      hasNewer: false,
+                      loading: false,
+                      error: paginationError(error),
+                    },
+              )
+            })
+            if (!page || staleSession(sessionID, owner)) return
+            const currentMessages = store.message[sessionID] ?? []
+            if (tracker.revertUpdated || hasUnmatchedAdditions(page.items, currentMessages, tracker)) {
+              queueLatest(sessionID)
+              return
+            }
+            setStore(
+              produce((draft) => {
+                const currentMessages = draft.message[sessionID] ?? []
+                const hydrated = mergeHydratedItems(
+                  page.items,
+                  currentMessages,
+                  draft.part,
+                  draft.message_cursor,
+                  tracker,
+                )
+                const visible = hydrated.map((message) => message.info)
+                const boundary = result.session.get(sessionID)?.revert?.messageID
+                const boundaryIndex = boundary ? visible.findIndex((message) => message.id === boundary) : -1
+                const previousUser =
+                  boundaryIndex === -1
+                    ? undefined
+                    : visible.slice(0, boundaryIndex).findLast((message) => message.role === "user")?.id
+                const preserved = new Set([boundary, previousUser].filter((id): id is string => !!id))
+                const removed = evictFromStart(visible, Math.max(0, visible.length - MESSAGE_PAGE_SIZE), preserved)
+                const visibleIDs = new Set(visible.map((message) => message.id))
+                for (const message of currentMessages) {
+                  if (visibleIDs.has(message.id)) continue
+                  delete draft.part[message.id]
+                  delete draft.message_cursor[message.id]
+                }
+                for (const message of hydrated) {
+                  if (!visibleIDs.has(message.info.id)) {
+                    delete draft.part[message.info.id]
+                    delete draft.message_cursor[message.info.id]
+                    continue
+                  }
+                  draft.message_cursor[message.info.id] = message.cursor
+                  draft.part[message.info.id] = message.parts
+                }
+                for (const message of removed) {
+                  delete draft.part[message.id]
+                  delete draft.message_cursor[message.id]
+                }
+                draft.message[sessionID] = visible
+                const oldest = windowOldest(visible, boundary) ?? page.oldest
+                const newest = windowNewest(visible, boundary) ?? page.newest
+                draft.message_page[sessionID] = {
+                  hasOlder: page.hasOlder || removed.length > 0,
+                  hasNewer: page.hasNewer,
+                  loading: false,
+                  oldest,
+                  newest,
+                  olderCursor:
+                    removed.length > 0
+                      ? (edgeCursor(draft.message_cursor, oldest) ?? page.olderCursor)
+                      : page.olderCursor,
+                  newerCursor: page.newerCursor,
+                  error: undefined,
+                }
+              }),
+            )
+            if (staleSession(sessionID, owner)) return
             fullSyncedSessions.add(sessionID)
           })().finally(() => {
-            syncingSessions.delete(sessionID)
-            hydratingSessions.delete(sessionID)
+            if (syncingSessions.get(sessionID) === task) syncingSessions.delete(sessionID)
+            if (hydratingSessions.get(sessionID) === tracker) hydratingSessions.delete(sessionID)
+            if (consumeLatest(sessionID, owner)) void result.session.jumpToLatest(sessionID, { force: true })
           })
           syncingSessions.set(sessionID, task)
           return task
+        },
+        async allMessages(sessionID: string) {
+          const latest = await sdk.client.session.messages(
+            { sessionID, limit: MESSAGE_PAGE_SIZE },
+            { throwOnError: true },
+          )
+          const items = [...(latest.data ?? [])]
+          const cursor = pageInfo(latest.response.headers.get("link") ?? "").olderCursor
+          if (!cursor) return items
+          return (await walkOlderPages({ sessionID, cursor, items })).items
+        },
+        async loadOlder(sessionID: string) {
+          const page = store.message_page[sessionID]
+          if (page?.loading || !page?.hasOlder) return
+          const cursor = page?.olderCursor
+          if (!cursor) return
+          if (loadingGuard.has(sessionID)) return
+          const owner = sessionOwner(sessionID)
+          loadingGuard.set(sessionID, owner)
+          const pinned = getRevertMarker(sessionID)
+          try {
+            setStore("message_page", sessionID, { ...page, loading: true, loadingDirection: "older", error: undefined })
+
+            const res = await sdk.client.session.messages(
+              { sessionID, before: cursor, limit: MESSAGE_PAGE_SIZE },
+              { throwOnError: true },
+            )
+            if (staleSession(sessionID, owner)) return
+            const info = pageInfo(res.response.headers.get("link") ?? "")
+            const incoming = res.data ?? []
+            const ids = new Set((store.message[sessionID] ?? []).map((message) => message.id))
+            requireNewMessages(
+              info.olderCursor,
+              incoming.length,
+              incoming.filter((message) => !ids.has(message.info.id)).length,
+            )
+            const next = info.olderCursor === cursor ? { ...info, hasOlder: false, olderCursor: undefined } : info
+            setStore(
+              produce((draft) => {
+                const existing = draft.message[sessionID] ?? []
+                const pageOldest = incoming.at(0)?.info.id
+                for (const msg of incoming) {
+                  draft.message_cursor[msg.info.id] = msg.cursor
+                  const match = messageInsert(existing, msg.info)
+                  if (!match.found) {
+                    existing.splice(match.index, 0, msg.info)
+                    draft.part[msg.info.id] = msg.parts
+                  }
+                }
+                const nextOldest = pageOldest ?? draft.message_page[sessionID]?.oldest
+                if (existing.length > MAX_LOADED_MESSAGES) {
+                  const evictCount = existing.length - MAX_LOADED_MESSAGES
+                  const evicted = evictFromEnd(existing, evictCount, pinned)
+                  for (const msg of evicted) {
+                    delete draft.part[msg.id]
+                    delete draft.message_cursor[msg.id]
+                  }
+                  const nextNewest = windowNewest(existing, pinned) ?? draft.message_page[sessionID]?.newest
+                  draft.message_page[sessionID] = {
+                    hasOlder: next.hasOlder,
+                    hasNewer: true,
+                    loading: false,
+                    oldest: nextOldest,
+                    newest: nextNewest,
+                    olderCursor: next.olderCursor,
+                    newerCursor:
+                      edgeCursor(draft.message_cursor, nextNewest) ?? draft.message_page[sessionID]?.newerCursor,
+                    error: undefined,
+                  }
+                } else {
+                  const nextNewest = windowNewest(existing, pinned) ?? draft.message_page[sessionID]?.newest
+                  draft.message_page[sessionID] = {
+                    hasOlder: next.hasOlder,
+                    hasNewer: draft.message_page[sessionID]?.hasNewer ?? false,
+                    loading: false,
+                    oldest: nextOldest,
+                    newest: nextNewest,
+                    olderCursor: next.olderCursor,
+                    newerCursor: draft.message_page[sessionID]?.newerCursor,
+                    error: undefined,
+                  }
+                }
+              }),
+            )
+          } catch (e) {
+            if (staleSession(sessionID, owner)) return
+            const page = store.message_page[sessionID]
+            setStore("message_page", sessionID, {
+              hasOlder: page?.hasOlder ?? false,
+              hasNewer: page?.hasNewer ?? false,
+              loading: false,
+              oldest: page?.oldest,
+              newest: page?.newest,
+              olderCursor: page?.olderCursor,
+              newerCursor: page?.newerCursor,
+              error: paginationError(e),
+            })
+          } finally {
+            if (loadingGuard.get(sessionID) === owner) loadingGuard.delete(sessionID)
+            if (consumeLatest(sessionID, owner)) void result.session.jumpToLatest(sessionID, { force: true })
+          }
+        },
+        async loadNewer(sessionID: string) {
+          const page = store.message_page[sessionID]
+          if (page?.loading || !page?.hasNewer) return
+          const cursor = page?.newerCursor
+          if (!cursor) return result.session.jumpToLatest(sessionID, { force: true })
+          if (loadingGuard.has(sessionID)) return
+          const owner = sessionOwner(sessionID)
+          loadingGuard.set(sessionID, owner)
+          const pinned = getRevertMarker(sessionID)
+          try {
+            setStore("message_page", sessionID, { ...page, loading: true, loadingDirection: "newer", error: undefined })
+            const res = await sdk.client.session.messages(
+              { sessionID, after: cursor, limit: MESSAGE_PAGE_SIZE },
+              { throwOnError: true },
+            )
+            if (staleSession(sessionID, owner)) return
+            const info = pageInfo(res.response.headers.get("link") ?? "")
+            const incoming = res.data ?? []
+            const ids = new Set((store.message[sessionID] ?? []).map((message) => message.id))
+            requireNewMessages(
+              info.newerCursor,
+              incoming.length,
+              incoming.filter((message) => !ids.has(message.info.id)).length,
+            )
+            const next = info.newerCursor === cursor ? { ...info, hasNewer: false, newerCursor: undefined } : info
+            setStore(
+              produce((draft) => {
+                const existing = draft.message[sessionID] ?? []
+                const pageNewest = incoming.at(-1)?.info.id
+                for (const msg of incoming) {
+                  draft.message_cursor[msg.info.id] = msg.cursor
+                  const match = messageInsert(existing, msg.info)
+                  if (!match.found) {
+                    existing.splice(match.index, 0, msg.info)
+                    draft.part[msg.info.id] = msg.parts
+                  }
+                }
+                const nextNewest = pageNewest ?? draft.message_page[sessionID]?.newest
+                if (existing.length > MAX_LOADED_MESSAGES) {
+                  const evictCount = existing.length - MAX_LOADED_MESSAGES
+                  const evicted = evictFromStart(existing, evictCount, pinned)
+                  for (const msg of evicted) {
+                    delete draft.part[msg.id]
+                    delete draft.message_cursor[msg.id]
+                  }
+                  const nextOldest = windowOldest(existing, pinned) ?? draft.message_page[sessionID]?.oldest
+                  draft.message_page[sessionID] = {
+                    hasOlder: true,
+                    hasNewer: next.hasNewer,
+                    loading: false,
+                    oldest: nextOldest,
+                    newest: nextNewest,
+                    olderCursor:
+                      edgeCursor(draft.message_cursor, nextOldest) ?? draft.message_page[sessionID]?.olderCursor,
+                    newerCursor: next.newerCursor,
+                    error: undefined,
+                  }
+                } else {
+                  const nextOldest = windowOldest(existing, pinned) ?? draft.message_page[sessionID]?.oldest
+                  draft.message_page[sessionID] = {
+                    hasOlder: draft.message_page[sessionID]?.hasOlder ?? false,
+                    hasNewer: next.hasNewer,
+                    loading: false,
+                    oldest: nextOldest,
+                    newest: nextNewest,
+                    olderCursor: draft.message_page[sessionID]?.olderCursor,
+                    newerCursor: next.newerCursor,
+                    error: undefined,
+                  }
+                }
+              }),
+            )
+          } catch (e) {
+            if (staleSession(sessionID, owner)) return
+            const page = store.message_page[sessionID]
+            setStore("message_page", sessionID, {
+              hasOlder: page?.hasOlder ?? false,
+              hasNewer: page?.hasNewer ?? false,
+              loading: false,
+              oldest: page?.oldest,
+              newest: page?.newest,
+              olderCursor: page?.olderCursor,
+              newerCursor: page?.newerCursor,
+              error: paginationError(e),
+            })
+          } finally {
+            if (loadingGuard.get(sessionID) === owner) loadingGuard.delete(sessionID)
+            if (consumeLatest(sessionID, owner)) void result.session.jumpToLatest(sessionID, { force: true })
+          }
+        },
+        async jumpToLatest(sessionID: string, opts?: { force?: boolean }) {
+          const page = store.message_page[sessionID]
+          if (page?.loading) {
+            if (opts?.force) queueLatest(sessionID)
+            return
+          }
+          if (!opts?.force && !page?.hasNewer) return
+          if (loadingGuard.has(sessionID)) {
+            if (opts?.force) queueLatest(sessionID)
+            return
+          }
+          const owner = sessionOwner(sessionID)
+          loadingGuard.set(sessionID, owner)
+          const tracker = createHydrationTracker()
+          hydratingSessions.set(sessionID, tracker)
+
+          try {
+            const session = store.session.find((s) => s.id === sessionID)
+            setStore("message_page", sessionID, {
+              hasOlder: page?.hasOlder ?? false,
+              hasNewer: page?.hasNewer ?? false,
+              loading: true,
+              loadingDirection: "newer",
+              oldest: page?.oldest,
+              newest: page?.newest,
+              olderCursor: page?.olderCursor,
+              newerCursor: page?.newerCursor,
+              error: undefined,
+            })
+
+            const latest = await loadLatestPage(sessionID, session?.revert)
+            if (staleSession(sessionID, owner)) return
+            const currentMessages = store.message[sessionID] ?? []
+            if (tracker.revertUpdated || hasUnmatchedAdditions(latest.items, currentMessages, tracker)) {
+              queueLatest(sessionID)
+              const current = store.message_page[sessionID]
+              if (current)
+                setStore("message_page", sessionID, {
+                  ...current,
+                  loading: false,
+                  loadingDirection: undefined,
+                })
+              return
+            }
+            const boundary = session?.revert?.messageID
+
+            setStore(
+              produce((draft) => {
+                const oldMessages = draft.message[sessionID] ?? []
+                const merged = mergeHydratedItems(latest.items, oldMessages, draft.part, draft.message_cursor, tracker)
+                const messages = merged.map((item) => item.info)
+                const boundaryIndex = boundary ? messages.findIndex((message) => message.id === boundary) : -1
+                const previousUser =
+                  boundaryIndex === -1
+                    ? undefined
+                    : messages.slice(0, boundaryIndex).findLast((message) => message.role === "user")?.id
+                const preserved = new Set([boundary, previousUser].filter((id): id is string => !!id))
+                const removed = evictFromStart(messages, Math.max(0, messages.length - MAX_LOADED_MESSAGES), preserved)
+                const messageIDs = new Set(messages.map((message) => message.id))
+                const items = merged.filter((item) => messageIDs.has(item.info.id))
+                const newIds = new Set(items.map((item) => item.info.id))
+                for (const msg of oldMessages) {
+                  if (!newIds.has(msg.id)) {
+                    delete draft.part[msg.id]
+                    delete draft.message_cursor[msg.id]
+                  }
+                }
+
+                draft.message[sessionID] = items.map((item) => item.info)
+                for (const msg of items) {
+                  draft.part[msg.info.id] = msg.parts
+                  draft.message_cursor[msg.info.id] = msg.cursor
+                }
+                const oldest = windowOldest(messages, boundary) ?? latest.oldest
+                const newest = windowNewest(messages, boundary) ?? latest.newest
+                draft.message_page[sessionID] = {
+                  hasOlder: latest.hasOlder || removed.length > 0,
+                  hasNewer: latest.hasNewer,
+                  loading: false,
+                  oldest,
+                  newest,
+                  olderCursor:
+                    removed.length > 0
+                      ? (edgeCursor(draft.message_cursor, oldest) ?? latest.olderCursor)
+                      : latest.olderCursor,
+                  newerCursor: latest.newerCursor,
+                  error: undefined,
+                }
+              }),
+            )
+            if (store.todo[sessionID] !== undefined && store.session_diff[sessionID] !== undefined)
+              fullSyncedSessions.add(sessionID)
+          } catch (e) {
+            if (staleSession(sessionID, owner)) return
+            fullSyncedSessions.delete(sessionID)
+            setStore(
+              produce((draft) => {
+                const p = draft.message_page[sessionID]
+                if (p) {
+                  p.loading = false
+                  p.error = paginationError(e)
+                }
+              }),
+            )
+          } finally {
+            if (loadingGuard.get(sessionID) === owner) loadingGuard.delete(sessionID)
+            if (hydratingSessions.get(sessionID) === tracker) hydratingSessions.delete(sessionID)
+            if (consumeLatest(sessionID, owner)) void result.session.jumpToLatest(sessionID, { force: true })
+          }
+        },
+        async jumpToOldest(sessionID: string) {
+          const page = store.message_page[sessionID]
+          if (page?.loading || !page?.hasOlder) return
+          if (loadingGuard.has(sessionID)) return
+          const owner = sessionOwner(sessionID)
+          loadingGuard.set(sessionID, owner)
+          const tracker = createHydrationTracker()
+          hydratingSessions.set(sessionID, tracker)
+
+          try {
+            setStore("message_page", sessionID, {
+              ...page,
+              loading: true,
+              loadingDirection: "older",
+              error: undefined,
+            })
+
+            const response = await sdk.client.session.messages(
+              { sessionID, oldest: "true", limit: MESSAGE_PAGE_SIZE },
+              { throwOnError: false },
+            )
+            const oldest = await (async () => {
+              if (response.response.status === 400) {
+                if (!page.olderCursor) throw new Error("Older message cursor is unavailable")
+                return walkOlderPages({ sessionID, cursor: page.olderCursor, items: [], terminalOnly: true })
+              }
+              if (response.error) throw response.error
+              if (!response.response.ok) throw new Error(`Failed to load oldest messages: ${response.response.status}`)
+              const items = response.data ?? []
+              const info = pageInfo(response.response.headers.get("link") ?? "")
+              if (!info.olderCursor) return { items, info }
+              return walkOlderPages({ sessionID, cursor: info.olderCursor, items, terminalOnly: true })
+            })()
+            if (staleSession(sessionID, owner)) return
+
+            const session = store.session.find((s) => s.id === sessionID)
+            const revert = session?.revert
+            const revertMessageID = revert?.messageID
+
+            const messages = [...oldest.items]
+            const info = oldest.info
+
+            if (revertMessageID && !messages.some((m) => m.info.id === revertMessageID)) {
+              try {
+                const revertResult = await sdk.client.session.message(
+                  { sessionID, messageID: revertMessageID },
+                  { throwOnError: false },
+                )
+                if (staleSession(sessionID, owner)) return
+                const boundary = boundaryFromMessageResponse(revertResult)
+                if (!boundary) {
+                  clearRevert(sessionID, revert)
+                } else {
+                  const index = messageInsert(
+                    messages.map((m) => m.info),
+                    boundary.info,
+                  )
+                  if (!index.found) messages.splice(index.index, 0, boundary)
+                }
+              } catch (e) {
+                if (staleSession(sessionID, owner)) return
+                console.error("Revert marker fetch failed during jumpToOldest", {
+                  messageID: revertMessageID,
+                  error: paginationError(e),
+                })
+                throw e
+              }
+            }
+
+            if (tracker.revertUpdated) {
+              const current = store.message_page[sessionID]
+              if (current)
+                setStore("message_page", sessionID, {
+                  ...current,
+                  loading: false,
+                  loadingDirection: undefined,
+                })
+              return
+            }
+
+            setStore(
+              produce((draft) => {
+                const oldMessages = draft.message[sessionID] ?? []
+                const merged = mergeHydratedItems(messages, oldMessages, draft.part, draft.message_cursor, tracker)
+                const infos = merged.map((message) => message.info)
+                const removed = evictFromEnd(infos, Math.max(0, infos.length - MAX_LOADED_MESSAGES), revertMessageID)
+                const messageIDs = new Set(infos.map((message) => message.id))
+                const items = merged.filter((message) => messageIDs.has(message.info.id))
+                const newIds = new Set(items.map((message) => message.info.id))
+                for (const msg of oldMessages) {
+                  if (!newIds.has(msg.id)) {
+                    delete draft.part[msg.id]
+                    delete draft.message_cursor[msg.id]
+                  }
+                }
+
+                draft.message[sessionID] = infos
+                for (const msg of items) {
+                  draft.part[msg.info.id] = msg.parts
+                  draft.message_cursor[msg.info.id] = msg.cursor
+                }
+                const nextOldest = windowOldest(infos, revertMessageID) ?? oldest.items.at(0)?.info.id
+                const nextNewest = windowNewest(infos, revertMessageID) ?? oldest.items.at(-1)?.info.id
+                draft.message_page[sessionID] = {
+                  hasOlder: info.hasOlder,
+                  hasNewer: info.hasNewer || removed.length > 0,
+                  loading: false,
+                  oldest: nextOldest,
+                  newest: nextNewest,
+                  olderCursor: info.olderCursor,
+                  newerCursor:
+                    removed.length > 0
+                      ? (edgeCursor(draft.message_cursor, nextNewest) ?? info.newerCursor)
+                      : info.newerCursor,
+                  error: undefined,
+                }
+              }),
+            )
+          } catch (e) {
+            if (staleSession(sessionID, owner)) return
+            setStore(
+              produce((draft) => {
+                const p = draft.message_page[sessionID]
+                if (p) {
+                  p.loading = false
+                  p.error = paginationError(e)
+                }
+              }),
+            )
+          } finally {
+            if (loadingGuard.get(sessionID) === owner) loadingGuard.delete(sessionID)
+            if (hydratingSessions.get(sessionID) === tracker) hydratingSessions.delete(sessionID)
+            if (consumeLatest(sessionID, owner)) void result.session.jumpToLatest(sessionID, { force: true })
+          }
         },
       },
       bootstrap,

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -19,7 +19,7 @@ import path from "node:path"
 import { mkdir, writeFile } from "node:fs/promises"
 import { useRoute, useRouteData } from "../../context/route"
 import { useProject } from "../../context/project"
-import { useSync } from "../../context/sync"
+import { MAX_LOADED_MESSAGES, MESSAGE_PAGE_SIZE, useSync } from "../../context/sync"
 import { useEvent } from "../../context/event"
 import { SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
@@ -30,12 +30,12 @@ import { Prompt, type PromptRef } from "../../component/prompt"
 import type {
   AssistantMessage,
   Part,
-  Provider,
   ToolPart,
   UserMessage,
   TextPart,
   ReasoningPart,
   SessionStatus,
+  Provider,
 } from "@opencode-ai/sdk/v2"
 import { useLocal } from "../../context/local"
 import { Locale } from "../../util/locale"
@@ -67,12 +67,12 @@ import { normalizePath } from "../../util/path"
 import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
-import * as Model from "../../util/model"
-import { formatTranscript } from "../../util/transcript"
+import { formatTranscript, type MessageWithParts } from "../../util/transcript"
 import { sessionEpilogue } from "../../util/presentation"
 import { setPreLayoutSiblingMargin } from "../../util/layout"
 import { useTuiConfig } from "../../config"
 import { useClipboard } from "../../context/clipboard"
+import { index as modelIndex, name as modelName } from "../../util/model"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
 import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
@@ -82,6 +82,17 @@ import { getRevertDiffFiles } from "../../util/revert-diff"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { LocationProvider } from "../../context/location"
+import {
+  edgeHints,
+  lastValidUser,
+  messageBefore,
+  olderScrollTarget,
+  olderSearchCanContinue,
+  queueBoundaryLoad,
+  revertMessageState,
+  visibleBeforeBoundary,
+  visiblePartsBeforeBoundary,
+} from "../../util/pagination"
 
 addDefaultParsers(parsers.parsers)
 
@@ -211,12 +222,6 @@ export function Session() {
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
-  const messagesBeforeRevert = () => {
-    const messageID = session()?.revert?.messageID
-    if (!messageID) return messages()
-    const index = messages().findIndex((message) => message.id === messageID)
-    return index === -1 ? messages() : messages().slice(0, index)
-  }
   const foregroundTasks = createMemo(() =>
     sync.data.capabilities.experimentalBackgroundSubagents
       ? messages().flatMap((message) =>
@@ -230,6 +235,8 @@ export function Session() {
         )
       : [],
   )
+  const paging = createMemo(() => sync.data.message_page[route.sessionID])
+  const providers = createMemo(() => modelIndex(sync.data.provider))
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
@@ -241,16 +248,73 @@ export function Session() {
   const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
   const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)
 
+  const LOAD_MORE_THRESHOLD = 5
+
+  const loadOlder = () => {
+    const page = paging()
+    if (!page?.hasOlder || page.loading || !scroll || scroll.isDestroyed) return
+    if (scroll.scrollTop > LOAD_MORE_THRESHOLD) return
+
+    const anchor = (() => {
+      const scrollTop = scroll.scrollTop
+      const children = scroll.getChildren()
+      for (const child of children) {
+        if (!child.id) continue
+        if (child.y + child.height > scrollTop) {
+          return { id: child.id, offset: scrollTop - child.y }
+        }
+      }
+      return undefined
+    })()
+
+    const height = scroll.scrollHeight
+    const scrollTop = scroll.scrollTop
+    sync.session.loadOlder(route.sessionID).then(() => {
+      queueMicrotask(() => {
+        requestAnimationFrame(() => {
+          if (!scroll || scroll.isDestroyed) return
+          const nextTop = olderScrollTarget(scroll.getChildren(), scroll.scrollHeight, height, scrollTop, anchor)
+          if (nextTop !== undefined) scroll.scrollTo(nextTop)
+          refreshEdges()
+        })
+      })
+    })
+  }
+
+  const loadNewer = () => {
+    const page = paging()
+    if (!page?.hasNewer || page.loading || !scroll || scroll.isDestroyed) return
+    const bottomDistance = scroll.scrollHeight - scroll.scrollTop - scroll.viewport.height
+    if (bottomDistance > LOAD_MORE_THRESHOLD) return
+    sync.session.loadNewer(route.sessionID).then(() => {
+      queueMicrotask(() => {
+        requestAnimationFrame(() => {
+          refreshEdges()
+        })
+      })
+    })
+  }
+
+  const refreshEdges = () => {
+    if (!scroll || scroll.isDestroyed) return
+    const edges = edgeHints(scroll.scrollTop, scroll.scrollHeight, scroll.viewport.height, HINT_THRESHOLD)
+    setNearTop(edges.nearTop)
+    setNearBottom(edges.nearBottom)
+  }
+
+  const scrollMove = (delta: number) => {
+    if (!scroll || scroll.isDestroyed) return
+    scroll.scrollBy(delta)
+    refreshEdges()
+    queueBoundaryLoad(delta, loadOlder, loadNewer)
+  }
+
   const pending = createMemo(() => {
     const completed = messages().findLastIndex((message) => message.role === "assistant" && message.time.completed)
     const pending = messages().findLastIndex(
       (message, index) => index > completed && message.role === "assistant" && !message.time.completed,
     )
     return pending === -1 ? undefined : pending
-  })
-
-  const lastAssistant = createMemo(() => {
-    return messages().findLast((x) => x.role === "assistant")
   })
 
   const dimensions = useTerminalDimensions()
@@ -267,6 +331,10 @@ export function Session() {
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
+  const [nearTop, setNearTop] = createSignal(false)
+  const [nearBottom, setNearBottom] = createSignal(false)
+  const [revertPreview, setRevertPreview] = createSignal<{ userCount: number; nextMessageID?: string }>()
+  const HINT_THRESHOLD = 20
 
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
@@ -277,12 +345,19 @@ export function Session() {
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
-  const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
   const toast = useToast()
   const sdk = useSDK()
   const editor = useEditorContext()
+
+  const loadRevertPreview = async (sessionID: string) => {
+    if (!session()?.revert) return
+    const preview = await sdk.client.session.revertPreview({ sessionID }, { throwOnError: false })
+    if (preview.response.status === 404 || preview.response.status === 405) return
+    if (preview.error) throw preview.error
+    return preview.data ?? undefined
+  }
 
   createEffect(() => {
     const sessionID = route.sessionID
@@ -312,7 +387,9 @@ export function Session() {
       }
       editor.reconnect(result.data.directory)
       await sync.session.sync(sessionID)
-      if (route.sessionID === sessionID && scroll) scroll.scrollBy(100_000)
+      if (route.sessionID !== sessionID || !scroll || scroll.isDestroyed) return
+      scroll.scrollBy(100_000)
+      refreshEdges()
     })().catch((error) => {
       if (route.sessionID !== sessionID) return
       toast.show({
@@ -321,6 +398,16 @@ export function Session() {
         duration: 5000,
       })
       navigate({ type: "home" })
+    })
+  })
+
+  createEffect(() => {
+    if (!scroll || scroll.isDestroyed) return
+    messages()
+    queueMicrotask(() => {
+      requestAnimationFrame(() => {
+        refreshEdges()
+      })
     })
   })
 
@@ -379,7 +466,7 @@ export function Session() {
   const findNextVisibleMessage = (direction: "next" | "prev"): string | null => {
     const children = scroll.getChildren()
     const messagesList = messages()
-    const scrollTop = scroll.y
+    const scrollTop = scroll.scrollTop
 
     // Get visible messages sorted by position, filtering for valid non-synthetic, non-ignored content
     const visibleMessages = children
@@ -411,13 +498,16 @@ export function Session() {
     const targetID = findNextVisibleMessage(direction)
 
     if (!targetID) {
-      scroll.scrollBy(direction === "next" ? scroll.height : -scroll.height)
+      scrollMove(direction === "next" ? scroll.height : -scroll.height)
       dialog.clear()
       return
     }
 
     const child = scroll.getChildren().find((c) => c.id === targetID)
-    if (child) scroll.scrollBy(child.y - scroll.y - 1)
+    if (child) {
+      scroll.scrollBy(child.y - scroll.scrollTop - 1)
+      refreshEdges()
+    }
     dialog.clear()
   }
 
@@ -425,7 +515,16 @@ export function Session() {
     setTimeout(() => {
       if (!scroll || scroll.isDestroyed) return
       scroll.scrollTo(scroll.scrollHeight)
+      requestAnimationFrame(() => {
+        refreshEdges()
+      })
     }, 50)
+  }
+
+  function afterSubmit() {
+    const detached = paging()?.hasNewer
+    toBottom()
+    if (detached) void sync.session.jumpToLatest(route.sessionID, { force: true })
   }
 
   const local = useLocal()
@@ -529,7 +628,10 @@ export function Session() {
               const child = scroll.getChildren().find((child) => {
                 return child.id === messageID
               })
-              if (child) scroll.scrollBy(child.y - scroll.y - 1)
+              if (child) {
+                scroll.scrollBy(child.y - scroll.scrollTop - 1)
+                refreshEdges()
+              }
             }}
             sessionID={route.sessionID}
             setPrompt={(promptInfo) => prompt?.set(promptInfo)}
@@ -552,7 +654,10 @@ export function Session() {
               const child = scroll.getChildren().find((child) => {
                 return child.id === messageID
               })
-              if (child) scroll.scrollBy(child.y - scroll.y - 1)
+              if (child) {
+                scroll.scrollBy(child.y - scroll.scrollTop - 1)
+                refreshEdges()
+              }
             }}
             sessionID={route.sessionID}
           />
@@ -618,7 +723,29 @@ export function Session() {
       run: async () => {
         const status = sync.data.session_status?.[route.sessionID]
         if (status?.type !== "idle") await sdk.client.session.abort({ sessionID: route.sessionID }).catch(() => {})
-        const message = messagesBeforeRevert().findLast((item) => item.role === "user")
+        const page = paging()
+        if (page?.hasNewer && page.loading) return
+        if (page?.hasNewer) {
+          await sync.session.jumpToLatest(route.sessionID)
+          const next = paging()
+          if (next?.hasNewer || next?.loading) return
+        }
+        const boundary = revertBoundary()
+        const findTarget = () =>
+          (sync.data.message[route.sessionID] ?? []).findLast(
+            (x) => x.role === "user" && (!boundary || messageBefore(x, boundary)),
+          )
+        let message = findTarget()
+        // A window of trailing assistant output can hide the undo target (#28257); walk older pages.
+        while (!message) {
+          const page = paging()
+          if (!page?.hasOlder || page.loading) break
+          const cursor = page.olderCursor
+          if (!cursor) break
+          await sync.session.loadOlder(route.sessionID)
+          message = findTarget()
+          if (!message && !olderSearchCanContinue(cursor, paging())) break
+        }
         if (!message) return
         void sdk.client.session
           .revert({
@@ -648,16 +775,16 @@ export function Session() {
       title: "Redo",
       value: "session.redo",
       category: "Session",
-      enabled: !!session()?.revert?.messageID,
+      enabled: !!session()?.revert?.messageID && !!revertPreview(),
       slash: {
         name: "redo",
       },
-      run: () => {
+      run: async () => {
         dialog.clear()
-        const messageID = session()?.revert?.messageID
-        if (!messageID) return
-        const message = messages().find((x) => x.role === "user" && x.id > messageID)
-        if (!message) {
+        const preview = revertPreview() ?? (await loadRevertPreview(route.sessionID))
+        const nextMessageID = preview?.nextMessageID
+        if (!preview && session()?.revert?.messageID) return
+        if (!nextMessageID) {
           void sdk.client.session.unrevert({
             sessionID: route.sessionID,
           })
@@ -666,7 +793,7 @@ export function Session() {
         }
         void sdk.client.session.revert({
           sessionID: route.sessionID,
-          messageID: message.id,
+          messageID: nextMessageID,
         })
       },
     },
@@ -755,7 +882,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollBy(-scroll.height / 2)
+        scrollMove(-scroll.height / 2)
         dialog.clear()
       },
     },
@@ -765,7 +892,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollBy(scroll.height / 2)
+        scrollMove(scroll.height / 2)
         dialog.clear()
       },
     },
@@ -775,7 +902,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollBy(-1)
+        scrollMove(-1)
         dialog.clear()
       },
     },
@@ -785,7 +912,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollBy(1)
+        scrollMove(1)
         dialog.clear()
       },
     },
@@ -795,7 +922,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollBy(-scroll.height / 4)
+        scrollMove(-scroll.height / 4)
         dialog.clear()
       },
     },
@@ -805,7 +932,7 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollBy(scroll.height / 4)
+        scrollMove(scroll.height / 4)
         dialog.clear()
       },
     },
@@ -815,7 +942,23 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollTo(0)
+        const page = paging()
+        if (page?.hasOlder && !page.loading) {
+          sync.session.jumpToOldest(route.sessionID).then(() => {
+            requestAnimationFrame(() => {
+              if (!scroll || scroll.isDestroyed) return
+              scroll.scrollTo(0)
+              refreshEdges()
+            })
+          })
+        } else {
+          if (!scroll || scroll.isDestroyed) {
+            dialog.clear()
+            return
+          }
+          scroll.scrollTo(0)
+          refreshEdges()
+        }
         dialog.clear()
       },
     },
@@ -825,7 +968,23 @@ export function Session() {
       category: "Session",
       hidden: true,
       run: () => {
-        scroll.scrollTo(scroll.scrollHeight)
+        const page = paging()
+        if (page?.hasNewer && !page.loading) {
+          sync.session.jumpToLatest(route.sessionID).then(() => {
+            requestAnimationFrame(() => {
+              if (!scroll || scroll.isDestroyed) return
+              scroll.scrollTo(scroll.scrollHeight)
+              refreshEdges()
+            })
+          })
+        } else {
+          if (!scroll || scroll.isDestroyed) {
+            dialog.clear()
+            return
+          }
+          scroll.scrollTo(scroll.scrollHeight)
+          refreshEdges()
+        }
         dialog.clear()
       },
     },
@@ -834,29 +993,42 @@ export function Session() {
       value: "session.messages_last_user",
       category: "Session",
       hidden: true,
-      run: () => {
-        const messages = sync.data.message[route.sessionID]
-        if (!messages || !messages.length) return
+      run: async () => {
+        const settle = () =>
+          new Promise<void>((resolve) => queueMicrotask(() => requestAnimationFrame(() => resolve())))
 
-        // Find the most recent user message with non-ignored, non-synthetic text parts
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const message = messages[i]
-          if (!message || message.role !== "user") continue
-
-          const parts = sync.data.part[message.id]
-          if (!parts || !Array.isArray(parts)) continue
-
-          const hasValidTextPart = parts.some(
-            (part) => part && part.type === "text" && !part.synthetic && !part.ignored,
-          )
-
-          if (hasValidTextPart) {
-            const child = scroll.getChildren().find((child) => {
-              return child.id === message.id
-            })
-            if (child) scroll.scrollBy(child.y - scroll.y - 1)
-            break
+        const scrollToLastUser = () => {
+          const loaded = sync.data.message[route.sessionID]
+          if (!loaded || !loaded.length) return false
+          const target = lastValidUser(loaded, (id) => sync.data.part[id])
+          if (!target) return false
+          if (scroll && !scroll.isDestroyed) {
+            const child = scroll.getChildren().find((c) => c.id === target.id)
+            if (child) {
+              scroll.scrollBy(child.y - scroll.scrollTop - 1)
+              refreshEdges()
+            }
           }
+          return true
+        }
+
+        // Detached windows need the newest page before searching for the last user prompt.
+        if (paging()?.hasNewer) {
+          await sync.session.jumpToLatest(route.sessionID)
+          await settle()
+        }
+        if (scrollToLastUser()) return
+
+        // Rare: a full window of trailing assistant output can hide the latest user prompt.
+        while (true) {
+          const page = paging()
+          if (!page?.hasOlder || page.loading) break
+          const cursor = page.olderCursor
+          if (!cursor) break
+          await sync.session.loadOlder(route.sessionID)
+          await settle()
+          if (scrollToLastUser()) return
+          if (!olderSearchCanContinue(cursor, paging())) break
         }
       },
     },
@@ -878,15 +1050,43 @@ export function Session() {
       title: "Copy last assistant message",
       value: "messages.copy",
       category: "Session",
-      run: () => {
-        const lastAssistantMessage = messagesBeforeRevert().findLast((message) => message.role === "assistant")
+      run: async () => {
+        if (paging()?.loading || paging()?.error) {
+          toast.show({ message: "Unable to load the latest assistant message", variant: "error" })
+          dialog.clear()
+          return
+        }
+        if (paging()?.hasNewer) {
+          await sync.session.jumpToLatest(route.sessionID, { force: true })
+          const page = paging()
+          if (page?.loading || page?.error || page?.hasNewer) {
+            toast.show({ message: "Unable to load the latest assistant message", variant: "error" })
+            dialog.clear()
+            return
+          }
+        }
+        const findLastAssistant = () =>
+          visibleSessionMessages(messages().map((info) => ({ info, parts: sync.data.part[info.id] ?? [] }))).findLast(
+            (message) => message.info.role === "assistant",
+          )
+        let lastAssistantMessage = findLastAssistant()
+        const cursors = new Set<string>()
+        let remainingPages = Math.max(0, Math.ceil((MAX_LOADED_MESSAGES - messages().length) / MESSAGE_PAGE_SIZE))
+        while (!lastAssistantMessage && remainingPages > 0) {
+          const page = paging()
+          if (!page?.hasOlder || page.loading || !page.olderCursor || cursors.has(page.olderCursor)) break
+          cursors.add(page.olderCursor)
+          remainingPages -= 1
+          await sync.session.loadOlder(route.sessionID)
+          lastAssistantMessage = findLastAssistant()
+        }
         if (!lastAssistantMessage) {
           toast.show({ message: "No assistant messages found", variant: "error" })
           dialog.clear()
           return
         }
 
-        const parts = sync.data.part[lastAssistantMessage.id] ?? []
+        const parts = lastAssistantMessage.parts
         const textParts = parts.filter((part) => part.type === "text")
         if (textParts.length === 0) {
           toast.show({ message: "No text parts found in last assistant message", variant: "error" })
@@ -925,10 +1125,10 @@ export function Session() {
         try {
           const sessionData = session()
           if (!sessionData) return
-          const sessionMessages = messages()
+          const sessionMessages = visibleSessionMessages(await sync.session.allMessages(route.sessionID))
           const transcript = formatTranscript(
             sessionData,
-            sessionMessages.map((msg) => ({ info: msg, parts: sync.data.part[msg.id] ?? [] })),
+            sessionMessages.map((msg) => ({ info: msg.info, parts: msg.parts })),
             {
               thinking: showThinking(),
               toolDetails: showDetails(),
@@ -955,7 +1155,7 @@ export function Session() {
         try {
           const sessionData = session()
           if (!sessionData) return
-          const sessionMessages = messages()
+          const sessionMessages = visibleSessionMessages(await sync.session.allMessages(route.sessionID))
 
           const defaultFilename = `session-${sessionData.id.slice(0, 8)}.md`
 
@@ -972,7 +1172,7 @@ export function Session() {
 
           const transcript = formatTranscript(
             sessionData,
-            sessionMessages.map((msg) => ({ info: msg, parts: sync.data.part[msg.id] ?? [] })),
+            sessionMessages.map((msg) => ({ info: msg.info, parts: msg.parts })),
             {
               thinking: options.thinking,
               toolDetails: options.toolDetails,
@@ -1122,22 +1322,71 @@ export function Session() {
 
   const revertInfo = createMemo(() => session()?.revert)
   const revertMessageID = createMemo(() => revertInfo()?.messageID)
-  const revertMessageIndex = createMemo(() => {
-    const messageID = revertMessageID()
-    if (!messageID) return -1
-    return messages().findIndex((message) => message.id === messageID)
-  })
+  let revertPreviewEpoch = 0
+
+  createEffect(
+    on(
+      () => [route.sessionID, revertMessageID()] as const,
+      ([sessionID, revert]) => {
+        const epoch = ++revertPreviewEpoch
+        setRevertPreview(undefined)
+        if (!revert) {
+          return
+        }
+        void loadRevertPreview(sessionID)
+          .then((result) => {
+            if (epoch !== revertPreviewEpoch) return
+            setRevertPreview(result)
+          })
+          .catch(() => {
+            if (epoch !== revertPreviewEpoch) return
+            setRevertPreview(undefined)
+          })
+      },
+    ),
+  )
 
   const revertDiffFiles = createMemo(() => getRevertDiffFiles(revertInfo()?.diff ?? ""))
 
   const revertRevertedMessages = createMemo(() => {
     const messageID = revertMessageID()
     if (!messageID) return []
-    const index = revertMessageIndex()
-    if (index === -1) return []
-    return messages()
-      .slice(index)
-      .filter((message) => message.role === "user")
+    const boundary = messages().find((x) => x.id === messageID)
+    if (!boundary) return []
+    return messages().filter((x) => x.role === "user" && !messageBefore(x, boundary))
+  })
+  const revertUserCount = createMemo(() => revertPreview()?.userCount ?? revertRevertedMessages().length)
+
+  const revertBoundary = createMemo(() => {
+    const messageID = revertMessageID()
+    if (!messageID) return undefined
+    return messages().find((x) => x.id === messageID)
+  })
+
+  const visibleMessageParts = (messageID: string, parts: Part[]) => {
+    const info = revertInfo()
+    if (info?.messageID !== messageID) return parts
+    return visiblePartsBeforeBoundary(parts, info.partID)
+  }
+
+  const visibleSessionMessages = (items: MessageWithParts[]) => {
+    const info = revertInfo()
+    const visible = visibleBeforeBoundary(items, info?.messageID, revertBoundary(), { includeBoundary: !!info?.partID })
+    if (!info?.partID) return visible
+    return visible.map((item) =>
+      item.info.id === info.messageID ? { ...item, parts: visiblePartsBeforeBoundary(item.parts, info.partID) } : item,
+    )
+  }
+
+  const lastAssistant = createMemo(() => {
+    return visibleBeforeBoundary(
+      messages().map((info) => ({ info, parts: [] as Part[] })),
+      revertMessageID(),
+      revertBoundary(),
+      { includeBoundary: !!revertInfo()?.partID },
+    )
+      .map((item) => item.info)
+      .findLast((x) => x.role === "assistant")
   })
 
   const revert = createMemo(() => {
@@ -1146,7 +1395,7 @@ export function Session() {
     if (!info.messageID) return
     return {
       messageID: info.messageID,
-      reverted: revertRevertedMessages(),
+      revertedCount: revertUserCount(),
       diff: info.diff,
       diffFiles: revertDiffFiles(),
     }
@@ -1178,8 +1427,44 @@ export function Session() {
         <box flexDirection="row" flexGrow={1} minHeight={0}>
           <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
             <Show when={session()}>
+              <Show when={paging()?.loading && paging()?.loadingDirection === "older"}>
+                <box flexShrink={0} paddingLeft={1}>
+                  <text fg={theme.textMuted}>Loading older messages...</text>
+                </box>
+              </Show>
+              <Show when={!paging()?.loading && paging()?.hasOlder && nearTop()}>
+                <box flexShrink={0} paddingLeft={1}>
+                  <text fg={theme.textMuted}>(scroll up for more)</text>
+                </box>
+              </Show>
+              <Show when={paging()?.error}>
+                <box flexShrink={0} paddingLeft={1}>
+                  <text fg={theme.error}>Failed to load: {paging()?.error}</text>
+                  <text fg={theme.textMuted}> (scroll to retry)</text>
+                </box>
+              </Show>
               <scrollbox
                 ref={(r) => (scroll = r)}
+                onMouseScroll={() => {
+                  refreshEdges()
+                  loadOlder()
+                  loadNewer()
+                }}
+                onKeyDown={(e) => {
+                  if (["up", "pageup", "home"].includes(e.name)) {
+                    setTimeout(() => {
+                      refreshEdges()
+                      loadOlder()
+                    }, 0)
+                  }
+                  if (["down", "pagedown", "end"].includes(e.name)) {
+                    setTimeout(() => {
+                      refreshEdges()
+                      loadNewer()
+                    }, 0)
+                  }
+                }}
+                viewportCulling={true}
                 viewportOptions={{
                   paddingRight: showScrollbar() ? 1 : 0,
                 }}
@@ -1196,11 +1481,15 @@ export function Session() {
                 flexGrow={1}
                 scrollAcceleration={scrollAcceleration()}
               >
-                <box height={1} />
                 <For each={messages()}>
                   {(message, index) => (
-                    <Switch>
-                      <Match when={message.id === revert()?.messageID}>
+                    <>
+                      <Show
+                        when={
+                          revertMessageState(message, revertMessageID(), revertBoundary(), revertInfo()?.partID)
+                            .showBanner
+                        }
+                      >
                         {(function () {
                           const redoShortcut = useCommandShortcut("session.redo")
                           const [hover, setHover] = createSignal(false)
@@ -1234,7 +1523,7 @@ export function Session() {
                                 paddingLeft={2}
                                 backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
                               >
-                                <text fg={theme.textMuted}>{revert()!.reverted.length} message reverted</text>
+                                <text fg={theme.textMuted}>{revert()!.revertedCount} message reverted</text>
                                 <text fg={theme.textMuted}>
                                   <span style={{ fg: theme.text }}>{redoShortcut()}</span> or /redo to restore
                                 </text>
@@ -1259,41 +1548,55 @@ export function Session() {
                             </box>
                           )
                         })()}
-                      </Match>
-                      <Match
-                        when={revert()?.messageID && revertMessageIndex() !== -1 && index() >= revertMessageIndex()}
+                      </Show>
+                      <Show
+                        when={
+                          revertMessageState(message, revertMessageID(), revertBoundary(), revertInfo()?.partID)
+                            .showMessage
+                        }
                       >
-                        <></>
-                      </Match>
-                      <Match when={message.role === "user"}>
-                        <UserMessage
-                          index={index()}
-                          onMouseUp={() => {
-                            if (renderer.getSelection()?.getSelectedText()) return
-                            dialog.replace(() => (
-                              <DialogMessage
-                                messageID={message.id}
-                                sessionID={route.sessionID}
-                                setPrompt={(promptInfo) => prompt?.set(promptInfo)}
-                              />
-                            ))
-                          }}
-                          message={message as UserMessage}
-                          parts={sync.data.part[message.id] ?? []}
-                          pending={pending()}
-                        />
-                      </Match>
-                      <Match when={message.role === "assistant"}>
-                        <AssistantMessage
-                          last={lastAssistant()?.id === message.id}
-                          message={message as AssistantMessage}
-                          parts={sync.data.part[message.id] ?? []}
-                        />
-                      </Match>
-                    </Switch>
+                        <Switch>
+                          <Match when={message.role === "user"}>
+                            <UserMessage
+                              index={index()}
+                              onMouseUp={() => {
+                                if (renderer.getSelection()?.getSelectedText()) return
+                                dialog.replace(() => (
+                                  <DialogMessage
+                                    messageID={message.id}
+                                    sessionID={route.sessionID}
+                                    setPrompt={(promptInfo) => prompt?.set(promptInfo)}
+                                  />
+                                ))
+                              }}
+                              message={message as UserMessage}
+                              parts={visibleMessageParts(message.id, sync.data.part[message.id] ?? [])}
+                              pending={pending()}
+                            />
+                          </Match>
+                          <Match when={message.role === "assistant"}>
+                            <AssistantMessage
+                              last={lastAssistant()?.id === message.id}
+                              message={message as AssistantMessage}
+                              parts={visibleMessageParts(message.id, sync.data.part[message.id] ?? [])}
+                            />
+                          </Match>
+                        </Switch>
+                      </Show>
+                    </>
                   )}
                 </For>
               </scrollbox>
+              <Show when={paging()?.loading && paging()?.loadingDirection === "newer"}>
+                <box flexShrink={0} paddingLeft={1}>
+                  <text fg={theme.textMuted}>Loading newer messages...</text>
+                </box>
+              </Show>
+              <Show when={!paging()?.loading && paging()?.hasNewer && nearBottom()}>
+                <box flexShrink={0} paddingLeft={1}>
+                  <text fg={theme.textMuted}>(scroll down for more)</text>
+                </box>
+              </Show>
               <box flexShrink={0}>
                 <Show when={permissions().length > 0}>
                   <PermissionPrompt
@@ -1324,9 +1627,7 @@ export function Session() {
                       visible={visible()}
                       ref={bind}
                       disabled={disabled()}
-                      onSubmit={() => {
-                        toBottom()
-                      }}
+                      onSubmit={afterSubmit}
                       sessionID={route.sessionID}
                       right={<pluginRuntime.Slot name="session_prompt_right" session_id={route.sessionID} />}
                     />
@@ -1473,7 +1774,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const { theme } = useTheme()
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
-  const model = createMemo(() => Model.name(ctx.providers(), props.message.providerID, props.message.modelID))
+  const model = createMemo(() => modelName(ctx.providers(), props.message.providerID, props.message.modelID))
 
   const final = createMemo(() => {
     return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)

--- a/packages/tui/src/util/pagination.ts
+++ b/packages/tui/src/util/pagination.ts
@@ -1,0 +1,235 @@
+import type { Message } from "@opencode-ai/sdk/v2"
+
+type Timed = {
+  id: string
+  time: {
+    created: number
+  }
+}
+
+const compare = (a: Timed, b: Timed) => {
+  if (a.time.created !== b.time.created) return a.time.created - b.time.created
+  if (a.id < b.id) return -1
+  if (a.id > b.id) return 1
+  return 0
+}
+
+export const messageInsert = <T extends Timed>(messages: T[], message: T) => {
+  let left = 0
+  let right = messages.length
+  while (left < right) {
+    const mid = (left + right) >>> 1
+    const current = messages[mid]
+    if (!current) break
+    if (compare(current, message) < 0) left = mid + 1
+    else right = mid
+  }
+  const found = left < messages.length && compare(messages[left]!, message) === 0
+  return { found, index: left }
+}
+
+export const messageBefore = (a: Timed, b: Timed) => compare(a, b) < 0
+
+export const revertMessageState = (message: Timed, boundaryID?: string, boundary?: Timed, boundaryPartID?: string) => {
+  if (boundaryID && !boundary) return { showBanner: false, showMessage: false }
+  const atBoundary = message.id === boundary?.id
+  return {
+    showBanner: atBoundary,
+    showMessage: !boundary || messageBefore(message, boundary) || (atBoundary && !!boundaryPartID),
+  }
+}
+
+export const hasBeforeBoundary = <T extends Timed>(messages: T[], boundary?: Timed) => {
+  if (!boundary) return true
+  return messages.some((message) => messageBefore(message, boundary))
+}
+
+export const hasUserBeforeBoundary = <T extends Timed & { role: string }>(messages: T[], boundary?: Timed) => {
+  if (!boundary) return true
+  return messages.some((message) => message.role === "user" && messageBefore(message, boundary))
+}
+
+export const visibleBeforeBoundary = <T extends { info: Timed }>(
+  messages: T[],
+  boundaryID?: string,
+  boundary?: Timed,
+  options?: { includeBoundary?: boolean },
+) => {
+  if (!boundaryID) return messages
+  const resolved = boundary ?? messages.find((message) => message.info.id === boundaryID)?.info
+  if (!resolved) return []
+  return messages.filter(
+    (message) =>
+      messageBefore(message.info, resolved) || (options?.includeBoundary === true && message.info.id === resolved.id),
+  )
+}
+
+export const visiblePartsBeforeBoundary = <T extends { id: string }>(parts: T[], boundaryPartID?: string) => {
+  if (!boundaryPartID) return parts
+  const index = parts.findIndex((part) => part.id === boundaryPartID)
+  if (index === -1) return []
+  return parts.slice(0, index)
+}
+
+type ValidatablePart = { type: string; synthetic?: boolean; ignored?: boolean }
+
+// The newest user message a human actually typed: a user message carrying at least one
+// real text part (not synthetic, not ignored). Scans newest-first and returns the match.
+export const lastValidUser = <T extends { id: string; role: string }>(
+  messages: T[],
+  partsFor: (id: string) => readonly ValidatablePart[] | undefined,
+) => {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i]
+    if (!message || message.role !== "user") continue
+    const parts = partsFor(message.id)
+    if (!parts) continue
+    if (parts.some((part) => part.type === "text" && !part.synthetic && !part.ignored)) return message
+  }
+  return undefined
+}
+
+const text = (value: unknown) => {
+  if (typeof value === "string") return value
+  if (typeof value === "number") return String(value)
+  if (typeof value === "boolean") return String(value)
+  return undefined
+}
+
+const message = (value: unknown) => {
+  if (typeof value !== "object" || value === null) return undefined
+  return text((value as Record<string, unknown>).message)
+}
+
+export const windowOldest = (messages: Message[], pinned?: string) => {
+  if (!pinned) return messages.at(0)?.id
+  for (const msg of messages) {
+    if (msg.id !== pinned) return msg.id
+  }
+  return undefined
+}
+
+export const windowNewest = (messages: Message[], pinned?: string) => {
+  if (!pinned) return messages.at(-1)?.id
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const msg = messages[i]
+    if (msg && msg.id !== pinned) return msg.id
+  }
+  return undefined
+}
+
+type Pinned = string | ReadonlySet<string>
+
+const isPinned = (id: string, pinned?: Pinned) =>
+  typeof pinned === "string" ? id === pinned : (pinned?.has(id) ?? false)
+
+export const evictFromStart = (messages: Message[], count: number, pinned?: Pinned) => {
+  const evicted: Message[] = []
+  if (count <= 0) return evicted
+  let index = 0
+  while (index < messages.length && evicted.length < count) {
+    const msg = messages[index]
+    if (!msg) break
+    if (!isPinned(msg.id, pinned)) {
+      evicted.push(msg)
+      messages.splice(index, 1)
+      continue
+    }
+    index += 1
+  }
+  return evicted
+}
+
+export const evictFromEnd = (messages: Message[], count: number, pinned?: Pinned) => {
+  const evicted: Message[] = []
+  if (count <= 0) return evicted
+  let index = messages.length - 1
+  while (index >= 0 && evicted.length < count) {
+    const msg = messages[index]
+    if (!msg) break
+    if (!isPinned(msg.id, pinned)) {
+      evicted.push(msg)
+      messages.splice(index, 1)
+    }
+    index -= 1
+  }
+  return evicted
+}
+
+export const paginationError = (error: unknown) => {
+  if (error instanceof Error) return error.message
+  const plain = text(error)
+  if (plain) return plain
+  const direct = message(error)
+  if (direct) return direct
+  if (typeof error === "object" && error !== null) {
+    const nested = message((error as Record<string, unknown>).error)
+    if (nested) return nested
+    return Bun.inspect(error)
+  }
+  return "Unknown error"
+}
+
+export const olderSearchCanContinue = (
+  previousCursor: string | undefined,
+  page: { hasOlder: boolean; loading: boolean; olderCursor?: string } | undefined,
+) => !!page?.hasOlder && !page.loading && !!page.olderCursor && page.olderCursor !== previousCursor
+
+export const queueBoundaryLoad = (
+  delta: number,
+  older: () => void,
+  newer: () => void,
+  queue: (run: () => void) => void = (run) => {
+    setTimeout(run, 0)
+  },
+) => {
+  if (delta < 0) {
+    queue(older)
+    return
+  }
+  if (delta > 0) queue(newer)
+}
+
+type Edges = {
+  nearTop: boolean
+  nearBottom: boolean
+}
+
+export const edgeHints = (
+  scrollTop: number,
+  scrollHeight: number,
+  viewportHeight: number,
+  threshold: number,
+): Edges => {
+  return {
+    nearTop: scrollTop <= threshold,
+    nearBottom: scrollHeight - scrollTop - viewportHeight <= threshold,
+  }
+}
+
+type Anchor = {
+  id: string
+  offset: number
+}
+
+type Child = {
+  id?: string
+  y: number
+  height: number
+}
+
+export const olderScrollTarget = (
+  children: Child[],
+  nextHeight: number,
+  prevHeight: number,
+  prevTop: number,
+  anchor?: Anchor,
+) => {
+  if (anchor) {
+    const child = children.find((item) => item.id === anchor.id)
+    if (child) return child.y + anchor.offset
+  }
+  const delta = nextHeight - prevHeight
+  if (delta > 0) return prevTop + delta
+  return undefined
+}

--- a/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
@@ -9,6 +9,8 @@ const messageID = "msg_hydration_race"
 const partID = "prt_hydration_race"
 const session = {
   id: sessionID,
+  slug: "race",
+  projectID: "proj_test",
   title: "race",
   time: { created: 0, updated: 0 },
   version: "1.15.13",
@@ -28,10 +30,109 @@ const assistant = {
   tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
   time: { created: 1, completed: 2 },
 }
+const olderLink = (before: string) => `<http://localhost/session/${sessionID}/message?before=${before}>; rel="next"`
+const newerLink = (after: string) => `<http://localhost/session/${sessionID}/message?after=${after}>; rel="prev"`
 
 function global(payload: GlobalEvent["payload"]): GlobalEvent {
   return { directory: "/tmp/other", project: "proj_test", payload }
 }
+
+test("session deletion clears the hydrated message window", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const part = { id: partID, sessionID, messageID, type: "text" as const, text: "hello" }
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`)
+      return json([{ info: assistant, parts: [part], cursor: "cursor_message" }])
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    expect(sync.data.message[sessionID]?.map((message) => message.id)).toEqual([messageID])
+    expect(sync.data.part[messageID]).toEqual([part])
+    expect(sync.data.message_page[sessionID]).toBeDefined()
+
+    emit(global({ id: "evt_delete", type: "session.deleted", properties: { sessionID, info: session } }))
+    await wait(() => sync.data.message[sessionID] === undefined)
+
+    expect(sync.data.part[messageID]).toBeUndefined()
+    expect(sync.data.message_cursor[messageID]).toBeUndefined()
+    expect(sync.data.message_page[sessionID]).toBeUndefined()
+    expect(sync.data.todo[sessionID]).toBeUndefined()
+    expect(sync.data.session_diff[sessionID]).toBeUndefined()
+
+    emit(
+      global({
+        id: "evt_late_message",
+        type: "message.updated",
+        properties: { sessionID, info: { ...assistant, id: "msg_late" } },
+      }),
+    )
+    emit(
+      global({
+        id: "evt_late_status",
+        type: "session.status",
+        properties: { sessionID, status: { type: "idle" } },
+      }),
+    )
+    expect(sync.data.message[sessionID]).toBeUndefined()
+    expect(sync.data.session_status[sessionID]).toBeUndefined()
+
+    const recreated = { ...session, time: { created: 1, updated: 1 } }
+    emit(global({ id: "evt_recreate", type: "session.created", properties: { sessionID, info: recreated } }))
+    await wait(() => sync.session.get(sessionID)?.time.created === 1)
+    expect(sync.session.get(sessionID)).toEqual(recreated)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("stale hydration cannot overwrite a recreated session with the same ID", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const recreated = { ...session, title: "recreated", time: { created: 2, updated: 2 } }
+  const staleMessage = { ...assistant, id: "msg_stale" }
+  const recreatedMessage = { ...assistant, id: "msg_recreated", time: { created: 3, completed: 4 } }
+  let resolveStaleMessages!: (response: Response) => void
+  const staleMessages = new Promise<Response>((resolve) => {
+    resolveStaleMessages = resolve
+  })
+  let messageRequests = 0
+  let recreatedSession = false
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(recreatedSession ? recreated : session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      messageRequests += 1
+      if (messageRequests === 1) return staleMessages
+      return json([{ info: recreatedMessage, parts: [], cursor: "cursor_recreated" }])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    const staleSync = sync.session.sync(sessionID)
+    await wait(() => messageRequests === 1)
+
+    emit(global({ id: "evt_delete", type: "session.deleted", properties: { sessionID, info: session } }))
+    recreatedSession = true
+    emit(global({ id: "evt_recreate", type: "session.created", properties: { sessionID, info: recreated } }))
+    await wait(() => sync.session.get(sessionID)?.title === "recreated")
+    await sync.session.sync(sessionID)
+
+    resolveStaleMessages(json([{ info: staleMessage, parts: [], cursor: "cursor_stale" }]))
+    await staleSync
+
+    expect(sync.session.get(sessionID)?.title).toBe("recreated")
+    expect(sync.data.message[sessionID]?.map((message) => message.id)).toEqual([recreatedMessage.id])
+  } finally {
+    app.renderer.destroy()
+  }
+})
 
 test("live messages use creation time with an ID tie-break", async () => {
   await using tmp = await tmpdir()
@@ -148,6 +249,83 @@ test("orphan live deltas do not suppress hydrated parts", async () => {
   }
 })
 
+test("orphan live part updates do not suppress hydrated parts", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let resolveMessages!: (response: Response) => void
+  const messages = new Promise<Response>((resolve) => {
+    resolveMessages = resolve
+  })
+  let requested = false
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      requested = true
+      return messages
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    const hydrate = sync.session.sync(sessionID)
+    await wait(() => requested)
+    emit(
+      global({
+        id: "evt_part",
+        type: "message.part.updated",
+        properties: {
+          sessionID,
+          time: 1,
+          part: { id: partID, sessionID, messageID, type: "text", text: "orphan" },
+        },
+      }),
+    )
+    resolveMessages(
+      json([{ info: assistant, parts: [{ id: partID, sessionID, messageID, type: "text", text: "hydrated" }] }]),
+    )
+    await hydrate
+
+    expect(sync.data.part[messageID][0]).toMatchObject({ text: "hydrated" })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("stale session hydration does not overwrite a live revert update", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let resolveMessages!: (response: Response) => void
+  const messages = new Promise<Response>((resolve) => {
+    resolveMessages = resolve
+  })
+  let requested = false
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      requested = true
+      return messages
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    const hydrate = sync.session.sync(sessionID)
+    await wait(() => requested)
+    const updated = { ...session, revert: { messageID: "msg_boundary" } }
+    emit(global({ id: "evt_revert", type: "session.updated", properties: { sessionID, info: updated } }))
+    resolveMessages(json([]))
+    await hydrate
+
+    expect(sync.session.get(sessionID)?.revert).toEqual(updated.revert)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("hydration does not clear text streamed before it starts", async () => {
   await using tmp = await tmpdir()
   await Bun.write(`${tmp.path}/kv.json`, "{}")
@@ -199,7 +377,7 @@ test("hydration does not clear text streamed before it starts", async () => {
   }
 })
 
-test("live messages merged during hydration retain the 100 message window", async () => {
+test("live messages trigger a fresh bounded latest page during hydration", async () => {
   await using tmp = await tmpdir()
   await Bun.write(`${tmp.path}/kv.json`, "{}")
 
@@ -207,12 +385,23 @@ test("live messages merged during hydration retain the 100 message window", asyn
   const messages = new Promise<Response>((resolve) => {
     resolveMessages = resolve
   })
-  let requested = false
+  let loads = 0
+  const live = { ...assistant, id: "msg_z_live" }
   const { app, emit, sync } = await mount((url) => {
     if (url.pathname === `/session/${sessionID}`) return json(session)
     if (url.pathname === `/session/${sessionID}/message`) {
-      requested = true
-      return messages
+      loads += 1
+      if (loads === 1) return messages
+      return json([
+        ...Array.from({ length: 99 }, (_, offset) => {
+          const id = `msg_${String(offset + 1).padStart(3, "0")}`
+          return {
+            info: { ...assistant, id },
+            parts: [{ id: `prt_${id}`, sessionID, messageID: id, type: "text", text: id }],
+          }
+        }),
+        { info: live, parts: [] },
+      ])
     }
     if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
     return undefined
@@ -220,8 +409,7 @@ test("live messages merged during hydration retain the 100 message window", asyn
 
   try {
     const hydrate = sync.session.sync(sessionID)
-    await wait(() => requested)
-    const live = { ...assistant, id: "msg_z_live" }
+    await wait(() => loads === 1)
     emit(global({ id: "evt_live", type: "message.updated", properties: { sessionID, info: live } }))
     await wait(() => sync.data.message[sessionID]?.some((message) => message.id === live.id) ?? false)
     resolveMessages(
@@ -236,11 +424,87 @@ test("live messages merged during hydration retain the 100 message window", asyn
       ),
     )
     await hydrate
+    await wait(() => loads === 2)
+    await wait(() => sync.data.message[sessionID]?.length === 100)
 
     expect(sync.data.message[sessionID]).toHaveLength(100)
     expect(sync.data.message[sessionID].at(-1)?.id).toBe(live.id)
     expect(sync.data.message[sessionID].some((message) => message.id === "msg_000")).toBe(false)
     expect(sync.data.part.msg_000).toBeUndefined()
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("failed live reconciliation leaves initial hydration retryable", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let resolveMessages!: (response: Response) => void
+  const messages = new Promise<Response>((resolve) => {
+    resolveMessages = resolve
+  })
+  let loads = 0
+  const live = { ...assistant, id: "msg_live_retry", time: { created: 4 } }
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      loads += 1
+      if (loads === 1) return messages
+      if (loads === 2) return json({ message: "retry failed" }, { status: 500 })
+      return json([{ info: live, parts: [] }])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    const hydrate = sync.session.sync(sessionID)
+    await wait(() => loads === 1)
+    emit(global({ id: "evt_live", type: "message.updated", properties: { sessionID, info: live } }))
+    await wait(() => sync.data.message[sessionID]?.some((message) => message.id === live.id) ?? false)
+    resolveMessages(json([]))
+    await hydrate
+    await wait(() => loads === 2)
+    await wait(() => !!sync.data.message_page[sessionID]?.error)
+
+    await sync.session.sync(sessionID)
+    await wait(() => loads === 3)
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual([live.id])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("failed latest reconciliation invalidates a completed session sync", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let loads = 0
+  const initial = { ...assistant, id: "msg_initial", time: { created: 1 } }
+  const recovered = { ...assistant, id: "msg_recovered", time: { created: 2 } }
+  const { app, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      loads += 1
+      if (loads === 1) return json([{ info: initial, parts: [] }])
+      if (loads === 2) return json({ message: "latest failed" }, { status: 500 })
+      return json([{ info: recovered, parts: [] }])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    await sync.session.jumpToLatest(sessionID, { force: true })
+    expect(sync.data.message_page[sessionID]?.error).toBeTruthy()
+
+    await sync.session.sync(sessionID)
+    await wait(() => loads === 3)
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual([recovered.id])
   } finally {
     app.renderer.destroy()
   }
@@ -279,6 +543,330 @@ test("a message removed during hydration does not regain stale parts", async () 
 
     expect(sync.data.message[sessionID]).toEqual([])
     expect(sync.data.part[messageID]).toBeUndefined()
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("revert repair exposes a newer cursor when its bounded window drops messages", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const previousUser = {
+    id: "msg_previous_user",
+    sessionID,
+    role: "user" as const,
+    agent: "build",
+    model: { providerID: "test", modelID: "model" },
+    time: { created: 0 },
+  }
+  const assistants = Array.from({ length: 150 }, (_, index) => ({
+    ...assistant,
+    id: `msg_gap_${String(index + 1).padStart(3, "0")}`,
+    parentID: previousUser.id,
+    time: { created: index + 1, completed: index + 1 },
+  }))
+  const boundary = {
+    ...previousUser,
+    id: "msg_boundary",
+    time: { created: 151 },
+  }
+  const latestAssistant = assistants.at(-1)
+  expect(latestAssistant).toBeDefined()
+  if (!latestAssistant) return
+  const item = (info: (typeof assistants)[number] | typeof previousUser | typeof boundary) => ({
+    info,
+    parts: [],
+    cursor: `cursor_${info.id}`,
+  })
+  let newerCursor: string | undefined
+  const { app, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: { messageID: boundary.id } })
+    if (url.pathname === `/session/${sessionID}/message/${boundary.id}`) return json(item(boundary))
+    if (url.pathname === `/session/${sessionID}/message`) {
+      const before = url.searchParams.get("before")
+      if (before === `cursor_${boundary.id}`)
+        return json(assistants.slice(51).map(item), { headers: { link: olderLink("cursor_gap") } })
+      if (before === "cursor_gap") return json([item(previousUser), ...assistants.slice(0, 51).map(item)])
+      const after = url.searchParams.get("after")
+      if (after) {
+        newerCursor = after
+        return json([item(latestAssistant)])
+      }
+      return json([item(boundary)])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    const page = sync.data.message_page[sessionID]
+    expect(page.hasNewer).toBe(true)
+    expect(page.newerCursor).toBeTruthy()
+
+    await sync.session.loadNewer(sessionID)
+    expect(newerCursor).toBe(page.newerCursor)
+    expect(sync.data.message[sessionID].some((message) => message.id === latestAssistant.id)).toBe(true)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("jump to latest preserves live messages received while the page loads", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let loads = 0
+  const live = { ...assistant, id: "msg_live", time: { created: 4 } }
+  let resolveLatest!: (response: Response) => void
+  const latest = new Promise<Response>((resolve) => {
+    resolveLatest = resolve
+  })
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      loads += 1
+      if (loads === 1)
+        return json([{ info: { ...assistant, id: "msg_old" }, parts: [] }], {
+          headers: { link: newerLink("newer") },
+        })
+      if (loads === 2) return latest
+      return json([
+        { info: { ...assistant, id: "msg_latest", time: { created: 3 } }, parts: [] },
+        { info: live, parts: [{ id: "prt_live", sessionID, messageID: live.id, type: "text", text: "live" }] },
+      ])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    const jump = sync.session.jumpToLatest(sessionID)
+    await wait(() => loads === 2)
+    emit(global({ id: "evt_live", type: "message.updated", properties: { sessionID, info: live } }))
+    emit(
+      global({
+        id: "evt_live_part",
+        type: "message.part.updated",
+        properties: {
+          sessionID,
+          time: 4,
+          part: { id: "prt_live", sessionID, messageID: live.id, type: "text", text: "live" },
+        },
+      }),
+    )
+    await wait(() => sync.data.part[live.id]?.length === 1)
+
+    resolveLatest(json([{ info: { ...assistant, id: "msg_latest", time: { created: 3 } }, parts: [] }]))
+    await jump
+    await wait(() => loads === 3)
+    await wait(() => sync.data.message[sessionID]?.at(-1)?.id === live.id)
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_latest", live.id])
+    expect(sync.data.part[live.id]?.[0]).toMatchObject({ text: "live" })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("jump to oldest keeps the fetched window contiguous when live messages arrive", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let resolveOldest!: (response: Response) => void
+  const oldest = new Promise<Response>((resolve) => {
+    resolveOldest = resolve
+  })
+  let oldestRequested = false
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("oldest") === "true") {
+      oldestRequested = true
+      return oldest
+    }
+    if (url.pathname === `/session/${sessionID}/message`)
+      return json([{ info: { ...assistant, id: "msg_latest", time: { created: 3 } }, parts: [] }], {
+        headers: { link: olderLink("older") },
+      })
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    const jump = sync.session.jumpToOldest(sessionID)
+    await wait(() => oldestRequested)
+    const live = { ...assistant, id: "msg_live", time: { created: 4 } }
+    emit(global({ id: "evt_live", type: "message.updated", properties: { sessionID, info: live } }))
+    emit(
+      global({
+        id: "evt_live_part",
+        type: "message.part.updated",
+        properties: {
+          sessionID,
+          time: 4,
+          part: { id: "prt_live", sessionID, messageID: live.id, type: "text", text: "live" },
+        },
+      }),
+    )
+    await wait(() => sync.data.part[live.id]?.length === 1)
+
+    resolveOldest(
+      json([{ info: { ...assistant, id: "msg_oldest", time: { created: 1 } }, parts: [] }], {
+        headers: { link: newerLink("newer") },
+      }),
+    )
+    await jump
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_oldest"])
+    expect(sync.data.part[live.id]).toBeUndefined()
+    expect(sync.data.message_page[sessionID]).toMatchObject({
+      newest: "msg_oldest",
+      newerCursor: "newer",
+    })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("jump to latest drops updated messages outside the fetched window", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let loads = 0
+  let resolveLatest!: (response: Response) => void
+  const latest = new Promise<Response>((resolve) => {
+    resolveLatest = resolve
+  })
+  const old = { ...assistant, id: "msg_old", time: { created: 1 } }
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      loads += 1
+      if (loads === 1) return json([{ info: old, parts: [] }], { headers: { link: newerLink("newer") } })
+      return latest
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    const jump = sync.session.jumpToLatest(sessionID)
+    await wait(() => loads === 2)
+    emit(
+      global({
+        id: "evt_old",
+        type: "message.updated",
+        properties: { sessionID, info: { ...old, time: { created: 1, completed: 4 } } },
+      }),
+    )
+    resolveLatest(json([{ info: { ...assistant, id: "msg_latest", time: { created: 3 } }, parts: [] }]))
+    await jump
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_latest"])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("message remove and re-add does not restore stale hydrated parts", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let loads = 0
+  let resolveLatest!: (response: Response) => void
+  const latest = new Promise<Response>((resolve) => {
+    resolveLatest = resolve
+  })
+  const old = { ...assistant, id: "msg_readded", time: { created: 1 } }
+  const stalePart = { id: "prt_stale", sessionID, messageID: old.id, type: "text" as const, text: "stale" }
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      loads += 1
+      if (loads === 1) return json([{ info: old, parts: [stalePart] }], { headers: { link: newerLink("newer") } })
+      return latest
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    const jump = sync.session.jumpToLatest(sessionID)
+    await wait(() => loads === 2)
+    emit(global({ id: "evt_removed", type: "message.removed", properties: { sessionID, messageID: old.id } }))
+    emit(global({ id: "evt_readded", type: "message.updated", properties: { sessionID, info: old } }))
+    await wait(() => sync.data.message[sessionID]?.some((message) => message.id === old.id) ?? false)
+    resolveLatest(json([{ info: old, parts: [stalePart] }]))
+    await jump
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual([old.id])
+    expect(sync.data.part[old.id]).toEqual([])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("jump to oldest drains a latest reconciliation queued by a revert update", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  let resolveOldest!: (response: Response) => void
+  const oldest = new Promise<Response>((resolve) => {
+    resolveOldest = resolve
+  })
+  let latestLoads = 0
+  let oldestRequested = false
+  const initial = { ...session, revert: undefined }
+  const updated = { ...session, revert: { messageID: "msg_boundary" } }
+  const boundary = {
+    id: "msg_boundary",
+    sessionID,
+    role: "user" as const,
+    agent: "build",
+    model: { providerID: "test", modelID: "model" },
+    time: { created: 2 },
+  }
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(initial)
+    if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("oldest") === "true") {
+      oldestRequested = true
+      return oldest
+    }
+    if (url.pathname === `/session/${sessionID}/message/${boundary.id}`) return json({ info: boundary, parts: [] })
+    if (url.pathname === `/session/${sessionID}/message`) {
+      latestLoads += 1
+      if (latestLoads === 1)
+        return json([{ info: { ...assistant, id: "msg_latest", time: { created: 3 } }, parts: [] }], {
+          headers: { link: olderLink("older") },
+        })
+      return json([
+        { info: boundary, parts: [] },
+        { info: { ...assistant, id: "msg_after_revert", time: { created: 3 } }, parts: [] },
+      ])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    await sync.session.sync(sessionID)
+    const jump = sync.session.jumpToOldest(sessionID)
+    await wait(() => oldestRequested)
+    emit(global({ id: "evt_revert", type: "session.updated", properties: { sessionID, info: updated } }))
+    resolveOldest(
+      json([{ info: { ...assistant, id: "msg_oldest", time: { created: 1 } }, parts: [] }], {
+        headers: { link: newerLink("newer") },
+      }),
+    )
+    await jump
+    await wait(() => latestLoads === 2)
+
+    expect(sync.data.message[sessionID].map((message) => message.id)).toEqual([boundary.id, "msg_after_revert"])
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/cli/cmd/tui/sync-undefined-messages.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-undefined-messages.test.tsx
@@ -19,6 +19,8 @@ describe("tui sync (#26560)", () => {
 
     const sessionPayload = {
       id: sessionID,
+      slug: "broken",
+      projectID: "proj_test",
       title: "broken",
       time: { created: 0, updated: 0 },
       version: "1.14.42",
@@ -27,7 +29,54 @@ describe("tui sync (#26560)", () => {
     }
     const { app, sync } = await mount((url) => {
       if (url.pathname === `/session/${sessionID}`) return json(sessionPayload)
-      if (url.pathname === `/session/${sessionID}/messages`) return json({}, { status: 500 })
+      if (url.pathname === `/session/${sessionID}/message`) return json({}, { status: 500 })
+      if (url.pathname === `/session/${sessionID}/todo`) return json([])
+      if (url.pathname === `/session/${sessionID}/diff`) return json([])
+      if (url.pathname === "/session") return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await expect(sync.session.sync(sessionID)).resolves.toBeUndefined()
+      expect(sync.session.get(sessionID)).toEqual(sessionPayload)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("retries message hydration after an initial endpoint error", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let loads = 0
+    const sessionPayload = {
+      id: sessionID,
+      slug: "broken",
+      projectID: "proj_test",
+      title: "broken",
+      time: { created: 0, updated: 0 },
+      version: "1.14.42",
+      directory,
+      project_id: "proj_test",
+    }
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json(sessionPayload)
+      if (url.pathname === `/session/${sessionID}/message`) {
+        loads += 1
+        if (loads === 1) return json({}, { status: 500 })
+        return json([
+          {
+            info: {
+              id: "msg_retry",
+              sessionID,
+              role: "user",
+              agent: "build",
+              model: { providerID: "test", modelID: "model" },
+              time: { created: 1 },
+            },
+            parts: [],
+          },
+        ])
+      }
       if (url.pathname === `/session/${sessionID}/todo`) return json([])
       if (url.pathname === `/session/${sessionID}/diff`) return json([])
       if (url.pathname === "/session") return json([sessionPayload])
@@ -35,7 +84,11 @@ describe("tui sync (#26560)", () => {
     }, tmp.path)
 
     try {
-      await expect(sync.session.sync(sessionID)).resolves.toBeUndefined()
+      await sync.session.sync(sessionID)
+      await sync.session.sync(sessionID)
+
+      expect(loads).toBe(2)
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_retry"])
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import { describe, expect, test } from "bun:test"
 import { tmpdir } from "../../../fixture/fixture"
-import { mount, wait } from "./sync-fixture"
+import { json, mount, wait } from "./sync-fixture"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 
 function branchEvent(branch: string, workspace?: string): GlobalEvent {
@@ -16,6 +16,40 @@ function branchEvent(branch: string, workspace?: string): GlobalEvent {
     },
   }
 }
+
+const sessionID = "ses_revert_window"
+const session = {
+  id: sessionID,
+  title: "revert",
+  time: { created: 0, updated: 0 },
+  version: "1.15.13",
+  directory: "/tmp/opencode/packages/tui",
+  revert: { messageID: "msg_boundary" },
+}
+const user = (id: string, created: number) => ({
+  id,
+  sessionID,
+  role: "user" as const,
+  agent: "build",
+  model: { providerID: "test", modelID: "model" },
+  time: { created },
+})
+const assistant = (id: string, created: number) => ({
+  id,
+  sessionID,
+  role: "assistant" as const,
+  agent: "build",
+  modelID: "model",
+  providerID: "test",
+  mode: "build",
+  parentID: "msg_boundary",
+  path: { cwd: session.directory, root: session.directory },
+  cost: 0,
+  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  time: { created, completed: created },
+})
+const link = (before: string) => `<http://localhost/session/${sessionID}/message?before=${before}>; rel="next"`
+const newerLink = (after: string) => `<http://localhost/session/${sessionID}/message?after=${after}>; rel="prev"`
 
 describe("tui sync", () => {
   test("refresh scopes sessions by default and lists project sessions when disabled", async () => {
@@ -58,6 +92,394 @@ describe("tui sync", () => {
       await wait(() => sync.data.vcs?.branch === "feature")
 
       expect(sync.data.vcs?.branch).toBe("feature")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("revert latest load walks the raw cursor when an older server omits the boundary cursor", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const requests: string[] = []
+    const { app, sync } = await mount((url) => {
+      requests.push(url.toString())
+      if (url.pathname === `/session/${sessionID}`) return json(session)
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("before") === "raw-hidden-older")
+        return json([{ info: user("msg_prior", 1), parts: [] }])
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: assistant("msg_newer", 3), parts: [] }], {
+          headers: { link: link("raw-hidden-older") },
+        })
+      if (url.pathname === `/session/${sessionID}/message/msg_boundary`)
+        return json({ info: user("msg_boundary", 2), parts: [] })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+
+      expect(requests.some((url) => new URL(url).searchParams.get("before") === "raw-hidden-older")).toBe(true)
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual([
+        "msg_prior",
+        "msg_boundary",
+        "msg_newer",
+      ])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ hasOlder: false, olderCursor: undefined })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("revert latest load retains the page cursor when an older server omits the boundary cursor", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json(session)
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json(
+          [
+            { info: user("msg_prior", 1), parts: [] },
+            { info: assistant("msg_newer", 3), parts: [] },
+          ],
+          { headers: { link: link("raw-hidden-older") } },
+        )
+      if (url.pathname === `/session/${sessionID}/message/msg_boundary`)
+        return json({ info: user("msg_boundary", 2), parts: [] })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual([
+        "msg_prior",
+        "msg_boundary",
+        "msg_newer",
+      ])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ hasOlder: true, olderCursor: "raw-hidden-older" })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("revert latest load stops when an older server repeats its page", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let olderRequests = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json(session)
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("before") === "repeat") {
+        olderRequests += 1
+        return json([{ info: assistant("msg_newer", 3), parts: [] }], { headers: { link: link("repeat") } })
+      }
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: assistant("msg_newer", 3), parts: [] }], { headers: { link: link("repeat") } })
+      if (url.pathname === `/session/${sessionID}/message/msg_boundary`)
+        return json({ info: user("msg_boundary", 2), parts: [] })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+
+      expect(olderRequests).toBe(1)
+      expect(sync.data.message[sessionID]).toBeUndefined()
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("jump to latest retains the 500 message window", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let loads = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message`) {
+        loads += 1
+        if (loads === 1)
+          return json([{ info: user("msg_old", 0), parts: [] }], {
+            headers: { link: newerLink("newer") },
+          })
+        return json(
+          Array.from({ length: 501 }, (_, index) => {
+            const id = `msg_${String(index).padStart(3, "0")}`
+            return { info: user(id, index + 1), parts: [] }
+          }),
+        )
+      }
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.jumpToLatest(sessionID)
+
+      expect(sync.data.message[sessionID]).toHaveLength(500)
+      expect(sync.data.message[sessionID].at(0)?.id).toBe("msg_001")
+      expect(sync.data.message[sessionID].at(-1)?.id).toBe("msg_500")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("jump to oldest falls back to before paging when an older server rejects oldest", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("oldest") === "true")
+        return json({}, { status: 400 })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("before") === "older")
+        return json([{ info: user("msg_oldest", 1), parts: [] }])
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: user("msg_latest", 2), parts: [] }], { headers: { link: link("older") } })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.jumpToOldest(sessionID)
+
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_oldest"])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ hasOlder: false, loading: false })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("jump to oldest walks before links when an older server ignores oldest", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("before") === "older")
+        return json([{ info: user("msg_oldest", 1), parts: [] }])
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: user("msg_latest", 2), parts: [] }], { headers: { link: link("older") } })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.jumpToOldest(sessionID)
+
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_oldest"])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ hasOlder: false, loading: false })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("jump to oldest does not hide server failures behind compatibility paging", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let fallbackRequests = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("oldest") === "true")
+        return json({}, { status: 500 })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("before") === "older") {
+        fallbackRequests += 1
+        return json([{ info: user("msg_oldest", 1), parts: [] }])
+      }
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: user("msg_latest", 2), parts: [] }], { headers: { link: link("older") } })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.jumpToOldest(sessionID)
+
+      expect(fallbackRequests).toBe(0)
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_latest"])
+      expect(sync.data.message_page[sessionID]?.error).toBeTruthy()
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("load older rejects a repeated page without losing the current window", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let requests = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message`) {
+        requests += 1
+        return json([{ info: user("msg_latest", 2), parts: [] }], { headers: { link: link("repeat") } })
+      }
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.loadOlder(sessionID)
+
+      expect(requests).toBe(2)
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_latest"])
+      expect(sync.data.message_page[sessionID]?.error).toBe("Message pagination returned no new messages")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("load older keeps unseen messages and closes a repeated cursor", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("before"))
+        return json([{ info: user("msg_older", 1), parts: [] }], { headers: { link: link("repeat") } })
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: user("msg_latest", 2), parts: [] }], { headers: { link: link("repeat") } })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.loadOlder(sessionID)
+
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_older", "msg_latest"])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ hasOlder: false, olderCursor: undefined })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("load newer rejects a repeated page without losing the current window", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let requests = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message`) {
+        requests += 1
+        return json([{ info: user("msg_oldest", 1), parts: [] }], { headers: { link: newerLink("repeat") } })
+      }
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.loadNewer(sessionID)
+
+      expect(requests).toBe(2)
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_oldest"])
+      expect(sync.data.message_page[sessionID]?.error).toBe("Message pagination returned no new messages")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("load newer keeps unseen messages and closes a repeated cursor", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message` && url.searchParams.get("after"))
+        return json([{ info: user("msg_newer", 2), parts: [] }], { headers: { link: newerLink("repeat") } })
+      if (url.pathname === `/session/${sessionID}/message`)
+        return json([{ info: user("msg_oldest", 1), parts: [] }], { headers: { link: newerLink("repeat") } })
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.loadNewer(sessionID)
+
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_oldest", "msg_newer"])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ hasNewer: false, newerCursor: undefined })
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("all messages rejects repeated cursors without looping", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let requests = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname !== `/session/${sessionID}/message`) return undefined
+      requests += 1
+      return json([{ info: user("msg_same", 1), parts: [] }], { headers: { link: link("repeat") } })
+    }, tmp.path)
+
+    try {
+      await expect(sync.session.allMessages(sessionID)).rejects.toThrow("Message pagination returned no new messages")
+      expect(requests).toBe(2)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("all messages rejects empty pages that advertise more history", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let requests = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname !== `/session/${sessionID}/message`) return undefined
+      requests += 1
+      if (url.searchParams.get("before")) return json([], { headers: { link: link("next") } })
+      return json([{ info: user("msg_latest", 2), parts: [] }], { headers: { link: link("first") } })
+    }, tmp.path)
+
+    try {
+      await expect(sync.session.allMessages(sessionID)).rejects.toThrow("Message pagination returned no new messages")
+      expect(requests).toBe(2)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("jump to latest preserves cached messages when the latest page fails", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    let loads = 0
+    const { app, sync } = await mount((url) => {
+      if (url.pathname === `/session/${sessionID}`) return json({ ...session, revert: undefined })
+      if (url.pathname === `/session/${sessionID}/message`) {
+        loads += 1
+        if (loads === 1)
+          return json([{ info: user("msg_old", 0), parts: [] }], {
+            headers: { link: newerLink("newer") },
+          })
+        return json({}, { status: 500 })
+      }
+      if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`)
+        return json([])
+      return undefined
+    }, tmp.path)
+
+    try {
+      await sync.session.sync(sessionID)
+      await sync.session.jumpToLatest(sessionID)
+
+      expect(sync.data.message[sessionID].map((message) => message.id)).toEqual(["msg_old"])
+      expect(sync.data.message_page[sessionID]).toMatchObject({ loading: false })
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/util/pagination-helpers.test.ts
+++ b/packages/tui/test/util/pagination-helpers.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, test } from "bun:test"
+import type { Message } from "@opencode-ai/sdk/v2"
+import {
+  edgeHints,
+  evictFromEnd,
+  evictFromStart,
+  hasBeforeBoundary,
+  hasUserBeforeBoundary,
+  lastValidUser,
+  messageBefore,
+  messageInsert,
+  olderScrollTarget,
+  olderSearchCanContinue,
+  paginationError,
+  queueBoundaryLoad,
+  revertMessageState,
+  visibleBeforeBoundary,
+  visiblePartsBeforeBoundary,
+  windowNewest,
+  windowOldest,
+} from "../../src/util/pagination"
+
+const make = (ids: string[]) =>
+  ids.map(
+    (id) =>
+      ({
+        id,
+        sessionID: "ses_test",
+        role: "user",
+        agent: "default",
+        model: { providerID: "test", modelID: "test" },
+        time: { created: Date.now() },
+      }) as Message,
+  )
+
+describe("tui pagination helpers", () => {
+  test("window bounds skip pinned message", () => {
+    const messages = make(["m1", "m2", "m3", "m4"])
+    expect(windowOldest(messages, "m1")).toBe("m2")
+    expect(windowNewest(messages, "m4")).toBe("m3")
+  })
+
+  test("detects whether any loaded message is visible before the revert boundary", () => {
+    const boundary = { ...make(["m6"])[0], time: { created: 6 } }
+    expect(hasBeforeBoundary([{ ...make(["m6"])[0], time: { created: 6 } }], boundary)).toBe(false)
+    expect(hasBeforeBoundary([{ ...make(["m5"])[0], time: { created: 5 } }, boundary], boundary)).toBe(true)
+  })
+
+  test("requires a user message before the revert boundary", () => {
+    const boundary = { ...make(["m6"])[0], time: { created: 6 }, role: "user" as const }
+    const assistant = { ...make(["m5"])[0], time: { created: 5 }, role: "assistant" as const }
+    const user = { ...make(["m4"])[0], time: { created: 4 }, role: "user" as const }
+    expect(hasUserBeforeBoundary([assistant, boundary], boundary)).toBe(false)
+    expect(hasUserBeforeBoundary([assistant, user, boundary], boundary)).toBe(true)
+  })
+
+  test("lastValidUser returns the newest real user message", () => {
+    const messages = [
+      { id: "m1", role: "user" },
+      { id: "m2", role: "assistant" },
+      { id: "m3", role: "user" },
+    ]
+    const parts: Record<string, { type: string; synthetic?: boolean; ignored?: boolean }[]> = {
+      m1: [{ type: "text" }],
+      m2: [{ type: "text" }],
+      m3: [{ type: "text" }],
+    }
+    expect(lastValidUser(messages, (id) => parts[id])?.id).toBe("m3")
+  })
+
+  test("lastValidUser skips synthetic-only, ignored-only, and partless users", () => {
+    const messages = [
+      { id: "m1", role: "user" },
+      { id: "m2", role: "user" },
+      { id: "m3", role: "user" },
+      { id: "m4", role: "user" },
+    ]
+    const parts: Record<string, { type: string; synthetic?: boolean; ignored?: boolean }[] | undefined> = {
+      m1: [{ type: "text" }],
+      m2: [{ type: "text", synthetic: true }],
+      m3: [{ type: "text", ignored: true }],
+      m4: undefined,
+    }
+    expect(lastValidUser(messages, (id) => parts[id])?.id).toBe("m1")
+  })
+
+  test("lastValidUser ignores assistant messages and returns undefined when none qualify", () => {
+    const messages = [
+      { id: "m1", role: "assistant" },
+      { id: "m2", role: "user" },
+    ]
+    const parts: Record<string, { type: string; synthetic?: boolean; ignored?: boolean }[]> = {
+      m1: [{ type: "text" }],
+      m2: [{ type: "file" }],
+    }
+    expect(lastValidUser(messages, (id) => parts[id])).toBeUndefined()
+  })
+
+  test("older history search continues only when its cursor advances", () => {
+    expect(
+      olderSearchCanContinue("cursor-1", {
+        hasOlder: true,
+        loading: false,
+        olderCursor: "cursor-2",
+      }),
+    ).toBe(true)
+    expect(
+      olderSearchCanContinue("cursor-1", {
+        hasOlder: true,
+        loading: false,
+        olderCursor: "cursor-1",
+      }),
+    ).toBe(false)
+    expect(
+      olderSearchCanContinue("cursor-1", {
+        hasOlder: false,
+        loading: false,
+        olderCursor: undefined,
+      }),
+    ).toBe(false)
+  })
+
+  test("messageBefore sorts by time then id", () => {
+    const a = { ...make(["m1"])[0], time: { created: 1 } }
+    const b = { ...make(["m2"])[0], time: { created: 2 } }
+    expect(messageBefore(a, b)).toBe(true)
+  })
+
+  test("messageBefore handles fractional timestamps numerically", () => {
+    const a = { ...make(["m1"])[0], time: { created: 1710000000000.5 } }
+    const b = { ...make(["m2"])[0], time: { created: 1710000000001 } }
+    expect(messageBefore(a, b)).toBe(true)
+  })
+
+  test("visibleBeforeBoundary filters by message ordering, not ID ordering", () => {
+    const items = [
+      { info: { ...make(["msg_9"])[0], time: { created: 1 } }, parts: [] },
+      { info: { ...make(["msg_2"])[0], time: { created: 2 } }, parts: [] },
+      { info: { ...make(["msg_1"])[0], time: { created: 3 } }, parts: [] },
+    ]
+
+    expect(visibleBeforeBoundary(items, "msg_2").map((item) => item.info.id)).toEqual(["msg_9"])
+  })
+
+  test("visibleBeforeBoundary uses an already loaded boundary", () => {
+    const boundary = { ...make(["msg_boundary"])[0], time: { created: 2 } }
+    const items = [
+      { info: { ...make(["msg_before"])[0], time: { created: 1 } }, parts: [] },
+      { info: { ...make(["msg_after"])[0], time: { created: 3 } }, parts: [] },
+    ]
+
+    expect(visibleBeforeBoundary(items, "msg_boundary", boundary).map((item) => item.info.id)).toEqual(["msg_before"])
+  })
+
+  test("visibleBeforeBoundary fails closed when the boundary is not loaded", () => {
+    const items = [
+      { info: { ...make(["msg_z"])[0], time: { created: 1 } }, parts: [] },
+      { info: { ...make(["msg_a"])[0], time: { created: 3 } }, parts: [] },
+    ]
+
+    expect(visibleBeforeBoundary(items, "msg_boundary")).toEqual([])
+    expect(visibleBeforeBoundary(items, "msg_boundary", undefined, { includeBoundary: true })).toEqual([])
+  })
+
+  test("visibleBeforeBoundary can include a part-level boundary message", () => {
+    const items = [
+      { info: { ...make(["msg_before"])[0], time: { created: 1 } }, parts: [] },
+      { info: { ...make(["msg_boundary"])[0], time: { created: 2 } }, parts: [] },
+      { info: { ...make(["msg_after"])[0], time: { created: 3 } }, parts: [] },
+    ]
+
+    expect(
+      visibleBeforeBoundary(items, "msg_boundary", undefined, { includeBoundary: true }).map((item) => item.info.id),
+    ).toEqual(["msg_before", "msg_boundary"])
+  })
+
+  test("visiblePartsBeforeBoundary trims parts from the boundary part onward", () => {
+    const parts = [{ id: "part_1" }, { id: "part_2" }, { id: "part_3" }]
+
+    expect(visiblePartsBeforeBoundary(parts, "part_2").map((part) => part.id)).toEqual(["part_1"])
+    expect(visiblePartsBeforeBoundary(parts).map((part) => part.id)).toEqual(["part_1", "part_2", "part_3"])
+  })
+
+  test("part-level revert boundary shows its banner and retained message parts", () => {
+    const boundary = { ...make(["msg_boundary"])[0], time: { created: 2 } }
+
+    expect(revertMessageState(boundary, boundary.id, boundary, "part_2")).toEqual({
+      showBanner: true,
+      showMessage: true,
+    })
+  })
+
+  test("whole-message revert boundary replaces the message with its banner", () => {
+    const boundary = { ...make(["msg_boundary"])[0], time: { created: 2 } }
+
+    expect(revertMessageState(boundary, boundary.id, boundary)).toEqual({ showBanner: true, showMessage: false })
+    expect(revertMessageState(boundary, boundary.id)).toEqual({ showBanner: false, showMessage: false })
+  })
+
+  test("messageInsert uses chronological ordering", () => {
+    const messages = [
+      { ...make(["m2"])[0], time: { created: 20 } },
+      { ...make(["m3"])[0], time: { created: 30 } },
+    ]
+    const result = messageInsert(messages, { ...make(["m1"])[0], time: { created: 10 } })
+    expect(result).toEqual({ found: false, index: 0 })
+  })
+
+  test("evictFromStart skips pinned messages", () => {
+    const messages = make(["m1", "m2", "m3", "m4", "m5"])
+    const evicted = evictFromStart(messages, 2, "m2")
+    expect(evicted.map((m) => m.id)).toEqual(["m1", "m3"])
+    expect(messages.map((m) => m.id)).toEqual(["m2", "m4", "m5"])
+  })
+
+  test("evictFromEnd skips pinned messages", () => {
+    const messages = make(["m1", "m2", "m3", "m4", "m5"])
+    const evicted = evictFromEnd(messages, 2, "m4")
+    expect(evicted.map((m) => m.id)).toEqual(["m5", "m3"])
+    expect(messages.map((m) => m.id)).toEqual(["m1", "m2", "m4"])
+  })
+
+  test("paginationError reads object message fields", () => {
+    expect(paginationError({ message: "timeout" })).toBe("timeout")
+    expect(paginationError({ error: { message: "denied" } })).toBe("denied")
+  })
+
+  test("paginationError avoids [object Object] fallback", () => {
+    expect(paginationError({ foo: "bar" })).not.toBe("[object Object]")
+  })
+
+  test("queueBoundaryLoad routes direction by delta", () => {
+    let older = 0
+    let newer = 0
+    const queue = (run: () => void) => run()
+    queueBoundaryLoad(
+      -1,
+      () => older++,
+      () => newer++,
+      queue,
+    )
+    queueBoundaryLoad(
+      1,
+      () => older++,
+      () => newer++,
+      queue,
+    )
+    queueBoundaryLoad(
+      0,
+      () => older++,
+      () => newer++,
+      queue,
+    )
+    expect(older).toBe(1)
+    expect(newer).toBe(1)
+  })
+
+  test("edgeHints computes nearTop and nearBottom", () => {
+    expect(edgeHints(0, 300, 100, 20)).toEqual({ nearTop: true, nearBottom: false })
+    expect(edgeHints(200, 300, 100, 20)).toEqual({ nearTop: false, nearBottom: true })
+  })
+
+  test("olderScrollTarget prefers anchor child", () => {
+    const top = olderScrollTarget(
+      [
+        { id: "m1", y: 80, height: 20 },
+        { id: "m2", y: 120, height: 20 },
+      ],
+      500,
+      400,
+      0,
+      { id: "m1", offset: 3 },
+    )
+    expect(top).toBe(83)
+  })
+
+  test("olderScrollTarget falls back to delta", () => {
+    const top = olderScrollTarget([{ id: "m1", y: 80, height: 20 }], 500, 400, 25, {
+      id: "missing",
+      offset: 0,
+    })
+    expect(top).toBe(125)
+  })
+
+  test("olderScrollTarget can keep viewport unchanged", () => {
+    expect(olderScrollTarget([], 400, 400, 10)).toBeUndefined()
+  })
+
+  test("anchor restore moves edge state away from top", () => {
+    const top = olderScrollTarget([{ id: "m1", y: 60, height: 20 }], 500, 400, 0, {
+      id: "m1",
+      offset: 0,
+    })
+    expect(top).toBe(60)
+    expect(edgeHints(top!, 500, 100, 20).nearTop).toBe(false)
+  })
+
+  test("command scroll flow updates top hint after older load restore", () => {
+    let older = 0
+    let newer = 0
+    const queue = (run: () => void) => run()
+
+    expect(edgeHints(0, 320, 100, 20)).toEqual({ nearTop: true, nearBottom: false })
+
+    queueBoundaryLoad(
+      -40,
+      () => older++,
+      () => newer++,
+      queue,
+    )
+
+    const top = olderScrollTarget([{ id: "a", y: 55, height: 10 }], 460, 320, 0, {
+      id: "a",
+      offset: 0,
+    })
+
+    expect(older).toBe(1)
+    expect(newer).toBe(0)
+    expect(top).toBe(55)
+    expect(edgeHints(top!, 460, 100, 20)).toEqual({ nearTop: false, nearBottom: false })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #6548
Closes #28257
Closes #30587

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds bidirectional cursor pagination for session messages across the server, app, TUI, experimental HttpApi routes, and generated SDK/OpenAPI types.

This keeps large sessions usable by loading bounded message windows, using RFC 8288 `Link` headers for older/newer pages, and preserving revert/restore correctness through server-backed revert preview metadata when boundary messages are outside the loaded page.

It also resolves two open issues rooted in the TUI's single-page history load:

- #30587: scrolling up now pages older history on demand instead of stopping at a hard limit, so fork-from-history works in long sessions.
- #28257: `/undo` now walks older pages to find the last user message when trailing agent output fills the loaded window.

### Scope: v1

This PR targets the current (v1) architecture on `dev`, where the TUI loads a single `limit: 100` page and stops. The `v2` branch redesigns the API with cursor pagination built in (`message.list` with `limit`/`order`/`cursor`), so v2 will solve this differently by design. Until v2 ships, this PR is the working solution for v1 releases, and the branch is kept rebased on `dev` for anyone building from it.

### How did you verify your code works?

Verified locally on the current branch (rebased on `dev`):

- `bun typecheck` in `packages/opencode`, `packages/app`, `packages/tui`, `packages/core`, and `packages/sdk/js`
- `bun test test/session/revert-compact.test.ts test/session/messages-pagination.test.ts test/server/httpapi-session.test.ts test/server/session-messages.test.ts test/util/parse-link-header.test.ts` in `packages/opencode` (98 pass)
- `bun test --preload ./happydom.ts ./src/context/server-session.test.ts ./src/context/revert-page.test.ts ./src/pages/session/timeline/model.test.ts ./src/pages/session/timeline/projection.test.ts` in `packages/app` (108 pass)
- `bun test test/util/pagination-helpers.test.ts test/cli/cmd/tui/sync.test.tsx` in `packages/tui` (29 pass)
- Regenerated OpenAPI and SDK surfaces (`bun run generate` in `packages/client`, `./packages/sdk/js/script/build.ts`)
- `git diff --check dev..HEAD`

### Screenshots / recordings

Not included. This changes session loading/scroll behavior rather than visual styling; the behavior is covered by the targeted tests above.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

process: human-driven and reviewed, with agentic assistance from anthropic/claude-fable-5.
