### PR TITLE
feat(plugin): add session.creating hook for customizing session creation

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -18,6 +18,7 @@ import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
 import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
+import { Plugin } from "@/plugin"
 
 import type { Provider } from "@/provider/provider"
 import { PermissionNext } from "@/permission/next"
@@ -136,9 +137,19 @@ export namespace Session {
       })
       .optional(),
     async (input) => {
+      const sessionID = Identifier.ascending("session")
+      
+      // Allow plugins to customize session creation (e.g., set custom directory)
+      const creating = await Plugin.trigger(
+        "session.creating",
+        { sessionID, parentID: input?.parentID },
+        { directory: Instance.directory },
+      )
+      
       return createNext({
+        id: sessionID,
         parentID: input?.parentID,
-        directory: Instance.directory,
+        directory: creating.directory,
         title: input?.title,
         permission: input?.permission,
       })

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -205,6 +205,16 @@ export interface Hooks {
     },
   ) => Promise<void>
   /**
+   * Called before a session is created. Allows plugins to customize
+   * session creation, including setting a custom working directory.
+   *
+   * - `directory`: The working directory for the session (defaults to Instance.directory)
+   */
+  "session.creating"?: (
+    input: { sessionID: string; parentID?: string },
+    output: { directory: string },
+  ) => Promise<void>
+  /**
    * Called before session compaction starts. Allows plugins to customize
    * the compaction prompt.
    *

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -179,6 +179,7 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 #### Session Events
 
+- `session.creating`
 - `session.created`
 - `session.compacted`
 - `session.deleted`


### PR DESCRIPTION
## Summary

Add a new plugin hook `session.creating` that is triggered before a session is created. This allows plugins to customize session creation, including setting a custom working directory.

### What does this PR do?

This PR adds a new plugin hook session.creating that fires before a session is created. Plugins can use this hook to customize session creation - most notably, setting a custom working directory for the session (e.g., for git worktrees, sandboxes, etc.).

Currently, there's no way for plugins to intercept session creation and customize it. Having a hook like this enables powerful use cases like:
- **Git worktrees**: Create isolated worktrees for each session so multiple sessions can work on different branches without conflicts
- **Sandboxed environments**: Run sessions in isolated directories for security or testing
- **Custom project layouts**: Support monorepos or non-standard project structures

## API
```typescript
"session.creating"?: (
  input: { sessionID: string; parentID?: string },
  output: { directory: string },
) => Promise<void>
```

- `input.sessionID`: The ID of the session being created
- `input.parentID`: The parent session ID (if creating a child session)
- `output.directory`: The working directory for the session (defaults to `Instance.directory`)

## Example Plugin
```typescript
export default {
  name: "worktree",
  hooks: {
    "session.creating": async (input, output) => {
      const worktreePath = await createWorktree(input.sessionID)
      output.directory = worktreePath
    }
  }
}
```

### How did you verify your code works?

Created a test plugin that uses the session.creating hook to create a git worktree workflow using opencode sessions. Verified that:
1. Created a test plugin using the session.creating hook to set a custom directory
2. Verified the hook is called with correct sessionID and parentID 
3. Verified output.directory is persisted to the session's directory field
4. Verified sessions created without plugins still default to Instance.directory



Closes #9366