### PR TITLE
fix(acp): Fix memory leak in session event streams

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -259,6 +259,12 @@ export namespace ACP {
           return
         }
 
+        case "session.deleted": {
+          const sessionId = event.properties.info.id
+          this.closeSession(sessionId)
+          return
+        }
+
         case "message.part.updated": {
           log.info("message part updated", { event: event.properties })
           const props = event.properties
@@ -1431,6 +1437,34 @@ export namespace ACP {
         },
         { throwOnError: true },
       )
+    }
+
+    /**
+     * Dispose of all session resources including event streams and session map entries.
+     * This should be called when the agent is being destroyed to prevent memory leaks.
+     */
+    async dispose() {
+      log.info("disposing agent", { sessionCount: this.sessionManager["sessions"].size })
+
+      // Abort global event stream
+      this.eventAbort.abort()
+
+      // Clear all sessions from the manager
+      this.sessionManager.clear()
+    }
+
+    /**
+     * Close a specific session and clean up its resources.
+     * This should be called when a session is explicitly closed/ended.
+     */
+    closeSession(sessionId: string) {
+      log.info("closing session", { sessionId })
+
+      // Remove from session manager
+      this.sessionManager.delete(sessionId)
+
+      // Clean up permission queue if present
+      this.permissionQueues.delete(sessionId)
     }
   }
 

--- a/packages/opencode/src/acp/session.ts
+++ b/packages/opencode/src/acp/session.ts
@@ -13,6 +13,14 @@ export class ACPSessionManager {
     this.sdk = sdk
   }
 
+  delete(sessionId: string): boolean {
+    return this.sessions.delete(sessionId)
+  }
+
+  clear(): void {
+    this.sessions.clear()
+  }
+
   tryGet(sessionId: string): ACPSessionState | undefined {
     return this.sessions.get(sessionId)
   }


### PR DESCRIPTION
## Summary

Fix ACP session resource cleanup to prevent stale session state and leaked per-session resources.

Fixes #9154
Relates to #5363

## Problem

ACP sessions were not fully cleaned up when sessions were deleted, leaving stale entries in session maps and per-session permission queues.

## Solution

- Handle session-deleted events by explicitly closing the session
- Add closeSession(sessionId) in ACP agent to remove session state + permission queue entries
- Add agent dispose() cleanup path to clear remaining session state and abort global event stream
- Add delete()/clear() helpers to ACPSessionManager

## Changes

- packages/opencode/src/acp/agent.ts
- packages/opencode/src/acp/session.ts

## Testing

- [x] TypeScript compilation passes (bun turbo typecheck)
- [x] Unit tests pass

## AI-Assisted
Yes