### PR TITLE
feat: set gemini-3-pro-preview as default model for plan agent

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -61,6 +61,10 @@ export namespace Agent {
       plan: {
         name: "plan",
         options: {},
+        model: {
+          providerID: "google",
+          modelID: "gemini-3-pro-preview",
+        },
         permission: PermissionNext.merge(
           defaults,
           PermissionNext.fromConfig({


### PR DESCRIPTION
## Summary

- Set `gemini-3-pro-preview` (Google) as the default model for the `plan` agent

## Change

The plan agent now has a default model configured:
```typescript
model: {
  providerID: "google",
  modelID: "gemini-3-pro-preview",
},
```

This means when users switch to the `plan` agent, it will automatically use Gemini 3 Pro Preview instead of their default model.

## Note

Users can still override this in their `opencode.json` config via the `agent.plan.model` setting.