### PR TITLE
feat(lsp): Add GraphQL LSP server support

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -2043,4 +2043,69 @@ export namespace LSPServer {
       }
     },
   }
+
+  export const GraphQL: Info = {
+    id: "graphql",
+    extensions: [".graphql", ".gql", ".ts", ".tsx", ".js", ".jsx", ".vue", ".svelte", ".astro"],
+    root: NearestRoot([
+      ".graphqlrc",
+      ".graphqlrc.json",
+      ".graphqlrc.yaml",
+      ".graphqlrc.yml",
+      ".graphqlrc.js",
+      ".graphqlrc.cjs",
+      ".graphqlrc.mjs",
+      "graphql.config.json",
+      "graphql.config.yaml",
+      "graphql.config.yml",
+      "graphql.config.js",
+      "graphql.config.cjs",
+      "graphql.config.mjs",
+    ]),
+    async spawn(root) {
+      let bin = Bun.which("graphql-lsp", {
+        PATH: process.env["PATH"] + path.delimiter + Global.Path.bin,
+      })
+
+      if (!bin) {
+        if (Flag.OPENCODE_DISABLE_LSP_DOWNLOAD) return
+        log.info("installing graphql-language-service-cli")
+
+        const proc = Bun.spawn([BunProc.which(), "install", "graphql-language-service-cli"], {
+          cwd: Global.Path.bin,
+          env: {
+            ...process.env,
+            BUN_BE_BUN: "1",
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: "pipe",
+        })
+
+        const exit = await proc.exited
+        if (exit !== 0) {
+          log.error("Failed to install graphql-language-service-cli")
+          return
+        }
+
+        bin = path.join(
+          Global.Path.bin,
+          "node_modules",
+          ".bin",
+          "graphql-lsp" + (process.platform === "win32" ? ".cmd" : ""),
+        )
+        log.info(`installed graphql-language-service-cli`, { bin })
+      }
+
+      return {
+        process: spawn(bin, ["server", "-m", "stream"], {
+          cwd: root,
+          env: {
+            ...process.env,
+            BUN_BE_BUN: "1",
+          },
+        }),
+      }
+    },
+  }
 }

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -25,6 +25,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | fsharp             | .fs, .fsi, .fsx, .fsscript                                          | `.NET SDK` installed                                         |
 | gleam              | .gleam                                                              | `gleam` command available                                    |
 | gopls              | .go                                                                 | `go` command available                                       |
+| graphql            | .graphql, .gql, .ts, .tsx, .js, .jsx, .vue, .svelte, .astro         | Auto-installs for projects with .graphqlrc or graphql.config |
 | jdtls              | .java                                                               | `Java SDK (version 21+)` installed                           |
 | kotlin-ls          | .kt, .kts                                                           | Auto-installs for Kotlin projects                            |
 | lua-ls             | .lua                                                                | Auto-installs for Lua projects                               |


### PR DESCRIPTION
## Summary

This PR adds GraphQL Language Server support to OpenCode, enabling IDE-like features (autocomplete, hover info, diagnostics, go-to-definition) for GraphQL projects.

## Changes

- Auto-detection via `.graphqlrc.*` or `graphql.config.*` files
- Auto-installs  when not found in system
- Supports, standalone files and inline GraphQL in .graphql, .gql, .ts, .tsx, .js, .jsx, .vue, .svelte, .astro files

## Testing

Tested locally with:
- Opening  and  files in GraphQL projects
- Opening inline GraphQL in TypeScript/JavaScript/Vue files
- Verified LSP server spawns automatically when GraphQL config files are detected
- Checked diagnostics for invalid GraphQL syntax
- Tested autocomplete and hover information
- Confirmed coexistence with Biome LSP (no conflicts)

Fixes #9308