### PR TITLE
docs: add opencode-antigravity-auth-remix to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -24,6 +24,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                           |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling  |
+| [opencode-antigravity-auth-remix](https://github.com/Darkstarrd-dev/opencode-antigravity-auth)     | Remix of Antigravity Auth: Antigravity / GeminiCLI Quota + Google Search + Text/Image to Image |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                          |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                 | Add native websearch support for supported providers with Google grounded style                |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                       | Enables AI agents to run background processes in a PTY, send interactive input to them.        |


### PR DESCRIPTION
Added opencode-antigravity-auth-remix to the ecosystem documentation.

Antigravity / GeminiCLI Quota 
Google Search
NanoBanana Pro Text/Image to Image