### PR TITLE
refactor(installation): update scoop installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -fsSL https://opencode.ai/install | bash
 
 # Package managers
 npm i -g opencode-ai@latest        # or bun/pnpm/yarn
-scoop bucket add extras; scoop install extras/opencode  # Windows
+scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS and Linux (recommended, always up to date)
 brew install opencode              # macOS and Linux (official brew formula, updated less)
@@ -52,6 +52,8 @@ OpenCode is also available as a desktop application. Download directly from the 
 ```bash
 # macOS (Homebrew)
 brew install --cask opencode-desktop
+# Windows (Scoop)
+scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
 #### Installation Directory

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,7 +26,7 @@ curl -fsSL https://opencode.ai/install | bash
 
 # 软件包管理器
 npm i -g opencode-ai@latest        # 也可使用 bun/pnpm/yarn
-scoop bucket add extras; scoop install extras/opencode  # Windows
+scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS 和 Linux（推荐，始终保持最新）
 brew install opencode              # macOS 和 Linux（官方 brew formula，更新频率较低）
@@ -52,6 +52,8 @@ OpenCode 也提供桌面版应用。可直接从 [发布页 (releases page)](htt
 ```bash
 # macOS (Homebrew Cask)
 brew install --cask opencode-desktop
+# Windows (Scoop)
+scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
 #### 安装目录

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -26,7 +26,7 @@ curl -fsSL https://opencode.ai/install | bash
 
 # 套件管理員
 npm i -g opencode-ai@latest        # 也可使用 bun/pnpm/yarn
-scoop bucket add extras; scoop install extras/opencode  # Windows
+scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS 與 Linux（推薦，始終保持最新）
 brew install opencode              # macOS 與 Linux（官方 brew formula，更新頻率較低）
@@ -52,6 +52,8 @@ OpenCode 也提供桌面版應用程式。您可以直接從 [發佈頁面 (rele
 ```bash
 # macOS (Homebrew Cask)
 brew install --cask opencode-desktop
+# Windows (Scoop)
+scoop bucket add extras; scoop install extras/opencode-desktop
 ```
 
 #### 安裝目錄

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -158,7 +158,7 @@ export namespace Installation {
         cmd = $`echo Y | choco upgrade opencode --version=${target}`
         break
       case "scoop":
-        cmd = $`scoop install extras/opencode@${target}`
+        cmd = $`scoop install opencode@${target}`
         break
       default:
         throw new Error(`Unknown method: ${method}`)
@@ -226,7 +226,7 @@ export namespace Installation {
     }
 
     if (detectedMethod === "scoop") {
-      return fetch("https://raw.githubusercontent.com/ScoopInstaller/Extras/master/bucket/opencode.json", {
+      return fetch("https://raw.githubusercontent.com/ScoopInstaller/Main/master/bucket/opencode.json", {
         headers: { Accept: "application/json" },
       })
         .then((res) => {

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -98,8 +98,7 @@ You can also install it with the following commands:
 - **Using Scoop**
 
   ```bash
-  scoop bucket add extras
-  scoop install extras/opencode
+  scoop install opencode
   ```
 
 - **Using NPM**


### PR DESCRIPTION
We have migrated the opencode manifest on Scoop to enable support
for the desktop variant. The migration was made to not be a breaking
change and wouldn't break existing installation but they do have to
perform a manual reinstallation to finalize the transition to get future
updates.

This patch updates the relevant files to reflect the changes. Close #9219

refs:
- https://github.com/ScoopInstaller/Main/pull/7524
- https://github.com/ScoopInstaller/Extras/pull/16996
- https://github.com/ScoopInstaller/Extras/pull/17040

