### PR TITLE
feat(sdk): Add tui select session to sdk v1

### DIFF
--- a/packages/sdk/js/src/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/gen/sdk.gen.ts
@@ -191,6 +191,9 @@ import type {
   TuiPublishData,
   TuiPublishResponses,
   TuiPublishErrors,
+  TuiSelectSessionData,
+  TuiSelectSessionResponses,
+  TuiSelectSessionErrors,
   TuiControlNextData,
   TuiControlNextResponses,
   TuiControlResponseData,
@@ -1132,6 +1135,22 @@ class Tui extends _HeyApiClient {
   public publish<ThrowOnError extends boolean = false>(options?: Options<TuiPublishData, ThrowOnError>) {
     return (options?.client ?? this._client).post<TuiPublishResponses, TuiPublishErrors, ThrowOnError>({
       url: "/tui/publish",
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    })
+  }
+
+  /**
+   * Select session
+   *
+   * Navigate the TUI to display the specified session.
+   */
+  public selectSession<ThrowOnError extends boolean = false>(options?: Options<TuiSelectSessionData, ThrowOnError>) {
+    return (options?.client ?? this._client).post<TuiSelectSessionResponses, TuiSelectSessionErrors, ThrowOnError>({
+      url: "/tui/select-session",
       ...options,
       headers: {
         "Content-Type": "application/json",

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -3813,6 +3813,42 @@ export type TuiPublishResponses = {
 
 export type TuiPublishResponse = TuiPublishResponses[keyof TuiPublishResponses]
 
+export type TuiSelectSessionData = {
+  body?: {
+    /**
+     * Session ID to navigate to
+     */
+    sessionID?: string
+  }
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/tui/select-session"
+}
+
+export type TuiSelectSessionErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type TuiSelectSessionError = TuiSelectSessionErrors[keyof TuiSelectSessionErrors]
+
+export type TuiSelectSessionResponses = {
+  /**
+   * Session selected successfully
+   */
+  200: boolean
+}
+
+export type TuiSelectSessionResponse = TuiSelectSessionResponses[keyof TuiSelectSessionResponses]
+
 export type TuiControlNextData = {
   body?: never
   path?: never


### PR DESCRIPTION
I've noticed 2 weeks ago there was a pr adding select session to command bus: #6565  but it was only done in the v2 version of sdk. From what I've encountered while writing a plugin the plugin create provides v1 version of the sdk still. Since it's not breaking anything I've added the same method to v1 of sdk.

Closes #9373 