### PR TITLE
docs: clarify question tool guidance

### DIFF
--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -5,6 +5,6 @@ Use this tool when you need to ask the user questions during execution. This all
 4. Offer choices to the user about what direction to take.
 
 Usage notes:
-- Users will always be able to select "Other" to provide custom text input
+- When `custom` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label


### PR DESCRIPTION
Fixes #8773

## Summary
- clarify that custom input is automatic
- discourage adding "Other" options

## Before

😭

<img width="849" height="412" alt="image" src="https://github.com/user-attachments/assets/9b9be6b3-0ee3-4fc1-ad34-f0ae7426fc79" />
