### PR TITLE
feat(bash): add config option to hide env prefix in command display

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -65,6 +65,7 @@ import { Toast, useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv.tsx"
 import { Editor } from "../../util/editor"
 import stripAnsi from "strip-ansi"
+import { stripEnvPrefix } from "@opencode-ai/util/bash"
 import { Footer } from "./footer.tsx"
 import { usePromptRef } from "../../context/prompt"
 import { useExit } from "../../context/exit"
@@ -1553,6 +1554,12 @@ function Bash(props: ToolProps<typeof BashTool>) {
     return [...lines().slice(0, 10), "…"].join("\n")
   })
 
+  const displayCommand = createMemo(() => {
+    const cmd = props.input.command ?? ""
+    if (sync.data.config.bash?.hideEnvPrefix) return stripEnvPrefix(cmd)
+    return cmd
+  })
+
   const workdirDisplay = createMemo(() => {
     const workdir = props.input.workdir
     if (!workdir || workdir === ".") return undefined
@@ -1587,7 +1594,7 @@ function Bash(props: ToolProps<typeof BashTool>) {
           onClick={overflow() ? () => setExpanded((prev) => !prev) : undefined}
         >
           <box gap={1}>
-            <text fg={theme.text}>$ {props.input.command}</text>
+            <text fg={theme.text}>$ {displayCommand()}</text>
             <text fg={theme.text}>{limited()}</text>
             <Show when={overflow()}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
@@ -1596,8 +1603,8 @@ function Bash(props: ToolProps<typeof BashTool>) {
         </BlockTool>
       </Match>
       <Match when={true}>
-        <InlineTool icon="$" pending="Writing command..." complete={props.input.command} part={props.part}>
-          {props.input.command}
+        <InlineTool icon="$" pending="Writing command..." complete={displayCommand()} part={props.part}>
+          {displayCommand()}
         </InlineTool>
       </Match>
     </Switch>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -771,6 +771,20 @@ export namespace Config {
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   })
 
+  export const Bash = z
+    .object({
+      hideEnvPrefix: z
+        .boolean()
+        .optional()
+        .describe(
+          "Hide environment variable prefix (export CI=true DEBIAN_FRONTEND=...) in bash command display. The prefix is still used during execution.",
+        ),
+    })
+    .strict()
+    .meta({
+      ref: "BashConfig",
+    })
+
   export const Server = z
     .object({
       port: z.number().int().positive().optional().describe("Port to listen on"),
@@ -848,6 +862,7 @@ export namespace Config {
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),
+      bash: Bash.optional().describe("Bash tool display settings"),
       server: Server.optional().describe("Server configuration for opencode serve and web commands"),
       command: z
         .record(z.string(), Command)

--- a/packages/opencode/test/util/bash.test.ts
+++ b/packages/opencode/test/util/bash.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import { stripEnvPrefix } from "@opencode-ai/util/bash"
+
+describe("util.bash.stripEnvPrefix", () => {
+  test("strips full Claude env prefix", () => {
+    const cmd =
+      "export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never HOMEBREW_NO_AUTO_UPDATE=1 GIT_EDITOR=: EDITOR=: VISUAL='' GIT_SEQUENCE_EDITOR=: GIT_MERGE_AUTOEDIT=no GIT_PAGER=cat PAGER=cat npm_config_yes=true PIP_NO_INPUT=1 YARN_ENABLE_IMMUTABLE_INSTALLS=false; git status"
+    expect(stripEnvPrefix(cmd)).toBe("git status")
+  })
+
+  test("handles single quoted values", () => {
+    const cmd = "export FOO='bar baz'; echo hello"
+    expect(stripEnvPrefix(cmd)).toBe("echo hello")
+  })
+
+  test("handles double quoted values", () => {
+    const cmd = 'export FOO="bar baz"; echo hello'
+    expect(stripEnvPrefix(cmd)).toBe("echo hello")
+  })
+
+  test("handles mixed quoted values", () => {
+    const cmd = "export FOO='bar' BAR=\"baz\" QUX=val; echo hello"
+    expect(stripEnvPrefix(cmd)).toBe("echo hello")
+  })
+
+  test("returns command unchanged if no prefix", () => {
+    const cmd = "git status"
+    expect(stripEnvPrefix(cmd)).toBe("git status")
+  })
+
+  test("handles empty string", () => {
+    expect(stripEnvPrefix("")).toBe("")
+  })
+
+  test("handles falsy input", () => {
+    expect(stripEnvPrefix(undefined as unknown as string)).toBe(undefined)
+    expect(stripEnvPrefix(null as unknown as string)).toBe(null)
+  })
+
+  test("preserves inline exports (not prefix)", () => {
+    const cmd = "echo hello && export FOO=bar"
+    expect(stripEnvPrefix(cmd)).toBe("echo hello && export FOO=bar")
+  })
+
+  test("handles empty value in exports", () => {
+    const cmd = "export FOO='' BAR=; echo hello"
+    expect(stripEnvPrefix(cmd)).toBe("echo hello")
+  })
+
+  test("handles special chars in values", () => {
+    const cmd = "export FOO=':' BAR='cat'; echo hello"
+    expect(stripEnvPrefix(cmd)).toBe("echo hello")
+  })
+})

--- a/packages/util/src/bash.ts
+++ b/packages/util/src/bash.ts
@@ -1,0 +1,8 @@
+/**
+ * Strips env prefix (export VAR=val VAR2='val'...; ) from command display.
+ * Pattern: /^export\s+(?:\w+=(?:'[^']*'|"[^"]*"|[^\s;]+)\s*)+;\s*/
+ */
+export function stripEnvPrefix(command: string): string {
+  if (!command) return command
+  return command.replace(/^export\s+(?:\w+=(?:'[^']*'|"[^"]*"|[^\s;]+)\s*)+;\s*/, "")
+}


### PR DESCRIPTION
## Summary

Add a config option to hide Claude's environment variable prefix in bash command display while keeping it intact for execution.

When using OpenCode with Claude (Anthropic) as the model provider, Claude adds a safety env prefix to bash commands:

```bash
export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 GCM_INTERACTIVE=never HOMEBREW_NO_AUTO_UPDATE=1 GIT_EDITOR=: EDITOR=: VISUAL='' GIT_SEQUENCE_EDITOR=: GIT_MERGE_AUTOEDIT=no GIT_PAGER=cat PAGER=cat npm_config_yes=true PIP_NO_INPUT=1 YARN_ENABLE_IMMUTABLE_INSTALLS=false; git status
```

This creates visual noise in the TUI. This PR adds a config option to hide this prefix **in the display only** - the command still executes with the env vars.

## Changes

- `packages/util/src/bash.ts` - New `stripEnvPrefix()` utility function
- `packages/opencode/src/config/config.ts` - Add `Bash` config schema with `hideEnvPrefix` option
- `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx` - Apply filter in TUI Bash component
- `packages/opencode/test/util/bash.test.ts` - Unit tests for the utility function

## Usage

Add to `opencode.json`:

```json
{
  "bash": {
    "hideEnvPrefix": true
  }
}
```

## Before/After

**Before** (default, `hideEnvPrefix: false`):
```
$ export CI=true DEBIAN_FRONTEND=noninteractive ...; git status
```

**After** (`hideEnvPrefix: true`):
```
$ git status
```

## Notes

- Default is `false` for backwards compatibility
- Web share view is unchanged (shows actual executed command, no config access)
- Display-only change - execution is unchanged

Closes #8668
Related to #2581