### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -627,7 +627,7 @@ Here are some common use cases for different agents.
 
 ## Examples
 
-Here are some examples agents you might find useful.
+Here are some example agents you might find useful.
 
 :::tip
 Do you have an agent you'd like to share? [Submit a PR](https://github.com/anomalyco/opencode).

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -58,7 +58,7 @@ Use the `command` option in your OpenCode [config](/docs/config):
     "test": {
       // This is the prompt that will be sent to the LLM
       "template": "Run the full test suite with coverage report and show any failures.\nFocus on the failing tests and suggest fixes.",
-      // This is show as the description in the TUI
+      // This is shown as the description in the TUI
       "description": "Run tests with coverage",
       "agent": "build",
       "model": "anthropic/claude-3-5-sonnet-20241022"

--- a/packages/web/src/content/docs/gitlab.mdx
+++ b/packages/web/src/content/docs/gitlab.mdx
@@ -55,7 +55,7 @@ Mention `@opencode` in a comment, and OpenCode will execute tasks within your Gi
 
 - **Triage issues**: Ask OpenCode to look into an issue and explain it to you.
 - **Fix and implement**: Ask OpenCode to fix an issue or implement a feature.
-  It will work create a new branch and raised a merge request with the changes.
+  It will create a new branch and raise a merge request with the changes.
 - **Secure**: OpenCode runs on your GitLab runners.
 
 ---

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -384,7 +384,7 @@ The glob pattern uses simple regex globbing patterns:
 - All other characters match literally
 
 :::note
-MCP server tools are registered with server name as prefix, so to diable all tools for a server simply use:
+MCP server tools are registered with server name as prefix, so to disable all tools for a server simply use:
 
 ```
 "mymcpservername_*": false


### PR DESCRIPTION
### What does this PR do?
Fixes small typos in the documentation:
- `agents.mdx`: "examples agents" → "example agents"
- `commands.mdx`: "This is show as" → "This is shown as"
- `gitlab.mdx`: "It will work create...raised" → "It will create...raise"
- `mcp-servers.mdx`: "diable" → "disable"

Fixes #8699

### How did you verify your code works?
Verified by manually reading the changes in the markdown files.
