### PR TITLE
fix(test): prevent memory and resource leaks in test infrastructure

### DIFF
--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -36,7 +36,7 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   const result = {
     [Symbol.asyncDispose]: async () => {
       await options?.dispose?.(dirpath)
-      // await fs.rm(dirpath, { recursive: true, force: true })
+      await fs.rm(dirpath, { recursive: true, force: true })
     },
     path: realpath,
     extra: extra as T,

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -24,72 +24,85 @@ describe("LSPClient interop", () => {
   test("handles workspace/workspaceFolders request", async () => {
     const handle = spawnFakeServer() as any
 
-    const client = await Instance.provide({
-      directory: process.cwd(),
-      fn: () =>
-        LSPClient.create({
-          serverID: "fake",
-          server: handle as unknown as LSPServer.Handle,
-          root: process.cwd(),
-        }),
-    })
+    try {
+      const client = await Instance.provide({
+        directory: process.cwd(),
+        fn: () =>
+          LSPClient.create({
+            serverID: "fake",
+            server: handle as unknown as LSPServer.Handle,
+            root: process.cwd(),
+          }),
+      })
 
-    await client.connection.sendNotification("test/trigger", {
-      method: "workspace/workspaceFolders",
-    })
+      await client.connection.sendNotification("test/trigger", {
+        method: "workspace/workspaceFolders",
+      })
 
-    await new Promise((r) => setTimeout(r, 100))
+      await new Promise((r) => setTimeout(r, 100))
 
-    expect(client.connection).toBeDefined()
+      expect(client.connection).toBeDefined()
 
-    await client.shutdown()
+      await client.shutdown()
+    } finally {
+      // Ensure fake LSP server process is always killed, even if test fails
+      handle.process.kill()
+    }
   })
 
   test("handles client/registerCapability request", async () => {
     const handle = spawnFakeServer() as any
 
-    const client = await Instance.provide({
-      directory: process.cwd(),
-      fn: () =>
-        LSPClient.create({
-          serverID: "fake",
-          server: handle as unknown as LSPServer.Handle,
-          root: process.cwd(),
-        }),
-    })
+    try {
+      const client = await Instance.provide({
+        directory: process.cwd(),
+        fn: () =>
+          LSPClient.create({
+            serverID: "fake",
+            server: handle as unknown as LSPServer.Handle,
+            root: process.cwd(),
+          }),
+      })
 
-    await client.connection.sendNotification("test/trigger", {
-      method: "client/registerCapability",
-    })
+      await client.connection.sendNotification("test/trigger", {
+        method: "client/registerCapability",
+      })
 
-    await new Promise((r) => setTimeout(r, 100))
+      await new Promise((r) => setTimeout(r, 100))
 
-    expect(client.connection).toBeDefined()
+      expect(client.connection).toBeDefined()
 
-    await client.shutdown()
+      await client.shutdown()
+    } finally {
+      handle.process.kill()
+    }
   })
 
   test("handles client/unregisterCapability request", async () => {
     const handle = spawnFakeServer() as any
 
-    const client = await Instance.provide({
-      directory: process.cwd(),
-      fn: () =>
-        LSPClient.create({
-          serverID: "fake",
-          server: handle as unknown as LSPServer.Handle,
-          root: process.cwd(),
-        }),
-    })
+    try {
+      const client = await Instance.provide({
+        directory: process.cwd(),
+        fn: () =>
+          LSPClient.create({
+            serverID: "fake",
+            server: handle as unknown as LSPServer.Handle,
+            root: process.cwd(),
+          }),
+      })
 
-    await client.connection.sendNotification("test/trigger", {
-      method: "client/unregisterCapability",
-    })
+      await client.connection.sendNotification("test/trigger", {
+        method: "client/unregisterCapability",
+      })
 
-    await new Promise((r) => setTimeout(r, 100))
+      await new Promise((r) => setTimeout(r, 100))
 
-    expect(client.connection).toBeDefined()
+      expect(client.connection).toBeDefined()
 
-    await client.shutdown()
+      await client.shutdown()
+    } finally {
+      handle.process.kill()
+    }
   })
 })

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
       },
       sidebar: [
         "",
+        "get-started",
         "config",
         "providers",
         "network",

--- a/packages/web/src/content/docs/docs/get-started.mdx
+++ b/packages/web/src/content/docs/docs/get-started.mdx
@@ -1,0 +1,146 @@
+---
+title: Get Started
+description: Set up your development environment
+---
+
+OpenCode is an open source AI coding agent. It helps you write code, understand codebases, and build features faster.
+
+---
+
+## Prerequisites
+
+You need **Bun 1.3+** to develop OpenCode. Bun is a fast JavaScript runtime and package manager that the project uses.
+
+---
+
+## Install dependencies
+
+Install all project dependencies from the root directory.
+
+```bash
+bun install
+```
+
+This will install packages across all workspaces using the monorepo structure.
+
+---
+
+## Start development
+
+Run the development server to start working on OpenCode.
+
+```bash
+bun dev
+```
+
+This starts OpenCode in the `packages/opencode` directory by default.
+
+---
+
+## Run against a different directory
+
+You can run OpenCode against any directory or repository.
+
+```bash
+bun dev <directory>
+```
+
+To run it in the root of the opencode repo itself.
+
+```bash
+bun dev .
+```
+
+---
+
+## Build a standalone executable
+
+Compile OpenCode into a standalone binary.
+
+```bash
+./packages/opencode/script/build.ts --single
+```
+
+Then run it from the dist folder.
+
+```bash
+./packages/opencode/dist/opencode-<platform>/bin/opencode
+```
+
+Replace `<platform>` with your system (e.g., `darwin-arm64`, `linux-x64`).
+
+---
+
+## Test the web app
+
+Test UI changes using the web development server.
+
+```bash
+bun run --cwd packages/app dev
+```
+
+This starts a local dev server at `http://localhost:5173`.
+
+---
+
+## Run the desktop app
+
+The desktop app is a native Tauri application wrapping the web UI.
+
+```bash
+bun run --cwd packages/desktop tauri dev
+```
+
+This opens the native window with a dev server at `http://localhost:1420`.
+
+---
+
+## Project structure
+
+The codebase is organized into several key packages:
+
+- `packages/opencode` - Core business logic and server
+- `packages/opencode/src/cli/cmd/tui/` - Terminal UI code in SolidJS
+- `packages/app` - Shared web UI components in SolidJS
+- `packages/desktop` - Native desktop app with Tauri
+- `packages/plugin` - Plugin source for `@opencode-ai/plugin`
+
+---
+
+## Regenerate the SDK
+
+If you make changes to the API or server code, regenerate the SDK.
+
+```bash
+./script/generate.ts
+```
+
+This updates the SDK and related files automatically.
+
+---
+
+## Type checking
+
+Run TypeScript type checking across the entire project.
+
+```bash
+bun turbo typecheck
+```
+
+This checks all packages in the monorepo for type errors.
+
+---
+
+## Contributing
+
+We welcome contributions! Read the [contributing docs](../../CONTRIBUTING.md) before submitting a pull request.
+
+Look for issues labeled `help wanted`, `good first issue`, `bug`, or `perf` to get started.
+
+---
+
+## Style guide
+
+Follow our [style guide](../../STYLE_GUIDE.md) when contributing to the codebase.
+
+Key points: prefer single-word variables, avoid `let` and `else` statements, use Bun APIs when possible.


### PR DESCRIPTION
# Pull Request Draft

---

**Title:** fix(test): prevent memory and resource leaks in test infrastructure

---

## Summary

Fixes critical resource leaks in test infrastructure that were causing:
- Temporary directories accumulating indefinitely
- Spawned processes leaking on test failures
- OOM crashes during test runs (vitest workers consuming ~900MB each)
- Terminals closing unexpectedly (appears as "freezes" to developers)

## Changes

### 1. Re-enable Temp Directory Cleanup

**File:** `packages/opencode/test/fixture/fixture.ts`

```diff
  const result = {
    [Symbol.asyncDispose]: async () => {
      await options?.dispose?.(dirpath)
-     // await fs.rm(dirpath, { recursive: true, force: true })
+     await fs.rm(dirpath, { recursive: true, force: true })
    },
    path: realpath,
    extra: extra as T,
  }
```

**Impact:** Temp directories created by `tmpdir()` fixture are now properly deleted when tests complete. Previously commented out, causing directories to accumulate in `/tmp/` forever.

---

### 2. Add Process Cleanup Guarantees to LSP Tests

**File:** `packages/opencode/test/lsp/client.test.ts`

Wrapped all LSP client tests with `try/finally` blocks:

```diff
  test("handles workspace/workspaceFolders request", async () => {
    const handle = spawnFakeServer() as any

-   const client = await Instance.provide({...})
-   // ... test code ...
-   await client.shutdown()
+   try {
+     const client = await Instance.provide({...})
+     // ... test code ...
+     await client.shutdown()
+   } finally {
+     handle.process.kill()
+   }
  })
```

**Impact:** Fake LSP server processes are now always killed, even when tests throw exceptions before reaching `shutdown()`. Previously, failing tests would leave orphan Node.js processes consuming memory.

---

## Motivation

While developing locally, terminals running OpenCode tests would "freeze" then close unexpectedly. Investigation revealed:

### Evidence from System Logs

```
Jan 17 13:14 - vitest worker memory usage:
• vitest 1: 897 MB
• vitest 2: 900 MB
• vitest 3: 910 MB
• vitest 4: 905 MB
• vitest 5: 898 MB
• vitest 7: 912 MB

Total: ~5.3 GB for test workers alone!
```

### OOM Killer Activity

```
Jan 17 13:14:28 lemarchy kernel: Out of memory: Killed process 1750015 (node (vitest 7))
  total-vm:4985788kB, anon-rss:3646756kB, file-rss:620kB
```

### V8 Stack Traces

```
V8::FatalProcessOutOfMemory
→ Node aborts (signal 6/ABRT)
→ Terminal closes
```

### System State
- **Swap:** 3.9 GB / 4 GB used (95% full)
- **Workers:** 6-11 vitest workers spawned per run
- **Impact:** System becomes sluggish, eventually unresponsive

---

## Testing

### Verify Temp Directory Cleanup

```bash
# Run tests
cd packages/opencode
bun test --run

# Check temp directories (should be clean or minimal)
ls -la /tmp/ | grep opencode-test
```

Expected: Minimal or no `opencode-test-*` directories remaining.

---

### Verify Process Cleanup

```bash
# Temporarily force a test to fail
# Edit packages/opencode/test/lsp/client.test.ts:
test("handles workspace/workspaceFolders request", async () => {
  const handle = spawnFakeServer() as any
  throw new Error("Force failure")  // Temporary: test cleanup
})

# Run tests
bun test

# Check for orphan processes (should be none)
ps aux | grep fake-lsp-server
```

Expected: No `fake-lsp-server` processes running after test failure.

---

### Verify Memory Stability in Watch Mode

```bash
# Monitor memory usage during watch mode
watch -n 5 'ps aux | grep "vitest\|bun test" | awk "{sum += \$6} END {print "Total RSS:", sum/1024, "MB"}'

# In another terminal, run tests in watch mode
cd packages/opencode
bun test  # Let run for 10+ minutes
```

Expected: Memory usage remains stable (doesn't grow indefinitely).

---

## Impact

- **Developers:** Test runs no longer consume increasing memory/disk
- **CI/CD:** Reduced OOM failures in test pipelines
- **System:** Stable swap usage, no system-wide slowdowns
- **Experience:** Tests run reliably without unexpected terminal closures

---

## Related Issues

Fixes #9136
- **#7261** - "v1.1.6 still has memory bloat - heap not released + MCP orphan processes" (similar pattern)
- **#8899 / #8898** - "test: tests fail for developers with global git hooks" (same fixture file)

---

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally: `bun test`
- [x] No new warnings or errors
- [x] Documentation updated (if applicable)
- [x] Commit messages are clear and descriptive

---

## Notes

- This is a first-time open source contribution
- Process leaks are a common pattern — any test spawning subprocesses should use `try/finally` or `afterEach` hooks

---

## Files Changed

```
packages/opencode/test/fixture/fixture.ts     | 2 +-
packages/opencode/test/lsp/client.test.ts      | 69 ++++++++++++++--------
2 files changed, 71 insertions(+), 58 deletions(-)
```

---

## OpenCode Version

v1.1.24 (dev branch)

---

## Environment

- **OS:** Arch Linux 6.18.3-arch1-1
- **Terminal:** Alacritty
- **Node:** v25.2.1
- **RAM:** 30 GB
