### PR TITLE
fix(desktop): move platform creation before event listener

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -292,6 +292,9 @@ root?.addEventListener("mousewheel", (e) => {
   e.stopPropagation()
 })
 
+const [serverPassword, setServerPassword] = createSignal<string | null>(null)
+const platform = createPlatform(() => serverPassword())
+
 // Handle external links - open in system browser instead of webview
 document.addEventListener("click", (e) => {
   const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
@@ -302,9 +305,6 @@ document.addEventListener("click", (e) => {
 })
 
 render(() => {
-  const [serverPassword, setServerPassword] = createSignal<string | null>(null)
-  const platform = createPlatform(() => serverPassword())
-
   return (
     <PlatformProvider value={platform}>
       <AppBaseProviders>

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -13,7 +13,7 @@ import { AsyncStorage } from "@solid-primitives/storage"
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http"
 import { Store } from "@tauri-apps/plugin-store"
 import { Logo } from "@opencode-ai/ui/logo"
-import { createSignal, Show, Accessor, JSX, createResource } from "solid-js"
+import { createSignal, createRoot, Show, Accessor, JSX, createResource } from "solid-js"
 
 import { UPDATER_ENABLED } from "./updater"
 import { createMenu } from "./menu"
@@ -292,8 +292,11 @@ root?.addEventListener("mousewheel", (e) => {
   e.stopPropagation()
 })
 
-const [serverPassword, setServerPassword] = createSignal<string | null>(null)
-const platform = createPlatform(() => serverPassword())
+const { serverPassword, setServerPassword, platform } = createRoot(() => {
+  const [serverPassword, setServerPassword] = createSignal<string | null>(null)
+  const platform = createPlatform(() => serverPassword())
+  return { serverPassword, setServerPassword, platform }
+})
 
 // Handle external links - open in system browser instead of webview
 document.addEventListener("click", (e) => {


### PR DESCRIPTION
### What does this PR do?

Fixes typecheck error `TS2304: Cannot find name 'platform'` introduced in #7360.

Moves `platform` and `serverPassword` creation outside `render()` so they're available to the click event listener that references `platform.openLink()`.

Fixes #8657

### How did you verify your code works?

- ✅ Typecheck passes: `bun run typecheck`
- ✅ Pre-push hooks pass (includes turbo typecheck)
- ✅ No functionality changes - only moves existing code to correct scope