### PR TITLE
fix(core): handle macro data as string in built artifacts

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -81,7 +81,7 @@ export namespace ModelsDev {
     const file = Bun.file(filepath)
     const result = await file.json().catch(() => {})
     if (result) return result as Record<string, Provider>
-    if (typeof data === "function") {
+    if (typeof data === "function" || typeof data === "string") {
       const json = await data()
       return JSON.parse(json) as Record<string, Provider>
     }


### PR DESCRIPTION
Adds check for string type to handle Bun macros inlined at build time.

## Changes
Modified the type check to include both function and string types:

```typescript
// Before
if (typeof data === 'function') {
  const json = await data()
  return JSON.parse(json) as Record<string, Provider>
}

// After  
if (typeof data === 'function' || typeof data === 'string') {
  const json = await data()
  return JSON.parse(json) as Record<string, Provider>
}
```

## Context
When Bun macros are enabled during compilation, the `data()` function may be executed and inlined as a string literal in the built artifacts. The original code only checked for function type, missing the string case.