### PR TITLE
fix(app): give feedback when trying to paste a unsupported filetype

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -300,7 +300,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     event.stopPropagation()
 
     const items = Array.from(clipboardData.items)
-    const imageItems = items.filter((item) => ACCEPTED_FILE_TYPES.includes(item.type))
+    const fileItems = items.filter((item) => item.kind === "file")
+    const imageItems = fileItems.filter((item) => ACCEPTED_FILE_TYPES.includes(item.type))
 
     if (imageItems.length > 0) {
       for (const item of imageItems) {
@@ -310,7 +311,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       return
     }
 
+    if (fileItems.length > 0) {
+      showToast({
+        title: "Unsupported paste",
+        description: "Only images or PDFs can be pasted here.",
+      })
+      return
+    }
+
     const plainText = clipboardData.getData("text/plain") ?? ""
+    if (!plainText) return
     addPart({ type: "text", content: plainText, start: 0, end: 0 })
   }
 


### PR DESCRIPTION
### What does this PR do?

Pops up a toast when trying to paste a unsupported file type

### How did you verify your code works?

Try to paste into prompt something else than pdf / image file.
Should pop a toast 

<img width="951" height="548" alt="image" src="https://github.com/user-attachments/assets/fae9828e-f1dd-4f1d-9605-630e93141c5a" />
