### PR TITLE
fix(bun): reinstall plugins when cache module missing

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -2,7 +2,7 @@ import z from "zod"
 import { Global } from "../global"
 import { Log } from "../util/log"
 import path from "path"
-import fs from "fs/promises"
+import { Filesystem } from "../util/filesystem"
 import { NamedError } from "@opencode-ai/util/error"
 import { readableStreamToText } from "bun"
 import { createRequire } from "module"
@@ -74,10 +74,7 @@ export namespace BunProc {
     })
     const dependencies = parsed.dependencies ?? {}
     if (!parsed.dependencies) parsed.dependencies = dependencies
-    const modExists = await fs
-      .stat(mod)
-      .then(() => true)
-      .catch(() => false)
+    const modExists = await Filesystem.exists(mod)
     if (dependencies[pkg] === version && modExists) return mod
 
     const proxied = !!(

--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import { Global } from "../global"
 import { Log } from "../util/log"
 import path from "path"
+import fs from "fs/promises"
 import { NamedError } from "@opencode-ai/util/error"
 import { readableStreamToText } from "bun"
 import { createRequire } from "module"
@@ -71,7 +72,13 @@ export namespace BunProc {
       await Bun.write(pkgjson.name!, JSON.stringify(result, null, 2))
       return result
     })
-    if (parsed.dependencies[pkg] === version) return mod
+    const dependencies = parsed.dependencies ?? {}
+    if (!parsed.dependencies) parsed.dependencies = dependencies
+    const modExists = await fs
+      .stat(mod)
+      .then(() => true)
+      .catch(() => false)
+    if (dependencies[pkg] === version && modExists) return mod
 
     const proxied = !!(
       process.env.HTTP_PROXY ||


### PR DESCRIPTION
### What does this PR do?

Fixes startup hangs when the plugin cache is partially deleted by re-installing a plugin if its cached module directory is missing (even when `package.json` still lists the dependency). Fixes #5338.

### How did you verify your code works?

**Reproducing the issue:**
```bash
rm -rf ~/.cache/opencode/node_modules ~/.cache/opencode/bun.lock
bun dev  # hangs with blank screen
```

**Verify fix:**
```bash
rm -rf ~/.cache/opencode/node_modules ~/.cache/opencode/bun.lock
bun dev  # now starts correctly, reinstalls plugins automatically
```