### PR TITLE
feat(config): add plugin_config for structured plugin options

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -88,6 +88,7 @@ export namespace Config {
     result.agent = result.agent || {}
     result.mode = result.mode || {}
     result.plugin = result.plugin || []
+    result.plugin_config = result.plugin_config || {}
 
     const directories = [
       Global.Path.config,
@@ -880,6 +881,10 @@ export namespace Config {
         })
         .optional(),
       plugin: z.string().array().optional(),
+      plugin_config: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe("Plugin configuration keyed by plugin package name or canonical plugin name"),
       snapshot: z.boolean().optional(),
       share: z
         .enum(["manual", "auto", "disabled"])

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -598,6 +598,54 @@ test("merges plugin arrays from global and local configs", async () => {
   })
 })
 
+test("merges plugin_config from global and local configs", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const projectDir = path.join(dir, "project")
+      const opencodeDir = path.join(projectDir, ".opencode")
+      await fs.mkdir(opencodeDir, { recursive: true })
+
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          plugin: ["my-plugin"],
+          plugin_config: {
+            "my-plugin": { a: 1, nested: { x: 1 } },
+            "global-only": { enabled: true },
+          },
+        }),
+      )
+
+      await Bun.write(
+        path.join(opencodeDir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          plugin_config: {
+            "my-plugin": { a: 9, b: 2, nested: { y: 2 } },
+            "local-only": { mode: "fast" },
+          },
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: path.join(tmp.path, "project"),
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.plugin_config).toBeDefined()
+      expect(config.plugin_config?.["global-only"]).toEqual({ enabled: true })
+      expect(config.plugin_config?.["local-only"]).toEqual({ mode: "fast" })
+      expect(config.plugin_config?.["my-plugin"]).toEqual({
+        a: 9,
+        b: 2,
+        nested: { x: 1, y: 2 },
+      })
+    },
+  })
+})
+
 test("does not error when only custom agent is a subagent", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1216,6 +1216,9 @@ export type Config = {
     ignore?: Array<string>
   }
   plugin?: Array<string>
+  plugin_config?: {
+    [key: string]: unknown
+  }
   snapshot?: boolean
   /**
    * Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1616,6 +1616,12 @@ export type Config = {
     ignore?: Array<string>
   }
   plugin?: Array<string>
+  /**
+   * Plugin configuration keyed by plugin package name or canonical plugin name
+   */
+  plugin_config?: {
+    [key: string]: unknown
+  }
   snapshot?: boolean
   /**
    * Control sharing behavior:'manual' allows manual sharing via commands, 'auto' enables automatic sharing, 'disabled' disables all sharing

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9271,6 +9271,14 @@
               "type": "string"
             }
           },
+          "plugin_config": {
+            "description": "Plugin configuration keyed by plugin package name or canonical plugin name",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          },
           "snapshot": {
             "type": "boolean"
           },


### PR DESCRIPTION
### What does this PR do?

Adds an optional top-level `plugin_config` map to the config schema so plugins can receive structured options via `opencode.json(c)`:

```jsonc
{
  "plugin": ["@acme/my-plugin"],
  "plugin_config": {
    "@acme/my-plugin": { "endpoint": "https://example.com" }
  }
}
```

### Why?

Config parsing is strict (`Config.Info` is `.strict()`), so plugins can’t add plugin-specific keys to `opencode.json(c)` today without an upstream schema change. The common workarounds are env vars or sidecar config files, which are harder to install/standardize.

`plugin_config` is a minimal, additive escape hatch: OpenCode already passes the resolved config to plugins via `Hooks.config`, so plugins can read/validate their own entry without any new lifecycle plumbing.

### Why this shape (vs `plugin: [{ name, config }]`)?

Keeping `plugin` as a plain “load list” avoids changing plugin loading/deduping/merge semantics. `plugin_config` adds configuration without altering how plugins are resolved or initialized.

### Notes

- `plugin_config` is deep-merged across config layers (same merge behavior as other config objects).
- Not intended for secrets; plugins should prefer existing auth/token flows when possible.

### How did you verify your code works?

- `bun test --cwd packages/opencode`
- `bun turbo typecheck`
- `bun ./script/generate.ts`

Fixes #4393