### PR TITLE
fix: use parent directory name for index.ts plugins in deduplication

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -331,17 +331,23 @@ export namespace Config {
 
   /**
    * Extracts a canonical plugin name from a plugin specifier.
-   * - For file:// URLs: extracts filename without extension
+   * - For file:// URLs: extracts filename without extension (or parent dir for index.ts)
    * - For npm packages: extracts package name without version
    *
    * @example
    * getPluginName("file:///path/to/plugin/foo.js") // "foo"
+   * getPluginName("file:///path/to/my-plugin/index.ts") // "my-plugin"
    * getPluginName("oh-my-opencode@2.4.3") // "oh-my-opencode"
    * getPluginName("@scope/pkg@1.0.0") // "@scope/pkg"
    */
   export function getPluginName(plugin: string): string {
     if (plugin.startsWith("file://")) {
-      return path.parse(new URL(plugin).pathname).name
+      const parsed = path.parse(new URL(plugin).pathname)
+      // Use parent directory name if file is index.ts/index.js to avoid collisions
+      if (parsed.name === "index") {
+        return path.basename(parsed.dir)
+      }
+      return parsed.name
     }
     const lastAt = plugin.lastIndexOf("@")
     if (lastAt > 0) {


### PR DESCRIPTION
## Summary

- Fixes plugin deduplication when multiple plugins use `index.ts` as their filename
- When a plugin file is named `index.ts` or `index.js`, the parent directory name is used instead for deduplication

## Problem

When configuring multiple local plugins with `file://` URLs that use the common `index.ts` naming convention:

```json
{
  "plugin": [
    "file:///path/to/my-plugin/index.ts",
    "file:///path/to/other-plugin/index.ts"
  ]
}
```

Both plugins resolve to the name `index`, causing the deduplication logic to keep only the last one.

## Solution

The `getPluginName` function now checks if the filename is `index` and uses the parent directory name instead:

- `file:///path/to/my-plugin/index.ts` → `my-plugin`
- `file:///path/to/other-plugin/index.ts` → `other-plugin`