### PR TITLE
fix(github): use share API URL for action links

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -120,6 +120,7 @@ let commentId: number
 let gitConfig: string
 let session: { id: string; title: string; version: string }
 let shareId: string | undefined
+let shareUrl: string | undefined
 let exitCode = 0
 type PromptFiles = Awaited<ReturnType<typeof getUserPrompt>>["promptFiles"]
 
@@ -145,15 +146,16 @@ try {
   const repoData = await fetchRepo()
   session = await client.session.create<true>().then((r) => r.data)
   await subscribeSessionEvents()
-  shareId = await (async () => {
-    if (useEnvShare() === false) return
-    if (!useEnvShare() && repoData.data.private) return
-    await client.session.share<true>({ path: session })
-    return session.id.slice(-8)
-  })()
+  const share = useEnvShare()
+  const canShare = share !== false && (share || !repoData.data.private)
+  if (canShare) {
+    const updated = await client.session.share<true>({ path: session }).then((r) => r.data)
+    shareUrl = updated.share?.url
+    shareId = session.id.slice(-8)
+  }
   console.log("opencode session", session.id)
-  if (shareId) {
-    console.log("Share link:", `${useShareUrl()}/s/${shareId}`)
+  if (shareUrl) {
+    console.log("Share link:", shareUrl)
   }
 
   // Handle 3 cases
@@ -162,30 +164,29 @@ try {
   // 3. Fork PR
   if (isPullRequest()) {
     const prData = await fetchPR()
-    // Local PR
-    if (prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner) {
+    const isLocal = prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner
+    const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl)) : false
+
+    if (isLocal) {
       await checkoutLocalBranch(prData)
-      const dataPrompt = buildPromptDataForPR(prData)
-      const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
-      if (await branchIsDirty()) {
-        const summary = await summarize(response)
+    }
+
+    if (!isLocal) {
+      await checkoutForkBranch(prData)
+    }
+
+    const dataPrompt = buildPromptDataForPR(prData)
+    const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
+    if (await branchIsDirty()) {
+      const summary = await summarize(response)
+      if (isLocal) {
         await pushToLocalBranch(summary)
       }
-      const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${useShareUrl()}/s/${shareId}`))
-      await updateComment(`${response}${footer({ image: !hasShared })}`)
-    }
-    // Fork PR
-    else {
-      await checkoutForkBranch(prData)
-      const dataPrompt = buildPromptDataForPR(prData)
-      const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
-      if (await branchIsDirty()) {
-        const summary = await summarize(response)
+      if (!isLocal) {
         await pushToForkBranch(summary, prData)
       }
-      const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${useShareUrl()}/s/${shareId}`))
-      await updateComment(`${response}${footer({ image: !hasShared })}`)
     }
+    await updateComment(`${response}${footer({ image: !hasShared })}`)
   }
   // Issue
   else {
@@ -359,10 +360,6 @@ function useContext() {
 function useIssueId() {
   const payload = useContext().payload as IssueCommentEvent
   return payload.issue.number
-}
-
-function useShareUrl() {
-  return isMock() ? "https://dev.opencode.ai" : "https://opencode.ai"
 }
 
 async function getAccessToken() {
@@ -817,14 +814,15 @@ function footer(opts?: { image?: boolean }) {
   const image = (() => {
     if (!shareId) return ""
     if (!opts?.image) return ""
+    if (!shareUrl) return ""
 
     const titleAlt = encodeURIComponent(session.title.substring(0, 50))
     const title64 = Buffer.from(session.title.substring(0, 700), "utf8").toString("base64")
 
-    return `<a href="${useShareUrl()}/s/${shareId}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareId}" /></a>\n`
+    return `<a href="${shareUrl}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareId}" /></a>\n`
   })()
-  const shareUrl = shareId ? `[opencode session](${useShareUrl()}/s/${shareId})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
-  return `\n\n${image}${shareUrl}[github run](${useEnvRunUrl()})`
+  const shareLink = shareUrl ? `[opencode session](${shareUrl})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
+  return `\n\n${image}${shareLink}[github run](${useEnvRunUrl()})`
 }
 
 async function fetchRepo() {

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -467,7 +467,6 @@ export const GithubRunCommand = cmd({
           ? (payload as IssueCommentEvent | IssuesEvent).issue.number
           : (payload as PullRequestEvent | PullRequestReviewCommentEvent).pull_request.number
       const runUrl = `/${owner}/${repo}/actions/runs/${runId}`
-      const shareBaseUrl = isMock ? "https://dev.opencode.ai" : "https://opencode.ai"
 
       let appToken: string
       let octoRest: Octokit
@@ -475,6 +474,7 @@ export const GithubRunCommand = cmd({
       let gitConfig: string
       let session: { id: string; title: string; version: string }
       let shareId: string | undefined
+      let shareUrl: string | undefined
       let exitCode = 0
       type PromptFiles = Awaited<ReturnType<typeof getUserPrompt>>["promptFiles"]
       const triggerCommentId = isCommentEvent
@@ -527,13 +527,16 @@ export const GithubRunCommand = cmd({
           ],
         })
         subscribeSessionEvents()
-        shareId = await (async () => {
-          if (share === false) return
-          if (!share && repoData.data.private) return
-          await Session.share(session.id)
-          return session.id.slice(-8)
-        })()
+        const canShare = share !== false && (share || !repoData.data.private)
+        if (canShare) {
+          const shared = await Session.share(session.id)
+          shareUrl = shared.url
+          shareId = session.id.slice(-8)
+        }
         console.log("opencode session", session.id)
+        if (shareUrl) {
+          console.log("Share link:", shareUrl)
+        }
 
         // Handle event types:
         // REPO_EVENTS (schedule, workflow_dispatch): no issue/PR context, output to logs/PR only
@@ -580,7 +583,8 @@ export const GithubRunCommand = cmd({
               const summary = await summarize(response)
               await pushToLocalBranch(summary, uncommittedChanges)
             }
-            const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+            const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl!)) : false
+
             await createComment(`${response}${footer({ image: !hasShared })}`)
             await removeReaction(commentType)
           }
@@ -595,7 +599,8 @@ export const GithubRunCommand = cmd({
               const summary = await summarize(response)
               await pushToForkBranch(summary, prData, uncommittedChanges)
             }
-            const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
+            const hasShared = shareUrl ? prData.comments.nodes.some((c) => c.body.includes(shareUrl!)) : false
+
             await createComment(`${response}${footer({ image: !hasShared })}`)
             await removeReaction(commentType)
           }
@@ -1300,14 +1305,15 @@ Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
         const image = (() => {
           if (!shareId) return ""
           if (!opts?.image) return ""
+          if (!shareUrl) return ""
 
           const titleAlt = encodeURIComponent(session.title.substring(0, 50))
           const title64 = Buffer.from(session.title.substring(0, 700), "utf8").toString("base64")
 
-          return `<a href="${shareBaseUrl}/s/${shareId}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareId}" /></a>\n`
+          return `<a href="${shareUrl}"><img width="200" alt="${titleAlt}" src="https://social-cards.sst.dev/opencode-share/${title64}.png?model=${providerID}/${modelID}&version=${session.version}&id=${shareId}" /></a>\n`
         })()
-        const shareUrl = shareId ? `[opencode session](${shareBaseUrl}/s/${shareId})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
-        return `\n\n${image}${shareUrl}[github run](${runUrl})`
+        const shareLink = shareUrl ? `[opencode session](${shareUrl})&nbsp;&nbsp;|&nbsp;&nbsp;` : ""
+        return `\n\n${image}${shareLink}[github run](${runUrl})`
       }
 
       async function fetchRepo() {


### PR DESCRIPTION
### What does this PR do?

Fixes github action to use share URL from share API instead of hard coded one.

### How did you verify your code works?

I tested github action in this repo: https://github.com/offlinehacker/oc-action-test

Fixes https://github.com/anomalyco/opencode/issues/9209