### PR TITLE
fix(tui): handle --prompt flag when used with --continue (#8850)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -67,6 +67,7 @@ import { Editor } from "../../util/editor"
 import stripAnsi from "strip-ansi"
 import { Footer } from "./footer.tsx"
 import { usePromptRef } from "../../context/prompt"
+import { useArgs } from "../../context/args"
 import { useExit } from "../../context/exit"
 import { Filesystem } from "@/util/filesystem"
 import { Global } from "@/global"
@@ -189,10 +190,19 @@ export function Session() {
   const toast = useToast()
   const sdk = useSDK()
 
-  // Handle initial prompt from fork
+  // Handle initial prompt from fork or from --prompt flag (when using --continue)
+  const args = useArgs()
+  let initialPromptHandled = false
   createEffect(() => {
+    if (initialPromptHandled) return
     if (route.initialPrompt && prompt) {
       prompt.set(route.initialPrompt)
+      initialPromptHandled = true
+    } else if (args.prompt && prompt && sync.status !== "loading") {
+      // Handle --prompt flag when using --continue
+      prompt.set({ input: args.prompt, parts: [] })
+      initialPromptHandled = true
+      prompt.submit()
     }
   })
 


### PR DESCRIPTION
### What does this PR do?
Fixes #8850 - Makes --continue --prompt flags work together.

Problem: When using opencode --continue --prompt "message", the prompt was ignored because:

--continue navigates directly to the session route (app.tsx:267-275)
--prompt was only handled in home.tsx:84-87, which never runs when continuing a session

### How did you verify your code works?
Solution: Added args.prompt handling to 
session/index.tsx
 so when a user continues a session with a prompt, it:

Waits for sync to complete loading
Sets the prompt text
Automatically submits it
Change:

Added useArgs import to 
session/index.tsx
Extended the existing createEffect for initialPrompt to also handle args.prompt
Added guard to prevent multiple submissions
How did you verify your code works?
Code review confirmed the fix follows the same pattern as home.tsx:84-87
The sync.status !== "loading" check ensures the session is ready before submitting
The initialPromptHandled guard prevents duplicate submissions from reactive effects
