### PR TITLE
feat: fix app list component jumping when mouse happens to be under the list and keyboard navigating.

### DIFF
--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -206,6 +206,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
                           setActive(props.key(item))
                         }}
                         onMouseLeave={() => {
+                          if (!store.mouseActive) return;
                           setActive(null)
                         }}
                       >


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where if your mouse/pointer happened to be below the cmd+p/list and you attempt to use keyboard navigation the list would jump around.

*NOTE* this would only cause jumpiness if your mouse happens to be positioned over the list. If you tested without having the mouse under the list it would not exhibit this behavior.

Its reproducable in both Tauri and the web app.

The issue is that the `onMouseLeave` event was not guarded against when mouse was active or not. So as you navigated with the keyboard or filtered onMouseLeave events would fire and set an unactive item, which then triggers the useFilteredList to call `reset` thus reseting the active item.

By guarding this we dont call `onMouseLeave` unless the mouse is the active "navigation" method for the list which seems to be the intended behavior. This means it won't try to reset as the dom nodes move around underneath the mouse position.

Before - notice if you place the mouse under the dialog and then navigate with keyboard, as soon as the onmouseleave would fire (i.e. scrolling the least with the keyboard) it resets. This is because the `reset` fires in useFilteredList when the active item is unset

![Jan-19-2026 10-27-14](https://github.com/user-attachments/assets/3d003901-492e-4096-ab9a-e0f68438bb9a)

Here is with the Fix

![Jan-19-2026 10-28-01-fix](https://github.com/user-attachments/assets/c4b7a503-7b75-48dd-ad20-2887ac4754db)


### How did you verify your code works?

Manual verification running the app before and after the changes on both tauri and web.