### PR TITLE
feat: Permissions dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/index.ts
+++ b/packages/opencode/src/cli/cmd/debug/index.ts
@@ -9,6 +9,7 @@ import { ScrapCommand } from "./scrap"
 import { SkillCommand } from "./skill"
 import { SnapshotCommand } from "./snapshot"
 import { AgentCommand } from "./agent"
+import { PermissionCommand } from "./permission"
 
 export const DebugCommand = cmd({
   command: "debug",
@@ -23,6 +24,7 @@ export const DebugCommand = cmd({
       .command(SkillCommand)
       .command(SnapshotCommand)
       .command(AgentCommand)
+      .command(PermissionCommand)
       .command(PathsCommand)
       .command({
         command: "wait",

--- a/packages/opencode/src/cli/cmd/debug/permission.ts
+++ b/packages/opencode/src/cli/cmd/debug/permission.ts
@@ -1,0 +1,68 @@
+import { bootstrap } from "../../bootstrap"
+import { cmd } from "../cmd"
+import { PermissionNext } from "@/permission/next"
+import { Agent } from "@/agent/agent"
+
+export const PermissionCommand = cmd({
+  command: "permission [agent]",
+  describe: "show all permissions with sources",
+  builder: (yargs) =>
+    yargs.positional("agent", {
+      describe: "agent name (default: build)",
+      type: "string",
+      default: "build",
+    }),
+  async handler(args) {
+    await bootstrap(process.cwd(), async () => {
+      const agent = args.agent as string
+
+      console.log(`\n=== Permission Report for Agent: ${agent} ===\n`)
+
+      const allPerms = await PermissionNext.all(agent)
+
+      // Group by source
+      const bySource = {
+        default: [] as PermissionNext.RuleWithSource[],
+        global: [] as PermissionNext.RuleWithSource[],
+        project: [] as PermissionNext.RuleWithSource[],
+        session: [] as PermissionNext.RuleWithSource[],
+      }
+
+      for (const rule of allPerms) {
+        bySource[rule.source].push(rule)
+      }
+
+      // Print by source
+      for (const [source, rules] of Object.entries(bySource)) {
+        if (rules.length === 0) continue
+
+        console.log(`\n[${source.toUpperCase()}] - ${rules.length} rules:`)
+        console.log("─".repeat(60))
+
+        // Group by permission type
+        const byPermission = new Map<string, PermissionNext.RuleWithSource[]>()
+        for (const rule of rules) {
+          if (!byPermission.has(rule.permission)) {
+            byPermission.set(rule.permission, [])
+          }
+          byPermission.get(rule.permission)!.push(rule)
+        }
+
+        for (const [permission, perms] of byPermission) {
+          console.log(`\n  ${permission}:`)
+          for (const perm of perms) {
+            const icon = perm.action === "allow" ? "✓" : perm.action === "deny" ? "✗" : "?"
+            const readonly = perm.readonly ? "[readonly]" : "[editable]"
+            console.log(`    ${icon} ${perm.action.padEnd(5)} ${perm.pattern.padEnd(30)} ${readonly}`)
+          }
+        }
+      }
+
+      console.log(`\n\nTotal rules: ${allPerms.length}`)
+      console.log("  Default:  ", bySource.default.length)
+      console.log("  Global:   ", bySource.global.length)
+      console.log("  Project:  ", bySource.project.length)
+      console.log("  Session:  ", bySource.session.length)
+    })
+  },
+})

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -14,6 +14,7 @@ import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
+import { DialogPermission } from "@tui/component/dialog-permission"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
@@ -423,6 +424,14 @@ function App() {
       value: "opencode.status",
       onSelect: () => {
         dialog.replace(() => <DialogStatus />)
+      },
+      category: "System",
+    },
+    {
+      title: "View permissions",
+      value: "permission.view",
+      onSelect: () => {
+        dialog.replace(() => <DialogPermission />)
       },
       category: "System",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-permission.tsx
@@ -5,20 +5,16 @@ import { useDialog } from "@tui/ui/dialog"
 import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
 import { TextAttributes, TextareaRenderable } from "@opentui/core"
 import { useSDK } from "@tui/context/sdk"
+import { useLocal } from "@tui/context/local"
 import type { PermissionNext } from "@/permission/next"
 
-type TabType = "file" | "execute" | "network" | "external" | "other"
+type TabType = "file" | "execute" | "network" | "external"
 
 const TABS: { id: TabType; label: string; permissions: string[] }[] = [
   { id: "file", label: "File", permissions: ["read", "edit", "glob", "grep", "list"] },
   { id: "execute", label: "Execute", permissions: ["bash", "task"] },
   { id: "network", label: "Network", permissions: ["webfetch", "websearch", "codesearch"] },
   { id: "external", label: "External", permissions: ["external_directory"] },
-  {
-    id: "other",
-    label: "Other",
-    permissions: ["todowrite", "todoread", "question", "lsp", "doom_loop"],
-  },
 ]
 
 const ACTION_ICONS: Record<PermissionNext.Action, string> = {
@@ -31,17 +27,21 @@ export function DialogPermission() {
   const { theme } = useTheme()
   const dialog = useDialog()
   const sdk = useSDK()
+  const local = useLocal()
   const [store, setStore] = createStore({
     tab: 0 as number,
     loading: true,
-    rules: [] as PermissionNext.Rule[],
+    rules: [] as PermissionNext.RuleWithSource[],
     selected: 0 as number,
     editing: null as null | {
-      rule: PermissionNext.Rule | null
+      rule: PermissionNext.RuleWithSource | null
       pattern: string
       action: PermissionNext.Action
       permission?: string
+      source: "session" | "project" | "global"
     },
+    confirmingDelete: false,
+    confirmingSave: false,
   })
 
   let createInput: TextareaRenderable | undefined
@@ -54,8 +54,22 @@ export function DialogPermission() {
   // Fetch permissions on mount
   onMount(async () => {
     try {
-      const result = await sdk.client.permission.approved()
-      setStore("rules", Array.isArray(result.data) ? result.data : [])
+      const agent = local.agent.current().name
+      const result = await sdk.client.permission.all({ agent })
+      // Filter out internal permissions that aren't interesting to users
+      const hiddenPermissions = new Set([
+        "question",
+        "doom_loop",
+        "plan_enter",
+        "plan_exit",
+        "todowrite",
+        "todoread",
+        "lsp",
+      ])
+      const filtered = Array.isArray(result.data)
+        ? result.data.filter((rule) => !hiddenPermissions.has(rule.permission))
+        : []
+      setStore("rules", filtered)
     } catch (error) {
       setStore("rules", [])
     } finally {
@@ -68,7 +82,7 @@ export function DialogPermission() {
   // Group rules by permission type for current tab
   const groupedRules = createMemo(() => {
     const permissionTypes = currentTab().permissions
-    const rulesByPermission = new Map<string, PermissionNext.Rule[]>()
+    const rulesByPermission = new Map<string, PermissionNext.RuleWithSource[]>()
 
     for (const permission of permissionTypes) {
       rulesByPermission.set(permission, [])
@@ -96,13 +110,34 @@ export function DialogPermission() {
     if (next < 0) next = 0
     if (next > max) next = max
     setStore("selected", next)
+    setStore("confirmingDelete", false)
   }
 
   async function deleteSelected() {
     const rule = flatRules()[store.selected]
-    if (!rule) return
+    // Only allow deleting session, project, and global permissions
+    if (!rule || (rule.source !== "session" && rule.source !== "project" && rule.source !== "global")) return
+
+    // For project and global permissions, require double confirmation
+    if ((rule.source === "project" || rule.source === "global") && !store.confirmingDelete) {
+      setStore("confirmingDelete", true)
+      return
+    }
+
+    setStore("confirmingDelete", false)
+
     try {
-      await sdk.client.permission.delete({ permissionRule: rule })
+      if (rule.source === "project") {
+        // Delete from project config file
+        await sdk.client.permission.deleteProject({ permission: rule.permission, pattern: rule.pattern })
+      } else if (rule.source === "global") {
+        // Delete from global config file
+        await sdk.client.permission.deleteGlobal({ permission: rule.permission, pattern: rule.pattern })
+      } else {
+        // Delete from session (in-memory)
+        await sdk.client.permission.delete({ permissionRule: rule })
+      }
+
       // Remove from local state using deep comparison
       setStore(
         "rules",
@@ -124,15 +159,31 @@ export function DialogPermission() {
 
   function startEditing() {
     const rule = flatRules()[store.selected]
-    if (!rule) return
-    setStore("editing", { rule, pattern: rule.pattern, action: rule.action })
+    // Only allow editing session, project, and global permissions (not default)
+    if (!rule || (rule.source !== "session" && rule.source !== "project" && rule.source !== "global")) return
+    // For binary permissions at project/global level, force pattern to "*"
+    const pattern =
+      (rule.source === "project" || rule.source === "global") && isBinaryPermission(rule.permission)
+        ? "*"
+        : rule.pattern
+    setStore("editing", { rule, pattern, action: rule.action, source: rule.source })
   }
 
   function startCreating() {
     // Get the first permission type from the current tab
     const permissionType = currentTab().permissions[0]
     if (!permissionType) return
-    setStore("editing", { rule: null, pattern: "", action: "allow", permission: permissionType })
+    // For binary permissions at project/global level, start with "*" pattern
+    const pattern = ""
+    setStore("editing", { rule: null, pattern, action: "allow", permission: permissionType, source: "session" })
+  }
+
+  function toggleSource() {
+    if (!store.editing || store.editing.rule) return // Only when creating new
+    const sources: ("session" | "project" | "global")[] = ["session", "project", "global"]
+    const currentIndex = sources.indexOf(store.editing.source)
+    const nextIndex = (currentIndex + 1) % sources.length
+    setStore("editing", "source", sources[nextIndex])
   }
 
   function cycleAction(direction: "forward" | "backward" = "forward") {
@@ -160,14 +211,51 @@ export function DialogPermission() {
     if (!oldRule) {
       const permissionType = store.editing.permission || currentTab().permissions[0]
       if (!permissionType) return
+      // For binary permissions at project/global level, force pattern to "*"
+      const pattern =
+        (store.editing.source === "project" || store.editing.source === "global") && isBinaryPermission(permissionType)
+          ? "*"
+          : store.editing.pattern
       const newRule: PermissionNext.Rule = {
         permission: permissionType,
-        pattern: store.editing.pattern,
+        pattern,
         action: store.editing.action,
       }
+
+      // Confirm project/global permission creation
+      if ((store.editing.source === "project" || store.editing.source === "global") && !store.confirmingSave) {
+        setStore("confirmingSave", true)
+        return
+      }
+
+      setStore("confirmingSave", false)
+
       try {
-        await sdk.client.permission.add({ permissionRule: newRule })
-        setStore("rules", [...store.rules, newRule])
+        if (store.editing.source === "project") {
+          await sdk.client.permission.updateProject({ permissionRule: newRule })
+          const newRuleWithSource: PermissionNext.RuleWithSource = {
+            ...newRule,
+            source: "project",
+            readonly: true,
+          }
+          setStore("rules", [...store.rules, newRuleWithSource])
+        } else if (store.editing.source === "global") {
+          await sdk.client.permission.updateGlobal({ permissionRule: newRule })
+          const newRuleWithSource: PermissionNext.RuleWithSource = {
+            ...newRule,
+            source: "global",
+            readonly: true,
+          }
+          setStore("rules", [...store.rules, newRuleWithSource])
+        } else {
+          await sdk.client.permission.add({ permissionRule: newRule })
+          const newRuleWithSource: PermissionNext.RuleWithSource = {
+            ...newRule,
+            source: "session",
+            readonly: false,
+          }
+          setStore("rules", [...store.rules, newRuleWithSource])
+        }
         setStore("editing", null)
       } catch (error) {
         // Silently handle error
@@ -175,23 +263,71 @@ export function DialogPermission() {
       return
     }
 
+    // Confirm project/global permission update
+    if ((oldRule.source === "project" || oldRule.source === "global") && !store.confirmingSave) {
+      setStore("confirmingSave", true)
+      return
+    }
+
+    setStore("confirmingSave", false)
+
     // Updating existing rule
+    // For binary permissions at project/global level, force pattern to "*"
+    const pattern =
+      (oldRule.source === "project" || oldRule.source === "global") && isBinaryPermission(oldRule.permission)
+        ? "*"
+        : store.editing.pattern
     const newRule: PermissionNext.Rule = {
       permission: oldRule.permission,
-      pattern: store.editing.pattern,
+      pattern,
       action: store.editing.action,
     }
     try {
-      await sdk.client.permission.update({ oldRule, newRule })
-      // Update local state
-      setStore(
-        "rules",
-        store.rules.map((r) =>
-          r.permission === oldRule.permission && r.pattern === oldRule.pattern && r.action === oldRule.action
-            ? newRule
-            : r,
-        ),
-      )
+      if (oldRule.source === "project") {
+        // Update project config file
+        // First delete the old pattern, then add the new one
+        if (oldRule.pattern !== store.editing.pattern) {
+          await sdk.client.permission.deleteProject({ permission: oldRule.permission, pattern: oldRule.pattern })
+        }
+        await sdk.client.permission.updateProject({ permissionRule: newRule })
+        // Update local state
+        setStore(
+          "rules",
+          store.rules.map((r) =>
+            r.permission === oldRule.permission && r.pattern === oldRule.pattern && r.action === oldRule.action
+              ? { ...newRule, source: "project", readonly: true }
+              : r,
+          ),
+        )
+      } else if (oldRule.source === "global") {
+        // Update global config file
+        // First delete the old pattern, then add the new one
+        if (oldRule.pattern !== store.editing.pattern) {
+          await sdk.client.permission.deleteGlobal({ permission: oldRule.permission, pattern: oldRule.pattern })
+        }
+        await sdk.client.permission.updateGlobal({ permissionRule: newRule })
+        // Update local state
+        setStore(
+          "rules",
+          store.rules.map((r) =>
+            r.permission === oldRule.permission && r.pattern === oldRule.pattern && r.action === oldRule.action
+              ? { ...newRule, source: "global", readonly: true }
+              : r,
+          ),
+        )
+      } else {
+        // Update session (in-memory)
+        await sdk.client.permission.update({ oldRule, newRule })
+        // Update local state
+        setStore(
+          "rules",
+          store.rules.map((r) =>
+            r.permission === oldRule.permission && r.pattern === oldRule.pattern && r.action === oldRule.action
+              ? { ...newRule, source: "session", readonly: false }
+              : r,
+          ),
+        )
+      }
       setStore("editing", null)
     } catch (error) {
       // Silently handle error
@@ -199,7 +335,16 @@ export function DialogPermission() {
   }
 
   function cancelEdit() {
+    if (store.confirmingSave) {
+      setStore("confirmingSave", false)
+      return
+    }
     setStore("editing", null)
+  }
+
+  function isBinaryPermission(permission: string): boolean {
+    // Binary permissions at project/global level can only have "*" pattern
+    return ["glob", "grep", "webfetch", "websearch", "codesearch", "task"].includes(permission)
   }
 
   function placeholderForPermission(permission: string): string {
@@ -226,8 +371,22 @@ export function DialogPermission() {
     }
   }
 
+  function sourceLabel(source: PermissionNext.Source): string {
+    switch (source) {
+      case "default":
+        return "default"
+      case "global":
+        return "global"
+      case "project":
+        return "project"
+      case "session":
+        return ""
+    }
+  }
+
   function selectTab(index: number) {
     setStore("tab", index)
+    setStore("confirmingDelete", false)
   }
 
   const dimensions = useTerminalDimensions()
@@ -264,6 +423,12 @@ export function DialogPermission() {
         evt.preventDefault()
         evt.stopPropagation()
         cyclePermission()
+        return
+      }
+      if (evt.ctrl && evt.name === "p" && !store.editing.rule) {
+        evt.preventDefault()
+        evt.stopPropagation()
+        toggleSource()
         return
       }
       return
@@ -351,7 +516,8 @@ export function DialogPermission() {
             <Show when={store.editing && !store.editing.rule}>
               <box gap={0}>
                 <text fg={theme.text} attributes={TextAttributes.BOLD}>
-                  ● New permission for {store.editing!.permission || currentTab().permissions[0]}
+                  ● New {store.editing!.source} permission for{" "}
+                  {store.editing!.permission || currentTab().permissions[0]}
                 </text>
                 <box paddingLeft={2} flexDirection="row" gap={1} backgroundColor={theme.backgroundElement}>
                   <Show when={store.editing}>
@@ -366,43 +532,71 @@ export function DialogPermission() {
                             return theme.warning
                         }
                       }
+                      const isBinary = () =>
+                        (editing().source === "project" || editing().source === "global") &&
+                        isBinaryPermission(editing().permission || currentTab().permissions[0])
                       return (
                         <>
                           <text fg={editActionColor()}>{ACTION_ICONS[editing().action]}</text>
                           <text fg={theme.textMuted}>{editing().action}</text>
+                          <Show when={isBinary()}>
+                            <text fg={theme.text}>*</text>
+                          </Show>
                         </>
                       )
                     }}
                   </Show>
-                  <textarea
-                    ref={(r) => {
-                      createInput = r
-                      setTimeout(() => r?.focus(), 1)
-                      // Handle escape directly on the textarea to prevent it from bubbling to dialog
-                      if (r) {
-                        const originalHandleKeyPress = r.handleKeyPress.bind(r)
-                        r.handleKeyPress = (evt) => {
-                          if (evt.name === "escape") {
-                            cancelEdit()
-                            return true
+                  <Show
+                    when={
+                      !(
+                        (store.editing!.source === "project" || store.editing!.source === "global") &&
+                        isBinaryPermission(store.editing!.permission || currentTab().permissions[0])
+                      )
+                    }
+                  >
+                    <textarea
+                      ref={(r) => {
+                        createInput = r
+                        setTimeout(() => r?.focus(), 1)
+                        // Handle escape directly on the textarea to prevent it from bubbling to dialog
+                        if (r) {
+                          const originalHandleKeyPress = r.handleKeyPress.bind(r)
+                          r.handleKeyPress = (evt) => {
+                            if (evt.name === "escape") {
+                              cancelEdit()
+                              return true
+                            }
+                            return originalHandleKeyPress(evt)
                           }
-                          return originalHandleKeyPress(evt)
                         }
-                      }
-                    }}
-                    height={1}
-                    initialValue={store.editing!.pattern}
-                    onContentChange={() => {
-                      setStore("editing", "pattern", createInput?.plainText ?? "")
-                    }}
-                    keyBindings={[{ name: "return", action: "submit" }]}
-                    onSubmit={() => saveEdit()}
-                    textColor={theme.text}
-                    focusedTextColor={theme.text}
-                    cursorColor={theme.primary}
-                    placeholder={placeholderForPermission(store.editing!.permission || currentTab().permissions[0])}
-                  />
+                      }}
+                      height={1}
+                      initialValue={store.editing!.pattern}
+                      onContentChange={() => {
+                        setStore("editing", "pattern", createInput?.plainText ?? "")
+                      }}
+                      keyBindings={[{ name: "return", action: "submit" }]}
+                      onSubmit={() => saveEdit()}
+                      textColor={theme.text}
+                      focusedTextColor={theme.text}
+                      cursorColor={theme.primary}
+                      placeholder={placeholderForPermission(store.editing!.permission || currentTab().permissions[0])}
+                    />
+                  </Show>
                 </box>
+                <Show
+                  when={
+                    store.confirmingSave && (store.editing!.source === "project" || store.editing!.source === "global")
+                  }
+                >
+                  <box paddingLeft={2}>
+                    <text fg={theme.warning}>
+                      {store.editing!.source === "global"
+                        ? "This will update ~/.config/opencode/opencode.json (affects ALL projects). Press enter again to confirm."
+                        : "This will update opencode.json. Press enter again to confirm."}
+                    </text>
+                  </box>
+                </Show>
               </box>
             </Show>
 
@@ -449,60 +643,109 @@ export function DialogPermission() {
                                   backgroundColor={isSelected() ? theme.backgroundElement : undefined}
                                 >
                                   <text fg={actionColor()}>{ACTION_ICONS[rule.action]}</text>
-                                  <text fg={theme.textMuted}>{rule.action}</text>
-                                  <text fg={theme.text}>{rule.pattern}</text>
+                                  <text fg={rule.readonly ? theme.textMuted : theme.textMuted}>{rule.action}</text>
+                                  <text fg={rule.readonly ? theme.textMuted : theme.text}>{rule.pattern}</text>
+                                  <Show when={sourceLabel(rule.source)}>
+                                    <text fg={theme.textMuted}>[{sourceLabel(rule.source)}]</text>
+                                  </Show>
+                                  <Show
+                                    when={
+                                      isSelected() &&
+                                      store.confirmingDelete &&
+                                      (rule.source === "project" || rule.source === "global")
+                                    }
+                                  >
+                                    <text fg={theme.error}>
+                                      {rule.source === "global"
+                                        ? " - Press 'd' again to delete (affects ALL projects)"
+                                        : " - Press 'd' again to delete"}
+                                    </text>
+                                  </Show>
                                 </box>
                               }
                             >
-                              <box flexDirection="row" gap={1} backgroundColor={theme.backgroundElement}>
-                                <Show when={store.editing}>
-                                  {(editing) => {
-                                    const editActionColor = () => {
-                                      switch (editing().action) {
-                                        case "allow":
-                                          return theme.success
-                                        case "deny":
-                                          return theme.error
-                                        case "ask":
-                                          return theme.warning
-                                      }
-                                    }
-                                    return (
-                                      <>
-                                        <text fg={editActionColor()}>{ACTION_ICONS[editing().action]}</text>
-                                        <text fg={theme.textMuted}>{editing().action}</text>
-                                      </>
-                                    )
-                                  }}
-                                </Show>
-                                <textarea
-                                  ref={(r) => {
-                                    editInput = r
-                                    setTimeout(() => r?.focus(), 1)
-                                    // Handle escape directly on the textarea to prevent it from bubbling to dialog
-                                    if (r) {
-                                      const originalHandleKeyPress = r.handleKeyPress.bind(r)
-                                      r.handleKeyPress = (evt) => {
-                                        if (evt.name === "escape") {
-                                          cancelEdit()
-                                          return true
+                              <box gap={0}>
+                                <box flexDirection="row" gap={1} backgroundColor={theme.backgroundElement}>
+                                  <Show when={store.editing}>
+                                    {(editing) => {
+                                      const editActionColor = () => {
+                                        switch (editing().action) {
+                                          case "allow":
+                                            return theme.success
+                                          case "deny":
+                                            return theme.error
+                                          case "ask":
+                                            return theme.warning
                                         }
-                                        return originalHandleKeyPress(evt)
                                       }
+                                      const isBinary = () =>
+                                        (editing().rule?.source === "project" || editing().rule?.source === "global") &&
+                                        isBinaryPermission(editing().rule?.permission || "")
+                                      return (
+                                        <>
+                                          <text fg={editActionColor()}>{ACTION_ICONS[editing().action]}</text>
+                                          <text fg={theme.textMuted}>{editing().action}</text>
+                                          <Show when={isBinary()}>
+                                            <text fg={theme.text}>*</text>
+                                          </Show>
+                                        </>
+                                      )
+                                    }}
+                                  </Show>
+                                  <Show
+                                    when={
+                                      !(
+                                        (store.editing!.rule?.source === "project" ||
+                                          store.editing!.rule?.source === "global") &&
+                                        isBinaryPermission(store.editing!.rule?.permission || "")
+                                      )
                                     }
-                                  }}
-                                  height={1}
-                                  initialValue={store.editing!.pattern}
-                                  onContentChange={() => {
-                                    setStore("editing", "pattern", editInput?.plainText ?? "")
-                                  }}
-                                  keyBindings={[{ name: "return", action: "submit" }]}
-                                  onSubmit={() => saveEdit()}
-                                  textColor={theme.text}
-                                  focusedTextColor={theme.text}
-                                  cursorColor={theme.primary}
-                                  placeholder="Pattern"
-                                />
+                                  >
+                                    <textarea
+                                      ref={(r) => {
+                                        editInput = r
+                                        setTimeout(() => r?.focus(), 1)
+                                        // Handle escape directly on the textarea to prevent it from bubbling to dialog
+                                        if (r) {
+                                          const originalHandleKeyPress = r.handleKeyPress.bind(r)
+                                          r.handleKeyPress = (evt) => {
+                                            if (evt.name === "escape") {
+                                              cancelEdit()
+                                              return true
+                                            }
+                                            return originalHandleKeyPress(evt)
+                                          }
+                                        }
+                                      }}
+                                      height={1}
+                                      initialValue={store.editing!.pattern}
+                                      onContentChange={() => {
+                                        setStore("editing", "pattern", editInput?.plainText ?? "")
+                                      }}
+                                      keyBindings={[{ name: "return", action: "submit" }]}
+                                      onSubmit={() => saveEdit()}
+                                      textColor={theme.text}
+                                      focusedTextColor={theme.text}
+                                      cursorColor={theme.primary}
+                                      placeholder="Pattern"
+                                    />
+                                  </Show>
+                                </box>
+                                <Show
+                                  when={
+                                    store.confirmingSave &&
+                                    (store.editing!.rule?.source === "project" ||
+                                      store.editing!.rule?.source === "global")
+                                  }
+                                >
+                                  <box paddingLeft={2}>
+                                    <text fg={theme.warning}>
+                                      {store.editing!.rule?.source === "global"
+                                        ? "This will update ~/.config/opencode/opencode.json (affects ALL projects). Press enter again to confirm."
+                                        : "This will update opencode.json. Press enter again to confirm."}
+                                    </text>
+                                  </box>
+                                </Show>
                               </box>
                             </Show>
                           )
@@ -553,18 +796,40 @@ export function DialogPermission() {
                 <text fg={theme.textMuted}>{"↑↓"}</text>
                 <text fg={theme.text}>select</text>
               </box>
-              <box flexDirection="row" gap={1}>
-                <text fg={theme.textMuted}>e</text>
-                <text fg={theme.text}>edit</text>
-              </box>
+              <Show
+                when={
+                  flatRules()[store.selected]?.source === "session" ||
+                  flatRules()[store.selected]?.source === "project" ||
+                  flatRules()[store.selected]?.source === "global"
+                }
+              >
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.textMuted}>e</text>
+                  <text fg={theme.text}>edit</text>
+                </box>
+              </Show>
               <box flexDirection="row" gap={1}>
                 <text fg={theme.textMuted}>n</text>
                 <text fg={theme.text}>new</text>
               </box>
-              <box flexDirection="row" gap={1}>
-                <text fg={theme.textMuted}>d</text>
-                <text fg={theme.text}>delete</text>
-              </box>
+              <Show
+                when={
+                  flatRules()[store.selected]?.source === "session" ||
+                  flatRules()[store.selected]?.source === "project" ||
+                  flatRules()[store.selected]?.source === "global"
+                }
+              >
+                <box flexDirection="row" gap={1}>
+                  <text fg={theme.textMuted}>d</text>
+                  <text fg={theme.text}>
+                    {store.confirmingDelete &&
+                    (flatRules()[store.selected]?.source === "project" ||
+                      flatRules()[store.selected]?.source === "global")
+                      ? "press again to confirm"
+                      : "delete"}
+                  </text>
+                </box>
+              </Show>
               <box flexDirection="row" gap={1}>
                 <text fg={theme.textMuted}>esc</text>
                 <text fg={theme.text}>close</text>
@@ -577,6 +842,10 @@ export function DialogPermission() {
               <text fg={theme.textMuted}>tab</text>
               <text fg={theme.text}>cycle permission</text>
             </box>
+            <box flexDirection="row" gap={1}>
+              <text fg={theme.textMuted}>ctrl+p</text>
+              <text fg={theme.text}>toggle source</text>
+            </box>
           </Show>
           <box flexDirection="row" gap={1}>
             <text fg={theme.textMuted}>{"↑↓"}</text>
@@ -584,7 +853,7 @@ export function DialogPermission() {
           </box>
           <box flexDirection="row" gap={1}>
             <text fg={theme.textMuted}>enter</text>
-            <text fg={theme.text}>save</text>
+            <text fg={theme.text}>{store.confirmingSave ? "confirm" : "save"}</text>
           </box>
           <box flexDirection="row" gap={1}>
             <text fg={theme.textMuted}>esc</text>

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-permission.tsx
@@ -1,0 +1,597 @@
+import { createMemo, For, Show, onMount } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useTheme } from "@tui/context/theme"
+import { useDialog } from "@tui/ui/dialog"
+import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
+import { TextAttributes, TextareaRenderable } from "@opentui/core"
+import { useSDK } from "@tui/context/sdk"
+import type { PermissionNext } from "@/permission/next"
+
+type TabType = "file" | "execute" | "network" | "external" | "other"
+
+const TABS: { id: TabType; label: string; permissions: string[] }[] = [
+  { id: "file", label: "File", permissions: ["read", "edit", "glob", "grep", "list"] },
+  { id: "execute", label: "Execute", permissions: ["bash", "task"] },
+  { id: "network", label: "Network", permissions: ["webfetch", "websearch", "codesearch"] },
+  { id: "external", label: "External", permissions: ["external_directory"] },
+  {
+    id: "other",
+    label: "Other",
+    permissions: ["todowrite", "todoread", "question", "lsp", "doom_loop"],
+  },
+]
+
+const ACTION_ICONS: Record<PermissionNext.Action, string> = {
+  allow: "✓",
+  deny: "✗",
+  ask: "?",
+}
+
+export function DialogPermission() {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const [store, setStore] = createStore({
+    tab: 0 as number,
+    loading: true,
+    rules: [] as PermissionNext.Rule[],
+    selected: 0 as number,
+    editing: null as null | {
+      rule: PermissionNext.Rule | null
+      pattern: string
+      action: PermissionNext.Action
+      permission?: string
+    },
+  })
+
+  let createInput: TextareaRenderable | undefined
+  let editInput: TextareaRenderable | undefined
+
+  onMount(() => {
+    dialog.setSize("large")
+  })
+
+  // Fetch permissions on mount
+  onMount(async () => {
+    try {
+      const result = await sdk.client.permission.approved()
+      setStore("rules", Array.isArray(result.data) ? result.data : [])
+    } catch (error) {
+      setStore("rules", [])
+    } finally {
+      setStore("loading", false)
+    }
+  })
+
+  const currentTab = createMemo(() => TABS[store.tab])
+
+  // Group rules by permission type for current tab
+  const groupedRules = createMemo(() => {
+    const permissionTypes = currentTab().permissions
+    const rulesByPermission = new Map<string, PermissionNext.Rule[]>()
+
+    for (const permission of permissionTypes) {
+      rulesByPermission.set(permission, [])
+    }
+
+    for (const rule of store.rules) {
+      if (permissionTypes.includes(rule.permission)) {
+        rulesByPermission.get(rule.permission)!.push(rule)
+      }
+    }
+
+    return rulesByPermission
+  })
+
+  // Flatten rules for navigation
+  const flatRules = createMemo(() => {
+    const permissionTypes = currentTab().permissions
+    return store.rules.filter((rule) => permissionTypes.includes(rule.permission))
+  })
+
+  function move(delta: number) {
+    const max = flatRules().length - 1
+    if (max < 0) return
+    let next = store.selected + delta
+    if (next < 0) next = 0
+    if (next > max) next = max
+    setStore("selected", next)
+  }
+
+  async function deleteSelected() {
+    const rule = flatRules()[store.selected]
+    if (!rule) return
+    try {
+      await sdk.client.permission.delete({ permissionRule: rule })
+      // Remove from local state using deep comparison
+      setStore(
+        "rules",
+        store.rules.filter(
+          (r) => !(r.permission === rule.permission && r.pattern === rule.pattern && r.action === rule.action),
+        ),
+      )
+      // Adjust selection if needed
+      const newLength = flatRules().length
+      if (store.selected >= newLength && newLength > 0) {
+        setStore("selected", newLength - 1)
+      } else if (newLength === 0) {
+        setStore("selected", 0)
+      }
+    } catch (error) {
+      // Silently handle error
+    }
+  }
+
+  function startEditing() {
+    const rule = flatRules()[store.selected]
+    if (!rule) return
+    setStore("editing", { rule, pattern: rule.pattern, action: rule.action })
+  }
+
+  function startCreating() {
+    // Get the first permission type from the current tab
+    const permissionType = currentTab().permissions[0]
+    if (!permissionType) return
+    setStore("editing", { rule: null, pattern: "", action: "allow", permission: permissionType })
+  }
+
+  function cycleAction(direction: "forward" | "backward" = "forward") {
+    if (!store.editing) return
+    const actions: PermissionNext.Action[] = ["allow", "deny", "ask"]
+    const currentIndex = actions.indexOf(store.editing.action)
+    const delta = direction === "forward" ? 1 : -1
+    const nextIndex = (currentIndex + delta + actions.length) % actions.length
+    setStore("editing", "action", actions[nextIndex])
+  }
+
+  function cyclePermission() {
+    if (!store.editing || store.editing.rule) return // Only when creating new
+    const permissions = currentTab().permissions
+    const currentIndex = permissions.indexOf(store.editing.permission || permissions[0])
+    const nextIndex = (currentIndex + 1) % permissions.length
+    setStore("editing", "permission", permissions[nextIndex])
+  }
+
+  async function saveEdit() {
+    if (!store.editing) return
+    const oldRule = store.editing.rule
+
+    // Creating new rule
+    if (!oldRule) {
+      const permissionType = store.editing.permission || currentTab().permissions[0]
+      if (!permissionType) return
+      const newRule: PermissionNext.Rule = {
+        permission: permissionType,
+        pattern: store.editing.pattern,
+        action: store.editing.action,
+      }
+      try {
+        await sdk.client.permission.add({ permissionRule: newRule })
+        setStore("rules", [...store.rules, newRule])
+        setStore("editing", null)
+      } catch (error) {
+        // Silently handle error
+      }
+      return
+    }
+
+    // Updating existing rule
+    const newRule: PermissionNext.Rule = {
+      permission: oldRule.permission,
+      pattern: store.editing.pattern,
+      action: store.editing.action,
+    }
+    try {
+      await sdk.client.permission.update({ oldRule, newRule })
+      // Update local state
+      setStore(
+        "rules",
+        store.rules.map((r) =>
+          r.permission === oldRule.permission && r.pattern === oldRule.pattern && r.action === oldRule.action
+            ? newRule
+            : r,
+        ),
+      )
+      setStore("editing", null)
+    } catch (error) {
+      // Silently handle error
+    }
+  }
+
+  function cancelEdit() {
+    setStore("editing", null)
+  }
+
+  function placeholderForPermission(permission: string): string {
+    switch (permission) {
+      case "read":
+      case "edit":
+      case "list":
+        return "Pattern (e.g. *, *.env, src/**/*)"
+      case "glob":
+      case "grep":
+        return "Pattern (e.g. *, **/*.ts, src/**)"
+      case "bash":
+        return "Pattern (e.g. *, npm, git)"
+      case "task":
+        return "Pattern (e.g. *)"
+      case "webfetch":
+      case "websearch":
+      case "codesearch":
+        return "Pattern (e.g. *, https://*)"
+      case "external_directory":
+        return "Pattern (e.g. *, /home/*, /tmp/*)"
+      default:
+        return "Pattern (e.g. *)"
+    }
+  }
+
+  function selectTab(index: number) {
+    setStore("tab", index)
+  }
+
+  const dimensions = useTerminalDimensions()
+  const height = createMemo(() => Math.floor(dimensions().height / 2) - 6)
+
+  useKeyboard((evt) => {
+    // Editing mode
+    if (store.editing) {
+      if (evt.name === "return") {
+        evt.preventDefault()
+        evt.stopPropagation()
+        saveEdit()
+        return
+      }
+      if (evt.name === "escape") {
+        evt.preventDefault()
+        evt.stopPropagation()
+        cancelEdit()
+        return
+      }
+      if (evt.name === "up") {
+        evt.preventDefault()
+        evt.stopPropagation()
+        cycleAction("backward")
+        return
+      }
+      if (evt.name === "down") {
+        evt.preventDefault()
+        evt.stopPropagation()
+        cycleAction("forward")
+        return
+      }
+      if (evt.name === "tab" && !store.editing.rule) {
+        evt.preventDefault()
+        evt.stopPropagation()
+        cyclePermission()
+        return
+      }
+      return
+    }
+
+    // Navigation mode
+    if (evt.name === "left" || evt.name === "h") {
+      evt.preventDefault()
+      selectTab((store.tab - 1 + TABS.length) % TABS.length)
+      setStore("selected", 0)
+    }
+    if (evt.name === "right" || evt.name === "l") {
+      evt.preventDefault()
+      selectTab((store.tab + 1) % TABS.length)
+      setStore("selected", 0)
+    }
+    if (evt.name === "tab") {
+      evt.preventDefault()
+      if (evt.shift) {
+        selectTab((store.tab - 1 + TABS.length) % TABS.length)
+      } else {
+        selectTab((store.tab + 1) % TABS.length)
+      }
+      setStore("selected", 0)
+    }
+    if (evt.name === "up" || evt.name === "k") {
+      evt.preventDefault()
+      move(-1)
+    }
+    if (evt.name === "down" || evt.name === "j") {
+      evt.preventDefault()
+      move(1)
+    }
+    if (evt.name === "e") {
+      evt.preventDefault()
+      startEditing()
+    }
+    if (evt.name === "n" || evt.name === "a") {
+      evt.preventDefault()
+      startCreating()
+    }
+    if (evt.name === "d" || evt.name === "x" || evt.name === "delete") {
+      evt.preventDefault()
+      deleteSelected()
+    }
+    if (evt.name === "escape") {
+      evt.preventDefault()
+      dialog.clear()
+    }
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} paddingTop={1} paddingBottom={1} gap={1}>
+      {/* Title */}
+      <box paddingBottom={1}>
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Permissions
+        </text>
+      </box>
+
+      {/* Tabs */}
+      <box flexDirection="row" gap={1} paddingBottom={1}>
+        <For each={TABS}>
+          {(tab, index) => {
+            const isActive = () => index() === store.tab
+            return (
+              <box
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={isActive() ? theme.accent : theme.backgroundElement}
+                onMouseUp={() => selectTab(index())}
+              >
+                <text fg={isActive() ? theme.selectedListItemText : theme.textMuted}>{tab.label}</text>
+              </box>
+            )
+          }}
+        </For>
+      </box>
+
+      {/* Content */}
+      <Show when={!store.loading} fallback={<text fg={theme.textMuted}>Loading...</text>}>
+        <scrollbox height={height()}>
+          <box gap={1}>
+            {/* Create mode - show at top */}
+            <Show when={store.editing && !store.editing.rule}>
+              <box gap={0}>
+                <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                  ● New permission for {store.editing!.permission || currentTab().permissions[0]}
+                </text>
+                <box paddingLeft={2} flexDirection="row" gap={1} backgroundColor={theme.backgroundElement}>
+                  <Show when={store.editing}>
+                    {(editing) => {
+                      const editActionColor = () => {
+                        switch (editing().action) {
+                          case "allow":
+                            return theme.success
+                          case "deny":
+                            return theme.error
+                          case "ask":
+                            return theme.warning
+                        }
+                      }
+                      return (
+                        <>
+                          <text fg={editActionColor()}>{ACTION_ICONS[editing().action]}</text>
+                          <text fg={theme.textMuted}>{editing().action}</text>
+                        </>
+                      )
+                    }}
+                  </Show>
+                  <textarea
+                    ref={(r) => {
+                      createInput = r
+                      setTimeout(() => r?.focus(), 1)
+                      // Handle escape directly on the textarea to prevent it from bubbling to dialog
+                      if (r) {
+                        const originalHandleKeyPress = r.handleKeyPress.bind(r)
+                        r.handleKeyPress = (evt) => {
+                          if (evt.name === "escape") {
+                            cancelEdit()
+                            return true
+                          }
+                          return originalHandleKeyPress(evt)
+                        }
+                      }
+                    }}
+                    height={1}
+                    initialValue={store.editing!.pattern}
+                    onContentChange={() => {
+                      setStore("editing", "pattern", createInput?.plainText ?? "")
+                    }}
+                    keyBindings={[{ name: "return", action: "submit" }]}
+                    onSubmit={() => saveEdit()}
+                    textColor={theme.text}
+                    focusedTextColor={theme.text}
+                    cursorColor={theme.primary}
+                    placeholder={placeholderForPermission(store.editing!.permission || currentTab().permissions[0])}
+                  />
+                </box>
+              </box>
+            </Show>
+
+            <For each={Array.from(groupedRules().entries())}>
+              {([permission, rules]) => (
+                <Show when={rules.length > 0}>
+                  <box gap={0}>
+                    {/* Permission type header */}
+                    <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                      ● {permission} ({rules.length} {rules.length === 1 ? "rule" : "rules"})
+                    </text>
+
+                    {/* Rules list */}
+                    <box paddingLeft={2}>
+                      <For each={rules}>
+                        {(rule) => {
+                          const ruleIndex = () => flatRules().indexOf(rule)
+                          const isSelected = () => ruleIndex() === store.selected
+                          const actionColor = () => {
+                            switch (rule.action) {
+                              case "allow":
+                                return theme.success
+                              case "deny":
+                                return theme.error
+                              case "ask":
+                                return theme.warning
+                            }
+                          }
+
+                          const isEditing = () =>
+                            store.editing &&
+                            store.editing.rule &&
+                            store.editing.rule.permission === rule.permission &&
+                            store.editing.rule.pattern === rule.pattern &&
+                            store.editing.rule.action === rule.action
+
+                          return (
+                            <Show
+                              when={isEditing()}
+                              fallback={
+                                <box
+                                  flexDirection="row"
+                                  gap={1}
+                                  backgroundColor={isSelected() ? theme.backgroundElement : undefined}
+                                >
+                                  <text fg={actionColor()}>{ACTION_ICONS[rule.action]}</text>
+                                  <text fg={theme.textMuted}>{rule.action}</text>
+                                  <text fg={theme.text}>{rule.pattern}</text>
+                                </box>
+                              }
+                            >
+                              <box flexDirection="row" gap={1} backgroundColor={theme.backgroundElement}>
+                                <Show when={store.editing}>
+                                  {(editing) => {
+                                    const editActionColor = () => {
+                                      switch (editing().action) {
+                                        case "allow":
+                                          return theme.success
+                                        case "deny":
+                                          return theme.error
+                                        case "ask":
+                                          return theme.warning
+                                      }
+                                    }
+                                    return (
+                                      <>
+                                        <text fg={editActionColor()}>{ACTION_ICONS[editing().action]}</text>
+                                        <text fg={theme.textMuted}>{editing().action}</text>
+                                      </>
+                                    )
+                                  }}
+                                </Show>
+                                <textarea
+                                  ref={(r) => {
+                                    editInput = r
+                                    setTimeout(() => r?.focus(), 1)
+                                    // Handle escape directly on the textarea to prevent it from bubbling to dialog
+                                    if (r) {
+                                      const originalHandleKeyPress = r.handleKeyPress.bind(r)
+                                      r.handleKeyPress = (evt) => {
+                                        if (evt.name === "escape") {
+                                          cancelEdit()
+                                          return true
+                                        }
+                                        return originalHandleKeyPress(evt)
+                                      }
+                                    }
+                                  }}
+                                  height={1}
+                                  initialValue={store.editing!.pattern}
+                                  onContentChange={() => {
+                                    setStore("editing", "pattern", editInput?.plainText ?? "")
+                                  }}
+                                  keyBindings={[{ name: "return", action: "submit" }]}
+                                  onSubmit={() => saveEdit()}
+                                  textColor={theme.text}
+                                  focusedTextColor={theme.text}
+                                  cursorColor={theme.primary}
+                                  placeholder="Pattern"
+                                />
+                              </box>
+                            </Show>
+                          )
+                        }}
+                      </For>
+                    </box>
+                  </box>
+                </Show>
+              )}
+            </For>
+
+            {/* Empty state */}
+            <Show when={Array.from(groupedRules().values()).every((rules) => rules.length === 0)}>
+              <box paddingTop={2}>
+                <text fg={theme.textMuted}>No rules configured for this category</text>
+              </box>
+            </Show>
+          </box>
+        </scrollbox>
+      </Show>
+
+      {/* Help text */}
+      <Show when={!store.editing}>
+        <box paddingTop={1} paddingBottom={0}>
+          <Show when={currentTab().id === "execute"}>
+            <text fg={theme.textMuted}>
+              Tip: "git status" matches only exactly that. Use "git *" to match all git commands (e.g. git status, git
+              commit, etc.)
+            </text>
+          </Show>
+          <Show when={currentTab().id === "file"}>
+            <text fg={theme.textMuted}>Tip: Use glob patterns like *.env, src/**/*, or * for all files</text>
+          </Show>
+        </box>
+      </Show>
+
+      {/* Footer hints */}
+      <box flexDirection="row" gap={2} paddingTop={1}>
+        <Show
+          when={store.editing}
+          fallback={
+            <>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.textMuted}>{"←→"}</text>
+                <text fg={theme.text}>switch tabs</text>
+              </box>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.textMuted}>{"↑↓"}</text>
+                <text fg={theme.text}>select</text>
+              </box>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.textMuted}>e</text>
+                <text fg={theme.text}>edit</text>
+              </box>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.textMuted}>n</text>
+                <text fg={theme.text}>new</text>
+              </box>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.textMuted}>d</text>
+                <text fg={theme.text}>delete</text>
+              </box>
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.textMuted}>esc</text>
+                <text fg={theme.text}>close</text>
+              </box>
+            </>
+          }
+        >
+          <Show when={!store.editing?.rule}>
+            <box flexDirection="row" gap={1}>
+              <text fg={theme.textMuted}>tab</text>
+              <text fg={theme.text}>cycle permission</text>
+            </box>
+          </Show>
+          <box flexDirection="row" gap={1}>
+            <text fg={theme.textMuted}>{"↑↓"}</text>
+            <text fg={theme.text}>cycle action</text>
+          </box>
+          <box flexDirection="row" gap={1}>
+            <text fg={theme.textMuted}>enter</text>
+            <text fg={theme.text}>save</text>
+          </box>
+          <box flexDirection="row" gap={1}>
+            <text fg={theme.textMuted}>esc</text>
+            <text fg={theme.text}>cancel</text>
+          </box>
+        </Show>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -58,6 +58,12 @@ function init() {
 
   useKeyboard((evt) => {
     if (evt.name === "escape" && store.stack.length > 0) {
+      // Check if a textarea is currently focused - if so, let the component handle escape
+      const focused = renderer.currentFocusedRenderable
+      if (focused && focused.constructor.name === "TextareaRenderable") {
+        return
+      }
+      if (evt.defaultPrevented) return
       const current = store.stack.at(-1)!
       current.onClose?.()
       setStore("stack", store.stack.slice(0, -1))

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1241,4 +1241,163 @@ export namespace Config {
   export async function directories() {
     return state().then((x) => x.directories)
   }
+
+  async function findProjectConfigFile(): Promise<string | null> {
+    const { Filesystem } = await import("@/util/filesystem")
+    const files = await Filesystem.findUp("opencode.json", Instance.directory, Instance.worktree)
+    return files.length > 0 ? files[0] : null
+  }
+
+  export async function updateProjectPermission(rule: { permission: string; pattern: string; action: string }) {
+    const configPath = await findProjectConfigFile()
+    if (!configPath) {
+      // Create new config file if it doesn't exist
+      const newPath = path.join(Instance.directory, "opencode.json")
+      await Bun.write(
+        newPath,
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            permission: {
+              [rule.permission]: {
+                [rule.pattern]: rule.action,
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+      )
+      await Instance.dispose()
+      return
+    }
+
+    // Read existing config
+    const content = await Bun.file(configPath).text()
+    const config = JSON.parse(content) as Info
+
+    // Initialize permission if not exists
+    if (!config.permission) {
+      config.permission = {}
+    }
+
+    // Update the permission rule
+    const perm = config.permission[rule.permission as keyof typeof config.permission]
+    if (typeof perm === "object" && perm !== null) {
+      ;(perm as Record<string, string>)[rule.pattern] = rule.action as any
+    } else {
+      // Convert to object if it was a simple string
+      config.permission[rule.permission as keyof typeof config.permission] = {
+        [rule.pattern]: rule.action,
+      } as any
+    }
+
+    // Write back
+    await Bun.write(configPath, JSON.stringify(config, null, 2) + "\n")
+    await Instance.dispose()
+  }
+
+  export async function removeProjectPermission(rule: { permission: string; pattern: string }) {
+    const configPath = await findProjectConfigFile()
+    if (!configPath) return
+
+    // Read existing config
+    const content = await Bun.file(configPath).text()
+    const config = JSON.parse(content) as Info
+
+    if (!config.permission) return
+
+    const perm = config.permission[rule.permission as keyof typeof config.permission]
+    if (typeof perm === "object" && perm !== null) {
+      delete (perm as Record<string, string>)[rule.pattern]
+
+      // If permission object is now empty, remove it entirely
+      if (Object.keys(perm).length === 0) {
+        delete config.permission[rule.permission as keyof typeof config.permission]
+      }
+    }
+
+    // Write back
+    await Bun.write(configPath, JSON.stringify(config, null, 2) + "\n")
+    await Instance.dispose()
+  }
+
+  export async function updateGlobalPermission(rule: { permission: string; pattern: string; action: string }) {
+    const configPath = path.join(Global.Path.config, "opencode.json")
+    const file = Bun.file(configPath)
+    const exists = await file.exists()
+
+    if (!exists) {
+      // Create new global config file if it doesn't exist
+      const dir = path.dirname(configPath)
+      await Bun.write(
+        configPath,
+        JSON.stringify(
+          {
+            $schema: "https://opencode.ai/config.json",
+            permission: {
+              [rule.permission]: {
+                [rule.pattern]: rule.action,
+              },
+            },
+          },
+          null,
+          2,
+        ) + "\n",
+      )
+      await Instance.dispose()
+      return
+    }
+
+    // Read existing config
+    const content = await file.text()
+    const config = JSON.parse(content) as Info
+
+    // Initialize permission if not exists
+    if (!config.permission) {
+      config.permission = {}
+    }
+
+    // Update the permission rule
+    const perm = config.permission[rule.permission as keyof typeof config.permission]
+    if (typeof perm === "object" && perm !== null) {
+      ;(perm as Record<string, string>)[rule.pattern] = rule.action as any
+    } else {
+      // Convert to object if it was a simple string
+      config.permission[rule.permission as keyof typeof config.permission] = {
+        [rule.pattern]: rule.action,
+      } as any
+    }
+
+    // Write back
+    await Bun.write(configPath, JSON.stringify(config, null, 2) + "\n")
+    await Instance.dispose()
+  }
+
+  export async function removeGlobalPermission(rule: { permission: string; pattern: string }) {
+    const configPath = path.join(Global.Path.config, "opencode.json")
+    const file = Bun.file(configPath)
+    const exists = await file.exists()
+    if (!exists) return
+
+    // Read existing config
+    const content = await file.text()
+    const config = JSON.parse(content) as Info
+
+    if (!config.permission) return
+
+    const perm = config.permission[rule.permission as keyof typeof config.permission]
+    if (typeof perm === "object" && perm !== null) {
+      delete (perm as Record<string, string>)[rule.pattern]
+
+      // If permission object is now empty, remove it entirely
+      if (Object.keys(perm).length === 0) {
+        delete config.permission[rule.permission as keyof typeof config.permission]
+      }
+    }
+
+    // Write back
+    await Bun.write(configPath, JSON.stringify(config, null, 2) + "\n")
+    await Instance.dispose()
+  }
 }

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -190,6 +190,11 @@ export namespace PermissionNext {
             action: "allow",
           })
         }
+        log.info("approved permission", {
+          permission: existing.info.permission,
+          patterns: existing.info.always,
+          total: s.approved.length,
+        })
 
         existing.resolve()
 
@@ -265,5 +270,39 @@ export namespace PermissionNext {
 
   export async function list() {
     return state().then((x) => Object.values(x.pending).map((x) => x.info))
+  }
+
+  export async function approved() {
+    const s = await state()
+    log.info("getting approved permissions", { count: s.approved.length, rules: s.approved })
+    return s.approved
+  }
+
+  export async function remove(rule: Rule) {
+    const s = await state()
+    const index = s.approved.findIndex(
+      (r) => r.permission === rule.permission && r.pattern === rule.pattern && r.action === rule.action,
+    )
+    if (index !== -1) {
+      s.approved.splice(index, 1)
+      log.info("removed permission", { rule, remaining: s.approved.length })
+    }
+  }
+
+  export async function update(oldRule: Rule, newRule: Rule) {
+    const s = await state()
+    const index = s.approved.findIndex(
+      (r) => r.permission === oldRule.permission && r.pattern === oldRule.pattern && r.action === oldRule.action,
+    )
+    if (index !== -1) {
+      s.approved[index] = newRule
+      log.info("updated permission", { oldRule, newRule })
+    }
+  }
+
+  export async function add(rule: Rule) {
+    const s = await state()
+    s.approved.push(rule)
+    log.info("added permission", { rule, total: s.approved.length })
   }
 }

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -33,6 +33,24 @@ export namespace PermissionNext {
   })
   export type Ruleset = z.infer<typeof Ruleset>
 
+  export const Source = z.enum(["default", "global", "project", "session"]).meta({
+    ref: "PermissionSource",
+  })
+  export type Source = z.infer<typeof Source>
+
+  export const RuleWithSource = Rule.extend({
+    source: Source,
+    readonly: z.boolean(),
+  }).meta({
+    ref: "PermissionRuleWithSource",
+  })
+  export type RuleWithSource = z.infer<typeof RuleWithSource>
+
+  export const RulesetWithSource = RuleWithSource.array().meta({
+    ref: "PermissionRulesetWithSource",
+  })
+  export type RulesetWithSource = z.infer<typeof RulesetWithSource>
+
   export function fromConfig(permission: Config.Permission) {
     const ruleset: Ruleset = []
     for (const [key, value] of Object.entries(permission)) {
@@ -276,6 +294,110 @@ export namespace PermissionNext {
     const s = await state()
     log.info("getting approved permissions", { count: s.approved.length, rules: s.approved })
     return s.approved
+  }
+
+  export async function all(agent?: string): Promise<RulesetWithSource> {
+    // Load configs separately to avoid automatic merging
+    const { Filesystem } = await import("@/util/filesystem")
+    const { Instance } = await import("@/project/instance")
+    const path = await import("path")
+
+    const [globalConfig, projectConfigFiles, sessionRules] = await Promise.all([
+      Config.global(),
+      Filesystem.findUp("opencode.json", Instance.directory, Instance.worktree),
+      approved(),
+    ])
+
+    // Load project config file directly (without global merged in)
+    let projectConfig: Config.Info | undefined
+    if (projectConfigFiles.length > 0) {
+      try {
+        const content = await Bun.file(projectConfigFiles[0]).text()
+        projectConfig = JSON.parse(content)
+      } catch (e) {
+        // Ignore if file doesn't exist or is invalid
+      }
+    }
+
+    const result: RulesetWithSource = []
+
+    // Build agent defaults manually (without user config)
+    if (agent) {
+      const { Truncate } = await import("@/tool/truncation")
+      const defaults = fromConfig({
+        "*": "allow",
+        doom_loop: "ask",
+        external_directory: {
+          "*": "ask",
+          [Truncate.DIR]: "allow",
+          [Truncate.GLOB]: "allow",
+        },
+        question: "deny",
+        plan_enter: "deny",
+        plan_exit: "deny",
+        read: {
+          "*": "allow",
+          "*.env": "ask",
+          "*.env.*": "ask",
+          "*.env.example": "allow",
+        },
+      })
+
+      // Add agent-specific overrides
+      const agentOverrides: Record<string, any> = {
+        build: {
+          question: "allow",
+          plan_enter: "allow",
+        },
+        plan: {
+          question: "allow",
+          plan_exit: "allow",
+        },
+        general: {
+          todoread: "deny",
+          todowrite: "deny",
+        },
+        explore: {
+          "*": "deny",
+          grep: "allow",
+          glob: "allow",
+          list: "allow",
+          bash: "allow",
+          read: "allow",
+        },
+      }
+
+      for (const rule of defaults) {
+        result.push({ ...rule, source: "default", readonly: true })
+      }
+
+      if (agentOverrides[agent]) {
+        for (const rule of fromConfig(agentOverrides[agent])) {
+          result.push({ ...rule, source: "default", readonly: true })
+        }
+      }
+    }
+
+    // Add global config rules
+    if (globalConfig.permission) {
+      for (const rule of fromConfig(globalConfig.permission)) {
+        result.push({ ...rule, source: "global", readonly: true })
+      }
+    }
+
+    // Add project config rules
+    if (projectConfig?.permission) {
+      for (const rule of fromConfig(projectConfig.permission)) {
+        result.push({ ...rule, source: "project", readonly: true })
+      }
+    }
+
+    // Add session rules (editable)
+    for (const rule of sessionRules) {
+      result.push({ ...rule, source: "session", readonly: false })
+    }
+
+    return result
   }
 
   export async function remove(rule: Rule) {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1730,6 +1730,31 @@ export namespace Server {
             return c.json(approved)
           },
         )
+        .get(
+          "/permission/all",
+          describeRoute({
+            summary: "List all permissions with sources",
+            description:
+              "Get all permission rules including defaults, global config, project config, and session rules with source metadata.",
+            operationId: "permission.all",
+            responses: {
+              200: {
+                description: "List of all permission rules with source information",
+                content: {
+                  "application/json": {
+                    schema: resolver(PermissionNext.RulesetWithSource),
+                  },
+                },
+              },
+            },
+          }),
+          validator("query", z.object({ agent: z.string().optional() })),
+          async (c) => {
+            const { agent } = c.req.valid("query")
+            const all = await PermissionNext.all(agent)
+            return c.json(all)
+          },
+        )
         .delete(
           "/permission/approved",
           describeRoute({
@@ -1802,6 +1827,108 @@ export namespace Server {
           async (c) => {
             const rule = c.req.valid("json")
             await PermissionNext.add(rule)
+            return c.json(true)
+          },
+        )
+        .put(
+          "/permission/project",
+          describeRoute({
+            summary: "Update project permission",
+            description: "Update a permission rule in the project config file.",
+            operationId: "permission.updateProject",
+            responses: {
+              200: {
+                description: "Permission updated successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", PermissionNext.Rule),
+          async (c) => {
+            const rule = c.req.valid("json")
+            await Config.updateProjectPermission(rule)
+            return c.json(true)
+          },
+        )
+        .delete(
+          "/permission/project",
+          describeRoute({
+            summary: "Delete project permission",
+            description: "Remove a permission rule from the project config file.",
+            operationId: "permission.deleteProject",
+            responses: {
+              200: {
+                description: "Permission deleted successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", z.object({ permission: z.string(), pattern: z.string() })),
+          async (c) => {
+            const rule = c.req.valid("json")
+            await Config.removeProjectPermission(rule)
+            return c.json(true)
+          },
+        )
+        .put(
+          "/permission/global",
+          describeRoute({
+            summary: "Update global permission",
+            description:
+              "Update a permission rule in the global config file (~/.config/opencode/opencode.json). This affects all projects.",
+            operationId: "permission.updateGlobal",
+            responses: {
+              200: {
+                description: "Permission updated successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", PermissionNext.Rule),
+          async (c) => {
+            const rule = c.req.valid("json")
+            await Config.updateGlobalPermission(rule)
+            return c.json(true)
+          },
+        )
+        .delete(
+          "/permission/global",
+          describeRoute({
+            summary: "Delete global permission",
+            description:
+              "Remove a permission rule from the global config file (~/.config/opencode/opencode.json). This affects all projects.",
+            operationId: "permission.deleteGlobal",
+            responses: {
+              200: {
+                description: "Permission deleted successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", z.object({ permission: z.string(), pattern: z.string() })),
+          async (c) => {
+            const rule = c.req.valid("json")
+            await Config.removeGlobalPermission(rule)
             return c.json(true)
           },
         )

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1708,6 +1708,103 @@ export namespace Server {
             return c.json(permissions)
           },
         )
+        .get(
+          "/permission/approved",
+          describeRoute({
+            summary: "List approved permissions",
+            description: "Get all approved permission rules for the current project.",
+            operationId: "permission.approved",
+            responses: {
+              200: {
+                description: "List of approved permission rules",
+                content: {
+                  "application/json": {
+                    schema: resolver(PermissionNext.Ruleset),
+                  },
+                },
+              },
+            },
+          }),
+          async (c) => {
+            const approved = await PermissionNext.approved()
+            return c.json(approved)
+          },
+        )
+        .delete(
+          "/permission/approved",
+          describeRoute({
+            summary: "Delete approved permission",
+            description: "Remove a specific approved permission rule.",
+            operationId: "permission.delete",
+            responses: {
+              200: {
+                description: "Permission deleted successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", PermissionNext.Rule),
+          async (c) => {
+            const rule = c.req.valid("json")
+            await PermissionNext.remove(rule)
+            return c.json(true)
+          },
+        )
+        .put(
+          "/permission/approved",
+          describeRoute({
+            summary: "Update approved permission",
+            description: "Update a specific approved permission rule.",
+            operationId: "permission.update",
+            responses: {
+              200: {
+                description: "Permission updated successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", z.object({ oldRule: PermissionNext.Rule, newRule: PermissionNext.Rule })),
+          async (c) => {
+            const { oldRule, newRule } = c.req.valid("json")
+            await PermissionNext.update(oldRule, newRule)
+            return c.json(true)
+          },
+        )
+        .post(
+          "/permission/approved",
+          describeRoute({
+            summary: "Add approved permission",
+            description: "Add a new approved permission rule.",
+            operationId: "permission.add",
+            responses: {
+              200: {
+                description: "Permission added successfully",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.boolean()),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          validator("json", PermissionNext.Rule),
+          async (c) => {
+            const rule = c.req.valid("json")
+            await PermissionNext.add(rule)
+            return c.json(true)
+          },
+        )
         .route("/question", QuestionRoute)
         .get(
           "/command",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -57,12 +57,20 @@ import type {
   PartUpdateErrors,
   PartUpdateResponses,
   PathGetResponses,
+  PermissionAddErrors,
+  PermissionAddResponses,
+  PermissionApprovedResponses,
+  PermissionDeleteErrors,
+  PermissionDeleteResponses,
   PermissionListResponses,
   PermissionReplyErrors,
   PermissionReplyResponses,
   PermissionRespondErrors,
   PermissionRespondResponses,
+  PermissionRule,
   PermissionRuleset,
+  PermissionUpdateErrors,
+  PermissionUpdateResponses,
   ProjectCurrentResponses,
   ProjectListResponses,
   ProjectUpdateErrors,
@@ -1785,6 +1793,132 @@ export class Permission extends HeyApiClient {
       url: "/permission",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Delete approved permission
+   *
+   * Remove a specific approved permission rule.
+   */
+  public delete<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      permissionRule?: PermissionRule
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "permissionRule", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<PermissionDeleteResponses, PermissionDeleteErrors, ThrowOnError>({
+      url: "/permission/approved",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * List approved permissions
+   *
+   * Get all approved permission rules for the current project.
+   */
+  public approved<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
+    return (options?.client ?? this.client).get<PermissionApprovedResponses, unknown, ThrowOnError>({
+      url: "/permission/approved",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Add approved permission
+   *
+   * Add a new approved permission rule.
+   */
+  public add<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      permissionRule?: PermissionRule
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "permissionRule", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PermissionAddResponses, PermissionAddErrors, ThrowOnError>({
+      url: "/permission/approved",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Update approved permission
+   *
+   * Update a specific approved permission rule.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      oldRule?: PermissionRule
+      newRule?: PermissionRule
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "oldRule" },
+            { in: "body", key: "newRule" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<PermissionUpdateResponses, PermissionUpdateErrors, ThrowOnError>({
+      url: "/permission/approved",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -59,8 +59,13 @@ import type {
   PathGetResponses,
   PermissionAddErrors,
   PermissionAddResponses,
+  PermissionAllResponses,
   PermissionApprovedResponses,
   PermissionDeleteErrors,
+  PermissionDeleteGlobalErrors,
+  PermissionDeleteGlobalResponses,
+  PermissionDeleteProjectErrors,
+  PermissionDeleteProjectResponses,
   PermissionDeleteResponses,
   PermissionListResponses,
   PermissionReplyErrors,
@@ -70,6 +75,10 @@ import type {
   PermissionRule,
   PermissionRuleset,
   PermissionUpdateErrors,
+  PermissionUpdateGlobalErrors,
+  PermissionUpdateGlobalResponses,
+  PermissionUpdateProjectErrors,
+  PermissionUpdateProjectResponses,
   PermissionUpdateResponses,
   ProjectCurrentResponses,
   ProjectListResponses,
@@ -1912,6 +1921,196 @@ export class Permission extends HeyApiClient {
     )
     return (options?.client ?? this.client).put<PermissionUpdateResponses, PermissionUpdateErrors, ThrowOnError>({
       url: "/permission/approved",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * List all permissions with sources
+   *
+   * Get all permission rules including defaults, global config, project config, and session rules with source metadata.
+   */
+  public all<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      agent?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "agent" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<PermissionAllResponses, unknown, ThrowOnError>({
+      url: "/permission/all",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Delete project permission
+   *
+   * Remove a permission rule from the project config file.
+   */
+  public deleteProject<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      permission?: string
+      pattern?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "permission" },
+            { in: "body", key: "pattern" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<
+      PermissionDeleteProjectResponses,
+      PermissionDeleteProjectErrors,
+      ThrowOnError
+    >({
+      url: "/permission/project",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Update project permission
+   *
+   * Update a permission rule in the project config file.
+   */
+  public updateProject<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      permissionRule?: PermissionRule
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "permissionRule", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<
+      PermissionUpdateProjectResponses,
+      PermissionUpdateProjectErrors,
+      ThrowOnError
+    >({
+      url: "/permission/project",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Delete global permission
+   *
+   * Remove a permission rule from the global config file (~/.config/opencode/opencode.json). This affects all projects.
+   */
+  public deleteGlobal<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      permission?: string
+      pattern?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "body", key: "permission" },
+            { in: "body", key: "pattern" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<
+      PermissionDeleteGlobalResponses,
+      PermissionDeleteGlobalErrors,
+      ThrowOnError
+    >({
+      url: "/permission/global",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Update global permission
+   *
+   * Update a permission rule in the global config file (~/.config/opencode/opencode.json). This affects all projects.
+   */
+  public updateGlobal<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      permissionRule?: PermissionRule
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "permissionRule", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<
+      PermissionUpdateGlobalResponses,
+      PermissionUpdateGlobalErrors,
+      ThrowOnError
+    >({
+      url: "/permission/global",
       ...options,
       ...params,
       headers: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1856,6 +1856,18 @@ export type SubtaskPartInput = {
   command?: string
 }
 
+export type PermissionSource = "default" | "global" | "project" | "session"
+
+export type PermissionRuleWithSource = {
+  permission: string
+  pattern: string
+  action: PermissionAction
+  source: PermissionSource
+  readonly: boolean
+}
+
+export type PermissionRulesetWithSource = Array<PermissionRuleWithSource>
+
 export type Command = {
   name: string
   description?: string
@@ -3748,6 +3760,139 @@ export type PermissionUpdateResponses = {
 }
 
 export type PermissionUpdateResponse = PermissionUpdateResponses[keyof PermissionUpdateResponses]
+
+export type PermissionAllData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    agent?: string
+  }
+  url: "/permission/all"
+}
+
+export type PermissionAllResponses = {
+  /**
+   * List of all permission rules with source information
+   */
+  200: PermissionRulesetWithSource
+}
+
+export type PermissionAllResponse = PermissionAllResponses[keyof PermissionAllResponses]
+
+export type PermissionDeleteProjectData = {
+  body?: {
+    permission: string
+    pattern: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/project"
+}
+
+export type PermissionDeleteProjectErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionDeleteProjectError = PermissionDeleteProjectErrors[keyof PermissionDeleteProjectErrors]
+
+export type PermissionDeleteProjectResponses = {
+  /**
+   * Permission deleted successfully
+   */
+  200: boolean
+}
+
+export type PermissionDeleteProjectResponse = PermissionDeleteProjectResponses[keyof PermissionDeleteProjectResponses]
+
+export type PermissionUpdateProjectData = {
+  body?: PermissionRule
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/project"
+}
+
+export type PermissionUpdateProjectErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionUpdateProjectError = PermissionUpdateProjectErrors[keyof PermissionUpdateProjectErrors]
+
+export type PermissionUpdateProjectResponses = {
+  /**
+   * Permission updated successfully
+   */
+  200: boolean
+}
+
+export type PermissionUpdateProjectResponse = PermissionUpdateProjectResponses[keyof PermissionUpdateProjectResponses]
+
+export type PermissionDeleteGlobalData = {
+  body?: {
+    permission: string
+    pattern: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/global"
+}
+
+export type PermissionDeleteGlobalErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionDeleteGlobalError = PermissionDeleteGlobalErrors[keyof PermissionDeleteGlobalErrors]
+
+export type PermissionDeleteGlobalResponses = {
+  /**
+   * Permission deleted successfully
+   */
+  200: boolean
+}
+
+export type PermissionDeleteGlobalResponse = PermissionDeleteGlobalResponses[keyof PermissionDeleteGlobalResponses]
+
+export type PermissionUpdateGlobalData = {
+  body?: PermissionRule
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/global"
+}
+
+export type PermissionUpdateGlobalErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionUpdateGlobalError = PermissionUpdateGlobalErrors[keyof PermissionUpdateGlobalErrors]
+
+export type PermissionUpdateGlobalResponses = {
+  /**
+   * Permission updated successfully
+   */
+  200: boolean
+}
+
+export type PermissionUpdateGlobalResponse = PermissionUpdateGlobalResponses[keyof PermissionUpdateGlobalResponses]
 
 export type QuestionListData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -3647,6 +3647,108 @@ export type PermissionListResponses = {
 
 export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
 
+export type PermissionDeleteData = {
+  body?: PermissionRule
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/approved"
+}
+
+export type PermissionDeleteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionDeleteError = PermissionDeleteErrors[keyof PermissionDeleteErrors]
+
+export type PermissionDeleteResponses = {
+  /**
+   * Permission deleted successfully
+   */
+  200: boolean
+}
+
+export type PermissionDeleteResponse = PermissionDeleteResponses[keyof PermissionDeleteResponses]
+
+export type PermissionApprovedData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/approved"
+}
+
+export type PermissionApprovedResponses = {
+  /**
+   * List of approved permission rules
+   */
+  200: PermissionRuleset
+}
+
+export type PermissionApprovedResponse = PermissionApprovedResponses[keyof PermissionApprovedResponses]
+
+export type PermissionAddData = {
+  body?: PermissionRule
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/approved"
+}
+
+export type PermissionAddErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionAddError = PermissionAddErrors[keyof PermissionAddErrors]
+
+export type PermissionAddResponses = {
+  /**
+   * Permission added successfully
+   */
+  200: boolean
+}
+
+export type PermissionAddResponse = PermissionAddResponses[keyof PermissionAddResponses]
+
+export type PermissionUpdateData = {
+  body?: {
+    oldRule: PermissionRule
+    newRule: PermissionRule
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/permission/approved"
+}
+
+export type PermissionUpdateErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionUpdateError = PermissionUpdateErrors[keyof PermissionUpdateErrors]
+
+export type PermissionUpdateResponses = {
+  /**
+   * Permission updated successfully
+   */
+  200: boolean
+}
+
+export type PermissionUpdateResponse = PermissionUpdateResponses[keyof PermissionUpdateResponses]
+
 export type QuestionListData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3165,6 +3165,356 @@
         ]
       }
     },
+    "/permission/approved": {
+      "get": {
+        "operationId": "permission.approved",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List approved permissions",
+        "description": "Get all approved permission rules for the current project.",
+        "responses": {
+          "200": {
+            "description": "List of approved permission rules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionRuleset"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.approved({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "permission.delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Delete approved permission",
+        "description": "Remove a specific approved permission rule.",
+        "responses": {
+          "200": {
+            "description": "Permission deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermissionRule"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.delete({\n  ...\n})"
+          }
+        ]
+      },
+      "put": {
+        "operationId": "permission.update",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Update approved permission",
+        "description": "Update a specific approved permission rule.",
+        "responses": {
+          "200": {
+            "description": "Permission updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "oldRule": {
+                    "$ref": "#/components/schemas/PermissionRule"
+                  },
+                  "newRule": {
+                    "$ref": "#/components/schemas/PermissionRule"
+                  }
+                },
+                "required": ["oldRule", "newRule"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.update({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "operationId": "permission.add",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Add approved permission",
+        "description": "Add a new approved permission rule.",
+        "responses": {
+          "200": {
+            "description": "Permission added successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermissionRule"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.add({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/permission/all": {
+      "get": {
+        "operationId": "permission.all",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "List all permissions with sources",
+        "description": "Get all permission rules including defaults, global config, project config, and session rules with source metadata.",
+        "responses": {
+          "200": {
+            "description": "List of all permission rules with source information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionRulesetWithSource"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.all({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/permission/project": {
+      "put": {
+        "operationId": "permission.updateProject",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Update project permission",
+        "description": "Update a permission rule in the project config file.",
+        "responses": {
+          "200": {
+            "description": "Permission updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermissionRule"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.updateProject({\n  ...\n})"
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "permission.deleteProject",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Delete project permission",
+        "description": "Remove a permission rule from the project config file.",
+        "responses": {
+          "200": {
+            "description": "Permission deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "permission": {
+                    "type": "string"
+                  },
+                  "pattern": {
+                    "type": "string"
+                  }
+                },
+                "required": ["permission", "pattern"]
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.deleteProject({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/question": {
       "get": {
         "operationId": "question.list",
@@ -9802,6 +10152,37 @@
           }
         },
         "required": ["type", "prompt", "description", "agent"]
+      },
+      "PermissionSource": {
+        "type": "string",
+        "enum": ["default", "global", "project", "session"]
+      },
+      "PermissionRuleWithSource": {
+        "type": "object",
+        "properties": {
+          "permission": {
+            "type": "string"
+          },
+          "pattern": {
+            "type": "string"
+          },
+          "action": {
+            "$ref": "#/components/schemas/PermissionAction"
+          },
+          "source": {
+            "$ref": "#/components/schemas/PermissionSource"
+          },
+          "readonly": {
+            "type": "boolean"
+          }
+        },
+        "required": ["permission", "pattern", "action", "source", "readonly"]
+      },
+      "PermissionRulesetWithSource": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PermissionRuleWithSource"
+        }
       },
       "Command": {
         "type": "object",


### PR DESCRIPTION
### What does this PR do?
Fixes #3261

Happy for feedback/pushback, implemented the way I would I have liked it, but it doesn't mean it fits everyone.

First, fixed small bug in TUI, causing edit-cancel to exit the dialog

Created a "permissions" dialog that shows the permissions from:
1. session level ("allow always" in the dialog)
2. project level (in `opencode.json`)
3. global level (in `~/.config/opencode/opencode.json`)
4. "default" (hardcoded, agent specific)

1-3 are editable (CRUD) in the dialog. 2-3 show confirmations prompts when writing.
Changes are persisted to the relevant files.
Small hint on how execute perms work with wildcards

Added debug command to show permissions for a quicker feedback loop.

### How did you verify your code works?
Tested locally with the following:
```
$ cat ~/.config/opencode/opencode.json
{
  "$schema": "https://opencode.ai/config.json",
  "permission": {
    "read": {
      "*.password": "deny",
      "*.key": "deny",
      "credentials.json": "deny"
    },
    "bash": {
      "dnf *": "deny",
      "yum *": "deny",
      "apt *": "deny"
    },
    "webfetch": "deny",
    "external_directory": {
      "/var/*": "deny",
      "/etc/*": "deny",
      "/sys/*": "deny"
    }
  }
}

$ cat opencode.json 
{
  "$schema": "https://opencode.ai/config.json",
  "permission": {
    "read": {
      "*": "allow",
      "*.secret": "deny",
      ".env*": "ask",
      "node_modules/**": "allow"
    },
    "edit": {
      "*": "allow",
      "package.json": "ask",
      "*.lock": "deny"
    },
    "bash": {
      "ffeff*": "ask",
      "rm *": "deny"
    },
    "glob": "allow",
    "grep": "allow",
    "webfetch": "allow",
    "websearch": "ask",
    "codesearch": "allow",
    "todowrite": "allow",
    "todoread": "allow",
    "question": "allow",
    "external_directory": {
      "/tmp/*": "allow",
      "/home/*": "ask"
    }
  }
}
```
Screenshots from `bun dev`:
<img width="1057" height="621" alt="image" src="https://github.com/user-attachments/assets/a13ed5b8-26dc-45fa-88f6-560745fc63d3" />
<img width="1246" height="940" alt="image" src="https://github.com/user-attachments/assets/c429e489-3efa-400a-b04d-52b1f3cda877" />
<img width="1296" height="975" alt="image" src="https://github.com/user-attachments/assets/304b48d4-68fb-46f9-b258-f3a915926fce" />
When editing
<img width="1356" height="909" alt="image" src="https://github.com/user-attachments/assets/b16a3a88-5b6b-4411-983b-323068f3cbec" />
When editing a non-session permission, after pressing enter
<img width="1270" height="891" alt="image" src="https://github.com/user-attachments/assets/c357c73e-6139-46ff-821b-1db23fb25572" />
<img width="1282" height="958" alt="image" src="https://github.com/user-attachments/assets/193b4c19-6e0c-45f9-af70-a78c31c72548" />
<img width="1267" height="966" alt="image" src="https://github.com/user-attachments/assets/a2dfe32b-c283-4bdb-8b50-5812efe4a853" />

