### PR TITLE
fix(openai): align GPT context windows with codex

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -41,6 +41,23 @@ import { ProviderTransform } from "./transform"
 export namespace Provider {
   const log = Log.create({ service: "provider" })
 
+  const CODEX_GPT_5_CONTEXT_WINDOW = 272_000
+  const CODEX_GPT_4_1_CONTEXT_WINDOW = 1_047_576
+  const CODEX_GPT_4O_CONTEXT_WINDOW = 128_000
+  const CODEX_GPT_3_5_CONTEXT_WINDOW = 16_385
+  const CODEX_GPT_OSS_CONTEXT_WINDOW = 96_000
+
+  function codexContextWindowForModelID(modelID: string): number | undefined {
+    const parts = modelID.split("/")
+    const slug = parts[parts.length - 1] ?? modelID
+    if (slug.startsWith("gpt-4.1")) return CODEX_GPT_4_1_CONTEXT_WINDOW
+    if (slug.startsWith("gpt-oss")) return CODEX_GPT_OSS_CONTEXT_WINDOW
+    if (slug.startsWith("gpt-4o")) return CODEX_GPT_4O_CONTEXT_WINDOW
+    if (slug.startsWith("gpt-3.5")) return CODEX_GPT_3_5_CONTEXT_WINDOW
+    if (slug.startsWith("gpt-5")) return CODEX_GPT_5_CONTEXT_WINDOW
+    return undefined
+  }
+
   const BUNDLED_PROVIDERS: Record<string, (options: any) => SDK> = {
     "@ai-sdk/amazon-bedrock": createAmazonBedrock,
     "@ai-sdk/anthropic": createAnthropic,
@@ -587,6 +604,7 @@ export namespace Provider {
   export type Info = z.infer<typeof Info>
 
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
+    const codexContextWindow = codexContextWindowForModelID(model.id)
     const m: Model = {
       id: model.id,
       providerID: provider.id,
@@ -619,7 +637,7 @@ export namespace Provider {
           : undefined,
       },
       limit: {
-        context: model.limit.context,
+        context: codexContextWindow ?? model.limit.context,
         input: model.limit.input,
         output: model.limit.output,
       },


### PR DESCRIPTION
### What does this PR do?

Updates opencode’s model limit.context handling to match codex’s model_info.rs context-window limits for GPT model families (e.g., gpt-4o* → 128k, gpt-4.1* → 1,047,576, gpt-3.5* → 16,385, gpt-oss* → 96k, gpt-5* → 272k) when loading models from models.dev.

### How did you verify your code works?

Ran bun install, then ran the full packages/opencode test suite via bun test (725 pass, 1 skip, 0 fail), plus targeted runs of bun test test/provider/provider.test.ts and bun test test/provider/transform.test.ts.

Fixes https://github.com/anomalyco/opencode/issues/7705