### PR TITLE
fix: keep primary model after subagent runs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -145,9 +145,9 @@ export function Prompt(props: PromptProps) {
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)
       if (msg.agent && isPrimaryAgent) {
         local.agent.set(msg.agent)
+        if (msg.model) local.model.set(msg.model)
+        if (msg.variant) local.model.variant.set(msg.variant)
       }
-      if (msg.model) local.model.set(msg.model)
-      if (msg.variant) local.model.variant.set(msg.variant)
     }
   })
 


### PR DESCRIPTION
## Summary

Prevents subagent model from overriding primary agent model in TUI.

Fixes #8946
Fixes #7430

## Reasoning

The existing `isPrimaryAgent` guard already prevents subagent names from overriding the primary agent selection. Model and variant appear to have been unintentionally left outside this guard, causing the leak. This fix moves them inside the same guard for consistency.

There is an existing PR #7428 that proposes a config option to opt-in to isolation. This would work but I think this is a bug and not a feature?

## Verification

Tested according to repro steps in #8946: configured subagent with different model, invoked it, interrupted during work, navigated back to primary agent, the primary agent model was retained.

Note: the web app (`packages/app/src/pages/session.tsx`) may have the same bug but is not addressed here.