### PR TITLE
feat(lsp): Add TailwindCSS LSP server support

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -2043,4 +2043,68 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const Tailwind: Info = {
+    id: "tailwindcss",
+    extensions: [".css", ".html", ".jsx", ".tsx", ".vue", ".astro", ".svelte", ".scss", ".less"],
+    root: NearestRoot([
+      "tailwind.config.js",
+      "tailwind.config.cjs",
+      "tailwind.config.mjs",
+      "tailwind.config.ts",
+      "tailwind.config.cts",
+      "tailwind.config.mts",
+      "postcss.config.js",
+      "postcss.config.cjs",
+      "postcss.config.mjs",
+      "postcss.config.ts",
+      "postcss.config.cts",
+      "postcss.config.mts",
+    ]),
+    async spawn(root) {
+      let bin = Bun.which("tailwindcss-language-server", {
+        PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
+      })
+
+      if (!bin) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+        log.info("installing @tailwindcss/language-server")
+
+        const proc = Bun.spawn([BunProc.which(), "install", "@tailwindcss/language-server"], {
+          cwd: Global.Path.bin,
+          env: {
+            ...process.env,
+            BUN_BE_BUN: "1",
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: "pipe",
+        })
+
+        const exit = await proc.exited
+        if (exit !== 0) {
+          log.error("Failed to install @tailwindcss/language-server")
+          return
+        }
+
+        bin = path.join(
+          Global.Path.bin,
+          "node_modules",
+          ".bin",
+          "tailwindcss-language-server" + (process.platform === "win32" ? ".cmd" : ""),
+        )
+        log.info(`installed @tailwindcss/language-server`, { bin })
+      }
+
+      return {
+        process: spawn(bin, ["--stdio"], {
+          cwd: root,
+          env: {
+            ...process.env,
+            BUN_BE_BUN: "1",
+          },
+        }),
+      }
+    },
+  }
 }

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -38,6 +38,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | rust               | .rs                                                                 | `rust-analyzer` command available                            |
 | sourcekit-lsp      | .swift, .objc, .objcpp                                              | `swift` installed (`xcode` on macOS)                         |
 | svelte             | .svelte                                                             | Auto-installs for Svelte projects                            |
+| tailwindcss        | .css, .html, .jsx, .tsx, .vue, .astro, .svelte, .scss, .less        | Auto-installs for projects with tailwind or postcss config   |
 | terraform          | .tf, .tfvars                                                        | Auto-installs from GitHub releases                           |
 | tinymist           | .typ, .typc                                                         | Auto-installs from GitHub releases                           |
 | typescript         | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts                        | `typescript` dependency in project                           |


### PR DESCRIPTION
## Summary

This PR adds TailwindCSS Language Server support to OpenCode, enabling IDE-like features (autocomplete, hover info, diagnostics) for TailwindCSS projects.

## Changes

- Added `Tailwind` LSP server configuration in `packages/opencode/src/lsp/server.ts`
- Auto-installs `@tailwindcss/language-server` when not found in system
- Supports `.css`, `.html`, `.jsx`, `.tsx`, `.vue`, `.astro`, `.svelte`, `.scss`, `.less` files
- Detects TailwindCSS projects via `tailwind.config.*` or `postcss.config.*` files
- Updated LSP documentation in `packages/web/src/content/docs/lsp.mdx`

## Testing

Tested locally with:
- Opening supported files in Tailwind projects
- Verified LSP server spawns automatically
- Checked diagnostics for invalid Tailwind classes
- Tested auto-detection of config files

Fixes #8518