### PR TITLE
feat(util): Add bounded LRU cache utility

### DIFF
--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -3,6 +3,7 @@ import { disposeInstance } from "@/effect/instance-registry"
 import { Filesystem } from "@/util/filesystem"
 import { iife } from "@/util/iife"
 import { Log } from "@/util/log"
+import { createLruCache } from "@/util/cache"
 import { Context } from "../util/context"
 import { Project } from "./project"
 import { State } from "./state"
@@ -13,7 +14,9 @@ export interface Shape {
   project: Project.Info
 }
 const context = Context.create<Shape>("instance")
-const cache = new Map<string, Promise<Shape>>()
+const cache = createLruCache<string, Promise<Shape>>({
+  maxEntries: 20,
+})
 
 const disposal = {
   all: undefined as Promise<void> | undefined,

--- a/packages/opencode/src/util/cache.ts
+++ b/packages/opencode/src/util/cache.ts
@@ -1,0 +1,86 @@
+/**
+ * LRU cache with max entries limit for preventing memory leaks
+ */
+
+export type LruCacheOpts = {
+  maxEntries?: number
+  onEvict?: (key: any, value: any) => void
+}
+
+type LruCacheEntry<V> = {
+  value: V
+  lastAccess: number
+}
+
+export function createLruCache<K = any, V = any>(opts: LruCacheOpts = {}) {
+  const { maxEntries = Infinity, onEvict } = opts
+  const cache = new Map<K, LruCacheEntry<V>>()
+
+  function evictOne() {
+    let oldestKey: K | null = null
+    let oldestAccess = Infinity
+
+    for (const [key, entry] of cache) {
+      if (entry.lastAccess < oldestAccess) {
+        oldestAccess = entry.lastAccess
+        oldestKey = key
+      }
+    }
+
+    if (oldestKey !== null) {
+      delete_(oldestKey)
+    }
+  }
+
+  function delete_(key: K): boolean {
+    const entry = cache.get(key)
+    if (!entry) return false
+    onEvict?.(key, entry.value)
+    return cache.delete(key)
+  }
+
+  return {
+    get(key: K): V | undefined {
+      const entry = cache.get(key)
+      if (!entry) return undefined
+      entry.lastAccess = Date.now()
+      return entry.value
+    },
+
+    set(key: K, value: V): void {
+      if (cache.size >= maxEntries && !cache.has(key)) {
+        evictOne()
+      }
+      cache.set(key, { value, lastAccess: Date.now() })
+    },
+
+    has(key: K): boolean {
+      return cache.has(key)
+    },
+
+    delete(key: K): boolean {
+      return delete_(key)
+    },
+
+    clear(): void {
+      for (const [key, entry] of cache) {
+        onEvict?.(key, entry.value)
+      }
+      cache.clear()
+    },
+
+    get size() {
+      return cache.size
+    },
+
+    *[Symbol.iterator](): IterableIterator<[K, V]> {
+      for (const [key, entry] of cache) {
+        yield [key, entry.value]
+      }
+    },
+
+    entries(): IterableIterator<[K, V]> {
+      return this[Symbol.iterator]()
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Add a bounded LRU (Least Recently Used) cache utility with eviction callbacks to prevent unbounded memory growth.

Fixes #9140

## Problem

Several places in the codebase use unbounded `Map` objects for caching:
- Instance cache in `project/instance.ts`
- Provider SDK cache in `provider/provider.ts`

These can grow without limit in long-running processes or when handling many directories/providers.

## Solution

Add a reusable `createLruCache` utility that:
- Limits cache size with `maxEntries` option
- Evicts least-recently-used entries when full
- Provides `onEvict` callback for cleanup logic
- Maintains Map-like interface for easy adoption

## Changes

- `packages/opencode/src/util/cache.ts` - New LRU cache utility with:
  - `maxEntries` limit (default: Infinity for backward compatibility)
  - `onEvict` callback for disposal logic
  - LRU tracking via `lastAccess` timestamp
  - Iterator support for `for...of` loops

## Testing

- [x] TypeScript compilation passes (`bun turbo typecheck`)
- [x] Unit tests pass (725 tests, 0 failures)
- [x] Cache utility has 36% line coverage from existing tests

**Note:** Manual memory testing (monitoring heap growth over time) was not performed.