### PR TITLE
fix(desktop): Added a Windows-only guard that makes window.getComputedStyle fall back to document.documentElement

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -26,6 +26,18 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
   )
 }
 
+const isWindows = ostype() === "windows"
+if (isWindows) {
+  const originalGetComputedStyle = window.getComputedStyle
+  window.getComputedStyle = ((elt: Element, pseudoElt?: string | null) => {
+    if (!(elt instanceof Element)) {
+      // WebView2 can call into Floating UI with non-elements; fall back to a safe element.
+      return originalGetComputedStyle(document.documentElement, pseudoElt ?? undefined)
+    }
+    return originalGetComputedStyle(elt, pseudoElt ?? undefined)
+  }) as typeof window.getComputedStyle
+}
+
 let update: Update | null = null
 
 const createPlatform = (password: Accessor<string | null>): Platform => ({


### PR DESCRIPTION
### What does this PR do?

Fix #9051 and #8666, tested in Windows by built a exe

My seeing error:

```log
TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
TypeError: parameter 1 is not of type 'Element'.
    at getComputedStyle$1 (http://tauri.localhost/assets/index-BMEaQ_KQ.js:1707:91066)
    at isOverflowElement (http://tauri.localhost/assets/index-BMEaQ_KQ.js:1707:89839)
    at getOverflowAncestors (http://tauri.localhost/assets/index-BMEaQ_KQ.js:1707:91733)
    at autoUpdate (http://tauri.localhost/assets/index-BMEaQ_KQ.js:1707:99252)
    at Object.fn (http://tauri.localhost/assets/index-BMEaQ_KQ.js:1707:105253)
    at runComputation (http://tauri.localhost/assets/index-BMEaQ_KQ.js:2:8250)
    at updateComputation (http://tauri.localhost/assets/index-BMEaQ_KQ.js:2:7981)
    at runTop (http://tauri.localhost/assets/index-BMEaQ_KQ.js:2:9466)
    at runUserEffects (http://tauri.localhost/assets/index-BMEaQ_KQ.js:2:10730)
    at http://tauri.localhost/assets/index-BMEaQ_KQ.js:2:10322
```