### PR TITLE
fix: stack question review answers

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -372,9 +372,11 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               const value = () => store.answers[index()]?.join(", ") ?? ""
               const answered = () => Boolean(value())
               return (
-                <box paddingLeft={1}>
+                <box paddingLeft={1} flexDirection="column">
                   <text>
-                    <span style={{ fg: theme.textMuted }}>{q.header}:</span>{" "}
+                    <span style={{ fg: theme.textMuted }}>{q.header}:</span>
+                  </text>
+                  <text>
                     <span style={{ fg: answered() ? theme.text : theme.error }}>
                       {answered() ? value() : "(not answered)"}
                     </span>


### PR DESCRIPTION
## Summary
- In the question review tool stack the question/answer rather than having it inline for better readability. 

before:
<img width="757" height="236" alt="image" src="https://github.com/user-attachments/assets/e70b3d66-e4e3-4eb8-a1b5-3b9721bc05ba" />

after:
<img width="763" height="273" alt="image" src="https://github.com/user-attachments/assets/1829ea03-5fe9-4ec3-9487-39fec84f9116" />


## Testing
- bun turbo typecheck