### PR TITLE
feat: add interactive mode support for bash commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,6 +7,7 @@ import {
   For,
   Match,
   on,
+  onCleanup,
   Show,
   Switch,
   useContext,
@@ -1541,7 +1542,124 @@ function BlockTool(props: { title: string; children: JSX.Element; onClick?: () =
   )
 }
 
+function BashInteractive(props: ToolProps<typeof BashTool> & { ptyId: string }) {
+  const { theme } = useTheme()
+  const sync = useSync()
+  const keyboard = useKeyboard()
+  const [output, setOutput] = createSignal<string>("")
+  const [ws, setWs] = createSignal<WebSocket | null>(null)
+  const [status, setStatus] = createSignal<"connecting" | "connected" | "error">("connecting")
+  const [retryCount, setRetryCount] = createSignal(0)
+  const [exited, setExited] = createSignal(false)
+
+  // WebSocket connection with retry logic
+  const connectToPty = () => {
+    const ptyId = props.ptyId
+    const endpoint = sync.data.endpoint || "http://localhost:4096"
+    const wsUrl = endpoint.replace(/^http/, "ws") + `/pty/${ptyId}/connect`
+
+    console.log("connecting to PTY", { wsUrl, ptyId })
+    const socket = new WebSocket(wsUrl)
+
+    socket.onopen = () => {
+      console.log("PTY WebSocket connected", { ptyId })
+      setStatus("connected")
+      setRetryCount(0)
+    }
+
+    socket.onmessage = (event) => {
+      setOutput((prev) => prev + event.data)
+    }
+
+    socket.onerror = (error) => {
+      console.error("PTY WebSocket error", { ptyId, error })
+      if (retryCount() < 3) {
+        setRetryCount((c) => c + 1)
+        const delay = Math.pow(2, retryCount()) * 1000 // Exponential backoff
+        setTimeout(() => {
+          if (!exited()) connectToPty()
+        }, delay)
+      } else {
+        setStatus("error")
+      }
+    }
+
+    socket.onclose = () => {
+      console.log("PTY WebSocket closed", { ptyId })
+      setExited(true)
+    }
+
+    setWs(socket)
+
+    onCleanup(() => {
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close()
+      }
+    })
+  }
+
+  createEffect(() => {
+    connectToPty()
+  })
+
+  // Keyboard input handling - disabled TUI shortcuts, send to PTY
+  createEffect(() => {
+    const key = keyboard.key()
+    const socket = ws()
+
+    if (!key || !socket || socket.readyState !== WebSocket.OPEN) return
+
+    // ESC key exits interactive mode
+    if (key === "\x1b") {
+      socket.close()
+      setExited(true)
+      return
+    }
+
+    // Send all other input to PTY
+    socket.send(key)
+  })
+
+  const statusIndicator = createMemo(() => {
+    switch (status()) {
+      case "connecting":
+        return "⏳ Connecting..."
+      case "connected":
+        return "✓ Connected"
+      case "error":
+        return "✗ Connection failed after 3 retries"
+    }
+  })
+
+  return (
+    <BlockTool title={`# ${props.input.description ?? "Interactive Shell"}`} part={props.part}>
+      <box gap={1} overflow="scroll">
+        <text fg={theme.textMuted}>🔄 Interactive Mode</text>
+        <text fg={theme.textMuted}>
+          {statusIndicator()} • Session: {props.ptyId}
+        </text>
+        <text fg={theme.text}>$ {props.input.command}</text>
+        <text fg={theme.text}>{output()}</text>
+        <Show when={!exited()}>
+          <text fg={theme.textMuted}>Press ESC to exit interactive mode</text>
+        </Show>
+        <Show when={exited()}>
+          <text fg={theme.textMuted}>Session ended</text>
+        </Show>
+      </box>
+    </BlockTool>
+  )
+}
+
 function Bash(props: ToolProps<typeof BashTool>) {
+  // Check if this is an interactive PTY session
+  const ptyId = props.metadata.ptyId as string | undefined
+
+  if (ptyId && props.metadata.interactive) {
+    return <BashInteractive {...props} ptyId={ptyId} />
+  }
+
+  // Existing non-interactive Bash component code
   const { theme } = useTheme()
   const sync = useSync()
   const output = createMemo(() => stripAnsi(props.metadata.output?.trim() ?? ""))

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -16,9 +16,41 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
+import { Pty } from "@/pty"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
+
+const INTERACTIVE_COMMANDS = new Set([
+  "vim",
+  "vi",
+  "nano",
+  "emacs",
+  "ssh",
+  "telnet",
+  "opencode",
+  "less",
+  "more",
+  "htop",
+  "top",
+  "man",
+  "psql",
+  "mysql",
+  "sqlite3",
+  "python",
+  "python3",
+  "node",
+  "irb",
+])
+
+function shouldUseInteractive(command: string, explicitInteractive: boolean): boolean {
+  if (!explicitInteractive) return false
+
+  // Extract first command from the command string
+  const firstCommand = command.trim().split(/\s+/)[0].split(/[;&|]/)[0]
+
+  return INTERACTIVE_COMMANDS.has(firstCommand)
+}
 
 export const log = Log.create({ service: "bash-tool" })
 
@@ -73,6 +105,13 @@ export const BashTool = Tool.define("bash", async () => {
         .describe(
           "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
         ),
+      interactive: z
+        .boolean()
+        .describe(
+          "Enable interactive mode for commands requiring user input (arrow keys, text entry, etc.). Examples: opencode auth login, vim file.txt, ssh user@host, psql. Only works with supported commands.",
+        )
+        .optional()
+        .default(false),
     }),
     async execute(params, ctx) {
       const cwd = params.workdir || Instance.directory
@@ -80,6 +119,45 @@ export const BashTool = Tool.define("bash", async () => {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
       const timeout = params.timeout ?? DEFAULT_TIMEOUT
+
+      // Interactive mode handling
+      const useInteractive = shouldUseInteractive(params.command, params.interactive ?? false)
+
+      if (useInteractive) {
+        try {
+          log.info("attempting interactive mode via PTY", { command: params.command })
+
+          // Create PTY session
+          const ptyInfo = await Pty.create({
+            command: shell,
+            args: ["-c", params.command],
+            cwd,
+            title: params.description,
+            env: process.env as Record<string, string>,
+          })
+
+          log.info("PTY session created for interactive command", { ptyId: ptyInfo.id })
+
+          // Return immediately with PTY info
+          return {
+            title: params.description,
+            metadata: {
+              ptyId: ptyInfo.id,
+              interactive: true,
+              description: params.description,
+              command: params.command,
+            },
+            output: `Interactive mode enabled. Use arrow keys, Enter, and type to interact with the command.`,
+          }
+        } catch (error) {
+          log.warn("PTY creation failed, falling back to regular spawn", {
+            command: params.command,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          // Fall through to regular spawn below
+        }
+      }
+
       const tree = await parser().then((p) => p.parse(params.command))
       if (!tree) {
         throw new Error("Failed to parse command")

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -25,6 +25,16 @@ Usage notes:
   - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds ${maxLines} lines or ${maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Because of this, you do NOT need to use `head`, `tail`, or other truncation commands to limit output - just run the command directly.
+  - For commands requiring interactive user input (password prompts, menu selections, text editors), set `interactive: true` to enable full terminal emulation. This supports arrow keys, Enter, text input, and proper terminal control sequences.
+    
+    Supported interactive commands: vim, vi, nano, emacs, ssh, opencode (for auth), less, more, htop, man, psql, mysql, sqlite3, python (REPL), node (REPL), irb.
+    
+    Examples:
+      - opencode auth login (interactive: true) - Select auth provider with arrow keys
+      - vim config.yaml (interactive: true) - Edit file in vim
+      - ssh user@host (interactive: true) - SSH with password prompt
+      
+    Note: Commands not in the supported list will automatically fall back to standard mode.
 
   - Avoid using Bash with the `find`, `grep`, `cat`, `head`, `tail`, `sed`, `awk`, or `echo` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
     - File search: Use Glob (NOT find or ls)


### PR DESCRIPTION
Fixes #1180

## Summary
Adds support for interactive bash commands (like `opencode auth login`, `vim`, `ssh`) by using the existing PTY infrastructure when `interactive: true` is set.

## Changes
- Added `interactive` parameter to bash tool with allowlist of supported commands
- Created `BashInteractive` TUI component that connects to PTY via WebSocket
- Falls back to regular spawn if PTY fails or command not in allowlist
- ESC key exits interactive mode

## How it works
When `interactive: true` and command is in allowlist → creates PTY session → TUI component captures keyboard input and streams it to/from PTY. Everything else works exactly as before.

## Testing needed
- Try `opencode auth login` with arrow keys
- Verify `vim test.txt` works 
- Check `ls -la` still works (falls back to regular mode)

## Allowlisted commands
vim, vi, nano, emacs, ssh, telnet, opencode, less, more, htop, top, man, psql, mysql, sqlite3, python, python3, node, irb