### PR TITLE
feat(ui): display subagent model in task header

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1785,7 +1785,12 @@ function Task(props: ToolProps<typeof TaskTool>) {
     <Switch>
       <Match when={props.metadata.summary?.length}>
         <BlockTool
-          title={"# " + Locale.titlecase(props.input.subagent_type ?? "unknown") + " Task"}
+          title={
+            "# " +
+            Locale.titlecase(props.input.subagent_type ?? "unknown") +
+            " Task" +
+            (props.metadata.model?.modelID ? ` · ${props.metadata.model.modelID}` : "")
+          }
           onClick={
             props.metadata.sessionId
               ? () => navigate({ type: "session", sessionID: props.metadata.sessionId! })

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -223,7 +223,11 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                   <Match when={props.request.permission === "task"}>
                     <TextBody
                       icon="#"
-                      title={`${Locale.titlecase((input().subagent_type as string) ?? "Unknown")} Task`}
+                      title={`${Locale.titlecase((input().subagent_type as string) ?? "Unknown")} Task${
+                        (props.request.metadata?.model as any)?.modelID
+                          ? ` · ${(props.request.metadata?.model as any).modelID}`
+                          : ""
+                      }`}
                       description={"◉ " + input().description}
                     />
                   </Match>

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -41,6 +41,17 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     async execute(params: z.infer<typeof parameters>, ctx) {
       const config = await Config.get()
 
+      const agent = await Agent.get(params.subagent_type)
+      if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
+
+      const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
+      if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
+
+      const model = agent.model ?? {
+        modelID: msg.info.modelID,
+        providerID: msg.info.providerID,
+      }
+
       // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
         await ctx.ask({
@@ -50,12 +61,10 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           metadata: {
             description: params.description,
             subagent_type: params.subagent_type,
+            model,
           },
         })
       }
-
-      const agent = await Agent.get(params.subagent_type)
-      if (!agent) throw new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`)
 
       const hasTaskPermission = agent.permission.some((rule) => rule.permission === "task")
 
@@ -96,16 +105,6 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           ],
         })
       })
-      const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
-      if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
-
-      ctx.metadata({
-        title: params.description,
-        metadata: {
-          sessionId: session.id,
-        },
-      })
-
       const messageID = Identifier.ascending("message")
       const parts: Record<string, { id: string; tool: string; state: { status: string; title?: string } }> = {}
       const unsub = Bus.subscribe(MessageV2.Event.PartUpdated, async (evt) => {
@@ -129,11 +128,6 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           },
         })
       })
-
-      const model = agent.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
-      }
 
       function cancel() {
         SessionPrompt.cancel(session.id)
@@ -180,6 +174,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         metadata: {
           summary,
           sessionId: session.id,
+          model,
         },
         output,
       }


### PR DESCRIPTION
## Summary
- Added `model` information to `TaskTool` metadata.
- Updated `Task` component in TUI to display the model ID in the header (e.g., `# Librarian Task · gpt-4o`).
- Updated `PermissionPrompt` to show the model ID when requesting permission.

## Problem
Users could not distinguish which model was powering a subagent task.

## Solution
Expose the resolved model ID in the task metadata and render it in the UI.