### PR TITLE
fix(TUI): Add Alt+Backspace support to Dialog Select

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -163,6 +163,34 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     if (evt.name === "pagedown") move(10)
     if (evt.name === "home") moveTo(0)
     if (evt.name === "end") moveTo(flat().length - 1)
+
+    const isBackspace = evt.name === "backspace" || evt.name === "delete"
+    const isWordDelete = (isBackspace && (evt.option || evt.meta)) || (evt.name === "w" && evt.ctrl)
+
+    if (isWordDelete) {
+      evt.preventDefault()
+      evt.stopPropagation()
+
+      const val = input.value
+      const pos = input.cursorPosition
+
+      if (pos > 0) {
+        let cut = pos
+        if (val[cut - 1] === " ") {
+          while (cut > 0 && val[cut - 1] === " ") cut--
+        } else {
+          while (cut > 0 && val[cut - 1] !== " ") cut--
+        }
+        const newVal = val.slice(0, cut) + val.slice(pos)
+
+        input.value = newVal
+        input.cursorPosition = cut
+        batch(() => {
+          setStore("filter", newVal)
+          props.onFilter?.(newVal)
+        })
+      }
+    }
     if (evt.name === "return") {
       const option = selected()
       if (option) {


### PR DESCRIPTION
## Summary
Adds support for `Alt+Backspace` (and `Option+Backspace` on macOS) to delete whole words in the Dialog Select component. 

Fixes #9381.

## Changes
- Updated keyboard event handling in `DialogSelect` to recognize `Alt+Backspace` (via `evt.option`) as a word deletion command.


## How / where it was tested
I have tested that this issue is present and fixed by this PR on the following terminals:

- Ghostty
- VSCode built-int

My operating system is macOS Sequoia