### PR TITLE
fix(tui): autocomplete getting stuck with trailing text

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -144,6 +144,10 @@ export function Autocomplete(props: {
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
     input.insertText(append)
 
+    if (!needsSpace) {
+      input.cursorOffset = input.cursorOffset + 1
+    }
+
     const virtualText = "@" + text
     const extmarkStart = store.index
     const extmarkEnd = extmarkStart + Bun.stringWidth(virtualText)


### PR DESCRIPTION
Closes https://github.com/anomalyco/opencode/issues/8806.

### What does this PR do?

Fixes @ autocomplete toolbar staying open when selecting a file with text after the cursor.
`blah @file| blah` → enter/tab → toolbar was staying open because cursor stayed before the existing space, causing the reopen check to trigger.

### How did you verify your code works?

Manual testing - typed `hello @file world`, selected a file, verified toolbar closes.