### PR TITLE
fix(tui): prevent crash in theme dialog when filter yields no results

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
@@ -26,7 +26,7 @@ export function DialogThemeList() {
       options={options}
       current={initial}
       onMove={(opt) => {
-        theme.set(opt.value)
+        if (opt) theme.set(opt.value)
       }}
       onSelect={(opt) => {
         theme.set(opt.value)


### PR DESCRIPTION
### What does this PR do?

Fixes #8873

Add guard clause in `onMove` callback to check if option exists before accessing its properties.

AI disclosure: I used opencode with Claude to figure out what was causing the error in the release (1.1.23, latest as of writing) of opencode I was running. I barely have any JS/TS knowledge, and it guided me to this solution.

If this is not the correct approach to solving this bug, and the maintainers would like to change things elsewhere to prevent this, please let me know and I am more than happy to learn and incorporate their feedback.

### How did you verify your code works?

- `./packages/opencode/script/build.ts --single` to build "localcode" with the change I made.
- `./packages/opencode/dist/opencode-darwin-arm64/bin/opencode` to start opencode.
- Opened the theme selector.
- Searched for `sonokai`.
- I did not observe the error being printed in the console, as it is in `1.1.23` when I typed `n`.
