### PR TITLE
fix: restore brand integrity of TUI wordmark

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -417,6 +417,13 @@ async function getCustomThemes() {
   return result
 }
 
+export function tint(base: RGBA, overlay: RGBA, alpha: number): RGBA {
+  const r = base.r + (overlay.r - base.r) * alpha
+  const g = base.g + (overlay.g - base.g) * alpha
+  const b = base.b + (overlay.b - base.b) * alpha
+  return RGBA.fromInts(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
+}
+
 function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
@@ -426,13 +433,6 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
     const value = colors.palette[i]
     if (value) return RGBA.fromHex(value)
     return ansiToRgba(i)
-  }
-
-  const tint = (base: RGBA, overlay: RGBA, alpha: number) => {
-    const r = base.r + (overlay.r - base.r) * alpha
-    const g = base.g + (overlay.g - base.g) * alpha
-    const b = base.b + (overlay.b - base.b) * alpha
-    return RGBA.fromInts(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
   }
 
   // Generate gray scale based on terminal background


### PR DESCRIPTION
## Summary

The TUI wordmark has been (egregiously) violating brand guidelines. The E and N letters were missing the inner shadow effect present in all other letters, resulting in a jarring inconsistency with the official wordmark.

This PR restores the integrity of the opencode brand.

## Demo

Video of the final result and process: https://x.com/kitlangton/status/2011626052955812046

## Changes

- Add shadow marker system using background colors instead of shade characters
- Shadow color adapts to theme by tinting background toward foreground
- Export existing `tint` function from theme.tsx for reuse

Fixes #8583