### PR TITLE
feat: Accessibility mode for screen reader users

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/border.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/border.tsx
@@ -19,3 +19,19 @@ export const SplitBorder = {
     vertical: "┃",
   },
 }
+
+export const SplitBorderAscii = {
+  border: ["left" as const, "right" as const],
+  customBorderChars: {
+    ...EmptyBorder,
+    vertical: "|",
+  },
+}
+
+export function getSplitBorder(accessible: boolean) {
+  return accessible ? SplitBorderAscii : SplitBorder
+}
+
+export function getSplitBorderChars(accessible: boolean) {
+  return accessible ? SplitBorderAscii.customBorderChars : SplitBorder.customBorderChars
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-mcp.tsx
@@ -7,16 +7,22 @@ import { useTheme } from "../context/theme"
 import { Keybind } from "@/util/keybind"
 import { TextAttributes } from "@opentui/core"
 import { useSDK } from "@tui/context/sdk"
+import { useAccessibility } from "@tui/util/accessibility"
 
 function Status(props: { enabled: boolean; loading: boolean }) {
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
   if (props.loading) {
-    return <span style={{ fg: theme.textMuted }}>⋯ Loading</span>
+    return <span style={{ fg: theme.textMuted }}>{accessibility() ? "Loading" : "⋯ Loading"}</span>
   }
   if (props.enabled) {
-    return <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>✓ Enabled</span>
+    return (
+      <span style={{ fg: theme.success, attributes: TextAttributes.BOLD }}>
+        {accessibility() ? "Enabled" : "✓ Enabled"}
+      </span>
+    )
   }
-  return <span style={{ fg: theme.textMuted }}>○ Disabled</span>
+  return <span style={{ fg: theme.textMuted }}>{accessibility() ? "Disabled" : "○ Disabled"}</span>
 }
 
 export function DialogMcp() {

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -8,9 +8,9 @@ import { useKeybind } from "../context/keybind"
 import { useTheme } from "../context/theme"
 import { useSDK } from "../context/sdk"
 import { DialogSessionRename } from "./dialog-session-rename"
-import { useKV } from "../context/kv"
 import { createDebouncedSignal } from "../util/signal"
 import { Spinner } from "./spinner"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export function DialogSessionList() {
   const dialog = useDialog()
@@ -19,7 +19,7 @@ export function DialogSessionList() {
   const keybind = useKeybind()
   const { theme } = useTheme()
   const sdk = useSDK()
-  const kv = useKV()
+  const accessibility = useAccessibility()
 
   const [toDelete, setToDelete] = createSignal<string>()
   const [search, setSearch] = createDebouncedSignal("", 150)
@@ -54,7 +54,11 @@ export function DialogSessionList() {
           value: x.id,
           category,
           footer: Locale.time(x.time.updated),
-          gutter: isWorking ? <Spinner /> : undefined,
+          gutter: isWorking ? (
+            <Show when={!accessibility()} fallback={<text fg={theme.textMuted}>[busy]</text>}>
+              <Spinner />
+            </Show>
+          ) : undefined,
         }
       })
   })

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "../context/theme"
 import { useDialog } from "@tui/ui/dialog"
 import { useSync } from "@tui/context/sync"
 import { For, Match, Switch, Show, createMemo } from "solid-js"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export type DialogStatusProps = {}
 
@@ -11,6 +12,8 @@ export function DialogStatus() {
   const sync = useSync()
   const { theme } = useTheme()
   const dialog = useDialog()
+  const accessibility = useAccessibility()
+  const bullet = createMemo(() => (accessibility() ? "-" : "•"))
 
   const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
 
@@ -69,7 +72,7 @@ export function DialogStatus() {
                     )[item.status],
                   }}
                 >
-                  •
+                  {bullet()}
                 </text>
                 <text fg={theme.text} wrapMode="word">
                   <b>{key}</b>{" "}
@@ -107,7 +110,7 @@ export function DialogStatus() {
                     }[item.status],
                   }}
                 >
-                  •
+                  {bullet()}
                 </text>
                 <text fg={theme.text} wrapMode="word">
                   <b>{item.id}</b> <span style={{ fg: theme.textMuted }}>{item.root}</span>
@@ -129,7 +132,7 @@ export function DialogStatus() {
                     fg: theme.success,
                   }}
                 >
-                  •
+                  {bullet()}
                 </text>
                 <text wrapMode="word" fg={theme.text}>
                   <b>{item.name}</b>
@@ -151,7 +154,7 @@ export function DialogStatus() {
                     fg: theme.success,
                   }}
                 >
-                  •
+                  {bullet()}
                 </text>
                 <text wrapMode="word" fg={theme.text}>
                   <b>{item.name}</b>

--- a/packages/opencode/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/logo.tsx
@@ -1,7 +1,8 @@
 import { TextAttributes, RGBA } from "@opentui/core"
-import { For, type JSX } from "solid-js"
+import { For, Show, type JSX } from "solid-js"
 import { useTheme, tint } from "@tui/context/theme"
 import { logo, marks } from "@/cli/logo"
+import { useAccessibility } from "@tui/util/accessibility"
 
 // Shadow markers (rendered chars in parens):
 // _ = full shadow cell (space with bg=shadow)
