### PR TITLE
fix: enable sticky header on changelog and download pages

### DIFF
--- a/packages/console/app/src/routes/changelog/index.css
+++ b/packages/console/app/src/routes/changelog/index.css
@@ -32,7 +32,6 @@
   font-family: var(--font-mono);
   color: var(--color-text);
   padding-bottom: 5rem;
-  overflow-x: hidden;
 
   @media (prefers-color-scheme: dark) {
     --color-background: hsl(0, 9%, 7%);

--- a/packages/console/app/src/routes/download/index.css
+++ b/packages/console/app/src/routes/download/index.css
@@ -34,7 +34,6 @@
   font-family: var(--font-mono);
   color: var(--color-text);
   padding-bottom: 5rem;
-  overflow-x: hidden;
 
   @media (prefers-color-scheme: dark) {
     --color-background: hsl(0, 9%, 7%);


### PR DESCRIPTION
## Summary
- Remove `overflow-x: hidden` from changelog and download page styles which was preventing the sticky header from working
- Both pages now have sticky headers consistent with `/` and `/brand` pages