### PR TITLE
fix(config): only run installDependencies when needed Fixes #9106

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -125,8 +125,9 @@ export namespace Config {
       }
 
       const exists = existsSync(path.join(dir, "node_modules"))
-      const installing = installDependencies(dir)
-      if (!exists) await installing
+      if (!exists) {
+        await installDependencies(dir)
+      }
 
       result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
       result.agent = mergeDeep(result.agent, await loadAgent(dir))


### PR DESCRIPTION
## Summary
- avoid running installDependencies on every startup
- only install when node_modules is missing, preventing unnecessary bun add runs
- fixes crash loops in standalone binary environments where process.execPath is not a valid bun runtime

Fixes #9106

## Test plan
- [ ] start opencode in a clean directory; plugin install runs once
- [ ] restart opencode in same directory; plugin install is skipped