### PR TITLE
fix: experimental plan mode build incorrectly uses plan's model

### DIFF
--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -7,6 +7,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Provider } from "../provider/provider"
 import { Instance } from "../project/instance"
+import { Agent } from "../agent/agent"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 import ENTER_DESCRIPTION from "./plan-enter.txt"
 
@@ -15,6 +16,11 @@ async function getLastModel(sessionID: string) {
     if (item.info.role === "user" && item.info.model) return item.info.model
   }
   return Provider.defaultModel()
+}
+
+async function getAgentModel(agentName: string) {
+  const agent = await Agent.get(agentName)
+  return agent.model
 }
 
 export const PlanExitTool = Tool.define("plan_exit", {
@@ -42,7 +48,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
     const answer = answers[0]?.[0]
     if (answer === "No") throw new Question.RejectedError()
 
-    const model = await getLastModel(ctx.sessionID)
+    const model = (await getAgentModel("build")) || (await getLastModel(ctx.sessionID))
 
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),
@@ -99,7 +105,7 @@ export const PlanEnterTool = Tool.define("plan_enter", {
 
     if (answer === "No") throw new Question.RejectedError()
 
-    const model = await getLastModel(ctx.sessionID)
+    const model = (await getAgentModel("plan")) || (await getLastModel(ctx.sessionID))
 
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),


### PR DESCRIPTION
### What does this PR do?

Resolves: https://github.com/anomalyco/opencode/issues/9296

Planned with configured GTP-5.2, handover to build errored with GPT-5.2 rather than the configured opus-4.5:

```
⚙ functions.glob [pattern=packages/opencode/src/**/__tests__/**/*, path=/Users/stevoland/workspace/github.com/sst/opencode]
Tool 'functions.glob' not in registry. External tools (MCP, environment) cannot be batched - call them directly. Available tools: question, bash, read, glob, grep, edit, write, task, webfetch, todowrite, todoread, skill, lsp, plan_exit, plan_enter, repo-explorer, repo-explorer_repo_ast, repo-explorer_repo_cleanup, repo-explorer_repo_clone, repo-explorer_repo_deps, repo-explorer_repo_exports, repo-explorer_repo_file, repo-explorer_repo_find, repo-explorer_repo_hotspots, repo-explorer_repo_search, repo-explorer_repo_structure, github-triage, github-pr-search
Invalid 'messages[15].tool_calls[1].function.name': string does not match pattern. Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
▣  Build · gpt-5.2
```

### How did you verify your code works?

```sh
 ./packages/opencode/script/build.ts --single
 ./packages/opencode/dist/opencode-darwin-arm64/bin/opencode
```

repeated previous prompt and build agent model was correctly invoked

