### PR TITLE
feat(app): Add OAuth rate limits and usage dashboard

### DIFF
--- a/packages/app/src/components/dialog-auth-usage.tsx
+++ b/packages/app/src/components/dialog-auth-usage.tsx
@@ -1,0 +1,222 @@
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
+import type { IconName } from "@opencode-ai/ui/icons/provider"
+import { Spinner } from "@opencode-ai/ui/spinner"
+import { createResource, For, Show, createMemo } from "solid-js"
+import { useGlobalSDK } from "@/context/global-sdk"
+
+interface AccountUsage {
+  id: string
+  label?: string
+  isActive?: boolean
+  health: {
+    successCount: number
+    failureCount: number
+    lastStatusCode?: number
+    cooldownUntil?: number
+  }
+}
+
+interface AnthropicUsage {
+  fiveHour?: { utilization: number; resetsAt?: string }
+  sevenDay?: { utilization: number; resetsAt?: string }
+  sevenDaySonnet?: { utilization: number; resetsAt?: string }
+}
+
+interface ProviderUsage {
+  accounts: AccountUsage[]
+  anthropicUsage?: AnthropicUsage
+}
+
+type AuthUsageData = Record<string, ProviderUsage>
+
+function formatResetTime(resetAt?: string): string {
+  if (!resetAt) return ""
+  const reset = new Date(resetAt)
+  const now = new Date()
+  const diffMs = reset.getTime() - now.getTime()
+  if (diffMs <= 0) return "now"
+
+  const totalMinutes = Math.floor(diffMs / (1000 * 60))
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+function getColorClass(percent: number): string {
+  if (percent <= 50) return "bg-fill-success-base"
+  if (percent <= 80) return "bg-fill-warning-base"
+  return "bg-fill-danger-base"
+}
+
+function UsageBarPercent(props: { label: string; utilization: number; resetsAt?: string }) {
+  return (
+    <div class="flex flex-col gap-1">
+      <div class="flex justify-between text-12-regular">
+        <span class="text-text-base">{props.label}</span>
+        <span class="text-text-muted">{props.utilization}% used</span>
+      </div>
+      <div class="h-2 w-full bg-fill-ghost-strong rounded-full overflow-hidden">
+        <div
+          class={`h-full rounded-full transition-all ${getColorClass(props.utilization)}`}
+          style={{ width: `${props.utilization}%` }}
+        />
+      </div>
+      <Show when={props.resetsAt}>
+        <div class="text-11-regular text-text-muted text-right">Resets in {formatResetTime(props.resetsAt)}</div>
+      </Show>
+    </div>
+  )
+}
+
+export function DialogAuthUsage() {
+  const globalSDK = useGlobalSDK()
+
+  const [usage, { refetch }] = createResource(async () => {
+    const result = await globalSDK.client.auth.usage({})
+    return result.data as AuthUsageData
+  })
+
+  const providers = createMemo(() => {
+    const data = usage()
+    if (!data) return []
+    return Object.entries(data).filter(([_, info]) => info.accounts.length > 0)
+  })
+
+  return (
+    <Dialog title="Rate Limits & Usage">
+      <div class="flex flex-col gap-6 px-4 pb-4 min-w-[420px]">
+        <Show when={usage.loading}>
+          <div class="flex items-center justify-center py-8">
+            <Spinner />
+          </div>
+        </Show>
+
+        <Show when={!usage.loading && providers().length === 0}>
+          <div class="text-14-regular text-text-muted py-4">
+            No OAuth providers configured. Login with Claude Max or another OAuth provider to see usage data.
+          </div>
+        </Show>
+
+        <For each={providers()}>
+          {([providerID, info]) => (
+            <div class="flex flex-col gap-4">
+              <div class="flex items-center gap-2">
+                <ProviderIcon id={providerID as IconName} class="size-5 shrink-0 icon-strong-base" />
+                <span class="text-14-medium text-text-strong capitalize">{providerID}</span>
+                <span class="text-12-regular text-text-muted">
+                  ({info.accounts.length} account{info.accounts.length > 1 ? "s" : ""})
+                </span>
+              </div>
+
+              {/* Anthropic Usage Limits */}
+              <Show when={info.anthropicUsage}>
+                <div class="flex flex-col gap-3 p-3 rounded-lg bg-fill-brand-ghost border border-fill-brand-base">
+                  <div class="text-13-medium text-text-strong">Usage Limits</div>
+                  <Show when={info.anthropicUsage?.fiveHour}>
+                    <UsageBarPercent
+                      label="5-Hour Limit"
+                      utilization={info.anthropicUsage!.fiveHour!.utilization}
+                      resetsAt={info.anthropicUsage!.fiveHour!.resetsAt}
+                    />
+                  </Show>
+                  <Show when={info.anthropicUsage?.sevenDay}>
+                    <UsageBarPercent
+                      label="7-Day Limit (All Models)"
+                      utilization={info.anthropicUsage!.sevenDay!.utilization}
+                      resetsAt={info.anthropicUsage!.sevenDay!.resetsAt}
+                    />
+                  </Show>
+                  <Show when={info.anthropicUsage?.sevenDaySonnet}>
+                    <UsageBarPercent
+                      label="7-Day Limit (Sonnet)"
+                      utilization={info.anthropicUsage!.sevenDaySonnet!.utilization}
+                      resetsAt={info.anthropicUsage!.sevenDaySonnet!.resetsAt}
+                    />
+                  </Show>
+                </div>
+              </Show>
+
+              <Show when={!info.anthropicUsage && providerID === "anthropic"}>
+                <div class="text-12-regular text-text-muted italic p-3 rounded-lg bg-fill-ghost-base">
+                  Unable to fetch usage limits. Make sure you're logged in with Claude Max.
+                </div>
+              </Show>
+
+              {/* Account Details */}
+              <div class="text-12-medium text-text-muted">Accounts</div>
+              <For each={info.accounts}>
+                {(account, index) => {
+                  const isInCooldown = () => {
+                    const cooldown = account.health.cooldownUntil
+                    return cooldown && cooldown > Date.now()
+                  }
+                  const cooldownRemaining = () => {
+                    const cooldown = account.health.cooldownUntil
+                    if (!cooldown) return ""
+                    const diff = cooldown - Date.now()
+                    if (diff <= 0) return ""
+                    const secs = Math.ceil(diff / 1000)
+                    return secs > 60 ? `${Math.ceil(secs / 60)}m` : `${secs}s`
+                  }
+
+                  return (
+                    <div
+                      class="flex flex-col gap-2 p-3 rounded-lg"
+                      classList={{
+                        "bg-fill-ghost-base": !account.isActive,
+                        "bg-fill-success-ghost border border-fill-success-base": account.isActive,
+                      }}
+                    >
+                      <div class="flex justify-between items-center">
+                        <div class="flex items-center gap-2">
+                          <span class="text-13-medium text-text-base">
+                            Account {index() + 1}
+                            <Show when={account.label && account.label !== "default"}>
+                              <span class="text-text-muted"> ({account.label})</span>
+                            </Show>
+                          </span>
+                          <Show when={account.isActive}>
+                            <span class="text-10-medium text-fill-success-base bg-fill-success-ghost px-1.5 py-0.5 rounded">
+                              Active
+                            </span>
+                          </Show>
+                          <Show when={isInCooldown()}>
+                            <span class="text-10-medium text-fill-danger-base bg-fill-danger-ghost px-1.5 py-0.5 rounded">
+                              Cooldown {cooldownRemaining()}
+                            </span>
+                          </Show>
+                        </div>
+                        <span class="text-11-regular text-text-muted">{account.health.successCount} requests</span>
+                      </div>
+
+                      <Show when={account.health.failureCount > 0}>
+                        <div class="text-11-regular text-fill-danger-base">
+                          {account.health.failureCount} failed requests
+                        </div>
+                      </Show>
+                    </div>
+                  )
+                }}
+              </For>
+            </div>
+          )}
+        </For>
+
+        <Show when={!usage.loading && providers().length > 0}>
+          <div class="flex justify-center pt-2 border-t border-border-weak-base">
+            <button
+              type="button"
+              class="text-12-regular text-text-muted hover:text-text-base transition-colors"
+              onClick={() => refetch()}
+            >
+              Refresh
+            </button>
+          </div>
+        </Show>
+      </div>
+    </Dialog>
+  )
+}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -59,6 +59,7 @@ import { ConstrainDragXAxis } from "@/utils/solid-dnd"
 import { navStart } from "@/utils/perf"
 import { DialogSelectDirectory } from "@/components/dialog-select-directory"
 import { DialogEditProject } from "@/components/dialog-edit-project"
+import { DialogAuthUsage } from "@/components/dialog-auth-usage"
 import { Titlebar } from "@/components/titlebar"
 import { useServer } from "@/context/server"
 
@@ -1354,8 +1355,13 @@ export default function Layout(props: ParentProps) {
             </DragDropProvider>
           </div>
           <div class="shrink-0 w-full pt-3 pb-3 flex flex-col items-center gap-2">
-            <Tooltip placement={sidebarProps.mobile ? "bottom" : "right"} value="Settings">
-              <IconButton disabled icon="settings-gear" variant="ghost" size="large" />
+            <Tooltip placement={sidebarProps.mobile ? "bottom" : "right"} value="Rate Limits & Usage">
+              <IconButton
+                icon="checklist"
+                variant="ghost"
+                size="large"
+                onClick={() => dialog.show(() => <DialogAuthUsage />)}
+              />
             </Tooltip>
             <Tooltip placement={sidebarProps.mobile ? "bottom" : "right"} value="Help">
               <IconButton

--- a/packages/opencode/src/auth/context.ts
+++ b/packages/opencode/src/auth/context.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from "async_hooks"
+
+type Store = {
+  oauthRecordByProvider: Map<string, string>
+}
+
+const storage = new AsyncLocalStorage<Store>()
+
+export function getOAuthRecordID(providerID: string): string | undefined {
+  return storage.getStore()?.oauthRecordByProvider.get(providerID)
+}
+
+export function withOAuthRecord<T>(providerID: string, recordID: string, fn: () => T): T {
+  const current = storage.getStore()
+  const next: Store = {
+    oauthRecordByProvider: new Map(current?.oauthRecordByProvider ?? []),
+  }
+  next.oauthRecordByProvider.set(providerID, recordID)
+
+  return storage.run(next, fn)
+}

--- a/packages/opencode/src/auth/context.ts
+++ b/packages/opencode/src/auth/context.ts
@@ -1,4 +1,4 @@
-import { AsyncLocalStorage } from "async_hooks"
+import { AsyncLocalStorage } from "node:async_hooks"
 
 type Store = {
   oauthRecordByProvider: Map<string, string>

--- a/packages/opencode/src/auth/credential-manager.ts
+++ b/packages/opencode/src/auth/credential-manager.ts
@@ -5,6 +5,7 @@ import { Log } from "../util/log"
 import { TuiEvent } from "../cli/cmd/tui/event"
 
 const log = Log.create({ service: "credential-manager" })
+const DEFAULT_FAILOVER_TOAST_MS = 8000
 
 export namespace CredentialManager {
   export const Event = {
@@ -25,11 +26,15 @@ export namespace CredentialManager {
     fromRecordID: string
     toRecordID?: string
     statusCode: number
+    toastDurationMs?: number
   }): Promise<void> {
     const isRateLimit = input.statusCode === 429
     const message = isRateLimit
       ? `Rate limited on "${input.providerID}". Switching OAuth credential...`
-      : `Auth error on "${input.providerID}". Switching OAuth credential...`
+      : input.statusCode === 0
+        ? `Request failed on "${input.providerID}". Switching OAuth credential...`
+        : `Auth error on "${input.providerID}". Switching OAuth credential...`
+    const duration = Math.max(0, input.toastDurationMs ?? DEFAULT_FAILOVER_TOAST_MS)
 
     log.info("oauth credential failover", {
       providerID: input.providerID,
@@ -50,7 +55,7 @@ export namespace CredentialManager {
       title: "OAuth Credential Failover",
       message,
       variant: "warning",
-      duration: 8000,
+      duration,
     }).catch((error) => log.debug("failed to show failover toast", { error }))
   }
 }

--- a/packages/opencode/src/auth/credential-manager.ts
+++ b/packages/opencode/src/auth/credential-manager.ts
@@ -50,7 +50,7 @@ export namespace CredentialManager {
       title: "OAuth Credential Failover",
       message,
       variant: "warning",
-      duration: 5000,
+      duration: 8000,
     }).catch((error) => log.debug("failed to show failover toast", { error }))
   }
 }

--- a/packages/opencode/src/auth/credential-manager.ts
+++ b/packages/opencode/src/auth/credential-manager.ts
@@ -1,0 +1,56 @@
+import z from "zod"
+import { Bus } from "../bus"
+import { BusEvent } from "../bus/bus-event"
+import { Log } from "../util/log"
+import { TuiEvent } from "../cli/cmd/tui/event"
+
+const log = Log.create({ service: "credential-manager" })
+
+export namespace CredentialManager {
+  export const Event = {
+    Failover: BusEvent.define(
+      "credential.failover",
+      z.object({
+        providerID: z.string(),
+        fromRecordID: z.string(),
+        toRecordID: z.string().optional(),
+        statusCode: z.number(),
+        message: z.string(),
+      }),
+    ),
+  }
+
+  export async function notifyFailover(input: {
+    providerID: string
+    fromRecordID: string
+    toRecordID?: string
+    statusCode: number
+  }): Promise<void> {
+    const isRateLimit = input.statusCode === 429
+    const message = isRateLimit
+      ? `Rate limited on "${input.providerID}". Switching OAuth credential...`
+      : `Auth error on "${input.providerID}". Switching OAuth credential...`
+
+    log.info("oauth credential failover", {
+      providerID: input.providerID,
+      fromRecordID: input.fromRecordID,
+      toRecordID: input.toRecordID,
+      statusCode: input.statusCode,
+    })
+
+    await Bus.publish(Event.Failover, {
+      providerID: input.providerID,
+      fromRecordID: input.fromRecordID,
+      toRecordID: input.toRecordID,
+      statusCode: input.statusCode,
+      message,
+    }).catch((error) => log.debug("failed to publish credential failover event", { error }))
+
+    await Bus.publish(TuiEvent.ToastShow, {
+      title: "OAuth Credential Failover",
+      message,
+      variant: "warning",
+      duration: 5000,
+    }).catch((error) => log.debug("failed to show failover toast", { error }))
+  }
+}

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -2,6 +2,8 @@ import path from "path"
 import { Global } from "../global"
 import fs from "fs/promises"
 import z from "zod"
+import { ulid } from "ulid"
+import { getOAuthRecordID } from "./context"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -37,37 +39,440 @@ export namespace Auth {
 
   const filepath = path.join(Global.Path.data, "auth.json")
 
-  export async function get(providerID: string) {
-    const auth = await all()
-    return auth[providerID]
+  const Health = z
+    .object({
+      cooldownUntil: z.number().optional(),
+      lastStatusCode: z.number().optional(),
+      lastErrorAt: z.number().optional(),
+      successCount: z.number().default(0),
+      failureCount: z.number().default(0),
+    })
+    .strict()
+    .default(() => ({ successCount: 0, failureCount: 0 }))
+  type Health = z.infer<typeof Health>
+
+  const OAuthRecord = z
+    .object({
+      id: z.string(),
+      namespace: z.string().default("default"),
+      label: z.string().optional(),
+      accountId: z.string().optional(),
+      enterpriseUrl: z.string().optional(),
+      refresh: z.string(),
+      access: z.string(),
+      expires: z.number(),
+      createdAt: z.number(),
+      updatedAt: z.number(),
+      health: Health,
+    })
+    .strict()
+  type OAuthRecord = z.infer<typeof OAuthRecord>
+
+  export type OAuthRecordMeta = Omit<OAuthRecord, "refresh" | "access" | "expires">
+
+  const OAuthProvider = z
+    .object({
+      type: z.literal("oauth"),
+      active: z.record(z.string(), z.string()).default({}),
+      order: z.record(z.string(), z.array(z.string())).default({}),
+      records: z.array(OAuthRecord).default([]),
+    })
+    .strict()
+  type OAuthProvider = z.infer<typeof OAuthProvider>
+
+  const ApiProvider = z
+    .object({
+      type: z.literal("api"),
+      key: z.string(),
+    })
+    .strict()
+
+  const WellKnownProvider = z
+    .object({
+      type: z.literal("wellknown"),
+      key: z.string(),
+      token: z.string(),
+    })
+    .strict()
+
+  const ProviderEntry = z.union([OAuthProvider, ApiProvider, WellKnownProvider])
+  type ProviderEntry = z.infer<typeof ProviderEntry>
+
+  const StoreFile = z
+    .object({
+      version: z.literal(2),
+      providers: z.record(z.string(), ProviderEntry).default({}),
+    })
+    .strict()
+  type StoreFile = z.infer<typeof StoreFile>
+
+  function toMeta(record: OAuthRecord): OAuthRecordMeta {
+    const { refresh: _refresh, access: _access, expires: _expires, ...meta } = record
+    return meta
+  }
+
+  async function ensureDataDir(): Promise<void> {
+    await fs.mkdir(path.dirname(filepath), { recursive: true })
+  }
+
+  async function writeStoreFile(store: StoreFile): Promise<void> {
+    await ensureDataDir()
+    const tempPath = `${filepath}.tmp`
+    const tempFile = Bun.file(tempPath)
+    await Bun.write(tempFile, JSON.stringify(store, null, 2))
+    await fs.rename(tempPath, filepath)
+    await fs.chmod(filepath, 0o600).catch(() => {})
+  }
+
+  async function loadStoreFile(): Promise<StoreFile> {
+    const file = Bun.file(filepath)
+    const raw = await file.json().catch(() => undefined)
+
+    const parsed = StoreFile.safeParse(raw)
+    if (parsed.success) return parsed.data
+
+    const legacyParsed = z.record(z.string(), Info).safeParse(raw)
+    if (legacyParsed.success) {
+      const now = Date.now()
+      const next: StoreFile = { version: 2, providers: {} }
+
+      for (const [providerID, info] of Object.entries(legacyParsed.data)) {
+        if (info.type === "api") {
+          next.providers[providerID] = { type: "api", key: info.key }
+          continue
+        }
+
+        if (info.type === "wellknown") {
+          next.providers[providerID] = { type: "wellknown", key: info.key, token: info.token }
+          continue
+        }
+
+        const recordID = ulid()
+        next.providers[providerID] = {
+          type: "oauth",
+          active: { default: recordID },
+          order: { default: [recordID] },
+          records: [
+            {
+              id: recordID,
+              namespace: "default",
+              label: "default",
+              accountId: info.accountId,
+              enterpriseUrl: info.enterpriseUrl,
+              refresh: info.refresh,
+              access: info.access,
+              expires: info.expires,
+              createdAt: now,
+              updatedAt: now,
+              health: { successCount: 0, failureCount: 0 },
+            },
+          ],
+        }
+      }
+
+      await writeStoreFile(next)
+      return next
+    }
+
+    return { version: 2, providers: {} }
+  }
+
+  function ensureOAuthProvider(store: StoreFile, providerID: string): OAuthProvider {
+    const existing = store.providers[providerID]
+    if (existing && existing.type === "oauth") return existing
+
+    const next: OAuthProvider = {
+      type: "oauth",
+      active: {},
+      order: {},
+      records: [],
+    }
+    store.providers[providerID] = next
+    return next
+  }
+
+  function findOAuthRecord(provider: OAuthProvider, recordID: string): OAuthRecord | undefined {
+    return provider.records.find((record) => record.id === recordID)
+  }
+
+  function normalizeOrder(ids: string[], order: string[]): string[] {
+    const ordered: string[] = []
+    for (const id of order) {
+      if (ids.includes(id) && !ordered.includes(id)) ordered.push(id)
+    }
+    for (const id of ids) {
+      if (!ordered.includes(id)) ordered.push(id)
+    }
+    return ordered
+  }
+
+  function recordIDsForNamespace(provider: OAuthProvider, namespace: string): string[] {
+    const ids = provider.records.filter((record) => record.namespace === namespace).map((record) => record.id)
+    const order = provider.order[namespace] ?? []
+    return normalizeOrder(ids, order)
+  }
+
+  async function findOAuthRecordIDByRefreshToken(input: {
+    providerID: string
+    namespace: string
+    refresh: string
+    provider: OAuthProvider
+  }): Promise<string | undefined> {
+    for (const record of input.provider.records) {
+      if (record.namespace !== input.namespace) continue
+      if (record.refresh === input.refresh) return record.id
+    }
+    return undefined
+  }
+
+  export async function get(providerID: string): Promise<Info | undefined> {
+    const store = await loadStoreFile()
+    const entry = store.providers[providerID]
+    if (!entry) return undefined
+
+    if (entry.type === "api") {
+      return { type: "api", key: entry.key }
+    }
+
+    if (entry.type === "wellknown") {
+      return { type: "wellknown", key: entry.key, token: entry.token }
+    }
+
+    const namespace = "default"
+    const contextID = getOAuthRecordID(providerID)
+    const active = contextID ?? entry.active[namespace]
+    const ordered = recordIDsForNamespace(entry, namespace)
+    const recordID = active && ordered.includes(active) ? active : ordered[0]
+    if (!recordID) return undefined
+
+    const record = findOAuthRecord(entry, recordID)
+    if (!record) return undefined
+    return {
+      type: "oauth",
+      refresh: record.refresh,
+      access: record.access,
+      expires: record.expires,
+      accountId: record.accountId,
+      enterpriseUrl: record.enterpriseUrl,
+    }
   }
 
   export async function all(): Promise<Record<string, Info>> {
-    const file = Bun.file(filepath)
-    const data = await file.json().catch(() => ({}) as Record<string, unknown>)
-    return Object.entries(data).reduce(
-      (acc, [key, value]) => {
-        const parsed = Info.safeParse(value)
-        if (!parsed.success) return acc
-        acc[key] = parsed.data
-        return acc
-      },
-      {} as Record<string, Info>,
-    )
+    const store = await loadStoreFile()
+    const out: Record<string, Info> = {}
+
+    for (const providerID of Object.keys(store.providers)) {
+      const info = await get(providerID)
+      if (!info) continue
+      out[providerID] = info
+    }
+
+    return out
   }
 
   export async function set(key: string, info: Info) {
-    const file = Bun.file(filepath)
-    const data = await all()
-    await Bun.write(file, JSON.stringify({ ...data, [key]: info }, null, 2))
-    await fs.chmod(file.name!, 0o600)
+    const store = await loadStoreFile()
+
+    if (info.type === "api") {
+      store.providers[key] = { type: "api", key: info.key }
+      await writeStoreFile(store)
+      return
+    }
+
+    if (info.type === "wellknown") {
+      store.providers[key] = { type: "wellknown", key: info.key, token: info.token }
+      await writeStoreFile(store)
+      return
+    }
+
+    const namespace = "default"
+    const provider = ensureOAuthProvider(store, key)
+    const recordID =
+      getOAuthRecordID(key) ??
+      (await findOAuthRecordIDByRefreshToken({ providerID: key, namespace, refresh: info.refresh, provider })) ??
+      provider.active[namespace] ??
+      recordIDsForNamespace(provider, namespace)[0] ??
+      ulid()
+
+    const now = Date.now()
+    const existing = findOAuthRecord(provider, recordID)
+    if (!existing) {
+      provider.records.push({
+        id: recordID,
+        namespace,
+        label: "default",
+        accountId: info.accountId,
+        enterpriseUrl: info.enterpriseUrl,
+        refresh: info.refresh,
+        access: info.access,
+        expires: info.expires,
+        createdAt: now,
+        updatedAt: now,
+        health: { successCount: 0, failureCount: 0 },
+      })
+      provider.order[namespace] = [...(provider.order[namespace] ?? []), recordID]
+    } else {
+      existing.refresh = info.refresh
+      existing.access = info.access
+      existing.expires = info.expires
+      existing.updatedAt = now
+      if (info.accountId !== undefined) existing.accountId = info.accountId
+      if (info.enterpriseUrl !== undefined) existing.enterpriseUrl = info.enterpriseUrl
+      const order = provider.order[namespace] ?? []
+      if (!order.includes(recordID)) {
+        provider.order[namespace] = [...order, recordID]
+      }
+    }
+    provider.active[namespace] = recordID
+
+    await writeStoreFile(store)
   }
 
   export async function remove(key: string) {
-    const file = Bun.file(filepath)
-    const data = await all()
-    delete data[key]
-    await Bun.write(file, JSON.stringify(data, null, 2))
-    await fs.chmod(file.name!, 0o600)
+    const store = await loadStoreFile()
+    const existing = store.providers[key]
+    if (!existing) return
+
+    delete store.providers[key]
+    await writeStoreFile(store)
+  }
+
+  export async function addOAuth(
+    providerID: string,
+    input: Omit<z.infer<typeof Oauth>, "type"> & { namespace?: string; label?: string },
+  ) {
+    const namespace = (input.namespace ?? "default").trim() || "default"
+    const store = await loadStoreFile()
+
+    const provider = ensureOAuthProvider(store, providerID)
+    const now = Date.now()
+    const existingRecordID = await findOAuthRecordIDByRefreshToken({
+      providerID,
+      namespace,
+      refresh: input.refresh,
+      provider,
+    })
+
+    if (existingRecordID) {
+      const existing = findOAuthRecord(provider, existingRecordID)
+      if (existing) {
+        existing.refresh = input.refresh
+        existing.access = input.access
+        existing.expires = input.expires
+        existing.updatedAt = now
+        if (input.accountId !== undefined) existing.accountId = input.accountId
+        if (input.enterpriseUrl !== undefined) existing.enterpriseUrl = input.enterpriseUrl
+        if (input.label) existing.label = input.label
+      }
+      const order = provider.order[namespace] ?? []
+      if (!order.includes(existingRecordID)) {
+        provider.order[namespace] = [...order, existingRecordID]
+      }
+      provider.active[namespace] = existingRecordID
+
+      await writeStoreFile(store)
+      return { providerID, namespace, recordID: existingRecordID }
+    }
+
+    const recordID = ulid()
+
+    provider.records.push({
+      id: recordID,
+      namespace,
+      label: input.label ?? "default",
+      accountId: input.accountId,
+      enterpriseUrl: input.enterpriseUrl,
+      refresh: input.refresh,
+      access: input.access,
+      expires: input.expires,
+      createdAt: now,
+      updatedAt: now,
+      health: { successCount: 0, failureCount: 0 },
+    })
+
+    provider.order[namespace] = [...(provider.order[namespace] ?? []), recordID]
+    provider.active[namespace] = recordID
+
+    await writeStoreFile(store)
+
+    return { providerID, namespace, recordID }
+  }
+
+  export namespace OAuthPool {
+    export async function snapshot(
+      providerID: string,
+      namespace = "default",
+    ): Promise<{ records: OAuthRecordMeta[]; orderedIDs: string[] }> {
+      const store = await loadStoreFile()
+      const provider = store.providers[providerID]
+      if (!provider || provider.type !== "oauth") return { records: [], orderedIDs: [] }
+
+      const normalized = namespace.trim() || "default"
+      const records = provider.records.filter((record) => record.namespace === normalized).map(toMeta)
+      const orderedIDs = recordIDsForNamespace(provider, normalized)
+
+      return { records, orderedIDs }
+    }
+
+    export async function list(providerID: string, namespace = "default"): Promise<OAuthRecordMeta[]> {
+      return snapshot(providerID, namespace).then((result) => result.records)
+    }
+
+    export async function orderedIDs(providerID: string, namespace = "default"): Promise<string[]> {
+      return snapshot(providerID, namespace).then((result) => result.orderedIDs)
+    }
+
+    export async function moveToBack(providerID: string, namespace: string, recordID: string): Promise<void> {
+      const store = await loadStoreFile()
+      const provider = store.providers[providerID]
+      if (!provider || provider.type !== "oauth") return
+      const order = recordIDsForNamespace(provider, namespace)
+      provider.order[namespace] = order.filter((id) => id !== recordID).concat(recordID)
+      provider.active[namespace] = provider.order[namespace][0] ?? provider.active[namespace]
+      await writeStoreFile(store)
+    }
+
+    export async function recordOutcome(input: {
+      providerID: string
+      recordID: string
+      statusCode: number
+      ok: boolean
+      cooldownUntil?: number
+    }): Promise<void> {
+      const store = await loadStoreFile()
+      const provider = store.providers[input.providerID]
+      if (!provider || provider.type !== "oauth") return
+
+      const record = findOAuthRecord(provider, input.recordID)
+      if (!record) return
+
+      const now = Date.now()
+      const prevCooldown =
+        record.health.cooldownUntil && record.health.cooldownUntil > now ? record.health.cooldownUntil : undefined
+      const cooldownUntil = input.ok ? undefined : input.cooldownUntil ?? prevCooldown
+
+      record.health = {
+        ...record.health,
+        cooldownUntil,
+        lastStatusCode: input.statusCode,
+        lastErrorAt: input.ok ? undefined : now,
+        successCount: record.health.successCount + (input.ok ? 1 : 0),
+        failureCount: record.health.failureCount + (input.ok ? 0 : 1),
+      }
+      record.updatedAt = now
+      await writeStoreFile(store)
+    }
+
+    export async function markAccessExpired(providerID: string, namespace: string, recordID: string): Promise<void> {
+      const store = await loadStoreFile()
+      const provider = store.providers[providerID]
+      if (!provider || provider.type !== "oauth") return
+      const record = findOAuthRecord(provider, recordID)
+      if (!record || record.namespace !== namespace) return
+      record.access = ""
+      record.expires = 0
+      record.updatedAt = Date.now()
+      await writeStoreFile(store)
+    }
   }
 }

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -543,7 +543,7 @@ export namespace Auth {
         const now = Date.now()
         const prevCooldown =
           record.health.cooldownUntil && record.health.cooldownUntil > now ? record.health.cooldownUntil : undefined
-        const cooldownUntil = input.ok ? undefined : input.cooldownUntil ?? prevCooldown
+        const cooldownUntil = input.ok ? undefined : (input.cooldownUntil ?? prevCooldown)
 
         record.health = {
           ...record.health,
@@ -569,6 +569,116 @@ export namespace Auth {
         record.updatedAt = Date.now()
         return { value: undefined, changed: true }
       })
+    }
+
+    export async function getUsage(
+      providerID: string,
+      namespace = "default",
+    ): Promise<
+      Array<{
+        id: string
+        label?: string
+        isActive: boolean
+        health: {
+          successCount: number
+          failureCount: number
+          lastStatusCode?: number
+          cooldownUntil?: number
+        }
+      }>
+    > {
+      const store = await loadStoreFile()
+      const provider = store.providers[providerID]
+      if (!provider || provider.type !== "oauth") return []
+
+      const orderedIDs = recordIDsForNamespace(provider, namespace)
+      const now = Date.now()
+      const activeID =
+        orderedIDs.find((id) => {
+          const record = provider.records.find((r) => r.id === id)
+          const cooldownUntil = record?.health.cooldownUntil
+          return !cooldownUntil || cooldownUntil <= now
+        }) ?? orderedIDs[0]
+
+      return provider.records
+        .filter((record) => record.namespace === namespace)
+        .map((record) => ({
+          id: record.id,
+          label: record.label,
+          isActive: record.id === activeID,
+          health: {
+            successCount: record.health.successCount,
+            failureCount: record.health.failureCount,
+            lastStatusCode: record.health.lastStatusCode,
+            cooldownUntil: record.health.cooldownUntil,
+          },
+        }))
+    }
+
+    export async function fetchAnthropicUsage(
+      providerID: string,
+      namespace = "default",
+    ): Promise<{
+      fiveHour?: { utilization: number; resetsAt?: string }
+      sevenDay?: { utilization: number; resetsAt?: string }
+      sevenDaySonnet?: { utilization: number; resetsAt?: string }
+    } | null> {
+      if (providerID !== "anthropic") return null
+
+      const store = await loadStoreFile()
+      const provider = store.providers[providerID]
+      if (!provider || provider.type !== "oauth") return null
+
+      const orderedIDs = recordIDsForNamespace(provider, namespace)
+      const now = Date.now()
+      const activeID =
+        orderedIDs.find((id) => {
+          const rec = provider.records.find((r) => r.id === id)
+          const cooldownUntil = rec?.health.cooldownUntil
+          return !cooldownUntil || cooldownUntil <= now
+        }) ?? orderedIDs[0]
+      const record = provider.records.find((r) => r.id === activeID && r.namespace === namespace)
+      if (!record?.access) return null
+
+      try {
+        const controller = new AbortController()
+        const timeout = setTimeout(() => controller.abort(), 5000)
+
+        const response = await fetch("https://api.anthropic.com/api/oauth/usage", {
+          method: "GET",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${record.access}`,
+            "anthropic-beta": "oauth-2025-04-20",
+          },
+          signal: controller.signal,
+        })
+
+        clearTimeout(timeout)
+
+        if (!response.ok) return null
+
+        const data = (await response.json()) as {
+          five_hour?: { utilization: number; resets_at?: string }
+          seven_day?: { utilization: number; resets_at?: string }
+          seven_day_sonnet?: { utilization: number; resets_at?: string }
+        }
+
+        return {
+          fiveHour: data.five_hour
+            ? { utilization: Math.round(data.five_hour.utilization), resetsAt: data.five_hour.resets_at }
+            : undefined,
+          sevenDay: data.seven_day
+            ? { utilization: Math.round(data.seven_day.utilization), resetsAt: data.seven_day.resets_at }
+            : undefined,
+          sevenDaySonnet: data.seven_day_sonnet
+            ? { utilization: Math.round(data.seven_day_sonnet.utilization), resetsAt: data.seven_day_sonnet.resets_at }
+            : undefined,
+        }
+      } catch {
+        return null
+      }
     }
   }
 }

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import z from "zod"
 import { ulid } from "ulid"
 import { getOAuthRecordID } from "./context"
+import { Log } from "../util/log"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -42,6 +43,17 @@ export namespace Auth {
   const STORE_LOCK_TIMEOUT_MS = 5_000
   const STORE_LOCK_STALE_MS = 30_000
   const STORE_LOCK_RETRY_MS = 25
+  const STORE_LOCK_BEST_EFFORT_TIMEOUT_MS = 250
+  const STORE_LOCK_BEST_EFFORT_RETRY_MS = 10
+
+  const log = Log.create({ service: "auth.store" })
+
+  class StoreLockTimeoutError extends Error {
+    constructor() {
+      super("Timed out waiting for auth store lock")
+      this.name = "StoreLockTimeoutError"
+    }
+  }
 
   const Health = z
     .object({
@@ -119,8 +131,14 @@ export namespace Auth {
     await fs.mkdir(path.dirname(filepath), { recursive: true })
   }
 
-  async function withStoreLock<T>(fn: () => Promise<T>): Promise<T> {
+  async function withStoreLock<T>(
+    fn: () => Promise<T>,
+    options: { timeoutMs?: number; staleMs?: number; retryMs?: number } = {},
+  ): Promise<T> {
     await ensureDataDir()
+    const timeoutMs = options.timeoutMs ?? STORE_LOCK_TIMEOUT_MS
+    const staleMs = options.staleMs ?? STORE_LOCK_STALE_MS
+    const retryMs = options.retryMs ?? STORE_LOCK_RETRY_MS
     const start = Date.now()
     while (true) {
       try {
@@ -131,14 +149,14 @@ export namespace Auth {
         const code = (error as { code?: string }).code
         if (code !== "EEXIST") throw error
         const stat = await fs.stat(lockpath).catch(() => undefined)
-        if (stat && Date.now() - stat.mtimeMs > STORE_LOCK_STALE_MS) {
+        if (stat && Date.now() - stat.mtimeMs > staleMs) {
           await fs.rm(lockpath).catch(() => {})
           continue
         }
-        if (Date.now() - start > STORE_LOCK_TIMEOUT_MS) {
-          throw new Error("Timed out waiting for auth store lock")
+        if (Date.now() - start > timeoutMs) {
+          throw new StoreLockTimeoutError()
         }
-        await Bun.sleep(STORE_LOCK_RETRY_MS + Math.random() * STORE_LOCK_RETRY_MS)
+        await Bun.sleep(retryMs + Math.random() * retryMs)
       }
     }
 
@@ -221,7 +239,10 @@ export namespace Auth {
     changed: boolean
   }
 
-  async function updateStore<T>(fn: (store: StoreFile) => Promise<StoreUpdateResult<T>> | StoreUpdateResult<T>) {
+  async function updateStoreWithLock<T>(
+    fn: (store: StoreFile) => Promise<StoreUpdateResult<T>> | StoreUpdateResult<T>,
+    lockOptions?: { timeoutMs?: number; staleMs?: number; retryMs?: number },
+  ) {
     return withStoreLock(async () => {
       const { store, needsWrite } = await readStoreFile()
       const result = await fn(store)
@@ -229,7 +250,28 @@ export namespace Auth {
         await writeStoreFile(store)
       }
       return result.value
-    })
+    }, lockOptions)
+  }
+
+  async function updateStore<T>(fn: (store: StoreFile) => Promise<StoreUpdateResult<T>> | StoreUpdateResult<T>) {
+    return updateStoreWithLock(fn)
+  }
+
+  async function updateStoreBestEffort(
+    fn: (store: StoreFile) => Promise<StoreUpdateResult<void>> | StoreUpdateResult<void>,
+  ): Promise<void> {
+    try {
+      await updateStoreWithLock(fn, {
+        timeoutMs: STORE_LOCK_BEST_EFFORT_TIMEOUT_MS,
+        retryMs: STORE_LOCK_BEST_EFFORT_RETRY_MS,
+      })
+    } catch (error) {
+      if (error instanceof StoreLockTimeoutError) {
+        log.warn("auth store lock busy, skipping update", { timeoutMs: STORE_LOCK_BEST_EFFORT_TIMEOUT_MS })
+        return
+      }
+      throw error
+    }
   }
 
   function ensureOAuthProvider(store: StoreFile, providerID: string): OAuthProvider {
@@ -474,7 +516,7 @@ export namespace Auth {
     }
 
     export async function moveToBack(providerID: string, namespace: string, recordID: string): Promise<void> {
-      await updateStore((store) => {
+      await updateStoreBestEffort((store) => {
         const provider = store.providers[providerID]
         if (!provider || provider.type !== "oauth") return { value: undefined, changed: false }
         const order = recordIDsForNamespace(provider, namespace)
@@ -491,7 +533,7 @@ export namespace Auth {
       ok: boolean
       cooldownUntil?: number
     }): Promise<void> {
-      await updateStore((store) => {
+      await updateStoreBestEffort((store) => {
         const provider = store.providers[input.providerID]
         if (!provider || provider.type !== "oauth") return { value: undefined, changed: false }
 
@@ -517,7 +559,7 @@ export namespace Auth {
     }
 
     export async function markAccessExpired(providerID: string, namespace: string, recordID: string): Promise<void> {
-      await updateStore((store) => {
+      await updateStoreBestEffort((store) => {
         const provider = store.providers[providerID]
         if (!provider || provider.type !== "oauth") return { value: undefined, changed: false }
         const record = findOAuthRecord(provider, recordID)

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -38,6 +38,10 @@ export namespace Auth {
   export type Info = z.infer<typeof Info>
 
   const filepath = path.join(Global.Path.data, "auth.json")
+  const lockpath = `${filepath}.lock`
+  const STORE_LOCK_TIMEOUT_MS = 5_000
+  const STORE_LOCK_STALE_MS = 30_000
+  const STORE_LOCK_RETRY_MS = 25
 
   const Health = z
     .object({
@@ -115,6 +119,36 @@ export namespace Auth {
     await fs.mkdir(path.dirname(filepath), { recursive: true })
   }
 
+  async function withStoreLock<T>(fn: () => Promise<T>): Promise<T> {
+    await ensureDataDir()
+    const start = Date.now()
+    while (true) {
+      try {
+        const handle = await fs.open(lockpath, "wx")
+        await handle.close()
+        break
+      } catch (error) {
+        const code = (error as { code?: string }).code
+        if (code !== "EEXIST") throw error
+        const stat = await fs.stat(lockpath).catch(() => undefined)
+        if (stat && Date.now() - stat.mtimeMs > STORE_LOCK_STALE_MS) {
+          await fs.rm(lockpath).catch(() => {})
+          continue
+        }
+        if (Date.now() - start > STORE_LOCK_TIMEOUT_MS) {
+          throw new Error("Timed out waiting for auth store lock")
+        }
+        await Bun.sleep(STORE_LOCK_RETRY_MS + Math.random() * STORE_LOCK_RETRY_MS)
+      }
+    }
+
+    try {
+      return await fn()
+    } finally {
+      await fs.rm(lockpath).catch(() => {})
+    }
+  }
+
   async function writeStoreFile(store: StoreFile): Promise<void> {
     await ensureDataDir()
     const tempPath = `${filepath}.tmp`
@@ -124,12 +158,13 @@ export namespace Auth {
     await fs.chmod(filepath, 0o600).catch(() => {})
   }
 
-  async function loadStoreFile(): Promise<StoreFile> {
+  async function readStoreFile(): Promise<{ store: StoreFile; needsWrite: boolean }> {
     const file = Bun.file(filepath)
+    const exists = await file.exists()
     const raw = await file.json().catch(() => undefined)
 
     const parsed = StoreFile.safeParse(raw)
-    if (parsed.success) return parsed.data
+    if (parsed.success) return { store: parsed.data, needsWrite: false }
 
     const legacyParsed = z.record(z.string(), Info).safeParse(raw)
     if (legacyParsed.success) {
@@ -170,11 +205,31 @@ export namespace Auth {
         }
       }
 
-      await writeStoreFile(next)
-      return next
+      return { store: next, needsWrite: true }
     }
 
-    return { version: 2, providers: {} }
+    return { store: { version: 2, providers: {} }, needsWrite: exists }
+  }
+
+  async function loadStoreFile(): Promise<StoreFile> {
+    const result = await readStoreFile()
+    return result.store
+  }
+
+  type StoreUpdateResult<T> = {
+    value: T
+    changed: boolean
+  }
+
+  async function updateStore<T>(fn: (store: StoreFile) => Promise<StoreUpdateResult<T>> | StoreUpdateResult<T>) {
+    return withStoreLock(async () => {
+      const { store, needsWrite } = await readStoreFile()
+      const result = await fn(store)
+      if (result.changed || needsWrite) {
+        await writeStoreFile(store)
+      }
+      return result.value
+    })
   }
 
   function ensureOAuthProvider(store: StoreFile, providerID: string): OAuthProvider {
@@ -271,70 +326,69 @@ export namespace Auth {
   }
 
   export async function set(key: string, info: Info) {
-    const store = await loadStoreFile()
-
-    if (info.type === "api") {
-      store.providers[key] = { type: "api", key: info.key }
-      await writeStoreFile(store)
-      return
-    }
-
-    if (info.type === "wellknown") {
-      store.providers[key] = { type: "wellknown", key: info.key, token: info.token }
-      await writeStoreFile(store)
-      return
-    }
-
-    const namespace = "default"
-    const provider = ensureOAuthProvider(store, key)
-    const recordID =
-      getOAuthRecordID(key) ??
-      (await findOAuthRecordIDByRefreshToken({ providerID: key, namespace, refresh: info.refresh, provider })) ??
-      provider.active[namespace] ??
-      recordIDsForNamespace(provider, namespace)[0] ??
-      ulid()
-
-    const now = Date.now()
-    const existing = findOAuthRecord(provider, recordID)
-    if (!existing) {
-      provider.records.push({
-        id: recordID,
-        namespace,
-        label: "default",
-        accountId: info.accountId,
-        enterpriseUrl: info.enterpriseUrl,
-        refresh: info.refresh,
-        access: info.access,
-        expires: info.expires,
-        createdAt: now,
-        updatedAt: now,
-        health: { successCount: 0, failureCount: 0 },
-      })
-      provider.order[namespace] = [...(provider.order[namespace] ?? []), recordID]
-    } else {
-      existing.refresh = info.refresh
-      existing.access = info.access
-      existing.expires = info.expires
-      existing.updatedAt = now
-      if (info.accountId !== undefined) existing.accountId = info.accountId
-      if (info.enterpriseUrl !== undefined) existing.enterpriseUrl = info.enterpriseUrl
-      const order = provider.order[namespace] ?? []
-      if (!order.includes(recordID)) {
-        provider.order[namespace] = [...order, recordID]
+    return updateStore(async (store) => {
+      if (info.type === "api") {
+        store.providers[key] = { type: "api", key: info.key }
+        return { value: undefined, changed: true }
       }
-    }
-    provider.active[namespace] = recordID
 
-    await writeStoreFile(store)
+      if (info.type === "wellknown") {
+        store.providers[key] = { type: "wellknown", key: info.key, token: info.token }
+        return { value: undefined, changed: true }
+      }
+
+      const namespace = "default"
+      const provider = ensureOAuthProvider(store, key)
+      const recordID =
+        getOAuthRecordID(key) ??
+        (await findOAuthRecordIDByRefreshToken({ providerID: key, namespace, refresh: info.refresh, provider })) ??
+        provider.active[namespace] ??
+        recordIDsForNamespace(provider, namespace)[0] ??
+        ulid()
+
+      const now = Date.now()
+      const existing = findOAuthRecord(provider, recordID)
+      if (!existing) {
+        provider.records.push({
+          id: recordID,
+          namespace,
+          label: "default",
+          accountId: info.accountId,
+          enterpriseUrl: info.enterpriseUrl,
+          refresh: info.refresh,
+          access: info.access,
+          expires: info.expires,
+          createdAt: now,
+          updatedAt: now,
+          health: { successCount: 0, failureCount: 0 },
+        })
+        provider.order[namespace] = [...(provider.order[namespace] ?? []), recordID]
+      } else {
+        existing.refresh = info.refresh
+        existing.access = info.access
+        existing.expires = info.expires
+        existing.updatedAt = now
+        if (info.accountId !== undefined) existing.accountId = info.accountId
+        if (info.enterpriseUrl !== undefined) existing.enterpriseUrl = info.enterpriseUrl
+        const order = provider.order[namespace] ?? []
+        if (!order.includes(recordID)) {
+          provider.order[namespace] = [...order, recordID]
+        }
+      }
+      provider.active[namespace] = recordID
+
+      return { value: undefined, changed: true }
+    })
   }
 
   export async function remove(key: string) {
-    const store = await loadStoreFile()
-    const existing = store.providers[key]
-    if (!existing) return
+    return updateStore((store) => {
+      const existing = store.providers[key]
+      if (!existing) return { value: undefined, changed: false }
 
-    delete store.providers[key]
-    await writeStoreFile(store)
+      delete store.providers[key]
+      return { value: undefined, changed: true }
+    })
   }
 
   export async function addOAuth(
@@ -342,60 +396,57 @@ export namespace Auth {
     input: Omit<z.infer<typeof Oauth>, "type"> & { namespace?: string; label?: string },
   ) {
     const namespace = (input.namespace ?? "default").trim() || "default"
-    const store = await loadStoreFile()
+    return updateStore(async (store) => {
+      const provider = ensureOAuthProvider(store, providerID)
+      const now = Date.now()
+      const existingRecordID = await findOAuthRecordIDByRefreshToken({
+        providerID,
+        namespace,
+        refresh: input.refresh,
+        provider,
+      })
 
-    const provider = ensureOAuthProvider(store, providerID)
-    const now = Date.now()
-    const existingRecordID = await findOAuthRecordIDByRefreshToken({
-      providerID,
-      namespace,
-      refresh: input.refresh,
-      provider,
-    })
+      if (existingRecordID) {
+        const existing = findOAuthRecord(provider, existingRecordID)
+        if (existing) {
+          existing.refresh = input.refresh
+          existing.access = input.access
+          existing.expires = input.expires
+          existing.updatedAt = now
+          if (input.accountId !== undefined) existing.accountId = input.accountId
+          if (input.enterpriseUrl !== undefined) existing.enterpriseUrl = input.enterpriseUrl
+          if (input.label) existing.label = input.label
+        }
+        const order = provider.order[namespace] ?? []
+        if (!order.includes(existingRecordID)) {
+          provider.order[namespace] = [...order, existingRecordID]
+        }
+        provider.active[namespace] = existingRecordID
 
-    if (existingRecordID) {
-      const existing = findOAuthRecord(provider, existingRecordID)
-      if (existing) {
-        existing.refresh = input.refresh
-        existing.access = input.access
-        existing.expires = input.expires
-        existing.updatedAt = now
-        if (input.accountId !== undefined) existing.accountId = input.accountId
-        if (input.enterpriseUrl !== undefined) existing.enterpriseUrl = input.enterpriseUrl
-        if (input.label) existing.label = input.label
+        return { value: { providerID, namespace, recordID: existingRecordID }, changed: true }
       }
-      const order = provider.order[namespace] ?? []
-      if (!order.includes(existingRecordID)) {
-        provider.order[namespace] = [...order, existingRecordID]
-      }
-      provider.active[namespace] = existingRecordID
 
-      await writeStoreFile(store)
-      return { providerID, namespace, recordID: existingRecordID }
-    }
+      const recordID = ulid()
 
-    const recordID = ulid()
+      provider.records.push({
+        id: recordID,
+        namespace,
+        label: input.label ?? "default",
+        accountId: input.accountId,
+        enterpriseUrl: input.enterpriseUrl,
+        refresh: input.refresh,
+        access: input.access,
+        expires: input.expires,
+        createdAt: now,
+        updatedAt: now,
+        health: { successCount: 0, failureCount: 0 },
+      })
 
-    provider.records.push({
-      id: recordID,
-      namespace,
-      label: input.label ?? "default",
-      accountId: input.accountId,
-      enterpriseUrl: input.enterpriseUrl,
-      refresh: input.refresh,
-      access: input.access,
-      expires: input.expires,
-      createdAt: now,
-      updatedAt: now,
-      health: { successCount: 0, failureCount: 0 },
+      provider.order[namespace] = [...(provider.order[namespace] ?? []), recordID]
+      provider.active[namespace] = recordID
+
+      return { value: { providerID, namespace, recordID }, changed: true }
     })
-
-    provider.order[namespace] = [...(provider.order[namespace] ?? []), recordID]
-    provider.active[namespace] = recordID
-
-    await writeStoreFile(store)
-
-    return { providerID, namespace, recordID }
   }
 
   export namespace OAuthPool {
@@ -423,13 +474,14 @@ export namespace Auth {
     }
 
     export async function moveToBack(providerID: string, namespace: string, recordID: string): Promise<void> {
-      const store = await loadStoreFile()
-      const provider = store.providers[providerID]
-      if (!provider || provider.type !== "oauth") return
-      const order = recordIDsForNamespace(provider, namespace)
-      provider.order[namespace] = order.filter((id) => id !== recordID).concat(recordID)
-      provider.active[namespace] = provider.order[namespace][0] ?? provider.active[namespace]
-      await writeStoreFile(store)
+      await updateStore((store) => {
+        const provider = store.providers[providerID]
+        if (!provider || provider.type !== "oauth") return { value: undefined, changed: false }
+        const order = recordIDsForNamespace(provider, namespace)
+        provider.order[namespace] = order.filter((id) => id !== recordID).concat(recordID)
+        provider.active[namespace] = provider.order[namespace][0] ?? provider.active[namespace]
+        return { value: undefined, changed: true }
+      })
     }
 
     export async function recordOutcome(input: {
@@ -439,40 +491,42 @@ export namespace Auth {
       ok: boolean
       cooldownUntil?: number
     }): Promise<void> {
-      const store = await loadStoreFile()
-      const provider = store.providers[input.providerID]
-      if (!provider || provider.type !== "oauth") return
+      await updateStore((store) => {
+        const provider = store.providers[input.providerID]
+        if (!provider || provider.type !== "oauth") return { value: undefined, changed: false }
 
-      const record = findOAuthRecord(provider, input.recordID)
-      if (!record) return
+        const record = findOAuthRecord(provider, input.recordID)
+        if (!record) return { value: undefined, changed: false }
 
-      const now = Date.now()
-      const prevCooldown =
-        record.health.cooldownUntil && record.health.cooldownUntil > now ? record.health.cooldownUntil : undefined
-      const cooldownUntil = input.ok ? undefined : input.cooldownUntil ?? prevCooldown
+        const now = Date.now()
+        const prevCooldown =
+          record.health.cooldownUntil && record.health.cooldownUntil > now ? record.health.cooldownUntil : undefined
+        const cooldownUntil = input.ok ? undefined : input.cooldownUntil ?? prevCooldown
 
-      record.health = {
-        ...record.health,
-        cooldownUntil,
-        lastStatusCode: input.statusCode,
-        lastErrorAt: input.ok ? undefined : now,
-        successCount: record.health.successCount + (input.ok ? 1 : 0),
-        failureCount: record.health.failureCount + (input.ok ? 0 : 1),
-      }
-      record.updatedAt = now
-      await writeStoreFile(store)
+        record.health = {
+          ...record.health,
+          cooldownUntil,
+          lastStatusCode: input.statusCode,
+          lastErrorAt: input.ok ? undefined : now,
+          successCount: record.health.successCount + (input.ok ? 1 : 0),
+          failureCount: record.health.failureCount + (input.ok ? 0 : 1),
+        }
+        record.updatedAt = now
+        return { value: undefined, changed: true }
+      })
     }
 
     export async function markAccessExpired(providerID: string, namespace: string, recordID: string): Promise<void> {
-      const store = await loadStoreFile()
-      const provider = store.providers[providerID]
-      if (!provider || provider.type !== "oauth") return
-      const record = findOAuthRecord(provider, recordID)
-      if (!record || record.namespace !== namespace) return
-      record.access = ""
-      record.expires = 0
-      record.updatedAt = Date.now()
-      await writeStoreFile(store)
+      await updateStore((store) => {
+        const provider = store.providers[providerID]
+        if (!provider || provider.type !== "oauth") return { value: undefined, changed: false }
+        const record = findOAuthRecord(provider, recordID)
+        if (!record || record.namespace !== namespace) return { value: undefined, changed: false }
+        record.access = ""
+        record.expires = 0
+        record.updatedAt = Date.now()
+        return { value: undefined, changed: true }
+      })
     }
   }
 }

--- a/packages/opencode/src/auth/rotating-fetch.ts
+++ b/packages/opencode/src/auth/rotating-fetch.ts
@@ -1,7 +1,9 @@
 import { Auth } from "./index"
 import { withOAuthRecord } from "./context"
+import { CredentialManager } from "./credential-manager"
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 30_000
+const DEFAULT_AUTH_FAILURE_COOLDOWN_MS = 5 * 60_000
 
 function isReadableStream(value: unknown): value is ReadableStream {
   return typeof ReadableStream !== "undefined" && value instanceof ReadableStream
@@ -59,8 +61,6 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
     const { records, orderedIDs } = await Auth.OAuthPool.snapshot(opts.providerID, namespace)
     if (records.length === 0) return fetchFn(input, init)
 
-    if (orderedIDs.length <= 1) return fetchFn(input, init)
-
     const recordByID = new Map(records.map((record) => [record.id, record]))
     const candidates = orderedIDs.filter((id) => recordByID.has(id))
     if (candidates.length === 0) return fetchFn(input, init)
@@ -78,6 +78,13 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
     const attempted = new Set<string>()
     const refreshed = new Set<string>()
     let lastError: unknown
+
+    const pickNextCandidate = (now: number) =>
+      candidates.find((id) => {
+        if (attempted.has(id)) return false
+        const cooldownUntil = recordByID.get(id)?.health.cooldownUntil
+        return !cooldownUntil || cooldownUntil <= now
+      }) ?? candidates.find((id) => !attempted.has(id))
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const now = Date.now()
@@ -143,6 +150,15 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
           cooldownUntil: Date.now() + cooldownMs,
         })
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+        if (hasMoreAttempts) {
+          const candidate = pickNextCandidate(Date.now())
+          void CredentialManager.notifyFailover({
+            providerID: opts.providerID,
+            fromRecordID: nextID,
+            toRecordID: candidate,
+            statusCode: response.status,
+          })
+        }
         if (!hasMoreAttempts) return response
         await drainResponse(response)
         continue
@@ -153,11 +169,13 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
 
         await Auth.OAuthPool.markAccessExpired(opts.providerID, namespace, nextID)
         if (!allowRetry) {
+          const cooldownUntil = Date.now() + DEFAULT_AUTH_FAILURE_COOLDOWN_MS
           await Auth.OAuthPool.recordOutcome({
             providerID: opts.providerID,
             recordID: nextID,
             statusCode: response.status,
             ok: false,
+            cooldownUntil,
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
           return response
@@ -186,17 +204,28 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
               ok: false,
               cooldownUntil: Date.now() + cooldownMs,
             })
-            await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
-            if (!hasMoreAttempts) return retry
-            await drainResponse(retry)
-            continue
+          await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+          if (hasMoreAttempts) {
+            const candidate = pickNextCandidate(Date.now())
+            void CredentialManager.notifyFailover({
+              providerID: opts.providerID,
+              fromRecordID: nextID,
+              toRecordID: candidate,
+              statusCode: retry.status,
+            })
           }
+          if (!hasMoreAttempts) return retry
+          await drainResponse(retry)
+          continue
+        }
 
+          const cooldownUntil = Date.now() + DEFAULT_AUTH_FAILURE_COOLDOWN_MS
           await Auth.OAuthPool.recordOutcome({
             providerID: opts.providerID,
             recordID: nextID,
             statusCode: retry.status,
             ok: false,
+            cooldownUntil,
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
           if (!hasMoreAttempts) return retry

--- a/packages/opencode/src/auth/rotating-fetch.ts
+++ b/packages/opencode/src/auth/rotating-fetch.ts
@@ -4,6 +4,7 @@ import { CredentialManager } from "./credential-manager"
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 30_000
 const DEFAULT_AUTH_FAILURE_COOLDOWN_MS = 5 * 60_000
+const DEFAULT_NETWORK_RETRY_ATTEMPTS = 1
 
 function isReadableStream(value: unknown): value is ReadableStream {
   return typeof ReadableStream !== "undefined" && value instanceof ReadableStream
@@ -43,6 +44,56 @@ function parseRetryAfterMs(response: Response): number | undefined {
   return undefined
 }
 
+const NETWORK_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ETIMEDOUT",
+  "ECONNABORTED",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_SOCKET",
+])
+const NETWORK_ERROR_NAMES = new Set(["AbortError", "TimeoutError", "FetchError"])
+
+function extractErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === "string" ? code : undefined
+}
+
+function extractErrorName(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const name = (error as { name?: unknown }).name
+  return typeof name === "string" ? name : undefined
+}
+
+function extractErrorMessage(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const message = (error as { message?: unknown }).message
+  return typeof message === "string" ? message : undefined
+}
+
+function isNetworkError(error: unknown): boolean {
+  const directCode = extractErrorCode(error)
+  const cause = typeof error === "object" && error !== null ? (error as { cause?: unknown }).cause : undefined
+  const causeCode = extractErrorCode(cause)
+  const code = directCode ?? causeCode
+  if (code && NETWORK_ERROR_CODES.has(code)) return true
+
+  const name = extractErrorName(error)
+  if (name && NETWORK_ERROR_NAMES.has(name)) return true
+
+  const message = extractErrorMessage(error)?.toLowerCase()
+  if (!message) return false
+  return message.includes("fetch failed") || message.includes("network error") || message.includes("network down")
+}
+
 function isAuthExpiredStatus(status: number): boolean {
   return status === 401 || status === 403
 }
@@ -55,6 +106,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
     maxAttempts?: number
     rateLimitCooldownMs?: number
     authFailureCooldownMs?: number
+    networkRetryAttempts?: number
     toastDurationMs?: number
   },
 ): TFetch {
@@ -73,6 +125,10 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
 
     const rateLimitCooldownMs = opts.rateLimitCooldownMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
     const authFailureCooldownMs = opts.authFailureCooldownMs ?? DEFAULT_AUTH_FAILURE_COOLDOWN_MS
+    const configuredNetworkRetryAttempts = Math.max(
+      0,
+      opts.networkRetryAttempts ?? DEFAULT_NETWORK_RETRY_ATTEMPTS,
+    )
     const maxAttemptBudget = opts.maxAttempts ?? candidates.length
     let maxAttempts = Math.max(1, maxAttemptBudget)
     if (!allowRetry) {
@@ -100,20 +156,41 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
       if (!nextID) break
       attempted.add(nextID)
 
-      let attemptInput = input
-      if (inputIsRequest && allowRetry) {
-        try {
-          attemptInput = input.clone()
-        } catch (e) {
-          lastError = e
-          allowRetry = false
-          maxAttempts = attempt + 1
+      const hasMoreAttempts = () => attempt + 1 < maxAttempts
+      let networkRetryAttempts = allowRetry ? configuredNetworkRetryAttempts : 0
+
+      const runWithNetworkRetry = async (): Promise<Response> => {
+        for (let networkAttempt = 0; ; networkAttempt++) {
+          let attemptInput = input
+          if (inputIsRequest && allowRetry) {
+            try {
+              attemptInput = input.clone()
+            } catch (e) {
+              lastError = e
+              allowRetry = false
+              networkRetryAttempts = 0
+              maxAttempts = attempt + 1
+            }
+          }
+
+          try {
+            return await withOAuthRecord(opts.providerID, nextID, () => fetchFn(attemptInput, init))
+          } catch (e) {
+            lastError = e
+            await Auth.OAuthPool.recordOutcome({
+              providerID: opts.providerID,
+              recordID: nextID,
+              statusCode: 0,
+              ok: false,
+            })
+            const networkError = isNetworkError(e)
+            if (networkError && allowRetry && networkAttempt < networkRetryAttempts) {
+              continue
+            }
+            throw e
+          }
         }
       }
-
-      const hasMoreAttempts = attempt + 1 < maxAttempts
-
-      const run = () => withOAuthRecord(opts.providerID, nextID, () => fetchFn(attemptInput, init))
       const notifyFailover = async (statusCode: number) => {
         const candidate = pickNextCandidate(Date.now())
         if (!candidate) return
@@ -128,18 +205,13 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
 
       let response: Response
       try {
-        response = await run()
+        response = await runWithNetworkRetry()
       } catch (e) {
-        lastError = e
-        await Auth.OAuthPool.recordOutcome({
-          providerID: opts.providerID,
-          recordID: nextID,
-          statusCode: 0,
-          ok: false,
-        })
+        if (isNetworkError(e)) throw e
+
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
         await notifyFailover(0)
-        if (!hasMoreAttempts) throw e
+        if (!hasMoreAttempts()) throw e
         continue
       }
 
@@ -164,7 +236,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
         })
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
         await notifyFailover(response.status)
-        if (!hasMoreAttempts) return response
+        if (!hasMoreAttempts()) return response
         await drainResponse(response)
         continue
       }
@@ -190,7 +262,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
         await drainResponse(response)
 
         try {
-          const retry = await run()
+          const retry = await runWithNetworkRetry()
           if (retry.ok) {
             await Auth.OAuthPool.recordOutcome({
               providerID: opts.providerID,
@@ -212,7 +284,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
             })
             await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
             await notifyFailover(retry.status)
-            if (!hasMoreAttempts) return retry
+            if (!hasMoreAttempts()) return retry
             await drainResponse(retry)
             continue
           }
@@ -227,19 +299,13 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
           await notifyFailover(retry.status)
-          if (!hasMoreAttempts) return retry
+          if (!hasMoreAttempts()) return retry
           await drainResponse(retry)
           continue
         } catch (e) {
-          lastError = e
-          await Auth.OAuthPool.recordOutcome({
-            providerID: opts.providerID,
-            recordID: nextID,
-            statusCode: 0,
-            ok: false,
-          })
+          if (isNetworkError(e)) throw e
           await notifyFailover(0)
-          if (!hasMoreAttempts) throw e
+          if (!hasMoreAttempts()) throw e
         }
 
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
@@ -252,7 +318,11 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
         statusCode: response.status,
         ok: false,
       })
-      return response
+      await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+      await notifyFailover(response.status)
+      if (!hasMoreAttempts()) return response
+      await drainResponse(response)
+      continue
     }
 
     if (lastError) throw lastError

--- a/packages/opencode/src/auth/rotating-fetch.ts
+++ b/packages/opencode/src/auth/rotating-fetch.ts
@@ -152,12 +152,14 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
         if (hasMoreAttempts) {
           const candidate = pickNextCandidate(Date.now())
-          void CredentialManager.notifyFailover({
-            providerID: opts.providerID,
-            fromRecordID: nextID,
-            toRecordID: candidate,
-            statusCode: response.status,
-          })
+          if (candidate && candidate !== nextID) {
+            void CredentialManager.notifyFailover({
+              providerID: opts.providerID,
+              fromRecordID: nextID,
+              toRecordID: candidate,
+              statusCode: response.status,
+            })
+          }
         }
         if (!hasMoreAttempts) return response
         await drainResponse(response)
@@ -178,6 +180,17 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
             cooldownUntil,
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+          if (hasMoreAttempts) {
+            const candidate = pickNextCandidate(Date.now())
+            if (candidate && candidate !== nextID) {
+              void CredentialManager.notifyFailover({
+                providerID: opts.providerID,
+                fromRecordID: nextID,
+                toRecordID: candidate,
+                statusCode: response.status,
+              })
+            }
+          }
           return response
         }
 
@@ -204,20 +217,22 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
               ok: false,
               cooldownUntil: Date.now() + cooldownMs,
             })
-          await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
-          if (hasMoreAttempts) {
-            const candidate = pickNextCandidate(Date.now())
-            void CredentialManager.notifyFailover({
-              providerID: opts.providerID,
-              fromRecordID: nextID,
-              toRecordID: candidate,
-              statusCode: retry.status,
-            })
+            await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+            if (hasMoreAttempts) {
+              const candidate = pickNextCandidate(Date.now())
+              if (candidate && candidate !== nextID) {
+                void CredentialManager.notifyFailover({
+                  providerID: opts.providerID,
+                  fromRecordID: nextID,
+                  toRecordID: candidate,
+                  statusCode: retry.status,
+                })
+              }
+            }
+            if (!hasMoreAttempts) return retry
+            await drainResponse(retry)
+            continue
           }
-          if (!hasMoreAttempts) return retry
-          await drainResponse(retry)
-          continue
-        }
 
           const cooldownUntil = Date.now() + DEFAULT_AUTH_FAILURE_COOLDOWN_MS
           await Auth.OAuthPool.recordOutcome({
@@ -228,6 +243,17 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
             cooldownUntil,
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+          if (hasMoreAttempts) {
+            const candidate = pickNextCandidate(Date.now())
+            if (candidate && candidate !== nextID) {
+              void CredentialManager.notifyFailover({
+                providerID: opts.providerID,
+                fromRecordID: nextID,
+                toRecordID: candidate,
+                statusCode: retry.status,
+              })
+            }
+          }
           if (!hasMoreAttempts) return retry
           await drainResponse(retry)
           continue

--- a/packages/opencode/src/auth/rotating-fetch.ts
+++ b/packages/opencode/src/auth/rotating-fetch.ts
@@ -1,0 +1,232 @@
+import { Auth } from "./index"
+import { withOAuthRecord } from "./context"
+
+const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 30_000
+
+function isReadableStream(value: unknown): value is ReadableStream {
+  return typeof ReadableStream !== "undefined" && value instanceof ReadableStream
+}
+
+function isAsyncIterable(value: unknown): boolean {
+  return typeof value === "object" && value !== null && Symbol.asyncIterator in value
+}
+
+function isReplayableBody(body: unknown): boolean {
+  if (!body) return true
+  if (isReadableStream(body)) return false
+  if (isAsyncIterable(body)) return false
+  return true
+}
+
+function isRequest(value: unknown): value is Request {
+  return typeof Request !== "undefined" && value instanceof Request
+}
+
+async function drainResponse(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel()
+  } catch {}
+}
+
+function parseRetryAfterMs(response: Response): number | undefined {
+  const value = response.headers.get("retry-after") ?? response.headers.get("Retry-After")
+  if (!value) return undefined
+
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds) * 1000
+
+  const dateMs = Date.parse(value)
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now())
+
+  return undefined
+}
+
+function isAuthExpiredStatus(status: number): boolean {
+  return status === 401 || status === 403
+}
+
+export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any) => Promise<Response>>(
+  fetchFn: TFetch,
+  opts: {
+    providerID: string
+    namespace?: string
+    maxAttempts?: number
+  },
+): TFetch {
+  const namespace = (opts.namespace ?? "default").trim() || "default"
+
+  return (async (input: any, init?: any) => {
+    const { records, orderedIDs } = await Auth.OAuthPool.snapshot(opts.providerID, namespace)
+    if (records.length === 0) return fetchFn(input, init)
+
+    if (orderedIDs.length <= 1) return fetchFn(input, init)
+
+    const recordByID = new Map(records.map((record) => [record.id, record]))
+    const candidates = orderedIDs.filter((id) => recordByID.has(id))
+    if (candidates.length === 0) return fetchFn(input, init)
+    const inputIsRequest = isRequest(input)
+    let allowRetry =
+      isReplayableBody(init?.body) && (!inputIsRequest || (!input.bodyUsed && !isReadableStream(input.body)))
+
+    let maxAttempts = Math.max(1, opts.maxAttempts ?? candidates.length)
+    if (!allowRetry) {
+      maxAttempts = 1
+    } else if (maxAttempts > candidates.length) {
+      maxAttempts = candidates.length
+    }
+
+    const attempted = new Set<string>()
+    const refreshed = new Set<string>()
+    let lastError: unknown
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const now = Date.now()
+
+      const nextID =
+        candidates.find((id) => {
+          if (attempted.has(id)) return false
+          const cooldownUntil = recordByID.get(id)?.health.cooldownUntil
+          return !cooldownUntil || cooldownUntil <= now
+        }) ?? candidates.find((id) => !attempted.has(id))
+
+      if (!nextID) break
+      attempted.add(nextID)
+
+      let attemptInput = input
+      if (inputIsRequest && allowRetry) {
+        try {
+          attemptInput = input.clone()
+        } catch (e) {
+          lastError = e
+          allowRetry = false
+          maxAttempts = attempt + 1
+        }
+      }
+
+      const hasMoreAttempts = attempt + 1 < maxAttempts
+
+      const run = () => withOAuthRecord(opts.providerID, nextID, () => fetchFn(attemptInput, init))
+
+      let response: Response
+      try {
+        response = await run()
+      } catch (e) {
+        lastError = e
+        await Auth.OAuthPool.recordOutcome({
+          providerID: opts.providerID,
+          recordID: nextID,
+          statusCode: 0,
+          ok: false,
+        })
+        await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+        if (!hasMoreAttempts) throw e
+        continue
+      }
+
+      if (response.ok) {
+        await Auth.OAuthPool.recordOutcome({
+          providerID: opts.providerID,
+          recordID: nextID,
+          statusCode: response.status,
+          ok: true,
+        })
+        return response
+      }
+
+      if (response.status === 429) {
+        const cooldownMs = parseRetryAfterMs(response) ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
+        await Auth.OAuthPool.recordOutcome({
+          providerID: opts.providerID,
+          recordID: nextID,
+          statusCode: response.status,
+          ok: false,
+          cooldownUntil: Date.now() + cooldownMs,
+        })
+        await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+        if (!hasMoreAttempts) return response
+        await drainResponse(response)
+        continue
+      }
+
+      if (isAuthExpiredStatus(response.status) && !refreshed.has(nextID)) {
+        refreshed.add(nextID)
+
+        await Auth.OAuthPool.markAccessExpired(opts.providerID, namespace, nextID)
+        if (!allowRetry) {
+          await Auth.OAuthPool.recordOutcome({
+            providerID: opts.providerID,
+            recordID: nextID,
+            statusCode: response.status,
+            ok: false,
+          })
+          await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+          return response
+        }
+
+        await drainResponse(response)
+
+        try {
+          const retry = await run()
+          if (retry.ok) {
+            await Auth.OAuthPool.recordOutcome({
+              providerID: opts.providerID,
+              recordID: nextID,
+              statusCode: retry.status,
+              ok: true,
+            })
+            return retry
+          }
+
+          if (retry.status === 429) {
+            const cooldownMs = parseRetryAfterMs(retry) ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
+            await Auth.OAuthPool.recordOutcome({
+              providerID: opts.providerID,
+              recordID: nextID,
+              statusCode: retry.status,
+              ok: false,
+              cooldownUntil: Date.now() + cooldownMs,
+            })
+            await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+            if (!hasMoreAttempts) return retry
+            await drainResponse(retry)
+            continue
+          }
+
+          await Auth.OAuthPool.recordOutcome({
+            providerID: opts.providerID,
+            recordID: nextID,
+            statusCode: retry.status,
+            ok: false,
+          })
+          await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+          if (!hasMoreAttempts) return retry
+          await drainResponse(retry)
+          continue
+        } catch (e) {
+          lastError = e
+          await Auth.OAuthPool.recordOutcome({
+            providerID: opts.providerID,
+            recordID: nextID,
+            statusCode: 0,
+            ok: false,
+          })
+          if (!hasMoreAttempts) throw e
+        }
+
+        await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+        continue
+      }
+
+      await Auth.OAuthPool.recordOutcome({
+        providerID: opts.providerID,
+        recordID: nextID,
+        statusCode: response.status,
+        ok: false,
+      })
+      return response
+    }
+
+    if (lastError) throw lastError
+    return fetchFn(input, init)
+  }) as TFetch
+}

--- a/packages/opencode/src/auth/rotating-fetch.ts
+++ b/packages/opencode/src/auth/rotating-fetch.ts
@@ -4,12 +4,13 @@ import { CredentialManager } from "./credential-manager"
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 30_000
 const DEFAULT_AUTH_FAILURE_COOLDOWN_MS = 5 * 60_000
+const DEFAULT_MAX_ATTEMPTS = 5
 
 function isReadableStream(value: unknown): value is ReadableStream {
   return typeof ReadableStream !== "undefined" && value instanceof ReadableStream
 }
 
-function isAsyncIterable(value: unknown): boolean {
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
   return typeof value === "object" && value !== null && Symbol.asyncIterator in value
 }
 
@@ -53,6 +54,9 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
     providerID: string
     namespace?: string
     maxAttempts?: number
+    rateLimitCooldownMs?: number
+    authFailureCooldownMs?: number
+    toastDurationMs?: number
   },
 ): TFetch {
   const namespace = (opts.namespace ?? "default").trim() || "default"
@@ -68,7 +72,10 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
     let allowRetry =
       isReplayableBody(init?.body) && (!inputIsRequest || (!input.bodyUsed && !isReadableStream(input.body)))
 
-    let maxAttempts = Math.max(1, opts.maxAttempts ?? candidates.length)
+    const rateLimitCooldownMs = opts.rateLimitCooldownMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
+    const authFailureCooldownMs = opts.authFailureCooldownMs ?? DEFAULT_AUTH_FAILURE_COOLDOWN_MS
+    const maxAttemptBudget = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+    let maxAttempts = Math.max(1, maxAttemptBudget)
     if (!allowRetry) {
       maxAttempts = 1
     } else if (maxAttempts > candidates.length) {
@@ -89,12 +96,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const now = Date.now()
 
-      const nextID =
-        candidates.find((id) => {
-          if (attempted.has(id)) return false
-          const cooldownUntil = recordByID.get(id)?.health.cooldownUntil
-          return !cooldownUntil || cooldownUntil <= now
-        }) ?? candidates.find((id) => !attempted.has(id))
+      const nextID = pickNextCandidate(now)
 
       if (!nextID) break
       attempted.add(nextID)
@@ -113,6 +115,17 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
       const hasMoreAttempts = attempt + 1 < maxAttempts
 
       const run = () => withOAuthRecord(opts.providerID, nextID, () => fetchFn(attemptInput, init))
+      const notifyFailover = async (statusCode: number) => {
+        const candidate = pickNextCandidate(Date.now())
+        if (!candidate) return
+        await CredentialManager.notifyFailover({
+          providerID: opts.providerID,
+          fromRecordID: nextID,
+          toRecordID: candidate,
+          statusCode,
+          toastDurationMs: opts.toastDurationMs,
+        })
+      }
 
       let response: Response
       try {
@@ -126,6 +139,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
           ok: false,
         })
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
+        await notifyFailover(0)
         if (!hasMoreAttempts) throw e
         continue
       }
@@ -141,7 +155,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
       }
 
       if (response.status === 429) {
-        const cooldownMs = parseRetryAfterMs(response) ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
+        const cooldownMs = parseRetryAfterMs(response) ?? rateLimitCooldownMs
         await Auth.OAuthPool.recordOutcome({
           providerID: opts.providerID,
           recordID: nextID,
@@ -150,17 +164,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
           cooldownUntil: Date.now() + cooldownMs,
         })
         await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
-        if (hasMoreAttempts) {
-          const candidate = pickNextCandidate(Date.now())
-          if (candidate && candidate !== nextID) {
-            void CredentialManager.notifyFailover({
-              providerID: opts.providerID,
-              fromRecordID: nextID,
-              toRecordID: candidate,
-              statusCode: response.status,
-            })
-          }
-        }
+        await notifyFailover(response.status)
         if (!hasMoreAttempts) return response
         await drainResponse(response)
         continue
@@ -171,7 +175,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
 
         await Auth.OAuthPool.markAccessExpired(opts.providerID, namespace, nextID)
         if (!allowRetry) {
-          const cooldownUntil = Date.now() + DEFAULT_AUTH_FAILURE_COOLDOWN_MS
+          const cooldownUntil = Date.now() + authFailureCooldownMs
           await Auth.OAuthPool.recordOutcome({
             providerID: opts.providerID,
             recordID: nextID,
@@ -180,17 +184,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
             cooldownUntil,
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
-          if (hasMoreAttempts) {
-            const candidate = pickNextCandidate(Date.now())
-            if (candidate && candidate !== nextID) {
-              void CredentialManager.notifyFailover({
-                providerID: opts.providerID,
-                fromRecordID: nextID,
-                toRecordID: candidate,
-                statusCode: response.status,
-              })
-            }
-          }
+          await notifyFailover(response.status)
           return response
         }
 
@@ -209,7 +203,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
           }
 
           if (retry.status === 429) {
-            const cooldownMs = parseRetryAfterMs(retry) ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
+            const cooldownMs = parseRetryAfterMs(retry) ?? rateLimitCooldownMs
             await Auth.OAuthPool.recordOutcome({
               providerID: opts.providerID,
               recordID: nextID,
@@ -218,23 +212,13 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
               cooldownUntil: Date.now() + cooldownMs,
             })
             await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
-            if (hasMoreAttempts) {
-              const candidate = pickNextCandidate(Date.now())
-              if (candidate && candidate !== nextID) {
-                void CredentialManager.notifyFailover({
-                  providerID: opts.providerID,
-                  fromRecordID: nextID,
-                  toRecordID: candidate,
-                  statusCode: retry.status,
-                })
-              }
-            }
+            await notifyFailover(retry.status)
             if (!hasMoreAttempts) return retry
             await drainResponse(retry)
             continue
           }
 
-          const cooldownUntil = Date.now() + DEFAULT_AUTH_FAILURE_COOLDOWN_MS
+          const cooldownUntil = Date.now() + authFailureCooldownMs
           await Auth.OAuthPool.recordOutcome({
             providerID: opts.providerID,
             recordID: nextID,
@@ -243,17 +227,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
             cooldownUntil,
           })
           await Auth.OAuthPool.moveToBack(opts.providerID, namespace, nextID)
-          if (hasMoreAttempts) {
-            const candidate = pickNextCandidate(Date.now())
-            if (candidate && candidate !== nextID) {
-              void CredentialManager.notifyFailover({
-                providerID: opts.providerID,
-                fromRecordID: nextID,
-                toRecordID: candidate,
-                statusCode: retry.status,
-              })
-            }
-          }
+          await notifyFailover(retry.status)
           if (!hasMoreAttempts) return retry
           await drainResponse(retry)
           continue
@@ -265,6 +239,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
             statusCode: 0,
             ok: false,
           })
+          await notifyFailover(0)
           if (!hasMoreAttempts) throw e
         }
 

--- a/packages/opencode/src/auth/rotating-fetch.ts
+++ b/packages/opencode/src/auth/rotating-fetch.ts
@@ -4,7 +4,6 @@ import { CredentialManager } from "./credential-manager"
 
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 30_000
 const DEFAULT_AUTH_FAILURE_COOLDOWN_MS = 5 * 60_000
-const DEFAULT_MAX_ATTEMPTS = 5
 
 function isReadableStream(value: unknown): value is ReadableStream {
   return typeof ReadableStream !== "undefined" && value instanceof ReadableStream
@@ -74,7 +73,7 @@ export function createOAuthRotatingFetch<TFetch extends (input: any, init?: any)
 
     const rateLimitCooldownMs = opts.rateLimitCooldownMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS
     const authFailureCooldownMs = opts.authFailureCooldownMs ?? DEFAULT_AUTH_FAILURE_COOLDOWN_MS
-    const maxAttemptBudget = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+    const maxAttemptBudget = opts.maxAttempts ?? candidates.length
     let maxAttempts = Math.max(1, maxAttemptBudget)
     if (!allowRetry) {
       maxAttempts = 1

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -157,11 +157,74 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
   return false
 }
 
+export const AuthUsageCommand = cmd({
+  command: "usage",
+  describe: "show rate limit usage for providers",
+  async handler() {
+    UI.empty()
+    prompts.intro("Usage")
+    const all = await Auth.all()
+    const database = await ModelsDev.get()
+
+    let hasOAuth = false
+    for (const [providerID, info] of Object.entries(all)) {
+      if (info.type !== "oauth") continue
+      hasOAuth = true
+
+      const name = database[providerID]?.name || providerID
+      const accounts = await Auth.OAuthPool.getUsage(providerID)
+
+      for (const account of accounts) {
+        const label = account.label || "default"
+        const status = account.isActive ? `${UI.Style.TEXT_SUCCESS}active` : UI.Style.TEXT_DIM + "inactive"
+        prompts.log.step(`${name} (${label}) - ${status}`)
+
+        if (account.health.cooldownUntil && account.health.cooldownUntil > Date.now()) {
+          const remaining = Math.ceil((account.health.cooldownUntil - Date.now()) / 1000)
+          prompts.log.warn(`  In cooldown for ${remaining}s`)
+        }
+
+        prompts.log.info(`  ${account.health.successCount} successful requests`)
+        if (account.health.failureCount > 0) {
+          prompts.log.warn(`  ${account.health.failureCount} failed requests`)
+        }
+      }
+
+      if (providerID === "anthropic") {
+        const usage = await Auth.OAuthPool.fetchAnthropicUsage(providerID)
+        if (usage) {
+          prompts.log.step("Anthropic Rate Limits:")
+          if (usage.fiveHour) {
+            prompts.log.info(`  5-Hour: ${usage.fiveHour.utilization}% used`)
+          }
+          if (usage.sevenDay) {
+            prompts.log.info(`  7-Day (All): ${usage.sevenDay.utilization}% used`)
+          }
+          if (usage.sevenDaySonnet) {
+            prompts.log.info(`  7-Day (Sonnet): ${usage.sevenDaySonnet.utilization}% used`)
+          }
+        }
+      }
+    }
+
+    if (!hasOAuth) {
+      prompts.log.warn("No OAuth providers configured")
+    }
+
+    prompts.outro("")
+  },
+})
+
 export const AuthCommand = cmd({
   command: "auth",
   describe: "manage credentials",
   builder: (yargs) =>
-    yargs.command(AuthLoginCommand).command(AuthLogoutCommand).command(AuthListCommand).demandCommand(),
+    yargs
+      .command(AuthLoginCommand)
+      .command(AuthLogoutCommand)
+      .command(AuthListCommand)
+      .command(AuthUsageCommand)
+      .demandCommand(),
   async handler() {},
 })
 

--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -82,13 +82,12 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
       if (result.type === "success") {
         const saveProvider = result.provider ?? provider
         if ("refresh" in result) {
-          const { type: _, provider: __, refresh, access, expires, ...extraFields } = result
-          await Auth.set(saveProvider, {
-            type: "oauth",
-            refresh,
-            access,
-            expires,
-            ...extraFields,
+          await Auth.addOAuth(saveProvider, {
+            refresh: result.refresh,
+            access: result.access,
+            expires: result.expires,
+            accountId: result.accountId,
+            enterpriseUrl: result.enterpriseUrl,
           })
         }
         if ("key" in result) {
@@ -114,13 +113,12 @@ async function handlePluginAuth(plugin: { auth: PluginAuth }, provider: string):
       if (result.type === "success") {
         const saveProvider = result.provider ?? provider
         if ("refresh" in result) {
-          const { type: _, provider: __, refresh, access, expires, ...extraFields } = result
-          await Auth.set(saveProvider, {
-            type: "oauth",
-            refresh,
-            access,
-            expires,
-            ...extraFields,
+          await Auth.addOAuth(saveProvider, {
+            refresh: result.refresh,
+            access: result.access,
+            expires: result.expires,
+            accountId: result.accountId,
+            enterpriseUrl: result.enterpriseUrl,
           })
         }
         if ("key" in result) {
@@ -182,7 +180,12 @@ export const AuthListCommand = cmd({
 
     for (const [providerID, result] of results) {
       const name = database[providerID]?.name || providerID
-      prompts.log.info(`${name} ${UI.Style.TEXT_DIM}${result.type}`)
+      if (result.type === "oauth") {
+        const count = await Auth.OAuthPool.list(providerID).then((accounts) => accounts.length)
+        prompts.log.info(`${name} ${UI.Style.TEXT_DIM}oauth${count > 1 ? ` (${count} accounts)` : ""}`)
+      } else {
+        prompts.log.info(`${name} ${UI.Style.TEXT_DIM}${result.type}`)
+      }
     }
 
     prompts.outro(`${results.length} credentials`)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -833,6 +833,20 @@ export namespace Config {
           }),
         )
         .optional(),
+      oauth: z
+        .object({
+          rateLimitCooldownMs: z.number().int().positive().optional().describe("Rate limit cooldown in milliseconds"),
+          authFailureCooldownMs: z.number().int().positive().optional().describe("Auth failure cooldown in milliseconds"),
+          maxAttempts: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum OAuth credential attempts per request"),
+          toastDurationMs: z.number().int().positive().optional().describe("Failover toast duration in milliseconds"),
+        })
+        .optional()
+        .describe("OAuth rotation settings"),
       options: z
         .object({
           apiKey: z.string().optional(),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -837,6 +837,12 @@ export namespace Config {
         .object({
           rateLimitCooldownMs: z.number().int().positive().optional().describe("Rate limit cooldown in milliseconds"),
           authFailureCooldownMs: z.number().int().positive().optional().describe("Auth failure cooldown in milliseconds"),
+          networkRetryAttempts: z
+            .number()
+            .int()
+            .nonnegative()
+            .optional()
+            .describe("Network retry attempts per OAuth credential before failing"),
           maxAttempts: z
             .number()
             .int()

--- a/packages/opencode/src/provider/auth.ts
+++ b/packages/opencode/src/provider/auth.ts
@@ -99,16 +99,13 @@ export namespace ProviderAuth {
           })
         }
         if ("refresh" in result) {
-          const info: Auth.Info = {
-            type: "oauth",
-            access: result.access,
+          await Auth.addOAuth(input.providerID, {
             refresh: result.refresh,
+            access: result.access,
             expires: result.expires,
-          }
-          if (result.accountId) {
-            info.accountId = result.accountId
-          }
-          await Auth.set(input.providerID, info)
+            accountId: result.accountId,
+            enterpriseUrl: result.enterpriseUrl,
+          })
         }
         return
       }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -9,6 +9,7 @@ import { Plugin } from "../plugin"
 import { ModelsDev } from "./models"
 import { NamedError } from "@opencode-ai/util/error"
 import { Auth } from "../auth"
+import { createOAuthRotatingFetch } from "../auth/rotating-fetch"
 import { Env } from "../env"
 import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
@@ -978,13 +979,13 @@ export namespace Provider {
           ...model.headers,
         }
 
-      const key = Bun.hash.xxHash32(JSON.stringify({ npm: model.api.npm, options }))
+      const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
       const existing = s.sdk.get(key)
       if (existing) return existing
 
       const customFetch = options["fetch"]
 
-      options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
+      const fetchWithTimeout = async (input: any, init?: BunFetchRequestInit) => {
         // Preserve custom fetch if it exists, wrap it with timeout logic
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
@@ -1005,6 +1006,10 @@ export namespace Provider {
           timeout: false,
         })
       }
+
+      options["fetch"] = createOAuthRotatingFetch(fetchWithTimeout, {
+        providerID: model.providerID,
+      })
 
       // Special case: google-vertex-anthropic uses a subpath import
       const bundledKey =

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1014,6 +1014,7 @@ export namespace Provider {
         maxAttempts: oauthConfig?.maxAttempts,
         rateLimitCooldownMs: oauthConfig?.rateLimitCooldownMs,
         authFailureCooldownMs: oauthConfig?.authFailureCooldownMs,
+        networkRetryAttempts: oauthConfig?.networkRetryAttempts,
         toastDurationMs: oauthConfig?.toastDurationMs,
       })
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -964,6 +964,7 @@ export namespace Provider {
         providerID: model.providerID,
       })
       const s = await state()
+      const config = await Config.get()
       const provider = s.providers[model.providerID]
       const options = { ...provider.options }
 
@@ -1007,8 +1008,13 @@ export namespace Provider {
         })
       }
 
+      const oauthConfig = config.provider?.[model.providerID]?.oauth
       options["fetch"] = createOAuthRotatingFetch(fetchWithTimeout, {
         providerID: model.providerID,
+        maxAttempts: oauthConfig?.maxAttempts,
+        rateLimitCooldownMs: oauthConfig?.rateLimitCooldownMs,
+        authFailureCooldownMs: oauthConfig?.authFailureCooldownMs,
+        toastDurationMs: oauthConfig?.toastDurationMs,
       })
 
       // Special case: google-vertex-anthropic uses a subpath import

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -497,6 +497,45 @@ export namespace Server {
           },
         )
         .get(
+          "/auth/usage",
+          describeRoute({
+            summary: "Get auth usage",
+            description: "Get rate limit and usage information for authenticated providers.",
+            operationId: "auth.usage",
+            responses: {
+              200: {
+                description: "Usage information per provider and account",
+                content: {
+                  "application/json": {
+                    schema: resolver(z.any().meta({ ref: "AuthUsage" })),
+                  },
+                },
+              },
+              ...errors(400),
+            },
+          }),
+          async (c) => {
+            const all = await Auth.all()
+            const result: Record<
+              string,
+              {
+                accounts: Awaited<ReturnType<typeof Auth.OAuthPool.getUsage>>
+                anthropicUsage?: Awaited<ReturnType<typeof Auth.OAuthPool.fetchAnthropicUsage>>
+              }
+            > = {}
+
+            for (const [providerID, info] of Object.entries(all)) {
+              if (info.type === "oauth") {
+                const accounts = await Auth.OAuthPool.getUsage(providerID)
+                const anthropicUsage = await Auth.OAuthPool.fetchAnthropicUsage(providerID)
+                result[providerID] = { accounts, anthropicUsage: anthropicUsage ?? undefined }
+              }
+            }
+
+            return c.json(result)
+          },
+        )
+        .get(
           "/experimental/tool/ids",
           describeRoute({
             summary: "List tool IDs",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -504,10 +504,8 @@ export namespace MessageV2 {
               text: part.text,
               providerMetadata: part.metadata,
             })
-          if (part.type === "step-start")
-            assistantMessage.parts.push({
-              type: "step-start",
-            })
+          // step-start parts are not added to UIMessage since "step-start" is not a valid
+          // UIMessagePart type in the AI SDK - they are only used internally for tracking
           if (part.type === "tool") {
             if (part.state.status === "completed") {
               assistantMessage.parts.push({
@@ -556,12 +554,9 @@ export namespace MessageV2 {
       }
     }
 
-    return convertToModelMessages(
-      result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
-      {
-        tools: options?.tools,
-      },
-    )
+    return convertToModelMessages(result, {
+      tools: options?.tools,
+    })
   }
 
   export const stream = fn(Identifier.schema("session"), async function* (sessionID) {

--- a/packages/opencode/test/auth/oauth-rotation.test.ts
+++ b/packages/opencode/test/auth/oauth-rotation.test.ts
@@ -210,4 +210,115 @@ describe("OAuth subscription failover", () => {
     expect(afterRateLimit[0]).toBe(a2.recordID)
     expect(afterRateLimit[1]).toBe(a1.recordID)
   })
+
+  test("does not retry non-replayable bodies but rotates for the next request", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const counts = new Map<string, number>()
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      counts.set(auth.refresh, (counts.get(auth.refresh) ?? 0) + 1)
+      return new Response("rate limited", { status: 429 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("payload"))
+        controller.close()
+      },
+    })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body })
+
+    expect(response.status).toBe(429)
+    expect(counts.get("r1") ?? 0).toBe(1)
+    expect(counts.get("r2") ?? 0).toBe(0)
+
+    const order = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(order[0]).toBe(a2.recordID)
+    expect(order[1]).toBe(a1.recordID)
+  })
+
+  test("returns the last response when all credentials are exhausted", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+      return new Response("rate limited", { status: 429 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+
+    expect(response.status).toBe(429)
+
+    const records = await Auth.OAuthPool.list(providerID)
+    const recordByID = new Map(records.map((record) => [record.id, record]))
+    expect(recordByID.get(a1.recordID)?.health.failureCount ?? 0).toBe(1)
+    expect(recordByID.get(a2.recordID)?.health.failureCount ?? 0).toBe(1)
+  })
+
+  test("fails over when a request throws", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      if (auth.refresh === "r1") {
+        throw new Error("network down")
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+
+    expect(response.status).toBe(200)
+
+    const records = await Auth.OAuthPool.list(providerID)
+    const recordByID = new Map(records.map((record) => [record.id, record]))
+    expect(recordByID.get(a1.recordID)?.health.failureCount ?? 0).toBe(1)
+    expect(recordByID.get(a2.recordID)?.health.failureCount ?? 0).toBe(0)
+  })
 })

--- a/packages/opencode/test/auth/oauth-rotation.test.ts
+++ b/packages/opencode/test/auth/oauth-rotation.test.ts
@@ -124,4 +124,90 @@ describe("OAuth subscription failover", () => {
     expect(record1?.type).toBe("oauth")
     expect(record1 && record1.type === "oauth" ? record1.access : "").toBe("refreshed-r1")
   })
+
+  test("fails over on 401/403 when refresh does not fix the credential", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "bad",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "ok",
+      expires: Date.now() + 60_000,
+    })
+
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      if (auth.refresh === "r1") {
+        return new Response("unauthorized", { status: 401 })
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+
+    expect(response.status).toBe(200)
+
+    const order = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(order[0]).toBe(a2.recordID)
+    expect(order[1]).toBe(a1.recordID)
+  })
+
+  test("sticks to the active credential until rate limited", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const counts = new Map<string, number>()
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      const refresh = auth.refresh
+      counts.set(refresh, (counts.get(refresh) ?? 0) + 1)
+
+      if (refresh === "r1" && (counts.get(refresh) ?? 0) >= 3) {
+        return new Response("rate limited", { status: 429 })
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+
+    const first = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+    expect(first.status).toBe(200)
+
+    const second = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+    expect(second.status).toBe(200)
+
+    const beforeRateLimit = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(beforeRateLimit[0]).toBe(a1.recordID)
+    expect(beforeRateLimit[1]).toBe(a2.recordID)
+
+    const third = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+    expect(third.status).toBe(200)
+
+    const afterRateLimit = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(afterRateLimit[0]).toBe(a2.recordID)
+    expect(afterRateLimit[1]).toBe(a1.recordID)
+  })
 })

--- a/packages/opencode/test/auth/oauth-rotation.test.ts
+++ b/packages/opencode/test/auth/oauth-rotation.test.ts
@@ -161,6 +161,42 @@ describe("OAuth subscription failover", () => {
     expect(order[1]).toBe(a1.recordID)
   })
 
+  test("fails over on non-auth errors", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      if (auth.refresh === "r1") {
+        return new Response("payment required", { status: 402 })
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+
+    expect(response.status).toBe(200)
+
+    const order = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(order[0]).toBe(a2.recordID)
+    expect(order[1]).toBe(a1.recordID)
+  })
+
   test("sticks to the active credential until rate limited", async () => {
     await Auth.remove(providerID)
 
@@ -285,7 +321,7 @@ describe("OAuth subscription failover", () => {
     expect(recordByID.get(a2.recordID)?.health.failureCount ?? 0).toBe(1)
   })
 
-  test("fails over when a request throws", async () => {
+  test("retries network errors without rotating", async () => {
     await Auth.remove(providerID)
 
     const a1 = await Auth.addOAuth(providerID, {
@@ -299,13 +335,20 @@ describe("OAuth subscription failover", () => {
       expires: Date.now() + 60_000,
     })
 
+    const counts = new Map<string, number>()
+    let failures = 0
     const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
       const auth = await Auth.get(providerID)
       expect(auth?.type).toBe("oauth")
       if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
 
-      if (auth.refresh === "r1") {
-        throw new Error("network down")
+      counts.set(auth.refresh, (counts.get(auth.refresh) ?? 0) + 1)
+
+      if (auth.refresh === "r1" && failures < 1) {
+        failures += 1
+        const error = new Error("network down")
+        ;(error as { code?: string }).code = "ECONNRESET"
+        throw error
       }
 
       return new Response("ok", { status: 200 })
@@ -316,10 +359,12 @@ describe("OAuth subscription failover", () => {
 
     expect(response.status).toBe(200)
 
-    const records = await Auth.OAuthPool.list(providerID)
-    const recordByID = new Map(records.map((record) => [record.id, record]))
-    expect(recordByID.get(a1.recordID)?.health.failureCount ?? 0).toBe(1)
-    expect(recordByID.get(a2.recordID)?.health.failureCount ?? 0).toBe(0)
+    expect(counts.get("r1") ?? 0).toBe(2)
+    expect(counts.get("r2") ?? 0).toBe(0)
+
+    const order = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(order[0]).toBe(a1.recordID)
+    expect(order[1]).toBe(a2.recordID)
   })
 
   test("respects Retry-After HTTP date headers", async () => {

--- a/packages/opencode/test/auth/oauth-rotation.test.ts
+++ b/packages/opencode/test/auth/oauth-rotation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test"
+import { Auth } from "../../src/auth"
+import { createOAuthRotatingFetch } from "../../src/auth/rotating-fetch"
+import { withOAuthRecord } from "../../src/auth/context"
+
+describe("OAuth subscription failover", () => {
+  const providerID = "oauth-rotation-test"
+
+  test("rotates on 429 (Retry-After) and succeeds with next account", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      if (auth.refresh === "r1") {
+        return new Response("rate limited", {
+          status: 429,
+          headers: {
+            "Retry-After": "1",
+          },
+        })
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+
+    expect(response.status).toBe(200)
+
+    const order = await Auth.OAuthPool.orderedIDs(providerID)
+    expect(order[0]).toBe(a2.recordID)
+    expect(order[1]).toBe(a1.recordID)
+  })
+
+  test("updates the correct OAuth record by refresh token without record context", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    const a2 = await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    await Auth.set(providerID, {
+      type: "oauth",
+      refresh: "r1",
+      access: "updated-a1",
+      expires: Date.now() + 60_000,
+    })
+
+    const record1 = await withOAuthRecord(providerID, a1.recordID, async () => Auth.get(providerID))
+    const record2 = await withOAuthRecord(providerID, a2.recordID, async () => Auth.get(providerID))
+
+    expect(record1?.type).toBe("oauth")
+    expect(record1 && record1.type === "oauth" ? record1.access : "").toBe("updated-a1")
+
+    expect(record2?.type).toBe("oauth")
+    expect(record2 && record2.type === "oauth" ? record2.access : "").toBe("a2")
+  })
+
+  test("retries once on 401/403 by forcing refresh, then succeeds", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "bad",
+      expires: Date.now() + 60_000,
+    })
+    await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "ok",
+      expires: Date.now() + 60_000,
+    })
+
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      // Simulate plugin refresh behavior: when access is cleared/expired,
+      // it refreshes and persists via Auth.set().
+      if (!auth.access) {
+        await Auth.set(providerID, {
+          type: "oauth",
+          refresh: auth.refresh,
+          access: `refreshed-${auth.refresh}`,
+          expires: Date.now() + 60_000,
+        })
+        return new Response("ok", { status: 200 })
+      }
+
+      if (auth.access === "bad") {
+        return new Response("unauthorized", { status: 401 })
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+    expect(response.status).toBe(200)
+
+    const record1 = await withOAuthRecord(providerID, a1.recordID, async () => Auth.get(providerID))
+    expect(record1?.type).toBe("oauth")
+    expect(record1 && record1.type === "oauth" ? record1.access : "").toBe("refreshed-r1")
+  })
+})

--- a/packages/opencode/test/auth/oauth-rotation.test.ts
+++ b/packages/opencode/test/auth/oauth-rotation.test.ts
@@ -321,4 +321,96 @@ describe("OAuth subscription failover", () => {
     expect(recordByID.get(a1.recordID)?.health.failureCount ?? 0).toBe(1)
     expect(recordByID.get(a2.recordID)?.health.failureCount ?? 0).toBe(0)
   })
+
+  test("respects Retry-After HTTP date headers", async () => {
+    await Auth.remove(providerID)
+
+    const a1 = await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const originalNow = Date.now
+    const now = 1_700_000_000_000
+    Date.now = () => now
+
+    try {
+      const retryAt = new Date(now + 5_000).toUTCString()
+      const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        const auth = await Auth.get(providerID)
+        expect(auth?.type).toBe("oauth")
+        if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+        if (auth.refresh === "r1") {
+          return new Response("rate limited", {
+            status: 429,
+            headers: {
+              "Retry-After": retryAt,
+            },
+          })
+        }
+
+        return new Response("ok", { status: 200 })
+      }
+
+      const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+      const response = await fetchWithFailover("https://example.com", { method: "POST", body: "{}" })
+
+      expect(response.status).toBe(200)
+
+      const records = await Auth.OAuthPool.list(providerID)
+      const recordByID = new Map(records.map((record) => [record.id, record]))
+      expect(recordByID.get(a1.recordID)?.health.cooldownUntil).toBe(now + 5_000)
+    } finally {
+      Date.now = originalNow
+    }
+  })
+
+  test("falls back when Request.clone throws", async () => {
+    await Auth.remove(providerID)
+
+    await Auth.addOAuth(providerID, {
+      refresh: "r1",
+      access: "a1",
+      expires: Date.now() + 60_000,
+    })
+    await Auth.addOAuth(providerID, {
+      refresh: "r2",
+      access: "a2",
+      expires: Date.now() + 60_000,
+    })
+
+    const counts = new Map<string, number>()
+    const baseFetch = async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      const auth = await Auth.get(providerID)
+      expect(auth?.type).toBe("oauth")
+      if (!auth || auth.type !== "oauth") return new Response("no auth", { status: 500 })
+
+      counts.set(auth.refresh, (counts.get(auth.refresh) ?? 0) + 1)
+
+      if (auth.refresh === "r1") {
+        return new Response("rate limited", { status: 429 })
+      }
+
+      return new Response("ok", { status: 200 })
+    }
+
+    const request = new Request("https://example.com", { method: "POST" })
+    ;(request as { clone: () => Request }).clone = () => {
+      throw new Error("clone failed")
+    }
+
+    const fetchWithFailover = createOAuthRotatingFetch(baseFetch, { providerID })
+    const response = await fetchWithFailover(request)
+
+    expect(response.status).toBe(429)
+    expect(counts.get("r1") ?? 0).toBe(1)
+    expect(counts.get("r2") ?? 0).toBe(0)
+  })
 })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -115,7 +115,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
                 access: string
                 expires: number
                 accountId?: string
-                enterpriseUrl?: string
+                enterpriseUrl?: string // Used for GitHub Copilot Enterprise auth flows.
               }
             | { key: string }
           ))
@@ -136,7 +136,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
                 access: string
                 expires: number
                 accountId?: string
-                enterpriseUrl?: string
+                enterpriseUrl?: string // Used for GitHub Copilot Enterprise auth flows.
               }
             | { key: string }
           ))

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -115,6 +115,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
                 access: string
                 expires: number
                 accountId?: string
+                enterpriseUrl?: string
               }
             | { key: string }
           ))
@@ -135,6 +136,7 @@ export type AuthOuathResult = { url: string; instructions: string } & (
                 access: string
                 expires: number
                 accountId?: string
+                enterpriseUrl?: string
               }
             | { key: string }
           ))


### PR DESCRIPTION
## Summary

Adds visibility into OAuth rate limits and usage information for authenticated providers, particularly useful for Claude Max users to monitor their 5-hour and 7-day usage limits.

Closes #8911

## Changes

### Backend (`packages/opencode`)
- **`src/auth/index.ts`**: Add `getUsage()` and `fetchAnthropicUsage()` functions to OAuthPool
- **`src/server/server.ts`**: Add `GET /auth/usage` API endpoint
- **`src/cli/cmd/auth.ts`**: Add `opencode auth usage` CLI command

### Frontend (`packages/app`)
- **`src/components/dialog-auth-usage.tsx`**: New dialog component with:
  - Provider list with account counts
  - Anthropic usage limits visualization (5-hour, 7-day)
  - Color-coded progress bars (green/yellow/red)
  - Account status with cooldown indicators
  - Refresh button
- **`src/pages/layout.tsx`**: Add sidebar button to open usage dialog

## Screenshots

The dialog displays:
- Usage bars showing utilization percentage
- Reset time countdown
- Active account indicator
- Cooldown status when rate-limited

## Testing

- [x] Tested with Claude Max account
- [x] CLI command works correctly
- [x] API endpoint returns expected data

## Note

This PR includes the OAuth multi-account failover commits from @gwizz as a foundation, since the usage dashboard builds on that infrastructure. Credit to gwizz for the excellent OAuth rotation system!