### PR TITLE
feat(auth): add OAuth token keepalive via Messages API

### DIFF
--- a/packages/opencode/src/auth/keepalive.ts
+++ b/packages/opencode/src/auth/keepalive.ts
@@ -1,0 +1,137 @@
+import { Log } from "../util/log"
+
+const log = Log.create({ service: "auth.keepalive" })
+
+const KEEPALIVE_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
+
+let interval: ReturnType<typeof setInterval> | undefined
+
+interface OAuthRecord {
+  id: string
+  namespace: string
+  label?: string
+  access: string
+  refresh: string
+  expires: number
+}
+
+async function loadAnthropicRecords(): Promise<OAuthRecord[]> {
+  const { Auth } = await import("./index")
+  const store = await Auth.all()
+  if (!store["anthropic"] || store["anthropic"].type !== "oauth") return []
+
+  const path = await import("path")
+  const { Global } = await import("../global")
+  const fs = await import("fs/promises")
+
+  const filepath = path.join(Global.Path.data, "auth.json")
+  const raw = await fs.readFile(filepath, "utf-8").catch(() => null)
+  if (!raw) return []
+
+  const data = JSON.parse(raw)
+  const provider = data.providers?.["anthropic"]
+  if (!provider || provider.type !== "oauth") return []
+
+  return provider.records.filter((r: OAuthRecord) => r.access && r.namespace === "default")
+}
+
+async function pingWithMessagesAPI(record: OAuthRecord): Promise<boolean> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 30000)
+
+    const response = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${record.access}`,
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+      body: JSON.stringify({
+        model: "claude-3-haiku-20240307",
+        max_tokens: 5,
+        messages: [{ role: "user", content: "ping" }],
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (response.ok) {
+      // Consume response body to complete the request
+      await response.json().catch(() => {})
+      return true
+    }
+
+    log.warn("keepalive ping failed", {
+      recordId: record.id,
+      label: record.label,
+      status: response.status,
+    })
+    return false
+  } catch (err) {
+    log.warn("keepalive ping error", {
+      recordId: record.id,
+      label: record.label,
+      error: String(err),
+    })
+    return false
+  }
+}
+
+async function pingAllAnthropicAccounts(): Promise<void> {
+  const records = await loadAnthropicRecords()
+  if (records.length === 0) {
+    log.info("no anthropic oauth accounts to ping")
+    return
+  }
+
+  log.info("pinging anthropic oauth accounts", { count: records.length })
+
+  for (const record of records) {
+    const success = await pingWithMessagesAPI(record)
+    if (success) {
+      log.info("keepalive ping successful", {
+        recordId: record.id,
+        label: record.label,
+      })
+    }
+  }
+}
+
+export function init(): void {
+  if (interval) return
+
+  log.info("starting oauth keepalive", { intervalMs: KEEPALIVE_INTERVAL_MS })
+
+  // Initial ping after 1 minute (to let everything settle)
+  setTimeout(() => {
+    pingAllAnthropicAccounts().catch((err) => {
+      log.error("keepalive ping error", { error: String(err) })
+    })
+  }, 60 * 1000)
+
+  // Then every hour
+  interval = setInterval(() => {
+    pingAllAnthropicAccounts().catch((err) => {
+      log.error("keepalive ping error", { error: String(err) })
+    })
+  }, KEEPALIVE_INTERVAL_MS)
+
+  interval.unref()
+}
+
+export function stop(): void {
+  if (interval) {
+    clearInterval(interval)
+    interval = undefined
+    log.info("stopped oauth keepalive")
+  }
+}
+
+export const AuthKeepAlive = {
+  init,
+  stop,
+  ping: pingAllAnthropicAccounts,
+}

--- a/packages/opencode/src/auth/keepalive.ts
+++ b/packages/opencode/src/auth/keepalive.ts
@@ -2,7 +2,8 @@ import { Log } from "../util/log"
 
 const log = Log.create({ service: "auth.keepalive" })
 
-const KEEPALIVE_INTERVAL_MS = 60 * 60 * 1000 // 1 hour
+const KEEPALIVE_INTERVAL_MS = 30 * 60 * 1000 // 30 minutes (more frequent to catch expiring tokens)
+const TOKEN_REFRESH_BUFFER_MS = 10 * 60 * 1000 // Refresh 10 minutes before expiry
 
 let interval: ReturnType<typeof setInterval> | undefined
 
@@ -32,7 +33,84 @@ async function loadAnthropicRecords(): Promise<OAuthRecord[]> {
   const provider = data.providers?.["anthropic"]
   if (!provider || provider.type !== "oauth") return []
 
-  return provider.records.filter((r: OAuthRecord) => r.access && r.namespace === "default")
+  return provider.records.filter((r: OAuthRecord) => r.access && r.refresh && r.namespace === "default")
+}
+
+async function refreshAnthropicToken(record: OAuthRecord): Promise<{ access: string; expires: number } | null> {
+  try {
+    log.info("refreshing anthropic token", { recordId: record.id, label: record.label })
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 30000)
+
+    const response = await fetch("https://console.anthropic.com/v1/oauth/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: record.refresh,
+        client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      log.error("token refresh failed", {
+        recordId: record.id,
+        status: response.status,
+        body: text.slice(0, 200),
+      })
+      return null
+    }
+
+    const data = (await response.json()) as {
+      access_token: string
+      expires_in?: number
+      refresh_token?: string
+    }
+
+    log.info("token refresh successful", { recordId: record.id })
+
+    return {
+      access: data.access_token,
+      expires: Date.now() + (data.expires_in ?? 3600) * 1000,
+    }
+  } catch (err) {
+    log.error("token refresh error", {
+      recordId: record.id,
+      error: String(err),
+    })
+    return null
+  }
+}
+
+async function updateStoredToken(recordId: string, access: string, expires: number): Promise<void> {
+  const path = await import("path")
+  const { Global } = await import("../global")
+  const fs = await import("fs/promises")
+
+  const filepath = path.join(Global.Path.data, "auth.json")
+  const raw = await fs.readFile(filepath, "utf-8").catch(() => null)
+  if (!raw) return
+
+  const data = JSON.parse(raw)
+  const provider = data.providers?.["anthropic"]
+  if (!provider || provider.type !== "oauth") return
+
+  const record = provider.records.find((r: OAuthRecord) => r.id === recordId)
+  if (!record) return
+
+  record.access = access
+  record.expires = expires
+  record.updatedAt = Date.now()
+
+  await fs.writeFile(filepath, JSON.stringify(data, null, 2))
+  log.info("updated stored token", { recordId })
 }
 
 async function pingWithMessagesAPI(record: OAuthRecord): Promise<boolean> {
@@ -59,7 +137,6 @@ async function pingWithMessagesAPI(record: OAuthRecord): Promise<boolean> {
     clearTimeout(timeout)
 
     if (response.ok) {
-      // Consume response body to complete the request
       await response.json().catch(() => {})
       return true
     }
@@ -80,6 +157,38 @@ async function pingWithMessagesAPI(record: OAuthRecord): Promise<boolean> {
   }
 }
 
+async function keepAliveAccount(record: OAuthRecord): Promise<void> {
+  const now = Date.now()
+  const expiresIn = record.expires - now
+
+  // If token is expired or about to expire, refresh it first
+  if (expiresIn < TOKEN_REFRESH_BUFFER_MS) {
+    log.info("token expired or expiring soon, refreshing", {
+      recordId: record.id,
+      expiresIn: Math.round(expiresIn / 1000),
+    })
+
+    const newToken = await refreshAnthropicToken(record)
+    if (newToken) {
+      await updateStoredToken(record.id, newToken.access, newToken.expires)
+      record.access = newToken.access
+      record.expires = newToken.expires
+    } else {
+      log.error("failed to refresh token, skipping ping", { recordId: record.id })
+      return
+    }
+  }
+
+  // Now ping with the (potentially refreshed) token
+  const success = await pingWithMessagesAPI(record)
+  if (success) {
+    log.info("keepalive ping successful", {
+      recordId: record.id,
+      label: record.label,
+    })
+  }
+}
+
 async function pingAllAnthropicAccounts(): Promise<void> {
   const records = await loadAnthropicRecords()
   if (records.length === 0) {
@@ -87,16 +196,10 @@ async function pingAllAnthropicAccounts(): Promise<void> {
     return
   }
 
-  log.info("pinging anthropic oauth accounts", { count: records.length })
+  log.info("processing anthropic oauth accounts", { count: records.length })
 
   for (const record of records) {
-    const success = await pingWithMessagesAPI(record)
-    if (success) {
-      log.info("keepalive ping successful", {
-        recordId: record.id,
-        label: record.label,
-      })
-    }
+    await keepAliveAccount(record)
   }
 }
 
@@ -105,17 +208,17 @@ export function init(): void {
 
   log.info("starting oauth keepalive", { intervalMs: KEEPALIVE_INTERVAL_MS })
 
-  // Initial ping after 1 minute (to let everything settle)
+  // Initial check after 30 seconds
   setTimeout(() => {
     pingAllAnthropicAccounts().catch((err) => {
-      log.error("keepalive ping error", { error: String(err) })
+      log.error("keepalive error", { error: String(err) })
     })
-  }, 60 * 1000)
+  }, 30 * 1000)
 
-  // Then every hour
+  // Then every 30 minutes
   interval = setInterval(() => {
     pingAllAnthropicAccounts().catch((err) => {
-      log.error("keepalive ping error", { error: String(err) })
+      log.error("keepalive error", { error: String(err) })
     })
   }, KEEPALIVE_INTERVAL_MS)
 

--- a/packages/opencode/src/auth/keepalive.ts
+++ b/packages/opencode/src/auth/keepalive.ts
@@ -46,13 +46,13 @@ async function refreshAnthropicToken(record: OAuthRecord): Promise<{ access: str
     const response = await fetch("https://console.anthropic.com/v1/oauth/token", {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
       },
-      body: JSON.stringify({
+      body: new URLSearchParams({
         grant_type: "refresh_token",
         refresh_token: record.refresh,
         client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
-      }),
+      }).toString(),
       signal: controller.signal,
     })
 

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,6 +11,7 @@ import { Instance } from "./instance"
 import { Vcs } from "./vcs"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { AuthKeepAlive } from "@/auth/keepalive"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -28,4 +29,6 @@ export async function InstanceBootstrap() {
       await Project.setInitialized(Instance.project.id)
     }
   })
+
+  AuthKeepAlive.init()
 }


### PR DESCRIPTION
## Summary

Prevents OAuth token expiration during long periods of inactivity by proactively refreshing tokens before they expire and sending periodic ping requests to the Anthropic Messages API.

Fixes #9121
Closes #6559
Closes #4992

## Problem

OAuth tokens expire after 1-2 hours of inactivity, causing "Token refresh failed: 400" errors. The previous approach in PR #9112 used `/api/oauth/usage` endpoint polling, which **does not actually keep tokens active** - it only retrieves usage statistics without extending the OAuth session lifetime.

The existing token refresh logic in `opencode-anthropic-auth` plugin only triggers **during API calls**. If the app is idle, no refresh happens and tokens expire.

## Solution

Proactive token keepalive that runs every 30 minutes:

1. **Checks token expiry** - If token expires within 10 minutes, refresh it
2. **Refreshes via OAuth endpoint** - Uses `POST /v1/oauth/token` with `grant_type: refresh_token`
3. **Updates stored tokens** - Saves refreshed tokens to `auth.json`
4. **Pings Messages API** - Sends minimal request to maintain session activity

```typescript
// packages/opencode/src/auth/keepalive.ts

