### PR TITLE
feat(tui): load conversation and session history

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -419,6 +419,58 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           )
           fullSyncedSessions.add(sessionID)
         },
+        async loadConversationHistory(sessionID: string) {
+          const messages = store.message[sessionID]
+          if (!messages || messages.length === 0) return
+
+          const earliest = messages[0]
+          const result = await sdk.client.session.messages({
+            sessionID,
+            ts_before: earliest.time.created,
+            breakpoint: true,
+          })
+
+          if (!result.data || result.data.length === 0) {
+            return 0
+          }
+
+          setStore(
+            produce((draft) => {
+              const existing = draft.message[sessionID] ?? []
+              draft.message[sessionID] = [...result.data!.map((x) => x.info), ...existing]
+              for (const message of result.data!) {
+                draft.part[message.info.id] = message.parts
+              }
+            }),
+          )
+          return result.data.length
+        },
+        async loadFullSessionHistory(sessionID: string) {
+          const messages = store.message[sessionID]
+          if (!messages || messages.length === 0) return
+
+          const earliest = messages[0]
+          const result = await sdk.client.session.messages({
+            sessionID,
+            ts_before: earliest.time.created,
+            // Omit breakpoint - undefined is falsy and won't stop at compaction
+          })
+
+          if (!result.data || result.data.length === 0) {
+            return 0
+          }
+
+          setStore(
+            produce((draft) => {
+              const existing = draft.message[sessionID] ?? []
+              draft.message[sessionID] = [...result.data!.map((x) => x.info), ...existing]
+              for (const message of result.data!) {
+                draft.part[message.info.id] = message.parts
+              }
+            }),
+          )
+          return result.data.length
+        },
       },
       bootstrap,
     }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -119,6 +119,22 @@ export function Session() {
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+
+  const messagesDisplay = createMemo(() => {
+    const msgs = messages()
+    if (msgs.length >= 100) {
+      const synthetic = {
+        id: "__load_more__",
+        sessionID: route.sessionID,
+        role: "system" as const,
+        time: { created: 0, updated: 0, completed: null },
+        _synthetic: true,
+      } as any
+      return [synthetic, ...msgs]
+    }
+    return msgs
+  })
+
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.permission[x.id] ?? [])
@@ -926,9 +942,78 @@ export function Session() {
               flexGrow={1}
               scrollAcceleration={scrollAcceleration()}
             >
-              <For each={messages()}>
+              <For each={messagesDisplay()}>
                 {(message, index) => (
                   <Switch>
+                    <Match when={message.id === "__load_more__"}>
+                      {(function () {
+                        const [hoveredButton, setHoveredButton] = createSignal<"conversation" | "full" | null>(null)
+                        const [loading, setLoading] = createSignal(false)
+
+                        const handleLoadConversation = async () => {
+                          if (loading()) return
+                          setLoading(true)
+                          try {
+                            const count = await sync.session.loadConversationHistory(route.sessionID)
+                            if (count === 0) {
+                              toast.show({ message: "No more messages loaded", variant: "info" })
+                            } else {
+                              toast.show({ message: `History loaded (${count} messages)`, variant: "success" })
+                            }
+                          } finally {
+                            setLoading(false)
+                          }
+                        }
+
+                        const handleLoadFull = async () => {
+                          if (loading()) return
+                          setLoading(true)
+                          try {
+                            const count = await sync.session.loadFullSessionHistory(route.sessionID)
+                            if (count === 0) {
+                              toast.show({ message: "No more messages loaded", variant: "info" })
+                            } else {
+                              toast.show({ message: `History loaded (${count} messages)`, variant: "success" })
+                            }
+                          } finally {
+                            setLoading(false)
+                          }
+                        }
+
+                        return (
+                          <box
+                            paddingLeft={2}
+                            paddingRight={2}
+                            paddingTop={1}
+                            paddingBottom={1}
+                            marginBottom={1}
+                            flexDirection="row"
+                            backgroundColor={theme.backgroundPanel}
+                          >
+                            <text fg={theme.textMuted}>Load more messages: </text>
+                            <box
+                              onMouseOver={() => setHoveredButton("conversation")}
+                              onMouseOut={() => setHoveredButton(null)}
+                              onMouseUp={handleLoadConversation}
+                            >
+                              <text fg={hoveredButton() === "conversation" ? theme.accent : theme.text}>
+                                load conversation history
+                              </text>
+                            </box>
+                            <text fg={theme.textMuted}> or </text>
+                            <box
+                              onMouseOver={() => setHoveredButton("full")}
+                              onMouseOut={() => setHoveredButton(null)}
+                              onMouseUp={handleLoadFull}
+                            >
+                              <text fg={hoveredButton() === "full" ? theme.accent : theme.text}>
+                                load full session history
+                              </text>
+                            </box>
+                          </box>
+                        )
+                      })()}
+                    </Match>
                     <Match when={message.id === revert()?.messageID}>
                       {(function () {
                         const command = useCommandDialog()

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1251,6 +1251,8 @@ export namespace Server {
             "query",
             z.object({
               limit: z.coerce.number().optional(),
+              ts_before: z.coerce.number().optional(),
+              breakpoint: z.coerce.boolean().optional(),
             }),
           ),
           async (c) => {
@@ -1258,6 +1260,8 @@ export namespace Server {
             const messages = await Session.messages({
               sessionID: c.req.valid("param").sessionID,
               limit: query.limit,
+              ts_before: query.ts_before,
+              breakpoint: query.breakpoint,
             })
             return c.json(messages)
           },

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -293,12 +293,26 @@ export namespace Session {
     z.object({
       sessionID: Identifier.schema("session"),
       limit: z.number().optional(),
+      ts_before: z.number().optional(),
+      breakpoint: z.boolean().optional(),
     }),
     async (input) => {
       const result = [] as MessageV2.WithParts[]
+
       for await (const msg of MessageV2.stream(input.sessionID)) {
+        if (input.ts_before && msg.info.time.created >= input.ts_before) {
+          continue
+        }
+
         if (input.limit && result.length >= input.limit) break
         result.push(msg)
+
+        if (input.ts_before && input.breakpoint) {
+          const hasCompaction = msg.parts.some((p) => p.type === "compaction")
+          if (hasCompaction) {
+            break
+          }
+        }
       }
       result.reverse()
       return result

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1279,6 +1279,8 @@ export class Session extends HeyApiClient {
       sessionID: string
       directory?: string
       limit?: number
+      ts_before?: number
+      breakpoint?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1290,6 +1292,8 @@ export class Session extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "query", key: "limit" },
+            { in: "query", key: "ts_before" },
+            { in: "query", key: "breakpoint" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3122,6 +3122,8 @@ export type SessionMessagesData = {
   query?: {
     directory?: string
     limit?: number
+    ts_before?: number
+    breakpoint?: boolean
   }
   url: "/session/{sessionID}/message"
 }

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2008,6 +2008,20 @@
             "schema": {
               "type": "number"
             }
+          },
+          {
+            "in": "query",
+            "name": "ts_before",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "breakpoint",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "summary": "Get session messages",


### PR DESCRIPTION
Resolves #6137, #4918, #7380
Related to #6548

## Problem

Users cannot access message history beyond the initial 100 messages loaded on session init. This makes OpenCode history for long-running sessions incomplete:
- Users need to reference earlier context (issue #7380)
- Sessions span hundreds of interactions (issue #4918)
- Important information from early messages becomes inaccessible (issue #6137)

## Solution

> This solution does not disrupt the natural 100 message limit for the TUI client maintaining the current message roll-off strategy in place.

Functional Core: ~38 lines (22% of changes)
- Server logic: 18 lines
- Client logic: 20 lines The rest is either:
- UI presentation (buttons, colors, hover states)
- Auto-generated SDK types (non-disruptive additional options for Session.messages())
- Comments and structure 

**Elegant, non-disruptive implementation** that adds on-demand message loading with two modes accessed via a "Load more messages" UI when 100+ messages are present:

1. **Load conversation history** - Loads messages up to the next compaction summary, providing relevant context without overwhelming the UI
2. **Load full session history** - Loads all remaining messages for complete session reconstruction

**Only pulls the missing messages** - does not reload the entire session, only the missing messages due to the `ts_before` implementation. 

**Zero breaking changes** - All parameters optional, existing functionality completely unchanged.

**Message roll-off maintained** - There is a system in the client today that once the messages reach over 100 messages, one message is rolled-off with each new message.  This roll-off strategy works perfectly with this feature. A user can load their conversation or their session history and continue their session and the last message will roll off as a new message comes in.  If for some reason the user wants to bring back the earliest messages again, they can click the load button at the top to load them all back in, but this natural pruning system is important to maintain and this solution fits perfectly with the entire existing system. 

## Implementation

Uses timestamp-based anchoring (immutable reference points) rather than offset/count tracking, eliminating state management complexity and race conditions.

**Server API Enhancement** - Added optional parameters to `Session.messages()`:
- `ts_before`: Unix timestamp for loading messages older than a specific point
- `breakpoint`: Boolean controlling whether to stop at compaction summaries

This enhances the robustness of the server messaging system by providing precise temporal queries rather than simple limits. The `ts_before` parameter acts as an immutable anchor point that naturally handles concurrent updates and message insertion without index drift.

**Client** - Two load functions that prepend older messages to the existing array, maintaining chronological order. Toast notifications show message counts.

Total addition: 176 lines across 7 files

## Technical Details

- Server logic handles reverse iteration with optional breakpoint stopping
- Client omits `breakpoint` parameter for full history (undefined = falsy)
- Uses `z.coerce.boolean()` pattern consistent with other boolean parameters like `roots`
- Timestamps are immutable - no race conditions or state tracking needed

## Testing

Verified with sessions containing 1000+ messages:
- Conversation history stops at compaction summaries ✅
- Full session history loads all remaining messages ✅
- Accurate message counts in toast notifications ✅
- No disruption to real-time message updates ✅

## Additional Consideration

The server Session.messages() enhancement with ts_before & breakpoint would greatly benefit the web client implementation, which currently reloads all messages when loading more. The timestamp-based approach would allow incremental loading without re-fetching existing messages.

## Screenshots

Option to load conversation (next breakpoint) or full session (all breakpoints)
<img width="1640" height="1034" alt="image" src="https://github.com/user-attachments/assets/4adc651d-234e-4c86-b053-b915f8ad4e13" />

Loading conversation history
<img width="1640" height="1034" alt="image" src="https://github.com/user-attachments/assets/0295acd6-4f65-4e0f-b3e2-138c78eee2a2" />

Loading full session history
<img width="1640" height="1034" alt="image" src="https://github.com/user-attachments/assets/d1cc2074-724d-4edf-8dc0-e1bbd5dbdcb7" />
