### PR TITLE
feat: add prop to hide queue badge

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1098,7 +1098,7 @@ function UserMessage(props: {
   const sync = useSync()
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
-  const queued = createMemo(() => props.pending && props.message.id > props.pending)
+  const queued = createMemo(() => props.pending && props.message.id > props.pending && !props.message.hideQueueBadge)
   const color = createMemo(() => (queued() ? theme.accent : local.agent.color(props.message.agent)))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -315,6 +315,7 @@ export namespace MessageV2 {
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
     variant: z.string().optional(),
+    hideQueueBadge: z.boolean().optional(),
   }).meta({
     ref: "UserMessage",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -92,6 +92,7 @@ export namespace SessionPrompt {
       .optional(),
     agent: z.string().optional(),
     noReply: z.boolean().optional(),
+    hideQueueBadge: z.boolean().optional(),
     tools: z
       .record(z.string(), z.boolean())
       .optional()
@@ -831,6 +832,7 @@ export namespace SessionPrompt {
       model: input.model ?? agent.model ?? (await lastModel(input.sessionID)),
       system: input.system,
       variant: input.variant,
+      hideQueueBadge: input.hideQueueBadge,
     }
 
     const parts = await Promise.all(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1317,6 +1317,7 @@ export class Session extends HeyApiClient {
       }
       agent?: string
       noReply?: boolean
+      hideQueueBadge?: boolean
       tools?: {
         [key: string]: boolean
       }
@@ -1337,6 +1338,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "model" },
             { in: "body", key: "agent" },
             { in: "body", key: "noReply" },
+            { in: "body", key: "hideQueueBadge" },
             { in: "body", key: "tools" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
@@ -1405,6 +1407,7 @@ export class Session extends HeyApiClient {
       }
       agent?: string
       noReply?: boolean
+      hideQueueBadge?: boolean
       tools?: {
         [key: string]: boolean
       }
@@ -1425,6 +1428,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "model" },
             { in: "body", key: "agent" },
             { in: "body", key: "noReply" },
+            { in: "body", key: "hideQueueBadge" },
             { in: "body", key: "tools" },
             { in: "body", key: "system" },
             { in: "body", key: "variant" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -92,6 +92,7 @@ export type UserMessage = {
     [key: string]: boolean
   }
   variant?: string
+  hideQueueBadge?: boolean
 }
 
 export type ProviderAuthError = {
@@ -3160,6 +3161,7 @@ export type SessionPromptData = {
     }
     agent?: string
     noReply?: boolean
+    hideQueueBadge?: boolean
     /**
      * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
      */
@@ -3347,6 +3349,7 @@ export type SessionPromptAsyncData = {
     }
     agent?: string
     noReply?: boolean
+    hideQueueBadge?: boolean
     /**
      * @deprecated tools and permissions have been merged, you can set permissions on the session itself now
      */


### PR DESCRIPTION
### What does this PR do?
Adds a way to hide the QUEUE badge on user queued messages