### PR TITLE
feat(opencode): added logic to probe loaded models from lmstudio and ollama

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -4,6 +4,7 @@ import { cmd } from "../cmd"
 import { ConfigCommand } from "./config"
 import { FileCommand } from "./file"
 import { LSPCommand } from "./lsp"
+import { ProviderCommand } from "./provider"
 import { RipgrepCommand } from "./ripgrep"
 import { ScrapCommand } from "./scrap"
 import { SkillCommand } from "./skill"
@@ -17,6 +18,7 @@ export const DebugCommand = cmd({
     yargs
       .command(ConfigCommand)
       .command(LSPCommand)
+      .command(ProviderCommand)
       .command(RipgrepCommand)
       .command(FileCommand)
       .command(ScrapCommand)

--- a/packages/opencode/src/cli/cmd/debug/provider.ts
+++ b/packages/opencode/src/cli/cmd/debug/provider.ts
@@ -1,0 +1,31 @@
+import { EOL } from "os"
+import { LocalProvider, type LocalModel } from "../../../provider/local"
+import { cmd } from "../cmd"
+
+export const ProviderCommand = cmd({
+  command: "provider",
+  describe: "probe local LLM providers",
+  builder: (yargs) =>
+    yargs.command({
+      command: "probe <type> <url>",
+      describe: "probe a local provider for loaded models",
+      builder: (yargs) =>
+        yargs
+          .positional("type", {
+            describe: "provider type",
+            type: "string",
+            choices: Object.values(LocalProvider).filter((v) => typeof v === "string") as LocalProvider[],
+          })
+          .positional("url", {
+            describe: "provider URL",
+            type: "string",
+          }),
+      async handler(args) {
+        const type = args.type as LocalProvider
+        const url = args.url as string
+        const result = await LocalProvider.probe(type, url)
+        process.stdout.write(JSON.stringify(result, null, 2) + EOL)
+      },
+    }),
+  async handler() {},
+})

--- a/packages/opencode/src/provider/local/index.ts
+++ b/packages/opencode/src/provider/local/index.ts
@@ -1,0 +1,34 @@
+import { Log } from "../../util/log"
+import { ollama_probe_loaded_models } from "./ollama"
+import { lmstudio_probe_loaded_models } from "./lmstudio"
+import { llamaccpp_probe_loaded_models } from "./llamacpp"
+
+export enum LocalProvider {
+  Ollama = "ollama",
+  LMStudio = "lmstudio",
+  LlamaCPP = "llamacpp",
+}
+
+export interface LocalModel {
+  id: string
+  context_length: number
+  tool_call: boolean
+  vision: boolean
+}
+
+export namespace LocalProvider {
+  const log = Log.create({ service: "localprovider" })
+
+  export async function probe(provider: LocalProvider, url: string): Promise<LocalModel[]> {
+    switch (provider) {
+      case LocalProvider.Ollama:
+        return await ollama_probe_loaded_models(url)
+      case LocalProvider.LMStudio:
+        return await lmstudio_probe_loaded_models(url)
+      case LocalProvider.LlamaCPP:
+        return await llamaccpp_probe_loaded_models(url)
+      default:
+        throw new Error(`Unsupported provider: ${provider}`)
+    }
+  }
+}

--- a/packages/opencode/src/provider/local/llamacpp.ts
+++ b/packages/opencode/src/provider/local/llamacpp.ts
@@ -1,0 +1,143 @@
+import { type LocalModel } from "./index"
+
+export interface LlamaCppModelStatus {
+  value?: "loaded" | "loading" | "unloaded"
+  args?: string[]
+  failed?: boolean
+  exit_code?: number
+}
+
+export interface LlamaCppModelInfo {
+  id: string
+  status?: LlamaCppModelStatus
+}
+
+export interface LlamaCppModelsResponse {
+  data?: LlamaCppModelInfo[]
+}
+
+export interface LlamaCppV1Model {
+  id: string
+  object?: string
+  meta?: Record<string, unknown> | null
+}
+
+export interface LlamaCppV1ModelsResponse {
+  data?: LlamaCppV1Model[]
+  object?: string
+}
+
+export interface LlamaCppPropsResponse {
+  default_generation_settings?: {
+    n_ctx?: number
+  }
+  modalities?: {
+    vision?: boolean
+  }
+  chat_template_caps?: Record<string, unknown>
+}
+
+function llamaccpp_base_url(url: string): string {
+  return url.replace(/\/$/, "")
+}
+
+function llamaccpp_tool_capable(caps?: Record<string, unknown>): boolean {
+  if (!caps) return false
+  const value = caps.supports_tool_calls
+  return value === true || value === "true"
+}
+
+function llamaccpp_context_from_meta(meta?: Record<string, unknown> | null): number {
+  if (!meta) return 0
+  const ctxTrain = meta.n_ctx_train
+  if (typeof ctxTrain === "number" && ctxTrain > 0) return ctxTrain
+  const ctx = meta.n_ctx
+  if (typeof ctx === "number" && ctx > 0) return ctx
+  return 0
+}
+
+async function llamaccpp_fetch_models(url: string): Promise<LlamaCppModelsResponse | null> {
+  const endpoint = llamaccpp_base_url(url) + "/models"
+  const res = await fetch(endpoint, { signal: AbortSignal.timeout(3000) })
+  if (!res.ok) return null
+  return res.json() as Promise<LlamaCppModelsResponse>
+}
+
+async function llamaccpp_fetch_v1_models(url: string): Promise<LlamaCppV1ModelsResponse> {
+  const endpoint = llamaccpp_base_url(url) + "/v1/models"
+  const res = await fetch(endpoint, { signal: AbortSignal.timeout(3000) })
+  if (!res.ok) {
+    const respText = await res.text()
+    throw new Error(`LlamaCPP probe failed with status ${res.status}: ${respText}`)
+  }
+
+  return res.json() as Promise<LlamaCppV1ModelsResponse>
+}
+
+async function llamaccpp_fetch_props(url: string, model?: string): Promise<LlamaCppPropsResponse> {
+  const base = llamaccpp_base_url(url)
+  const query = model ? `?model=${encodeURIComponent(model)}` : ""
+  const endpoint = `${base}/props${query}`
+  const res = await fetch(endpoint, { signal: AbortSignal.timeout(3000) })
+  if (!res.ok) {
+    const respText = await res.text()
+    throw new Error(`LlamaCPP props failed with status ${res.status}: ${respText}`)
+  }
+
+  return res.json() as Promise<LlamaCppPropsResponse>
+}
+
+async function llamaccpp_model_from_props(url: string, id: string, model?: string): Promise<LocalModel> {
+  const props = await llamaccpp_fetch_props(url, model)
+  const context = props.default_generation_settings?.n_ctx ?? 0
+  const vision = props.modalities?.vision === true
+  const tool_call = llamaccpp_tool_capable(props.chat_template_caps)
+
+  return {
+    id,
+    context_length: context,
+    tool_call,
+    vision,
+  }
+}
+
+async function llamaccpp_model_from_props_or_meta(
+  url: string,
+  id: string,
+  model: string | undefined,
+  meta?: Record<string, unknown> | null,
+): Promise<LocalModel> {
+  return llamaccpp_model_from_props(url, id, model).catch(() => ({
+    id,
+    context_length: llamaccpp_context_from_meta(meta),
+    tool_call: false,
+    vision: false,
+  }))
+}
+
+export async function llamaccpp_probe_loaded_models(url: string): Promise<LocalModel[]> {
+  const models = await llamaccpp_fetch_models(url).catch(() => null)
+  if (models) {
+    const items = models.data ?? []
+    const router = items.some((m) => m.status)
+    if (router) {
+      const loaded = items.filter((m) => m.status?.value === "loaded")
+      if (loaded.length === 0) return []
+      const v1 = await llamaccpp_fetch_v1_models(url).catch(() => ({ data: [] }) as LlamaCppV1ModelsResponse)
+      const map = new Map(v1.data?.map((m) => [m.id, m.meta]) ?? [])
+      return Promise.all(
+        loaded.map((m) => {
+          const id = m.id
+          const meta = map.get(id) ?? null
+          return llamaccpp_model_from_props_or_meta(url, id, id, meta)
+        }),
+      )
+    }
+  }
+
+  const v1 = await llamaccpp_fetch_v1_models(url)
+  const v1items = v1.data ?? []
+  if (v1items.length === 0) return []
+
+  return Promise.all(v1items.map((m) => llamaccpp_model_from_props_or_meta(url, m.id, m.id, m.meta)))
+}

--- a/packages/opencode/src/provider/local/lmstudio.ts
+++ b/packages/opencode/src/provider/local/lmstudio.ts
@@ -1,0 +1,47 @@
+import { type LocalModel } from "./index"
+
+export interface LMStudioModel {
+  id: string
+  object: "model"
+  type: "llm" | "vlm" | "embeddings"
+  publisher: string
+  arch: string
+  compatibility_type: string
+  quantization: string
+  state: "loaded" | "loading" | "not-loaded"
+  max_context_length: number
+  loaded_context_length?: number
+  capabilities?: string[]
+}
+
+export interface LMStudioModelsResponse {
+  data: LMStudioModel[]
+  object: "list"
+}
+
+export async function lmstudio_probe_loaded_models(url: string): Promise<LocalModel[]> {
+  const endpoint = url.replace(/\/$/, "") + "/api/v0/models"
+
+  const res = await fetch(endpoint, { signal: AbortSignal.timeout(3000) })
+  if (!res.ok) {
+    const respText = await res.text()
+    throw new Error(`LMStudio probe failed with status ${res.status}: ${respText}`)
+  }
+
+  const body = (await res.json()) as LMStudioModelsResponse
+  if (!body.data) {
+    throw new Error("LMStudio probe failed: no data field in response")
+  }
+
+  const loaded_models = body.data
+    .filter((m) => m.state === "loaded")
+    .filter((m) => m.type === "llm" || m.type === "vlm")
+    .filter((m) => m.loaded_context_length && m.loaded_context_length > 0)
+
+  return loaded_models.map((m) => ({
+    id: m.id,
+    context_length: m.loaded_context_length as number,
+    tool_call: m.capabilities ? m.capabilities.includes("tool_use") : false,
+    vision: m.type === "vlm",
+  }))
+}

--- a/packages/opencode/src/provider/local/ollama.ts
+++ b/packages/opencode/src/provider/local/ollama.ts
@@ -1,0 +1,84 @@
+import { type LocalModel } from "./index"
+
+export interface OllamaModelDetails {
+  parent_model?: string
+  format?: string
+  family?: string
+  families?: string[]
+  parameter_size?: string
+  quantization_level?: string
+}
+
+export interface OllamaLoadedModel {
+  name: string
+  model: string
+  size: number
+  digest: string
+  details?: OllamaModelDetails
+  expires_at?: string
+  size_vram: number
+  context_length: number
+}
+
+export interface OllamaLoadedModelsResponse {
+  models: OllamaLoadedModel[]
+}
+
+export interface OllamaModelShowResponse {
+  parameters?: string
+  license?: string
+  capabilities?: string[]
+  modified_at?: string
+  details?: OllamaModelDetails
+  template?: string
+  model_info?: Record<string, any>
+}
+
+async function ollama_show_model(url: string, model: string): Promise<OllamaModelShowResponse> {
+  const endpoint = url.replace(/\/$/, "") + "/api/show"
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model }),
+    signal: AbortSignal.timeout(3000),
+  })
+
+  if (!res.ok) {
+    const respText = await res.text()
+    throw new Error(`Ollama show model failed with status ${res.status}: ${respText}`)
+  }
+
+  return res.json() as Promise<OllamaModelShowResponse>
+}
+
+export async function ollama_probe_loaded_models(url: string): Promise<LocalModel[]> {
+  const endpoint = url.replace(/\/$/, "") + "/api/ps"
+
+  const res = await fetch(endpoint, { signal: AbortSignal.timeout(3000) })
+  if (!res.ok) {
+    const respText = await res.text()
+    throw new Error(`Ollama probe failed with status ${res.status}: ${respText}`)
+  }
+
+  const body = (await res.json()) as OllamaLoadedModelsResponse
+  if (body.models === undefined) {
+    throw new Error("Ollama probe failed: no models field in response")
+  }
+
+  const models: LocalModel[] = await Promise.all(
+    body.models.map(async (m) => {
+      const show = await ollama_show_model(url, m.model).catch(() => ({} as OllamaModelShowResponse))
+      const caps = show.capabilities ?? []
+
+      return {
+        id: m.name,
+        context_length: m.context_length,
+        tool_call: caps.includes("tools"),
+        vision: caps.includes("vision"),
+      }
+    })
+  )
+
+  return models
+}


### PR DESCRIPTION
### What does this PR do?
- Added core logic for enumerating *loaded* models from Ollama and LMStudio in `packages/opencode/src/provider/local/index.ts`
- Added debug cli `opencode debug provider probe <type: ollama|lmstudio> <url: string>`

### How did you verify your code works?
<img width="612" height="171" alt="image" src="https://github.com/user-attachments/assets/90a38769-7ce8-49e8-b673-55587d17366b" />

<img width="621" height="166" alt="image" src="https://github.com/user-attachments/assets/c952dc22-7ad9-4e9b-8055-e7bb4c7037fd" />
