### PR TITLE
fix(session): add cross-project session lookup with fallback search

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -22,9 +22,62 @@ import { Snapshot } from "@/snapshot"
 import type { Provider } from "@/provider/provider"
 import { PermissionNext } from "@/permission/next"
 import { Global } from "@/global"
+import fs from "fs/promises"
 
 export namespace Session {
   const log = Log.create({ service: "session" })
+
+  // LRU-like cache for session→projectID mapping (avoids repeated directory scans)
+  const PROJECT_ID_CACHE_MAX_SIZE = 1000
+  const projectIDCache = new Map<string, string>()
+
+  function cacheProjectID(sessionID: string, projectID: string): void {
+    if (projectIDCache.size >= PROJECT_ID_CACHE_MAX_SIZE) {
+      const firstKey = projectIDCache.keys().next().value
+      if (firstKey) projectIDCache.delete(firstKey)
+    }
+    projectIDCache.set(sessionID, projectID)
+  }
+
+  async function resolveProjectID(sessionID: string): Promise<string> {
+    // Check cache first
+    const cached = projectIDCache.get(sessionID)
+    if (cached) {
+      const exists = await Storage.read<Info>(["session", cached, sessionID]).catch(() => null)
+      if (exists) return cached
+      projectIDCache.delete(sessionID)
+    }
+
+    // Try current project
+    const currentProjectID = Instance.project.id
+    const existsInCurrent = await Storage.read<Info>(["session", currentProjectID, sessionID]).catch(() => null)
+    if (existsInCurrent) {
+      cacheProjectID(sessionID, currentProjectID)
+      return currentProjectID
+    }
+
+    // Fallback: search all project directories
+    const storageDir = path.join(Global.Path.data, "storage", "session")
+    let projectDirs: string[] = []
+    try {
+      projectDirs = await fs.readdir(storageDir)
+    } catch {
+      throw new Storage.NotFoundError({ message: `Session not found: ${sessionID}` })
+    }
+
+    for (const projectID of projectDirs) {
+      if (projectID === currentProjectID) continue
+      if (projectID.startsWith(".")) continue
+      const exists = await Storage.read<Info>(["session", projectID, sessionID]).catch(() => null)
+      if (exists) {
+        cacheProjectID(sessionID, projectID)
+        log.info("resolved session to different project", { sessionID, projectID, currentProjectID })
+        return projectID
+      }
+    }
+
+    throw new Storage.NotFoundError({ message: `Session not found: ${sessionID}` })
+  }
 
   const parentTitlePrefix = "New session - "
   const childTitlePrefix = "Child session - "
@@ -240,7 +293,8 @@ export namespace Session {
   }
 
   export const get = fn(Identifier.schema("session"), async (id) => {
-    const read = await Storage.read<Info>(["session", Instance.project.id, id])
+    const projectID = await resolveProjectID(id)
+    const read = await Storage.read<Info>(["session", projectID, id])
     return read as Info
   })
 
@@ -273,8 +327,8 @@ export namespace Session {
   })
 
   export async function update(id: string, editor: (session: Info) => void) {
-    const project = Instance.project
-    const result = await Storage.update<Info>(["session", project.id, id], (draft) => {
+    const projectID = await resolveProjectID(id)
+    const result = await Storage.update<Info>(["session", projectID, id], (draft) => {
       editor(draft)
       draft.time.updated = Date.now()
     })
@@ -324,9 +378,9 @@ export namespace Session {
   })
 
   export const remove = fn(Identifier.schema("session"), async (sessionID) => {
-    const project = Instance.project
     try {
       const session = await get(sessionID)
+      const projectID = await resolveProjectID(sessionID)
       for (const child of await children(sessionID)) {
         await remove(child.id)
       }
@@ -337,7 +391,8 @@ export namespace Session {
         }
         await Storage.remove(msg)
       }
-      await Storage.remove(["session", project.id, sessionID])
+      await Storage.remove(["session", projectID, sessionID])
+      projectIDCache.delete(sessionID)
       Bus.publish(Event.Deleted, {
         info: session,
       })


### PR DESCRIPTION
### What does this PR do?

Fixes session lookup failing when sessions are accessed from a different project context (e.g., SDK clients connecting to `opencode serve` from different directories).

**Problem:** `Session.get()` uses `Instance.project.id` directly, causing `NotFoundError` when sessions are stored in a different project directory than the current context.

**Solution:**
- Add `resolveProjectID()` helper that searches project directories to find the session
- LRU cache (1000 entries) for resolved projectIDs to avoid repeated directory scans
- Update `get()`, `update()`, `remove()` to use the helper

Fixes #8538
Related to #7773

**Credit:** This builds on the approach identified by @zenyr in #3018. That PR falls back to `[current_project, "global"]` only. This PR extends the fallback to search all project directories and adds caching for performance.

### How did you verify your code works?

1. Started `opencode serve` in project A
2. Connected via SDK from project B context and attempted to access sessions created in project A - got `NotFoundError`
3. After fix: Sessions resolve correctly across project contexts
4. Build passes: `./packages/opencode/script/build.ts --single`