### PR TITLE
feat(nix): nix-shell shebang update-hashes script

### DIFF
--- a/nix/scripts/update-hashes.sh
+++ b/nix/scripts/update-hashes.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p bash jq coreutils
 
 set -euo pipefail
 


### PR DESCRIPTION
make the update-hashes script a nix-shell shebang - useful if jq is not installed
the script already assumes nix is installed so adding a nix-shell dependency should be fine
