### PR TITLE
feat(tui): system-like custom themes

### DIFF
--- a/packages/console/app/public/theme.json
+++ b/packages/console/app/public/theme.json
@@ -25,8 +25,8 @@
             },
             {
               "type": "string",
-              "enum": ["none"],
-              "description": "No color (uses terminal default)"
+              "enum": ["none", "system"],
+              "description": "No color (uses terminal default or system-calculated color)"
             }
           ]
         }
@@ -110,8 +110,8 @@
         },
         {
           "type": "string",
-          "enum": ["none"],
-          "description": "No color (uses terminal default)"
+          "enum": ["none", "system"],
+          "description": "No color (uses terminal default) or system-calculated color"
         },
         {
           "type": "string",
@@ -136,8 +136,8 @@
                 },
                 {
                   "type": "string",
-                  "enum": ["none"],
-                  "description": "No color (uses terminal default)"
+                  "enum": ["none", "system"],
+                  "description": "No color (uses terminal default or system-calculated color)"
                 },
                 {
                   "type": "string",
@@ -161,8 +161,8 @@
                 },
                 {
                   "type": "string",
-                  "enum": ["none"],
-                  "description": "No color (uses terminal default)"
+                  "enum": ["none", "system"],
+                  "description": "No color (uses terminal default or system-calculated color)"
                 },
                 {
                   "type": "string",

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
@@ -1,16 +1,18 @@
 import { DialogSelect, type DialogSelectRef } from "../ui/dialog-select"
 import { useTheme } from "../context/theme"
 import { useDialog } from "../ui/dialog"
-import { onCleanup, onMount } from "solid-js"
+import { onCleanup } from "solid-js"
 
 export function DialogThemeList() {
   const theme = useTheme()
-  const options = Object.keys(theme.all())
-    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))
-    .map((value) => ({
-      title: value,
-      value: value,
-    }))
+  const options = () =>
+    Object.keys(theme.all())
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))
+      .map((value) => ({
+        title: value,
+        value: value,
+      }))
+
   const dialog = useDialog()
   let confirmed = false
   let ref: DialogSelectRef<string>
@@ -23,7 +25,7 @@ export function DialogThemeList() {
   return (
     <DialogSelect
       title="Themes"
-      options={options}
+      options={options()}
       current={initial}
       onMove={(opt) => {
         theme.set(opt.value)

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -73,6 +73,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
       path: Path
+      config_generation: number
     }>({
       provider_next: {
         all: [],
@@ -100,6 +101,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: [],
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
+      config_generation: 0,
     })
 
     const sdk = useSDK()
@@ -331,7 +333,12 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           })
         }),
         sdk.client.app.agents({}, { throwOnError: true }).then((x) => setStore("agent", reconcile(x.data ?? []))),
-        sdk.client.config.get({}, { throwOnError: true }).then((x) => setStore("config", reconcile(x.data!))),
+        sdk.client.config.get({}, { throwOnError: true }).then((x) => {
+          batch(() => {
+            setStore("config", reconcile(x.data!))
+            setStore("config_generation", (g) => g + 1)
+          })
+        }),
         ...(args.continue ? [sessionListPromise] : []),
       ]
 

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -123,9 +123,10 @@ export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
 
 type HexColor = `#${string}`
 type RefName = string
