### PR TITLE
fix: expose autoloadBunfig setting as define for subprocess isolation

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -126,6 +126,7 @@ for (const item of targets) {
   // Use platform-specific bunfs root path based on target OS
   const bunfsRoot = item.os === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/"
   const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
+  const autoloadBunfig = false
 
   await Bun.build({
     conditions: ["browser"],
@@ -133,7 +134,7 @@ for (const item of targets) {
     plugins: [solidPlugin],
     sourcemap: "external",
     compile: {
-      autoloadBunfig: false,
+      autoloadBunfig,
       autoloadDotenv: false,
       //@ts-ignore (bun types aren't up to date)
       autoloadTsconfig: true,
@@ -150,6 +151,7 @@ for (const item of targets) {
       OPENCODE_WORKER_PATH: workerPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
+      OPENCODE_AUTOLOAD_BUNFIG: String(autoloadBunfig),
     },
   })
 


### PR DESCRIPTION
## Summary
- Add `OPENCODE_AUTOLOAD_BUNFIG` define that exposes the compile-time `autoloadBunfig` setting to runtime code
- Extract `autoloadBunfig` to a variable so both compile option and define stay in sync

This enables subprocess spawning logic to apply equivalent bunfig isolation when spawning Bun processes with `BUN_BE_BUN=1`.

## Test plan
- [ ] Build the binary and verify `OPENCODE_AUTOLOAD_BUNFIG` is defined
- [ ] Verify runtime code can access the define value

Fixes #5349

## Root cause analysis (by claude code)
```
autoloadBunfig: false in the compile options only affects the initial startup of the compiled binary itself. It's baked into the binary at build time.          
                                                                                                                                                                                 
  The problem is:                                                                                                                                                                
                                                                                                                                                                                 
  1. Compiled binary starts → autoloadBunfig: false is respected → no bunfig.toml loaded ✓                                                                                       
  2. Binary spawns subprocess with BUN_BE_BUN=1 → subprocess runs as "raw Bun" → the compile option doesn't carry over → bunfig.toml gets loaded ✗                               
                                                                                                                                                                                 
  The autoloadBunfig setting isn't inherited by child processes. When BUN_BE_BUN=1 is set, the subprocess essentially becomes a fresh Bun runtime that doesn't know about the    
  parent's compile settings.                                                                                                                                                     
                                                                                                                                                                                 
  That's why we need --config=/dev/null as a runtime workaround for subprocesses. The OPENCODE_AUTOLOAD_BUNFIG define just lets the runtime code know what the compile setting   
  was, so it can apply the equivalent protection to subprocesses.                                                                                                                
                                                                                                                                                                                 
  Compiled binary (autoloadBunfig: false)                                                                                                                                        
      │                                                                                                                                                                          
      └─► Subprocess (BUN_BE_BUN=1)                                                                                                                                              
              │                                                                                                                                                                  
              └─► Needs --config=/dev/null to match parent's behavior    
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)