### PR TITLE
fix(config): rename uv formatter from 'uv format' to 'uv' for config consistency

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -226,7 +226,7 @@ export const rlang: Info = {
 }
 
 export const uvformat: Info = {
-  name: "uv format",
+  name: "uv",
   command: ["uv", "format", "--", "$FILE"],
   extensions: [".py", ".pyi"],
   async enabled() {


### PR DESCRIPTION
Replace uv formatter's internal from `uv format` to `uv` to match current naming styles and documentation.

Fixes #9406.