### PR TITLE
feat: add restart and reload menu items on macOS

### DIFF
--- a/packages/desktop/src/menu.ts
+++ b/packages/desktop/src/menu.ts
@@ -1,5 +1,7 @@
 import { Menu, MenuItem, PredefinedMenuItem, Submenu } from "@tauri-apps/api/menu"
 import { type as ostype } from "@tauri-apps/plugin-os"
+import { invoke } from "@tauri-apps/api/core"
+import { relaunch } from "@tauri-apps/plugin-process"
 
 import { runUpdater, UPDATER_ENABLED } from "./updater"
 import { installCli } from "./cli"
@@ -23,6 +25,17 @@ export async function createMenu() {
           await MenuItem.new({
             action: () => installCli(),
             text: "Install CLI...",
+          }),
+          await MenuItem.new({
+            action: async () => window.location.reload(),
+            text: "Reload Webview",
+          }),
+          await MenuItem.new({
+            action: async () => {
+              await invoke("kill_sidecar").catch(() => undefined)
+              await relaunch().catch(() => undefined)
+            },
+            text: "Restart",
           }),
           await PredefinedMenuItem.new({
             item: "Separator",


### PR DESCRIPTION
### What does this PR do?
I was getting annoyed by having to quit and restart the app everytime

Added 2 menu items for Reloading the webview (no app/server restart) and Restarting the full app (+server)

<img width="316" height="296" alt="Screenshot 2026-01-18 at 13 24 30" src="https://github.com/user-attachments/assets/5af77540-1a84-47f7-b6d0-c67348c17bb8" />

Closes #9213

### How did you verify your code works?
The buttons do what they are supposed to do