### PR TITLE
fix: use full URL for file:// plugin deduplication

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -18,7 +18,7 @@ import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
-import { existsSync } from "fs"
+import { existsSync, readFileSync } from "fs"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -329,32 +329,56 @@ export namespace Config {
     return plugins
   }
 
+  function findPackageJsonName(filePath: string): string | undefined {
+    let dir = path.dirname(filePath)
+    const root = path.parse(dir).root
+
+    for (let i = 0; i < 5 && dir !== root; i++) {
+      const pkgPath = path.join(dir, "package.json")
+      if (existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"))
+          if (pkg.name && typeof pkg.name === "string") {
+            return pkg.name
+          }
+        } catch {
+          // Invalid JSON, continue searching up
+        }
+      }
+      dir = path.dirname(dir)
+    }
+
+    return undefined
+  }
+
   /**
    * Extracts a canonical plugin name from a plugin specifier.
-   * - For file:// URLs: extracts filename, or parent directory if filename is generic (index, main, plugin)
+   * - For file:// URLs: looks for package.json name, falls back to filename/parent directory
    * - For npm packages: extracts package name without version
    *
    * @example
-   * getPluginName("file:///path/to/plugin-a/index.js") // "plugin-a"
-   * getPluginName("file:///path/to/plugin-b/dist/index.js") // "plugin-b"
-   * getPluginName("file:///path/to/oh-my-opencode.js") // "oh-my-opencode"
+   * getPluginName("file:///path/to/oh-my-opencode/dist/index.js") // "oh-my-opencode" (from package.json)
+   * getPluginName("file:///path/to/plugin/foo.js") // "foo" (no package.json, uses filename)
    * getPluginName("oh-my-opencode@2.4.3") // "oh-my-opencode"
    * getPluginName("@scope/pkg@1.0.0") // "@scope/pkg"
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
       const pathname = new URL(plugin).pathname
+
+      const packageName = findPackageJsonName(pathname)
+      if (packageName) {
+        return packageName
+      }
+
       const parts = pathname.split("/").filter(Boolean)
       const filename = path.parse(pathname).name
-
-      // Generic names that don't uniquely identify a plugin
       const genericNames = new Set(["index", "main", "plugin", "dist", "build", "out", "lib"])
 
       if (!genericNames.has(filename)) {
         return filename
       }
 
-      // Filename is generic, walk up directories to find meaningful name
       for (let i = parts.length - 2; i >= 0; i--) {
         const dirName = parts[i]
         if (!genericNames.has(dirName) && dirName !== ".opencode") {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -331,17 +331,17 @@ export namespace Config {
 
   /**
    * Extracts a canonical plugin name from a plugin specifier.
-   * - For file:// URLs: extracts filename without extension
+   * - For file:// URLs: uses full URL as identity (to support multiple plugins in same directory)
    * - For npm packages: extracts package name without version
    *
    * @example
-   * getPluginName("file:///path/to/plugin/foo.js") // "foo"
+   * getPluginName("file:///path/to/plugin/foo.js") // "file:///path/to/plugin/foo.js"
    * getPluginName("oh-my-opencode@2.4.3") // "oh-my-opencode"
    * getPluginName("@scope/pkg@1.0.0") // "@scope/pkg"
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
-      return path.parse(new URL(plugin).pathname).name
+      return plugin
     }
     const lastAt = plugin.lastIndexOf("@")
     if (lastAt > 0) {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -331,16 +331,37 @@ export namespace Config {
 
   /**
    * Extracts a canonical plugin name from a plugin specifier.
-   * - For file:// URLs: uses full URL as identity (to support multiple plugins in same directory)
+   * - For file:// URLs: extracts filename, or parent directory if filename is generic (index, main, plugin)
    * - For npm packages: extracts package name without version
    *
    * @example
-   * getPluginName("file:///path/to/plugin/foo.js") // "file:///path/to/plugin/foo.js"
+   * getPluginName("file:///path/to/plugin-a/index.js") // "plugin-a"
+   * getPluginName("file:///path/to/plugin-b/dist/index.js") // "plugin-b"
+   * getPluginName("file:///path/to/oh-my-opencode.js") // "oh-my-opencode"
    * getPluginName("oh-my-opencode@2.4.3") // "oh-my-opencode"
    * getPluginName("@scope/pkg@1.0.0") // "@scope/pkg"
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
+      const pathname = new URL(plugin).pathname
+      const parts = pathname.split("/").filter(Boolean)
+      const filename = path.parse(pathname).name
+
+      // Generic names that don't uniquely identify a plugin
+      const genericNames = new Set(["index", "main", "plugin", "dist", "build", "out", "lib"])
+
+      if (!genericNames.has(filename)) {
+        return filename
+      }
+
+      // Filename is generic, walk up directories to find meaningful name
+      for (let i = parts.length - 2; i >= 0; i--) {
+        const dirName = parts[i]
+        if (!genericNames.has(dirName) && dirName !== ".opencode") {
+          return dirName
+        }
+      }
+
       return plugin
     }
     const lastAt = plugin.lastIndexOf("@")

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1,6 +1,6 @@
 import { Log } from "../util/log"
 import path from "path"
-import { pathToFileURL } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
 import os from "os"
 import z from "zod"
 import { Filesystem } from "../util/filesystem"
@@ -18,7 +18,7 @@ import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
-import { existsSync, readFileSync } from "fs"
+import { existsSync } from "fs"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -329,56 +329,30 @@ export namespace Config {
     return plugins
   }
 
-  function findPackageJsonName(filePath: string): string | undefined {
-    let dir = path.dirname(filePath)
-    const root = path.parse(dir).root
-
-    for (let i = 0; i < 5 && dir !== root; i++) {
-      const pkgPath = path.join(dir, "package.json")
-      if (existsSync(pkgPath)) {
-        try {
-          const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"))
-          if (pkg.name && typeof pkg.name === "string") {
-            return pkg.name
-          }
-        } catch {
-          // Invalid JSON, continue searching up
-        }
-      }
-      dir = path.dirname(dir)
-    }
-
-    return undefined
-  }
-
   /**
    * Extracts a canonical plugin name from a plugin specifier.
-   * - For file:// URLs: looks for package.json name, falls back to filename/parent directory
+   * - For file:// URLs: extracts filename, or walks up to find non-generic parent directory
    * - For npm packages: extracts package name without version
    *
    * @example
-   * getPluginName("file:///path/to/oh-my-opencode/dist/index.js") // "oh-my-opencode" (from package.json)
-   * getPluginName("file:///path/to/plugin/foo.js") // "foo" (no package.json, uses filename)
+   * getPluginName("file:///path/to/plugin/foo.js") // "foo"
+   * getPluginName("file:///path/to/plugin-a/index.js") // "plugin-a"
+   * getPluginName("file:///path/to/oh-my-opencode/dist/index.js") // "oh-my-opencode"
    * getPluginName("oh-my-opencode@2.4.3") // "oh-my-opencode"
    * getPluginName("@scope/pkg@1.0.0") // "@scope/pkg"
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
-      const pathname = new URL(plugin).pathname
-
-      const packageName = findPackageJsonName(pathname)
-      if (packageName) {
-        return packageName
-      }
-
-      const parts = pathname.split("/").filter(Boolean)
-      const filename = path.parse(pathname).name
+      const filePath = fileURLToPath(plugin)
+      const parsed = path.parse(filePath)
+      const filename = parsed.name
       const genericNames = new Set(["index", "main", "plugin", "dist", "build", "out", "lib"])
 
       if (!genericNames.has(filename)) {
         return filename
       }
 
+      const parts = filePath.split(path.sep).filter(Boolean)
       for (let i = parts.length - 2; i >= 0; i--) {
         const dirName = parts[i]
         if (!genericNames.has(dirName) && dirName !== ".opencode") {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1188,6 +1188,7 @@ export namespace Config {
       if (data.plugin) {
         for (let i = 0; i < data.plugin.length; i++) {
           const plugin = data.plugin[i]
+          if (plugin.startsWith("file://")) continue // Already absolute
           try {
             data.plugin[i] = import.meta.resolve!(plugin, configFilepath)
           } catch (err) {}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -18,7 +18,7 @@ import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
-import { existsSync } from "fs"
+import { existsSync, readFileSync } from "fs"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -329,21 +329,48 @@ export namespace Config {
     return plugins
   }
 
+  function findPackageJsonName(filePath: string): string | undefined {
+    let dir = path.dirname(filePath)
+    const root = path.parse(dir).root
+
+    for (let i = 0; i < 5 && dir !== root; i++) {
+      const pkgPath = path.join(dir, "package.json")
+      if (existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"))
+          if (pkg.name && typeof pkg.name === "string") {
+            return pkg.name
+          }
+        } catch {
+          // Invalid JSON, continue searching up
+        }
+      }
+      dir = path.dirname(dir)
+    }
+
+    return undefined
+  }
+
   /**
    * Extracts a canonical plugin name from a plugin specifier.
-   * - For file:// URLs: extracts filename, or walks up to find non-generic parent directory
+   * - For file:// URLs: reads package.json name (cross-platform, canonical), falls back to path heuristic
    * - For npm packages: extracts package name without version
    *
    * @example
-   * getPluginName("file:///path/to/plugin/foo.js") // "foo"
-   * getPluginName("file:///path/to/plugin-a/index.js") // "plugin-a"
-   * getPluginName("file:///path/to/oh-my-opencode/dist/index.js") // "oh-my-opencode"
+   * getPluginName("file:///path/to/oh-my-opencode/dist/index.js") // "oh-my-opencode" (from package.json)
+   * getPluginName("file:///path/to/plugin/foo.js") // "foo" (no package.json, uses filename)
    * getPluginName("oh-my-opencode@2.4.3") // "oh-my-opencode"
    * getPluginName("@scope/pkg@1.0.0") // "@scope/pkg"
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
       const filePath = fileURLToPath(plugin)
+
+      const packageName = findPackageJsonName(filePath)
+      if (packageName) {
+        return packageName
+      }
+
       const parsed = path.parse(filePath)
       const filename = parsed.name
       const genericNames = new Set(["index", "main", "plugin", "dist", "build", "out", "lib"])
@@ -352,12 +379,14 @@ export namespace Config {
         return filename
       }
 
-      const parts = filePath.split(path.sep).filter(Boolean)
-      for (let i = parts.length - 2; i >= 0; i--) {
-        const dirName = parts[i]
+      let dir = path.dirname(filePath)
+      const root = path.parse(dir).root
+      for (let i = 0; i < 5 && dir !== root; i++) {
+        const dirName = path.basename(dir)
         if (!genericNames.has(dirName) && dirName !== ".opencode") {
           return dirName
         }
+        dir = path.dirname(dir)
       }
 
       return plugin

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1294,45 +1294,11 @@ describe("getPluginName", () => {
     expect(Config.getPluginName("file:///some/path/my-plugin.js")).toBe("my-plugin")
   })
 
-  test("extracts parent directory name for generic filenames (fallback when no package.json)", () => {
+  test("extracts parent directory name for generic filenames", () => {
     expect(Config.getPluginName("file:///path/to/plugin-a/index.js")).toBe("plugin-a")
     expect(Config.getPluginName("file:///path/to/plugin-b/dist/index.js")).toBe("plugin-b")
     expect(Config.getPluginName("file:///path/to/oh-my-opencode/dist/index.js")).toBe("oh-my-opencode")
     expect(Config.getPluginName("file:///path/to/my-plugin/build/main.js")).toBe("my-plugin")
-  })
-
-  test("extracts name from package.json when present", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const pluginDir = path.join(dir, "my-awesome-plugin", "dist")
-        await fs.mkdir(pluginDir, { recursive: true })
-        await Bun.write(
-          path.join(dir, "my-awesome-plugin", "package.json"),
-          JSON.stringify({ name: "my-awesome-plugin", version: "1.0.0" }),
-        )
-        await Bun.write(path.join(pluginDir, "index.js"), "export default {}")
-      },
-    })
-
-    const pluginPath = `file://${path.join(tmp.path, "my-awesome-plugin", "dist", "index.js")}`
-    expect(Config.getPluginName(pluginPath)).toBe("my-awesome-plugin")
-  })
-
-  test("prefers package.json name over directory name", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const pluginDir = path.join(dir, "wrong-name", "dist")
-        await fs.mkdir(pluginDir, { recursive: true })
-        await Bun.write(
-          path.join(dir, "wrong-name", "package.json"),
-          JSON.stringify({ name: "@scope/correct-name", version: "1.0.0" }),
-        )
-        await Bun.write(path.join(pluginDir, "index.js"), "export default {}")
-      },
-    })
-
-    const pluginPath = `file://${path.join(tmp.path, "wrong-name", "dist", "index.js")}`
-    expect(Config.getPluginName(pluginPath)).toBe("@scope/correct-name")
   })
 
   test("extracts name from npm package with version", () => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1294,6 +1294,13 @@ describe("getPluginName", () => {
     expect(Config.getPluginName("file:///some/path/my-plugin.js")).toBe("my-plugin")
   })
 
+  test("extracts parent directory name for generic filenames", () => {
+    expect(Config.getPluginName("file:///path/to/plugin-a/index.js")).toBe("plugin-a")
+    expect(Config.getPluginName("file:///path/to/plugin-b/dist/index.js")).toBe("plugin-b")
+    expect(Config.getPluginName("file:///path/to/oh-my-opencode/dist/index.js")).toBe("oh-my-opencode")
+    expect(Config.getPluginName("file:///path/to/my-plugin/build/main.js")).toBe("my-plugin")
+  })
+
   test("extracts name from npm package with version", () => {
     expect(Config.getPluginName("oh-my-opencode@2.4.3")).toBe("oh-my-opencode")
     expect(Config.getPluginName("some-plugin@1.0.0")).toBe("some-plugin")
@@ -1339,6 +1346,21 @@ describe("deduplicatePlugins", () => {
     const result = Config.deduplicatePlugins(plugins)
 
     expect(result).toEqual(["a-plugin@1.0.0", "b-plugin@1.0.0", "c-plugin@1.0.0"])
+  })
+
+  test("allows multiple plugins with same generic filename in different directories", () => {
+    const plugins = [
+      "file:///path/to/plugin-a/dist/index.js",
+      "file:///path/to/plugin-b/dist/index.js",
+      "file:///path/to/plugin-c/index.js",
+    ]
+
+    const result = Config.deduplicatePlugins(plugins)
+
+    expect(result.length).toBe(3)
+    expect(result).toContain("file:///path/to/plugin-a/dist/index.js")
+    expect(result).toContain("file:///path/to/plugin-b/dist/index.js")
+    expect(result).toContain("file:///path/to/plugin-c/index.js")
   })
 
   test("local plugin directory overrides global opencode.json plugin", async () => {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1294,11 +1294,45 @@ describe("getPluginName", () => {
     expect(Config.getPluginName("file:///some/path/my-plugin.js")).toBe("my-plugin")
   })
 
-  test("extracts parent directory name for generic filenames", () => {
+  test("extracts parent directory name for generic filenames (fallback when no package.json)", () => {
     expect(Config.getPluginName("file:///path/to/plugin-a/index.js")).toBe("plugin-a")
     expect(Config.getPluginName("file:///path/to/plugin-b/dist/index.js")).toBe("plugin-b")
     expect(Config.getPluginName("file:///path/to/oh-my-opencode/dist/index.js")).toBe("oh-my-opencode")
     expect(Config.getPluginName("file:///path/to/my-plugin/build/main.js")).toBe("my-plugin")
+  })
+
+  test("extracts name from package.json when present", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const pluginDir = path.join(dir, "my-awesome-plugin", "dist")
+        await fs.mkdir(pluginDir, { recursive: true })
+        await Bun.write(
+          path.join(dir, "my-awesome-plugin", "package.json"),
+          JSON.stringify({ name: "my-awesome-plugin", version: "1.0.0" }),
+        )
+        await Bun.write(path.join(pluginDir, "index.js"), "export default {}")
+      },
+    })
+
+    const pluginPath = `file://${path.join(tmp.path, "my-awesome-plugin", "dist", "index.js")}`
+    expect(Config.getPluginName(pluginPath)).toBe("my-awesome-plugin")
+  })
+
+  test("prefers package.json name over directory name", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const pluginDir = path.join(dir, "wrong-name", "dist")
+        await fs.mkdir(pluginDir, { recursive: true })
+        await Bun.write(
+          path.join(dir, "wrong-name", "package.json"),
+          JSON.stringify({ name: "@scope/correct-name", version: "1.0.0" }),
+        )
+        await Bun.write(path.join(pluginDir, "index.js"), "export default {}")
+      },
+    })
+
+    const pluginPath = `file://${path.join(tmp.path, "wrong-name", "dist", "index.js")}`
+    expect(Config.getPluginName(pluginPath)).toBe("@scope/correct-name")
   })
 
   test("extracts name from npm package with version", () => {


### PR DESCRIPTION
## Summary

Fixes a bug in plugin deduplication logic where multiple file:// plugins with the same filename (e.g., `index.js`) would be incorrectly treated as duplicates and only the last one would load.

## Problem

The `getPluginName()` function extracted only the filename for file:// URLs:

```typescript
// Before
if (plugin.startsWith("file://")) {
  return path.parse(new URL(plugin).pathname).name  // "index"
}
```

This caused issues when using multiple plugins with standard entry points:

```json
{
  "plugin": [
    "file:///path/to/plugin-a/dist/index.js",  // -> "index"
    "file:///path/to/plugin-b/dist/index.js",  // -> "index" (duplicate!)
    "file:///path/to/plugin-c/dist/index.js"   // -> "index" (duplicate!)
  ]
}
```

Result: Only the last plugin loaded because all were seen as duplicates of "index".

## Solution

Use the full URL as the identity for file:// plugins:

```typescript
// After
if (plugin.startsWith("file://")) {
  return plugin  // Full URL
}
```

This allows:
- ✅ Multiple plugins in the same directory with different filenames
- ✅ Multiple plugins in different directories with the same filename  
- ✅ Same file:// URL appearing twice → correctly deduplicated
- ✅ npm packages continue to deduplicate by package name as expected

## Testing

Verified with real-world setup using four local file:// plugins, all with `index.js` or `index.mjs` entry points:
- `custom-toolkit-alpha/dist/index.js`
- `custom-toolkit-beta/dist/index.js`
- `custom-toolkit-gamma/dist/index.js`
- `custom-auth-plugin/index.mjs`

Before fix: Only the last plugin loaded.
After fix: All four plugins load correctly.