### PR TITLE
fix: open help dialog with tui/open-help route

### DIFF
--- a/packages/opencode/src/server/routes/tui.ts
+++ b/packages/opencode/src/server/routes/tui.ts
@@ -119,7 +119,9 @@ export const TuiRoutes = lazy(() =>
         },
       }),
       async (c) => {
-        // TODO: open dialog
+        await Bus.publish(TuiEvent.CommandExecute, {
+          command: "help.show",
+        })
         return c.json(true)
       },
     )


### PR DESCRIPTION
### What does this PR do?

- Allows /tui/open-help to open the help command dialog in the TUI.
- The endpoint previously returned success without triggering any UI action. Publishing the same TUI command used by /help opens the help dialog as expected.

### How did you verify your code works?

- bun dev -- --port 4096 (Should open OpenCode)
- curl -X POST http://127.0.0.1:4096/tui/open-help (in different terminal/window)
- Go to terminal where you ran bun dev, help dialog should show up now

### Issue

- Closes #8595  

### Screenshots/Videos

Before:

https://github.com/user-attachments/assets/af1a7dbe-7ead-46b7-94bf-65493254c553

After:

https://github.com/user-attachments/assets/e91c2e31-0871-4029-951f-da4a64a2d039


