### PR TITLE
feat(session): add LLM API call duration logging

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -162,7 +162,9 @@ export namespace LLM {
       })
     }
 
-    return streamText({
+    const startTime = Date.now()
+
+    const result = streamText({
       onError(error) {
         l.error("stream error", {
           error,
@@ -253,6 +255,28 @@ export namespace LLM {
       }),
       experimental_telemetry: { isEnabled: cfg.experimental?.openTelemetry },
     })
+
+    // Wrap fullStream to log duration on completion
+    const originalFullStream = result.fullStream
+    const wrappedFullStream = (async function* () {
+      try {
+        for await (const chunk of originalFullStream) {
+          yield chunk
+        }
+      } finally {
+        const duration = Date.now() - startTime
+        l.info("stream completed", {
+          modelID: input.model.id,
+          providerID: input.model.providerID,
+          duration,
+        })
+      }
+    })()
+
+    return {
+      ...result,
+      fullStream: wrappedFullStream,
+    }
   }
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {


### PR DESCRIPTION
### What does this PR do?
Fixes #9037

Adds duration logging for LLM API calls to help users monitor and analyze API latency.


### How did you verify your code works?

## Changes
-   Modified `packages/opencode/src/session/llm.ts`.
-   Capture `startTime` before calling `streamText()`.
-   Wrap `fullStream` async iterable to log duration on stream completion.
-   Log format: `service=llm ... stream completed ... duration=xxx`

