### PR TITLE
fix(mcp): Fix memory leaks in OAuth transport and process cleanup

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -31,6 +31,7 @@ import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
 import path from "path"
+import { Instance } from "./project/instance"
 import { Global } from "./global"
 import { JsonMigration } from "./storage/json-migration"
 import { Database } from "./storage/db"
@@ -165,6 +166,19 @@ cli = cli
   })
   .strict()
 
+// Dispose instances on termination to prevent orphan MCP/LSP processes
+let cleanupDone = false
+async function cleanup(signal: string) {
+  if (cleanupDone) return
+  cleanupDone = true
+  Log.Default.info("cleanup triggered", { signal })
+  try {
+    await Instance.disposeAll()
+  } catch {}
+}
+process.on("SIGINT", () => cleanup("SIGINT").then(() => process.exit(130)))
+process.on("SIGTERM", () => cleanup("SIGTERM").then(() => process.exit(143)))
+
 try {
   await cli.parse()
 } catch (e) {
@@ -205,6 +219,7 @@ try {
   }
   process.exitCode = 1
 } finally {
+  await cleanup("exit")
   // Some subprocesses don't react properly to SIGTERM and similar signals.
   // Most notably, some docker-container-based MCP servers don't handle such signals unless
   // run using `docker run --init`.

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -152,6 +152,28 @@ export namespace MCP {
   type TransportWithAuth = StreamableHTTPClientTransport | SSEClientTransport
   const pendingOAuthTransports = new Map<string, TransportWithAuth>()
 
+  // Helper function to close a transport properly
+  async function closeTransport(transport: TransportWithAuth | undefined): Promise<void> {
+    if (!transport) return
+    try {
+      // The transport should have a close method or similar cleanup
+      if (typeof (transport as any).close === "function") {
+        await (transport as any).close()
+      }
+    } catch (error) {
+      log.error("Failed to close transport", { error })
+    }
+  }
+
+  // Helper function to set a transport while properly cleaning up the old one
+  async function setPendingOAuthTransport(key: string, transport: TransportWithAuth): Promise<void> {
+    const existing = pendingOAuthTransports.get(key)
+    if (existing) {
+      await closeTransport(existing)
+    }
+    pendingOAuthTransports.set(key, transport)
+  }
+
   // Prompt cache types
   type PromptInfo = Awaited<ReturnType<MCPClient["listPrompts"]>>["prompts"][number]
 
@@ -418,7 +440,7 @@ export namespace MCP {
               }).catch((e) => log.debug("failed to show toast", { error: e }))
             } else {
               // Store transport for later finishAuth call
-              pendingOAuthTransports.set(key, transport)
+              await setPendingOAuthTransport(key, transport)
               status = { status: "needs_auth" as const }
               // Show toast for needs_auth
               Bus.publish(TuiEvent.ToastShow, {
@@ -812,7 +834,7 @@ export namespace MCP {
     } catch (error) {
       if (error instanceof UnauthorizedError && capturedUrl) {
         // Store transport for finishAuth
-        pendingOAuthTransports.set(mcpName, transport)
+        await setPendingOAuthTransport(mcpName, transport)
         return { authorizationUrl: capturedUrl.toString() }
       }
       throw error
@@ -939,6 +961,9 @@ export namespace MCP {
   export async function removeAuth(mcpName: string): Promise<void> {
     await McpAuth.remove(mcpName)
     McpOAuthCallback.cancelPending(mcpName)
+    // Properly close the transport before removing it
+    const transport = pendingOAuthTransports.get(mcpName)
+    await closeTransport(transport)
     pendingOAuthTransports.delete(mcpName)
     await McpAuth.clearOAuthState(mcpName)
     log.info("removed oauth credentials", { mcpName })


### PR DESCRIPTION
## Summary

Fix memory leaks in MCP OAuth transport management and add process exit cleanup to prevent orphaned MCP server processes.

Fixes #9153
Relates to #5363

## Problem

1. **OAuth transport leaks**: When MCP OAuth flows retry, a new transport is created for the same server but the previous transport is never closed. Similarly, `removeAuth()` deletes the map entry without closing the transport.
2. **Orphan processes**: MCP server child processes continue running after the main process exits because there is no cleanup handler.

## Solution

### Transport Cleanup (`mcp/index.ts`)
- Add `closeTransport()` helper that safely calls `.close()` on a transport
- Add `setPendingOAuthTransport()` that closes old transports before replacing them
- Close transport in `removeAuth()` before deleting the map entry

### Process Exit Cleanup (`index.ts`)
- Register `SIGINT`/`SIGTERM` handlers that call `Instance.disposeAll()` before exit
- Call cleanup in the existing `finally` block for normal exit paths
- Guard against duplicate cleanup with a `cleanupDone` flag

## Testing

- [x] TypeScript compilation passes (`bun turbo typecheck`)
- [x] Unit tests pass

## AI-Assisted
Yes