### PR TITLE
feat(config): provider requestOptions for request-level params

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -831,6 +831,10 @@ export namespace Config {
           }),
         )
         .optional(),
+      defaults: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe("Default model options applied to all models for this provider"),
       options: z
         .object({
           apiKey: z.string().optional(),
@@ -857,6 +861,26 @@ export namespace Config {
         .optional(),
     })
     .strict()
+    .transform((provider) => {
+      const store = provider.options?.store
+      const defaults = {
+        ...(provider.defaults ?? {}),
+        ...(typeof store === "boolean" && provider.defaults?.store === undefined ? { store } : {}),
+      }
+
+      const options =
+        provider.options == null
+          ? undefined
+          : Object.fromEntries(Object.entries(provider.options).filter(([key]) => key !== "store"))
+
+      const hasDefaults = Object.keys(defaults).length > 0
+
+      return {
+        ...provider,
+        options,
+        defaults: hasDefaults ? defaults : undefined,
+      }
+    })
     .meta({
       ref: "ProviderConfig",
     })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -831,10 +831,10 @@ export namespace Config {
           }),
         )
         .optional(),
-      defaults: z
+      requestOptions: z
         .record(z.string(), z.any())
         .optional()
-        .describe("Default model options applied to all models for this provider"),
+        .describe("Default per-request model options applied to all models for this provider"),
       options: z
         .object({
           apiKey: z.string().optional(),
@@ -863,9 +863,9 @@ export namespace Config {
     .strict()
     .transform((provider) => {
       const store = provider.options?.store
-      const defaults = {
-        ...(provider.defaults ?? {}),
-        ...(typeof store === "boolean" && provider.defaults?.store === undefined ? { store } : {}),
+      const requestOptions = {
+        ...(provider.requestOptions ?? {}),
+        ...(typeof store === "boolean" && provider.requestOptions?.store === undefined ? { store } : {}),
       }
 
       const options =
@@ -873,12 +873,12 @@ export namespace Config {
           ? undefined
           : Object.fromEntries(Object.entries(provider.options).filter(([key]) => key !== "store"))
 
-      const hasDefaults = Object.keys(defaults).length > 0
+      const hasRequestOptions = Object.keys(requestOptions).length > 0
 
       return {
         ...provider,
         options,
-        defaults: hasDefaults ? defaults : undefined,
+        requestOptions: hasRequestOptions ? requestOptions : undefined,
       }
     })
     .meta({

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -579,7 +579,7 @@ export namespace Provider {
       env: z.string().array(),
       key: z.string().optional(),
       options: z.record(z.string(), z.any()),
-      defaults: z.record(z.string(), z.any()).optional(),
+      requestOptions: z.record(z.string(), z.any()).optional(),
       models: z.record(z.string(), Model),
     })
     .meta({
@@ -726,7 +726,7 @@ export namespace Provider {
         name: provider.name ?? existing?.name ?? providerID,
         env: provider.env ?? existing?.env ?? [],
         options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
-        defaults: mergeDeep(existing?.defaults ?? {}, provider.defaults ?? {}),
+        requestOptions: mergeDeep(existing?.requestOptions ?? {}, provider.requestOptions ?? {}),
         source: "config",
         models: existing?.models ?? {},
       }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -579,6 +579,7 @@ export namespace Provider {
       env: z.string().array(),
       key: z.string().optional(),
       options: z.record(z.string(), z.any()),
+      defaults: z.record(z.string(), z.any()).optional(),
       models: z.record(z.string(), Model),
     })
     .meta({
@@ -725,6 +726,7 @@ export namespace Provider {
         name: provider.name ?? existing?.name ?? providerID,
         env: provider.env ?? existing?.env ?? [],
         options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
+        defaults: mergeDeep(existing?.defaults ?? {}, provider.defaults ?? {}),
         source: "config",
         models: existing?.models ?? {},
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -505,7 +505,7 @@ export namespace ProviderTransform {
     model: Provider.Model
     sessionID: string
     providerOptions?: Record<string, any>
-    defaults?: Record<string, any>
+    requestOptions?: Record<string, any>
   }): Record<string, any> {
     const result: Record<string, any> = {}
 
@@ -515,8 +515,8 @@ export namespace ProviderTransform {
       result["store"] = false
     }
 
-    if (openai && typeof input.defaults?.store === "boolean") {
-      result["store"] = input.defaults.store
+    if (openai && typeof input.requestOptions?.store === "boolean") {
+      result["store"] = input.requestOptions.store
     }
 
     if (input.model.api.npm === "@openrouter/ai-sdk-provider") {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -505,12 +505,18 @@ export namespace ProviderTransform {
     model: Provider.Model
     sessionID: string
     providerOptions?: Record<string, any>
+    defaults?: Record<string, any>
   }): Record<string, any> {
     const result: Record<string, any> = {}
 
     // openai and providers using openai package should set store to false by default.
-    if (input.model.providerID === "openai" || input.model.api.npm === "@ai-sdk/openai") {
+    const openai = input.model.providerID === "openai" || input.model.api.npm === "@ai-sdk/openai"
+    if (openai) {
       result["store"] = false
+    }
+
+    if (openai && typeof input.defaults?.store === "boolean") {
+      result["store"] = input.defaults.store
     }
 
     if (input.model.api.npm === "@openrouter/ai-sdk-provider") {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -101,7 +101,7 @@ export namespace LLM {
           model: input.model,
           sessionID: input.sessionID,
           providerOptions: provider.options,
-          defaults: provider.defaults,
+          requestOptions: provider.requestOptions,
         })
     const options: Record<string, any> = pipe(
       base,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -101,6 +101,7 @@ export namespace LLM {
           model: input.model,
           sessionID: input.sessionID,
           providerOptions: provider.options,
+          defaults: provider.defaults,
         })
     const options: Record<string, any> = pipe(
       base,


### PR DESCRIPTION
Fixes #9028.

Context
- `store` is a per-request OpenAI Responses option; putting it under generic `provider.options` (SDK init options) is awkward.
- Introduce a clear separation:
  - `provider.<id>.options`: SDK init / transport settings (`apiKey`, `baseURL`, `timeout`, ...)
  - `provider.<id>.requestOptions`: default per-request model options applied to all models in that provider.

Changes
- Add `provider.<id>.requestOptions` and plumb into `ProviderTransform.options()`.
- Apply `requestOptions.store` only for OpenAI providers (OpenAI still defaults to `store=false`).
- Migration: if users had `provider.<id>.options.store`, it is moved to `provider.<id>.requestOptions.store` during config load.

Example
```json
{
  "provider": {
    "openai": {
      "requestOptions": { "store": true }
    }
  }
}
```