### PR TITLE
docs: clarify CLI env loading behavior

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -124,7 +124,7 @@ OpenCode is powered by the provider list at [Models.dev](https://models.dev), so
 opencode auth login
 ```
 
-When OpenCode starts up it loads the providers from the credentials file. And if there are any keys defined in your environments or a `.env` file in your project.
+When OpenCode starts up it loads the providers from the credentials file and checks the environment for any configured keys. The CLI does not automatically load `.env` files from your project.
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Clarify that the CLI reads environment variables but [does not auto-load project .env files](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/script/build.ts#L137).

### How did you verify your code works?

Not run (docs-only change).