### PR TITLE
chore: update GitHub stars and commits statistics

### DIFF
--- a/packages/console/app/src/config.ts
+++ b/packages/console/app/src/config.ts
@@ -9,8 +9,8 @@ export const config = {
   github: {
     repoUrl: "https://github.com/anomalyco/opencode",
     starsFormatted: {
-      compact: "60K",
-      full: "60,000",
+      compact: "70K",
+      full: "70,000",
     },
   },
 
@@ -23,7 +23,7 @@ export const config = {
   // Static stats (used on landing page)
   stats: {
     contributors: "500",
-    commits: "6,500",
+    commits: "7,000",
     monthlyUsers: "650,000",
   },
 } as const


### PR DESCRIPTION
### What does this PR do?
Updates the constant to reflect GitHub stars and commits count properly