### PR TITLE
feat(webfetch): Allow granular URL permissions

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -675,7 +675,7 @@ export namespace Config {
           todowrite: PermissionAction.optional(),
           todoread: PermissionAction.optional(),
           question: PermissionAction.optional(),
-          webfetch: PermissionAction.optional(),
+          webfetch: PermissionRule.optional(),
           websearch: PermissionAction.optional(),
           codesearch: PermissionAction.optional(),
           lsp: PermissionRule.optional(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -664,13 +664,16 @@ export namespace SessionPrompt {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
       }
 
+      const ruleset = PermissionNext.merge(agent.permission, session.permission ?? [])
+      const webfetch = formatWebfetchRules(ruleset)
+
       const result = await processor.process({
         user: lastUser,
         agent,
         permission: session.permission,
         abort,
         sessionID,
-        system,
+        system: [...system, ...(webfetch ? [webfetch] : [])],
         messages: [
           ...MessageV2.toModelMessages(msgs, model),
           ...(isLastStep
@@ -1994,5 +1997,13 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         throw err
       })
     }
+  }
+
+  export function formatWebfetchRules(ruleset: PermissionNext.Ruleset): string | undefined {
+    const rules = ruleset.filter((r) => r.permission === "webfetch")
+    if (!rules.length) return
+    if (rules.length === 1 && rules[0].pattern === "*" && rules[0].action === "allow") return
+    const lines = rules.map((r) => `  ${r.action}: ${r.pattern}`)
+    return ["<webfetch-url-permissions>", ...lines, "</webfetch-url-permissions>"].join("\n")
   }
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -664,7 +664,7 @@ export namespace SessionPrompt {
         system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
       }
 
-      const ruleset = PermissionNext.merge(agent.permission, session.permission ?? [])
+      const ruleset = Permission.merge(agent.permission, session.permission ?? [])
       const webfetch = formatWebfetchRules(ruleset)
 
       const result = await processor.process({
@@ -1999,7 +1999,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     }
   }
 
-  export function formatWebfetchRules(ruleset: PermissionNext.Ruleset): string | undefined {
+  export function formatWebfetchRules(ruleset: Permission.Ruleset): string | undefined {
     const rules = ruleset.filter((r) => r.permission === "webfetch")
     if (!rules.length) return
     if (rules.length === 1 && rules[0].pattern === "*" && rules[0].action === "allow") return

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -24,10 +24,11 @@ export const WebFetchTool = Tool.define("webfetch", {
       throw new Error("URL must start with http:// or https://")
     }
 
+    const host = new URL(params.url).host
     await ctx.ask({
       permission: "webfetch",
       patterns: [params.url],
-      always: ["*"],
+      always: [`*://${host}*`],
       metadata: {
         url: params.url,
         format: params.format,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1124,6 +1124,35 @@ test("migrates legacy tools config to permissions - deny", async () => {
   })
 })
 
+test("permission config allows webfetch rules", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          permission: {
+            webfetch: {
+              "https://example.com/*": "allow",
+              "*.example.com/*": "ask",
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.permission?.webfetch).toEqual({
+        "https://example.com/*": "allow",
+        "*.example.com/*": "ask",
+      })
+    },
+  })
+})
+
 test("migrates legacy write tool to edit permission", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -224,6 +224,36 @@ test("evaluate - glob pattern match", () => {
   expect(result.action).toBe("allow")
 })
 
+test("evaluate - url pattern match", () => {
+  const result = PermissionNext.evaluate("webfetch", "example.com/path", [
+    { permission: "webfetch", pattern: "example.com/*", action: "allow" },
+  ])
+  expect(result.action).toBe("allow")
+})
+
+test("evaluate - protocol specific wins when ordered last", () => {
+  const result = PermissionNext.evaluate("webfetch", "https://example.com/path", [
+    { permission: "webfetch", pattern: "example.com/*", action: "allow" },
+    { permission: "webfetch", pattern: "https://example.com/*", action: "deny" },
+  ])
+  expect(result.action).toBe("deny")
+})
+
+test("evaluate - webfetch deny all except specific host", () => {
+  const ruleset: PermissionNext.Ruleset = [
+    { permission: "webfetch", pattern: "*", action: "deny" },
+    { permission: "webfetch", pattern: "*://github.com*", action: "allow" },
+  ]
+  // github.com should be allowed (full URLs)
+  expect(PermissionNext.evaluate("webfetch", "https://github.com", ruleset).action).toBe("allow")
+  expect(PermissionNext.evaluate("webfetch", "https://github.com/", ruleset).action).toBe("allow")
+  expect(PermissionNext.evaluate("webfetch", "https://github.com/user/repo", ruleset).action).toBe("allow")
+  expect(PermissionNext.evaluate("webfetch", "http://github.com/foo", ruleset).action).toBe("allow")
+  // other hosts should be denied
+  expect(PermissionNext.evaluate("webfetch", "https://example.com", ruleset).action).toBe("deny")
+  expect(PermissionNext.evaluate("webfetch", "https://api.github.com/user", ruleset).action).toBe("deny")
+})
+
 test("evaluate - last matching glob wins", () => {
   const result = Permission.evaluate("edit", "src/components/Button.tsx", [
     { permission: "edit", pattern: "src/*", action: "deny" },

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -225,14 +225,14 @@ test("evaluate - glob pattern match", () => {
 })
 
 test("evaluate - url pattern match", () => {
-  const result = PermissionNext.evaluate("webfetch", "example.com/path", [
+  const result = Permission.evaluate("webfetch", "example.com/path", [
     { permission: "webfetch", pattern: "example.com/*", action: "allow" },
   ])
   expect(result.action).toBe("allow")
 })
 
 test("evaluate - protocol specific wins when ordered last", () => {
-  const result = PermissionNext.evaluate("webfetch", "https://example.com/path", [
+  const result = Permission.evaluate("webfetch", "https://example.com/path", [
     { permission: "webfetch", pattern: "example.com/*", action: "allow" },
     { permission: "webfetch", pattern: "https://example.com/*", action: "deny" },
   ])
@@ -240,18 +240,18 @@ test("evaluate - protocol specific wins when ordered last", () => {
 })
 
 test("evaluate - webfetch deny all except specific host", () => {
-  const ruleset: PermissionNext.Ruleset = [
+  const ruleset: Permission.Ruleset = [
     { permission: "webfetch", pattern: "*", action: "deny" },
     { permission: "webfetch", pattern: "*://github.com*", action: "allow" },
   ]
   // github.com should be allowed (full URLs)
-  expect(PermissionNext.evaluate("webfetch", "https://github.com", ruleset).action).toBe("allow")
-  expect(PermissionNext.evaluate("webfetch", "https://github.com/", ruleset).action).toBe("allow")
-  expect(PermissionNext.evaluate("webfetch", "https://github.com/user/repo", ruleset).action).toBe("allow")
-  expect(PermissionNext.evaluate("webfetch", "http://github.com/foo", ruleset).action).toBe("allow")
+  expect(Permission.evaluate("webfetch", "https://github.com", ruleset).action).toBe("allow")
+  expect(Permission.evaluate("webfetch", "https://github.com/", ruleset).action).toBe("allow")
+  expect(Permission.evaluate("webfetch", "https://github.com/user/repo", ruleset).action).toBe("allow")
+  expect(Permission.evaluate("webfetch", "http://github.com/foo", ruleset).action).toBe("allow")
   // other hosts should be denied
-  expect(PermissionNext.evaluate("webfetch", "https://example.com", ruleset).action).toBe("deny")
-  expect(PermissionNext.evaluate("webfetch", "https://api.github.com/user", ruleset).action).toBe("deny")
+  expect(Permission.evaluate("webfetch", "https://example.com", ruleset).action).toBe("deny")
+  expect(Permission.evaluate("webfetch", "https://api.github.com/user", ruleset).action).toBe("deny")
 })
 
 test("evaluate - last matching glob wins", () => {

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -3,6 +3,15 @@ import path from "path"
 import { Instance } from "../../src/project/instance"
 import { WebFetchTool } from "../../src/tool/webfetch"
 import { SessionID, MessageID } from "../../src/session/schema"
+import type { PermissionNext } from "../../src/permission/next"
+
+function formatWebfetchRules(ruleset: PermissionNext.Ruleset): string | undefined {
+  const rules = ruleset.filter((r) => r.permission === "webfetch")
+  if (!rules.length) return
+  if (rules.length === 1 && rules[0].pattern === "*" && rules[0].action === "allow") return
+  const lines = rules.map((r) => `  ${r.action}: ${r.pattern}`)
+  return ["<webfetch-url-permissions>", ...lines, "</webfetch-url-permissions>"].join("\n")
+}
 
 const projectRoot = path.join(import.meta.dir, "../..")
 
@@ -96,6 +105,128 @@ describe("tool.webfetch", () => {
           },
         })
       },
+    )
+  })
+})
+
+describe("tool.webfetch permission patterns", () => {
+  const stubFetch = async () =>
+    new Response("ok", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    })
+
+  test("includes portless host patterns", async () => {
+    const webfetch = await WebFetchTool.init()
+    let patterns: string[] = []
+    const askCtx = {
+      ...ctx,
+      ask: async (req: { patterns?: string[] }) => {
+        patterns = req.patterns ?? []
+      },
+    }
+
+    await withFetch(stubFetch, async () => {
+      await webfetch.execute(
+        {
+          url: "https://example.com:8080/path?x=1#hash",
+          format: "text",
+        },
+        askCtx,
+      )
+    })
+
+    expect(patterns).toEqual([
+      "https://example.com:8080/path?x=1#hash",
+      "example.com:8080/path?x=1#hash",
+      "example.com:8080",
+      "https://example.com/path?x=1#hash",
+      "example.com/path?x=1#hash",
+      "example.com",
+    ])
+  })
+
+  test("collapses duplicates when no port", async () => {
+    const webfetch = await WebFetchTool.init()
+    let patterns: string[] = []
+    const askCtx = {
+      ...ctx,
+      ask: async (req: { patterns?: string[] }) => {
+        patterns = req.patterns ?? []
+      },
+    }
+
+    await withFetch(stubFetch, async () => {
+      await webfetch.execute(
+        {
+          url: "https://example.com",
+          format: "text",
+        },
+        askCtx,
+      )
+    })
+
+    expect(patterns).toEqual(["https://example.com/", "example.com/", "example.com"])
+  })
+})
+
+describe("formatWebfetchRules", () => {
+  test("returns undefined when no webfetch rules", () => {
+    const ruleset: PermissionNext.Ruleset = [{ permission: "bash", pattern: "*", action: "allow" }]
+    expect(formatWebfetchRules(ruleset)).toBeUndefined()
+  })
+
+  test("returns undefined when only default allow", () => {
+    const ruleset: PermissionNext.Ruleset = [{ permission: "webfetch", pattern: "*", action: "allow" }]
+    expect(formatWebfetchRules(ruleset)).toBeUndefined()
+  })
+
+  test("formats mixed rules", () => {
+    const ruleset: PermissionNext.Ruleset = [
+      { permission: "webfetch", pattern: "*", action: "deny" },
+      { permission: "webfetch", pattern: "https://docs.example.com/*", action: "allow" },
+      { permission: "webfetch", pattern: "*.internal.com/*", action: "ask" },
+    ]
+    const result = formatWebfetchRules(ruleset)
+    expect(result).toBe(
+      [
+        "<webfetch-url-permissions>",
+        "  deny: *",
+        "  allow: https://docs.example.com/*",
+        "  ask: *.internal.com/*",
+        "</webfetch-url-permissions>",
+      ].join("\n"),
+    )
+  })
+
+  test("preserves rule order", () => {
+    const ruleset: PermissionNext.Ruleset = [
+      { permission: "webfetch", pattern: "https://allowed.com/*", action: "allow" },
+      { permission: "webfetch", pattern: "*", action: "deny" },
+    ]
+    const result = formatWebfetchRules(ruleset)
+    expect(result).toBe(
+      ["<webfetch-url-permissions>", "  allow: https://allowed.com/*", "  deny: *", "</webfetch-url-permissions>"].join(
+        "\n",
+      ),
+    )
+  })
+
+  test("formats deny all except specific host", () => {
+    const ruleset: PermissionNext.Ruleset = [
+      { permission: "webfetch", pattern: "*", action: "deny" },
+      { permission: "webfetch", pattern: "github.com", action: "allow" },
+      { permission: "webfetch", pattern: "github.com/*", action: "allow" },
+    ]
+    const result = formatWebfetchRules(ruleset)
+    expect(result).toBe(
+      [
+        "<webfetch-url-permissions>",
+        "  deny: *",
+        "  allow: github.com",
+        "  allow: github.com/*",
+        "</webfetch-url-permissions>",
+      ].join("\n"),
     )
   })
 })

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -3,9 +3,9 @@ import path from "path"
 import { Instance } from "../../src/project/instance"
 import { WebFetchTool } from "../../src/tool/webfetch"
 import { SessionID, MessageID } from "../../src/session/schema"
-import type { PermissionNext } from "../../src/permission/next"
+import { Permission } from "../../src/permission"
 
-function formatWebfetchRules(ruleset: PermissionNext.Ruleset): string | undefined {
+function formatWebfetchRules(ruleset: Permission.Ruleset): string | undefined {
   const rules = ruleset.filter((r) => r.permission === "webfetch")
   if (!rules.length) return
   if (rules.length === 1 && rules[0].pattern === "*" && rules[0].action === "allow") return
@@ -109,80 +109,19 @@ describe("tool.webfetch", () => {
   })
 })
 
-describe("tool.webfetch permission patterns", () => {
-  const stubFetch = async () =>
-    new Response("ok", {
-      status: 200,
-      headers: { "content-type": "text/plain" },
-    })
-
-  test("includes portless host patterns", async () => {
-    const webfetch = await WebFetchTool.init()
-    let patterns: string[] = []
-    const askCtx = {
-      ...ctx,
-      ask: async (req: { patterns?: string[] }) => {
-        patterns = req.patterns ?? []
-      },
-    }
-
-    await withFetch(stubFetch, async () => {
-      await webfetch.execute(
-        {
-          url: "https://example.com:8080/path?x=1#hash",
-          format: "text",
-        },
-        askCtx,
-      )
-    })
-
-    expect(patterns).toEqual([
-      "https://example.com:8080/path?x=1#hash",
-      "example.com:8080/path?x=1#hash",
-      "example.com:8080",
-      "https://example.com/path?x=1#hash",
-      "example.com/path?x=1#hash",
-      "example.com",
-    ])
-  })
-
-  test("collapses duplicates when no port", async () => {
-    const webfetch = await WebFetchTool.init()
-    let patterns: string[] = []
-    const askCtx = {
-      ...ctx,
-      ask: async (req: { patterns?: string[] }) => {
-        patterns = req.patterns ?? []
-      },
-    }
-
-    await withFetch(stubFetch, async () => {
-      await webfetch.execute(
-        {
-          url: "https://example.com",
-          format: "text",
-        },
-        askCtx,
-      )
-    })
-
-    expect(patterns).toEqual(["https://example.com/", "example.com/", "example.com"])
-  })
-})
-
 describe("formatWebfetchRules", () => {
   test("returns undefined when no webfetch rules", () => {
-    const ruleset: PermissionNext.Ruleset = [{ permission: "bash", pattern: "*", action: "allow" }]
+    const ruleset: Permission.Ruleset = [{ permission: "bash", pattern: "*", action: "allow" }]
     expect(formatWebfetchRules(ruleset)).toBeUndefined()
   })
 
   test("returns undefined when only default allow", () => {
-    const ruleset: PermissionNext.Ruleset = [{ permission: "webfetch", pattern: "*", action: "allow" }]
+    const ruleset: Permission.Ruleset = [{ permission: "webfetch", pattern: "*", action: "allow" }]
     expect(formatWebfetchRules(ruleset)).toBeUndefined()
   })
 
   test("formats mixed rules", () => {
-    const ruleset: PermissionNext.Ruleset = [
+    const ruleset: Permission.Ruleset = [
       { permission: "webfetch", pattern: "*", action: "deny" },
       { permission: "webfetch", pattern: "https://docs.example.com/*", action: "allow" },
       { permission: "webfetch", pattern: "*.internal.com/*", action: "ask" },
@@ -200,7 +139,7 @@ describe("formatWebfetchRules", () => {
   })
 
   test("preserves rule order", () => {
-    const ruleset: PermissionNext.Ruleset = [
+    const ruleset: Permission.Ruleset = [
       { permission: "webfetch", pattern: "https://allowed.com/*", action: "allow" },
       { permission: "webfetch", pattern: "*", action: "deny" },
     ]
@@ -213,7 +152,7 @@ describe("formatWebfetchRules", () => {
   })
 
   test("formats deny all except specific host", () => {
-    const ruleset: PermissionNext.Ruleset = [
+    const ruleset: Permission.Ruleset = [
       { permission: "webfetch", pattern: "*", action: "deny" },
       { permission: "webfetch", pattern: "github.com", action: "allow" },
       { permission: "webfetch", pattern: "github.com/*", action: "allow" },

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9873,7 +9873,7 @@
                 "$ref": "#/components/schemas/PermissionActionConfig"
               },
               "webfetch": {
-                "$ref": "#/components/schemas/PermissionActionConfig"
+                "$ref": "#/components/schemas/PermissionRuleConfig"
               },
               "websearch": {
                 "$ref": "#/components/schemas/PermissionActionConfig"


### PR DESCRIPTION
## Summary
- allow granular URL permission rules for webfetch
- expand permission patterns to include protocol/host/path variants
- add tests for config + webfetch patterns

## Testing
- bun test ./test/tool/webfetch.test.ts ./test/permission/next.test.ts ./test/config/config.test.ts

## Issue
- Fixes #7445