### PR TITLE
test(fixture): isolate test git repos from developer global hooks

### DIFF
--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -20,6 +20,16 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) {
     await $`git init`.cwd(dirpath).quiet()
+
+    // Make git commits in tests independent from developers' global git config.
+    // In particular, some setups enforce sign-off via hooks.
+    await $`git config user.email opencode-test@localhost`.cwd(dirpath).quiet()
+    await $`git config user.name opencode-test`.cwd(dirpath).quiet()
+
+    const hookspath = path.join(dirpath, ".githooks")
+    await fs.mkdir(hookspath, { recursive: true })
+    await $`git config core.hooksPath ${hookspath}`.cwd(dirpath).quiet()
+
     await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
   }
   if (options?.config) {

--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -23,12 +23,12 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
 
     // Make git commits in tests independent from developers' global git config.
     // In particular, some setups enforce sign-off via hooks.
-    await $`git config user.email opencode-test@localhost`.cwd(dirpath).quiet()
-    await $`git config user.name opencode-test`.cwd(dirpath).quiet()
+    await $`git config --local user.email opencode-test@localhost`.cwd(dirpath).quiet()
+    await $`git config --local user.name opencode-test`.cwd(dirpath).quiet()
 
     const hookspath = path.join(dirpath, ".githooks")
     await fs.mkdir(hookspath, { recursive: true })
-    await $`git config core.hooksPath ${hookspath}`.cwd(dirpath).quiet()
+    await $`git config --local core.hooksPath ${hookspath}`.cwd(dirpath).quiet()
 
     await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
   }


### PR DESCRIPTION
Tests could fail for developers with global git hooks (e.g., sign-off requirements). Test fixtures now use isolated git config and an empty hooks directory.

Fixes #8899