### PR TITLE
fix: skip corrupted session files when listing sessions

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -308,7 +308,14 @@ export namespace Session {
   export async function* list() {
     const project = Instance.project
     for (const item of await Storage.list(["session", project.id])) {
-      yield Storage.read<Info>(item)
+      try {
+        const session = await Storage.read<Info>(item)
+        if (session && session.id) {
+          yield session
+        }
+      } catch (e) {
+        log.warn("skipping corrupted session file", { path: item.join("/"), error: e })
+      }
     }
   }
 
@@ -316,9 +323,15 @@ export namespace Session {
     const project = Instance.project
     const result = [] as Session.Info[]
     for (const item of await Storage.list(["session", project.id])) {
-      const session = await Storage.read<Info>(item)
-      if (session.parentID !== parentID) continue
-      result.push(session)
+      try {
+        const session = await Storage.read<Info>(item)
+        if (!session || !session.id) continue
+        if (session.parentID !== parentID) continue
+        result.push(session)
+      } catch (e) {
+        log.warn("skipping corrupted session file", { path: item.join("/"), error: e })
+        continue
+      }
     }
     return result
   })


### PR DESCRIPTION
## Summary

When a session JSON file is empty or contains invalid JSON, the entire session list fails to load with `Unexpected end of JSON input` error. This causes all sessions to appear missing even though valid session files exist.

## Problem

- A single corrupted/empty session file causes `Storage.read()` to throw an exception
- The exception propagates up and causes the entire `list()` generator to fail
- Users see "No results found" when running `/sessions` even though they have many valid sessions
- This is a data loss UX issue - users think their sessions are gone

## Root Cause

The `list()` and `children()` functions in `packages/opencode/src/session/index.ts` don't handle JSON parsing errors:

```typescript
export async function* list() {
  const project = Instance.project
  for (const item of await Storage.list(["session", project.id])) {
    yield Storage.read<Info>(item)  // No error handling
  }
}
```

## Solution

Add try-catch blocks to gracefully skip corrupted session files:

- Log a warning for each skipped file (helps users identify corrupted files)
- Continue processing remaining valid sessions
- Validate that the parsed session has required fields (`id`)

## Testing

Manually tested by:
1. Creating an empty session JSON file in the storage directory
2. Verifying that `/sessions` now shows valid sessions instead of failing
3. Confirming warning is logged for the corrupted file

## Related

This addresses the scenario described in logs like:
```
ERROR service=server error=Unexpected end of JSON input failed
```