### PR TITLE
Migrate lines range syntax from # to :

### DIFF
--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -10,6 +10,7 @@
     "test": "bun test",
     "build": "bun run script/build.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
+    "debug": "bun run --inspect-wait=6499 --conditions=browser ./src/index.ts",
     "random": "echo 'Random script updated at $(date)' && echo 'Change queued successfully' && echo 'Another change made' && echo 'Yet another change' && echo 'One more change' && echo 'Final change' && echo 'Another final change' && echo 'Yet another final change'",
     "clean": "echo 'Cleaning up...' && rm -rf node_modules dist",
     "lint": "echo 'Running lint checks...' && bun test --coverage",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -13,13 +13,15 @@ import { Locale } from "@/util/locale"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
 
+const linesRangeToken = ":"
+
 function removeLineRange(input: string) {
-  const hashIndex = input.lastIndexOf("#")
+  const hashIndex = input.lastIndexOf(linesRangeToken)
   return hashIndex !== -1 ? input.substring(0, hashIndex) : input
 }
 
 function extractLineRange(input: string) {
-  const hashIndex = input.lastIndexOf("#")
+  const hashIndex = input.lastIndexOf(linesRangeToken)
   if (hashIndex === -1) {
     return { baseQuery: input }
   }
@@ -230,7 +232,7 @@ export function Autocomplete(props: {
             let url = `file://${process.cwd()}/${item}`
             let filename = item
             if (lineRange && !item.endsWith("/")) {
-              filename = `${item}#${lineRange.startLine}${lineRange.endLine ? `-${lineRange.endLine}` : ""}`
+              filename = `${item}${linesRangeToken}${lineRange.startLine}${lineRange.endLine ? `-${lineRange.endLine}` : ""}`
               const urlObj = new URL(url)
               urlObj.searchParams.set("start", String(lineRange.startLine))
               if (lineRange.endLine !== undefined) {

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -41,6 +41,12 @@ How is auth handled in @packages/functions/src/api/index.ts?
 
 The content of the file is added to the conversation automatically.
 
+You can narrow the file reference down to a specific lines range using `:{1}-{2}`.
+
+```text
+How is auth handled in @packages/functions/src/api/index.ts:12-34?
+```
+
 ---
 
 ## Bash commands


### PR DESCRIPTION
### What does this PR do?

Moves lines range syntax from # to :. 
Addresses https://github.com/anomalyco/opencode/issues/2129 

### How did you verify your code works?

Unfortunately only manually, proof: https://opncd.ai/share/vCAqcqDv

1. I don't know why, but I couldn't reproduce if from the first attempt, sometimes in the thread it doesn't show the read tool call, so it may create an observation like it reads the entire file, e.g. https://opncd.ai/share/g5iytPsd
2. Pls advise me how to tweak the unit tests on this case if the change itself is good

**Note**
It may require updating docs adding clearly the line numbers start from 0, not 1 as usually we see in the text editors.