### PR TITLE
fix: desktop conflict keybinds

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -596,7 +596,7 @@ export default function Layout(props: ParentProps) {
         id: "theme.cycle",
         title: "Cycle theme",
         category: "Theme",
-        keybind: "mod+shift+t",
+        keybind: "mod+shift+l",
         onSelect: () => cycleTheme(1),
       },
     ]
@@ -618,7 +618,7 @@ export default function Layout(props: ParentProps) {
       id: "theme.scheme.cycle",
       title: "Cycle color scheme",
       category: "Theme",
-      keybind: "mod+shift+s",
+      keybind: "mod+shift+h",
       onSelect: () => cycleColorScheme(1),
     })
 


### PR DESCRIPTION
### What does this PR do?
Fixes #8597 
fix conflict keybinds for desktop app:
**previous keybinds:** 
*  <mod+shift+t>  [theme.cycle]  CONFLICT WITH <shift+mod+t>  [model.variant.cycle]
*  <mod+shift+s>  [theme.scheme.cycle] CONFLICT WITH <mod+shift+s> [session.new]

**after:**
* <shift+mod+t>  [model.variant.cycle]
* <mod+shift+s> [session.new]
* <mod+shift+h> [theme.scheme.cycle]
* <mod+shift+l> [theme.cycle]

PS: The keybindings I chose (mod+shift+l for theme cycling, mod+shift+h for color scheme) are just placeholders to resolve the conflicts. Please feel free to adjust these to whatever keybinds the product team prefers.

### How did you verify your code works?
Run the desktop app locally, manually tested.
