### PR TITLE
feat(config): support config.d/ directory for split configuration

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -122,6 +122,8 @@ export namespace Config {
           result.mode ??= {}
           result.plugin ??= []
         }
+        // Load config.d/ files (alphabetically, after main config files)
+        result = mergeConfigConcatArrays(result, await loadConfigDir(dir))
       }
 
       const exists = existsSync(path.join(dir, "node_modules"))
@@ -1084,6 +1086,9 @@ export namespace Config {
       mergeDeep(await loadFile(path.join(Global.Path.config, "opencode.jsonc"))),
     )
 
+    // Load config.d/ files (alphabetically, after main config files)
+    result = mergeConfigConcatArrays(result, await loadConfigDir(Global.Path.config))
+
     await import(path.join(Global.Path.config, "config"), {
       with: {
         type: "toml",
@@ -1112,6 +1117,26 @@ export namespace Config {
       })
     if (!text) return {}
     return load(text, filepath)
+  }
+
+  const CONFIG_D_GLOB = new Bun.Glob("*.{json,jsonc}")
+
+  async function loadConfigDir(dir: string): Promise<Info> {
+    const configDir = path.join(dir, "config.d")
+    if (!existsSync(configDir)) return {}
+
+    const files: string[] = []
+    for await (const file of CONFIG_D_GLOB.scan({ cwd: configDir, absolute: true })) {
+      files.push(file)
+    }
+    files.sort() // alphabetical order
+
+    let result: Info = {}
+    for (const file of files) {
+      log.debug(`loading config from ${file}`)
+      result = mergeConfigConcatArrays(result, await loadFile(file))
+    }
+    return result
   }
 
   async function load(text: string, configFilepath: string) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1311,6 +1311,297 @@ describe("getPluginName", () => {
   })
 })
 
