### PR TITLE
fix: mdns discover hostname

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -60,7 +60,7 @@ export const WebCommand = cmd({
       }
 
       if (opts.mdns) {
-        UI.println(UI.Style.TEXT_INFO_BOLD + "  mDNS:              ", UI.Style.TEXT_NORMAL, "opencode.local")
+        UI.println(UI.Style.TEXT_INFO_BOLD + "  mDNS:              ", UI.Style.TEXT_NORMAL, `opencode.local:${server.port}`)
       }
 
       // Open localhost in browser

--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -7,15 +7,17 @@ export namespace MDNS {
   let bonjour: Bonjour | undefined
   let currentPort: number | undefined
 
-  export function publish(port: number, name = "opencode") {
+  export function publish(port: number) {
     if (currentPort === port) return
     if (bonjour) unpublish()
 
     try {
+      const name = `opencode-${port}`
       bonjour = new Bonjour()
       const service = bonjour.publish({
         name,
         type: "http",
+        host: "opencode.local",
         port,
         txt: { path: "/" },
       })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -562,7 +562,7 @@ export namespace Server {
       opts.hostname !== "localhost" &&
       opts.hostname !== "::1"
     if (shouldPublishMDNS) {
-      MDNS.publish(server.port!, `opencode-${server.port!}`)
+      MDNS.publish(server.port!)
     } else if (opts.mdns) {
       log.warn("mDNS enabled but hostname is loopback; skipping mDNS publish")
     }


### PR DESCRIPTION
Fix: #9040

### What does this PR do?

  1. Adds explicit hostname to mDNS publication - Sets host: "opencode.local" when publishing the mDNS service,
  ensuring the service is advertised with the correct discoverable hostname.
  2. Simplifies the MDNS.publish API - Moves the service name generation (opencode-${port}) inside the function,
  removing the optional name parameter since it was always being overridden by the caller anyway.
  3. Fixes CLI display - Updates the mDNS info message to show the full address including the port
  (opencode.local:${server.port}) instead of just opencode.local.

### How did you verify your code works?

  - Running the web server with mDNS enabled (--mdns flag)
  - Using dns-sd -B _http._tcp to verify the service is advertised with
  opencode.local as the hostname
  - Confirming the service is discoverable and resolves correctly on the local network
