### PR TITLE
refactor(desktop): improve layout and styling of session search button

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -133,14 +133,14 @@ export function SessionHeader() {
               class="hidden md:flex w-[320px] p-1 pl-1.5 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-raised-base transition-colors cursor-default hover:bg-surface-raised-base-hover focus:bg-surface-raised-base-hover active:bg-surface-raised-base-active"
               onClick={() => command.trigger("file.open")}
             >
-              <div class="flex items-center gap-2">
-                <Icon name="magnifying-glass" size="normal" class="icon-base" />
-                <span class="flex-1 min-w-0 text-14-regular text-text-weak truncate h-3.5 flex items-center overflow-visible">
+              <div class="flex min-w-0 flex-1 items-center gap-2 overflow-visible">
+                <Icon name="magnifying-glass" size="normal" class="icon-base shrink-0" />
+                <span class="flex-1 min-w-0 text-14-regular text-text-weak truncate h-4.5 flex items-center">
                   Search {name()}
                 </span>
               </div>
 
-              <Show when={hotkey()}>{(keybind) => <Keybind>{keybind()}</Keybind>}</Show>
+              <Show when={hotkey()}>{(keybind) => <Keybind class="shrink-0">{keybind()}</Keybind>}</Show>
             </button>
           </Portal>
         )}


### PR DESCRIPTION
### What does this PR do?

Improves the style of the Session Search Button to properly truncate long project names maintaining the position of the Keybind component.

It also increases the height of the span that contains the name, as it was previously too small, and letters with long bottom part like `g` and `p` would get cut off during render. This does change the look, then

Closes #9249 

### How did you verify your code works?

Tested on my machine, and tested with short project names to make sure the changes didnt affect other working cases.

Before
<img width="400" height="44" alt="Screenshot 2026-01-18 at 14 30 30" src="https://github.com/user-attachments/assets/34464bf9-2161-42a7-a19e-1be0692a3282" />

After
<img width="334" height="34" alt="Screenshot 2026-01-18 at 14 49 57" src="https://github.com/user-attachments/assets/36be6877-2c18-4ab7-9dca-7124da1b2fd1" />
