### PR TITLE
feat(cli): uninstall opencode installed via windows package managers

### DIFF
--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -196,7 +196,7 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
           ? await $`echo Y | choco uninstall opencode -y -r`.quiet().nothrow()
           : await $`${cmd}`.quiet().nothrow()
       if (result.exitCode !== 0) {
-        spinner.stop(`Package manager uninstall failed`, 1)
+        spinner.stop(`Package manager uninstall failed: exit code ${result.exitCode}`, 1)
         if (
           method === "choco" &&
           result.stdout.toString("utf8").includes("not running from an elevated command shell")
@@ -205,8 +205,6 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
         } else {
           prompts.log.warn(`You may need to run manually: ${cmd.join(" ")}`)
         }
-
-        errors.push(`Package manager: exit code ${result.exitCode}`)
       } else {
         spinner.stop("Package removed")
       }

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -133,6 +133,8 @@ async function showRemovalSummary(targets: RemovalTargets, method: Installation.
       bun: "bun remove -g opencode-ai",
       yarn: "yarn global remove opencode-ai",
       brew: "brew uninstall opencode",
+      choco: "choco uninstall opencode",
+      scoop: "scoop uninstall opencode",
     }
     prompts.log.info(`  ✓ Package: ${cmds[method] || method}`)
   }
@@ -182,12 +184,17 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
       bun: ["bun", "remove", "-g", "opencode-ai"],
       yarn: ["yarn", "global", "remove", "opencode-ai"],
       brew: ["brew", "uninstall", "opencode"],
+      choco: ["choco", "uninstall", "opencode"],
+      scoop: ["scoop", "uninstall", "opencode"],
     }
 
     const cmd = cmds[method]
     if (cmd) {
       spinner.start(`Running ${cmd.join(" ")}...`)
-      const result = await $`${cmd}`.quiet().nothrow()
+      const result =
+        method === "choco"
+          ? await $`echo Y | choco uninstall opencode -y -r`.quiet().nothrow()
+          : await $`${cmd}`.quiet().nothrow()
       if (result.exitCode !== 0) {
         spinner.stop(`Package manager uninstall failed`, 1)
         prompts.log.warn(`You may need to run manually: ${cmd.join(" ")}`)

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -197,7 +197,15 @@ async function executeUninstall(method: Installation.Method, targets: RemovalTar
           : await $`${cmd}`.quiet().nothrow()
       if (result.exitCode !== 0) {
         spinner.stop(`Package manager uninstall failed`, 1)
-        prompts.log.warn(`You may need to run manually: ${cmd.join(" ")}`)
+        if (
+          method === "choco" &&
+          result.stdout.toString("utf8").includes("not running from an elevated command shell")
+        ) {
+          prompts.log.warn(`You may need to run '${cmd.join(" ")}' from an elevated command shell`)
+        } else {
+          prompts.log.warn(`You may need to run manually: ${cmd.join(" ")}`)
+        }
+
         errors.push(`Package manager: exit code ${result.exitCode}`)
       } else {
         spinner.stop("Package removed")


### PR DESCRIPTION
Fixes: #8573 

### What does this PR do?

- Adds uninstall information and commands for choco/scoop installs
- Informs user if they're trying to uninstall opencode via `choco` from a non-elevated command shell

<img width="734" height="406" alt="Screenshot 2026-01-14 194122" src="https://github.com/user-attachments/assets/e04367a0-fa9d-45e2-8b3a-2ff537b0ec70" />


### How did you verify your code works?

I tested every install method on Windows (Windows Terminal, WezTerm) and uninstalled w/ every method to ensure that the uninstallation happens cleanly and does not leave behind artifacts.

#### Choco Uninstall
<img width="1055" height="719" alt="Screenshot 2026-01-14 192823" src="https://github.com/user-attachments/assets/0a7f31a3-e46c-4b14-8faf-e6374f2ded6d" />

#### Scoop Uninstall
<img width="1058" height="723" alt="Screenshot 2026-01-14 191139" src="https://github.com/user-attachments/assets/f17615d9-e757-45af-889a-eda683354b84" />
