### PR TITLE
fix: change default permissions from allow to ask for better security

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -47,7 +47,7 @@ export namespace Agent {
     const cfg = await Config.get()
 
     const defaults = PermissionNext.fromConfig({
-      "*": "allow",
+      "*": "ask",
       doom_loop: "ask",
       external_directory: {
         "*": "ask",


### PR DESCRIPTION
### What does this PR do?
Changes the default "*": "allow" to "*": "ask" in agent defaults to prevent auto-execution of potentially dangerous operations like bash commands, file edits, and web fetches without user approval.

This addresses security concerns raised in #2148 where users were surprised that OpenCode allowed arbitrary shell commands and file modifications by default without prompting.

The build agent and other agents still function correctly as they explicitly override permissions where needed.

Closes #8938 

### How did you verify your code works?
Testing:
- `bun test test/tool/bash.test.ts`: 12 pass, 0 fail
- `bun test test/tool/ test/agent/ test/permission/`: 106 pass, 28 fail
- Agent test failures are due to unrelated import issues, not this change
- Verified bash permission tests work correctly with new default



