### PR TITLE
feat: add glm-4.7-flash model

### DIFF
--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -248,6 +248,22 @@
         "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
         "limit": { "context": 204800, "output": 131072 }
       },
+      "glm-4.7-flash": {
+        "id": "glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "family": "glm-4.7-flash",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-04",
+        "release_date": "2026-01-19",
+        "last_updated": "2026-01-19",
+        "modalities": { "input": ["text"], "output": ["text"] },
+        "open_weights": true,
+        "cost": { "input": 0, "output": 0, "cache_read": 0, "cache_write": 0 },
+        "limit": { "context": 200000, "output": 131072 }
+      },
       "glm-4.5-flash": {
         "id": "glm-4.5-flash",
         "name": "GLM-4.5-Flash",


### PR DESCRIPTION
Add GLM-4.7-Flash model to test fixtures under zai-coding-plan provider.

- Context: 200K tokens
- Max output: 131K tokens  
- Pricing: $0.07/1M input, $0.40/1M output
- Released: 2026-01-19