### PR TITLE
feat(hook): session.before.idle

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -631,8 +631,12 @@ export namespace SessionPrompt {
     if (beforeIdleOutput.resumePrompt) {
       log.info("resuming session", { sessionID })
       delete state()[sessionID]
+      const resumeAgent = await lastAgent(sessionID)
+      const resumeModel = await lastModel(sessionID)
       await prompt({
         sessionID,
+        agent: resumeAgent,
+        model: resumeModel,
         parts: [{ type: "text", text: beforeIdleOutput.resumePrompt }],
       })
     }
@@ -653,6 +657,13 @@ export namespace SessionPrompt {
       if (item.info.role === "user" && item.info.model) return item.info.model
     }
     return Provider.defaultModel()
+  }
+
+  async function lastAgent(sessionID: string) {
+    for await (const item of MessageV2.stream(sessionID)) {
+      if (item.info.role === "user" && item.info.agent) return item.info.agent
+    }
+    return Agent.defaultAgent()
   }
 
   async function resolveTools(input: {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -266,6 +266,8 @@ export namespace SessionPrompt {
     using _ = defer(() => cancel(sessionID))
 
     let step = 0
+    let sessionAgent: string | undefined
+    let sessionModel: { providerID: string; modelID: string } | undefined
     const session = await Session.get(sessionID)
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
@@ -291,6 +293,8 @@ export namespace SessionPrompt {
       }
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
+      sessionAgent = lastUser.agent
+      sessionModel = lastUser.model
       if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
@@ -626,13 +630,19 @@ export namespace SessionPrompt {
     // Allow plugins to optionally resume this session before it completes
     const sessionInfo = await Session.get(sessionID)
     const beforeIdleOutput = { resumePrompt: undefined as string | undefined }
-    await Plugin.trigger("session.before.idle", { sessionID, parentSessionID: sessionInfo?.parentID }, beforeIdleOutput)
+    await Plugin.trigger(
+      "session.before.idle",
+      { sessionID, parentSessionID: sessionInfo?.parentID, agent: sessionAgent, model: sessionModel },
+      beforeIdleOutput,
+    )
 
     if (beforeIdleOutput.resumePrompt) {
       log.info("resuming session", { sessionID })
       delete state()[sessionID]
       await prompt({
         sessionID,
+        agent: sessionAgent,
+        model: sessionModel,
         parts: [{ type: "text", text: beforeIdleOutput.resumePrompt }],
       })
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -625,19 +625,15 @@ export namespace SessionPrompt {
 
     // Allow plugins to optionally resume this session before it completes
     const sessionInfo = await Session.get(sessionID)
-    const beforeCompleteOutput = { resumePrompt: undefined as string | undefined }
-    await Plugin.trigger(
-      "session.before_complete",
-      { sessionID, parentSessionID: sessionInfo?.parentID },
-      beforeCompleteOutput,
-    )
+    const beforeIdleOutput = { resumePrompt: undefined as string | undefined }
+    await Plugin.trigger("session.before.idle", { sessionID, parentSessionID: sessionInfo?.parentID }, beforeIdleOutput)
 
-    if (beforeCompleteOutput.resumePrompt) {
+    if (beforeIdleOutput.resumePrompt) {
       log.info("resuming session", { sessionID })
       delete state()[sessionID]
       await prompt({
         sessionID,
-        parts: [{ type: "text", text: beforeCompleteOutput.resumePrompt }],
+        parts: [{ type: "text", text: beforeIdleOutput.resumePrompt }],
       })
     }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -266,8 +266,6 @@ export namespace SessionPrompt {
     using _ = defer(() => cancel(sessionID))
 
     let step = 0
-    let sessionAgent: string | undefined
-    let sessionModel: { providerID: string; modelID: string } | undefined
     const session = await Session.get(sessionID)
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
@@ -293,8 +291,6 @@ export namespace SessionPrompt {
       }
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
-      sessionAgent = lastUser.agent
-      sessionModel = lastUser.model
       if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
@@ -630,19 +626,13 @@ export namespace SessionPrompt {
     // Allow plugins to optionally resume this session before it completes
     const sessionInfo = await Session.get(sessionID)
     const beforeIdleOutput = { resumePrompt: undefined as string | undefined }
-    await Plugin.trigger(
-      "session.before.idle",
-      { sessionID, parentSessionID: sessionInfo?.parentID, agent: sessionAgent, model: sessionModel },
-      beforeIdleOutput,
-    )
+    await Plugin.trigger("session.before.idle", { sessionID, parentSessionID: sessionInfo?.parentID }, beforeIdleOutput)
 
     if (beforeIdleOutput.resumePrompt) {
       log.info("resuming session", { sessionID })
       delete state()[sessionID]
       await prompt({
         sessionID,
-        agent: sessionAgent,
-        model: sessionModel,
         parts: [{ type: "text", text: beforeIdleOutput.resumePrompt }],
       })
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -622,6 +622,25 @@ export namespace SessionPrompt {
       continue
     }
     SessionCompaction.prune({ sessionID })
+
+    // Allow plugins to optionally resume this session before it completes
+    const sessionInfo = await Session.get(sessionID)
+    const beforeCompleteOutput = { resumePrompt: undefined as string | undefined }
+    await Plugin.trigger(
+      "session.before_complete",
+      { sessionID, parentSessionID: sessionInfo?.parentID },
+      beforeCompleteOutput,
+    )
+
+    if (beforeCompleteOutput.resumePrompt) {
+      log.info("resuming session", { sessionID })
+      delete state()[sessionID]
+      await prompt({
+        sessionID,
+        parts: [{ type: "text", text: beforeCompleteOutput.resumePrompt }],
+      })
+    }
+
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue
       const queued = state()[sessionID]?.callbacks ?? []

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -217,12 +217,7 @@ export interface Hooks {
   ) => Promise<void>
 
   "session.before.idle"?: (
-    input: {
-      sessionID: string
-      parentSessionID?: string
-      agent?: string
-      model?: { providerID: string; modelID: string }
-    },
+    input: { sessionID: string; parentSessionID?: string },
     output: { resumePrompt?: string },
   ) => Promise<void>
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -217,7 +217,12 @@ export interface Hooks {
   ) => Promise<void>
 
   "session.before.idle"?: (
-    input: { sessionID: string; parentSessionID?: string },
+    input: {
+      sessionID: string
+      parentSessionID?: string
+      agent?: string
+      model?: { providerID: string; modelID: string }
+    },
     output: { resumePrompt?: string },
   ) => Promise<void>
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -216,7 +216,7 @@ export interface Hooks {
     output: { text: string },
   ) => Promise<void>
 
-  "session.before_complete"?: (
+  "session.before.idle"?: (
     input: { sessionID: string; parentSessionID?: string },
     output: { resumePrompt?: string },
   ) => Promise<void>

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -215,4 +215,9 @@ export interface Hooks {
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },
   ) => Promise<void>
+
+  "session.before_complete"?: (
+    input: { sessionID: string; parentSessionID?: string },
+    output: { resumePrompt?: string },
+  ) => Promise<void>
 }


### PR DESCRIPTION
### What does this PR do?
This PR add a session.before.idle hook.

This allows (for example) plugins to do async work for a subagent session, and resume that subagent session on work result.

### How did you verify your code works?
Using it in Pocket Universe plugin, works as expected.