### PR TITLE
Fix TUI crashes from undefined values (#8588, #8579, #8580)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -20,7 +20,7 @@ export function DialogAgent() {
   return (
     <DialogSelect
       title="Select agent"
-      current={local.agent.current().name}
+      current={local.agent.current()?.name ?? ""}
       options={options()}
       onSelect={(option) => {
         local.agent.set(option.value)

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -9,7 +9,7 @@ export function DialogStatus() {
   const sync = useSync()
   const { theme } = useTheme()
 
-  const enabledFormatters = createMemo(() => sync.data.formatter.filter((f) => f.enabled))
+  const enabledFormatters = createMemo(() => sync.data.formatter?.filter((f) => f.enabled) ?? [])
 
   const plugins = createMemo(() => {
     const list = sync.data.config.plugin ?? []

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -530,7 +530,7 @@ export function Prompt(props: PromptProps) {
     if (store.mode === "shell") {
       sdk.client.session.shell({
         sessionID,
-        agent: local.agent.current().name,
+        agent: currentAgent(),
         model: {
           providerID: selectedModel.providerID,
           modelID: selectedModel.modelID,
@@ -551,7 +551,7 @@ export function Prompt(props: PromptProps) {
         sessionID,
         command: command.slice(1),
         arguments: args.join(" "),
-        agent: local.agent.current().name,
+        agent: currentAgent(),
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         messageID,
         variant,
@@ -568,7 +568,7 @@ export function Prompt(props: PromptProps) {
           sessionID,
           ...selectedModel,
           messageID,
-          agent: local.agent.current().name,
+          agent: currentAgent(),
           model: selectedModel,
           variant,
           parts: [
@@ -689,7 +689,7 @@ export function Prompt(props: PromptProps) {
   const highlight = createMemo(() => {
     if (keybind.leader) return theme.border
     if (store.mode === "shell") return theme.primary
-    return local.agent.color(local.agent.current().name)
+    return local.agent.color(currentAgent())
   })
 
   const showVariant = createMemo(() => {
@@ -699,8 +699,10 @@ export function Prompt(props: PromptProps) {
     return !!current
   })
 
+  const currentAgent = createMemo(() => local.agent.current()?.name ?? "build")
+
   const spinnerDef = createMemo(() => {
-    const color = local.agent.color(local.agent.current().name)
+    const color = local.agent.color(local.agent.current()?.name ?? "build")
     return {
       frames: createFrames({
         color,
@@ -933,9 +935,7 @@ export function Prompt(props: PromptProps) {
               syntaxStyle={syntax()}
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
-              <text fg={highlight()}>
-                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
-              </text>
+              <text fg={highlight()}>{store.mode === "shell" ? "Shell" : Locale.titlecase(currentAgent())} </text>
               <Show when={store.mode === "normal"}>
                 <box flexDirection="row" gap={1}>
                   <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -623,7 +623,7 @@ export namespace MessageV2 {
       case (e as SystemError)?.code === "ECONNRESET":
         return new MessageV2.APIError(
           {
-            message: "Connection reset by server",
+            message: "Connection reset by server. If this persists, check your network/proxy settings.",
             isRetryable: true,
             metadata: {
               code: (e as SystemError).code ?? "",

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -110,7 +110,8 @@ describe("session.message-v2.fromError", () => {
 
       expect(MessageV2.APIError.isInstance(result)).toBe(true)
       expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
-      expect((result as MessageV2.APIError).data.message).toBe("Connection reset by server")
+      expect((result as MessageV2.APIError).data.message).toInclude("Connection reset by server")
+      expect((result as MessageV2.APIError).data.message).toInclude("network/proxy")
       expect((result as MessageV2.APIError).data.metadata?.code).toBe("ECONNRESET")
       expect((result as MessageV2.APIError).data.metadata?.message).toInclude("socket connection")
     },
@@ -119,13 +120,13 @@ describe("session.message-v2.fromError", () => {
 
   test("ECONNRESET socket error is retryable", () => {
     const error = new MessageV2.APIError({
-      message: "Connection reset by server",
+      message: "Connection reset by server. If this persists, check your network/proxy settings.",
       isRetryable: true,
       metadata: { code: "ECONNRESET", message: "The socket connection was closed unexpectedly" },
     }).toObject() as MessageV2.APIError
 
     const retryable = SessionRetry.retryable(error)
     expect(retryable).toBeDefined()
-    expect(retryable).toBe("Connection reset by server")
+    expect(retryable).toInclude("Connection reset by server")
   })
 })


### PR DESCRIPTION
## Summary

Fixes three TUI crash bugs:

### #8588 - enabledFormatters undefined
- **Problem**: TUI crashes with "undefined is not an object (evaluating 'enabledFormatters().length')" when adding MCP server and running `/status`
- **Root cause**: `sync.data.formatter` is undefined during initialization
- **Fix**: Added null check `sync.data.formatter?.filter((f) => f.enabled) ?? []`

### #8579 - local.agent.current undefined
- **Problem**: TUI crashes with "undefined is not an object (evaluating 'local.agent.current().name')" during startup
- **Root cause**: `local.agent.current()` returns undefined during initialization
- **Fix**: Created safe memo `currentAgent` that returns "build" as fallback, used throughout component

### #8580 - ECONNRESET error message
- **Problem**: Users experiencing "socket connection closed unexpectedly" errors get minimal guidance
- **Fix**: Enhanced error message to include "If this persists, check your network/proxy settings."

## Changes

### packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
- Add null check for `sync.data.formatter`

### packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
- Add `currentAgent` memo with safe fallback
- Replace all unsafe `local.agent.current().name` with `currentAgent()`

### packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
- Add null check for `local.agent.current()?.name`

### packages/opencode/src/session/message-v2.ts
- Improve ECONNRESET error message with network/proxy guidance

### packages/opencode/test/session/retry.test.ts
- Update tests to match new error message format

## Testing

- All existing tests pass (11 tests in retry.test.ts)
- Manual verification of null safety patterns