### PR TITLE
fix(agent): default agent selection in acp and headless mode

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -731,6 +731,9 @@ export namespace ACP {
       const defaultAgentName = await AgentModule.defaultAgent()
       const currentModeId = availableModes.find((m) => m.name === defaultAgentName)?.id ?? availableModes[0].id
 
+      // Persist the default mode so prompt() uses it immediately
+      this.sessionManager.setMode(sessionId, currentModeId)
+
       const mcpServers: Record<string, Config.Mcp> = {}
       for (const server of params.mcpServers) {
         if ("type" in server) {

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -255,7 +255,14 @@ export namespace Agent {
   }
 
   export async function defaultAgent() {
-    return state().then((x) => Object.keys(x)[0])
+    const agents = await list()
+    const primary = agents.find((a) => a.mode !== "subagent" && a.hidden !== true)
+    if (primary) return primary.name
+
+    const visible = agents.find((a) => a.hidden !== true)
+    if (visible) return visible.name
+
+    return "build"
   }
 
   export async function generate(input: { description: string; model?: { providerID: string; modelID: string } }) {

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -255,9 +255,20 @@ export namespace Agent {
   }
 
   export async function defaultAgent() {
-    const agents = await list()
-    const primaryVisible = agents.find((a) => a.mode !== "subagent" && a.hidden !== true)
-    return primaryVisible?.name || "build"
+    const cfg = await Config.get()
+    const agents = await state()
+
+    if (cfg.default_agent) {
+      const agent = agents[cfg.default_agent]
+      if (!agent) throw new Error(`default agent "${cfg.default_agent}" not found`)
+      if (agent.mode === "subagent") throw new Error(`default agent "${cfg.default_agent}" is a subagent`)
+      if (agent.hidden === true) throw new Error(`default agent "${cfg.default_agent}" is hidden`)
+      return agent.name
+    }
+
+    const primaryVisible = Object.values(agents).find((a) => a.mode !== "subagent" && a.hidden !== true)
+    if (!primaryVisible) throw new Error("no primary visible agent found")
+    return primaryVisible.name
   }
 
   export async function generate(input: { description: string; model?: { providerID: string; modelID: string } }) {

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -256,13 +256,8 @@ export namespace Agent {
 
   export async function defaultAgent() {
     const agents = await list()
-    const primary = agents.find((a) => a.mode !== "subagent" && a.hidden !== true)
-    if (primary) return primary.name
-
-    const visible = agents.find((a) => a.hidden !== true)
-    if (visible) return visible.name
-
-    return "build"
+    const primaryVisible = agents.find((a) => a.mode !== "subagent" && a.hidden !== true)
+    return primaryVisible?.name || "build"
   }
 
   export async function generate(input: { description: string; model?: { providerID: string; modelID: string } }) {

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -559,7 +559,7 @@ test("defaultAgent respects default_agent config set to custom agent with mode a
   })
 })
 
-test("defaultAgent falls back when default_agent points to subagent", async () => {
+test("defaultAgent throws when default_agent points to subagent", async () => {
   await using tmp = await tmpdir({
     config: {
       default_agent: "explore",
@@ -568,15 +568,12 @@ test("defaultAgent falls back when default_agent points to subagent", async () =
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agent = await Agent.defaultAgent()
-      // explore is a subagent, so it should fall back to first primary-capable agent
-      expect(agent).not.toBe("explore")
-      expect(agent).toBe("build")
+      await expect(Agent.defaultAgent()).rejects.toThrow('default agent "explore" is a subagent')
     },
   })
 })
 
-test("defaultAgent falls back when default_agent points to hidden agent", async () => {
+test("defaultAgent throws when default_agent points to hidden agent", async () => {
   await using tmp = await tmpdir({
     config: {
       default_agent: "compaction",
@@ -585,15 +582,12 @@ test("defaultAgent falls back when default_agent points to hidden agent", async 
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agent = await Agent.defaultAgent()
-      // compaction is hidden, so it should fall back to first primary-capable agent
-      expect(agent).not.toBe("compaction")
-      expect(agent).toBe("build")
+      await expect(Agent.defaultAgent()).rejects.toThrow('default agent "compaction" is hidden')
     },
   })
 })
 
-test("defaultAgent falls back when default_agent points to non-existent agent", async () => {
+test("defaultAgent throws when default_agent points to non-existent agent", async () => {
   await using tmp = await tmpdir({
     config: {
       default_agent: "does_not_exist",
@@ -602,8 +596,7 @@ test("defaultAgent falls back when default_agent points to non-existent agent", 
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agent = await Agent.defaultAgent()
-      expect(agent).toBe("build")
+      await expect(Agent.defaultAgent()).rejects.toThrow('default agent "does_not_exist" not found')
     },
   })
 })
@@ -626,7 +619,7 @@ test("defaultAgent returns plan when build is disabled and default_agent not set
   })
 })
 
-test("defaultAgent returns first primary-capable agent when all natives are disabled", async () => {
+test("defaultAgent throws when all primary agents are disabled", async () => {
   await using tmp = await tmpdir({
     config: {
       agent: {
@@ -638,9 +631,8 @@ test("defaultAgent returns first primary-capable agent when all natives are disa
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      const agent = await Agent.defaultAgent()
-      // build and plan are disabled, so it should return general
-      expect(agent).toBe("build")
+      // build and plan are disabled, no primary-capable agents remain
+      await expect(Agent.defaultAgent()).rejects.toThrow("no primary visible agent found")
     },
   })
 })

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -513,8 +513,6 @@ test("explicit Truncate.DIR deny is respected", async () => {
   })
 })
 
-// Tests for Agent.defaultAgent()
-
 test("defaultAgent returns build when no default_agent config", async () => {
   await using tmp = await tmpdir()
   await Instance.provide({
@@ -624,6 +622,25 @@ test("defaultAgent returns plan when build is disabled and default_agent not set
       const agent = await Agent.defaultAgent()
       // build is disabled, so it should return plan (next primary agent)
       expect(agent).toBe("plan")
+    },
+  })
+})
+
+test("defaultAgent returns first primary-capable agent when all natives are disabled", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        build: { disable: true },
+        plan: { disable: true },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      // build and plan are disabled, so it should return general
+      expect(agent).toBe("build")
     },
   })
 })

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -512,3 +512,118 @@ test("explicit Truncate.DIR deny is respected", async () => {
     },
   })
 })
+
+// Tests for Agent.defaultAgent()
+
+test("defaultAgent returns build when no default_agent config", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      expect(agent).toBe("build")
+    },
+  })
+})
+
+test("defaultAgent respects default_agent config set to plan", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      default_agent: "plan",
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      expect(agent).toBe("plan")
+    },
+  })
+})
+
+test("defaultAgent respects default_agent config set to custom agent with mode all", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      default_agent: "my_custom",
+      agent: {
+        my_custom: {
+          description: "My custom agent",
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      expect(agent).toBe("my_custom")
+    },
+  })
+})
+
+test("defaultAgent falls back when default_agent points to subagent", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      default_agent: "explore",
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      // explore is a subagent, so it should fall back to first primary-capable agent
+      expect(agent).not.toBe("explore")
+      expect(agent).toBe("build")
+    },
+  })
+})
+
+test("defaultAgent falls back when default_agent points to hidden agent", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      default_agent: "compaction",
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      // compaction is hidden, so it should fall back to first primary-capable agent
+      expect(agent).not.toBe("compaction")
+      expect(agent).toBe("build")
+    },
+  })
+})
+
+test("defaultAgent falls back when default_agent points to non-existent agent", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      default_agent: "does_not_exist",
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      expect(agent).toBe("build")
+    },
+  })
+})
+
+test("defaultAgent returns plan when build is disabled and default_agent not set", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        build: { disable: true },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent = await Agent.defaultAgent()
+      // build is disabled, so it should return plan (next primary agent)
+      expect(agent).toBe("plan")
+    },
+  })
+})


### PR DESCRIPTION
## Summary
Make ACP and headless mode respect `default_agent` config and properly handle agent modes and visibilities. Previously, subagents and hidden agents could be incorrectly selected as the default agent.

Fixes #8680

## Changes
- Filter out subagents (`mode === "subagent"`) from defaultAgent candidates
- Filter out hidden agents (`hidden === true`) from defaultAgent candidates
- 4 different errors introduced:
  - `default agent "${cfg.default_agent}" not found`
  - `default agent "${cfg.default_agent}" is a subagent`
  - `default agent "${cfg.default_agent}" is hidden`
  - `no primary visible agent found`
- Add 7 test cases for defaultAgent selection logic
- Persist default mode in session manager during ACP session init

## Breaking Changes
None

## Testing
- Added unit tests covering agent selection cases