### PR TITLE
fix: guard empty command templates

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -547,21 +547,30 @@ export function Prompt(props: PromptProps) {
       })
     ) {
       let [command, ...args] = inputText.split(" ")
-      sdk.client.session.command({
-        sessionID,
-        command: command.slice(1),
-        arguments: args.join(" "),
-        agent: local.agent.current().name,
-        model: `${selectedModel.providerID}/${selectedModel.modelID}`,
-        messageID,
-        variant,
-        parts: nonTextParts
-          .filter((x) => x.type === "file")
-          .map((x) => ({
-            id: Identifier.ascending("part"),
-            ...x,
-          })),
-      })
+      sdk.client.session
+        .command({
+          sessionID,
+          command: command.slice(1),
+          arguments: args.join(" "),
+          agent: local.agent.current().name,
+          model: `${selectedModel.providerID}/${selectedModel.modelID}`,
+          messageID,
+          variant,
+          parts: nonTextParts
+            .filter((x) => x.type === "file")
+            .map((x) => ({
+              id: Identifier.ascending("part"),
+              ...x,
+            })),
+        })
+        .catch((error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          toast.show({
+            variant: "error",
+            message: message ? `Command failed: ${message}` : "Command failed",
+            duration: 3000,
+          })
+        })
     } else {
       sdk.client.session
         .prompt({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1632,6 +1632,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       template = template.replace(bashRegex, () => results[index++])
     }
     template = template.trim()
+    if (!template) {
+      const error = new NamedError.Unknown({
+        message: `Command "${input.command}" resolved to an empty prompt. Add content to the command template.`,
+      })
+      Bus.publish(Session.Event.Error, {
+        sessionID: input.sessionID,
+        error: error.toObject(),
+      })
+      throw error
+    }
 
     const model = await (async () => {
       if (command.model) {


### PR DESCRIPTION
## Issue
- Fixes #8445

## Summary
- reject command templates that resolve to empty prompts to avoid blank message cards
- surface slash command failures with a toast in the TUI

## Motivation
- empty templates currently yield a blank/black card; failing early makes the mistake visible

## Validation
- It has been verified