+type RGBAVariant = { dark: RGBA; light: RGBA }
 type Variant = {
-  dark: HexColor | RefName
-  light: HexColor | RefName
+  dark: HexColor | RefName | RGBA
+  light: HexColor | RefName | RGBA
 }
 type ColorValue = HexColor | RefName | Variant | RGBA
 type ThemeJson = {
@@ -337,7 +338,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
           }
           setStore(
             produce((draft) => {
-              draft.themes.system = generateSystem(colors, store.mode)
+              draft.themes.system = generateSystem(colors)
               if (store.active === "system") {
                 draft.ready = true
               }
@@ -426,10 +427,9 @@ export function tint(base: RGBA, overlay: RGBA, alpha: number): RGBA {
   return RGBA.fromInts(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
 }
 
-function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
+function generateSystem(colors: TerminalColors): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
-  const isDark = mode == "dark"
 
   const col = (i: number) => {
     const value = colors.palette[i]
@@ -438,8 +438,22 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
   }
 
   // Generate gray scale based on terminal background
-  const grays = generateGrayScale(bg, isDark)
-  const textMuted = generateMutedTextColor(bg, isDark)
+  const graysLight = generateGrayScale(bg, false)
+  const graysDark = generateGrayScale(bg, true)
+  const grays: Record<number, RGBAVariant> = {}
+
+  Object.keys(graysDark).forEach((index) => {
+    const i = Number(index)
+    grays[i] = {
+      dark: graysDark[i],
+      light: graysLight[i],
+    }
+  })
+
+  const textMuted: RGBAVariant = {
+    dark: generateMutedTextColor(bg, true),
+    light: generateMutedTextColor(bg, false),
+  }
 
   // ANSI color references
   const ansiColors = {
@@ -455,11 +469,30 @@ function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJs
     greenBright: col(10),
   }
 
-  const diffAlpha = isDark ? 0.22 : 0.14
-  const diffAddedBg = tint(bg, ansiColors.green, diffAlpha)
-  const diffRemovedBg = tint(bg, ansiColors.red, diffAlpha)
-  const diffAddedLineNumberBg = tint(grays[3], ansiColors.green, diffAlpha)
-  const diffRemovedLineNumberBg = tint(grays[3], ansiColors.red, diffAlpha)
+  const diffAlpha = {
+    dark: 0.22,
+    light: 0.14,
+  }
+
+  const diffAddedBg: RGBAVariant = {
+    dark: tint(bg, ansiColors.green, diffAlpha.dark),
+    light: tint(bg, ansiColors.green, diffAlpha.light),
+  }
+
+  const diffRemovedBg: RGBAVariant = {
+    dark: tint(bg, ansiColors.red, diffAlpha.dark),
+    light: tint(bg, ansiColors.red, diffAlpha.light),
+  }
+
+  const diffAddedLineNumberBg: RGBAVariant = {
+    dark: tint(graysDark[3], ansiColors.green, diffAlpha.dark),
+    light: tint(graysLight[3], ansiColors.green, diffAlpha.light),
+  }
+
+  const diffRemovedLineNumberBg: RGBAVariant = {
+    dark: tint(graysDark[3], ansiColors.red, diffAlpha.dark),
+    light: tint(graysLight[3], ansiColors.red, diffAlpha.light),
+  }
 
   return {
     theme: {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,8 +1,9 @@
-import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
+import { SyntaxStyle, RGBA, type TerminalColors, CliRenderer } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo, onMount } from "solid-js"
+import { createEffect, createMemo, createResource, on } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
+import { useToast } from "../ui/toast"
 import aura from "./theme/aura.json" with { type: "json" }
 import ayu from "./theme/ayu.json" with { type: "json" }
 import catppuccin from "./theme/catppuccin.json" with { type: "json" }
@@ -38,10 +39,9 @@ import zenburn from "./theme/zenburn.json" with { type: "json" }
 import carbonfox from "./theme/carbonfox.json" with { type: "json" }
 import { useKV } from "./kv"
 import { useRenderer } from "@opentui/solid"
-import { createStore, produce } from "solid-js/store"
+import { createStore } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
-import { useSDK } from "./sdk"
 
 type ThemeColors = {
   primary: RGBA
@@ -175,6 +175,11 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   carbonfox,
 }
 
+const FALLBACK_THEME_KEY = "opencode"
+const SYSTEM_THEME_KEY = "system"
+
+type ThemeStore = Record<string, ThemeJson>
+
 function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   const defs = theme.defs ?? {}
   function resolveColor(c: ColorValue): RGBA {
@@ -283,78 +288,154 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   init: (props: { mode: "dark" | "light" }) => {
     const sync = useSync()
     const kv = useKV()
+
+    const requested = sync.data.config.theme
+      || (kv.get("theme") as string | undefined)
+      || FALLBACK_THEME_KEY
+
     const [store, setStore] = createStore({
-      themes: DEFAULT_THEMES,
+      themes: { ...DEFAULT_THEMES },
       mode: kv.get("theme_mode", props.mode),
-      active: (sync.data.config.theme ?? kv.get("theme", "opencode")) as string,
+      requested, active: requested,
       ready: false,
     })
 
-    createEffect(() => {
-      const theme = sync.data.config.theme
-      if (theme) setStore("active", theme)
-    })
+    const createLoader = (loader: () => Promise<ThemeStore>) => {
+      const [loaded, { refetch: reload }] =
+        createResource(async () => {
+          const themes = await loader();
+          setStore("themes", themes)
+          return themes
+        })
 
-    function init() {
-      resolveSystemTheme()
-      getCustomThemes()
-        .then((custom) => {
-          setStore(
-            produce((draft) => {
-              Object.assign(draft.themes, custom)
-            }),
-          )
-        })
-        .catch(() => {
-          setStore("active", "opencode")
-        })
-        .finally(() => {
-          if (store.active !== "system") {
-            setStore("ready", true)
-          }
-        })
+      return {
+        loaded,
+        reload,
+      }
     }
 
-    onMount(init)
-
-    function resolveSystemTheme() {
-      console.log("resolveSystemTheme")
-      renderer
-        .getPalette({
-          size: 16,
-        })
-        .then((colors) => {
-          console.log(colors.palette)
-          if (!colors.palette[0]) {
-            if (store.active === "system") {
-              setStore(
-                produce((draft) => {
-                  draft.active = "opencode"
-                  draft.ready = true
-                }),
-              )
-            }
-            return
-          }
-          setStore(
-            produce((draft) => {
-              draft.themes.system = generateSystem(colors)
-              if (store.active === "system") {
-                draft.ready = true
-              }
-            }),
-          )
-        })
-    }
+    const customLoader = createLoader(loadCustomThemes)
 
     const renderer = useRenderer()
-    process.on("SIGUSR2", async () => {
-      renderer.clearPaletteCache()
-      init()
+    const systemLoader = createLoader(async () => {
+      const colors = await detectSystemColors(renderer)
+      const theme = generateSystemTheme(colors)
+      return { [SYSTEM_THEME_KEY]: theme }
     })
 
+    const getStatus = (key: string) => {
+      const customState = customLoader.loaded.state
+      const systemState = systemLoader.loaded.state
+
+      if (key in DEFAULT_THEMES) {
+        return "succeeded"
+      }
+
+      if (key === SYSTEM_THEME_KEY) {
+        switch (systemState) {
+          case "ready":
+            return "succeeded"
+          case "errored":
+            return "errored"
+          default:
+            return "pending"
+        }
+      }
+
+      switch (customState) {
+        case "ready": {
+          const themes = customLoader.loaded.latest
+          const theme = themes[key]
+
+          if (!theme) return "errored"
+
+          return "succeeded"
+        }
+        case "errored": {
+          return "errored"
+        }
+        default: {
+          return "pending"
+        }
+      }
+    }
+
+    const requestedStatus = createMemo(
+      () => {
+        const key = store.requested
+        const status = getStatus(key)
+        return { key, status }
+      },
+      undefined,
+      {
+        equals: (prev, next) => (
+          next.key === prev.key &&
+          next.status === prev.status
+        )
+      }
+    )
+
+    const toast = useToast()
+    createEffect(on(
+      requestedStatus,
+      ({ key, status }) => {
+        console.debug("theme", "requested", { key, status })
+
+        const promote = (override?: string) => {
+          const active = override ?? key
+          console.debug("theme", "active", { key: active })
+
+          setStore({
+            ready: true,
+            active,
+          })
+        }
+
+        switch(status) {
+          case "pending": {
+            return
+          }
+          case "succeeded": {
+            promote()
+            return
+          }
+          case "errored": {
+            toast.show({
+              message: `Theme ${key} may not have resolved correctly`,
+              variant: "warning", duration: 3000,
+            })
+
+            if (key in store.themes) {
+              promote()
+              return
+            }
+
+            if (!store.ready) {
+              promote(FALLBACK_THEME_KEY)
+              return
+            }
+
+            return
+          }
+        }
+      }))
+
+    createEffect(on(
+      () => sync.data.config_generation,
+      () => {
+        renderer.clearPaletteCache()
+        systemLoader.reload()
+        customLoader.reload()
+
+        const key = sync.data.config.theme || store.active
+        setStore("requested", key)
+      },
+      { defer: true }
+    ))
+
     const values = createMemo(() => {
-      return resolveTheme(store.themes[store.active] ?? store.themes.opencode, store.mode)
+      const theme = store.themes[store.active] ?? store.themes[FALLBACK_THEME_KEY]
+      return resolveTheme(theme, store.mode)
     })
 
     const syntax = createMemo(() => generateSyntax(values()))
@@ -382,9 +463,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         setStore("mode", mode)
         kv.set("theme_mode", mode)
       },
-      set(theme: string) {
-        setStore("active", theme)
-        kv.set("theme", theme)
+      set(themeKey: string) {
+        setStore("requested", themeKey)
+        kv.set("theme", themeKey)
       },
       get ready() {
         return store.ready
@@ -394,7 +475,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 })
 
 const CUSTOM_THEME_GLOB = new Bun.Glob("themes/*.json")
-async function getCustomThemes() {
+async function loadCustomThemes() {
   const directories = [
     Global.Path.config,
     ...(await Array.fromAsync(
@@ -427,7 +508,14 @@ export function tint(base: RGBA, overlay: RGBA, alpha: number): RGBA {
   return RGBA.fromInts(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
 }
 
-function generateSystem(colors: TerminalColors): ThemeJson {
+async function detectSystemColors(renderer: CliRenderer) {
+  const colors = await renderer.getPalette({ size: 16 })
+  if (colors.palette[0]) return colors
+
+  throw new Error("System color detection failed")
+}
+
+function generateSystemTheme(colors: TerminalColors): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
 

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -42,6 +42,7 @@ import { useRenderer } from "@opentui/solid"
 import { createStore } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
+import { iife } from "@/util/iife"
 
 type ThemeColors = {
   primary: RGBA
@@ -123,21 +124,26 @@ export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
 
 type HexColor = `#${string}`
 type RefName = string
-type RGBAVariant = { dark: RGBA; light: RGBA }
-type Variant = {
-  dark: HexColor | RefName | RGBA
-  light: HexColor | RefName | RGBA
-}
-type ColorValue = HexColor | RefName | Variant | RGBA
-type ThemeJson = {
+type AnsiCode = number
+type PrimitiveColor = HexColor | RefName | AnsiCode | RGBA
+type Variant = { dark: PrimitiveColor; light: PrimitiveColor }
+type ColorValue = PrimitiveColor | Variant
+
+type BaseThemeJson<V> = {
   $schema?: string
   defs?: Record<string, HexColor | RefName>
-  theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
-    selectedListItemText?: ColorValue
-    backgroundMenu?: ColorValue
+  theme: Omit<Record<keyof ThemeColors, V>, "selectedListItemText" | "backgroundMenu"> & {
+    selectedListItemText?: V
+    backgroundMenu?: V
     thinkingOpacity?: number
   }
 }
+
+type ThemeJson = BaseThemeJson<ColorValue>
+
+type RGBAVariant = { dark: RGBA; light: RGBA }
+type RGBAValue = RGBA | RGBAVariant
+type SystemThemeJson = BaseThemeJson<RGBAValue>
 
 export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   aura,
@@ -178,43 +184,51 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
 const FALLBACK_THEME_KEY = "opencode"
 const SYSTEM_THEME_KEY = "system"
 
-type ThemeStore = Record<string, ThemeJson>
+type ThemeStore = Record<string, ThemeJson | SystemThemeJson>
 
-function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
+function resolveTheme(theme: ThemeJson, systemTheme: SystemThemeJson | undefined, mode: "dark" | "light") {
   const defs = theme.defs ?? {}
-  function resolveColor(c: ColorValue): RGBA {
-    if (c instanceof RGBA) return c
-    if (typeof c === "string") {
-      if (c === "transparent" || c === "none") return RGBA.fromInts(0, 0, 0, 0)
 
-      if (c.startsWith("#")) return RGBA.fromHex(c)
+  function resolveColor(value: ColorValue, systemKey: keyof ThemeColors): RGBA {
+    if (value instanceof RGBA) return value
+    if (typeof value === "number") return ansiToRgba(value)
+    if (typeof value !== "string") return resolveColor(value[mode], systemKey)
 
-      if (defs[c] != null) {
-        return resolveColor(defs[c])
-      } else if (theme.theme[c as keyof ThemeColors] !== undefined) {
-        return resolveColor(theme.theme[c as keyof ThemeColors]!)
-      } else {
-        throw new Error(`Color reference "${c}" not found in defs or theme`)
+    switch (value) {
+      case "transparent":
+      case "none":
+        return RGBA.fromInts(0, 0, 0, 0)
+      case "system": {
+        const newValue = systemTheme?.theme[systemKey]
+        if (newValue === undefined) return RGBA.fromInts(0, 0, 0, 0)
+        return resolveColor(newValue, systemKey)
       }
     }
-    if (typeof c === "number") {
-      return ansiToRgba(c)
-    }
-    return resolveColor(c[mode])
+
+    if (value.startsWith("#")) return RGBA.fromHex(value)
+    if (defs[value] !== undefined) return resolveColor(defs[value], systemKey)
+
+    const newKey = value as keyof ThemeColors
+    const newValue = theme.theme[newKey]
+    if (newValue !== undefined)
+      // Cross-referencing must update `systemKey`.
+      return resolveColor(newValue, newKey)
+
+    throw new Error(`Color reference "${value}" not found in defs or theme`)
   }
 
   const resolved = Object.fromEntries(
     Object.entries(theme.theme)
       .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
       .map(([key, value]) => {
-        return [key, resolveColor(value as ColorValue)]
+        return [key, resolveColor(value as ColorValue, key as keyof ThemeColors)]
       }),
   ) as Partial<ThemeColors>
 
   // Handle selectedListItemText separately since it's optional
   const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
   if (hasSelectedListItemText) {
-    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!)
+    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!, "selectedListItemText")
   } else {
     // Backward compatibility: if selectedListItemText is not defined, use background color
     // This preserves the current behavior for all existing themes
@@ -223,7 +237,7 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
 
   // Handle backgroundMenu - optional with fallback to backgroundElement
   if (theme.theme.backgroundMenu !== undefined) {
-    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
+    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu, "backgroundMenu")
   } else {
     resolved.backgroundMenu = resolved.backgroundElement
   }
@@ -328,10 +342,14 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
       const systemState = systemLoader.loaded.state
 
       if (key in DEFAULT_THEMES) {
+        /**
+         * This bakes the assumption that _none_ of the  preloaded default
+         * themes reference system colors.
+         */
         return "succeeded"
       }
 
-      if (key === SYSTEM_THEME_KEY) {
+      const systemStatus = iife(() => {
         switch (systemState) {
           case "ready":
             return "succeeded"
@@ -340,6 +358,10 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
           default:
             return "pending"
         }
+      })
+
+      if (key === SYSTEM_THEME_KEY) {
+        return systemStatus
       }
 
       switch (customState) {
@@ -348,6 +370,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
           const theme = themes[key]
 
           if (!theme) return "errored"
+          if (referencesSystemTheme(theme)) return systemStatus
 
           return "succeeded"
         }
@@ -435,7 +458,8 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     const values = createMemo(() => {
       const theme = store.themes[store.active] ?? store.themes[FALLBACK_THEME_KEY]
-      return resolveTheme(theme, store.mode)
+      const systemTheme = store.themes[SYSTEM_THEME_KEY] as SystemThemeJson | undefined
+      return resolveTheme(theme, systemTheme, store.mode)
     })
 
     const syntax = createMemo(() => generateSyntax(values()))
@@ -515,7 +539,18 @@ async function detectSystemColors(renderer: CliRenderer) {
   throw new Error("System color detection failed")
 }
 
-function generateSystemTheme(colors: TerminalColors): ThemeJson {
+function referencesSystemTheme(value: unknown) {
+  switch (typeof value) {
+    case "object":
+      return Object.values(value || {}).some(referencesSystemTheme)
+    case "string":
+      return value === "system"
+    default:
+      return false
+  }
+}
+
+function generateSystemTheme(colors: TerminalColors): SystemThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
 

--- a/packages/web/public/theme.json
+++ b/packages/web/public/theme.json
@@ -25,8 +25,8 @@
             },
             {
               "type": "string",
-              "enum": ["none"],
-              "description": "No color (uses terminal default)"
+              "enum": ["none", "system"],
+              "description": "No color (uses terminal default or system-calculated color)"
             }
           ]
         }
@@ -111,8 +111,8 @@
         },
         {
           "type": "string",
-          "enum": ["none"],
-          "description": "No color (uses terminal default)"
+          "enum": ["none", "system"],
+          "description": "No color (uses terminal default) or system-calculated color"
         },
         {
           "type": "string",
@@ -137,8 +137,8 @@
                 },
                 {
                   "type": "string",
-                  "enum": ["none"],
-                  "description": "No color (uses terminal default)"
+                  "enum": ["none", "system"],
+                  "description": "No color (uses terminal default or system-calculated color)"
                 },
                 {
                   "type": "string",
@@ -162,8 +162,8 @@
                 },
                 {
                   "type": "string",
-                  "enum": ["none"],
-                  "description": "No color (uses terminal default)"
+                  "enum": ["none", "system"],
+                  "description": "No color (uses terminal default or system-calculated color)"
                 },
                 {
                   "type": "string",

--- a/packages/web/src/content/docs/themes.mdx
+++ b/packages/web/src/content/docs/themes.mdx
@@ -120,6 +120,7 @@ Themes use a flexible JSON format with support for:
 - **Color references**: `"primary"` or custom definitions
 - **Dark/light variants**: `{"dark": "#000", "light": "#fff"}`
 - **No color**: `"none"` - Uses the terminal's default color or transparent
+- **System colors**: `"system"` - Uses colors detected from terminal palette
 
 ---
 
@@ -135,6 +136,26 @@ The special value `"none"` can be used for any color to inherit the terminal's d
 
 - `"text": "none"` - Uses terminal's default foreground color
 - `"background": "none"` - Uses terminal's default background color
+
+---
+
+### System color references
+
+Custom themes can use `"system"` as a color value to inherit colors from your terminal's palette. This lets you create themes that blend custom branding with your terminal's native colors:
+
+```json title="my-system-theme.json"
+{
+  "theme": {
+    "background": "system",
+    "text": "system",
+    "primary": "#ff5500",
+    "secondary": "system",
+    ...
+  }
+}
+```
+
+Colors set to `"system"` will update when your terminal's palette changes (after sending SIGUSR2 to reload).
 
 ---
 


### PR DESCRIPTION
### Issues
- Closes #6322 
- Closes #4236
  - _Something akin to this feature is discussed within the comments_

### Feature
<img src="https://github.com/user-attachments/assets/e5384fac-27f9-4a87-9940-783b5c1951d3" alt="tui-theme" width="600" />

---
Custom themes can now reference the `system` theme that is generated from the user's terminal color palette by using `"system"` as a color value:
```json
{
  "theme": {
    "background": "system",
    "foreground": "system",
    "primary": "#ff5500"
  }
}
```

### Performance optimization
The theme context now readies **10x faster** in the by-far most common case (using one of the default themes). The speedup is due to not waiting for resources to load that are irrelevant for the requested theme.
_Timed using this [patch](https://github.com/user-attachments/files/24698744/ready-timing.patch) that calls `console.time` inside `createSimpleContext`._

#### After = 3.558ms
```
...
[17:05:25] [LOG] '%s: %s' 'context:Theme' '3.558ms'
...
```

#### Before = 31.264ms
```
...
[17:04:19] [LOG] '%s: %s' 'context:Theme' '31.264ms'
...
```

### More details
**Key behaviors**
- Custom theme loading and system palette detection each modeled w/ SolidJS's `createResource`
- These in turn are accessed in SolidJS's `createMemo` returning `(requested theme, resource loading status)`
  - Considers only the relevant resource loading statuses for the given requested theme
  - Drives the reactivity into theme resolution
- Somewhat conservative & simplistic design choices

**Miscellany**
- Warning toasts on errored (this functionality could easily be removed)
- System theme now responds to `Toggle appearance`
- Theme picker list now updates on reload

### Commits
Three atomic commits build up to this feature:
1. `fix(tui): system theme light & dark variants`
2. `refactor(tui): theme switching & loading reactivity`
3. `feat(tui): system-like custom themes`

#### Notes
- This can be split into 3 sequential PRs if preferred, one per atomic commit above
- The first 2 commits might be valuable without adding this feature in the 3rd commit
- The performance optimization is in the 2nd, refactor commit