### PR TITLE
fix(tool): treat .fbs files as text instead of images

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -59,7 +59,9 @@ export const ReadTool = Tool.define("read", {
       throw new Error(`File not found: ${filepath}`)
     }
 
-    const isImage = file.type.startsWith("image/") && file.type !== "image/svg+xml"
+    // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
+    const isImage =
+      file.type.startsWith("image/") && file.type !== "image/svg+xml" && file.type !== "image/vnd.fastbidsheet"
     const isPdf = file.type === "application/pdf"
     if (isImage || isPdf) {
       const mime = file.type


### PR DESCRIPTION
## Summary
Fixes #9210

The `.fbs` file extension (commonly used for FlatBuffers schema files) was being detected as `image/vnd.fastbidsheet` due to Bun's MIME type mapping. This caused these text files to be treated as images, leading to errors with providers that don't support this obscure image format (e.g., Bedrock with Anthropic models returns "Unsupported image mime type: image/vnd.fastbidsheet").

## Changes
- Added `image/vnd.fastbidsheet` to the exclusion list alongside `image/svg+xml` in the read tool's image detection logic
- Added test case to verify `.fbs` files are read as text, not images

## Test plan
- [x] Added test case that verifies `.fbs` files are read as text content
- [x] Test passes with `bun test test/tool/read.test.ts --test-name-pattern "fbs"`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)