### PR TITLE
fix(app): session-header directory name overflow

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -130,7 +130,7 @@ export function SessionHeader() {
           <Portal mount={mount()}>
             <button
               type="button"
-              class="hidden md:flex w-[320px] p-1 pl-1.5 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-raised-base transition-colors cursor-default hover:bg-surface-raised-base-hover focus:bg-surface-raised-base-hover active:bg-surface-raised-base-active"
+              class="hidden md:flex min-w-[320px] max-w-1/2 p-1 pl-1.5 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-raised-base transition-colors cursor-default hover:bg-surface-raised-base-hover focus:bg-surface-raised-base-hover active:bg-surface-raised-base-active"
               onClick={() => command.trigger("file.open")}
             >
               <div class="flex min-w-0 flex-1 items-center gap-2 overflow-visible">


### PR DESCRIPTION
### What does this PR do?
Fixes #9288 
If the working dir is too long it just bleeds out of the side of the session header. I changed the width from static to bounded, not sure if yall would rather truncate with an ellipsis...

before 
<img width="569" height="59" alt="image" src="https://github.com/user-attachments/assets/a9101ca1-e357-473c-a883-04f922bacfe4" />
after
<img width="559" height="55" alt="image" src="https://github.com/user-attachments/assets/2f628dde-6118-462a-84c0-fbd6fa723a0b" />

### How did you verify your code works?
Waiting for any comments