### PR TITLE
fix: handle deleted file references in prompt rerun

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -944,7 +944,24 @@ export namespace SessionPrompt {
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filepath = fileURLToPath(part.url)
-              const stat = await Bun.file(filepath).stat()
+              const file = Bun.file(filepath)
+              const exists = await file.exists()
+
+              if (!exists) {
+                log.error("referenced file not found", { filepath })
+                return [
+                  {
+                    id: Identifier.ascending("part"),
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: `File not found: ${filepath}\n\nThe file may have been moved or deleted since it was originally referenced.`,
+                  },
+                ]
+              }
+
+              const stat = await file.stat()
 
               if (stat.isDirectory()) {
                 part.mime = "application/x-directory"
@@ -1098,7 +1115,6 @@ export namespace SessionPrompt {
                 ]
               }
 
-              const file = Bun.file(filepath)
               FileTime.read(input.sessionID, filepath)
               return [
                 {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1,0 +1,125 @@
+import { $ } from "bun"
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionPrompt } from "../../src/session/prompt"
+import { Instance } from "../../src/project/instance"
+import { Log } from "../../src/util/log"
+import { tmpdir } from "../fixture/fixture"
+
+Log.init({ print: false })
+
+// Helper to create a git-initialized tmpdir with local git config
+async function tmpdirWithGit<T>(options?: { init?: (dir: string) => Promise<T> }) {
+  const tmp = await tmpdir({ init: options?.init })
+  await $`git init`.cwd(tmp.path).quiet()
+  await $`git config user.email "test@test.com"`.cwd(tmp.path).quiet()
+  await $`git config user.name "Test"`.cwd(tmp.path).quiet()
+  await $`git commit --allow-empty -m "root"`.cwd(tmp.path).quiet()
+  return tmp
+}
+
+describe("session.prompt file parts", () => {
+  test("handles missing file reference gracefully", async () => {
+    await using tmp = await tmpdirWithGit()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const missingFile = path.join(tmp.path, "deleted-file.txt")
+
+        const message = await SessionPrompt.prompt({
+          sessionID: session.id,
+          parts: [
+            {
+              type: "file",
+              mime: "text/plain",
+              filename: "deleted-file.txt",
+              url: pathToFileURL(missingFile).href,
+            },
+          ],
+          noReply: true,
+        })
+
+        // message is { info, parts } - check the parts directly
+        const textPart = message.parts.find((p) => p.type === "text" && p.text?.includes("not found"))
+
+        expect(textPart).toBeDefined()
+        expect(textPart?.text).toContain("File not found")
+        expect(textPart?.text).toContain("deleted-file.txt")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("handles missing image file reference gracefully", async () => {
+    await using tmp = await tmpdirWithGit()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const missingImage = path.join(tmp.path, "deleted-image.png")
+
+        const message = await SessionPrompt.prompt({
+          sessionID: session.id,
+          parts: [
+            {
+              type: "file",
+              mime: "image/png",
+              filename: "deleted-image.png",
+              url: pathToFileURL(missingImage).href,
+            },
+          ],
+          noReply: true,
+        })
+
+        // message is { info, parts } - check the parts directly
+        const textPart = message.parts.find((p) => p.type === "text" && p.text?.includes("not found"))
+
+        expect(textPart).toBeDefined()
+        expect(textPart?.text).toContain("File not found")
+        expect(textPart?.text).toContain("deleted-image.png")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("processes existing file reference successfully", async () => {
+    await using tmp = await tmpdirWithGit({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "existing-file.txt"), "hello world")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+        const existingFile = path.join(tmp.path, "existing-file.txt")
+
+        const message = await SessionPrompt.prompt({
+          sessionID: session.id,
+          parts: [
+            {
+              type: "file",
+              mime: "text/plain",
+              filename: "existing-file.txt",
+              url: pathToFileURL(existingFile).href,
+            },
+          ],
+          noReply: true,
+        })
+
+        // message is { info, parts } - check the parts directly
+        const contentPart = message.parts.find((p) => p.type === "text" && p.text?.includes("hello world"))
+
+        expect(contentPart).toBeDefined()
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+})


### PR DESCRIPTION
Fixes #9048 #8807

## Summary
- Add file existence check before calling `.stat()` on file references
- Return graceful error message when referenced file is missing
- Add tests for missing file handling

## Before
https://github.com/user-attachments/assets/393a9ba8-b952-4195-8372-e4bc09e502dc

## After
https://github.com/user-attachments/assets/2e4b9601-cc0b-47ce-80a8-1b7c0abf6c81

## How to replicate
1. Reference a file
2. Run the prompt
3. Delete the file
4. Press up arrow and rerun
5. Should see error message instead of crash