### PR TITLE
fix(tui): correct theme count tip

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -1,5 +1,8 @@
 import { createMemo, createSignal, For } from "solid-js"
-import { useTheme } from "@tui/context/theme"
+import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"
+
+const themeCount = Object.keys(DEFAULT_THEMES).length
+const themeTip = `Use {highlight}/theme{/highlight} or {highlight}Ctrl+X T{/highlight} to switch between ${themeCount} built-in themes`
 
 type TipPart = { text: string; highlight: boolean }
 
@@ -57,7 +60,7 @@ const TIPS = [
   "Press {highlight}Ctrl+X E{/highlight} or {highlight}/editor{/highlight} to compose messages in your external editor",
   "Run {highlight}/init{/highlight} to auto-generate project rules based on your codebase",
   "Run {highlight}/models{/highlight} or {highlight}Ctrl+X M{/highlight} to see and switch between available AI models",
-  "Use {highlight}/theme{/highlight} or {highlight}Ctrl+X T{/highlight} to switch between 50+ built-in themes",
+  themeTip,
   "Press {highlight}Ctrl+X N{/highlight} or {highlight}/new{/highlight} to start a fresh conversation session",
   "Use {highlight}/sessions{/highlight} or {highlight}Ctrl+X L{/highlight} to list and continue previous conversations",
   "Run {highlight}/compact{/highlight} to summarize long sessions near context limits",


### PR DESCRIPTION
Fixes #8772

## Summary
- compute theme count dynamically
- keep tip text accurate

## Before (Lies)

<img width="813" height="129" alt="image" src="https://github.com/user-attachments/assets/fc8e727f-db44-4afe-9dc7-564498a5599b" />