### PR TITLE
feat(mcp): support explicit OAuth callback host binding

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -689,6 +689,7 @@ export const McpDebugCommand = cmd({
                 clientSecret: oauthConfig?.clientSecret,
                 scope: oauthConfig?.scope,
                 redirectUri: oauthConfig?.redirectUri,
+                callbackHost: oauthConfig?.callbackHost,
               },
               {
                 onRedirect: async () => {},

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -403,8 +403,31 @@ export namespace Config {
         .string()
         .optional()
         .describe("OAuth redirect URI (default: http://127.0.0.1:19876/mcp/oauth/callback)."),
+      callbackHost: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Host address to bind the OAuth callback server to explicitly (for example, '127.0.0.1' or '0.0.0.0').",
+        ),
     })
     .strict()
+    .refine(
+      (value) => {
+        if (!value.callbackHost || value.callbackHost === "0.0.0.0" || value.callbackHost === "::" || !value.redirectUri) {
+          return true
+        }
+        try {
+          return new URL(value.redirectUri).hostname.replace(/^\[(.*)\]$/, "$1") === value.callbackHost
+        } catch {
+          return true
+        }
+      },
+      {
+        path: ["callbackHost"],
+        message: "callbackHost must match redirectUri host unless it is 0.0.0.0 or ::.",
+      },
+    )
     .meta({
       ref: "McpOAuthConfig",
     })

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -287,6 +287,7 @@ export namespace MCP {
               clientSecret: oauthConfig?.clientSecret,
               scope: oauthConfig?.scope,
               redirectUri: oauthConfig?.redirectUri,
+              callbackHost: oauthConfig?.callbackHost,
             },
             {
               onRedirect: async (url) => {
@@ -721,7 +722,12 @@ export namespace MCP {
         const oauthConfig = typeof mcpConfig.oauth === "object" ? mcpConfig.oauth : undefined
 
         // Start the callback server with custom redirectUri if configured
-        yield* Effect.promise(() => McpOAuthCallback.ensureRunning(oauthConfig?.redirectUri))
+        yield* Effect.promise(() =>
+          McpOAuthCallback.ensureRunning({
+            redirectUri: oauthConfig?.redirectUri,
+            callbackHost: oauthConfig?.callbackHost,
+          }),
+        )
 
         const oauthState = Array.from(crypto.getRandomValues(new Uint8Array(32)))
           .map((b) => b.toString(16).padStart(2, "0"))
@@ -736,6 +742,7 @@ export namespace MCP {
             clientSecret: oauthConfig?.clientSecret,
             scope: oauthConfig?.scope,
             redirectUri: oauthConfig?.redirectUri,
+            callbackHost: oauthConfig?.callbackHost,
           },
           {
             onRedirect: async (url) => {

--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -58,6 +58,7 @@ interface PendingAuth {
 
 export namespace McpOAuthCallback {
   let server: ReturnType<typeof createServer> | undefined
+  let currentHost: string | undefined
   const pendingAuths = new Map<string, PendingAuth>()
   // Reverse index: mcpName → oauthState, so cancelPending(mcpName) can
   // find the right entry in pendingAuths (which is keyed by oauthState).
@@ -139,19 +140,20 @@ export namespace McpOAuthCallback {
     res.end(HTML_SUCCESS)
   }
 
-  export async function ensureRunning(redirectUri?: string): Promise<void> {
+  export async function ensureRunning(opts?: { redirectUri?: string; callbackHost?: string }): Promise<void> {
     // Parse the redirect URI to get port and path (uses defaults if not provided)
-    const { port, path } = parseRedirectUri(redirectUri)
+    const { port, path } = parseRedirectUri(opts?.redirectUri)
 
     // If server is running on a different port/path, stop it first
-    if (server && (currentPort !== port || currentPath !== path)) {
+    if (server && (currentPort !== port || currentPath !== path || currentHost !== opts?.callbackHost)) {
       log.info("stopping oauth callback server to reconfigure", { oldPort: currentPort, newPort: port })
       await stop()
     }
 
     if (server) return
 
-    const running = await isPortInUse(port)
+    const targetHost = !opts?.callbackHost || opts.callbackHost === "0.0.0.0" ? "127.0.0.1" : opts.callbackHost === "::" ? "::1" : opts.callbackHost
+    const running = await isPortInUse(port, targetHost)
     if (running) {
       log.info("oauth callback server already running on another instance", { port })
       return
@@ -159,10 +161,11 @@ export namespace McpOAuthCallback {
 
     currentPort = port
     currentPath = path
+    currentHost = opts?.callbackHost
 
     server = createServer(handleRequest)
     await new Promise<void>((resolve, reject) => {
-      server!.listen(currentPort, () => {
+      server!.listen(currentPort, currentHost, () => {
         log.info("oauth callback server started", { port: currentPort, path: currentPath })
         resolve()
       })
@@ -198,9 +201,9 @@ export namespace McpOAuthCallback {
     }
   }
 
-  export async function isPortInUse(port: number = OAUTH_CALLBACK_PORT): Promise<boolean> {
+  export async function isPortInUse(port: number = OAUTH_CALLBACK_PORT, host: string = "127.0.0.1"): Promise<boolean> {
     return new Promise((resolve) => {
-      const socket = createConnection(port, "127.0.0.1")
+      const socket = createConnection(port, host)
       socket.on("connect", () => {
         socket.destroy()
         resolve(true)
@@ -215,6 +218,7 @@ export namespace McpOAuthCallback {
     if (server) {
       await new Promise<void>((resolve) => server!.close(() => resolve()))
       server = undefined
+      currentHost = undefined
       log.info("oauth callback server stopped")
     }
 

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -18,6 +18,7 @@ export interface McpOAuthConfig {
   clientSecret?: string
   scope?: string
   redirectUri?: string
+  callbackHost?: string
 }
 
 export interface McpOAuthCallbacks {
@@ -36,7 +37,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.config.redirectUri) {
       return this.config.redirectUri
     }
-    return `http://127.0.0.1:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
+    const host =
+      this.config.callbackHost && this.config.callbackHost !== "0.0.0.0" && this.config.callbackHost !== "::"
+        ? this.config.callbackHost
+        : "127.0.0.1"
+    const safeHost = host.includes(":") ? `[${host}]` : host
+    return `http://${safeHost}:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`
   }
 
   get clientMetadata(): OAuthClientMetadata {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2219,6 +2219,39 @@ describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {
   })
 })
 
+describe("MCP OAuth callbackHost validation", () => {
+  test("accepts concrete callbackHost on its own", () => {
+    const result = Config.McpOAuth.safeParse({ callbackHost: "127.0.0.2" })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.callbackHost).toBe("127.0.0.2")
+  })
+
+  test("accepts wildcard callbackHost with explicit redirectUri", () => {
+    const result = Config.McpOAuth.safeParse({
+      redirectUri: "http://127.0.0.1:19876/mcp/oauth/callback",
+      callbackHost: "0.0.0.0",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test("rejects mismatched concrete callbackHost", () => {
+    const result = Config.McpOAuth.safeParse({
+      redirectUri: "http://127.0.0.1:19876/mcp/oauth/callback",
+      callbackHost: "127.0.0.2",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test("works with other oauth fields when hosts agree", () => {
+    const result = Config.McpOAuth.safeParse({
+      clientId: "my-client",
+      redirectUri: "http://127.0.0.2:19876/mcp/oauth/callback",
+      callbackHost: "127.0.0.2",
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
 describe("OPENCODE_CONFIG_CONTENT token substitution", () => {
   test("substitutes {env:} tokens in OPENCODE_CONFIG_CONTENT", async () => {
     const originalEnv = process.env["OPENCODE_CONFIG_CONTENT"]

--- a/packages/opencode/test/mcp/oauth-callback.test.ts
+++ b/packages/opencode/test/mcp/oauth-callback.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, afterEach } from "bun:test"
 import { McpOAuthCallback } from "../../src/mcp/oauth-callback"
-import { parseRedirectUri } from "../../src/mcp/oauth-provider"
+import { McpOAuthProvider, parseRedirectUri } from "../../src/mcp/oauth-provider"
 
 describe("parseRedirectUri", () => {
   test("returns defaults when no URI provided", () => {
@@ -28,7 +28,23 @@ describe("McpOAuthCallback.ensureRunning", () => {
   })
 
   test("starts server with custom redirectUri port and path", async () => {
-    await McpOAuthCallback.ensureRunning("http://127.0.0.1:18000/custom/callback")
+    await McpOAuthCallback.ensureRunning({ redirectUri: "http://127.0.0.1:18000/custom/callback" })
     expect(McpOAuthCallback.isRunning()).toBe(true)
+    expect(await McpOAuthCallback.isPortInUse(18000)).toBe(true)
+  })
+
+  test("allows wildcard callbackHost with explicit redirectUri", async () => {
+    await McpOAuthCallback.ensureRunning({
+      redirectUri: "http://127.0.0.1:18002/custom/callback",
+      callbackHost: "0.0.0.0",
+    })
+
+    expect(McpOAuthCallback.isRunning()).toBe(true)
+    expect(await McpOAuthCallback.isPortInUse(18002, "127.0.0.1")).toBe(true)
+  })
+
+  test("binds to redirectUri host by default", async () => {
+    await McpOAuthCallback.ensureRunning({ redirectUri: "http://127.0.0.1:18003/custom/callback" })
+    expect(await McpOAuthCallback.isPortInUse(18003, "127.0.0.1")).toBe(true)
   })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1379,6 +1379,10 @@ export type McpOAuthConfig = {
    * OAuth redirect URI (default: http://127.0.0.1:19876/mcp/oauth/callback).
    */
   redirectUri?: string
+  /**
+   * Host address to bind the OAuth callback server to explicitly (for example, '127.0.0.1' or '0.0.0.0').
+   */
+  callbackHost?: string
 }
 
 export type McpRemoteConfig = {

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -272,6 +272,8 @@ If you want to disable automatic OAuth for a server (e.g., for servers that use 
 | `clientId`     | String          | OAuth client ID. If not provided, dynamic client registration will be attempted. |
 | `clientSecret` | String          | OAuth client secret, if required by the authorization server.                    |
 | `scope`        | String          | OAuth scopes to request during authorization.                                    |
+| `redirectUri`  | String          | Custom OAuth callback URL.                                                       |
+| `callbackHost` | String          | Host address to bind the local callback server to. Use `0.0.0.0` or `::` for wildcard binds. |
 
 #### Debugging
 
@@ -286,6 +288,25 @@ opencode mcp debug my-oauth-server
 ```
 
 The `mcp debug` command shows the current auth status, tests HTTP connectivity, and attempts the OAuth discovery flow.
+
+By default, OpenCode binds the callback server to the `redirectUri` host, or `127.0.0.1` when `redirectUri` is omitted. Set `callbackHost` only when you need to override that bind address.
+
+:::caution
+`callbackHost` only changes the local bind address. If you set it to a concrete host, it must match the `redirectUri` host. Use `0.0.0.0` or `::` when you need a broader bind without changing the callback URL.
+:::
+
+```json title="opencode.json" {4-5}
+{
+  "mcp": {
+    "my-server": {
+      "oauth": {
+        "redirectUri": "http://127.0.0.1:19876/mcp/oauth/callback",
+        "callbackHost": "0.0.0.0"
+      }
+    }
+  }
+}
+```
 
 ---
 


### PR DESCRIPTION
Adds `mcp.<name>.oauth.callbackHost` to control the bind address for the local OAuth callback server used during MCP OAuth flows.

This is useful in WSL2, Docker, and devcontainers where the browser may need the callback listener bound more broadly than the default loopback setup.

Behavior:
- if `redirectUri` is unset, `callbackHost` can be used to change the host in the default callback URL
- if `redirectUri` is set, `callbackHost` must match its host, unless it is `0.0.0.0` or `::`
- `0.0.0.0` and `::` widen the local bind address without changing the callback URL

This threads `callbackHost` through MCP auth and `opencode mcp debug`, binds the existing callback server to the configured host, adds config validation for incompatible combinations, updates the docs, and regenerates the SDK types.

Testing:
- `bun typecheck`
- `bun test test/mcp/oauth-callback.test.ts`
- `bun test test/config/config.test.ts`
- `bun test test/mcp/oauth-auto-connect.test.ts`

Fixes #9081