### PR TITLE
feat(hook): add noReply option to command.execute.before hook

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1702,14 +1702,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         : await lastModel(input.sessionID)
       : taskModel
 
-    await Plugin.trigger(
+    const hookOutput = await Plugin.trigger(
       "command.execute.before",
       {
         command: input.command,
         sessionID: input.sessionID,
         arguments: input.arguments,
       },
-      { parts },
+      { parts, noReply: false },
     )
 
     const result = (await prompt({
@@ -1718,6 +1718,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       model: userModel,
       agent: userAgent,
       parts,
+      noReply: hookOutput.noReply,
       variant: input.variant,
     })) as MessageV2.WithParts
 

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -175,7 +175,7 @@ export interface Hooks {
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
-    output: { parts: Part[] },
+    output: { parts: Part[]; noReply?: boolean },
   ) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },


### PR DESCRIPTION
## Summary
- Adds `noReply?: boolean` to the `command.execute.before` hook output type
- Passes `hookOutput.noReply` to `prompt()` to skip LLM when set

## Use Case
Plugins can handle slash commands directly without invoking the LLM.

## Verification
Tested with a plugin that handles `/tty` commands. Setting `output.noReply = true` in the hook skips LLM invocation and the command output is displayed directly.

Fixes #9306