### PR TITLE
chore: cleanup nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ opencode.json
 a.out
 target
 .scripts
+.direnv/
 
 # Local dev files
 opencode-dev

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768395095,
-        "narHash": "sha256-ZhuYJbwbZT32QA95tSkXd9zXHcdZj90EzHpEXBMabaw=",
+        "lastModified": 1768302833,
+        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13868c071cc73a5e9f610c47d7bb08e5da64fdd5",
+        "rev": "61db79b0c6b838d9894923920b612048e1201926",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
 
   outputs =
     {
+      self,
       nixpkgs,
       ...
     }:
@@ -107,32 +108,9 @@
           };
         in
         {
-          default = opencodePkg;
+          default = self.packages.${system}.opencode;
+          opencode = opencodePkg;
           desktop = desktopPkg;
-        }
-      );
-
-      apps = forEachSystem (
-        system:
-        let
-          pkgs = pkgsFor system;
-        in
-        {
-          opencode-dev = {
-            type = "app";
-            meta = {
-              description = "Nix devshell shell for OpenCode";
-              runtimeInputs = [ pkgs.bun ];
-            };
-            program = "${
-              pkgs.writeShellApplication {
-                name = "opencode-dev";
-                text = ''
-                  exec bun run dev "$@"
-                '';
-              }
-            }/bin/opencode-dev";
-          };
         }
       );
     };


### PR DESCRIPTION
"nix run .#opencode-dev" doesnt even work there's already a devShell which enables running "bun run dev" so the wrapper app is basically useless

also reverts nixpkgs to use bun 1.3.5 in line with the package.json
