### PR TITLE
fix(opencode): clarify how the "Other" option works on the questions tool

### DIFF
--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -5,6 +5,6 @@ Use this tool when you need to ask the user questions during execution. This all
 4. Offer choices to the user about what direction to take.
 
 Usage notes:
-- Users will always be able to select "Other" to provide custom text input
+- Users will always be able to select "Other" to provide custom text input; the system automatically adds this option
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label


### PR DESCRIPTION
### What does this PR do?
Clarifies on the tool description that the "Type your own answer" option is injected by the system to prevent some models from adding their own "Other" option.
<img width="873" height="321" alt="image" src="https://github.com/user-attachments/assets/f61835b8-f086-40a2-b55d-54c83fe21984" />

### How did you verify your code works?
Tested it for a couple of hours, didn't see any model adding it anymore.