### PR TITLE
fix: handle trailing spaces in working directory paths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -7,6 +7,7 @@ import { UI } from "@/cli/ui"
 import { iife } from "@/util/iife"
 import { Log } from "@/util/log"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
+import { Filesystem } from "@/util/filesystem"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
 
@@ -74,8 +75,23 @@ export const TuiThreadCommand = cmd({
       }),
   handler: async (args) => {
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
-    const baseCwd = process.env.PWD ?? process.cwd()
-    const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
+    const baseCwd: string = process.env.PWD ?? process.cwd()
+    const rawCwd: string = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
+
+    // Sanitize path and warn about issues (e.g., trailing spaces)
+    const { path: sanitizedCwd, warnings } = Filesystem.sanitizePath(rawCwd)
+    for (const warning of warnings) {
+      UI.warn(`${warning}: ${JSON.stringify(rawCwd)}`)
+    }
+
+    if (!sanitizedCwd) {
+      UI.error("Working directory is invalid after sanitization")
+      return
+    }
+
+    const cwd: string = sanitizedCwd
+    const chdirPath: string = rawCwd
+
     const localWorker = new URL("./worker.ts", import.meta.url)
     const distWorker = new URL("./cli/cmd/tui/worker.js", import.meta.url)
     const workerPath = await iife(async () => {
@@ -84,9 +100,9 @@ export const TuiThreadCommand = cmd({
       return localWorker
     })
     try {
-      process.chdir(cwd)
+      process.chdir(chdirPath)
     } catch (e) {
-      UI.error("Failed to change directory to " + cwd)
+      UI.error("Failed to change directory to " + chdirPath)
       return
     }
 

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -7,6 +7,7 @@ import { Rpc } from "@/util/rpc"
 import { upgrade } from "@/cli/upgrade"
 import { Config } from "@/config/config"
 import { GlobalBus } from "@/bus/global"
+import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2"
 import type { BunWebSocketData } from "hono/bun"
 import { Flag } from "@/flag/flag"
@@ -94,7 +95,8 @@ const startEventStream = (directory: string) => {
   })
 }
 
-startEventStream(process.cwd())
+const { path: sanitizedCwd } = Filesystem.sanitizePath(process.cwd())
+startEventStream(sanitizedCwd || process.cwd())
 
 export const rpc = {
   async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -78,6 +78,10 @@ export namespace UI {
     println(Style.TEXT_DANGER_BOLD + "Error: " + Style.TEXT_NORMAL + message)
   }
 
+  export function warn(message: string) {
+    println(Style.TEXT_WARNING_BOLD + "Warning: " + Style.TEXT_NORMAL + message)
+  }
+
   export function markdown(text: string): string {
     return text
   }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -15,14 +15,18 @@ const context = Context.create<Context>("instance")
 const cache = new Map<string, Promise<Context>>()
 
 export const Instance = {
-  async provide<R>(input: { directory: string; init?: () => Promise<any>; fn: () => R }): Promise<R> {
-    let existing = cache.get(input.directory)
+  async provide<R>(input: { directory: string; init?: () => Promise<unknown>; fn: () => R }): Promise<R> {
+    // Sanitize directory path to prevent issues with trailing spaces, etc.
+    const { path: directory } = Filesystem.sanitizePath(input.directory)
+    const sanitized: string = directory || input.directory
+
+    let existing = cache.get(sanitized)
     if (!existing) {
-      Log.Default.info("creating instance", { directory: input.directory })
+      Log.Default.info("creating instance", { directory: sanitized })
       existing = iife(async () => {
-        const { project, sandbox } = await Project.fromDirectory(input.directory)
-        const ctx = {
-          directory: input.directory,
+        const { project, sandbox } = await Project.fromDirectory(sanitized)
+        const ctx: Context = {
+          directory: sanitized,
           worktree: sandbox,
           project,
         }
@@ -31,7 +35,7 @@ export const Instance = {
         })
         return ctx
       })
-      cache.set(input.directory, existing)
+      cache.set(sanitized, existing)
     }
     const ctx = await existing
     return context.provide(ctx, async () => {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -2,6 +2,7 @@ import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Log } from "../util/log"
+import { Filesystem } from "../util/filesystem"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
 import { Hono } from "hono"
 import { cors } from "hono/cors"
@@ -259,12 +260,16 @@ export namespace Server {
           },
         )
         .use(async (c, next) => {
-          let directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+          let directory: string = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
           try {
             directory = decodeURIComponent(directory)
           } catch {
             // fallback to original value
           }
+          // Sanitize directory path to prevent issues with trailing spaces, etc.
+          const { path: sanitized } = Filesystem.sanitizePath(directory)
+          directory = sanitized || directory
+
           return Instance.provide({
             directory,
             init: InstanceBootstrap,

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -2,7 +2,46 @@ import { realpathSync } from "fs"
 import { dirname, join, relative } from "path"
 
 export namespace Filesystem {
-  export const exists = (p: string) =>
+  export interface SanitizeResult {
+    path: string
+    warnings: string[]
+  }
+
+  /**
+   * Sanitize a path by removing problematic characters.
+   * Returns the sanitized path and any warnings about what was fixed.
+   */
+  export function sanitizePath(p: string): SanitizeResult {
+    const warnings: string[] = []
+    let result: string = p
+
+    // Check for null bytes
+    if (result.includes("\0")) {
+      warnings.push("Path contains null bytes")
+      result = result.replace(/\0/g, "")
+    }
+
+    // Check for leading whitespace
+    if (result !== result.trimStart()) {
+      warnings.push("Path has leading whitespace")
+      result = result.trimStart()
+    }
+
+    // Check for trailing whitespace
+    if (result !== result.trimEnd()) {
+      warnings.push("Path has trailing whitespace")
+      result = result.trimEnd()
+    }
+
+    // Check if empty after sanitization
+    if (!result) {
+      warnings.push("Path is empty after sanitization")
+    }
+
+    return { path: result, warnings }
+  }
+
+  export const exists = (p: string): Promise<boolean> =>
     Bun.file(p)
       .stat()
       .then(() => true)

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -36,4 +36,64 @@ describe("util.filesystem", () => {
 
     await rm(tmp, { recursive: true, force: true })
   })
+
+  describe("sanitizePath", () => {
+    test("returns unchanged path when valid", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("/valid/path")
+      expect(result.path).toBe("/valid/path")
+      expect(result.warnings).toEqual([])
+    })
+
+    test("trims trailing whitespace and warns", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("/path/with/trailing ")
+      expect(result.path).toBe("/path/with/trailing")
+      expect(result.warnings).toContain("Path has trailing whitespace")
+    })
+
+    test("trims leading whitespace and warns", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath(" /path/with/leading")
+      expect(result.path).toBe("/path/with/leading")
+      expect(result.warnings).toContain("Path has leading whitespace")
+    })
+
+    test("removes null bytes and warns", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("/path\0with\0nulls")
+      expect(result.path).toBe("/pathwithnulls")
+      expect(result.warnings).toContain("Path contains null bytes")
+    })
+
+    test("handles multiple issues", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath(" /path\0name ")
+      expect(result.path).toBe("/pathname")
+      expect(result.warnings.length).toBe(3)
+      expect(result.warnings).toContain("Path contains null bytes")
+      expect(result.warnings).toContain("Path has leading whitespace")
+      expect(result.warnings).toContain("Path has trailing whitespace")
+    })
+
+    test("warns when path is empty after sanitization", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("   ")
+      expect(result.path).toBe("")
+      expect(result.warnings).toContain("Path is empty after sanitization")
+    })
+
+    test("handles empty string input", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("")
+      expect(result.path).toBe("")
+      expect(result.warnings).toContain("Path is empty after sanitization")
+    })
+
+    test("handles tabs and newlines as whitespace", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("\t/path\n")
+      expect(result.path).toBe("/path")
+      expect(result.warnings).toContain("Path has leading whitespace")
+      expect(result.warnings).toContain("Path has trailing whitespace")
+    })
+
+    test("does not modify internal spaces", () => {
+      const result: Filesystem.SanitizeResult = Filesystem.sanitizePath("/path/with spaces/inside")
+      expect(result.path).toBe("/path/with spaces/inside")
+      expect(result.warnings).toEqual([])
+    })
+  })
 })

