### PR TITLE
feat(app): Add ability to select project directory text to web

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1637,7 +1637,7 @@ export default function Layout(props: ParentProps) {
                             transform: "translate3d(52px, 0, 0)",
                           }}
                         >
-                          <span class="text-12-regular text-text-base truncate">
+                          <span class="text-12-regular text-text-base truncate select-text">
                             {project()?.worktree.replace(homedir(), "~")}
                           </span>
                         </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Makes the project directory text selectable. 
<img width="361" height="273" alt="image" src="https://github.com/user-attachments/assets/ea129786-9d45-4513-b10d-1f588446060e" />

### How did you verify your code works?
Built opencode web and validated that the text is selectable with the new select-text class:
 

https://github.com/user-attachments/assets/ff422727-5480-441f-a958-0242e88e1d18

Closes: https://github.com/anomalyco/opencode/issues/9343

