### PR TITLE
fix(session): ensure agent exists before processing title in session summary

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -77,6 +77,7 @@ export namespace SessionSummary {
     const textPart = msgWithParts.parts.find((p) => p.type === "text" && !p.synthetic) as MessageV2.TextPart
     if (textPart && !userMsg.summary?.title) {
       const agent = await Agent.get("title")
+      if (!agent) return
       const stream = await LLM.stream({
         agent,
         user: userMsg,


### PR DESCRIPTION
the title agent may be disabled, and if it's disabled will lead to error:
```
TypeError: Cannot read properties of undefined
```

Fixes #8663 