### PR TITLE
fix(tui): add mouse/touch support to permission prompt buttons

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -456,6 +456,8 @@ function Prompt<const T extends Record<string, string>>(props: {
                 paddingLeft={1}
                 paddingRight={1}
                 backgroundColor={option === store.selected ? theme.warning : theme.backgroundMenu}
+                onMouseOver={() => setStore("selected", option)}
+                onMouseUp={() => props.onSelect(option)}
               >
                 <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
                   {props.options[option]}


### PR DESCRIPTION
## Summary
- Add `onMouseOver` and `onMouseUp` handlers to permission prompt option buttons
- Allows users to select "Allow once", "Allow always", or "Reject" via mouse click or touch input
- Selection follows cursor/touch on hover for visual feedback

## Details
The permission prompt previously only supported keyboard navigation (arrow keys + enter). This change adds mouse/touch support following the existing pattern used throughout the codebase (e.g., `dialog-confirm.tsx`, `question.tsx`).

This is particularly useful for users running OpenCode in terminal emulators that support mouse/touch input (e.g., Termux on mobile devices).