### PR TITLE
fix(app): load ghostty wasm via asset url

### DIFF
--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -1,4 +1,5 @@
 import type { Ghostty, Terminal as Term, FitAddon } from "ghostty-web"
+import ghosttyWasmUrl from "ghostty-web/ghostty-vt.wasm?url"
 import { ComponentProps, createEffect, createSignal, onCleanup, onMount, splitProps } from "solid-js"
 import { useSDK } from "@/context/sdk"
 import { SerializeAddon } from "@/addons/serialize"
@@ -98,7 +99,7 @@ export const Terminal = (props: TerminalProps) => {
 
   onMount(async () => {
     const mod = await import("ghostty-web")
-    ghostty = await mod.Ghostty.load()
+    ghostty = await mod.Ghostty.load(ghosttyWasmUrl)
 
     const url = new URL(sdk.url + `/pty/${local.pty.id}/connect?directory=${encodeURIComponent(sdk.directory)}`)
     if (window.__OPENCODE__?.serverPassword) {

--- a/packages/app/src/env.d.ts
+++ b/packages/app/src/env.d.ts
@@ -6,3 +6,8 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+declare module "*.wasm?url" {
+  const url: string
+  export default url
+}


### PR DESCRIPTION
Fixes #7578 

Problem: Ghostty WASM loads via a data: URL, which is blocked by strict CSP (connect-src 'self') in Safari/Firefox/Cloudflare Access, leaving the web terminal blank.

Change: Load ghostty-vt.wasm via Vite asset URL (ghostty-web/ghostty-vt.wasm?url).

Verification: not run here; reproduced in a CSP-restricted environment.
