### PR TITLE
fix(lsp): Clear diagnostics and files maps on client shutdown

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -241,6 +241,8 @@ export namespace LSPClient {
         connection.end()
         connection.dispose()
         input.server.process.kill()
+        diagnostics.clear()
+        for (const path in files) delete files[path]
         l.info("shutdown")
       },
     }


### PR DESCRIPTION
## Summary

Properly clean up LSP client resources when the underlying LSP server process disconnects or exits.

Fixes #9143
Relates to #5363

## Problem

When an LSP client shuts down, the `diagnostics` Map and `files` object are not cleared. This can cause:
1. Memory retention from diagnostics data for closed files
2. Stale data if the same LSP server reconnects
3. Memory growth over multiple LSP reconnections

## Solution

Add cleanup logic in the LSP client `shutdown()` method to:
- Clear the `diagnostics` Map
- Clear the `files` object

## Changes

- `packages/opencode/src/lsp/client.ts` - Add cleanup in shutdown() method

## Testing

- [x] TypeScript compilation passes (`bun turbo typecheck`)
- [x] Unit tests pass (725 tests, 0 failures)
- [x] LSP client tests pass (3 tests)

**Note:** Manual LSP server disconnect testing was not performed.