### PR TITLE
fix: nix desktop workflow

### DIFF
--- a/.github/workflows/nix-desktop.yml
+++ b/.github/workflows/nix-desktop.yml
@@ -25,6 +25,8 @@ jobs:
       matrix:
         os:
           - blacksmith-4vcpu-ubuntu-2404
+          - blacksmith-4vcpu-ubuntu-2404-arm
+          - macos-15
           - macos-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -33,7 +35,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Nix
-        uses: DeterminateSystems/nix-installer-action@v21
+        uses: nixbuild/nix-quick-install-action@v34
 
       - name: Build desktop via flake
         run: |

--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   update-flake:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       TITLE: flake.lock
 
@@ -101,9 +101,9 @@ jobs:
       matrix:
         include:
           - system: x86_64-linux
-            host: ubuntu-latest
+            host: blacksmith-4vcpu-ubuntu-2404
           - system: aarch64-linux
-            host: ubuntu-22.04-arm
+            host: blacksmith-4vcpu-ubuntu-2404-arm
           - system: x86_64-darwin
             host: macos-15-intel
           - system: aarch64-darwin

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-4ndHIlS9t1ynRdFszJ1nvcu3YhunhuOc7jcuHI1FbnM=",
+    "x86_64-linux": "sha256-Fl1BdjNSg19LJVSgDMiBX8JuTaGlL2I5T+rqLfjSeO4=",
     "aarch64-linux": "sha256-H9eUk/yVrQqVrAYONlb6As7mjkPXtOauBVfMBeVAmRo=",
     "aarch64-darwin": "sha256-C0E9KAEj3GI83HwirIL2zlXYIe92T+7Iv6F51BB6slY=",
     "x86_64-darwin": "sha256-wj5fZnyfu6Sf1HcqvsQM3M7dl5BKRAHmoqm1Ai1cL2M="

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -3,6 +3,6 @@
     "x86_64-linux": "sha256-Fl1BdjNSg19LJVSgDMiBX8JuTaGlL2I5T+rqLfjSeO4=",
     "aarch64-linux": "sha256-6d20RnBuhOUMaY+5Ms/IOAta1HqHCtb/3yjkGsPgJzA=",
     "aarch64-darwin": "sha256-C0E9KAEj3GI83HwirIL2zlXYIe92T+7Iv6F51BB6slY=",
-    "x86_64-darwin": "sha256-wj5fZnyfu6Sf1HcqvsQM3M7dl5BKRAHmoqm1Ai1cL2M="
+    "x86_64-darwin": "sha256-u3izLZJZ0+KVqOu0agm4lBY8A3cY62syF0QaL9c1E/g="
   }
 }

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -2,7 +2,7 @@
   "nodeModules": {
     "x86_64-linux": "sha256-Fl1BdjNSg19LJVSgDMiBX8JuTaGlL2I5T+rqLfjSeO4=",
     "aarch64-linux": "sha256-6d20RnBuhOUMaY+5Ms/IOAta1HqHCtb/3yjkGsPgJzA=",
-    "aarch64-darwin": "sha256-C0E9KAEj3GI83HwirIL2zlXYIe92T+7Iv6F51BB6slY=",
+    "aarch64-darwin": "sha256-7UajHu40n7JKqurU/+CGlitErsVFA2qDneUytI8+/zQ=",
     "x86_64-darwin": "sha256-u3izLZJZ0+KVqOu0agm4lBY8A3cY62syF0QaL9c1E/g="
   }
 }

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,7 +1,7 @@
 {
   "nodeModules": {
     "x86_64-linux": "sha256-Fl1BdjNSg19LJVSgDMiBX8JuTaGlL2I5T+rqLfjSeO4=",
-    "aarch64-linux": "sha256-H9eUk/yVrQqVrAYONlb6As7mjkPXtOauBVfMBeVAmRo=",
+    "aarch64-linux": "sha256-6d20RnBuhOUMaY+5Ms/IOAta1HqHCtb/3yjkGsPgJzA=",
     "aarch64-darwin": "sha256-C0E9KAEj3GI83HwirIL2zlXYIe92T+7Iv6F51BB6slY=",
     "x86_64-darwin": "sha256-wj5fZnyfu6Sf1HcqvsQM3M7dl5BKRAHmoqm1Ai1cL2M="
   }


### PR DESCRIPTION
### What does this PR do?

- Replace DeterminateSystems/nix-installer-action with nixbuild/nix-quick-install-action in nix-desktop.yml 
- Use blacksmith runners (blacksmith-4vcpu-ubuntu-2404, blacksmith-4vcpu-ubuntu-2404-arm) instead of GitHub-hosted Ubuntu runners
- Add blacksmith-4vcpu-ubuntu-2404-arm and macos-15 (x86_64-darwin) to the nix-desktop build matrix
- Fixes #8756 