### PR TITLE
fix: escape CSS selector keys to handle special characters

### DIFF
--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -69,7 +69,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
     if (!props.current) return
     const key = props.key(props.current)
     requestAnimationFrame(() => {
-      const element = scrollRef()?.querySelector(`[data-key="${key}"]`)
+      const element = scrollRef()?.querySelector(`[data-key="${CSS.escape(key)}"]`)
       element?.scrollIntoView({ block: "center" })
     })
   })
@@ -81,7 +81,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
       scrollRef()?.scrollTo(0, 0)
       return
     }
-    const element = scrollRef()?.querySelector(`[data-key="${active()}"]`)
+    const element = scrollRef()?.querySelector(`[data-key="${CSS.escape(active()!)}"]`)
     element?.scrollIntoView({ block: "center" })
   })
 


### PR DESCRIPTION
Use CSS.escape() for data-key attribute selectors in querySelector to properly handle file paths with non-ASCII characters (e.g., Chinese) and special URL protocols (file://).

### What does this PR do?
The desktop app crashes with:
SyntaxError: 'data-key="file://xxxxxx.md""' is not a valid selector.

This occurs because `querySelector` requires special characters in attribute selectors to be escaped.
<img width="1460" height="842" alt="image" src="https://github.com/user-attachments/assets/4df71b3f-6115-4555-816d-6f0a48786d71" />

## Solution
Wrap key values with `CSS.escape()` before using them in selectors:
```typescript
// Before
querySelector(`[data-key="${key}"]`)
// After  
querySelector(`[data-key="${CSS.escape(key)}"]`)
Changes
- packages/ui/src/components/list.tsx: Added CSS.escape() to both querySelector calls (lines 72, 84)

### How did you verify your code works?
I did a local test.
1. CSS.escape() correctly escapes :, /, and . characters that are special in CSS selectors
2. The escaped selector successfully finds the element