### PR TITLE
feat(core): add server.enabled config option to restore HTTP server

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -134,9 +134,10 @@ export const TuiThreadCommand = cmd({
         return piped ? piped + "\n" + args.prompt : args.prompt
       })
 
-      // Check if server should be started (port or hostname explicitly set in CLI or config)
+      // Check if server should be started (explicitly enabled or network options set)
       const networkOpts = await resolveNetworkOptions(args)
       const shouldStartServer =
+        networkOpts.enabled ||
         process.argv.includes("--port") ||
         process.argv.includes("--hostname") ||
         process.argv.includes("--mdns") ||

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -22,6 +22,11 @@ const options = {
     describe: "custom domain name for mDNS service (default: opencode.local)",
     default: "opencode.local",
   },
+  "enable-server": {
+    type: "boolean" as const,
+    describe: "enable HTTP server for external connections",
+    default: false,
+  },
   cors: {
     type: "string" as const,
     array: true,
@@ -55,6 +60,8 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
+  const enableServerExplicitlySet = process.argv.includes("--enable-server")
+  const enabled = enableServerExplicitlySet ? args["enable-server"] : (config?.server?.enabled ?? false)
 
-  return { hostname, port, mdns, mdnsDomain, cors }
+  return { hostname, port, mdns, mdnsDomain, cors, enabled }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -938,6 +938,7 @@ export namespace Config {
 
   export const Server = z
     .object({
+      enabled: z.boolean().optional().describe("Enable HTTP server for TUI (allows external connections)"),
       port: z.number().int().positive().optional().describe("Port to listen on"),
       hostname: z.string().optional().describe("Hostname to listen on"),
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),


### PR DESCRIPTION
## Summary

Adds a `server.enabled` config option and `--enable-server` CLI flag that explicitly enable the HTTP server for the TUI, restoring the pre-982b71e behavior for users who need external connections (desktop app, SDK, etc).

Fixes #8561

## Usage

Config (`opencode.json`):
```json
{
  "server": {
    "enabled": true
  }
}
```

CLI:
```bash
opencode --enable-server
```

Both use the default port-0 fallback (try 4096, then random) on `127.0.0.1` — the same resilient behavior as before the server was disabled by default.

## Changes

- **`config.ts`**: Add `enabled: z.boolean().optional()` to Server schema
- **`network.ts`**: Add `--enable-server` CLI option, resolve `enabled` from CLI flag or config, return in `resolveNetworkOptions()`
- **`thread.ts`**: Add `networkOpts.enabled ||` to `shouldStartServer` condition

## Why

Since 982b71e ("disable server unless explicitly opted in"), users who need the HTTP server have no clean way to enable it:
- `port: 0` fails (schema rejects non-positive)
- `hostname: "127.0.0.1"` doesn't trigger server (matches default)
- `mdns: true` works but has unwanted side effects
- There was no config-only path to start the server on default host/port

This provides a clear, self-documenting opt-in via both config and CLI with no side effects.

## Testing

Tested locally — setting `"server": { "enabled": true }` in `opencode.json` or passing `--enable-server` correctly starts the HTTP server with the default port-0 fallback behavior.