### PR TITLE
fix: remove invalid step-start parts from UIMessage conversion

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -504,10 +504,8 @@ export namespace MessageV2 {
               text: part.text,
               providerMetadata: part.metadata,
             })
-          if (part.type === "step-start")
-            assistantMessage.parts.push({
-              type: "step-start",
-            })
+          // step-start parts are not added to UIMessage since "step-start" is not a valid
+          // UIMessagePart type in the AI SDK - they are only used internally for tracking
           if (part.type === "tool") {
             if (part.state.status === "completed") {
               assistantMessage.parts.push({
@@ -556,12 +554,9 @@ export namespace MessageV2 {
       }
     }
 
-    return convertToModelMessages(
-      result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
-      {
-        tools: options?.tools,
-      },
-    )
+    return convertToModelMessages(result, {
+      tools: options?.tools,
+    })
   }
 
   export const stream = fn(Identifier.schema("session"), async function* (sessionID) {


### PR DESCRIPTION
## Summary

Fixes `AI_InvalidPromptError` that breaks sessions when compaction is triggered.

## Problem

When a session's context overflows and compaction is triggered, the following error occurs:

```
AI_InvalidPromptError: Invalid prompt: The messages must be a ModelMessage[]. 
If you have passed a UIMessage[], you can use convertToModelMessages to convert them.
```

This happens because `step-start` parts are being added to `UIMessage` objects, but `step-start` is not a valid `UIMessagePart` type in the AI SDK's `convertToModelMessages()` function.

## Solution

- Remove `step-start` from being added to UIMessage parts (it's only used internally for tracking)
- Simplify the result filter since `step-start` is no longer included

## Testing

- [x] Sessions can now compact without errors
- [x] Existing sessions with context overflow can be recovered