// Token refresh (using standard OAuth form-urlencoded format)
const response = await fetch("https://console.anthropic.com/v1/oauth/token", {
  method: "POST",
  headers: { "Content-Type": "application/x-www-form-urlencoded" },
  body: new URLSearchParams({
    grant_type: "refresh_token",
    refresh_token: record.refresh,
    client_id: "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
  }).toString(),
})

// Session ping (minimal tokens, uses cheapest model)
await fetch("https://api.anthropic.com/v1/messages", {
  method: "POST",
  headers: {
    Authorization: `Bearer ${record.access}`,
    "anthropic-version": "2023-06-01",
    "anthropic-beta": "oauth-2025-04-20",
  },
  body: JSON.stringify({
    model: "claude-3-haiku-20240307",
    max_tokens: 5,
    messages: [{ role: "user", content: "ping" }],
  }),
})
```

## Key Functions

| Function | Purpose |
|----------|---------|
| `refreshAnthropicToken()` | Calls Anthropic OAuth token endpoint |
| `updateStoredToken()` | Persists refreshed token to auth.json |
| `keepAliveAccount()` | Checks expiry, refreshes if needed, then pings |
| `pingAllAnthropicAccounts()` | Processes all OAuth accounts |
| `init()` | Starts 30-minute interval timer |

## Changes

- **New**: `packages/opencode/src/auth/keepalive.ts` - Keepalive service
  - Runs every 30 minutes (first ping after 30 seconds)
  - Refreshes tokens 10 minutes before expiry
  - Uses same `client_id` as `opencode-anthropic-auth` plugin
  - Logs under `auth.keepalive` service
  
- **Modified**: `packages/opencode/src/project/bootstrap.ts`
  - Initializes `AuthKeepAlive` on startup

## Testing

1. Start OpenCode with Anthropic OAuth authentication
2. Leave idle for 2+ hours
3. Check logs for `auth.keepalive` service:
   ```
   INFO auth.keepalive: starting oauth keepalive {"intervalMs": 1800000}
   INFO auth.keepalive: token expired or expiring soon, refreshing {"recordId": "...", "expiresIn": 300}
   INFO auth.keepalive: token refresh successful {"recordId": "..."}
   INFO auth.keepalive: keepalive ping successful {"recordId": "..."}
   ```
4. Resume usage - no token expiration errors

## Token Cost

- ~10 tokens per ping (input + output)
- ~480 tokens/day with 30-minute pings
- Negligible cost vs. user experience improvement

## Note

App must be running for keepalive to work. If the app is closed, tokens will still expire normally.