### PR TITLE
tweak(console): Prevent accidental exiting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -122,9 +122,9 @@ export function tui(input: {
             fallback={(error, reset) => <ErrorComponent error={error} reset={reset} onExit={onExit} mode={mode} />}
           >
             <ArgsProvider {...input.args}>
-              <ExitProvider onExit={onExit}>
-                <KVProvider>
-                  <ToastProvider>
+              <ToastProvider>
+                <ExitProvider onExit={onExit}>
+                  <KVProvider>
                     <RouteProvider>
                       <SDKProvider
                         url={input.url}
@@ -155,9 +155,9 @@ export function tui(input: {
                         </SyncProvider>
                       </SDKProvider>
                     </RouteProvider>
-                  </ToastProvider>
-                </KVProvider>
-              </ExitProvider>
+                  </KVProvider>
+                </ExitProvider>
+              </ToastProvider>
             </ArgsProvider>
           </ErrorBoundary>
         )
@@ -473,7 +473,7 @@ function App() {
     {
       title: "Exit the app",
       value: "app.exit",
-      onSelect: () => exit(),
+      onSelect: () => exit(undefined, true),
       category: "System",
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -487,7 +487,7 @@ export function Prompt(props: PromptProps) {
     if (!store.prompt.input) return
     const trimmed = store.prompt.input.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
-      exit()
+      exit(undefined, true)
       return
     }
     const selectedModel = local.model.current()

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -1,12 +1,18 @@
 import { useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { useToast } from "../ui/toast"
+
+const TIMEOUT = 2000
 
 export const { use: useExit, provider: ExitProvider } = createSimpleContext({
   name: "Exit",
   init: (input: { onExit?: () => Promise<void> }) => {
     const renderer = useRenderer()
-    return async (reason?: any) => {
+    const toast = useToast()
+    let pending: number | null = null
+
+    const exit = async (reason?: any) => {
       // Reset window title before destroying renderer
       renderer.setTerminalTitle("")
       renderer.destroy()
@@ -18,6 +24,24 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
         }
       }
       process.exit(0)
+    }
+
+    return async (reason?: any, force = false) => {
+      if (force) return exit(reason)
+
+      const now = Date.now()
+      if (pending && now - pending < TIMEOUT) return exit(reason)
+
+      pending = now
+      setTimeout(() => {
+        pending = null
+      }, TIMEOUT)
+      toast.show({
+        title: "Exit",
+        message: "Press Ctrl+C again to exit",
+        variant: "warning",
+        duration: TIMEOUT,
+      })
     }
   },
 })


### PR DESCRIPTION
It's easy to push ctrl+c accidentally which closes the entire app.  Just as Claude and Gemini do, require ctrl+c twice in order to close the app.

Fixes #7957

### What does this PR do?

### How did you verify your code works?
