### PR TITLE
feat(tool): expose session context to child processes via environment variables

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1485,6 +1485,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         ...process.env,
         TERM: "dumb",
         OPENCODE_SESSION_ID: input.sessionID,
+        OPENCODE_SESSION_TITLE: session.title,
       },
     })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1484,6 +1484,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       env: {
         ...process.env,
         TERM: "dumb",
+        OPENCODE_SESSION_ID: input.sessionID,
       },
     })
 

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -159,6 +159,7 @@ export const BashTool = Tool.define("bash", async () => {
         cwd,
         env: {
           ...process.env,
+          OPENCODE_SESSION_ID: ctx.sessionID,
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -16,6 +16,7 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
+import { Session } from "@/session"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -154,12 +155,20 @@ export const BashTool = Tool.define("bash", async () => {
         })
       }
 
+      const session = await (async () => {
+        try {
+          return await Session.get(ctx.sessionID)
+        } catch {
+          return undefined
+        }
+      })()
       const proc = spawn(params.command, {
         shell,
         cwd,
         env: {
           ...process.env,
           OPENCODE_SESSION_ID: ctx.sessionID,
+          ...(session?.title && { OPENCODE_SESSION_TITLE: session.title }),
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -5,6 +5,7 @@ import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 import type { PermissionNext } from "../../src/permission/next"
 import { Truncate } from "../../src/tool/truncation"
+import { Session } from "../../src/session"
 
 const ctx = {
   sessionID: "test",
@@ -56,6 +57,31 @@ describe("tool.bash", () => {
         )
         expect(result.metadata.exit).toBe(0)
         expect(result.metadata.output.trim()).toBe(sessionID)
+      },
+    })
+  })
+
+  test("exposes OPENCODE_SESSION_TITLE environment variable", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const title = "My Custom Session Title"
+        const session = await Session.create({ title })
+        const bash = await BashTool.init()
+        const testCtx = {
+          ...ctx,
+          sessionID: session.id,
+        }
+        const result = await bash.execute(
+          {
+            command: process.platform === "win32" ? "echo %OPENCODE_SESSION_TITLE%" : "echo $OPENCODE_SESSION_TITLE",
+            description: "Print session title env var",
+          },
+          testCtx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.output.trim()).toBe(title)
+        await Session.remove(session.id)
       },
     })
   })

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -36,6 +36,29 @@ describe("tool.bash", () => {
       },
     })
   })
+
+  test("exposes OPENCODE_SESSION_ID environment variable", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const sessionID = "session_abc123"
+        const testCtx = {
+          ...ctx,
+          sessionID,
+        }
+        const result = await bash.execute(
+          {
+            command: process.platform === "win32" ? "echo %OPENCODE_SESSION_ID%" : "echo $OPENCODE_SESSION_ID",
+            description: "Print session ID env var",
+          },
+          testCtx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.output.trim()).toBe(sessionID)
+      },
+    })
+  })
 })
 
 describe("tool.bash permissions", () => {


### PR DESCRIPTION
## What does this PR do?
Exposes the current opencode session ID and title to child processes via environment variables, enabling user scripts and tools to correlate their work with specific opencode sessions.
### Changes
- **OPENCODE_SESSION_ID**: Unique session identifier (e.g., `ses_xyz123`)
- **OPENCODE_SESSION_TITLE**: Human-readable session name (e.g., `"Fix bug in auth flow"`)
These are set dynamically in two user-facing command execution contexts:
1. Bash tool (`bash.ts`)
2. Prompt shell (`prompt.ts`)
### Motivation
Users running iterative workflows (e.g., Ralph loops with multiple sessions per iteration) need to correlate logs and outputs with the specific opencode session they're running in. Previously, child processes had no access to session metadata.
### Implementation Notes
- Environment variables are set per-spawn (not globally) because sessions can change during interactive work
- Session lookup includes graceful error handling to avoid breaking existing tests with mock session IDs
- Both variables are always exposed; `OPENCODE_SESSION_TITLE` gracefully degrades if session lookup fails
## How did you verify your code works?
- Added a unit test for `OPENCODE_SESSION_TITLE` environment variable exposure
- Used `bun run dev` with a prompt to `echo $OPENCODE_SESSION_ID` to verify variables are correctly passed to child processes
- Didn't test on Windows
### Example Usage
```bash
#!/bin/bash
echo "Session: $OPENCODE_SESSION_TITLE ($OPENCODE_SESSION_ID)" >> logs.txt
```

Closes #9292