### PR TITLE
docs: add opencode-puter-auth to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -22,6 +22,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                  |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                           |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                           |
+| [opencode-puter-auth](https://github.com/Mihai-Codes/opencode-puter-auth)                          | Access 500+ AI models (Claude, GPT-5, Gemini, DeepSeek) via Puter.com OAuth                    |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling  |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                          |


### PR DESCRIPTION
## Summary

Adds [opencode-puter-auth](https://github.com/Mihai-Codes/opencode-puter-auth) to the ecosystem plugins list.

## About the Plugin

**opencode-puter-auth** enables OpenCode to authenticate with [Puter.com](https://puter.com) via OAuth, providing access to 500+ AI models including:

- Claude Opus 4.5, Sonnet 4.5, Haiku 4.5
- GPT-5.2, o3-mini, o4-mini
- Gemini 2.5 Pro/Flash
- DeepSeek R1
- And many more

### Features

- Browser-based OAuth authentication
- Real-time SSE streaming
- Tool/function calling support
- Full AI SDK v3 provider implementation

### npm

[![npm version](https://img.shields.io/npm/v/opencode-puter-auth.svg)](https://www.npmjs.com/package/opencode-puter-auth)

### Installation

```json
{
  "plugin": ["opencode-puter-auth"],
  "provider": {
    "puter": {
      "npm": "opencode-puter-auth",
      "models": { ... }
    }
  }
}
```

---

Happy to make any changes if needed!