### PR TITLE
feat(tui): use mouse for permission buttons

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -280,6 +280,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                     reply: "reject",
                     requestID: props.request.id,
                   })
+                  return
                 }
                 sdk.client.permission.reply({
                   reply: "once",
@@ -456,6 +457,11 @@ function Prompt<const T extends Record<string, string>>(props: {
                 paddingLeft={1}
                 paddingRight={1}
                 backgroundColor={option === store.selected ? theme.warning : theme.backgroundMenu}
+                onMouseOver={() => setStore("selected", option)}
+                onMouseUp={() => {
+                  setStore("selected", option)
+                  props.onSelect(option)
+                }}
               >
                 <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
                   {props.options[option]}


### PR DESCRIPTION
### What does this PR do?

The question tool is cool to click and use the TUI with a mouse.

This adds similar functionality

### How did you verify your code works?

https://github.com/user-attachments/assets/0e3c2850-6ba8-437c-9c93-9eae849b75cc
