### PR TITLE
feat: add Question tool instructions to system prompts

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
-const childProcess = require("child_process")
-const fs = require("fs")
-const path = require("path")
-const os = require("os")
+import { spawnSync } from "child_process"
+import fs from "fs"
+import path from "path"
+import os from "os"
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 function run(target) {
-  const result = childProcess.spawnSync(target, process.argv.slice(2), {
+  const result = spawnSync(target, process.argv.slice(2), {
     stdio: "inherit",
   })
   if (result.error) {
@@ -48,6 +52,12 @@ const base = "opencode-" + platform + "-" + arch
 const binary = platform === "windows" ? "opencode.exe" : "opencode"
 
 function findBinary(startDir) {
+  // Check dist folder for local development
+  const distCandidate = path.join(startDir, "..", "dist", base, "bin", binary)
+  if (fs.existsSync(distCandidate)) {
+    return distCandidate
+  }
+
   let current = startDir
   for (;;) {
     const modules = path.join(current, "node_modules")

--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -117,6 +117,9 @@ export const McpListCommand = cmd({
             statusIcon = "✗"
             statusText = "needs client registration"
             hint = "\n    " + status.error
+          } else if (status.status === "connecting") {
+            statusIcon = "⋯"
+            statusText = "connecting"
           } else {
             statusIcon = "✗"
             statusText = "failed"

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -93,7 +93,7 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
     timeout = setTimeout(() => {
       cleanup()
       resolve("dark")
-    }, 1000)
+    }, 100)
   })
 }
 

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -74,6 +74,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { FilePathLink } from "../../ui/link"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1507,7 +1508,12 @@ function InlineTool(props: {
   )
 }
 
-function BlockTool(props: { title: string; children: JSX.Element; onClick?: () => void; part?: ToolPart }) {
+function BlockTool(props: {
+  title: string | JSX.Element
+  children: JSX.Element
+  onClick?: () => void
+  part?: ToolPart
+}) {
   const { theme } = useTheme()
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
@@ -1619,7 +1625,14 @@ function Write(props: ToolProps<typeof WriteTool>) {
   return (
     <Switch>
       <Match when={props.metadata.diagnostics !== undefined}>
-        <BlockTool title={"# Wrote " + normalizePath(props.input.filePath!)} part={props.part}>
+        <BlockTool
+          title={
+            <>
+              # Wrote <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>
+            </>
+          }
+          part={props.part}
+        >
           <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
             <code
               conceal={false}
@@ -1642,7 +1655,7 @@ function Write(props: ToolProps<typeof WriteTool>) {
       </Match>
       <Match when={true}>
         <InlineTool icon="←" pending="Preparing write..." complete={props.input.filePath} part={props.part}>
-          Write {normalizePath(props.input.filePath!)}
+          Write <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>
         </InlineTool>
       </Match>
     </Switch>
@@ -1652,7 +1665,10 @@ function Write(props: ToolProps<typeof WriteTool>) {
 function Glob(props: ToolProps<typeof GlobTool>) {
   return (
     <InlineTool icon="✱" pending="Finding files..." complete={props.input.pattern} part={props.part}>
-      Glob "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      Glob "{props.input.pattern}"{" "}
+      <Show when={props.input.path}>
+        in <FilePathLink path={props.input.path!}>{normalizePath(props.input.path)}</FilePathLink>{" "}
+      </Show>
       <Show when={props.metadata.count}>({props.metadata.count} matches)</Show>
     </InlineTool>
   )
@@ -1661,7 +1677,8 @@ function Glob(props: ToolProps<typeof GlobTool>) {
 function Read(props: ToolProps<typeof ReadTool>) {
   return (
     <InlineTool icon="→" pending="Reading file..." complete={props.input.filePath} part={props.part}>
-      Read {normalizePath(props.input.filePath!)} {input(props.input, ["filePath"])}
+      Read <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>{" "}
+      {input(props.input, ["filePath"])}
     </InlineTool>
   )
 }
@@ -1669,30 +1686,31 @@ function Read(props: ToolProps<typeof ReadTool>) {
 function Grep(props: ToolProps<typeof GrepTool>) {
   return (
     <InlineTool icon="✱" pending="Searching content..." complete={props.input.pattern} part={props.part}>
-      Grep "{props.input.pattern}" <Show when={props.input.path}>in {normalizePath(props.input.path)} </Show>
+      Grep "{props.input.pattern}"{" "}
+      <Show when={props.input.path}>
+        in <FilePathLink path={props.input.path!}>{normalizePath(props.input.path)}</FilePathLink>{" "}
+      </Show>
       <Show when={props.metadata.matches}>({props.metadata.matches} matches)</Show>
     </InlineTool>
   )
 }
 
 function List(props: ToolProps<typeof ListTool>) {
-  const dir = createMemo(() => {
-    if (props.input.path) {
-      return normalizePath(props.input.path)
-    }
-    return ""
-  })
   return (
     <InlineTool icon="→" pending="Listing directory..." complete={props.input.path !== undefined} part={props.part}>
-      List {dir()}
+      List{" "}
+      <Show when={props.input.path}>
+        <FilePathLink path={props.input.path!}>{normalizePath(props.input.path)}</FilePathLink>
+      </Show>
     </InlineTool>
   )
 }
 
 function WebFetch(props: ToolProps<typeof WebFetchTool>) {
+  const url = () => (props.input as any).url
   return (
-    <InlineTool icon="%" pending="Fetching from the web..." complete={(props.input as any).url} part={props.part}>
-      WebFetch {(props.input as any).url}
+    <InlineTool icon="%" pending="Fetching from the web..." complete={url()} part={props.part}>
+      WebFetch <a href={url()}>{url()}</a>
     </InlineTool>
   )
 }
@@ -1795,7 +1813,15 @@ function Edit(props: ToolProps<typeof EditTool>) {
   return (
     <Switch>
       <Match when={props.metadata.diff !== undefined}>
-        <BlockTool title={"← Edit " + normalizePath(props.input.filePath!)} part={props.part}>
+        <BlockTool
+          title={
+            <>
+              {"← Edit "}
+              <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>
+            </>
+          }
+          part={props.part}
+        >
           <box paddingLeft={1}>
             <diff
               diff={diffContent()}
@@ -1833,7 +1859,8 @@ function Edit(props: ToolProps<typeof EditTool>) {
       </Match>
       <Match when={true}>
         <InlineTool icon="←" pending="Preparing edit..." complete={props.input.filePath} part={props.part}>
-          Edit {normalizePath(props.input.filePath!)} {input({ replaceAll: props.input.replaceAll })}
+          Edit <FilePathLink path={props.input.filePath!}>{normalizePath(props.input.filePath!)}</FilePathLink>{" "}
+          {input({ replaceAll: props.input.replaceAll })}
         </InlineTool>
       </Match>
     </Switch>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -75,6 +75,7 @@ import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { FilePathLink } from "../../ui/link"
+import { TextWithLinks } from "../../ui/text-with-links"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1302,6 +1303,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+
   return (
     <Show when={props.part.text.trim()}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
@@ -1518,6 +1520,24 @@ function BlockTool(props: {
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
+
+  // Wrap title in a fragment instead of text if it's already an element (like FilePathLink)
+  // to avoid nested text rendering issues which might break links
+  const titleContent = createMemo(() => {
+    if (typeof props.title === "string") {
+      return (
+        <text paddingLeft={3} fg={theme.textMuted}>
+          {props.title}
+        </text>
+      )
+    }
+    return (
+      <text paddingLeft={3} fg={theme.textMuted}>
+        {props.title}
+      </text>
+    )
+  })
+
   return (
     <box
       border={["left"]}
@@ -1536,9 +1556,7 @@ function BlockTool(props: {
         props.onClick?.()
       }}
     >
-      <text paddingLeft={3} fg={theme.textMuted}>
-        {props.title}
-      </text>
+      {titleContent()}
       {props.children}
       <Show when={error()}>
         <text fg={theme.error}>{error()}</text>
@@ -1594,7 +1612,7 @@ function Bash(props: ToolProps<typeof BashTool>) {
         >
           <box gap={1}>
             <text fg={theme.text}>$ {props.input.command}</text>
-            <text fg={theme.text}>{limited()}</text>
+            <TextWithLinks text={limited()} fg={theme.text} />
             <Show when={overflow()}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
             </Show>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -11,6 +11,7 @@ import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
+import { FilePathLink } from "../../ui/link"
 
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const sync = useSync()
@@ -240,7 +241,9 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                       return (
                         <box flexDirection="row" gap={1} justifyContent="space-between">
                           <text fg={theme.textMuted} wrapMode="none">
-                            {item.file}
+                            <FilePathLink path={item.file} fg={theme.textMuted}>
+                              {item.file}
+                            </FilePathLink>
                           </text>
                           <box flexDirection="row" gap={1} flexShrink={0}>
                             <Show when={item.additions}>

--- a/packages/opencode/src/cli/cmd/tui/ui/link.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/link.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "solid-js"
 import type { RGBA } from "@opentui/core"
-import open from "open"
+import path from "path"
 
 export interface LinkProps {
   href: string
@@ -8,21 +8,30 @@ export interface LinkProps {
   fg?: RGBA
 }
 
-/**
- * Link component that renders clickable hyperlinks.
- * Clicking anywhere on the link text opens the URL in the default browser.
- */
 export function Link(props: LinkProps) {
   const displayText = props.children ?? props.href
 
   return (
-    <text
-      fg={props.fg}
-      onMouseUp={() => {
-        open(props.href).catch(() => {})
-      }}
-    >
+    <a href={props.href} style={{ fg: props.fg }}>
       {displayText}
-    </text>
+    </a>
+  )
+}
+
+export interface FilePathLinkProps {
+  path: string
+  children?: JSX.Element | string
+  fg?: RGBA
+}
+
+export function FilePathLink(props: FilePathLinkProps) {
+  const displayText = props.children ?? props.path
+  const absolutePath = path.isAbsolute(props.path) ? props.path : path.resolve(process.cwd(), props.path)
+  const fileUrl = `file://${absolutePath}`
+
+  return (
+    <a href={fileUrl} style={{ fg: props.fg }}>
+      {displayText}
+    </a>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/ui/text-with-links.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/text-with-links.tsx
@@ -1,0 +1,98 @@
+import { For, createMemo } from "solid-js"
+import { FilePathLink, Link } from "./link"
+import type { RGBA } from "@opentui/core"
+import { useTheme } from "@tui/context/theme"
+
+const PATH_REGEX =
+  /((?:https?:\/\/[^\s"'()<>]+)|(?:\/|~|\.\.?\/)[^\s"'()<>]+|(?:[\w.-]+\/[^\s"'()<>]*)|(?:[a-zA-Z][\w.-]*\.\w{2,})|(?:[\w.-]+[*@/])|(?:\*\*[^*]+\*\*)|(?:_[^_]+_)|(?:`[^`]+`))/g
+
+export function TextWithLinks(props: { text: string; fg?: RGBA }) {
+  const { theme } = useTheme()
+
+  const parts = createMemo(() => {
+    const text = props.text
+    const result = []
+    let lastIndex = 0
+    let match
+
+    while ((match = PATH_REGEX.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        result.push({ type: "text", content: text.slice(lastIndex, match.index) })
+      }
+
+      let content = match[0]
+
+      // Handle Markdown formatting
+      if (content.startsWith("**") && content.endsWith("**")) {
+        result.push({ type: "bold", content: content.slice(2, -2) })
+      } else if (content.startsWith("_") && content.endsWith("_")) {
+        result.push({ type: "italic", content: content.slice(1, -1) })
+      } else if (content.startsWith("`") && content.endsWith("`")) {
+        // For code spans, we strip backticks.
+        // Optionally we could check if the code content is a file path?
+        // Let's just treat it as styled text for now to be safe.
+        result.push({ type: "code", content: content.slice(1, -1) })
+      } else {
+        // Trim trailing punctuation usually found at end of sentences or in lists
+        const suffixMatch = content.match(/[.,:;`'"})\]>]+$/)
+        const suffix = suffixMatch ? suffixMatch[0] : ""
+        content = content.substring(0, content.length - suffix.length)
+
+        if (content.length < 2) {
+          result.push({ type: "text", content: match[0] })
+        } else {
+          const isUrl = content.startsWith("http")
+          result.push({
+            type: isUrl ? "url" : "path",
+            content: content,
+          })
+          if (suffix) {
+            result.push({ type: "text", content: suffix })
+          }
+        }
+      }
+
+      lastIndex = PATH_REGEX.lastIndex
+    }
+
+    if (lastIndex < text.length) {
+      result.push({ type: "text", content: text.slice(lastIndex) })
+    }
+
+    return result
+  })
+
+  return (
+    <text fg={props.fg}>
+      <For each={parts()}>
+        {(part) => {
+          if (part.type === "url") {
+            return (
+              <Link href={part.content} fg={props.fg}>
+                {part.content}
+              </Link>
+            )
+          }
+          if (part.type === "path") {
+            return (
+              <FilePathLink path={part.content} fg={props.fg}>
+                {part.content}
+              </FilePathLink>
+            )
+          }
+          if (part.type === "bold") {
+            return <span style={{ bold: true }}>{part.content}</span>
+          }
+          if (part.type === "italic") {
+            // TUI might not support italic widely, but we can try or use another style
+            return <span style={{ italic: true }}>{part.content}</span>
+          }
+          if (part.type === "code") {
+            return <span style={{ bg: theme.backgroundElement }}>{part.content}</span>
+          }
+          return part.content
+        }}
+      </For>
+    </text>
+  )
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -125,8 +125,7 @@ export namespace Config {
       }
 
       const exists = existsSync(path.join(dir, "node_modules"))
-      const installing = installDependencies(dir)
-      if (!exists) await installing
+      if (!exists) await installDependencies(dir)
 
       result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
       result.agent = mergeDeep(result.agent, await loadAgent(dir))

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -900,6 +900,10 @@ export namespace Config {
         .describe(
           "Automatically update to the latest version. Set to true to auto-update, false to disable, or 'notify' to show update notifications",
         ),
+      notifications: z
+        .boolean()
+        .optional()
+        .describe("Send desktop notifications when sessions complete (macOS only). Defaults to true."),
       disabled_providers: z.array(z.string()).optional().describe("Disable providers that are loaded automatically"),
       enabled_providers: z
         .array(z.string())

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -102,6 +102,13 @@ export namespace MCP {
         .meta({
           ref: "MCPStatusNeedsClientRegistration",
         }),
+      z
+        .object({
+          status: z.literal("connecting"),
+        })
+        .meta({
+          ref: "MCPStatusConnecting",
+        }),
     ])
     .meta({
       ref: "MCPStatus",
@@ -167,7 +174,7 @@ export namespace MCP {
       const clients: Record<string, MCPClient> = {}
       const status: Record<string, Status> = {}
 
-      await Promise.all(
+      Promise.all(
         Object.entries(config).map(async ([key, mcp]) => {
           if (!isMcpConfigured(mcp)) {
             log.error("Ignoring MCP config entry without type", { key })
@@ -180,6 +187,9 @@ export namespace MCP {
             return
           }
 
+          status[key] = { status: "connecting" }
+          Bus.publish(ToolsChanged, { server: key })
+
           const result = await create(key, mcp).catch(() => undefined)
           if (!result) return
 
@@ -187,9 +197,12 @@ export namespace MCP {
 
           if (result.mcpClient) {
             clients[key] = result.mcpClient
+            Bus.publish(ToolsChanged, { server: key })
           }
         }),
-      )
+      ).catch((error) => {
+        log.error("Unexpected error in MCP background connection", { error })
+      })
       return {
         status,
         clients,

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -123,11 +123,39 @@ export namespace MCP {
     })
   }
 
+  function coerceJsonStrings(args: Record<string, unknown>, schema: JSONSchema7): Record<string, unknown> {
+    const properties = schema.properties ?? {}
+    const result: Record<string, unknown> = { ...args }
+
+    for (const [key, value] of Object.entries(args)) {
+      if (typeof value !== "string") continue
+
+      const propSchema = properties[key]
+      if (!propSchema || typeof propSchema === "boolean") continue
+
+      const expectedType = propSchema.type
+      if (!expectedType) continue
+
+      const isArrayOrObject = expectedType === "array" || expectedType === "object"
+      if (!isArrayOrObject) continue
+
+      const trimmed = value.trim()
+      const looksLikeJson =
+        (trimmed.startsWith("[") && trimmed.endsWith("]")) || (trimmed.startsWith("{") && trimmed.endsWith("}"))
+      if (!looksLikeJson) continue
+
+      try {
+        result[key] = JSON.parse(value)
+      } catch {}
+    }
+
+    return result
+  }
+
   // Convert MCP tool definition to AI SDK Tool type
   async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
 
-    // Spread first, then override type to ensure it's always "object"
     const schema: JSONSchema7 = {
       ...(inputSchema as JSONSchema7),
       type: "object",
@@ -139,10 +167,11 @@ export namespace MCP {
       description: mcpTool.description ?? "",
       inputSchema: jsonSchema(schema),
       execute: async (args: unknown) => {
+        const coerced = coerceJsonStrings(args as Record<string, unknown>, schema)
         return client.callTool(
           {
             name: mcpTool.name,
-            arguments: args as Record<string, unknown>,
+            arguments: coerced,
           },
           CallToolResultSchema,
           {

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -1,0 +1,189 @@
+import { Bus } from "@/bus"
+import { SessionStatus } from "@/session/status"
+import { Session } from "@/session"
+import { Log } from "@/util/log"
+import { Config } from "@/config/config"
+
+const log = Log.create({ name: "notification" })
+
+export namespace Notification {
+  let initialized = false
+
+  export async function init() {
+    if (initialized) return
+    initialized = true
+
+    Bus.subscribe(SessionStatus.Event.Idle, async (event) => {
+      const config = await Config.get()
+      // Default to true if not explicitly set to false
+      if (config.notifications === false) return
+
+      try {
+        await sendCompletionNotification(event.properties.sessionID)
+      } catch (err) {
+        log.error("failed to send notification", { error: err })
+      }
+    })
+  }
+
+  async function sendCompletionNotification(sessionID: string) {
+    const session = await Session.get(sessionID)
+    if (!session) return
+
+    const messagesWithParts = await Session.messages({ sessionID, limit: 10 })
+    const lastAssistant = messagesWithParts
+      .filter((m) => m.info.role === "assistant")
+      .pop()
+
+    // Build notification content
+    const title = session.title || "OpenCode"
+    let message = "Session completed"
+
+    if (lastAssistant) {
+      // Get a summary from the last assistant message
+      const textPart = lastAssistant.parts.find((p) => p.type === "text")
+      if (textPart && textPart.type === "text") {
+        // Truncate to first 100 chars
+        const text = textPart.text.slice(0, 100)
+        message = text.length < textPart.text.length ? text + "..." : text
+      }
+    }
+
+    // Get tmux info if available
+    const tmux = await getTmuxInfo()
+    if (tmux?.windowName) {
+      message = `[${tmux.windowName}] ${message}`
+    }
+
+    // Build URL if share is available
+    const url = session.share?.url
+
+    await sendMacOSNotification({
+      title,
+      message,
+      url,
+      sessionID,
+      tmux,
+    })
+  }
+
+  interface TmuxInfo {
+    windowName?: string
+    pane?: string // e.g., "%123"
+    sessionName?: string
+    windowIndex?: string
+  }
+
+  async function getTmuxInfo(): Promise<TmuxInfo | undefined> {
+    if (!process.env["TMUX"]) return undefined
+
+    try {
+      // Get window name, session name, window index, and pane ID
+      const proc = Bun.spawn(["tmux", "display-message", "-p", "#{window_name}\t#{session_name}\t#{window_index}\t#{pane_id}"], {
+        stdout: "pipe",
+        stderr: "ignore",
+      })
+      const output = await new Response(proc.stdout).text()
+      await proc.exited
+      const [windowName, sessionName, windowIndex, pane] = output.trim().split("\t")
+      return {
+        windowName: windowName || undefined,
+        sessionName: sessionName || undefined,
+        windowIndex: windowIndex || undefined,
+        pane: pane || process.env["TMUX_PANE"],
+      }
+    } catch {
+      return undefined
+    }
+  }
+
+  async function getTerminalBundleId(): Promise<string> {
+    // Check common terminal emulators by looking at parent process or known env vars
+    const termProgram = process.env["TERM_PROGRAM"]
+
+    switch (termProgram) {
+      case "ghostty":
+        return "com.mitchellh.ghostty"
+      case "iTerm.app":
+        return "com.googlecode.iterm2"
+      case "Apple_Terminal":
+        return "com.apple.Terminal"
+      case "WezTerm":
+        return "com.github.wez.wezterm"
+      case "Alacritty":
+        return "org.alacritty"
+      case "kitty":
+        return "net.kovidgoyal.kitty"
+      default:
+        // Fallback: try to detect from TERM_PROGRAM_VERSION or default to Terminal
+        if (process.env["GHOSTTY_RESOURCES_DIR"]) return "com.mitchellh.ghostty"
+        if (process.env["ITERM_SESSION_ID"]) return "com.googlecode.iterm2"
+        if (process.env["KITTY_WINDOW_ID"]) return "net.kovidgoyal.kitty"
+        if (process.env["WEZTERM_PANE"]) return "com.github.wez.wezterm"
+        return "com.apple.Terminal"
+    }
+  }
+
+  async function sendMacOSNotification(opts: {
+    title: string
+    message: string
+    url?: string
+    sessionID: string
+    tmux?: TmuxInfo
+  }) {
+    if (process.platform !== "darwin") return
+
+    const terminalBundleId = await getTerminalBundleId()
+
+    // Try terminal-notifier first (better UX with click actions)
+    const terminalNotifierArgs = [
+      "-title",
+      opts.title,
+      "-message",
+      opts.message,
+      "-group",
+      `opencode-${opts.sessionID}`,
+    ]
+
+    // Build click action: activate terminal and optionally switch tmux window
+    if (opts.tmux?.sessionName && opts.tmux?.windowIndex) {
+      // Use -execute to run tmux select-window, then activate terminal
+      const tmuxCmd = `tmux select-window -t '${opts.tmux.sessionName}:${opts.tmux.windowIndex}' 2>/dev/null; open -a '${terminalBundleId}'`
+      terminalNotifierArgs.push("-execute", tmuxCmd)
+    } else {
+      // Just activate the terminal
+      terminalNotifierArgs.push("-activate", terminalBundleId)
+    }
+
+    // Add subtitle with share URL if available
+    if (opts.url) {
+      terminalNotifierArgs.push("-subtitle", opts.url)
+    }
+
+    try {
+      const proc = Bun.spawn(["terminal-notifier", ...terminalNotifierArgs], {
+        stdout: "ignore",
+        stderr: "pipe",
+      })
+      await proc.exited
+      if (proc.exitCode === 0) return
+    } catch {
+      // terminal-notifier not available, fall back to osascript
+    }
+
+    // Fallback to osascript (no click action support)
+    const escapedTitle = opts.title.replace(/"/g, '\\"')
+    const escapedMessage = opts.message.replace(/"/g, '\\"')
+    const script = `display notification "${escapedMessage}" with title "${escapedTitle}"`
+
+    try {
+      const proc = Bun.spawn(["osascript", "-e", script], {
+        stdout: "ignore",
+        stderr: "ignore",
+      })
+      await proc.exited
+    } catch (err) {
+      log.error("osascript notification failed", { error: err })
+    }
+  }
+}

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,6 +11,7 @@ import { Instance } from "./instance"
 import { Vcs } from "./vcs"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { Notification } from "@/notification"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -22,6 +23,7 @@ export async function InstanceBootstrap() {
   FileWatcher.init()
   File.init()
   Vcs.init()
+  await Notification.init()
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/session/prompt/anthropic.txt
+++ b/packages/opencode/src/session/prompt/anthropic.txt
@@ -67,9 +67,24 @@ I've found some existing telemetry code. Let me mark the first todo as in_progre
 </example>
 
 
+# Asking questions
+
+You have access to the Question tool to ask the user questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about. Use this tool to:
+1. Gather user preferences or requirements
+2. Clarify ambiguous instructions
+3. Get decisions on implementation choices as you work
+4. Offer choices to the user about what direction to take
+
+When using the Question tool:
+- Provide 2-4 clear options for the user to choose from
+- Include a brief description for each option explaining what it means or what will happen
+- If you recommend a specific option, make it the first option and add "(Recommended)" to the label
+- Set `multiple: true` if the user should be able to select more than one option
+- A "Type your own answer" option is automatically added, so don't include an "Other" option
+
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
-- 
+- Use the Question tool to clarify ambiguous requirements before starting work
 - Use the TodoWrite tool to plan the task if required
 
 - Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.

--- a/packages/opencode/src/session/prompt/gemini.txt
+++ b/packages/opencode/src/session/prompt/gemini.txt
@@ -49,6 +49,13 @@ When requested to perform tasks like fixing bugs, adding features, refactoring, 
 - **Explain Critical Commands:** Before executing commands with 'bash' that modify the file system, codebase, or system state, you *must* provide a brief explanation of the command's purpose and potential impact. Prioritize user understanding and safety. You should not ask permission to use the tool; the user will be presented with a confirmation dialogue upon use (you do not need to tell them this).
 - **Security First:** Always apply security best practices. Never introduce code that exposes, logs, or commits secrets, API keys, or other sensitive information.
 
+## Asking Questions
+- **Question Tool:** Use the 'question' tool to ask users structured questions when you need clarification, want to validate assumptions, or need to make implementation decisions. This provides a better experience than asking questions in plain text.
+- **When to Use:** Gather user preferences, clarify ambiguous instructions, get decisions on implementation choices, or offer choices about direction.
+- **Options:** Provide 2-4 clear options with brief descriptions. If you recommend one, make it first and add "(Recommended)" to the label.
+- **Multiple Selection:** Set `multiple: true` if users should select more than one option.
+- **Custom Input:** A "Type your own answer" option is automatically added, so don't include an "Other" option.
+
 ## Tool Usage
 - **File Paths:** Always use absolute paths when referring to files with tools like 'read' or 'write'. Relative paths are not supported. You must provide an absolute path.
 - **Parallelism:** Execute multiple independent tool calls in parallel when feasible (i.e. searching the codebase).

--- a/packages/opencode/src/session/prompt/qwen.txt
+++ b/packages/opencode/src/session/prompt/qwen.txt
@@ -79,8 +79,24 @@ When making changes to files, first understand the file's code conventions. Mimi
 # Code style
 - IMPORTANT: DO NOT ADD ***ANY*** COMMENTS unless asked
 
+# Asking questions
+
+You have access to the Question tool to ask users structured questions when you need clarification, want to validate assumptions, or need to make a decision you're unsure about. Use this tool to:
+1. Gather user preferences or requirements
+2. Clarify ambiguous instructions
+3. Get decisions on implementation choices as you work
+4. Offer choices to the user about what direction to take
+
+When using the Question tool:
+- Provide 2-4 clear options for the user to choose from
+- Include a brief description for each option explaining what it means
+- If you recommend a specific option, make it the first option and add "(Recommended)" to the label
+- Set `multiple: true` if the user should be able to select more than one option
+- A "Type your own answer" option is automatically added, so don't include an "Other" option
+
 # Doing tasks
 The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
+- Use the Question tool to clarify ambiguous requirements before starting work
 - Use the available search tools to understand the codebase and the user's query. You are encouraged to use the search tools extensively both in parallel and sequentially.
 - Implement the solution using all tools available to you
 - Verify the solution if possible with tests. NEVER assume specific test framework or test script. Check the README or search codebase to determine the testing approach.

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2037,12 +2037,17 @@ export type McpStatusNeedsClientRegistration = {
   error: string
 }
 
+export type McpStatusConnecting = {
+  status: "connecting"
+}
+
 export type McpStatus =
   | McpStatusConnected
   | McpStatusDisabled
   | McpStatusFailed
   | McpStatusNeedsAuth
   | McpStatusNeedsClientRegistration
+  | McpStatusConnecting
 
 export type Path = {
   home: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10379,6 +10379,16 @@
         },
         "required": ["status", "error"]
       },
+      "MCPStatusConnecting": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "const": "connecting"
+          }
+        },
+        "required": ["status"]
+      },
       "MCPStatus": {
         "anyOf": [
           {
@@ -10395,6 +10405,9 @@
           },
           {
             "$ref": "#/components/schemas/MCPStatusNeedsClientRegistration"
+          },
+          {
+            "$ref": "#/components/schemas/MCPStatusConnecting"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Add instructions for using the structured Question tool to the main provider system prompts (anthropic, gemini, qwen)
- The Question tool was already registered and available but models weren't being instructed to use it, resulting in plain text questions instead of the structured multi-choice UI
- This aligns with how the plan agent already instructs models to use the question tool for clarifications

## Changes
- `anthropic.txt`: Added "Asking questions" section with guidance on when and how to use the Question tool
- `gemini.txt`: Added "Asking Questions" section in the same style as other operational guidelines
- `qwen.txt`: Added "Asking questions" section similar to anthropic.txt

## Test plan
- [ ] Start a session with the build agent (default)
- [ ] Ask a question that requires clarification (e.g., "help me add authentication to my app")
- [ ] Verify the model uses the Question tool with structured options instead of plain text questions