### PR TITLE
feat: add OAuth token keep-alive to prevent expiration

### DIFF
--- a/packages/opencode/src/auth/keepalive.ts
+++ b/packages/opencode/src/auth/keepalive.ts
@@ -1,0 +1,74 @@
+import { Log } from "../util/log"
+import { Auth } from "./index"
+
+const log = Log.create({ service: "auth.keepalive" })
+
+const KEEPALIVE_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
+
+let interval: ReturnType<typeof setInterval> | undefined
+
+async function pingAllAnthropicAccounts(): Promise<void> {
+  const store = await Auth.all()
+  const anthropic = store["anthropic"]
+  if (!anthropic || anthropic.type !== "oauth") return
+
+  const records = await Auth.OAuthPool.list("anthropic", "default")
+  if (records.length === 0) return
+
+  log.info("pinging anthropic oauth accounts", { count: records.length })
+
+  for (const record of records) {
+    const usage = await Auth.OAuthPool.fetchAnthropicUsage("anthropic", "default", record.id)
+    if (usage) {
+      log.info("keepalive ping successful", {
+        recordId: record.id,
+        label: record.label,
+        fiveHourUsage: usage.fiveHour?.utilization,
+      })
+    } else {
+      log.warn("keepalive ping failed", {
+        recordId: record.id,
+        label: record.label,
+      })
+    }
+  }
+}
+
+export function init(): void {
+  if (interval) return
+
+  log.info("starting oauth keepalive", { intervalMs: KEEPALIVE_INTERVAL_MS })
+
+  // Initial ping after 5 minutes (to let everything settle)
+  setTimeout(
+    () => {
+      pingAllAnthropicAccounts().catch((err) => {
+        log.error("keepalive ping error", { error: err })
+      })
+    },
+    5 * 60 * 1000,
+  )
+
+  // Then every hour
+  interval = setInterval(() => {
+    pingAllAnthropicAccounts().catch((err) => {
+      log.error("keepalive ping error", { error: err })
+    })
+  }, KEEPALIVE_INTERVAL_MS)
+
+  interval.unref()
+}
+
+export function stop(): void {
+  if (interval) {
+    clearInterval(interval)
+    interval = undefined
+    log.info("stopped oauth keepalive")
+  }
+}
+
+export const AuthKeepAlive = {
+  init,
+  stop,
+  ping: pingAllAnthropicAccounts,
+}

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,6 +11,7 @@ import { Instance } from "./instance"
 import { Vcs } from "./vcs"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { AuthKeepAlive } from "@/auth/keepalive"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -28,4 +29,6 @@ export async function InstanceBootstrap() {
       await Project.setInitialized(Instance.project.id)
     }
   })
+
+  AuthKeepAlive.init()
 }


### PR DESCRIPTION
## Summary

Implements an automatic keep-alive mechanism for Anthropic OAuth tokens to prevent the "Token refresh failed: 400" error that occurs after periods of inactivity.

## Problem

Users report that after several hours of inactivity (especially after sleep/overnight), the Anthropic OAuth token expires and refresh fails:

```
Error: Token refresh failed: 400
```

This forces users to re-login every morning. See related issues:
- Fixes #9111
- Related: #6559, #4992

## Solution

New module `auth/keepalive.ts` that periodically pings all logged-in Anthropic OAuth accounts using the `/api/oauth/usage` endpoint:

- **Zero token cost** - The usage endpoint doesn't consume any tokens
- **Hourly ping** - First ping after 5 minutes, then every 60 minutes
- **Multi-account support** - Pings ALL logged-in Anthropic accounts (account 1, 2, 3, etc.)
- **Anthropic-only** - Other providers (Copilot, OpenAI) are not affected
- **Automatic** - Starts with `InstanceBootstrap()`, no user action required
- **Logged** - All pings logged under `auth.keepalive` for debugging

## Changes

- `packages/opencode/src/auth/keepalive.ts` - New module with keep-alive logic
- `packages/opencode/src/project/bootstrap.ts` - Initialize keep-alive on startup

## Testing

- Run OpenCode for extended periods
- Monitor logs for `auth.keepalive` messages:
  ```
  auth.keepalive: pinging anthropic oauth accounts { count: 2 }
  auth.keepalive: keepalive ping successful { recordId: "...", label: "default" }
  ```
- Verify tokens remain valid after previously problematic timeframes