### PR TITLE
tweak: experimental batch, up restrictive max batch tool from `10` to `25` 

### DIFF
--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -123,14 +123,7 @@ export const BatchTool = Tool.define("batch", async () => {
         }
       }
 
-      const results: typeof toolCalls extends (infer T)[]
-        ? (Awaited<ReturnType<typeof executeCall>> & { tool: string })[]
-        : never = []
-
-      for (let i = 0; i < toolCalls.length; i++) {
-        if (i > 0) await Bun.sleep(50)
-        results.push(await executeCall(toolCalls[i]))
-      }
+      const results = await Promise.all(toolCalls.map((call) => executeCall(call)))
 
       // Add discarded calls as errors
       const now = Date.now()

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -33,8 +33,8 @@ export const BatchTool = Tool.define("batch", async () => {
       const { Session } = await import("../session")
       const { Identifier } = await import("../id/id")
 
-      const toolCalls = params.tool_calls.slice(0, 10)
-      const discardedCalls = params.tool_calls.slice(10)
+      const toolCalls = params.tool_calls.slice(0, 25)
+      const discardedCalls = params.tool_calls.slice(25)
 
       const { ToolRegistry } = await import("./registry")
       const availableTools = await ToolRegistry.tools({ modelID: "", providerID: "" })
@@ -123,7 +123,15 @@ export const BatchTool = Tool.define("batch", async () => {
         }
       }
 
-      const results = await Promise.all(toolCalls.map((call) => executeCall(call)))
+      const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+      const results: typeof toolCalls extends (infer T)[]
+        ? (Awaited<ReturnType<typeof executeCall>> & { tool: string })[]
+        : never = []
+
+      for (let i = 0; i < toolCalls.length; i++) {
+        if (i > 0) await delay(50)
+        results.push(await executeCall(toolCalls[i]))
+      }
 
       // Add discarded calls as errors
       const now = Date.now()
@@ -139,14 +147,14 @@ export const BatchTool = Tool.define("batch", async () => {
           state: {
             status: "error",
             input: call.parameters,
-            error: "Maximum of 10 tools allowed in batch",
+            error: "Maximum of 25 tools allowed in batch",
             time: { start: now, end: now },
           },
         })
         results.push({
           success: false as const,
           tool: call.tool,
-          error: new Error("Maximum of 10 tools allowed in batch"),
+          error: new Error("Maximum of 25 tools allowed in batch"),
         })
       }
 

--- a/packages/opencode/src/tool/batch.ts
+++ b/packages/opencode/src/tool/batch.ts
@@ -123,13 +123,12 @@ export const BatchTool = Tool.define("batch", async () => {
         }
       }
 
-      const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
       const results: typeof toolCalls extends (infer T)[]
         ? (Awaited<ReturnType<typeof executeCall>> & { tool: string })[]
         : never = []
 
       for (let i = 0; i < toolCalls.length; i++) {
-        if (i > 0) await delay(50)
+        if (i > 0) await Bun.sleep(50)
         results.push(await executeCall(toolCalls[i]))
       }
 

--- a/packages/opencode/src/tool/batch.txt
+++ b/packages/opencode/src/tool/batch.txt
@@ -6,7 +6,7 @@ Payload Format (JSON array):
 [{"tool": "read", "parameters": {"filePath": "src/index.ts", "limit": 350}},{"tool": "grep", "parameters": {"pattern": "Session\\.updatePart", "include": "src/**/*.ts"}},{"tool": "bash", "parameters": {"command": "git status", "description": "Shows working tree status"}}]
 
 Notes:
-- 1–10 tool calls per batch
+- 1–25 tool calls per batch
 - All calls start in parallel; ordering NOT guaranteed
 - Partial failures do not stop other tool calls
 - Do NOT use the batch tool within another batch tool.

--- a/packages/opencode/src/tool/batch.txt
+++ b/packages/opencode/src/tool/batch.txt
@@ -6,7 +6,7 @@ Payload Format (JSON array):
 [{"tool": "read", "parameters": {"filePath": "src/index.ts", "limit": 350}},{"tool": "grep", "parameters": {"pattern": "Session\\.updatePart", "include": "src/**/*.ts"}},{"tool": "bash", "parameters": {"command": "git status", "description": "Shows working tree status"}}]
 
 Notes:
-- 1–25 tool calls per batch
+- 1–20 tool calls per batch
 - All calls start in parallel; ordering NOT guaranteed
 - Partial failures do not stop other tool calls
 - Do NOT use the batch tool within another batch tool.


### PR DESCRIPTION
### What does this PR do?
This PR ups the max tool number batch can accept from 10 to 25 (I had originally set 10 thinking it was fine, but I now realise that it was somewhat arbitrary and doesn't necessarily plays well with models such as GPT 5.x

This PR also staggers the tool calling by 50ms, which gives a much better visual experience of the batch tool (UX win for a maximum of 1sec additional latency on the whole batch execution)

I initially had hopes it would fix the random tool duplication that happens when using batch, but this one is still out there...

### How did you verify your code works?
Used it, works as expected.