### PR TITLE
fix: Prevent excessive Copilot premium request consumption

### DIFF
--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -38,13 +38,15 @@ function hasSyntheticContent(content: unknown): boolean {
 function detectAgent(messages: any[]): boolean {
   if (!Array.isArray(messages) || messages.length === 0) return false
 
+  // Rule 1: If any assistant/tool message exists, this is a continuation
   const hasNonUser = messages.some((msg: any) => ["assistant", "tool"].includes(msg.role))
   if (hasNonUser) return true
 
-  const users = messages.filter((msg: any) => msg.role === "user")
-  if (users.length > 1) return true
+  // Rule 2: Check if the LAST user message is synthetic (compaction, tool result, etc.)
+  const last = messages[messages.length - 1]
+  if (last?.role === "user" && hasSyntheticContent(last.content)) return true
 
-  return users.some((msg: any) => hasSyntheticContent(msg.content))
+  return false
 }
 
 function detectVision(messages: any[]): boolean {

--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -15,6 +15,47 @@ function getUrls(domain: string) {
   }
 }
 
+const SYNTHETIC_PATTERNS = [
+  /^Tool \w+ returned an attachment:/,
+  /^What did we do so far\?/,
+  /^The following tool was executed by the user$/,
+  /^Tool result:/i,
+  /^Tool output:/i,
+]
+
+function isSynthetic(text: string): boolean {
+  if (!text || typeof text !== "string") return false
+  const trimmed = text.trim()
+  return SYNTHETIC_PATTERNS.some((p) => p.test(trimmed))
+}
+
+function hasSyntheticContent(content: unknown): boolean {
+  if (typeof content === "string") return isSynthetic(content)
+  if (!Array.isArray(content)) return false
+  return content.some((part: any) => isSynthetic(part.text || part.content || ""))
+}
+
+function detectAgent(messages: any[]): boolean {
+  if (!Array.isArray(messages) || messages.length === 0) return false
+
+  const hasNonUser = messages.some((msg: any) => ["assistant", "tool"].includes(msg.role))
+  if (hasNonUser) return true
+
+  const users = messages.filter((msg: any) => msg.role === "user")
+  if (users.length > 1) return true
+
+  return users.some((msg: any) => hasSyntheticContent(msg.content))
+}
+
+function detectVision(messages: any[]): boolean {
+  return (
+    messages?.some((msg: any) => {
+      if (!Array.isArray(msg.content)) return false
+      return msg.content.some((part: any) => part.type === "image_url" || part.type === "input_image")
+    }) ?? false
+  )
+}
+
 export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
   return {
     auth: {
@@ -51,32 +92,14 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
             const { isVision, isAgent } = iife(() => {
               try {
                 const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body
-
-                // Completions API
-                if (body?.messages) {
-                  const last = body.messages[body.messages.length - 1]
-                  return {
-                    isVision: body.messages.some(
-                      (msg: any) =>
-                        Array.isArray(msg.content) && msg.content.some((part: any) => part.type === "image_url"),
-                    ),
-                    isAgent: last?.role !== "user",
-                  }
+                const messages = body?.messages || body?.input || []
+                return {
+                  isVision: detectVision(messages),
+                  isAgent: detectAgent(messages),
                 }
-
-                // Responses API
-                if (body?.input) {
-                  const last = body.input[body.input.length - 1]
-                  return {
-                    isVision: body.input.some(
-                      (item: any) =>
-                        Array.isArray(item?.content) && item.content.some((part: any) => part.type === "input_image"),
-                    ),
-                    isAgent: last?.role !== "user",
-                  }
-                }
-              } catch {}
-              return { isVision: false, isAgent: false }
+              } catch {
+                return { isVision: false, isAgent: false }
+              }
             })
 
             const headers: Record<string, string> = {

--- a/packages/opencode/test/plugin/copilot.test.ts
+++ b/packages/opencode/test/plugin/copilot.test.ts
@@ -23,13 +23,15 @@ function hasSyntheticContent(content: unknown): boolean {
 function detectAgent(messages: any[]): boolean {
   if (!Array.isArray(messages) || messages.length === 0) return false
 
+  // Rule 1: If any assistant/tool message exists, this is a continuation
   const hasNonUser = messages.some((msg: any) => ["assistant", "tool"].includes(msg.role))
   if (hasNonUser) return true
 
-  const users = messages.filter((msg: any) => msg.role === "user")
-  if (users.length > 1) return true
+  // Rule 2: Check if the LAST user message is synthetic (compaction, tool result, etc.)
+  const last = messages[messages.length - 1]
+  if (last?.role === "user" && hasSyntheticContent(last.content)) return true
 
-  return users.some((msg: any) => hasSyntheticContent(msg.content))
+  return false
 }
 
 function getInitiator(body: any): "user" | "agent" {
@@ -98,14 +100,15 @@ describe("plugin.copilot", () => {
       expect(getInitiator(body)).toBe("agent")
     })
 
-    test("multiple user messages returns agent", () => {
+    test("multiple user messages without assistant returns user (each charges)", () => {
       const body = {
         messages: [
           { role: "user", content: "First" },
           { role: "user", content: "Second" },
         ],
       }
-      expect(getInitiator(body)).toBe("agent")
+      // Real user follow-ups should charge premium - this is correct Copilot behavior
+      expect(getInitiator(body)).toBe("user")
     })
 
     test("synthetic tool attachment returns agent", () => {
@@ -162,7 +165,7 @@ describe("plugin.copilot", () => {
       expect(getInitiator(body)).toBe("agent")
     })
 
-    test("multi-turn with real user follow-up does not charge premium", () => {
+    test("multi-turn with real user follow-up correctly detected as agent (assistant exists)", () => {
       const body = {
         messages: [
           { role: "user", content: "Hello" },
@@ -170,6 +173,7 @@ describe("plugin.copilot", () => {
           { role: "user", content: "Now do something else" },
         ],
       }
+      // Agent because assistant message exists, not because of multiple users
       expect(getInitiator(body)).toBe("agent")
     })
   })

--- a/packages/opencode/test/plugin/copilot.test.ts
+++ b/packages/opencode/test/plugin/copilot.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test"
+
+const SYNTHETIC_PATTERNS = [
+  /^Tool \w+ returned an attachment:/,
+  /^What did we do so far\?/,
+  /^The following tool was executed by the user$/,
+  /^Tool result:/i,
+  /^Tool output:/i,
+]
+
+function isSynthetic(text: string): boolean {
+  if (!text || typeof text !== "string") return false
+  const trimmed = text.trim()
+  return SYNTHETIC_PATTERNS.some((p) => p.test(trimmed))
+}
+
+function hasSyntheticContent(content: unknown): boolean {
+  if (typeof content === "string") return isSynthetic(content)
+  if (!Array.isArray(content)) return false
+  return content.some((part: any) => isSynthetic(part.text || part.content || ""))
+}
+
+function detectAgent(messages: any[]): boolean {
+  if (!Array.isArray(messages) || messages.length === 0) return false
+
+  const hasNonUser = messages.some((msg: any) => ["assistant", "tool"].includes(msg.role))
+  if (hasNonUser) return true
+
+  const users = messages.filter((msg: any) => msg.role === "user")
+  if (users.length > 1) return true
+
+  return users.some((msg: any) => hasSyntheticContent(msg.content))
+}
+
+function getInitiator(body: any): "user" | "agent" {
+  const messages = body?.messages || body?.input || []
+  return detectAgent(messages) ? "agent" : "user"
+}
+
+describe("plugin.copilot", () => {
+  describe("isSynthetic", () => {
+    test("detects tool attachment pattern", () => {
+      expect(isSynthetic("Tool read_file returned an attachment:")).toBe(true)
+      expect(isSynthetic("Tool bash returned an attachment:")).toBe(true)
+    })
+
+    test("detects compaction pattern", () => {
+      expect(isSynthetic("What did we do so far?")).toBe(true)
+      expect(isSynthetic("What did we do so far? ")).toBe(true)
+    })
+
+    test("detects subtask pattern", () => {
+      expect(isSynthetic("The following tool was executed by the user")).toBe(true)
+    })
+
+    test("ignores normal user messages", () => {
+      expect(isSynthetic("Hello, can you help me?")).toBe(false)
+      expect(isSynthetic("Read the file README.md")).toBe(false)
+      expect(isSynthetic("What did we do yesterday?")).toBe(false)
+    })
+
+    test("handles empty and invalid input", () => {
+      expect(isSynthetic("")).toBe(false)
+      expect(isSynthetic(null as any)).toBe(false)
+      expect(isSynthetic(undefined as any)).toBe(false)
+    })
+  })
+
+  describe("detectAgent", () => {
+    test("first user message returns user", () => {
+      const body = { messages: [{ role: "user", content: "Hello" }] }
+      expect(getInitiator(body)).toBe("user")
+    })
+
+    test("empty messages returns user", () => {
+      expect(getInitiator({ messages: [] })).toBe("user")
+      expect(getInitiator({})).toBe("user")
+      expect(getInitiator(null)).toBe("user")
+    })
+
+    test("assistant message returns agent", () => {
+      const body = {
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi there" },
+        ],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("tool message returns agent", () => {
+      const body = {
+        messages: [
+          { role: "user", content: "Run test" },
+          { role: "tool", content: "Test passed" },
+        ],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("multiple user messages returns agent", () => {
+      const body = {
+        messages: [
+          { role: "user", content: "First" },
+          { role: "user", content: "Second" },
+        ],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("synthetic tool attachment returns agent", () => {
+      const body = {
+        messages: [{ role: "user", content: "Tool read_file returned an attachment:" }],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("synthetic compaction returns agent", () => {
+      const body = {
+        messages: [{ role: "user", content: "What did we do so far? " }],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("synthetic with array content returns agent", () => {
+      const body = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Tool bash returned an attachment:" },
+              { type: "file", url: "file://out.txt" },
+            ],
+          },
+        ],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("responses API format works", () => {
+      expect(getInitiator({ input: [{ role: "user", content: "Hello" }] })).toBe("user")
+      expect(
+        getInitiator({
+          input: [
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: "Hi" },
+          ],
+        }),
+      ).toBe("agent")
+    })
+  })
+
+  describe("regression: issue #8030 and #8067", () => {
+    test("synthetic user message after conversation does not charge premium", () => {
+      const body = {
+        messages: [
+          { role: "user", content: "Read file.txt" },
+          { role: "assistant", content: "Reading..." },
+          { role: "user", content: "Tool read_file returned an attachment:" },
+        ],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+
+    test("multi-turn with real user follow-up does not charge premium", () => {
+      const body = {
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi" },
+          { role: "user", content: "Now do something else" },
+        ],
+      }
+      expect(getInitiator(body)).toBe("agent")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #8030

**Builds on #8393** — Adds synthetic message detection to prevent excessive premium requests.

The official plugin (#8393) uses `last?.role !== "user"` which fails for synthetic user messages created by OpenCode (compaction, tool attachments, subtasks). This PR detects those synthetic messages and correctly marks them as agent-initiated.

## How VSCode Copilot Chat Handles This

From [`microsoft/vscode-copilot-chat`](https://github.com/microsoft/vscode-copilot-chat) @ `main`:

```typescript
// toolCallingLoop.ts:469
userInitiatedRequest: iterationNumber === 0 && !isContinuation && !this.options.request.subAgentInvocationId
```

VSCode uses **explicit flags** to mark tool loops, continuations, and subagents as `agent`. OpenCode doesn't have these flags, so we **infer** the same intent by checking message history.

## Detection Logic

| Scenario | X-Initiator | Charges Premium? |
|----------|-------------|------------------|
| First user message | `user` | ✅ Yes |
| After assistant/tool message exists | `agent` | ❌ No |
| Synthetic user message (compaction, tool result) | `agent` | ❌ No |

**Rules:**
1. If ANY assistant/tool message exists → `agent` (matches VSCode's tool loop behavior)
2. If LAST user message is synthetic → `agent`
3. Otherwise → `user`

**Synthetic patterns detected:**
- `"What did we do so far?"` (compaction)
- `"Tool X returned an attachment:"` (tool results)
- `"The following tool was executed by the user"` (subtasks)

## Why This Approach

OpenCode creates synthetic `user` messages for internal operations that VSCode handles differently. Since we can't use VSCode's explicit flags (`iterationNumber`, `isContinuation`, `subAgentInvocationId`), we infer agent status from:
1. Presence of assistant/tool messages in history
2. Pattern matching on synthetic user message content

This aligns with third-party Copilot clients (litellm, copilot-api, crush) that use the same "Sticky" inference approach.

## Changes

**`copilot.ts`**:
- Added `isSynthetic()` and `hasSyntheticContent()` for pattern matching
- Added `detectAgent()` with history-based inference
- Unified `detectVision()` for both Completions and Responses API

**`copilot.test.ts`** (new):
- 16 tests covering synthetic detection and agent detection

## Verification

| Check | Result |
|-------|--------|
| Prettier | ✅ Pass |
| Type check | ✅ Pass |
| Copilot tests (local) | ✅ 16 pass |
| Copilot tests (Docker) | ✅ 16 pass |
| Rebased on latest dev | ✅ (includes #8393) |

## Related

- #8067 — Original discussion on Copilot premium request consumption (closed, discussion ongoing)
- #8030 — Report of excessive premium requests
- #8700 — Synthetic user messages burning premium requests
- #8766 — Follow-up: migrate to metadata-based detection (long-term)