### PR TITLE
refactor(desktop): tweak share button to prevent layout shift

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -244,7 +244,11 @@ export function SessionHeader() {
                     }
                     trigger={
                       <Tooltip class="shrink-0" value="Share session">
-                        <Button variant="secondary" classList={{ "rounded-r-none": shareUrl() !== undefined }}>
+                        <Button
+                          variant="secondary"
+                          classList={{ "rounded-r-none": shareUrl() !== undefined }}
+                          style={{ scale: 1 }}
+                        >
                           Share
                         </Button>
                       </Tooltip>
@@ -293,12 +297,12 @@ export function SessionHeader() {
                       </Show>
                     </div>
                   </Popover>
-                  <Show when={shareUrl()}>
+                  <Show when={shareUrl()} fallback={<div class="size-6" aria-hidden="true" />}>
                     <Tooltip value={state.copied ? "Copied" : "Copy link"} placement="top" gutter={8}>
                       <IconButton
                         icon={state.copied ? "check" : "copy"}
                         variant="secondary"
-                        class="rounded-l-none border-l border-border-weak-base"
+                        class="rounded-l-none"
                         onClick={copyLink}
                         disabled={state.unshare}
                       />


### PR DESCRIPTION
### What does this PR do?

- Adds a fallback for the `Copy Link` IconButton so the share popover doesn't shift when the user clicks on the `Publish` button.
- Removes the unnecessary left border for the `Copy Link` icon
- Nullifies the `secondary` button active scaling for Share button to prevent weird border shifting between `Share` & `Copy Link`

### How did you verify your code works?

#### Before

https://github.com/user-attachments/assets/1c5bc0f2-1655-4c80-bd93-c2df6791f397

#### After

https://github.com/user-attachments/assets/82a91f86-5ef4-4221-aed1-7805670d4251
