### PR TITLE
docs: Add OpenWork to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -57,7 +57,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk  |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode            |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embedds OpenCode in Obsidian's UI          |
-| [OpenWork](https://github.com/different-ai/openwork)                                      | Alternative GUI for OpenCode, designed for non-technical users  |
+| [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode|
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -57,6 +57,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk  |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode            |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embedds OpenCode in Obsidian's UI          |
+| [OpenWork](https://github.com/different-ai/openwork)                                      | Alternative GUI for OpenCode, designed for non-technical users  |
 
 ---
 


### PR DESCRIPTION
Adds OpenWork to the ecosystem page.

OpenWork is an alternative GUI for OpenCode (claude cowork fully built around opencode), designed to make agentic workflows accessible to non-technical users (still early/WIP, but heading in that direction).

We hit front page of Show HN today and got around ~100 stars on GH at the moment.

Features:
- Host mode: runs opencode serve in a chosen workspace
- Client mode: connect to an existing OpenCode server by URL
- Live streaming + todo/plan timeline + permission prompts
- Templates + skills manager for reusable workflows
