### PR TITLE
fix(opencode): sets input mode based on whether mouse vs keyboard is in use to prevent mouse events firing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -85,6 +85,7 @@ export function Autocomplete(props: {
     index: 0,
     selected: 0,
     visible: false as AutocompleteRef["visible"],
+    input: "keyboard" as "keyboard" | "mouse",
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -525,11 +526,13 @@ export function Autocomplete(props: {
           const isNavDown = name === "down" || (ctrlOnly && name === "n")
 
           if (isNavUp) {
+            setStore("input", "keyboard")
             move(-1)
             e.preventDefault()
             return
           }
           if (isNavDown) {
+            setStore("input", "keyboard")
             move(1)
             e.preventDefault()
             return
@@ -612,7 +615,17 @@ export function Autocomplete(props: {
               paddingRight={1}
               backgroundColor={index === store.selected ? theme.primary : undefined}
               flexDirection="row"
-              onMouseOver={() => moveTo(index)}
+              onMouseMove={() => {
+                setStore('input', 'mouse');
+              }}
+              onMouseOver={() => {
+                if (store.input !== "mouse") return
+                moveTo(index)
+              }}
+              onMouseDown={() => {
+                setStore("input", "mouse")
+                moveTo(index)
+              }}
               onMouseUp={() => select()}
             >
               <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -616,7 +616,7 @@ export function Autocomplete(props: {
               backgroundColor={index === store.selected ? theme.primary : undefined}
               flexDirection="row"
               onMouseMove={() => {
-                setStore('input', 'mouse');
+                setStore("input", "mouse")
               }}
               onMouseOver={() => {
                 if (store.input !== "mouse") return

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -129,6 +129,14 @@ export function Autocomplete(props: {
     return props.input().getTextRange(store.index + 1, props.input().cursorOffset)
   })
 
+  // When the filter changes due to how TUI works, the mousemove might still be triggered
+  // via a synthetic event as the layout moves underneath the cursor. This is a workaround to make sure the input mode remains keyboard so
+  // that the mouseover event doesn't trigger when filtering.
+  createEffect(() => {
+    filter();
+    setStore("input", "keyboard")
+  })
+
   function insertPart(text: string, part: PromptInfo["parts"][number]) {
     const input = props.input()
     const currentCursorOffset = input.cursorOffset

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -84,6 +84,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     return result
   })
 
+  // When the filter changes due to how TUI works, the mousemove might still be triggered
+  // via a synthetic event as the layout moves underneath the cursor. This is a workaround to make sure the input mode remains keyboard
+  // that the mouseover event doesn't trigger when filtering.
+  createEffect(() => {
+    filtered();
+    setStore("input", "keyboard")
+  })
+
   const grouped = createMemo(() => {
     const result = pipe(
       filtered(),

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -159,14 +159,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const keybind = useKeybind()
   useKeyboard((evt) => {
     setStore("input", "keyboard")
-    
+
     if (evt.name === "up" || (evt.ctrl && evt.name === "p")) move(-1)
     if (evt.name === "down" || (evt.ctrl && evt.name === "n")) move(1)
     if (evt.name === "pageup") move(-10)
     if (evt.name === "pagedown") move(10)
     if (evt.name === "home") moveTo(0)
     if (evt.name === "end") moveTo(flat().length - 1)
-      
+
     if (evt.name === "return") {
       const option = selected()
       if (option) {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -159,25 +159,14 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const keybind = useKeybind()
   useKeyboard((evt) => {
     setStore("input", "keyboard")
-
-    if (evt.name === "up" || (evt.ctrl && evt.name === "p")) {
-      move(-1)
-    }
-    if (evt.name === "down" || (evt.ctrl && evt.name === "n")) {
-      move(1)
-    }
-    if (evt.name === "pageup") {
-      move(-10)
-    }
-    if (evt.name === "pagedown") {
-      move(10)
-    }
-    if (evt.name === "home") {
-      moveTo(0)
-    }
-    if (evt.name === "end") {
-      moveTo(flat().length - 1)
-    }
+    
+    if (evt.name === "up" || (evt.ctrl && evt.name === "p")) move(-1)
+    if (evt.name === "down" || (evt.ctrl && evt.name === "n")) move(1)
+    if (evt.name === "pageup") move(-10)
+    if (evt.name === "pagedown") move(10)
+    if (evt.name === "home") moveTo(0)
+    if (evt.name === "end") moveTo(flat().length - 1)
+      
     if (evt.name === "return") {
       const option = selected()
       if (option) {

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -52,6 +52,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const [store, setStore] = createStore({
     selected: 0,
     filter: "",
+    input: "keyboard" as "keyboard" | "mouse",
   })
 
   createEffect(
@@ -157,12 +158,26 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   const keybind = useKeybind()
   useKeyboard((evt) => {
-    if (evt.name === "up" || (evt.ctrl && evt.name === "p")) move(-1)
-    if (evt.name === "down" || (evt.ctrl && evt.name === "n")) move(1)
-    if (evt.name === "pageup") move(-10)
-    if (evt.name === "pagedown") move(10)
-    if (evt.name === "home") moveTo(0)
-    if (evt.name === "end") moveTo(flat().length - 1)
+    setStore("input", "keyboard")
+
+    if (evt.name === "up" || (evt.ctrl && evt.name === "p")) {
+      move(-1)
+    }
+    if (evt.name === "down" || (evt.ctrl && evt.name === "n")) {
+      move(1)
+    }
+    if (evt.name === "pageup") {
+      move(-10)
+    }
+    if (evt.name === "pagedown") {
+      move(10)
+    }
+    if (evt.name === "home") {
+      moveTo(0)
+    }
+    if (evt.name === "end") {
+      moveTo(flat().length - 1)
+    }
     if (evt.name === "return") {
       const option = selected()
       if (option) {
@@ -259,11 +274,20 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                       <box
                         id={JSON.stringify(option.value)}
                         flexDirection="row"
+                        onMouseMove={() => {
+                          setStore("input", "mouse")
+                        }}
                         onMouseUp={() => {
                           option.onSelect?.(dialog)
                           props.onSelect?.(option)
                         }}
                         onMouseOver={() => {
+                          if (store.input !== "mouse") return
+                          const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
+                          if (index === -1) return
+                          moveTo(index)
+                        }}
+                        onMouseDown={() => {
                           const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
                           if (index === -1) return
                           moveTo(index)


### PR DESCRIPTION
### What does this PR do?

Related to: https://github.com/anomalyco/opencode/pull/9435 which was present in the web apps.

In the opencode cli there is no distinguishing between when you are currently using the mouse or the keyboard. Due to this if you use keyboard events to navigate, mouse events will still fire. This leads to the highlighted/active item in menus jumping up to whatever the mouse is under since the "dom" (tui) moves around under the mouse triggering the events.

To fix this we can distinguish between if the user is actively using the keyboard and disable certain mouse events from firing while it is the active input mode. On mousemove we set the active mode back to the mouse and those events then continue to fire.

Before the fix note the highlighted item jumps up to wherever the mouse was:
![mouse-events-firing-when-keyboard-used](https://github.com/user-attachments/assets/df9e704c-b7f1-476b-bdee-e9474878ff08)

After note the highlighted item does not jump to the item the mouse happens to be over while keyboard navigating:
![mouse-events-not-fired-when-keyboard-active](https://github.com/user-attachments/assets/948c0ba2-7742-46e2-a2da-deacc8d836e1)

Credit to @JosXa in https://github.com/anomalyco/opencode/pull/8797/changes for figuring out the behavior around mousemove events also being triggered when the filter occurs due to the background element moving around under the cursor causing TUI mousemove events to fire.


### How did you verify your code works?

Using the app, see videos.

Fixes: #9448 #8799