### PR TITLE
fix(tui): scope session list to current directory (#8836)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-session-list.tsx
@@ -38,8 +38,9 @@ export function DialogSessionList() {
 
   const options = createMemo(() => {
     const today = new Date().toDateString()
+    const currentDirectory = sync.data.path.directory || process.cwd()
     return sessions()
-      .filter((x) => x.parentID === undefined)
+      .filter((x) => x.parentID === undefined && x.directory === currentDirectory)
       .toSorted((a, b) => b.time.updated - a.time.updated)
       .map((x) => {
         const date = new Date(x.time.updated)


### PR DESCRIPTION
### What does this PR do?
Fixes #8836 - Scopes the session list (/sessions command) to the current working directory.

Problem: When using /sessions or opening the session list dialog, it displayed ALL sessions from ALL directories/projects instead of only sessions that belong to the current working directory.

### How did you verify your code works?
Root Cause: The 
dialog-session-list.tsx
 component only filtered sessions by parentID === undefined (to exclude child sessions) but didn't filter by the session's directory field.

Solution: Added a directory filter to only show sessions where session.directory === currentDirectory:

diff
const options = createMemo(() => {
     const today = new Date().toDateString()
+    const currentDirectory = sync.data.path.directory || process.cwd()
     return sessions()
-      .filter((x) => x.parentID === undefined)
+      .filter((x) => x.parentID === undefined && x.directory === currentDirectory)

How did you verify your code works?

Code review confirmed that Session.Info schema has a directory field that stores the working directory when a session is created
The filter uses the same path source (sync.data.path.directory) that's used elsewhere in the TUI (e.g., 
useDirectory
 context)
The || process.cwd() fallback ensures the filter still works if sync.data.path.directory is not yet populated
