### PR TITLE
docs: clarify agent tool access and explore vs general distinction

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -21,7 +21,7 @@ There are two types of agents in OpenCode; primary agents and subagents.
 
 ### Primary agents
 
-Primary agents are the main assistants you interact with directly. You can cycle through them using the **Tab** key, or your configured `switch_agent` keybind. These agents handle your main conversation and can access all configured tools.
+Primary agents are the main assistants you interact with directly. You can cycle through them using the **Tab** key, or your configured `switch_agent` keybind. These agents handle your main conversation. Tool access is configured via permissions — for example, Build has all tools enabled while Plan is restricted.
 
 :::tip
 You can use the **Tab** key to switch between primary agents during a session.
@@ -72,7 +72,7 @@ This agent is useful when you want the LLM to analyze code, suggest changes, or 
 
 _Mode_: `subagent`
 
-A general-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. Use when searching for keywords or files and you're not confident you'll find the right match in the first few tries.
+A general-purpose agent for researching complex questions and executing multi-step tasks. Has full tool access (except todo), so it can make file changes when needed. Use this to run multiple units of work in parallel.
 
 ---
 
@@ -80,7 +80,7 @@ A general-purpose agent for researching complex questions, searching for code, a
 
 _Mode_: `subagent`
 
-A fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns, search code for keywords, or answer questions about the codebase.
+A fast, read-only agent for exploring codebases. Cannot modify files. Use this when you need to quickly find files by patterns, search code for keywords, or answer questions about the codebase.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #9297

- Clarifies that primary agents don't automatically have access to all tools (Plan is restricted)
- Explains the key difference between General and Explore subagents: General has full tool access while Explore is read-only

## Changes

1. **Primary agents section**: Replaced "can access all configured tools" with accurate statement about permissions
2. **General section**: Clarified it has full tool access (except todo) and can make file changes  
3. **Explore section**: Added "read-only" and "Cannot modify files" to distinguish from General