### PR TITLE
fix(disposal): Complete Instance disposal chain for plugins and caches

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -5,207 +5,146 @@ import { Log } from "../util/log"
 import { createOpencodeClient } from "@opencode-ai/sdk"
 import { Server } from "../server/server"
 import { BunProc } from "../bun"
+import { Instance } from "../project/instance"
 import { Flag } from "../flag/flag"
 import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
-import { gitlabAuthPlugin as GitlabAuthPlugin } from "opencode-gitlab-auth"
-import { PoeAuthPlugin } from "opencode-poe-auth"
-import { Effect, Layer, ServiceMap } from "effect"
-import { InstanceState } from "@/effect/instance-state"
-import { makeRunPromise } from "@/effect/run-service"
+import { gitlabAuthPlugin as GitlabAuthPlugin } from "@gitlab/opencode-gitlab-auth"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
 
-  type State = {
-    hooks: Hooks[]
-  }
-
-  // Hook names that follow the (input, output) => Promise<void> trigger pattern
-  type TriggerName = {
-    [K in keyof Hooks]-?: NonNullable<Hooks[K]> extends (input: any, output: any) => Promise<void> ? K : never
-  }[keyof Hooks]
-
-  export interface Interface {
-    readonly trigger: <
-      Name extends TriggerName,
-      Input = Parameters<Required<Hooks>[Name]>[0],
-      Output = Parameters<Required<Hooks>[Name]>[1],
-    >(
-      name: Name,
-      input: Input,
-      output: Output,
-    ) => Effect.Effect<Output>
-    readonly list: () => Effect.Effect<Hooks[]>
-    readonly init: () => Effect.Effect<void>
-  }
-
-  export class Service extends ServiceMap.Service<Service, Interface>()("@opencode/Plugin") {}
+  const BUILTIN = ["opencode-anthropic-auth@0.0.13"]
 
   // Built-in plugins that are directly imported (not installed from npm)
-  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin, PoeAuthPlugin]
+  const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin, GitlabAuthPlugin]
 
