### PR TITLE
fix(tui): prevent accidental hover selection in autocomplete menus

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -85,6 +85,7 @@ export function Autocomplete(props: {
     index: 0,
     selected: 0,
     visible: false as AutocompleteRef["visible"],
+    mouseHasMoved: false,
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -588,8 +589,16 @@ export function Autocomplete(props: {
     setStore({
       visible: mode,
       index: props.input().cursorOffset,
+      mouseHasMoved: false,
     })
   }
+
+  // Reset mouse movement tracking when filter changes to prevent accidental selection
+  // when items change position under a stationary cursor
+  createEffect(() => {
+    filter()
+    setStore("mouseHasMoved", false)
+  })
 
   function hide() {
     const text = props.input().plainText
@@ -723,41 +732,54 @@ export function Autocomplete(props: {
       {...SplitBorder}
       borderColor={theme.border}
     >
-      <scrollbox
-        ref={(r: ScrollBoxRenderable) => (scroll = r)}
-        backgroundColor={theme.backgroundMenu}
-        height={height()}
-        scrollbarOptions={{ visible: false }}
-      >
-        <Index
-          each={options()}
-          fallback={
-            <box paddingLeft={1} paddingRight={1}>
-              <text fg={theme.textMuted}>No matching items</text>
-            </box>
-          }
+      <box onMouseMove={() => setStore("mouseHasMoved", true)}>
+        <scrollbox
+          ref={(r: ScrollBoxRenderable) => (scroll = r)}
+          backgroundColor={theme.backgroundMenu}
+          height={height()}
+          scrollbarOptions={{ visible: false }}
         >
-          {(option, index) => (
-            <box
-              paddingLeft={1}
-              paddingRight={1}
-              backgroundColor={index === store.selected ? theme.primary : undefined}
-              flexDirection="row"
-              onMouseOver={() => moveTo(index)}
-              onMouseUp={() => select()}
-            >
-              <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>
-                {option().display}
-              </text>
-              <Show when={option().description}>
-                <text fg={index === store.selected ? selectedForeground(theme) : theme.textMuted} wrapMode="none">
-                  {option().description}
+          <Index
+            each={options()}
+            fallback={
+              <box paddingLeft={1} paddingRight={1}>
+                <text fg={theme.textMuted}>No matching items</text>
+              </box>
+            }
+          >
+            {(option, index) => (
+              <box
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={index === store.selected ? theme.primary : undefined}
+                flexDirection="row"
+                onMouseMove={() => {
+                  // Once mouse moves, enable hover selection and immediately select this item
+                  if (!store.mouseHasMoved) {
+                    setStore("mouseHasMoved", true)
+                    moveTo(index)
+                  }
+                }}
+                onMouseOver={() => {
+                  // Only select on hover if mouse has moved (prevents accidental selection)
+                  if (!store.mouseHasMoved) return
+                  moveTo(index)
+                }}
+                onMouseUp={() => select()}
+              >
+                <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>
+                  {option().display}
                 </text>
-              </Show>
-            </box>
-          )}
-        </Index>
-      </scrollbox>
+                <Show when={option().description}>
+                  <text fg={index === store.selected ? selectedForeground(theme) : theme.textMuted} wrapMode="none">
+                    {option().description}
+                  </text>
+                </Show>
+              </box>
+            )}
+          </Index>
+        </scrollbox>
+      </box>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -52,6 +52,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const [store, setStore] = createStore({
     selected: 0,
     filter: "",
+    mouseHasMoved: false,
   })
 
   createEffect(
@@ -109,6 +110,10 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
+      // Reset mouse movement tracking when filter changes to prevent accidental selection
+      // when items change position under a stationary cursor
+      setStore("mouseHasMoved", false)
+
       setTimeout(() => {
         if (filter.length > 0) {
           moveTo(0, true)
@@ -248,61 +253,75 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           </box>
         }
       >
-        <scrollbox
-          paddingLeft={1}
-          paddingRight={1}
-          scrollbarOptions={{ visible: false }}
-          ref={(r: ScrollBoxRenderable) => (scroll = r)}
-          maxHeight={height()}
-        >
-          <For each={grouped()}>
-            {([category, options], index) => (
-              <>
-                <Show when={category}>
-                  <box paddingTop={index() > 0 ? 1 : 0} paddingLeft={3}>
-                    <text fg={theme.accent} attributes={TextAttributes.BOLD}>
-                      {category}
-                    </text>
-                  </box>
-                </Show>
-                <For each={options}>
-                  {(option) => {
-                    const active = createMemo(() => isDeepEqual(option.value, selected()?.value))
-                    const current = createMemo(() => isDeepEqual(option.value, props.current))
-                    return (
-                      <box
-                        id={JSON.stringify(option.value)}
-                        flexDirection="row"
-                        onMouseUp={() => {
-                          option.onSelect?.(dialog)
-                          props.onSelect?.(option)
-                        }}
-                        onMouseOver={() => {
-                          const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
-                          if (index === -1) return
-                          moveTo(index)
-                        }}
-                        backgroundColor={active() ? (option.bg ?? theme.primary) : RGBA.fromInts(0, 0, 0, 0)}
-                        paddingLeft={current() || option.gutter ? 1 : 3}
-                        paddingRight={3}
-                        gap={1}
-                      >
-                        <Option
-                          title={option.title}
-                          footer={option.footer}
-                          description={option.description !== category ? option.description : undefined}
-                          active={active()}
-                          current={current()}
-                          gutter={option.gutter}
-                        />
-                      </box>
-                    )
-                  }}
-                </For>
-              </>
-            )}
-          </For>
-        </scrollbox>
+        <box onMouseMove={() => setStore("mouseHasMoved", true)}>
+          <scrollbox
+            paddingLeft={1}
+            paddingRight={1}
+            scrollbarOptions={{ visible: false }}
+            ref={(r: ScrollBoxRenderable) => (scroll = r)}
+            maxHeight={height()}
+          >
+            <For each={grouped()}>
+              {([category, options], index) => (
+                <>
+                  <Show when={category}>
+                    <box paddingTop={index() > 0 ? 1 : 0} paddingLeft={3}>
+                      <text fg={theme.accent} attributes={TextAttributes.BOLD}>
+                        {category}
+                      </text>
+                    </box>
+                  </Show>
+                  <For each={options}>
+                    {(option) => {
+                      const active = createMemo(() => isDeepEqual(option.value, selected()?.value))
+                      const current = createMemo(() => isDeepEqual(option.value, props.current))
+                      return (
+                        <box
+                          id={JSON.stringify(option.value)}
+                          flexDirection="row"
+                          onMouseMove={() => {
+                            // Once mouse moves, enable hover selection and immediately select this item
+                            if (!store.mouseHasMoved) {
+                              setStore("mouseHasMoved", true)
+                              const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
+                              if (index !== -1) moveTo(index)
+                            }
+                          }}
+                          onMouseUp={() => {
+                            option.onSelect?.(dialog)
+                            props.onSelect?.(option)
+                          }}
+                          onMouseOver={() => {
+                            // Only select on hover if mouse has moved (prevents accidental selection)
+                            if (!store.mouseHasMoved) return
+
+                            const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
+                            if (index === -1) return
+
+                            moveTo(index)
+                          }}
+                          backgroundColor={active() ? (option.bg ?? theme.primary) : RGBA.fromInts(0, 0, 0, 0)}
+                          paddingLeft={current() || option.gutter ? 1 : 3}
+                          paddingRight={3}
+                          gap={1}
+                        >
+                          <Option
+                            title={option.title}
+                            footer={option.footer}
+                            description={option.description !== category ? option.description : undefined}
+                            active={active()}
+                            current={current()}
+                            gutter={option.gutter}
+                          />
+                        </box>
+                      )
+                    }}
+                  </For>
+                </>
+              )}
+            </For>
+          </scrollbox>
+        </box>
       </Show>
       <Show when={keybinds().length} fallback={<box flexShrink={0} />}>
         <box paddingRight={2} paddingLeft={4} flexDirection="row" gap={2} flexShrink={0} paddingTop={1}>


### PR DESCRIPTION
# Problem 🔽

Autocomplete menus (`@` and `/` in TUI) and dialog select components currently auto-select items when UI elements move under a stationary cursor. This creates two problematic scenarios:

1. **Menu appears under stationary cursor**: When a menu opens, if the user's mouse happens to be over where an item renders, that item gets selected immediately even though the user hasn't moved the mouse
2. **Filter changes reorder items**: When typing to filter, items shift position and if one lands under the stationary cursor, it gets auto-selected, breaking keyboard navigation

Users expect hover selection to activate only on **intentional mouse movement**, not when UI elements move under a stationary cursor.

https://github.com/user-attachments/assets/75582f1c-873e-4489-a361-17bf506f8404

# Solution 🔽

https://github.com/user-attachments/assets/39fdf3e8-e3c7-4eb6-8ab8-ebcdceac0d18

Just checked, and it's fixed in the menu aswell:

https://github.com/user-attachments/assets/6c3afb9b-90b4-4ed6-a1cf-5c16cd934a97

The fix tracks actual mouse movement to distinguish between:
- **Intentional hover**: User moves mouse → selection updates normally
- **Accidental hover**: Menu appears/items reorder under stationary cursor → selection remains unchanged

This is implemented by:
1. Setting a `hasMouseMoved` flag to `false` when menus open or filter text changes
2. Listening for `mousemove` events to set the flag to `true`
3. Only updating selection on hover when `hasMouseMoved === true`

Components updated:
- `Select.tsx`: Dialog select menus
- `ChatInput.tsx`: Autocomplete menus (`@` and `/`)

This ensures hover selection only activates on deliberate user action, making keyboard navigation reliable and preventing surprising auto-selections.

Closes #8799