### PR TITLE
fix: remove opencode fallback in getSmallModel

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1141,12 +1141,7 @@ export namespace Provider {
       }
     }
 
-    // Check if opencode provider is available before using it
-    const opencodeProvider = await state().then((state) => state.providers["opencode"])
-    if (opencodeProvider && opencodeProvider.models["gpt-5-nano"]) {
-      return getModel("opencode", "gpt-5-nano")
-    }
-
+    // Return undefined to let callers fall back to main model as documented
     return undefined
   }
 


### PR DESCRIPTION
## Summary
- Removes the automatic fallback to OpenCode's `gpt-5-nano` when no small model is found for the user's provider
- Now returns `undefined`, allowing callers to fall back to the user's main model as documented

## Problem
The `getSmallModel` function was falling back to OpenCode's `gpt-5-nano` even when users had their own provider configured (e.g., Anthropic, OpenAI). This contradicted the documentation which states the small model "falls back to your main model."

Users who set up their own provider expected their configured model to be used, not OpenCode's `gpt-5-nano`.

## Solution
Removed the OpenCode provider fallback (lines 1144-1148). The callers already handle `undefined` correctly:
- `prompt.ts:1750`: `getSmallModel(...) ?? getModel(providerID, modelID)`
- `summary.ts:86`: `getSmallModel(...) ?? ...`

This ensures the documented behavior: when no small model is configured or found, it falls back to the user's main model.

Fixes #8609

## Test plan
- [ ] Configure a non-OpenCode provider (e.g., Anthropic)
- [ ] Do not configure `small_model` in config
- [ ] Use a feature that triggers `getSmallModel` (e.g., summarization)
- [ ] Verify it uses a model from the configured provider, not OpenCode's `gpt-5-nano`

🤖 Generated with [Claude Code](https://claude.com/claude-code)