### PR TITLE
fix(desktop): apply getComputedStyle polyfill on all platforms

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -26,17 +26,16 @@ if (import.meta.env.DEV && !(root instanceof HTMLElement)) {
   )
 }
 
-const isWindows = ostype() === "windows"
-if (isWindows) {
-  const originalGetComputedStyle = window.getComputedStyle
-  window.getComputedStyle = ((elt: Element, pseudoElt?: string | null) => {
-    if (!(elt instanceof Element)) {
-      // WebView2 can call into Floating UI with non-elements; fall back to a safe element.
-      return originalGetComputedStyle(document.documentElement, pseudoElt ?? undefined)
-    }
-    return originalGetComputedStyle(elt, pseudoElt ?? undefined)
-  }) as typeof window.getComputedStyle
-}
+// Floating UI can call getComputedStyle with non-elements (e.g., null refs, virtual elements).
+// This happens on all platforms (WebView2 on Windows, WKWebView on macOS), not just Windows.
+const originalGetComputedStyle = window.getComputedStyle
+window.getComputedStyle = ((elt: Element, pseudoElt?: string | null) => {
+  if (!(elt instanceof Element)) {
+    // Fall back to a safe element when a non-element is passed.
+    return originalGetComputedStyle(document.documentElement, pseudoElt ?? undefined)
+  }
+  return originalGetComputedStyle(elt, pseudoElt ?? undefined)
+}) as typeof window.getComputedStyle
 
 let update: Update | null = null
 


### PR DESCRIPTION
Floating UI can call getComputedStyle with non-elements (e.g., null refs, virtual elements) on all platforms, not just Windows. This removes the Windows-only condition so the safety wrapper works on macOS and Linux too.

Fixes TypeError: Argument 1 ('element') to Window.getComputedStyle must be an instance of Element

### What does this PR do?
On MacOS, I got error with the following:
```
TypeError: Argument 1 ('element') to Window.getComputedStyle must be an instance of Element
getComputedStyle@[native code]
ku@tauri://localhost/assets/index-D9T6R7qf.js:1707:89841
ru@tauri://localhost/assets/index-D9T6R7qf.js:1707:91735
wN@tauri://localhost/assets/index-D9T6R7qf.js:1707:99254
@tauri://localhost/assets/index-D9T6R7qf.js:1707:105255
Cb@tauri://localhost/assets/index-D9T6R7qf.js:2:8252
$l@tauri://localhost/assets/index-D9T6R7qf.js:2:7983
Ld@tauri://localhost/assets/index-D9T6R7qf.js:2:9468
Qk@tauri://localhost/assets/index-D9T6R7qf.js:2:10732
yn@tauri://localhost/assets/index-D9T6R7qf.js:2:9656
Jk@tauri://localhost/assets/index-D9T6R7qf.js:2:10317
yn@tauri://localhost/assets/index-D9T6R7qf.js:2:9668
M@tauri://localhost/assets/index-D9T6R7qf.js:2:3736
```
Removes the if (isWindows) condition from the getComputedStyle polyfill in packages/desktop/src/index.tsx

Applies the safety wrapper on all platforms (macOS, Windows, Linux) instead of Windows only


### How did you verify your code works?
Tested on local test cases. I can't reproduce this error on desktop version. It pop out sometimes when I continue on a conversation. But I am sure that this error occurs on MacOS.