### PR TITLE
docs: add oh-my-opencode-slim to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                      |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                        |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible         |
+| [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim)                          | Lightweight oh-my-opencode fork with reduced token usage and specialized agent orchestration   |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                   |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events            |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                           |


### PR DESCRIPTION
## Summary

- Adds [oh-my-opencode-slim](https://github.com/alvinunreal/oh-my-opencode-slim) to the ecosystem plugins list
- Lightweight fork of oh-my-opencode focused on reduced token usage and specialized agent orchestration
