### PR TITLE
fix(nix): add desktop application entry

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -15,6 +15,8 @@
   cargo,
   rustc,
   makeBinaryWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
   nodejs,
   jq,
 }:
@@ -57,10 +59,26 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     bun
     makeBinaryWrapper
+    copyDesktopItems
     cargo
     rustc
     nodejs
     jq
+  ];
+
+  # based on packages/desktop/src-tauri/release/appstream.metainfo.xml
+  desktopItems = lib.optionals stdenv.isLinux [
+    (makeDesktopItem {
+      name = "ai.opencode.opencode";
+      desktopName = "OpenCode";
+      comment = "Open source AI coding agent";
+      exec = "opencode-desktop";
+      icon = "opencode";
+      terminal = false;
+      type = "Application";
+      categories = [ "Development" "IDE" ];
+      startupWMClass = "opencode";
+    })
   ];
 
   buildInputs = [
@@ -121,6 +139,10 @@ rustPlatform.buildRustPackage rec {
   # It looks for them in the location specified in tauri.conf.json.
 
   postInstall = lib.optionalString stdenv.isLinux ''
+    # Install icon
+    mkdir -p $out/share/icons/hicolor/128x128/apps
+    cp ../../../packages/desktop/src-tauri/icons/prod/128x128.png $out/share/icons/hicolor/128x128/apps/opencode.png
+
     # Wrap the binary to ensure it finds the libraries
     wrapProgram $out/bin/opencode-desktop \
       --prefix LD_LIBRARY_PATH : ${


### PR DESCRIPTION
Adds desktop entry to nix opencode-desktop app
<img width="933" height="623" alt="image" src="https://github.com/user-attachments/assets/b8289b8d-1c4f-4363-abcb-12a0cda88b80" />

Before:
<img width="365" height="103" alt="image" src="https://github.com/user-attachments/assets/729b120e-573d-4a3c-9686-a16b306f8b4a" />

After:
<img width="391" height="134" alt="image" src="https://github.com/user-attachments/assets/6b6c9a59-deb3-493d-b3bb-cda0be77d351" />


Closes #8971 