### PR TITLE
docs(web): add opencode-antigravity-img plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -42,6 +42,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                      |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                          |
+| [opencode-antigravity-img](https://github.com/ominiverdi/opencode-antigravity-img)                 | Generate images using Gemini 3 Pro Image model (companion to antigravity-auth)                 |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `opencode-antigravity-img` to the plugins list in the ecosystem documentation.

This plugin enables image generation using the Gemini 3 Pro Image model via the Antigravity/CloudCode API. It's a companion to `opencode-antigravity-auth` (already listed).

**Links:**
- GitHub: https://github.com/ominiverdi/opencode-antigravity-img
- npm: https://www.npmjs.com/package/opencode-antigravity-img

**Features:**
- `generate_image` tool - Generate images from text prompts
- `image_quota` tool - Check remaining quota for image generation