### PR TITLE
feat(tui): implement double Ctrl+C to quit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -114,10 +114,12 @@ export function Prompt(props: PromptProps) {
   })
 
   const [store, setStore] = createStore<{
+
     prompt: PromptInfo
     mode: "normal" | "shell"
     extmarkToPartIndex: Map<number, number>
     interrupt: number
+    quitArmed: boolean
     placeholder: number
   }>({
     placeholder: Math.floor(Math.random() * PLACEHOLDERS.length),
@@ -128,6 +130,7 @@ export function Prompt(props: PromptProps) {
     mode: "normal",
     extmarkToPartIndex: new Map(),
     interrupt: 0,
+    quitArmed: false,
   })
 
   // Initialize agent/model/variant from last user message when session changes
@@ -807,7 +810,19 @@ export function Prompt(props: PromptProps) {
                 }
                 if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
-                    await exit()
+                    if (store.quitArmed) {
+                      await exit()
+                    } else {
+                      setStore("quitArmed", true)
+                      toast.show({
+                        message: "Press Ctrl+C again to exit",
+                        variant: "info",
+                        duration: 3000,
+                      })
+                      setTimeout(() => {
+                        setStore("quitArmed", false)
+                      }, 3000)
+                    }
                     // Don't preventDefault - let textarea potentially handle the event
                     e.preventDefault()
                     return


### PR DESCRIPTION
### What does this PR do?
Fixes #9041
Implements a "double Ctrl+C to quit" mechanism to prevent accidental session termination.

### How did you verify your code works?

## Changes
-   Modified [packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx](cci:7://file:///Users/shoaib/Downloads/opencode-dev/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx:0:0-0:0).
-   Added `quitArmed` state to the Prompt component.
-   Updated `app_exit` keybinding handler:
    -   **First Press** (on empty prompt): Shows a toast "Press Ctrl+C again to exit" and sets a 3-second timeout.
    -   **Second Press** (within 3s): Exits the application.

## Testing
-   Verified manually:
    -   Pressing Ctrl+C once on empty prompt shows the toast.
    -   Pressing again within 3s exits.
    -   Pressing again after 3s shows the toast again (timeout reset).
    -   Ctrl+C with text still clears the input (existing behavior).