+// config.d/ directory tests
+
+test("loads config from .opencode/config.d directory", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      await Bun.write(
+        path.join(configDDir, "10-theme.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "dracula",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("dracula")
+    },
+  })
+})
+
+test("config.d files are loaded in alphabetical order", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      // Later alphabetically should override earlier
+      await Bun.write(
+        path.join(configDDir, "00-base.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "base-theme",
+          username: "base-user",
+        }),
+      )
+      await Bun.write(
+        path.join(configDDir, "50-override.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "override-theme",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("override-theme")
+      expect(config.username).toBe("base-user")
+    },
+  })
+})
+
+test("config.d supports both .json and .jsonc files", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      await Bun.write(
+        path.join(configDDir, "01-json.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "json-theme",
+        }),
+      )
+      await Bun.write(
+        path.join(configDDir, "02-jsonc.jsonc"),
+        `{
+          // This is a comment
+          "$schema": "https://opencode.ai/config.json",
+          "username": "jsonc-user"
+        }`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("json-theme")
+      expect(config.username).toBe("jsonc-user")
+    },
+  })
+})
+
+test("config.d overrides main config file", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      // Main config in .opencode
+      await Bun.write(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "main-theme",
+          username: "main-user",
+        }),
+      )
+      // config.d file overrides theme
+      await Bun.write(
+        path.join(configDDir, "override.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          theme: "fragment-theme",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("fragment-theme")
+      expect(config.username).toBe("main-user")
+    },
+  })
+})
+
+test("config.d supports file and env substitution", async () => {
+  const originalEnv = process.env["TEST_CONFIG_D_VAR"]
+  process.env["TEST_CONFIG_D_VAR"] = "env-theme"
+
+  try {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        const configDDir = path.join(opencodeDir, "config.d")
+        await fs.mkdir(configDDir, { recursive: true })
+
+        await Bun.write(path.join(configDDir, "secret.txt"), "secret-user")
+        await Bun.write(
+          path.join(configDDir, "substitutions.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            theme: "{env:TEST_CONFIG_D_VAR}",
+            username: "{file:secret.txt}",
+          }),
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.theme).toBe("env-theme")
+        expect(config.username).toBe("secret-user")
+      },
+    })
+  } finally {
+    if (originalEnv !== undefined) {
+      process.env["TEST_CONFIG_D_VAR"] = originalEnv
+    } else {
+      delete process.env["TEST_CONFIG_D_VAR"]
+    }
+  }
+})
+
+test("config.d throws error for invalid JSON", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      await Bun.write(path.join(configDDir, "invalid.json"), "{ invalid json }")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await expect(Config.get()).rejects.toThrow()
+    },
+  })
+})
+
+test("config.d loads permissions from .opencode/config.d", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      await Bun.write(
+        path.join(configDDir, "permissions.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          permission: {
+            external_directory: {
+              "*": "ask",
+              "~/allowed/*": "allow",
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.permission?.external_directory).toEqual({
+        "*": "ask",
+        "~/allowed/*": "allow",
+      })
+    },
+  })
+})
+
+test("config.d merges plugin arrays correctly", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+
+      await Bun.write(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["main-plugin"],
+        }),
+      )
+      await Bun.write(
+        path.join(configDDir, "plugins.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["fragment-plugin"],
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      const plugins = config.plugin ?? []
+      expect(plugins.some((p) => p.includes("main-plugin"))).toBe(true)
+      expect(plugins.some((p) => p.includes("fragment-plugin"))).toBe(true)
+    },
+  })
+})
+
+test("handles empty config.d directory gracefully", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      const configDDir = path.join(opencodeDir, "config.d")
+      await fs.mkdir(configDDir, { recursive: true })
+      // Empty directory - no files
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config).toBeDefined()
+    },
+  })
+})
+
+test("handles non-existent config.d directory gracefully", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const opencodeDir = path.join(dir, ".opencode")
+      await fs.mkdir(opencodeDir, { recursive: true })
+      // No config.d directory
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config).toBeDefined()
+    },
+  })
+})
+
 describe("deduplicatePlugins", () => {
   test("removes duplicates keeping higher priority (later entries)", () => {
     const plugins = ["global-plugin@1.0.0", "shared-plugin@1.0.0", "local-plugin@2.0.0", "shared-plugin@2.0.0"]

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -44,10 +44,11 @@ Config sources are loaded in this order (later sources override earlier ones):
 
 1. **Remote config** (from `.well-known/opencode`) - organizational defaults
 2. **Global config** (`~/.config/opencode/opencode.json`) - user preferences
-3. **Custom config** (`OPENCODE_CONFIG` env var) - custom overrides
-4. **Project config** (`opencode.json` in project) - project-specific settings
-5. **`.opencode` directories** - agents, commands, plugins
-6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
+3. **Global config.d** (`~/.config/opencode/config.d/*.json[c]`) - drop-in config files
+4. **Custom config** (`OPENCODE_CONFIG` env var) - custom overrides
+5. **Project config** (`opencode.json` in project) - project-specific settings
+6. **`.opencode` directories** - agents, commands, plugins, and config.d files
+7. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
 
 This means project configs can override global defaults, and global configs can override remote organizational defaults.
 
@@ -137,6 +138,44 @@ opencode run "Hello world"
 ```
 
 The custom directory is loaded after the global config and `.opencode` directories, so it **can override** their settings.
+
+---
+
+### Split config
+
+You can split your configuration into multiple files using the `config.d/` directory. Files are loaded alphabetically and merged after the main config.
+
+```bash title="Directory structure"
+~/.config/opencode/
+├── opencode.jsonc           # main config
+└── config.d/
+    ├── 00-base.jsonc        # loaded first
+    ├── 10-permissions.jsonc
+    └── 99-overrides.jsonc   # loaded last
+```
+
+Use numeric prefixes to control load order. Each file can contain any subset of the config schema.
+
+```jsonc title="~/.config/opencode/config.d/10-permissions.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "*": "ask",
+      "~/trusted-projects/*": "allow",
+    },
+  },
+}
+```
+
+The `config.d/` pattern works in both locations:
+
+- `~/.config/opencode/config.d/` - global
+- `.opencode/config.d/` - project-specific
+
+:::tip
+Files in `config.d/` support `{env:VAR}` and `{file:path}` substitutions.
+:::
 
 ---
 


### PR DESCRIPTION
Allow users to organize configuration into multiple files within a config.d/ directory. Files are loaded alphabetically and merged after the main config file, making it easier to manage modular config setups (e.g., separate files for permissions, plugins, theming).

Supports both ~/.config/opencode/config.d/ (global) and .opencode/config.d/ (project-specific) locations.



### How did you verify your code works?

added testcases


Closes #9062