### PR TITLE
Allow disabling Claude Code spoofing

### DIFF
--- a/packages/console/app/vite.config.ts
+++ b/packages/console/app/vite.config.ts
@@ -4,14 +4,14 @@ import { nitro } from "nitro/vite"
 
 export default defineConfig({
   plugins: [
-    solidStart() as PluginOption,
+    solidStart() as unknown as PluginOption,
     nitro({
       compatibilityDate: "2024-09-19",
       preset: "cloudflare_module",
       cloudflare: {
         nodeCompat: true,
       },
-    }),
+    }) as unknown as PluginOption,
   ],
   server: {
     allowedHosts: true,

--- a/packages/enterprise/vite.config.ts
+++ b/packages/enterprise/vite.config.ts
@@ -20,11 +20,11 @@ const nitroConfig: any = (() => {
 export default defineConfig({
   plugins: [
     tailwindcss(),
-    solidStart() as PluginOption,
+    solidStart() as unknown as PluginOption,
     nitro({
       ...nitroConfig,
       baseURL: process.env.OPENCODE_BASE_URL,
-    }),
+    }) as unknown as PluginOption,
   ],
   server: {
     host: "0.0.0.0",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -75,14 +75,14 @@ export namespace Provider {
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
     async anthropic() {
+      const betaFlags = ["interleaved-thinking-2025-05-14", "fine-grained-tool-streaming-2025-05-14"]
+      if (!Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+        betaFlags.unshift("claude-code-20250219")
+      }
+      const headers = betaFlags.length > 0 ? { "anthropic-beta": betaFlags.join(",") } : undefined
       return {
         autoload: false,
-        options: {
-          headers: {
-            "anthropic-beta":
-              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
-          },
-        },
+        options: headers ? { headers } : {},
       }
     },
     async opencode(input) {

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -20,7 +20,9 @@ import { Flag } from "@/flag/flag"
 
 export namespace SystemPrompt {
   export function header(providerID: string) {
-    if (providerID.includes("anthropic")) return [PROMPT_ANTHROPIC_SPOOF.trim()]
+    if (providerID.includes("anthropic") && !Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+      return [PROMPT_ANTHROPIC_SPOOF.trim()]
+    }
     return []
   }
 


### PR DESCRIPTION
## Summary
- Skip the Claude Code spoof system header when `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` is set
- Omit the `claude-code-20250219` beta flag when the Claude Code prompt is disabled
- Relax SolidStart/Nitro plugin typing to avoid Vite version type conflicts

## Testing
- `bun test test/provider/provider.test.ts`
- `bun run typecheck` (turbo)