### PR TITLE
fix(app): remove redundant toast for thinking effort changes

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -533,10 +533,6 @@ export default function Page() {
       keybind: "shift+mod+t",
       onSelect: () => {
         local.model.variant.cycle()
-        showToast({
-          title: "Thinking effort changed",
-          description: "The thinking effort has been changed to " + (local.model.variant.current() ?? "Default"),
-        })
       },
     },
     {


### PR DESCRIPTION
Closes #9180

Explanatory tweet. https://x.com/kitlangton/status/2012717028172263568

Remove the toast notification when cycling thinking effort via hotkey. The level is already visible in the prompt bar.