### PR TITLE
docs(config): explain that `autoupdate` doesn't work when installed with a package manager

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -425,6 +425,7 @@ OpenCode will automatically download any new updates when it starts up. You can 
 ```
 
 If you don't want updates but want to be notified when a new version is available, set `autoupdate` to `"notify"`.
+Notice that this only works if it was not installed using a package manager such as Homebrew.
 
 ---
 


### PR DESCRIPTION
### What does this PR do?
Sets expectations for the `autoupdate` behavior
