### PR TITLE
fix:subagent reasoningEffort not being applied

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -150,6 +150,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           providerID: model.providerID,
         },
         agent: agent.name,
+        options: agent.options,
         tools: {
           todowrite: false,
           todoread: false,


### PR DESCRIPTION
Fixes #8643

Using GPT 5.2, primary agents (build, plan) respect reasoningEffort config, but subagents (explore, general) ignore it.

**Root cause**
In task.ts:145-160, when calling SessionPrompt.prompt() for subagents, agent.options (which contains reasoningEffort) is not passed.

Primary agents work because llm.ts:106 merges input.agent.options into LLM options.

**Fix**
Add options: agent.options to the SessionPrompt.prompt() call in task.ts.