### PR TITLE
fix(windows): fix jdtls download on Windows

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1157,10 +1157,24 @@ export namespace LSPServer {
         await fs.mkdir(distPath, { recursive: true })
         const releaseURL =
           "https://www.eclipse.org/downloads/download.php?file=/jdtls/snapshots/jdt-language-server-latest.tar.gz"
-        const archivePath = path.join(distPath, "release.tar.gz")
-        await $`curl -L -o '${archivePath}' '${releaseURL}'`.quiet().nothrow()
-        await $`tar -xzf ${archivePath}`.cwd(distPath).quiet().nothrow()
-        await fs.rm(archivePath, { force: true })
+        const archiveName = "release.tar.gz"
+
+        log.info("Downloading JDTLS archive", { url: releaseURL, dest: distPath })
+        const curlResult = await $`curl -L -o ${archiveName} '${releaseURL}'`.cwd(distPath).quiet().nothrow()
+        if (curlResult.exitCode !== 0) {
+          log.error("Failed to download JDTLS", { exitCode: curlResult.exitCode, stderr: curlResult.stderr.toString() })
+          return
+        }
+
+        log.info("Extracting JDTLS archive")
+        const tarResult = await $`tar -xzf ${archiveName}`.cwd(distPath).quiet().nothrow()
+        if (tarResult.exitCode !== 0) {
+          log.error("Failed to extract JDTLS", { exitCode: tarResult.exitCode, stderr: tarResult.stderr.toString() })
+          return
+        }
+
+        await fs.rm(path.join(distPath, archiveName), { force: true })
+        log.info("JDTLS download and extraction completed")
       }
       const jarFileName = await $`ls org.eclipse.equinox.launcher_*.jar`
         .cwd(launcherDir)


### PR DESCRIPTION
Fixes #7270

## Fix JDTLS auto-download failure on Windows

JDTLS auto-download fails on Windows with error:

```
tar (child): Cannot connect to C: resolve failed
```

## Root Cause

When using Windows absolute paths like `C:/Users/.../.../release.tar.gz` in the `tar -xzf` command, tar utility misinterprets the C: prefix as a remote hostname instead of a drive letter, attempting a remote connection instead of extracting the local file.

## Solution
- Changed both curl and tar commands to use `.cwd(distPath)` and work with basename only (`release.tar.gz`)
- This avoids passing Windows absolute paths to MSYS tar
- Added proper error logging with exit code checks

## Testing

Verified JDTLS now downloads and extracts successfully on Windows, providing immediate Java diagnostics:
- Using write tool on a java file (in java project) with errors shows LSP diagnostics

## Workaround before patch is merged

```sh
cd C:/Users/YOUR_USERNAME/.local/share/opencode/bin
mkdir jdtls
cd jdtls
curl -L -o release.tar.gz "https://www.eclipse.org/downloads/download.php?file=/jdtls/snapshots/jdt-language-server-latest.tar.gz"
tar -xzf release.tar.gz
rm release.tar.gz
```
