### PR TITLE
fix: Windows evaluating text on copy

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -125,9 +125,25 @@ export namespace Clipboard {
     if (os === "win32") {
       console.log("clipboard: using powershell")
       return async (text: string) => {
-        // need to escape backticks because powershell uses them as escape code
-        const escaped = text.replace(/"/g, '""').replace(/`/g, "``")
-        await $`powershell -NonInteractive -NoProfile -Command "Set-Clipboard -Value \"${escaped}\""`.nothrow().quiet()
+        // Pipe via stdin to avoid PowerShell string interpolation ($env:FOO, $(), etc.)
+        const proc = Bun.spawn(
+          [
+            "powershell.exe",
+            "-NonInteractive",
+            "-NoProfile",
+            "-Command",
+            "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())",
+          ],
+          {
+            stdin: "pipe",
+            stdout: "ignore",
+            stderr: "ignore",
+          },
+        )
+
+        proc.stdin.write(text)
+        proc.stdin.end()
+        await proc.exited.catch(() => {})
       }
     }
 


### PR DESCRIPTION
### What does this PR do?

Fixes [#8166](https://github.com/anomalyco/opencode/issues/8166)

copying text like

<img width="874" height="264" alt="image" src="https://github.com/user-attachments/assets/0aa512c8-2549-49e5-aee1-a221238eebdb" />

on windows would expand these variables because it uses powershell

changes to use stdin - the same as linux clipboard

I found a duplicate PR - however mine stays consistent with linux
https://github.com/anomalyco/opencode/pull/8150


### How did you verify your code works?
copying the same text on latest release and my branch on windows