### PR TITLE
feat: add version to session header and /status dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-status.tsx
@@ -2,6 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useSync } from "@tui/context/sync"
 import { For, Match, Switch, Show, createMemo } from "solid-js"
+import { Installation } from "@/installation"
 
 export type DialogStatusProps = {}
 
@@ -44,6 +45,7 @@ export function DialogStatus() {
         </text>
         <text fg={theme.textMuted}>esc</text>
       </box>
+      <text fg={theme.textMuted}>OpenCode v{Installation.VERSION}</text>
       <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
           <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -7,6 +7,7 @@ import { SplitBorder } from "@tui/component/border"
 import type { AssistantMessage, Session } from "@opencode-ai/sdk/v2"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
+import { Installation } from "@/installation"
 
 const Title = (props: { session: Accessor<Session> }) => {
   const { theme } = useTheme()
@@ -113,13 +114,19 @@ export function Header() {
                 </text>
               </box>
               <box flexGrow={1} flexShrink={1} />
-              <ContextInfo context={context} cost={cost} />
+              <box flexDirection="row" gap={1} flexShrink={0}>
+                <ContextInfo context={context} cost={cost} />
+                <text fg={theme.textMuted}>v{Installation.VERSION}</text>
+              </box>
             </box>
           </Match>
           <Match when={true}>
             <box flexDirection="row" justifyContent="space-between" gap={1}>
               <Title session={session} />
-              <ContextInfo context={context} cost={cost} />
+              <box flexDirection="row" gap={1} flexShrink={0}>
+                <ContextInfo context={context} cost={cost} />
+                <text fg={theme.textMuted}>v{Installation.VERSION}</text>
+              </box>
             </box>
           </Match>
         </Switch>


### PR DESCRIPTION
### What does this PR do?

- Adds version number to session header and /status dialog 

### How did you verify your code works?

- `bun dev`
- start a chat, collapse sidebar, look at header for version
- run `/status` and check for version

### Issue

- Closes #8801 

### Screenshots

Before:
<img width="1415" height="687" alt="session-header-dev-no-version" src="https://github.com/user-attachments/assets/deb8a1a2-f0f5-440c-a232-45a96d233655" />
<img width="437" height="224" alt="status-dialog-dev-no-version" src="https://github.com/user-attachments/assets/19388040-87ed-4ce7-b97c-c05d47e0f039" />

After:
<img width="1406" height="677" alt="session-header-feature-version" src="https://github.com/user-attachments/assets/633af77d-032d-4c60-84a8-bf0d82393f20" />
<img width="433" height="257" alt="status-dialog-feature-version" src="https://github.com/user-attachments/assets/0b0921a8-7328-42a4-996f-3339d85f75e8" />
