### PR TITLE
fix(nix): make shell completion installation resilient to failures

### DIFF
--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -69,15 +69,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
     completion_bash=$($out/bin/opencode completion || true)
-    # trick yargs into also generating zsh completions
-    completion_zsh=$(SHELL=/bin/zsh $out/bin/opencode completion || true)
     if [ -n "$completion_bash" ]; then
       installShellCompletion --cmd opencode \
         --bash <(echo "$completion_bash")
+    else
+      echo >&2 "[1;31mwarning: bash completion generation failed or produced no output[0m"
     fi
+
+    # trick yargs into also generating zsh completions
+    completion_zsh=$(SHELL=/bin/zsh $out/bin/opencode completion || true)
     if [ -n "$completion_zsh" ]; then
       installShellCompletion --cmd opencode \
         --zsh <(echo "$completion_zsh")
+    else
+      echo >&2 "[1;31mwarning: zsh completion generation failed or produced no output[0m"
     fi
   '';
 

--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -75,7 +75,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       installShellCompletion --cmd opencode \
         --bash <(echo "$completion_bash")
     fi
-
     if [ -n "$completion_zsh" ]; then
       installShellCompletion --cmd opencode \
         --zsh <(echo "$completion_zsh")

--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -68,10 +68,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    completion_bash=$($out/bin/opencode completion || true)
     # trick yargs into also generating zsh completions
-    installShellCompletion --cmd opencode \
-      --bash <($out/bin/opencode completion) \
-      --zsh <(SHELL=/bin/zsh $out/bin/opencode completion)
+    completion_zsh=$(SHELL=/bin/zsh $out/bin/opencode completion || true)
+    if [ -n "$completion_bash" ]; then
+      installShellCompletion --cmd opencode \
+        --bash <(echo "$completion_bash")
+    fi
+
+    if [ -n "$completion_zsh" ]; then
+      installShellCompletion --cmd opencode \
+        --zsh <(echo "$completion_zsh")
+    fi
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
Fixes #9285

## Summary

Fixes Nix build failure when shell completion generation fails or produces empty output.

## Changes

- Capture completion output before installation
- Add error handling with `|| true` to prevent build failures if bash or zsh are not installed
- Only install completions if they contain content (using `-n` test)
- Use safe piping with `echo` instead of direct command substitution
- Add warning messages (following nixpkgs convention with ANSI color codes) when completion generation fails

## Problem

The build was failing with:
```
ERROR: installShellCompletion: installed shell completion file does not exist or has zero size
```

This occurred when:
- `opencode completion` command failed or returned empty output during the Nix build process
- bash or zsh shells were not installed in the build environment

## Solution

The completion installation is now optional and gracefully handles failures, allowing the build to succeed even if completions cannot be generated. Warning messages are displayed when completion generation fails.