### PR TITLE
fix(skill): handle malformed frontmatter gracefully to prevent app crash

### DIFF
--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -42,27 +42,31 @@ export namespace Skill {
     const skills: Record<string, Info> = {}
 
     const addSkill = async (match: string) => {
-      const md = await ConfigMarkdown.parse(match)
-      if (!md) {
-        return
-      }
+      try {
+        const md = await ConfigMarkdown.parse(match)
+        if (!md) {
+          return
+        }
 
-      const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
-      if (!parsed.success) return
+        const parsed = Info.pick({ name: true, description: true }).safeParse(md.data)
+        if (!parsed.success) return
 
-      // Warn on duplicate skill names
-      if (skills[parsed.data.name]) {
-        log.warn("duplicate skill name", {
+        // Warn on duplicate skill names
+        if (skills[parsed.data.name]) {
+          log.warn("duplicate skill name", {
+            name: parsed.data.name,
+            existing: skills[parsed.data.name].location,
+            duplicate: match,
+          })
+        }
+
+        skills[parsed.data.name] = {
           name: parsed.data.name,
-          existing: skills[parsed.data.name].location,
-          duplicate: match,
-        })
-      }
-
-      skills[parsed.data.name] = {
-        name: parsed.data.name,
-        description: parsed.data.description,
-        location: match,
+          description: parsed.data.description,
+          location: match,
+        }
+      } catch (error) {
+        log.warn("failed to parse skill file", { path: match, error })
       }
     }
 


### PR DESCRIPTION
### Problem
The application completely crashes and stops sending messages if a single `SKILL.md` file contains malformed YAML frontmatter. This happens because the exception in `ConfigMarkdown.parse` is unhandled during `Skill.state` initialization.

### Solution
Wrapped `ConfigMarkdown.parse` in a `try-catch` block within the `addSkill` function. Now, malformed skill files are logged as warnings and skipped, allowing the rest of the application to function normally.