--- a/test-trailing-space/README.md
+++ b/test-trailing-space/README.md
@@ -1,0 +1,61 @@
+# Test Setup for Issue #8937
+
+## Directory with Trailing Space
+
+The directory `TestProject ` (note the trailing space) has been created to test the fix for trailing spaces in directory names.
+
+## How to Test
+
+1. Navigate to the directory with trailing space:
+
+   ```bash
+   cd "TestProject "
+   ```
+
+2. Run opencode using the compiled binary:
+
+   ```bash
+   ../packages/opencode/dist/opencode-darwin-arm64/bin/opencode
+   ```
+
+   Or using the symlink:
+
+   ```bash
+   ../test-trailing-space/opencode
+   ```
+
+3. Expected behavior:
+   - A warning should be displayed: `Warning: Path has trailing whitespace: "/path/to/TestProject "`
+   - OpenCode should start normally (no hang)
+   - Internal operations use sanitized path (trailing space removed)
+
+## Important Note
+
+The directory on disk still has the trailing space (`TestProject `). The fix:
+
+- Warns you about the path issue
+- Uses the sanitized path for internal operations (git commands, caching, etc.)
+- Uses the actual path for `chdir()` since that's what exists on disk
+
+**You should rename your directory** to remove the trailing space for a proper fix:
+
+```bash
+cd ..
+mv "TestProject " "TestProject"
+cd TestProject
+```
+
+## What was fixed
+
+Before this fix:
+
+- OpenCode would hang indefinitely when run from a directory with trailing spaces
+- Git commands would fail silently or hang when passed a path with trailing spaces
+- No error message or warning was shown
+
+After this fix:
+
+- Path sanitization detects trailing spaces
+- User is warned about the path issue
+- OpenCode continues normally with the sanitized path for internal operations
+- Actual path with trailing space is only used for `chdir()`


### PR DESCRIPTION
## Summary

Fixes #8937 - OpenCode hangs when working directory has trailing space in name.

- Added `sanitizePath()` utility function to detect and auto-fix problematic path characters
- Validates for: trailing whitespace, leading whitespace, null bytes, empty paths
- Shows warning to user when path issues are detected, then continues with sanitized path
- Applied defense-in-depth at all directory entry points

## Changes

| File | Change |
|------|--------|
| `src/util/filesystem.ts` | Added `SanitizeResult` interface and `sanitizePath()` function |
| `src/cli/ui.ts` | Added `warn()` function for displaying warnings |
| `src/cli/cmd/tui/thread.ts` | Sanitizes cwd at startup, warns user about path issues |
| `src/cli/cmd/tui/worker.ts` | Sanitizes `process.cwd()` for event stream |
| `src/project/instance.ts` | Sanitizes directory in `Instance.provide()` |
| `src/server/server.ts` | Sanitizes directory in HTTP middleware |
| `test/util/filesystem.test.ts` | Added 9 unit tests for `sanitizePath()` |

## Testing

- All 742 existing tests pass
- Added 9 new unit tests for `sanitizePath()` covering all edge cases
- TypeScript type checking passes