### PR TITLE
docs: clarify skill naming is convention, not enforced

### DIFF
--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -44,28 +44,21 @@ Unknown frontmatter fields are ignored.
 
 ---
 
-## Validate names
+## Naming conventions
 
-`name` must:
+For consistency and compatibility with Claude Code's `.claude/skills/` format, we recommend:
 
-- Be 1–64 characters
-- Be lowercase alphanumeric with single hyphen separators
-- Not start or end with `-`
-- Not contain consecutive `--`
-- Match the directory name that contains `SKILL.md`
+- Lowercase alphanumeric names with hyphens (e.g., `git-release`, `code-review`)
+- Matching the directory name to the skill name
+- Keeping names concise and descriptive
 
-Equivalent regex:
-
-```text
-^[a-z0-9]+(-[a-z0-9]+)*$
-```
+These are conventions, not enforced requirements. The `name` field accepts any non-empty string.
 
 ---
 
-## Follow length rules
+## Description length
 
-`description` must be 1-1024 characters.
-Keep it specific enough for the agent to choose correctly.
+Keep descriptions specific enough for the agent to choose correctly—aim for 1-2 sentences that clearly explain when to use the skill.
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Fixes the Agent Skills documentation which incorrectly states that skill names must follow strict validation rules (regex `^[a-z0-9]+(-[a-z0-9]+)*$`, directory name matching, etc).

The actual code in `packages/opencode/src/skill/skill.ts` shows no such validation:
```typescript
export const Info = z.object({
  name: z.string(),  // No regex validation
  description: z.string(),
  location: z.string(),
})
```

**How this happened:**

The documentation (PR #5931) and code (PR #5930) were created together but merged in different order:

1. PR #5931 (docs) merged first at `2025-12-22T05:49:28Z`
2. Maintainer simplified PR #5930 in commit `9a5dd18`, removing `NAME_REGEX` validation
3. PR #5930 (code) merged at `2025-12-22T23:24:07Z` without the validation

The docs were accurate when written, but became incorrect when the code was simplified before merging.

**Changes:**
- Renamed "Validate names" → "Naming conventions"
- Changed strict requirements to recommended conventions
- Clarified that the `name` field accepts any non-empty string
- Simplified the description length section

Fixes #9294

### How did you verify your code works?

1. Traced git history to confirm timeline:
   - `git log --all --oneline -- "packages/web/src/content/docs/skills.mdx"` shows PR #5931 added the docs
   - `git show 9a5dd18` shows maintainer removed `NAME_REGEX` from skill.ts
2. Reviewed current `packages/opencode/src/skill/skill.ts` confirming `name: z.string()` with no validation
3. Verified PR merge timestamps via `gh pr view --json mergedAt`