### PR TITLE
fix(Desktop): Fix floating sidebar when is mobile colliding with macos

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1301,7 +1301,10 @@ export default function Layout(props: ParentProps) {
     const homedir = createMemo(() => sync.data.path.home)
 
     return (
-      <div class="flex h-full w-full overflow-hidden">
+      <div classList={{
+        "flex h-full w-full overflow-hidden": true,
+        "mt-10": sidebarProps.mobile,
+      }}>
         <div class="w-16 shrink-0 bg-background-base flex flex-col items-center overflow-hidden">
           <div class="flex-1 min-h-0 w-full">
             <DragDropProvider


### PR DESCRIPTION
buttons

### What does this PR do?
Fixes the content of the floating sidebar displayed below the macOS window buttons

Closes #8764

### How did you verify your code works?

https://github.com/user-attachments/assets/e1fd0ea3-60a1-4c12-86eb-ad6e3079c60c

Checked it in macOS, see my video above

> [!CAUTION]
> Please test on windows and other compatible platforms that have a different window bar, I don't have the hardware to test it, happy to help addressing afterwards  