### PR TITLE
fix(opentui): prevent long session titles from wrapping

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -12,7 +12,7 @@ import { Installation } from "@/installation"
 const Title = (props: { session: Accessor<Session> }) => {
   const { theme } = useTheme()
   return (
-    <text fg={theme.text}>
+    <text fg={theme.text} wrapMode="none">
       <span style={{ bold: true }}>#</span> <span style={{ bold: true }}>{props.session().title}</span>
     </text>
   )


### PR DESCRIPTION
## Summary

- Add `wrapMode="none"` to the Title component to prevent long session titles from creating an empty line

Fixes #8916

## Problem

When a session title is very long, the default `wrapMode="word"` causes the text to wrap to a new line, creating an unwanted empty line in the header.

## Solution

Added `wrapMode="none"` to the `<text>` element in the Title component, consistent with how `ContextInfo` already handles this on line 25.

## Verification

- Ran `bun turbo typecheck` - passes
- The fix follows the same pattern used in `ContextInfo` component