### PR TITLE
feat: add interactive tip cycling on click with hover effect

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -29,16 +29,37 @@ function parse(tip: string): TipPart[] {
 
 export function Tips() {
   const theme = useTheme().theme
-  const parts = parse(TIPS[Math.floor(Math.random() * TIPS.length)])
+  const [index, setIndex] = createSignal(Math.floor(Math.random() * TIPS.length))
+  const [hover, setHover] = createSignal(false)
+  const parts = createMemo(() => parse(TIPS[index()]))
+
+  function cycle() {
+    setIndex((i) => (i + 1) % TIPS.length)
+  }
 
   return (
-    <box flexDirection="row" maxWidth="100%">
+    <box
+      flexDirection="row"
+      maxWidth="100%"
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+      onMouseUp={cycle}
+    >
       <text flexShrink={0} style={{ fg: theme.warning }}>
         ● Tip{" "}
       </text>
       <text flexShrink={1}>
-        <For each={parts}>
-          {(part) => <span style={{ fg: part.highlight ? theme.text : theme.textMuted }}>{part.text}</span>}
+        <For each={parts()}>
+          {(part) => (
+            <span
+              style={{
+                fg: part.highlight ? theme.text : theme.textMuted,
+                underline: hover(),
+              }}
+            >
+              {part.text}
+            </span>
+          )}
         </For>
       </text>
     </box>


### PR DESCRIPTION
## Summary
- Add interactive tip cycling - users can click on tips to cycle through them
- Add hover underline effect to indicate tips are interactive
- Convert tip display to use reactive signals for state management

## Changes
- Added `index` signal to track current tip
- Added `hover` signal for hover state
- Added `cycle()` function to advance through tips
- Added mouse event handlers (`onMouseOver`, `onMouseOut`, `onMouseUp`)
- Converted static `parts` to reactive `createMemo` for dynamic updates
- Added underline style on hover for visual feedback

## Testing
Tested locally with `bun dev` - tips now cycle on click and show underline on hover.