@@ -11,6 +12,7 @@ const SHADOW_MARKER = new RegExp(`[${marks}]`)
 
 export function Logo() {
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
 
   const renderLine = (line: string, fg: RGBA, bold: boolean): JSX.Element[] => {
     const shadow = tint(theme.background, fg, 0.25)
@@ -72,14 +74,23 @@ export function Logo() {
 
   return (
     <box>
-      <For each={logo.left}>
-        {(line, index) => (
-          <box flexDirection="row" gap={1}>
-            <box flexDirection="row">{renderLine(line, theme.textMuted, false)}</box>
-            <box flexDirection="row">{renderLine(logo.right[index()], theme.text, true)}</box>
-          </box>
-        )}
-      </For>
+      <Show
+        when={!accessibility()}
+        fallback={
+          <text fg={theme.text} attributes={TextAttributes.BOLD} selectable={false}>
+            OpenCode
+          </text>
+        }
+      >
+        <For each={logo.left}>
+          {(line, index) => (
+            <box flexDirection="row" gap={1}>
+              <box flexDirection="row">{renderLine(line, theme.textMuted, false)}</box>
+              <box flexDirection="row">{renderLine(logo.right[index()], theme.text, true)}</box>
+            </box>
+          )}
+        </For>
+      </Show>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -7,12 +7,13 @@ import { createStore } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
 import { useSync } from "@tui/context/sync"
 import { useTheme, selectedForeground } from "@tui/context/theme"
-import { SplitBorder } from "@tui/component/border"
+import { getSplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util/locale"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
+import { useAccessibility } from "@tui/util/accessibility"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -79,6 +80,7 @@ export function Autocomplete(props: {
   const sync = useSync()
   const command = useCommandDialog()
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
   const dimensions = useTerminalDimensions()
   const frecency = useFrecency()
 
@@ -614,7 +616,7 @@ export function Autocomplete(props: {
       left={position().x}
       width={position().width}
       zIndex={100}
-      {...SplitBorder}
+      {...getSplitBorder(accessibility())}
       borderColor={theme.border}
     >
       <scrollbox

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -34,6 +34,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export type PromptProps = {
   sessionID?: string
@@ -77,6 +78,7 @@ export function Prompt(props: PromptProps) {
   const renderer = useRenderer()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+  const accessibility = useAccessibility()
 
   function promptModelWarning() {
     toast.show({
@@ -777,6 +779,22 @@ export function Prompt(props: PromptProps) {
       }),
     }
   })
+  const showSpinner = createMemo(() => kv.get("animations_enabled", true) && !accessibility())
+  const busyFallback = createMemo(() => (accessibility() ? "[busy]" : "[⋯]"))
+  const separator = createMemo(() => (accessibility() ? "-" : "·"))
+  const promptBorderChars = createMemo(() => ({
+    ...EmptyBorder,
+    vertical: accessibility() ? "|" : "┃",
+    bottomLeft: accessibility() ? "|" : "╹",
+  }))
+  const dividerBorderChars = createMemo(() => ({
+    ...EmptyBorder,
+    vertical: theme.backgroundElement.a !== 0 ? (accessibility() ? "|" : "╹") : " ",
+  }))
+  const dividerHorizontalChars = createMemo(() => ({
+    ...EmptyBorder,
+    horizontal: theme.backgroundElement.a !== 0 ? (accessibility() ? "-" : "▀") : " ",
+  }))
 
   return (
     <>
@@ -804,11 +822,7 @@ export function Prompt(props: PromptProps) {
         <box
           border={["left"]}
           borderColor={highlight()}
-          customBorderChars={{
-            ...EmptyBorder,
-            vertical: "┃",
-            bottomLeft: "╹",
-          }}
+          customBorderChars={promptBorderChars()}
         >
           <box
             paddingLeft={2}
@@ -1007,7 +1021,7 @@ export function Prompt(props: PromptProps) {
                   </text>
                   <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
                   <Show when={showVariant()}>
-                    <text fg={theme.textMuted}>·</text>
+                    <text fg={theme.textMuted}>{separator()}</text>
                     <text>
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
@@ -1021,26 +1035,13 @@ export function Prompt(props: PromptProps) {
           height={1}
           border={["left"]}
           borderColor={highlight()}
-          customBorderChars={{
-            ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
-          }}
+          customBorderChars={dividerBorderChars()}
         >
           <box
             height={1}
             border={["bottom"]}
             borderColor={theme.backgroundElement}
-            customBorderChars={
-              theme.backgroundElement.a !== 0
-                ? {
-                    ...EmptyBorder,
-                    horizontal: "▀",
-                  }
-                : {
-                    ...EmptyBorder,
-                    horizontal: " ",
-                  }
-            }
+            customBorderChars={dividerHorizontalChars()}
           />
         </box>
         <box flexDirection="row" justifyContent="space-between">
@@ -1053,7 +1054,7 @@ export function Prompt(props: PromptProps) {
             >
               <box flexShrink={0} flexDirection="row" gap={1}>
                 <box marginLeft={1}>
-                  <Show when={kv.get("animations_enabled", true)} fallback={<text fg={theme.textMuted}>[⋯]</text>}>
+                  <Show when={showSpinner()} fallback={<text fg={theme.textMuted}>{busyFallback()}</text>}>
                     <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
                   </Show>
                 </box>

--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -1,5 +1,6 @@
 import { createMemo, createSignal, For } from "solid-js"
 import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"
+import { useAccessibility } from "@tui/util/accessibility"
 
 const themeCount = Object.keys(DEFAULT_THEMES).length
 const themeTip = `Use {highlight}/themes{/highlight} or {highlight}Ctrl+X T{/highlight} to switch between ${themeCount} built-in themes`
@@ -32,12 +33,13 @@ function parse(tip: string): TipPart[] {
 
 export function Tips() {
   const theme = useTheme().theme
+  const accessibility = useAccessibility()
   const parts = parse(TIPS[Math.floor(Math.random() * TIPS.length)])
 
   return (
     <box flexDirection="row" maxWidth="100%">
       <text flexShrink={0} style={{ fg: theme.warning }}>
-        ● Tip{" "}
+        {accessibility() ? "Tip:" : "● Tip"}{" "}
       </text>
       <text flexShrink={1}>
         <For each={parts}>

--- a/packages/opencode/src/cli/cmd/tui/component/todo-item.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/todo-item.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "../context/theme"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export interface TodoItemProps {
   status: string
@@ -7,6 +8,15 @@ export interface TodoItemProps {
 
 export function TodoItem(props: TodoItemProps) {
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
+  const marker = () => {
+    if (!accessibility()) {
+      return props.status === "completed" ? "✓" : props.status === "in_progress" ? "•" : " "
+    }
+    if (props.status === "completed") return "x"
+    if (props.status === "in_progress") return "~"
+    return " "
+  }
 
   return (
     <box flexDirection="row" gap={0}>
@@ -16,7 +26,7 @@ export function TodoItem(props: TodoItemProps) {
           fg: props.status === "in_progress" ? theme.warning : theme.textMuted,
         }}
       >
-        [{props.status === "completed" ? "✓" : props.status === "in_progress" ? "•" : " "}]{" "}
+        [{marker()}]{" "}
       </text>
       <text
         flexGrow={1}

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -14,6 +14,7 @@ import { usePromptRef } from "../context/prompt"
 import { Installation } from "@/installation"
 import { useKV } from "../context/kv"
 import { useCommandDialog } from "../component/dialog-command"
+import { useAccessibility } from "@tui/util/accessibility"
 
 // TODO: what is the best way to do this?
 let once = false
@@ -25,6 +26,7 @@ export function Home() {
   const route = useRouteData("home")
   const promptRef = usePromptRef()
   const command = useCommandDialog()
+  const accessibility = useAccessibility()
   const mcp = createMemo(() => Object.keys(sync.data.mcp).length > 0)
   const mcpError = createMemo(() => {
     return Object.values(sync.data.mcp).some((x) => x.status === "failed")
@@ -61,11 +63,16 @@ export function Home() {
         <text fg={theme.text}>
           <Switch>
             <Match when={mcpError()}>
-              <span style={{ fg: theme.error }}>•</span> mcp errors{" "}
+              <Show when={!accessibility()}>
+                <span style={{ fg: theme.error }}>•</span>{" "}
+              </Show>
+              mcp errors{" "}
               <span style={{ fg: theme.textMuted }}>ctrl+x s</span>
             </Match>
             <Match when={true}>
-              <span style={{ fg: theme.success }}>•</span>{" "}
+              <Show when={!accessibility()}>
+                <span style={{ fg: theme.success }}>•</span>{" "}
+              </Show>
               {Locale.pluralize(connectedMcpCount(), "{} mcp server", "{} mcp servers")}
             </Match>
           </Switch>
@@ -90,6 +97,12 @@ export function Home() {
   const directory = useDirectory()
 
   const keybind = useKeybind()
+  const mcpTextColor = createMemo(() => {
+    if (!accessibility()) return theme.text
+    if (mcpError()) return theme.error
+    if (connectedMcpCount() > 0) return theme.success
+    return theme.textMuted
+  })
 
   return (
     <>
@@ -121,15 +134,17 @@ export function Home() {
         <text fg={theme.textMuted}>{directory()}</text>
         <box gap={1} flexDirection="row" flexShrink={0}>
           <Show when={mcp()}>
-            <text fg={theme.text}>
-              <Switch>
-                <Match when={mcpError()}>
-                  <span style={{ fg: theme.error }}>⊙ </span>
-                </Match>
-                <Match when={true}>
-                  <span style={{ fg: connectedMcpCount() > 0 ? theme.success : theme.textMuted }}>⊙ </span>
-                </Match>
-              </Switch>
+            <text fg={mcpTextColor()}>
+              <Show when={!accessibility()}>
+                <Switch>
+                  <Match when={mcpError()}>
+                    <span style={{ fg: theme.error }}>⊙ </span>
+                  </Match>
+                  <Match when={true}>
+                    <span style={{ fg: connectedMcpCount() > 0 ? theme.success : theme.textMuted }}>⊙ </span>
+                  </Match>
+                </Switch>
+              </Show>
               {connectedMcpCount()} MCP
             </text>
             <text fg={theme.textMuted}>/status</text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/footer.tsx
@@ -5,6 +5,7 @@ import { useDirectory } from "../../context/directory"
 import { useConnected } from "../../component/dialog-model"
 import { createStore } from "solid-js/store"
 import { useRoute } from "../../context/route"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export function Footer() {
   const { theme } = useTheme()
@@ -19,12 +20,14 @@ export function Footer() {
   })
   const directory = useDirectory()
   const connected = useConnected()
+  const accessibility = useAccessibility()
 
   const [store, setStore] = createStore({
     welcome: false,
   })
 
   onMount(() => {
+    if (accessibility()) return
     // Track all timeouts to ensure proper cleanup
     const timeouts: ReturnType<typeof setTimeout>[] = []
 
@@ -48,13 +51,25 @@ export function Footer() {
       timeouts.forEach(clearTimeout)
     })
   })
+  const showWelcome = createMemo(() => (accessibility() ? !connected() : store.welcome))
+  const lspBullet = createMemo(() => (accessibility() ? "-" : "•"))
+  const permissionLabel = createMemo(() => {
+    if (!accessibility()) return "Permission"
+    return permissions().length === 1 ? "Permission" : "Permissions"
+  })
+  const mcpTextColor = createMemo(() => {
+    if (!accessibility()) return theme.text
+    if (mcpError()) return theme.error
+    if (mcp() > 0) return theme.success
+    return theme.textMuted
+  })
 
   return (
     <box flexDirection="row" justifyContent="space-between" gap={1} flexShrink={0}>
       <text fg={theme.textMuted}>{directory()}</text>
       <box gap={2} flexDirection="row" flexShrink={0}>
         <Switch>
-          <Match when={store.welcome}>
+          <Match when={showWelcome()}>
             <text fg={theme.text}>
               Get started <span style={{ fg: theme.textMuted }}>/connect</span>
             </text>
@@ -62,23 +77,29 @@ export function Footer() {
           <Match when={connected()}>
             <Show when={permissions().length > 0}>
               <text fg={theme.warning}>
-                <span style={{ fg: theme.warning }}>△</span> {permissions().length} Permission
-                {permissions().length > 1 ? "s" : ""}
+                <Show when={!accessibility()}>
+                  <span style={{ fg: theme.warning }}>△</span>{" "}
+                </Show>
+                {permissions().length} {permissionLabel()}
+                {permissions().length > 1 && !accessibility() ? "s" : ""}
               </text>
             </Show>
             <text fg={theme.text}>
-              <span style={{ fg: lsp().length > 0 ? theme.success : theme.textMuted }}>•</span> {lsp().length} LSP
+              <span style={{ fg: lsp().length > 0 ? theme.success : theme.textMuted }}>{lspBullet()}</span>{" "}
+              {lsp().length} LSP
             </text>
             <Show when={mcp()}>
-              <text fg={theme.text}>
-                <Switch>
-                  <Match when={mcpError()}>
-                    <span style={{ fg: theme.error }}>⊙ </span>
-                  </Match>
-                  <Match when={true}>
-                    <span style={{ fg: theme.success }}>⊙ </span>
-                  </Match>
-                </Switch>
+              <text fg={mcpTextColor()}>
+                <Show when={!accessibility()}>
+                  <Switch>
+                    <Match when={mcpError()}>
+                      <span style={{ fg: theme.error }}>⊙ </span>
+                    </Match>
+                    <Match when={true}>
+                      <span style={{ fg: theme.success }}>⊙ </span>
+                    </Match>
+                  </Switch>
+                </Show>
                 {mcp()} MCP
               </text>
             </Show>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -3,11 +3,12 @@ import { useRouteData } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { pipe, sumBy } from "remeda"
 import { useTheme } from "@tui/context/theme"
-import { SplitBorder } from "@tui/component/border"
+import { getSplitBorder } from "@tui/component/border"
 import type { AssistantMessage, Session } from "@opencode-ai/sdk/v2"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
 import { useTerminalDimensions } from "@opentui/solid"
+import { useAccessibility } from "@tui/util/accessibility"
 
 const Title = (props: { session: Accessor<Session> }) => {
   const { theme } = useTheme()
@@ -65,6 +66,7 @@ export function Header() {
   const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
+  const accessibility = useAccessibility()
 
   return (
     <box flexShrink={0}>
@@ -73,7 +75,7 @@ export function Header() {
         paddingBottom={1}
         paddingLeft={2}
         paddingRight={1}
-        {...SplitBorder}
+        {...getSplitBorder(accessibility())}
         border={["left"]}
         borderColor={theme.border}
         flexShrink={0}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -15,7 +15,7 @@ import { Dynamic } from "solid-js/web"
 import path from "path"
 import { useRoute, useRouteData } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
-import { SplitBorder } from "@tui/component/border"
+import { getSplitBorderChars } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
 import { selectedForeground, useTheme } from "@tui/context/theme"
 import {
@@ -78,6 +78,7 @@ import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
+import { useAccessibility } from "@tui/util/accessibility"
 
 addDefaultParsers(parsers.parsers)
 
@@ -116,6 +117,7 @@ export function Session() {
   const kv = useKV()
   const { theme } = useTheme()
   const promptRef = usePromptRef()
+  const accessibility = useAccessibility()
   const session = createMemo(() => sync.session.get(route.sessionID))
   const children = createMemo(() => {
     const parentID = session()?.parentID ?? session()?.id
@@ -1042,7 +1044,7 @@ export function Session() {
                             marginTop={1}
                             flexShrink={0}
                             border={["left"]}
-                            customBorderChars={SplitBorder.customBorderChars}
+                            customBorderChars={getSplitBorderChars(accessibility())}
                             borderColor={theme.backgroundPanel}
                           >
                             <box
@@ -1186,6 +1188,7 @@ function UserMessage(props: {
   const sync = useSync()
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
+  const accessibility = useAccessibility()
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
   const color = createMemo(() => local.agent.color(props.message.agent))
   const queuedFg = createMemo(() => selectedForeground(theme, color()))
@@ -1200,7 +1203,7 @@ function UserMessage(props: {
           id={props.message.id}
           border={["left"]}
           borderColor={color()}
-          customBorderChars={SplitBorder.customBorderChars}
+          customBorderChars={getSplitBorderChars(accessibility())}
           marginTop={props.index === 0 ? 0 : 1}
         >
           <box
@@ -1274,6 +1277,8 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const { theme } = useTheme()
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
+  const accessibility = useAccessibility()
+  const separator = createMemo(() => (accessibility() ? " - " : " · "))
 
   const final = createMemo(() => {
     return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)
@@ -1312,7 +1317,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           paddingLeft={2}
           marginTop={1}
           backgroundColor={theme.backgroundPanel}
-          customBorderChars={SplitBorder.customBorderChars}
+          customBorderChars={getSplitBorderChars(accessibility())}
           borderColor={theme.error}
         >
           <text fg={theme.textMuted}>{props.message.error?.data.message}</text>
@@ -1330,15 +1335,15 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
                       : local.agent.color(props.message.agent),
                 }}
               >
-                ▣{" "}
+                <Show when={!accessibility()}>▣{" "}</Show>
               </span>{" "}
               <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
-              <span style={{ fg: theme.textMuted }}> · {props.message.modelID}</span>
+              <span style={{ fg: theme.textMuted }}>{separator() + props.message.modelID}</span>
               <Show when={duration()}>
-                <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
+                <span style={{ fg: theme.textMuted }}>{separator() + Locale.duration(duration())}</span>
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
-                <span style={{ fg: theme.textMuted }}> · interrupted</span>
+                <span style={{ fg: theme.textMuted }}>{separator() + "interrupted"}</span>
               </Show>
             </text>
           </box>
@@ -1357,6 +1362,7 @@ const PART_MAPPING = {
 function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage }) {
   const { theme, subtleSyntax } = useTheme()
   const ctx = use()
+  const accessibility = useAccessibility()
   const content = createMemo(() => {
     // Filter out redacted reasoning chunks from OpenRouter
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
@@ -1370,7 +1376,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
         marginTop={1}
         flexDirection="column"
         border={["left"]}
-        customBorderChars={SplitBorder.customBorderChars}
+        customBorderChars={getSplitBorderChars(accessibility())}
         borderColor={theme.backgroundElement}
       >
         <code
@@ -1559,10 +1565,14 @@ function GenericTool(props: ToolProps<any>) {
 
 function ToolTitle(props: { fallback: string; when: any; icon: string; children: JSX.Element }) {
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
   return (
     <text paddingLeft={3} fg={props.when ? theme.textMuted : theme.text}>
       <Show fallback={<>~ {props.fallback}</>} when={props.when}>
-        <span style={{ bold: true }}>{props.icon}</span> {props.children}
+        <Show when={!accessibility()}>
+          <span style={{ bold: true }}>{props.icon}</span>{" "}
+        </Show>
+        {props.children}
       </Show>
     </text>
   )
@@ -1580,6 +1590,12 @@ function InlineTool(props: {
   const { theme } = useTheme()
   const ctx = use()
   const sync = useSync()
+  const accessibility = useAccessibility()
+  const displayIcon = createMemo(() => {
+    if (!accessibility()) return props.icon
+    if (!props.icon) return ""
+    return props.icon.length === 1 && props.icon.charCodeAt(0) <= 127 ? props.icon : ""
+  })
 
   const permission = createMemo(() => {
     const callID = sync.data.permission[ctx.sessionID]?.at(0)?.tool?.callID
@@ -1631,7 +1647,10 @@ function InlineTool(props: {
     >
       <text paddingLeft={3} fg={fg()} attributes={denied() ? TextAttributes.STRIKETHROUGH : undefined}>
         <Show fallback={<>~ {props.pending}</>} when={props.complete}>
-          <span style={{ fg: props.iconColor }}>{props.icon}</span> {props.children}
+          <Show when={displayIcon()}>
+            <span style={{ fg: props.iconColor }}>{displayIcon()}</span>{" "}
+          </Show>
+          {props.children}
         </Show>
       </text>
       <Show when={error() && !denied()}>
@@ -1651,6 +1670,7 @@ function BlockTool(props: {
   const { theme } = useTheme()
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
+  const accessibility = useAccessibility()
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
   return (
     <box
@@ -1661,7 +1681,7 @@ function BlockTool(props: {
       marginTop={1}
       gap={1}
       backgroundColor={hover() ? theme.backgroundMenu : theme.backgroundPanel}
-      customBorderChars={SplitBorder.customBorderChars}
+      customBorderChars={getSplitBorderChars(accessibility())}
       borderColor={theme.background}
       onMouseOver={() => props.onClick && setHover(true)}
       onMouseOut={() => setHover(false)}
@@ -1692,13 +1712,14 @@ function Bash(props: ToolProps<typeof BashTool>) {
   const { theme } = useTheme()
   const sync = useSync()
   const isRunning = createMemo(() => props.part.state.status === "running")
+  const accessibility = useAccessibility()
   const output = createMemo(() => stripAnsi(props.metadata.output?.trim() ?? ""))
   const [expanded, setExpanded] = createSignal(false)
   const lines = createMemo(() => output().split("\n"))
   const overflow = createMemo(() => lines().length > 10)
   const limited = createMemo(() => {
     if (expanded() || !overflow()) return output()
-    return [...lines().slice(0, 10), "…"].join("\n")
+    return [...lines().slice(0, 10), accessibility() ? "..." : "…"].join("\n")
   })
 
   const workdirDisplay = createMemo(() => {
@@ -1897,6 +1918,7 @@ function Task(props: ToolProps<typeof TaskTool>) {
   const { navigate } = useRoute()
   const local = useLocal()
   const sync = useSync()
+  const accessibility = useAccessibility()
 
   const tools = createMemo(() => {
     const sessionID = props.metadata.sessionId
@@ -1931,10 +1953,11 @@ function Task(props: ToolProps<typeof TaskTool>) {
             </text>
             <Show when={current()}>
               {(item) => {
-                const title = item().state.status === "completed" ? (item().state as any).title : ""
+                const entry = item()
+                const title = entry.state.status === "completed" ? (entry.state as any).title : ""
                 return (
-                  <text style={{ fg: item().state.status === "error" ? theme.error : theme.textMuted }}>
-                    └ {Locale.titlecase(item().tool)} {title}
+                  <text style={{ fg: entry.state.status === "error" ? theme.error : theme.textMuted }}>
+                    {accessibility() ? "->" : "└"} {Locale.titlecase(entry.tool)} {title}
                   </text>
                 )
               }}
@@ -1960,6 +1983,7 @@ function Task(props: ToolProps<typeof TaskTool>) {
 function Edit(props: ToolProps<typeof EditTool>) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const accessibility = useAccessibility()
 
   const view = createMemo(() => {
     const diffStyle = ctx.sync.data.config.tui?.diff_style
@@ -1981,7 +2005,10 @@ function Edit(props: ToolProps<typeof EditTool>) {
   return (
     <Switch>
       <Match when={props.metadata.diff !== undefined}>
-        <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
+        <BlockTool
+          title={(accessibility() ? "Edit " : "← Edit ") + normalizePath(props.input.filePath!)}
+          part={props.part}
+        >
           <box paddingLeft={1}>
             <diff
               diff={diffContent()}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -6,7 +6,7 @@ import { useKeybind } from "../../context/keybind"
 import { useTheme, selectedForeground } from "../../context/theme"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
-import { SplitBorder } from "../../component/border"
+import { getSplitBorderChars } from "../../component/border"
 import { useSync } from "../../context/sync"
 import { useTextareaKeybindings } from "../../component/textarea-keybindings"
 import path from "path"
@@ -15,6 +15,7 @@ import { Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 import { Global } from "@/global"
 import { useDialog } from "../../ui/dialog"
+import { useAccessibility } from "@tui/util/accessibility"
 
 type PermissionStage = "permission" | "always" | "reject"
 
@@ -49,6 +50,7 @@ function EditBody(props: { request: PermissionRequest }) {
   const theme = themeState.theme
   const syntax = themeState.syntax
   const sync = useSync()
+  const accessibility = useAccessibility()
   const dimensions = useTerminalDimensions()
 
   const filepath = createMemo(() => (props.request.metadata?.filepath as string) ?? "")
@@ -106,10 +108,11 @@ function EditBody(props: { request: PermissionRequest }) {
 
 function TextBody(props: { title: string; description?: string; icon?: string }) {
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
   return (
     <>
       <box flexDirection="row" gap={1} paddingLeft={1}>
-        <Show when={props.icon}>
+        <Show when={props.icon && !accessibility()}>
           <text fg={theme.textMuted} flexShrink={0}>
             {props.icon}
           </text>
@@ -128,6 +131,7 @@ function TextBody(props: { title: string; description?: string; icon?: string })
 export function PermissionPrompt(props: { request: PermissionRequest }) {
   const sdk = useSDK()
   const sync = useSync()
+  const accessibility = useAccessibility()
   const [store, setStore] = createStore({
     stage: "permission" as PermissionStage,
   })
@@ -305,7 +309,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                 body: (
                   <Show when={desc}>
                     <box paddingLeft={1}>
-                      <text fg={theme.text}>{"◉ " + desc}</text>
+                      <text fg={theme.text}>{(accessibility() ? "- " : "◉ ") + desc}</text>
                     </box>
                   </Show>
                 ),
@@ -413,13 +417,15 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
           const header = () => (
             <box flexDirection="column" gap={0}>
               <box flexDirection="row" gap={1} flexShrink={0}>
-                <text fg={theme.warning}>{"△"}</text>
+                <text fg={theme.warning}>{accessibility() ? "!" : "△"}</text>
                 <text fg={theme.text}>Permission required</text>
               </box>
               <box flexDirection="row" gap={1} paddingLeft={2} flexShrink={0}>
-                <text fg={theme.textMuted} flexShrink={0}>
-                  {current.icon}
-                </text>
+                <Show when={!accessibility()}>
+                  <text fg={theme.textMuted} flexShrink={0}>
+                    {current.icon}
+                  </text>
+                </Show>
                 <text fg={theme.text}>{current.title}</text>
               </box>
             </box>
@@ -472,6 +478,8 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
   const dialog = useDialog()
+  const accessibility = useAccessibility()
+  const warningIcon = () => (accessibility() ? "!" : "△")
 
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
@@ -492,11 +500,11 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
       backgroundColor={theme.backgroundPanel}
       border={["left"]}
       borderColor={theme.error}
-      customBorderChars={SplitBorder.customBorderChars}
+      customBorderChars={getSplitBorderChars(accessibility())}
     >
       <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
         <box flexDirection="row" gap={1} paddingLeft={1}>
-          <text fg={theme.error}>{"△"}</text>
+          <text fg={theme.error}>{warningIcon()}</text>
           <text fg={theme.text}>Reject permission</text>
         </box>
         <box paddingLeft={1}>
@@ -548,6 +556,7 @@ function Prompt<const T extends Record<string, string>>(props: {
   const { theme } = useTheme()
   const keybind = useKeybind()
   const dimensions = useTerminalDimensions()
+  const accessibility = useAccessibility()
   const keys = Object.keys(props.options) as (keyof T)[]
   const [store, setStore] = createStore({
     selected: keys[0],
@@ -599,7 +608,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       backgroundColor={theme.backgroundPanel}
       border={["left"]}
       borderColor={theme.warning}
-      customBorderChars={SplitBorder.customBorderChars}
+      customBorderChars={getSplitBorderChars(accessibility())}
       {...(store.expanded
         ? { top: dimensions().height * -1 + 1, bottom: 1, left: 2, right: 2, position: "absolute" }
         : {
@@ -616,7 +625,7 @@ function Prompt<const T extends Record<string, string>>(props: {
           when={props.header}
           fallback={
             <box flexDirection="row" gap={1} paddingLeft={1} flexShrink={0}>
-              <text fg={theme.warning}>{"△"}</text>
+              <text fg={theme.warning}>{accessibility() ? "!" : "△"}</text>
               <text fg={theme.text}>{props.title}</text>
             </box>
           }
@@ -666,7 +675,7 @@ function Prompt<const T extends Record<string, string>>(props: {
             </text>
           </Show>
           <text fg={theme.text}>
-            {"⇆"} <span style={{ fg: theme.textMuted }}>select</span>
+            {accessibility() ? "left/right" : "⇆"} <span style={{ fg: theme.textMuted }}>select</span>
           </text>
           <text fg={theme.text}>
             enter <span style={{ fg: theme.textMuted }}>confirm</span>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -6,15 +6,17 @@ import { useKeybind } from "../../context/keybind"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
-import { SplitBorder } from "../../component/border"
+import { getSplitBorderChars } from "../../component/border"
 import { useTextareaKeybindings } from "../../component/textarea-keybindings"
 import { useDialog } from "../../ui/dialog"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export function QuestionPrompt(props: { request: QuestionRequest }) {
   const sdk = useSDK()
   const { theme } = useTheme()
   const keybind = useKeybind()
   const bindings = useTextareaKeybindings()
+  const accessibility = useAccessibility()
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -42,6 +44,9 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
     if (!value) return false
     return store.answers[store.tab]?.includes(value) ?? false
   })
+  const checkMark = createMemo(() => (accessibility() ? "x" : "✓"))
+  const tabHint = createMemo(() => (accessibility() ? "tab" : "⇆"))
+  const navHint = createMemo(() => (accessibility() ? "up/down" : "↑↓"))
 
   function submit() {
     const answers = questions().map((_, i) => store.answers[i] ?? [])
@@ -255,7 +260,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
       backgroundColor={theme.backgroundPanel}
       border={["left"]}
       borderColor={theme.accent}
-      customBorderChars={SplitBorder.customBorderChars}
+      customBorderChars={getSplitBorderChars(accessibility())}
     >
       <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
         <Show when={!single()}>
@@ -338,11 +343,11 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                         </box>
                         <box backgroundColor={active() ? theme.backgroundElement : undefined}>
                           <text fg={active() ? theme.secondary : picked() ? theme.success : theme.text}>
-                            {multi() ? `[${picked() ? "✓" : " "}] ${opt.label}` : opt.label}
+                            {multi() ? `[${picked() ? checkMark() : " "}] ${opt.label}` : opt.label}
                           </text>
                         </box>
                         <Show when={!multi()}>
-                          <text fg={theme.success}>{picked() ? "✓" : ""}</text>
+                          <text fg={theme.success}>{picked() ? checkMark() : ""}</text>
                         </Show>
                       </box>
 
@@ -367,12 +372,14 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                     </box>
                     <box backgroundColor={other() ? theme.backgroundElement : undefined}>
                       <text fg={other() ? theme.secondary : customPicked() ? theme.success : theme.text}>
-                        {multi() ? `[${customPicked() ? "✓" : " "}] Type your own answer` : "Type your own answer"}
+                        {multi()
+                          ? `[${customPicked() ? checkMark() : " "}] Type your own answer`
+                          : "Type your own answer"}
                       </text>
                     </box>
 
                     <Show when={!multi()}>
-                      <text fg={theme.success}>{customPicked() ? "✓" : ""}</text>
+                      <text fg={theme.success}>{customPicked() ? checkMark() : ""}</text>
                     </Show>
                   </box>
                   <Show when={store.editing}>
@@ -441,12 +448,12 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         <box flexDirection="row" gap={2}>
           <Show when={!single()}>
             <text fg={theme.text}>
-              {"⇆"} <span style={{ fg: theme.textMuted }}>tab</span>
+              {tabHint()} <span style={{ fg: theme.textMuted }}>tab</span>
             </text>
           </Show>
           <Show when={!confirm()}>
             <text fg={theme.text}>
-              {"↑↓"} <span style={{ fg: theme.textMuted }}>select</span>
+              {navHint()} <span style={{ fg: theme.textMuted }}>select</span>
             </text>
           </Show>
           <text fg={theme.text}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -11,6 +11,7 @@ import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const sync = useSync()
@@ -62,11 +63,14 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
 
   const directory = useDirectory()
   const kv = useKV()
+  const accessibility = useAccessibility()
 
   const hasProviders = createMemo(() =>
     sync.data.provider.some((x) => x.id !== "opencode" || Object.values(x.models).some((y) => y.cost?.input !== 0)),
   )
   const gettingStartedDismissed = createMemo(() => kv.get("dismissed_getting_started", false))
+  const bullet = createMemo(() => (accessibility() ? "-" : "•"))
+  const toggleIcon = (expanded: boolean) => (accessibility() ? (expanded ? "v" : ">") : expanded ? "▼" : "▶")
 
   return (
     <Show when={session()}>
@@ -114,7 +118,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   onMouseDown={() => mcpEntries().length > 2 && setExpanded("mcp", !expanded.mcp)}
                 >
                   <Show when={mcpEntries().length > 2}>
-                    <text fg={theme.text}>{expanded.mcp ? "▼" : "▶"}</text>
+                    <text fg={theme.text}>{toggleIcon(expanded.mcp)}</text>
                   </Show>
                   <text fg={theme.text}>
                     <b>MCP</b>
@@ -145,7 +149,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                             )[item.status],
                           }}
                         >
-                          •
+                          {bullet()}
                         </text>
                         <text fg={theme.text} wrapMode="word">
                           {key}{" "}
@@ -174,7 +178,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 onMouseDown={() => sync.data.lsp.length > 2 && setExpanded("lsp", !expanded.lsp)}
               >
                 <Show when={sync.data.lsp.length > 2}>
-                  <text fg={theme.text}>{expanded.lsp ? "▼" : "▶"}</text>
+                  <text fg={theme.text}>{toggleIcon(expanded.lsp)}</text>
                 </Show>
                 <text fg={theme.text}>
                   <b>LSP</b>
@@ -200,7 +204,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                           }[item.status],
                         }}
                       >
-                        •
+                        {bullet()}
                       </text>
                       <text fg={theme.textMuted}>
                         {item.id} {item.root}
@@ -218,7 +222,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   onMouseDown={() => todo().length > 2 && setExpanded("todo", !expanded.todo)}
                 >
                   <Show when={todo().length > 2}>
-                    <text fg={theme.text}>{expanded.todo ? "▼" : "▶"}</text>
+                    <text fg={theme.text}>{toggleIcon(expanded.todo)}</text>
                   </Show>
                   <text fg={theme.text}>
                     <b>Todo</b>
@@ -237,7 +241,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   onMouseDown={() => diff().length > 2 && setExpanded("diff", !expanded.diff)}
                 >
                   <Show when={diff().length > 2}>
-                    <text fg={theme.text}>{expanded.diff ? "▼" : "▶"}</text>
+                    <text fg={theme.text}>{toggleIcon(expanded.diff)}</text>
                   </Show>
                   <text fg={theme.text}>
                     <b>Modified Files</b>
@@ -281,7 +285,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
               gap={1}
             >
               <text flexShrink={0} fg={theme.text}>
-                ⬖
+                {accessibility() ? "!" : "⬖"}
               </text>
               <box flexGrow={1} gap={1}>
                 <box flexDirection="row" justifyContent="space-between">
@@ -289,7 +293,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                     <b>Getting started</b>
                   </text>
                   <text fg={theme.textMuted} onMouseDown={() => kv.set("dismissed_getting_started", true)}>
-                    ✕
+                    {accessibility() ? "x" : "✕"}
                   </text>
                 </box>
                 <text fg={theme.textMuted}>OpenCode includes free models so you can start immediately.</text>
@@ -308,7 +312,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
             <span style={{ fg: theme.text }}>{directory().split("/").at(-1)}</span>
           </text>
           <text fg={theme.textMuted}>
-            <span style={{ fg: theme.success }}>•</span> <b>Open</b>
+            <span style={{ fg: theme.success }}>{bullet()}</span> <b>Open</b>
             <span style={{ fg: theme.text }}>
               <b>Code</b>
             </span>{" "}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -177,7 +177,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     let next = store.selected + direction
     if (next < 0) next = flat().length - 1
     if (next >= flat().length) next = 0
-    moveTo(next, true)
+    moveTo(next)
   }
 
   function moveTo(next: number, opts?: { preserveNumberBuffer?: boolean; center?: boolean }) {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -1,15 +1,16 @@
 import { InputRenderable, RGBA, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { useTheme, selectedForeground } from "@tui/context/theme"
 import { entries, filter, flatMap, groupBy, pipe, take } from "remeda"
-import { batch, createEffect, createMemo, For, Show, type JSX, on } from "solid-js"
+import { batch, createEffect, createMemo, createSignal, For, Show, type JSX, on } from "solid-js"
 import { createStore } from "solid-js/store"
-import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
+import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import * as fuzzysort from "fuzzysort"
 import { isDeepEqual } from "remeda"
 import { useDialog, type DialogContext } from "@tui/ui/dialog"
 import { useKeybind } from "@tui/context/keybind"
 import { Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
+import { useAccessibility, useNumberedMenus } from "@tui/util/accessibility"
 
 export interface DialogSelectProps<T> {
   title: string
@@ -50,6 +51,9 @@ export type DialogSelectRef<T> = {
 export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const dialog = useDialog()
   const { theme } = useTheme()
+  const renderer = useRenderer()
+  const [numberBuffer, setNumberBuffer] = createSignal("")
+  const numberedMenus = useNumberedMenus()
   const [store, setStore] = createStore({
     selected: 0,
     filter: "",
@@ -71,6 +75,24 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   )
 
   let input: InputRenderable
+  const placeholder = createMemo(() => props.placeholder ?? (numberedMenus() ? "Search (/)" : "Search"))
+  const isInputFocused = () => !!input && renderer.currentFocusedRenderable === input
+
+  createEffect(
+    on(
+      () => numberedMenus(),
+      (enabled) => {
+        if (!input) return
+        if (numberBuffer().length > 0) setNumberBuffer("")
+        if (enabled) {
+          input.blur()
+        } else {
+          setTimeout(() => input.focus(), 1)
+        }
+      },
+      { defer: true },
+    ),
+  )
 
   const filtered = createMemo(() => {
     if (props.skipFilter) return props.options.filter((x) => x.disabled !== true)
@@ -120,6 +142,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
       flatMap(([_, options]) => options),
     )
   })
+  const numberWidth = createMemo(() => String(Math.max(flat().length, 1)).length)
 
   const rows = createMemo(() => {
     const headers = grouped().reduce((acc, [category], i) => {
@@ -138,11 +161,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     on([() => store.filter, () => props.current], ([filter, current]) => {
       setTimeout(() => {
         if (filter.length > 0) {
-          moveTo(0, true)
+          moveTo(0, { center: true })
         } else if (current) {
           const currentIndex = flat().findIndex((opt) => isDeepEqual(opt.value, current))
           if (currentIndex >= 0) {
-            moveTo(currentIndex, true)
+            moveTo(currentIndex, { center: true })
           }
         }
       }, 0)
@@ -157,7 +180,10 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     moveTo(next, true)
   }
 
-  function moveTo(next: number, center = false) {
+  function moveTo(next: number, opts?: { preserveNumberBuffer?: boolean; center?: boolean }) {
+    if (!opts?.preserveNumberBuffer && numberBuffer().length > 0) {
+      setNumberBuffer("")
+    }
     setStore("selected", next)
     const option = selected()
     if (option) props.onMove?.(option)
@@ -167,7 +193,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     })
     if (!target) return
     const y = target.y - scroll.y
-    if (center) {
+    if (opts?.center) {
       const centerOffset = Math.floor(scroll.height / 2)
       scroll.scrollBy(y - centerOffset)
     } else {
@@ -183,9 +209,59 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     }
   }
 
+  function isDigit(value?: string) {
+    return value !== undefined && value.length === 1 && value >= "0" && value <= "9"
+  }
+
+  function updateNumberBuffer(next: string) {
+    setNumberBuffer(next)
+    const index = Number.parseInt(next, 10) - 1
+    if (!Number.isNaN(index) && index >= 0 && index < flat().length) {
+      moveTo(index, { preserveNumberBuffer: true })
+    }
+  }
+
   const keybind = useKeybind()
   useKeyboard((evt) => {
     setStore("input", "keyboard")
+    if (numberedMenus() && !isInputFocused()) {
+      if (evt.name === "/") {
+        if (numberBuffer().length > 0) setNumberBuffer("")
+        input?.focus()
+        evt.preventDefault()
+        evt.stopPropagation()
+        return
+      }
+
+      if (evt.name === "backspace" && numberBuffer().length > 0) {
+        setNumberBuffer(numberBuffer().slice(0, -1))
+        evt.preventDefault()
+        evt.stopPropagation()
+        return
+      }
+
+      if (evt.name === "return" && numberBuffer().length > 0) {
+        const index = Number.parseInt(numberBuffer(), 10) - 1
+        const option = flat()[index]
+        setNumberBuffer("")
+        if (option) {
+          evt.preventDefault()
+          evt.stopPropagation()
+          if (option.onSelect) option.onSelect(dialog)
+          props.onSelect?.(option)
+        }
+        return
+      }
+
+      if (isDigit(evt.name)) {
+        const maxDigits = numberWidth()
+        const next = (numberBuffer() + evt.name).slice(0, maxDigits)
+        updateNumberBuffer(next)
+        evt.preventDefault()
+        evt.stopPropagation()
+        return
+      }
+    }
 
     if (evt.name === "up" || (evt.ctrl && evt.name === "p")) move(-1)
     if (evt.name === "down" || (evt.ctrl && evt.name === "n")) move(1)
@@ -236,9 +312,17 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           <text fg={theme.text} attributes={TextAttributes.BOLD}>
             {props.title}
           </text>
-          <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
-            esc
-          </text>
+          <box flexDirection="row" gap={1}>
+            <Show when={numberedMenus()}>
+              <text fg={theme.textMuted}>/ search</text>
+            </Show>
+            <Show when={numberedMenus() && numberBuffer().length > 0}>
+              <text fg={theme.textMuted}>select {numberBuffer()}</text>
+            </Show>
+            <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+              esc
+            </text>
+          </box>
         </box>
         <box paddingTop={1}>
           <input
@@ -246,6 +330,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
               batch(() => {
                 setStore("filter", e)
                 props.onFilter?.(e)
+                if (numberedMenus()) setNumberBuffer("")
               })
             }}
             focusedBackgroundColor={theme.backgroundPanel}
@@ -253,13 +338,15 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
             focusedTextColor={theme.textMuted}
             ref={(r) => {
               input = r
-              setTimeout(() => {
-                if (!input) return
-                if (input.isDestroyed) return
-                input.focus()
-              }, 1)
+              if (!numberedMenus()) {
+                setTimeout(() => {
+                  if (!input) return
+                  if (input.isDestroyed) return
+                  input.focus()
+                }, 1)
+              }
             }}
-            placeholder={props.placeholder ?? "Search"}
+            placeholder={placeholder()}
           />
         </box>
       </box>
@@ -292,6 +379,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                   {(option) => {
                     const active = createMemo(() => isDeepEqual(option.value, selected()?.value))
                     const current = createMemo(() => isDeepEqual(option.value, props.current))
+                    const index = createMemo(() => flat().indexOf(option))
                     return (
                       <box
                         id={JSON.stringify(option.value)}
@@ -315,7 +403,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                           moveTo(index)
                         }}
                         backgroundColor={active() ? (option.bg ?? theme.primary) : RGBA.fromInts(0, 0, 0, 0)}
-                        paddingLeft={current() || option.gutter ? 1 : 3}
+                        paddingLeft={numberedMenus() ? 1 : current() || option.gutter ? 1 : 3}
                         paddingRight={3}
                         gap={1}
                       >
@@ -326,6 +414,9 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                           active={active()}
                           current={current()}
                           gutter={option.gutter}
+                          index={index()}
+                          numbered={numberedMenus()}
+                          numberWidth={numberWidth()}
                         />
                       </box>
                     )
@@ -361,16 +452,31 @@ function Option(props: {
   current?: boolean
   footer?: JSX.Element | string
   gutter?: JSX.Element
+  index?: number
+  numbered?: boolean
+  numberWidth?: number
   onMouseOver?: () => void
 }) {
   const { theme } = useTheme()
+  const accessibility = useAccessibility()
   const fg = selectedForeground(theme)
+  const currentIcon = createMemo(() => (accessibility() ? "*" : "●"))
+  const numberLabel = createMemo(() => {
+    if (props.index === undefined || props.index < 0) return ""
+    const width = props.numberWidth ?? String(props.index + 1).length
+    return `${String(props.index + 1).padStart(width, " ")}.`
+  })
 
   return (
     <>
+      <Show when={props.numbered && props.index !== undefined && props.index >= 0}>
+        <text flexShrink={0} fg={props.active ? fg : theme.textMuted}>
+          {numberLabel()}
+        </text>
+      </Show>
       <Show when={props.current}>
         <text flexShrink={0} fg={props.active ? fg : props.current ? theme.primary : theme.text} marginRight={0}>
-          ●
+          {currentIcon()}
         </text>
       </Show>
       <Show when={!props.current && props.gutter}>

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -2,10 +2,11 @@ import { createContext, useContext, type ParentProps, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "@tui/context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
-import { SplitBorder } from "../component/border"
+import { getSplitBorderChars } from "../component/border"
 import { TextAttributes } from "@opentui/core"
 import z from "zod"
 import { TuiEvent } from "../event"
+import { useAccessibility } from "@tui/util/accessibility"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
 
@@ -13,6 +14,7 @@ export function Toast() {
   const toast = useToast()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
+  const accessibility = useAccessibility()
 
   return (
     <Show when={toast.currentToast}>
@@ -31,7 +33,7 @@ export function Toast() {
           backgroundColor={theme.backgroundPanel}
           borderColor={theme[current().variant]}
           border={["left", "right"]}
-          customBorderChars={SplitBorder.customBorderChars}
+          customBorderChars={getSplitBorderChars(accessibility())}
         >
           <Show when={current().title}>
             <text attributes={TextAttributes.BOLD} marginBottom={1} fg={theme.text}>

--- a/packages/opencode/src/cli/cmd/tui/util/accessibility.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/accessibility.ts
@@ -1,0 +1,18 @@
+import { createMemo } from "solid-js"
+import { useSync } from "@tui/context/sync"
+
+type AccessibilityConfig = {
+  tui?: {
+    accessibility?: {
+      numbered_menus?: boolean
+    }
+  }
+}
+
+export function useAccessibility() {
+  const sync = useSync()
+  return createMemo(() => {
+    const config = sync.data.config as AccessibilityConfig
+    return config.tui?.accessibility?.numbered_menus === true
+  })
+}

--- a/packages/opencode/src/cli/cmd/tui/util/accessibility.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/accessibility.ts
@@ -5,11 +5,20 @@ type AccessibilityConfig = {
   tui?: {
     accessibility?: {
       numbered_menus?: boolean
+      ascii?: boolean
     }
   }
 }
 
 export function useAccessibility() {
+  const sync = useSync()
+  return createMemo(() => {
+    const config = sync.data.config as AccessibilityConfig
+    return config.tui?.accessibility?.ascii === true
+  })
+}
+
+export function useNumberedMenus() {
   const sync = useSync()
   return createMemo(() => {
     const config = sync.data.config as AccessibilityConfig

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -941,6 +941,15 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    accessibility: z
+      .object({
+        numbered_menus: z
+          .boolean()
+          .optional()
+          .describe("Enable numbered selection and slash-to-search in TUI dialogs"),
+      })
+      .optional()
+      .describe("Accessibility settings"),
   })
 
   export const Server = z

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -947,6 +947,7 @@ export namespace Config {
           .boolean()
           .optional()
           .describe("Enable numbered selection and slash-to-search in TUI dialogs"),
+        ascii: z.boolean().optional().describe("Use ASCII-only text mode in the TUI"),
       })
       .optional()
       .describe("Accessibility settings"),

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -164,7 +164,11 @@ You can configure TUI-specific settings through the `tui` option.
     "scroll_acceleration": {
       "enabled": true
     },
-    "diff_style": "auto"
+    "diff_style": "auto",
+    "accessibility": {
+      "numbered_menus": true,
+      "ascii": true
+    }
   }
 }
 ```
@@ -174,6 +178,8 @@ Available options:
 - `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration. **Takes precedence over `scroll_speed`.**
 - `scroll_speed` - Custom scroll speed multiplier (default: `3`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
 - `diff_style` - Control diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows single column.
+- `accessibility.numbered_menus` - Enable numbered selection and `/` to focus search in TUI dialogs.
+- `accessibility.ascii` - Use ASCII-only TUI rendering (no Unicode icons/box drawing, and no spinner animations).
 
 [Learn more about using the TUI here](/docs/tui).
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -364,6 +364,10 @@ You can customize TUI behavior through your OpenCode config file.
     "scroll_speed": 3,
     "scroll_acceleration": {
       "enabled": true
+    },
+    "accessibility": {
+      "numbered_menus": true,
+      "ascii": true
     }
   }
 }
@@ -373,6 +377,8 @@ You can customize TUI behavior through your OpenCode config file.
 
 - `scroll_acceleration` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `1`). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
+- `accessibility.numbered_menus` - Enable numbered selection and `/` to focus search in TUI dialogs.
+- `accessibility.ascii` - Use ASCII-only TUI rendering (no Unicode icons/box drawing, and no spinner animations).
 
 ---
 


### PR DESCRIPTION
### What does this PR do?
This PR adds an accessibility mode for screen reader users. Animations, emojis and unicode characters add extra information to what the text to speech voice is reading, which is often meaningless and only there to look nice. These are removed in accessibility mode to make the interface cleaner and easier to read. A prime example of this is the spinner which is modified in the PR. When the spinner updates and you're reviewing text with the screen reader, it immediately loses focus because text was updated and the window changed, and in that instance the safest thing to do is focus the bottom of the window. Instead, the spinner now shows as [busy] when the AI is working. Numbering in menus is also introduced, because screen readers don't announce what TUI item is focused so in any dialog or menu, a blind user has to guess what option is selected and use the arrow keys to hopefully find the option they want. Now you type the number you want to go to, and press enter to activate it. These configs are exposed in tui.accessibility. Anyone without the config options set will not have their workflows changed and the UI will remain the same as it always has. Disclaimer, codex was used entirely to make these fixes as I'm not familiar with JS and everything around it but know other languages quite well. Fixes #8565 
### How did you verify your code works?
Set the config options and ran bun run dev in the packages/opencode directory and tested going to the models dialog with /models and ctrl x m, tested sessions with /sessions. Typed numbers when numbered menus were active and the menu options triggered the expected config dialogs. Disabled and enabled both options to confirm the UI preserved the original functionality and original look compared to the accessible variant. Used / to focus the search box in accessibility mode and confirmed that search worked and in the original UI as well.