### PR TITLE
feat(mcp): allow 'never' option for mcp_timeout to disable timeout

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1036,11 +1036,9 @@ export namespace Config {
             .describe("Tools that should only be available to primary agents."),
           continue_loop_on_deny: z.boolean().optional().describe("Continue the agent loop when a tool call is denied"),
           mcp_timeout: z
-            .number()
-            .int()
-            .positive()
+            .union([z.literal("never"), z.number().int().positive()])
             .optional()
-            .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+            .describe("Timeout in milliseconds for MCP requests, or 'never' to disable timeout"),
         })
         .optional(),
     })

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -125,6 +125,7 @@ export namespace MCP {
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
       execute: async (args: unknown) => {
+        const timeout = config.experimental?.mcp_timeout
         return client.callTool(
           {
             name: mcpTool.name,
@@ -133,7 +134,7 @@ export namespace MCP {
           CallToolResultSchema,
           {
             resetTimeoutOnProgress: true,
-            timeout: config.experimental?.mcp_timeout,
+            timeout: timeout === "never" ? undefined : timeout,
           },
         )
       },


### PR DESCRIPTION
Closes #8633

## Summary
- Add `"never"` option to `mcp_timeout` config to allow disabling timeout for MCP tool calls
- Previously only positive integers (milliseconds) were supported

## Changes
- `config.ts`: Update schema to accept `"never" | number`
- `mcp/index.ts`: Handle `"never"` by passing `undefined` to disable timeout

## Usage
```json
{
  "experimental": {
    "mcp_timeout": "never"
  }
}
```

Or with a specific timeout:
```json
{
  "experimental": {
    "mcp_timeout": 60000
  }
}
```