-  // Old npm package names for plugins that are now built-in — skip if users still have them in config
-  const DEPRECATED_PLUGIN_PACKAGES = ["opencode-openai-codex-auth", "opencode-copilot-auth"]
+  const state = Instance.state(async () => {
+    const client = createOpencodeClient({
+      baseUrl: "http://localhost:4096",
+      directory: Instance.directory,
+      // @ts-ignore - fetch type incompatibility
+      fetch: async (...args) => Server.App().fetch(...args),
+    })
+    const config = await Config.get()
+    const hooks: Hooks[] = []
+    const input: PluginInput = {
+      client,
+      project: Instance.project,
+      worktree: Instance.worktree,
+      directory: Instance.directory,
+      serverUrl: Server.url(),
+      $: Bun.$,
+    }
 
-  export const layer = Layer.effect(
-    Service,
-    Effect.gen(function* () {
-      const cache = yield* InstanceState.make<State>(
-        Effect.fn("Plugin.state")(function* (ctx) {
-          const hooks: Hooks[] = []
+    for (const plugin of INTERNAL_PLUGINS) {
+      log.info("loading internal plugin", { name: plugin.name })
+      const init = await plugin(input).catch((err) => {
+        log.error("failed to load internal plugin", { name: plugin.name, error: err })
+      })
+      if (init) hooks.push(init)
+    }
 
-          yield* Effect.promise(async () => {
-            const client = createOpencodeClient({
-              baseUrl: "http://localhost:4096",
-              directory: ctx.directory,
-              headers: Flag.OPENCODE_SERVER_PASSWORD
-                ? {
-                    Authorization: `Basic ${Buffer.from(`${Flag.OPENCODE_SERVER_USERNAME ?? "opencode"}:${Flag.OPENCODE_SERVER_PASSWORD}`).toString("base64")}`,
-                  }
-                : undefined,
-              fetch: async (...args) => Server.Default().fetch(...args),
-            })
-            const cfg = await Config.get()
-            const input: PluginInput = {
-              client,
-              project: ctx.project,
-              worktree: ctx.worktree,
-              directory: ctx.directory,
-              get serverUrl(): URL {
-                return Server.url ?? new URL("http://localhost:4096")
-              },
-              $: Bun.$,
-            }
+    let plugins = config.plugin ?? []
+    if (plugins.length) await Config.waitForDependencies()
+    if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {
+      plugins = [...BUILTIN, ...plugins]
+    }
 
-            for (const plugin of INTERNAL_PLUGINS) {
-              log.info("loading internal plugin", { name: plugin.name })
-              const init = await plugin(input).catch((err) => {
-                log.error("failed to load internal plugin", { name: plugin.name, error: err })
-              })
-              if (init) hooks.push(init)
-            }
-
-            let plugins = cfg.plugin ?? []
-            if (plugins.length) await Config.waitForDependencies()
-
-            for (let plugin of plugins) {
-              if (DEPRECATED_PLUGIN_PACKAGES.some((pkg) => plugin.includes(pkg))) continue
-              log.info("loading plugin", { path: plugin })
-              if (!plugin.startsWith("file://")) {
-                const idx = plugin.lastIndexOf("@")
-                const pkg = idx > 0 ? plugin.substring(0, idx) : plugin
-                const version = idx > 0 ? plugin.substring(idx + 1) : "latest"
-                plugin = await BunProc.install(pkg, version).catch((err) => {
-                  const cause = err instanceof Error ? err.cause : err
-                  const detail = cause instanceof Error ? cause.message : String(cause ?? err)
-                  log.error("failed to install plugin", { pkg, version, error: detail })
-                  Bus.publish(Session.Event.Error, {
-                    error: new NamedError.Unknown({
-                      message: `Failed to install plugin ${pkg}@${version}: ${detail}`,
-                    }).toObject(),
-                  })
-                  return ""
-                })
-                if (!plugin) continue
-              }
-
-              // Prevent duplicate initialization when plugins export the same function
-              // as both a named export and default export (e.g., `export const X` and `export default X`).
-              // Object.entries(mod) would return both entries pointing to the same function reference.
-              await import(plugin)
-                .then(async (mod) => {
-                  const seen = new Set<PluginInstance>()
-                  for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
-                    if (seen.has(fn)) continue
-                    seen.add(fn)
-                    hooks.push(await fn(input))
-                  }
-                })
-                .catch((err) => {
-                  const message = err instanceof Error ? err.message : String(err)
-                  log.error("failed to load plugin", { path: plugin, error: message })
-                  Bus.publish(Session.Event.Error, {
-                    error: new NamedError.Unknown({
-                      message: `Failed to load plugin ${plugin}: ${message}`,
-                    }).toObject(),
-                  })
-                })
-            }
-
-            // Notify plugins of current config
-            for (const hook of hooks) {
-              try {
-                await (hook as any).config?.(cfg)
-              } catch (err) {
-                log.error("plugin config hook failed", { error: err })
-              }
-            }
+    for (let plugin of plugins) {
+      // ignore old codex plugin since it is supported first party now
+      if (plugin.includes("opencode-openai-codex-auth") || plugin.includes("opencode-copilot-auth")) continue
+      log.info("loading plugin", { path: plugin })
+      if (!plugin.startsWith("file://")) {
+        const lastAtIndex = plugin.lastIndexOf("@")
+        const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
+        const version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
+        plugin = await BunProc.install(pkg, version).catch((err) => {
+          const cause = err instanceof Error ? err.cause : err
+          const detail = cause instanceof Error ? cause.message : String(cause ?? err)
+          log.error("failed to install plugin", { pkg, version, error: detail })
+          Bus.publish(Session.Event.Error, {
+            error: new NamedError.Unknown({
+              message: `Failed to install plugin ${pkg}@${version}: ${detail}`,
+            }).toObject(),
           })
-
-          // Subscribe to bus events, clean up when scope is closed
-          yield* Effect.acquireRelease(
-            Effect.sync(() =>
-              Bus.subscribeAll(async (input) => {
-                for (const hook of hooks) {
-                  hook["event"]?.({ event: input })
-                }
-              }),
-            ),
-            (unsub) => Effect.sync(unsub),
-          )
-
-          return { hooks }
-        }),
-      )
-
-      const trigger = Effect.fn("Plugin.trigger")(function* <
-        Name extends TriggerName,
-        Input = Parameters<Required<Hooks>[Name]>[0],
-        Output = Parameters<Required<Hooks>[Name]>[1],
-      >(name: Name, input: Input, output: Output) {
-        if (!name) return output
-        const state = yield* InstanceState.get(cache)
-        yield* Effect.promise(async () => {
-          for (const hook of state.hooks) {
-            const fn = hook[name] as any
-            if (!fn) continue
-            await fn(input, output)
+          return ""
+        })
+        if (!plugin) continue
+      }
+      // Prevent duplicate initialization when plugins export the same function
+      // as both a named export and default export (e.g., `export const X` and `export default X`).
+      // Object.entries(mod) would return both entries pointing to the same function reference.
+      await import(plugin)
+        .then(async (mod) => {
+          const seen = new Set<PluginInstance>()
+          for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+            if (seen.has(fn)) continue
+            seen.add(fn)
+            hooks.push(await fn(input))
           }
         })
-        return output
-      })
+        .catch((err) => {
+          const message = err instanceof Error ? err.message : String(err)
+          log.error("failed to load plugin", { path: plugin, error: message })
+          Bus.publish(Session.Event.Error, {
+            error: new NamedError.Unknown({
+              message: `Failed to load plugin ${plugin}: ${message}`,
+            }).toObject(),
+          })
+        })
+    }
 
-      const list = Effect.fn("Plugin.list")(function* () {
-        const state = yield* InstanceState.get(cache)
-        return state.hooks
-      })
-
-      const init = Effect.fn("Plugin.init")(function* () {
-        yield* InstanceState.get(cache)
-      })
-
-      return Service.of({ trigger, list, init })
-    }),
-  )
-
-  const runPromise = makeRunPromise(Service, layer)
+    return {
+      hooks,
+      input,
+      unsubscribe: undefined as (() => void) | undefined,
+    }
+  },
+  async (state) => {
+    state.unsubscribe?.()
+    for (const hook of state.hooks) {
+      await hook.dispose?.()
+    }
+  })
 
   export async function trigger<
-    Name extends TriggerName,
+    Name extends Exclude<keyof Required<Hooks>, "auth" | "event" | "tool">,
     Input = Parameters<Required<Hooks>[Name]>[0],
     Output = Parameters<Required<Hooks>[Name]>[1],
   >(name: Name, input: Input, output: Output): Promise<Output> {
-    return runPromise((svc) => svc.trigger(name, input, output))
+    if (!name) return output
+    for (const hook of await state().then((x) => x.hooks)) {
+      const fn = hook[name]
+      if (!fn) continue
+      // @ts-expect-error if you feel adventurous, please fix the typing, make sure to bump the try-counter if you
+      // give up.
+      // try-counter: 2
+      await fn(input, output)
+    }
+    return output
   }
 
-  export async function list(): Promise<Hooks[]> {
-    return runPromise((svc) => svc.list())
+  export async function list() {
+    return state().then((x) => x.hooks)
   }
 
   export async function init() {
-    return runPromise((svc) => svc.init())
+    const s = await state()
+    const config = await Config.get()
+    for (const hook of s.hooks) {
+      // @ts-expect-error this is because we haven't moved plugin to sdk v2
+      await hook.config?.(config)
+    }
+    s.unsubscribe = Bus.subscribeAll(async (input) => {
+      const hooks = await state().then((x) => x.hooks)
+      for (const hook of hooks) {
+        hook["event"]?.({
+          event: input,
+        })
+      }
+    })
   }
 }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -1,16 +1,31 @@
 import { Plugin } from "../plugin"
 import { Format } from "../format"
 import { LSP } from "../lsp"
-import { File } from "../file"
 import { FileWatcher } from "../file/watcher"
-import { Snapshot } from "../snapshot"
+import { File } from "../file"
 import { Project } from "./project"
-import { Vcs } from "./vcs"
 import { Bus } from "../bus"
 import { Command } from "../command"
 import { Instance } from "./instance"
+import { Vcs } from "./vcs"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { Snapshot } from "../snapshot"
+import { Truncate } from "../tool/truncation"
+
+const commandSubscription = Instance.state(
+  () => {
+    const unsubscribe = Bus.subscribe(Command.Event.Executed, async (payload) => {
+      if (payload.properties.name === Command.Default.INIT) {
+        await Project.setInitialized(Instance.project.id)
+      }
+    })
+    return { unsubscribe }
+  },
+  async (state) => {
+    state.unsubscribe()
+  },
+)
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -18,14 +33,10 @@ export async function InstanceBootstrap() {
   ShareNext.init()
   Format.init()
   await LSP.init()
-  File.init()
   FileWatcher.init()
+  File.init()
   Vcs.init()
   Snapshot.init()
-
-  Bus.subscribe(Command.Event.Executed, async (payload) => {
-    if (payload.properties.name === Command.Default.INIT) {
-      Project.setInitialized(Instance.project.id)
-    }
-  })
+  Truncate.init()
+  commandSubscription()
 }

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -3,6 +3,7 @@ import { disposeInstance } from "@/effect/instance-registry"
 import { Filesystem } from "@/util/filesystem"
 import { iife } from "@/util/iife"
 import { Log } from "@/util/log"
+import { createLruCache } from "@/util/cache"
 import { Context } from "../util/context"
 import { Project } from "./project"
 import { State } from "./state"
@@ -13,7 +14,9 @@ export interface Shape {
   project: Project.Info
 }
 const context = Context.create<Shape>("instance")
-const cache = new Map<string, Promise<Shape>>()
+const cache = createLruCache<string, Promise<Shape>>({
+  maxEntries: 20,
+})
 
 const disposal = {
   all: undefined as Promise<void> | undefined,

--- a/packages/opencode/src/project/instance.ts
+++ b/packages/opencode/src/project/instance.ts
@@ -16,6 +16,14 @@ export interface Shape {
 const context = Context.create<Shape>("instance")
 const cache = createLruCache<string, Promise<Shape>>({
   maxEntries: 20,
+  onEvict: async (_key, value) => {
+    const ctx = await value.catch(() => null)
+    if (ctx) {
+      await context.provide(ctx, async () => {
+        await State.dispose(ctx.directory)
+      })
+    }
+  },
 })
 
 const disposal = {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -6,10 +6,9 @@ import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
 import { NoSuchModelError, type Provider as SDK } from "ai"
 import { Log } from "../util/log"
 import { BunProc } from "../bun"
-import { Hash } from "../util/hash"
 import { Plugin } from "../plugin"
-import { NamedError } from "@opencode-ai/util/error"
 import { ModelsDev } from "./models"
+import { NamedError } from "@opencode-ai/util/error"
 import { Auth } from "../auth"
 import { Env } from "../env"
 import { Instance } from "../project/instance"
@@ -18,6 +17,7 @@ import { iife } from "@/util/iife"
 import { Global } from "../global"
 import path from "path"
 import { Filesystem } from "../util/filesystem"
+import { createLruCache } from "@/util/cache"
 
 // Direct imports for bundled providers
 import { createAmazonBedrock, type AmazonBedrockProviderSettings } from "@ai-sdk/amazon-bedrock"
@@ -40,72 +40,48 @@ import { createGateway } from "@ai-sdk/gateway"
 import { createTogetherAI } from "@ai-sdk/togetherai"
 import { createPerplexity } from "@ai-sdk/perplexity"
 import { createVercel } from "@ai-sdk/vercel"
-import {
-  createGitLab,
-  VERSION as GITLAB_PROVIDER_VERSION,
-  isWorkflowModel,
-  discoverWorkflowModels,
-} from "gitlab-ai-provider"
+import { createGitLab, VERSION as GITLAB_PROVIDER_VERSION } from "@gitlab/gitlab-ai-provider"
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { GoogleAuth } from "google-auth-library"
 import { ProviderTransform } from "./transform"
 import { Installation } from "../installation"
-import { ModelID, ProviderID } from "./schema"
 
 export namespace Provider {
   const log = Log.create({ service: "provider" })
 
-  function shouldUseCopilotResponsesApi(modelID: string): boolean {
+  function isGpt5OrLater(modelID: string): boolean {
     const match = /^gpt-(\d+)/.exec(modelID)
-    if (!match) return false
-    return Number(match[1]) >= 5 && !modelID.startsWith("gpt-5-mini")
+    if (!match) {
+      return false
+    }
+    return Number(match[1]) >= 5
   }
 
-  function wrapSSE(res: Response, ms: number, ctl: AbortController) {
-    if (typeof ms !== "number" || ms <= 0) return res
-    if (!res.body) return res
-    if (!res.headers.get("content-type")?.includes("text/event-stream")) return res
+  function shouldUseCopilotResponsesApi(modelID: string): boolean {
+    return isGpt5OrLater(modelID) && !modelID.startsWith("gpt-5-mini")
+  }
 
-    const reader = res.body.getReader()
-    const body = new ReadableStream<Uint8Array>({
-      async pull(ctrl) {
-        const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
-          const id = setTimeout(() => {
-            const err = new Error("SSE read timed out")
-            ctl.abort(err)
-            void reader.cancel(err)
-            reject(err)
-          }, ms)
+  function googleVertexVars(options: Record<string, any>) {
+    const project =
+      options["project"] ?? Env.get("GOOGLE_CLOUD_PROJECT") ?? Env.get("GCP_PROJECT") ?? Env.get("GCLOUD_PROJECT")
+    const location =
+      options["location"] ?? Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "us-central1"
+    const endpoint = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
 
-          reader.read().then(
-            (part) => {
-              clearTimeout(id)
-              resolve(part)
-            },
-            (err) => {
-              clearTimeout(id)
-              reject(err)
-            },
-          )
-        })
+    return {
+      GOOGLE_VERTEX_PROJECT: project,
+      GOOGLE_VERTEX_LOCATION: location,
+      GOOGLE_VERTEX_ENDPOINT: endpoint,
+    }
+  }
 
-        if (part.done) {
-          ctrl.close()
-          return
-        }
-
-        ctrl.enqueue(part.value)
-      },
-      async cancel(reason) {
-        ctl.abort(reason)
-        await reader.cancel(reason)
-      },
-    })
-
-    return new Response(body, {
-      headers: new Headers(res.headers),
-      status: res.status,
-      statusText: res.statusText,
+  function loadBaseURL(model: Model, options: Record<string, any>) {
+    const raw = options["baseURL"] ?? model.api.url
+    if (typeof raw !== "string") return raw
+    const vars = model.providerID === "google-vertex" ? googleVertexVars(options) : undefined
+    return raw.replace(/\$\{([^}]+)\}/g, (match, key) => {
+      const val = Env.get(String(key)) ?? vars?.[String(key) as keyof typeof vars]
+      return val ?? match
     })
   }
 
@@ -129,25 +105,17 @@ export namespace Provider {
     "@ai-sdk/togetherai": createTogetherAI,
     "@ai-sdk/perplexity": createPerplexity,
     "@ai-sdk/vercel": createVercel,
-    "gitlab-ai-provider": createGitLab,
+    "@gitlab/gitlab-ai-provider": createGitLab,
     // @ts-ignore (TODO: kill this code so we dont have to maintain it)
     "@ai-sdk/github-copilot": createGitHubCopilotOpenAICompatible,
   }
 
   type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>) => Promise<any>
-  type CustomVarsLoader = (options: Record<string, any>) => Record<string, string>
-  type CustomDiscoverModels = () => Promise<Record<string, Model>>
   type CustomLoader = (provider: Info) => Promise<{
     autoload: boolean
     getModel?: CustomModelLoader
-    vars?: CustomVarsLoader
     options?: Record<string, any>
-    discoverModels?: CustomDiscoverModels
   }>
-
-  function useLanguageModel(sdk: any) {
-    return sdk.responses === undefined && sdk.chat === undefined
-  }
 
   const CUSTOM_LOADERS: Record<string, CustomLoader> = {
     async anthropic() {
@@ -155,7 +123,8 @@ export namespace Provider {
         autoload: false,
         options: {
           headers: {
-            "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+            "anthropic-beta":
+              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
           },
         },
       }
@@ -191,36 +160,30 @@ export namespace Provider {
         options: {},
       }
     },
-    xai: async () => {
-      return {
-        autoload: false,
-        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-          return sdk.responses(modelID)
-        },
-        options: {},
-      }
-    },
     "github-copilot": async () => {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
-          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
+          if (sdk.responses === undefined && sdk.chat === undefined) return sdk.languageModel(modelID)
           return shouldUseCopilotResponsesApi(modelID) ? sdk.responses(modelID) : sdk.chat(modelID)
         },
         options: {},
       }
     },
-    azure: async (provider) => {
-      const resource = iife(() => {
-        const name = provider.options?.resourceName
-        if (typeof name === "string" && name.trim() !== "") return name
-        return Env.get("AZURE_RESOURCE_NAME")
-      })
-
+    "github-copilot-enterprise": async () => {
+      return {
+        autoload: false,
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>) {
+          if (sdk.responses === undefined && sdk.chat === undefined) return sdk.languageModel(modelID)
+          return shouldUseCopilotResponsesApi(modelID) ? sdk.responses(modelID) : sdk.chat(modelID)
+        },
+        options: {},
+      }
+    },
+    azure: async () => {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
           if (options?.["useCompletionUrls"]) {
             return sdk.chat(modelID)
           } else {
@@ -228,11 +191,6 @@ export namespace Provider {
           }
         },
         options: {},
-        vars(_options) {
-          return {
-            ...(resource && { AZURE_RESOURCE_NAME: resource }),
-          }
-        },
       }
     },
     "azure-cognitive-services": async () => {
@@ -240,7 +198,6 @@ export namespace Provider {
       return {
         autoload: false,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
-          if (useLanguageModel(sdk)) return sdk.languageModel(modelID)
           if (options?.["useCompletionUrls"]) {
             return sdk.chat(modelID)
           } else {
@@ -429,26 +386,13 @@ export namespace Provider {
         Env.get("GCP_PROJECT") ??
         Env.get("GCLOUD_PROJECT")
 
-      const location = String(
-        provider.options?.location ??
-          Env.get("GOOGLE_VERTEX_LOCATION") ??
-          Env.get("GOOGLE_CLOUD_LOCATION") ??
-          Env.get("VERTEX_LOCATION") ??
-          "us-central1",
-      )
+      const location =
+        provider.options?.location ?? Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "us-central1"
 
       const autoload = Boolean(project)
       if (!autoload) return { autoload: false }
       return {
         autoload: true,
-        vars(_options: Record<string, any>) {
-          const endpoint = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
-          return {
-            ...(project && { GOOGLE_VERTEX_PROJECT: project }),
-            GOOGLE_VERTEX_LOCATION: location,
-            GOOGLE_VERTEX_ENDPOINT: endpoint,
-          }
-        },
         options: {
           project,
           location,
@@ -536,14 +480,7 @@ export namespace Provider {
 
       const aiGatewayHeaders = {
         "User-Agent": `opencode/${Installation.VERSION} gitlab-ai-provider/${GITLAB_PROVIDER_VERSION} (${os.platform()} ${os.release()}; ${os.arch()})`,
-        "anthropic-beta": "context-1m-2025-08-07",
         ...(providerConfig?.options?.aiGatewayHeaders || {}),
-      }
-
-      const featureFlags = {
-        duo_agent_platform_agentic_chat: true,
-        duo_agent_platform: true,
-        ...(providerConfig?.options?.featureFlags || {}),
       }
 
       return {
@@ -552,92 +489,21 @@ export namespace Provider {
           instanceUrl,
           apiKey,
           aiGatewayHeaders,
-          featureFlags,
+          featureFlags: {
+            duo_agent_platform_agentic_chat: true,
+            duo_agent_platform: true,
+            ...(providerConfig?.options?.featureFlags || {}),
+          },
         },
-        async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string, options?: Record<string, any>) {
-          if (modelID.startsWith("duo-workflow-")) {
-            const workflowRef = options?.workflowRef as string | undefined
-            // Use the static mapping if it exists, otherwise use duo-workflow with selectedModelRef
-            const sdkModelID = isWorkflowModel(modelID) ? modelID : "duo-workflow"
-            const model = sdk.workflowChat(sdkModelID, {
-              featureFlags,
-            })
-            if (workflowRef) {
-              model.selectedModelRef = workflowRef
-            }
-            return model
-          }
+        async getModel(sdk: ReturnType<typeof createGitLab>, modelID: string) {
           return sdk.agenticChat(modelID, {
             aiGatewayHeaders,
-            featureFlags,
+            featureFlags: {
+              duo_agent_platform_agentic_chat: true,
+              duo_agent_platform: true,
+              ...(providerConfig?.options?.featureFlags || {}),
+            },
           })
-        },
-        async discoverModels(): Promise<Record<string, Model>> {
-          if (!apiKey) {
-            log.info("gitlab model discovery skipped: no apiKey")
-            return {}
-          }
-
-          try {
-            const token = apiKey
-            const getHeaders = (): Record<string, string> =>
-              auth?.type === "api" ? { "PRIVATE-TOKEN": token } : { Authorization: `Bearer ${token}` }
-
-            log.info("gitlab model discovery starting", { instanceUrl })
-            const result = await discoverWorkflowModels(
-              { instanceUrl, getHeaders },
-              { workingDirectory: Instance.directory },
-            )
-
-            if (!result.models.length) {
-              log.info("gitlab model discovery skipped: no models found", {
-                project: result.project ? { id: result.project.id, path: result.project.pathWithNamespace } : null,
-              })
-              return {}
-            }
-
-            const models: Record<string, Model> = {}
-            for (const m of result.models) {
-              if (!input.models[m.id]) {
-                models[m.id] = {
-                  id: ModelID.make(m.id),
-                  providerID: ProviderID.make("gitlab"),
-                  name: `Agent Platform (${m.name})`,
-                  family: "",
-                  api: {
-                    id: m.id,
-                    url: instanceUrl,
-                    npm: "gitlab-ai-provider",
-                  },
-                  status: "active",
-                  headers: {},
-                  options: { workflowRef: m.ref },
-                  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
-                  limit: { context: m.context, output: m.output },
-                  capabilities: {
-                    temperature: false,
-                    reasoning: true,
-                    attachment: true,
-                    toolcall: true,
-                    input: { text: true, audio: false, image: true, video: false, pdf: true },
-                    output: { text: true, audio: false, image: false, video: false, pdf: false },
-                    interleaved: false,
-                  },
-                  release_date: "",
-                  variants: {},
-                }
-              }
-            }
-
-            log.info("gitlab model discovery complete", {
-              count: Object.keys(models).length,
-              models: Object.keys(models),
-            })
-            return models
-          } catch (e) {
-            log.warn("gitlab model discovery failed", { error: e })
-            return {}
-          }
         },
       }
     },
@@ -657,14 +523,10 @@ export namespace Provider {
         autoload: !!apiKey,
         options: {
           apiKey,
+          baseURL: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
         },
         async getModel(sdk: any, modelID: string) {
           return sdk.languageModel(modelID)
-        },
-        vars(_options) {
-          return {
-            CLOUDFLARE_ACCOUNT_ID: accountId,
-          }
         },
       }
     },
@@ -694,28 +556,7 @@ export namespace Provider {
       const { createAiGateway } = await import("ai-gateway-provider")
       const { createUnified } = await import("ai-gateway-provider/providers/unified")
 
-      const metadata = iife(() => {
-        if (input.options?.metadata) return input.options.metadata
-        try {
-          return JSON.parse(input.options?.headers?.["cf-aig-metadata"])
-        } catch {
-          return undefined
-        }
-      })
-      const opts = {
-        metadata,
-        cacheTtl: input.options?.cacheTtl,
-        cacheKey: input.options?.cacheKey,
-        skipCache: input.options?.skipCache,
-        collectLog: input.options?.collectLog,
-      }
-
-      const aigateway = createAiGateway({
-        accountId,
-        gateway,
-        apiKey: apiToken,
-        ...(Object.values(opts).some((v) => v !== undefined) ? { options: opts } : {}),
-      })
+      const aigateway = createAiGateway({ accountId, gateway, apiKey: apiToken })
       const unified = createUnified()
 
       return {
@@ -752,8 +593,8 @@ export namespace Provider {
 
   export const Model = z
     .object({
-      id: ModelID.zod,
-      providerID: ProviderID.zod,
+      id: z.string(),
+      providerID: z.string(),
       api: z.object({
         id: z.string(),
         url: z.string(),
@@ -823,7 +664,7 @@ export namespace Provider {
 
   export const Info = z
     .object({
-      id: ProviderID.zod,
+      id: z.string(),
       name: z.string(),
       source: z.enum(["env", "config", "custom", "api"]),
       env: z.string().array(),
@@ -838,8 +679,8 @@ export namespace Provider {
 
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
     const m: Model = {
-      id: ModelID.make(model.id),
-      providerID: ProviderID.make(provider.id),
+      id: model.id,
+      providerID: provider.id,
       name: model.name,
       family: model.family,
       api: {
@@ -905,7 +746,7 @@ export namespace Provider {
 
   export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
     return {
-      id: ProviderID.make(provider.id),
+      id: provider.id,
       source: "custom",
       name: provider.name,
       env: provider.env ?? [],
@@ -923,30 +764,40 @@ export namespace Provider {
     const disabled = new Set(config.disabled_providers ?? [])
     const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
 
-    function isProviderAllowed(providerID: ProviderID): boolean {
+    function isProviderAllowed(providerID: string): boolean {
       if (enabled && !enabled.has(providerID)) return false
       if (disabled.has(providerID)) return false
       return true
     }
 
-    const providers: Record<ProviderID, Info> = {} as Record<ProviderID, Info>
-    const languages = new Map<string, LanguageModelV2>()
+    const providers: { [providerID: string]: Info } = {}
+    const languages = createLruCache<string, LanguageModelV2>({
+      maxEntries: 100,
+    })
     const modelLoaders: {
       [providerID: string]: CustomModelLoader
     } = {}
-    const varsLoaders: {
-      [providerID: string]: CustomVarsLoader
-    } = {}
-    const discoveryLoaders: {
-      [providerID: string]: CustomDiscoverModels
-    } = {}
-    const sdk = new Map<string, SDK>()
+    const sdk = new Map<number, SDK>()
 
     log.info("init")
 
     const configProviders = Object.entries(config.provider ?? {})
 
-    function mergeProvider(providerID: ProviderID, provider: Partial<Info>) {
+    // Add GitHub Copilot Enterprise provider that inherits from GitHub Copilot
+    if (database["github-copilot"]) {
+      const githubCopilot = database["github-copilot"]
+      database["github-copilot-enterprise"] = {
+        ...githubCopilot,
+        id: "github-copilot-enterprise",
+        name: "GitHub Copilot Enterprise",
+        models: mapValues(githubCopilot.models, (model) => ({
+          ...model,
+          providerID: "github-copilot-enterprise",
+        })),
+      }
+    }
+
+    function mergeProvider(providerID: string, provider: Partial<Info>) {
       const existing = providers[providerID]
       if (existing) {
         // @ts-expect-error
@@ -963,7 +814,7 @@ export namespace Provider {
     for (const [providerID, provider] of configProviders) {
       const existing = database[providerID]
       const parsed: Info = {
-        id: ProviderID.make(providerID),
+        id: providerID,
         name: provider.name ?? existing?.name ?? providerID,
         env: provider.env ?? existing?.env ?? [],
         options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
@@ -979,7 +830,7 @@ export namespace Provider {
           return existingModel?.name ?? modelID
         })
         const parsedModel: Model = {
-          id: ModelID.make(modelID),
+          id: modelID,
           api: {
             id: model.id ?? existingModel?.api.id ?? modelID,
             npm:
@@ -992,7 +843,7 @@ export namespace Provider {
           },
           status: model.status ?? existingModel?.status ?? "active",
           name,
-          providerID: ProviderID.make(providerID),
+          providerID,
           capabilities: {
             temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
             reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
@@ -1044,8 +895,7 @@ export namespace Provider {
 
     // load env
     const env = Env.all()
-    for (const [id, provider] of Object.entries(database)) {
-      const providerID = ProviderID.make(id)
+    for (const [providerID, provider] of Object.entries(database)) {
       if (disabled.has(providerID)) continue
       const apiKey = provider.env.map((item) => env[item]).find(Boolean)
       if (!apiKey) continue
@@ -1056,8 +906,7 @@ export namespace Provider {
     }
 
     // load apikeys
-    for (const [id, provider] of Object.entries(await Auth.all())) {
-      const providerID = ProviderID.make(id)
+    for (const [providerID, provider] of Object.entries(await Auth.all())) {
       if (disabled.has(providerID)) continue
       if (provider.type === "api") {
         mergeProvider(providerID, {
@@ -1069,23 +918,52 @@ export namespace Provider {
 
     for (const plugin of await Plugin.list()) {
       if (!plugin.auth) continue
-      const providerID = ProviderID.make(plugin.auth.provider)
+      const providerID = plugin.auth.provider
       if (disabled.has(providerID)) continue
 
+      // For github-copilot plugin, check if auth exists for either github-copilot or github-copilot-enterprise
+      let hasAuth = false
       const auth = await Auth.get(providerID)
-      if (!auth) continue
+      if (auth) hasAuth = true
+
+      // Special handling for github-copilot: also check for enterprise auth
+      if (providerID === "github-copilot" && !hasAuth) {
+        const enterpriseAuth = await Auth.get("github-copilot-enterprise")
+        if (enterpriseAuth) hasAuth = true
+      }
+
+      if (!hasAuth) continue
       if (!plugin.auth.loader) continue
 
+      // Load for the main provider if auth exists
       if (auth) {
         const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
         const opts = options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
       }
+
+      // If this is github-copilot plugin, also register for github-copilot-enterprise if auth exists
+      if (providerID === "github-copilot") {
+        const enterpriseProviderID = "github-copilot-enterprise"
+        if (!disabled.has(enterpriseProviderID)) {
+          const enterpriseAuth = await Auth.get(enterpriseProviderID)
+          if (enterpriseAuth) {
+            const enterpriseOptions = await plugin.auth.loader(
+              () => Auth.get(enterpriseProviderID) as any,
+              database[enterpriseProviderID],
+            )
+            const opts = enterpriseOptions ?? {}
+            const patch: Partial<Info> = providers[enterpriseProviderID]
+              ? { options: opts }
+              : { source: "custom", options: opts }
+            mergeProvider(enterpriseProviderID, patch)
+          }
+        }
+      }
     }
 
-    for (const [id, fn] of Object.entries(CUSTOM_LOADERS)) {
-      const providerID = ProviderID.make(id)
+    for (const [providerID, fn] of Object.entries(CUSTOM_LOADERS)) {
       if (disabled.has(providerID)) continue
       const data = database[providerID]
       if (!data) {
@@ -1095,8 +973,6 @@ export namespace Provider {
       const result = await fn(data)
       if (result && (result.autoload || providers[providerID])) {
         if (result.getModel) modelLoaders[providerID] = result.getModel
-        if (result.vars) varsLoaders[providerID] = result.vars
-        if (result.discoverModels) discoveryLoaders[providerID] = result.discoverModels
         const opts = result.options ?? {}
         const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
         mergeProvider(providerID, patch)
@@ -1104,8 +980,7 @@ export namespace Provider {
     }
 
     // load config
-    for (const [id, provider] of configProviders) {
-      const providerID = ProviderID.make(id)
+    for (const [providerID, provider] of configProviders) {
       const partial: Partial<Info> = { source: "config" }
       if (provider.env) partial.env = provider.env
       if (provider.name) partial.name = provider.name
@@ -1113,8 +988,7 @@ export namespace Provider {
       mergeProvider(providerID, partial)
     }
 
-    for (const [id, provider] of Object.entries(providers)) {
-      const providerID = ProviderID.make(id)
+    for (const [providerID, provider] of Object.entries(providers)) {
       if (!isProviderAllowed(providerID)) {
         delete providers[providerID]
         continue
@@ -1124,10 +998,7 @@ export namespace Provider {
 
       for (const [modelID, model] of Object.entries(provider.models)) {
         model.api.id = model.api.id ?? model.id ?? modelID
-        if (
-          modelID === "gpt-5-chat-latest" ||
-          (providerID === ProviderID.openrouter && modelID === "openai/gpt-5-chat")
-        )
+        if (modelID === "gpt-5-chat-latest" || (providerID === "openrouter" && modelID === "openai/gpt-5-chat"))
           delete provider.models[modelID]
         if (model.status === "alpha" && !Flag.OPENCODE_ENABLE_EXPERIMENTAL_MODELS) delete provider.models[modelID]
         if (model.status === "deprecated") delete provider.models[modelID]
@@ -1158,24 +1029,19 @@ export namespace Provider {
       log.info("found", { providerID })
     }
 
-    const gitlab = ProviderID.make("gitlab")
-    if (discoveryLoaders[gitlab] && providers[gitlab]) {
-      await (async () => {
-        const discovered = await discoveryLoaders[gitlab]()
-        for (const [modelID, model] of Object.entries(discovered)) {
-          if (!providers[gitlab].models[modelID]) {
-            providers[gitlab].models[modelID] = model
-          }
-        }
-      })().catch((e) => log.warn("state discovery error", { id: "gitlab", error: e }))
-    }
-
     return {
       models: languages,
       providers,
-      sdk,
+      sdk: createLruCache({
+        maxEntries: 50,
+        onEvict: (key, sdk) => {
+          // SDK may have cleanup methods
+          if (sdk && typeof sdk === "object" && "destroy" in sdk) {
+            sdk.destroy?.()
+          }
+        },
+      }),
       modelLoaders,
-      varsLoaders,
     }
   })
 
@@ -1200,30 +1066,7 @@ export namespace Provider {
         options["includeUsage"] = true
       }
 
-      const baseURL = iife(() => {
-        let url =
-          typeof options["baseURL"] === "string" && options["baseURL"] !== "" ? options["baseURL"] : model.api.url
-        if (!url) return
-
-        // some models/providers have variable urls, ex: "https://${AZURE_RESOURCE_NAME}.services.ai.azure.com/anthropic/v1"
-        // We track this in models.dev, and then when we are resolving the baseURL
-        // we need to string replace that literal: "${AZURE_RESOURCE_NAME}"
-        const loader = s.varsLoaders[model.providerID]
-        if (loader) {
-          const vars = loader(options)
-          for (const [key, value] of Object.entries(vars)) {
-            const field = "${" + key + "}"
-            url = url.replaceAll(field, value)
-          }
-        }
-
-        url = url.replace(/\$\{([^}]+)\}/g, (item, key) => {
-          const val = Env.get(String(key))
-          return val ?? item
-        })
-        return url
-      })
-
+      const baseURL = loadBaseURL(model, options)
       if (baseURL !== undefined) options["baseURL"] = baseURL
       if (options["apiKey"] === undefined && provider.key) options["apiKey"] = provider.key
       if (model.headers)
@@ -1232,28 +1075,26 @@ export namespace Provider {
           ...model.headers,
         }
 
-      const key = Hash.fast(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
+      const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
       const existing = s.sdk.get(key)
-      if (existing) return existing
+      if (existing) return existing.value
 
       const customFetch = options["fetch"]
-      const chunkTimeout = options["chunkTimeout"]
-      delete options["chunkTimeout"]
 
       options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
         // Preserve custom fetch if it exists, wrap it with timeout logic
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
-        const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
-        const signals: AbortSignal[] = []
 
-        if (opts.signal) signals.push(opts.signal)
-        if (chunkAbortCtl) signals.push(chunkAbortCtl.signal)
-        if (options["timeout"] !== undefined && options["timeout"] !== null && options["timeout"] !== false)
-          signals.push(AbortSignal.timeout(options["timeout"]))
+        if (options["timeout"] !== undefined && options["timeout"] !== null) {
+          const signals: AbortSignal[] = []
+          if (opts.signal) signals.push(opts.signal)
+          if (options["timeout"] !== false) signals.push(AbortSignal.timeout(options["timeout"]))
 
-        const combined = signals.length === 0 ? null : signals.length === 1 ? signals[0] : AbortSignal.any(signals)
-        if (combined) opts.signal = combined
+          const combined = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
+
+          opts.signal = combined
+        }
 
         // Strip openai itemId metadata following what codex does
         // Codex uses #[serde(skip_serializing)] on id fields for all item types:
@@ -1273,14 +1114,11 @@ export namespace Provider {
           }
         }
 
-        const res = await fetchFn(input, {
+        return fetchFn(input, {
           ...opts,
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
-
-        if (!chunkAbortCtl) return res
-        return wrapSSE(res, chunkTimeout, chunkAbortCtl)
       }
 
       const bundledFn = BUNDLED_PROVIDERS[model.api.npm]
@@ -1290,7 +1128,7 @@ export namespace Provider {
           name: model.providerID,
           ...options,
         })
-        s.sdk.set(key, loaded)
+        s.sdk.set(key, loaded.value)
         return loaded as SDK
       }
 
@@ -1309,18 +1147,18 @@ export namespace Provider {
         name: model.providerID,
         ...options,
       })
-      s.sdk.set(key, loaded)
+      s.sdk.set(key, loaded.value)
       return loaded as SDK
     } catch (e) {
       throw new InitError({ providerID: model.providerID }, { cause: e })
     }
   }
 
-  export async function getProvider(providerID: ProviderID) {
+  export async function getProvider(providerID: string) {
     return state().then((s) => s.providers[providerID])
   }
 
-  export async function getModel(providerID: ProviderID, modelID: ModelID) {
+  export async function getModel(providerID: string, modelID: string) {
     const s = await state()
     const provider = s.providers[providerID]
     if (!provider) {
@@ -1350,7 +1188,7 @@ export namespace Provider {
 
     try {
       const language = s.modelLoaders[model.providerID]
-        ? await s.modelLoaders[model.providerID](sdk, model.api.id, { ...provider.options, ...model.options })
+        ? await s.modelLoaders[model.providerID](sdk, model.api.id, provider.options)
         : sdk.languageModel(model.api.id)
       s.models.set(key, language)
       return language
@@ -1367,7 +1205,7 @@ export namespace Provider {
     }
   }
 
-  export async function closest(providerID: ProviderID, query: string[]) {
+  export async function closest(providerID: string, query: string[]) {
     const s = await state()
     const provider = s.providers[providerID]
     if (!provider) return undefined
@@ -1382,7 +1220,7 @@ export namespace Provider {
     }
   }
 
-  export async function getSmallModel(providerID: ProviderID) {
+  export async function getSmallModel(providerID: string) {
     const cfg = await Config.get()
 
     if (cfg.small_model) {
@@ -1409,7 +1247,7 @@ export namespace Provider {
         priority = ["gpt-5-mini", "claude-haiku-4.5", ...priority]
       }
       for (const item of priority) {
-        if (providerID === ProviderID.amazonBedrock) {
+        if (providerID === "amazon-bedrock") {
           const crossRegionPrefixes = ["global.", "us.", "eu."]
           const candidates = Object.keys(provider.models).filter((m) => m.includes(item))
 
@@ -1418,32 +1256,38 @@ export namespace Provider {
           // 2. User's region prefix (us., eu.)
           // 3. Unprefixed model
           const globalMatch = candidates.find((m) => m.startsWith("global."))
-          if (globalMatch) return getModel(providerID, ModelID.make(globalMatch))
+          if (globalMatch) return getModel(providerID, globalMatch)
 
           const region = provider.options?.region
           if (region) {
             const regionPrefix = region.split("-")[0]
             if (regionPrefix === "us" || regionPrefix === "eu") {
               const regionalMatch = candidates.find((m) => m.startsWith(`${regionPrefix}.`))
-              if (regionalMatch) return getModel(providerID, ModelID.make(regionalMatch))
+              if (regionalMatch) return getModel(providerID, regionalMatch)
             }
           }
 
           const unprefixed = candidates.find((m) => !crossRegionPrefixes.some((p) => m.startsWith(p)))
-          if (unprefixed) return getModel(providerID, ModelID.make(unprefixed))
+          if (unprefixed) return getModel(providerID, unprefixed)
         } else {
           for (const model of Object.keys(provider.models)) {
-            if (model.includes(item)) return getModel(providerID, ModelID.make(model))
+            if (model.includes(item)) return getModel(providerID, model)
           }
         }
       }
+    }
+
+    // Check if opencode provider is available before using it
+    const opencodeProvider = await state().then((state) => state.providers["opencode"])
+    if (opencodeProvider && opencodeProvider.models["gpt-5-nano"]) {
+      return getModel("opencode", "gpt-5-nano")
     }
 
     return undefined
   }
 
   const priority = ["gpt-5", "claude-sonnet-4", "big-pickle", "gemini-3-pro"]
-  export function sort<T extends { id: string }>(models: T[]) {
+  export function sort(models: Model[]) {
     return sortBy(
       models,
       [(model) => priority.findIndex((filter) => model.id.includes(filter)), "desc"],
@@ -1457,11 +1301,11 @@ export namespace Provider {
     if (cfg.model) return parseModel(cfg.model)
 
     const providers = await list()
-    const recent = (await Filesystem.readJson<{ recent?: { providerID: ProviderID; modelID: ModelID }[] }>(
+    const recent = (await Filesystem.readJson<{ recent?: { providerID: string; modelID: string }[] }>(
       path.join(Global.Path.state, "model.json"),
     )
       .then((x) => (Array.isArray(x.recent) ? x.recent : []))
-      .catch(() => [])) as { providerID: ProviderID; modelID: ModelID }[]
+      .catch(() => [])) as { providerID: string; modelID: string }[]
     for (const entry of recent) {
       const provider = providers[entry.providerID]
       if (!provider) continue
@@ -1482,16 +1326,16 @@ export namespace Provider {
   export function parseModel(model: string) {
     const [providerID, ...rest] = model.split("/")
     return {
-      providerID: ProviderID.make(providerID),
-      modelID: ModelID.make(rest.join("/")),
+      providerID: providerID,
+      modelID: rest.join("/"),
     }
   }
 
   export const ModelNotFoundError = NamedError.create(
     "ProviderModelNotFoundError",
     z.object({
-      providerID: ProviderID.zod,
-      modelID: ModelID.zod,
+      providerID: z.string(),
+      modelID: z.string(),
       suggestions: z.array(z.string()).optional(),
     }),
   )
@@ -1499,7 +1343,7 @@ export namespace Provider {
   export const InitError = NamedError.create(
     "ProviderInitError",
     z.object({
-      providerID: ProviderID.zod,
+      providerID: z.string(),
     }),
   )
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1077,7 +1077,7 @@ export namespace Provider {
 
       const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
       const existing = s.sdk.get(key)
-      if (existing) return existing.value
+      if (existing) return existing
 
       const customFetch = options["fetch"]
 
@@ -1128,7 +1128,7 @@ export namespace Provider {
           name: model.providerID,
           ...options,
         })
-        s.sdk.set(key, loaded.value)
+        s.sdk.set(key, loaded)
         return loaded as SDK
       }
 
@@ -1147,7 +1147,7 @@ export namespace Provider {
         name: model.providerID,
         ...options,
       })
-      s.sdk.set(key, loaded.value)
+      s.sdk.set(key, loaded)
       return loaded as SDK
     } catch (e) {
       throw new InitError({ providerID: model.providerID }, { cause: e })

--- a/packages/opencode/src/util/cache.ts
+++ b/packages/opencode/src/util/cache.ts
@@ -1,0 +1,86 @@
+/**
+ * LRU cache with max entries limit for preventing memory leaks
+ */
+
+export type LruCacheOpts = {
+  maxEntries?: number
+  onEvict?: (key: any, value: any) => void
+}
+
+type LruCacheEntry<V> = {
+  value: V
+  lastAccess: number
+}
+
+export function createLruCache<K = any, V = any>(opts: LruCacheOpts = {}) {
+  const { maxEntries = Infinity, onEvict } = opts
+  const cache = new Map<K, LruCacheEntry<V>>()
+
+  function evictOne() {
+    let oldestKey: K | null = null
+    let oldestAccess = Infinity
+
+    for (const [key, entry] of cache) {
+      if (entry.lastAccess < oldestAccess) {
+        oldestAccess = entry.lastAccess
+        oldestKey = key
+      }
+    }
+
+    if (oldestKey !== null) {
+      delete_(oldestKey)
+    }
+  }
+
+  function delete_(key: K): boolean {
+    const entry = cache.get(key)
+    if (!entry) return false
+    onEvict?.(key, entry.value)
+    return cache.delete(key)
+  }
+
+  return {
+    get(key: K): V | undefined {
+      const entry = cache.get(key)
+      if (!entry) return undefined
+      entry.lastAccess = Date.now()
+      return entry.value
+    },
+
+    set(key: K, value: V): void {
+      if (cache.size >= maxEntries && !cache.has(key)) {
+        evictOne()
+      }
+      cache.set(key, { value, lastAccess: Date.now() })
+    },
+
+    has(key: K): boolean {
+      return cache.has(key)
+    },
+
+    delete(key: K): boolean {
+      return delete_(key)
+    },
+
+    clear(): void {
+      for (const [key, entry] of cache) {
+        onEvict?.(key, entry.value)
+      }
+      cache.clear()
+    },
+
+    get size() {
+      return cache.size
+    },
+
+    *[Symbol.iterator](): IterableIterator<[K, V]> {
+      for (const [key, entry] of cache) {
+        yield [key, entry.value]
+      }
+    },
+
+    entries(): IterableIterator<[K, V]> {
+      return this[Symbol.iterator]()
+    },
+  }
+}

--- a/packages/opencode/src/util/cache.ts
+++ b/packages/opencode/src/util/cache.ts
@@ -72,5 +72,15 @@ export function createLruCache<K = any, V = any>(opts: LruCacheOpts = {}) {
     get size() {
       return cache.size
     },
+
+    *[Symbol.iterator](): IterableIterator<[K, V]> {
+      for (const [key, entry] of cache) {
+        yield [key, entry.value]
+      }
+    },
+
+    entries(): IterableIterator<[K, V]> {
+      return this[Symbol.iterator]()
+    },
   }
 }

--- a/packages/opencode/src/util/cache.ts
+++ b/packages/opencode/src/util/cache.ts
@@ -72,15 +72,5 @@ export function createLruCache<K = any, V = any>(opts: LruCacheOpts = {}) {
     get size() {
       return cache.size
     },
-
-    *[Symbol.iterator](): IterableIterator<[K, V]> {
-      for (const [key, entry] of cache) {
-        yield [key, entry.value]
-      }
-    },
-
-    entries(): IterableIterator<[K, V]> {
-      return this[Symbol.iterator]()
-    },
   }
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -245,4 +245,8 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+  /**
+   * Called when the plugin is being disposed/cleaned up
+   */
+  dispose?: () => Promise<void>
 }


### PR DESCRIPTION
## Summary

Complete the Instance disposal chain to ensure plugins and cached resources are properly cleaned up when instances are disposed.

Fixes #9157
Depends on #9141 (LRU cache utility)

> **Note:** This PR builds on the LRU cache utility from #9141. Please merge that PR first.

## Problem

When `Instance.dispose()` is called:

1. **Plugins not disposed** - Plugins may hold resources (connections, file handles) that need cleanup
2. **Cached instances not disposed** - The instance cache doesn't call disposal hooks when evicting entries
3. **No disposal hook in Hooks interface** - Plugins have no way to register cleanup logic

## Solution

### 1. Plugin Dispose Hook

Add `dispose()` method to plugin Hooks interface.

### 2. LRU Cache onEvict Callback

Use the LRU cache's `onEvict` callback to dispose instances when evicted.

### 3. Bootstrap Cleanup

Add cleanup in bootstrap to dispose plugins before process exit.

## Changes

- `packages/plugin/src/index.ts` - Add `dispose()` to Hooks interface
- `packages/opencode/src/plugin/index.ts` - Call plugin dispose() on instance disposal
- `packages/opencode/src/project/instance.ts` - Add onEvict callback for cache eviction
- `packages/opencode/src/project/bootstrap.ts` - Add cleanup for plugins on exit
- `packages/opencode/src/provider/provider.ts` - Use LRU cache for SDK instances
- `packages/opencode/src/util/cache.ts` - Add iterator support (from #9141)

## Testing

- [x] TypeScript compilation passes (`bun turbo typecheck`)
- [x] Unit tests pass (725 tests, 0 failures)
- [x] Instance/project tests pass

**Note:** Manual plugin disposal testing was not performed. This requires creating a test plugin with cleanup logic and verifying it's called.

## Stacking

This PR includes commits from #9141 (LRU cache utility). After #9141 is merged, this PR can be rebased to only include the disposal-specific changes.