### PR TITLE
fix: add bun-types to tsconfig to resolve process type error

### DIFF
--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -5,7 +5,7 @@
     "jsx": "preserve",
     "jsxImportSource": "@opentui/solid",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "types": [],
+    "types": ["bun-types"],
     "noUncheckedIndexedAccess": false,
     "customConditions": ["browser"],
     "paths": {


### PR DESCRIPTION
## Summary
- Add `bun-types` to the `types` array in `packages/opencode/tsconfig.json`
- Fixes TypeScript error: `Cannot find name 'process'`

## Context
The `types: []` configuration prevented TypeScript from recognizing Bun global types like `process`. 

Note: This issue was observed with Bun 1.3.6. It may be a regression in that version, but adding `bun-types` explicitly is a more robust solution regardless.

## Test
- Run `bun run typecheck` in `packages/opencode` - passes successfully