### PR TITLE
feat: add keyboard shortcut to toggle thinking visibility

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import { For, onCleanup, onMount, Show, Match, Switch, createMemo, createEffect, on } from "solid-js"
+import { For, onCleanup, onMount, Show, Match, Switch, createMemo, createEffect, on, createSignal } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { Dynamic } from "solid-js/web"
@@ -170,6 +170,8 @@ export default function Page() {
   const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
   const tabs = createMemo(() => layout.tabs(sessionKey()))
   const view = createMemo(() => layout.view(sessionKey()))
+
+  const [showReasoning, setShowReasoning] = createSignal(false)
 
   if (import.meta.env.DEV) {
     createEffect(
@@ -537,6 +539,22 @@ export default function Page() {
         showToast({
           title: "Thinking effort changed",
           description: "The thinking effort has been changed to " + (local.model.variant.current() ?? "Default"),
+        })
+      },
+    },
+    {
+      id: "session.toggle.reasoning",
+      title: showReasoning() ? "Hide reasoning" : "Show reasoning",
+      description: "Toggle visibility of reasoning/thinking content",
+      category: "Session",
+      keybind: "mod+shift+r",
+      onSelect: () => {
+        setShowReasoning((prev) => !prev)
+        showToast({
+          title: showReasoning() ? "Reasoning visible" : "Reasoning hidden",
+          description: showReasoning()
+            ? "Reasoning content will be shown in messages"
+            : "Reasoning content will be hidden from messages",
         })
       },
     },
@@ -1187,6 +1205,7 @@ export default function Page() {
                                     messageID={message.id}
                                     lastUserMessageID={lastUserMessage()?.id}
                                     stepsExpanded={store.expanded[message.id] ?? false}
+                                    showReasoning={showReasoning()}
                                     onStepsExpandedToggle={() =>
                                       setStore("expanded", message.id, (open: boolean | undefined) => !open)
                                     }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -504,6 +504,7 @@ export function Session() {
       title: showThinking() ? "Hide thinking" : "Show thinking",
       value: "session.toggle.thinking",
       category: "Session",
+      keybind: "thinking_toggle" as const,
       onSelect: (dialog) => {
         setShowThinking((prev) => !prev)
         dialog.clear()

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -671,6 +671,7 @@ export namespace Config {
         .default("<leader>h")
         .describe("Toggle code block concealment in messages"),
       tool_details: z.string().optional().default("none").describe("Toggle tool details visibility"),
+      thinking_toggle: z.string().optional().default("ctrl+alt+t").describe("Toggle thinking visibility"),
       model_list: z.string().optional().default("<leader>m").describe("List available models"),
       model_cycle_recent: z.string().optional().default("f2").describe("Next recently used model"),
       model_cycle_recent_reverse: z.string().optional().default("shift+f2").describe("Previous recently used model"),

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -122,6 +122,7 @@ export function SessionTurn(
     messageID: string
     lastUserMessageID?: string
     stepsExpanded?: boolean
+    showReasoning?: boolean
     onStepsExpandedToggle?: () => void
     onUserInteracted?: () => void
     classes?: {
@@ -564,7 +565,7 @@ export function SessionTurn(
                               message={assistantMessage}
                               responsePartId={responsePartId()}
                               hideResponsePart={hideResponsePart()}
-                              hideReasoning={!working()}
+                              hideReasoning={!working() && !props.showReasoning}
                             />
                           )}
                         </For>

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -18,6 +18,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "username_toggle": "none",
     "status_view": "<leader>s",
     "tool_details": "none",
+    "thinking_toggle": "ctrl+alt+t",
     "session_export": "<leader>x",
     "session_new": "<leader>n",
     "session_list": "<leader>l",


### PR DESCRIPTION
### What does this PR do?
Thinking can be toggled via command, but not via keyboard shortcut. Now it can.
Default shortcut: `ctrl+alt+t`.
Shortcut name: `thinking_toggle` 

### How did you verify your code works?
Ran locally using `bun dev`, asked it what's the best apple

Without thinking:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/c35f9775-1c24-42c5-8bab-5e843e1f8a96" />

After ctrl+alt+t:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/a3287c2e-9b28-457e-96b8-416a06152164" />

Fixes #8167

