### PR TITLE
fix(tui):  clarify resume session tip

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -106,7 +106,7 @@ const TIPS = [
   "Use plugins to send OS notifications when sessions complete",
   "Create a plugin to prevent OpenCode from reading sensitive files",
   "Use {highlight}opencode run{/highlight} for non-interactive scripting",
-  "Use {highlight}opencode run --continue{/highlight} to resume the last session",
+  "Use {highlight}opencode --continue{/highlight} (or {highlight}opencode --c{/highlight}) to resume the last session",
   "Use {highlight}opencode run -f file.ts{/highlight} to attach files via CLI",
   "Use {highlight}--format json{/highlight} for machine-readable output in scripts",
   "Run {highlight}opencode serve{/highlight} for headless API access to OpenCode",


### PR DESCRIPTION
Fixes #9475
## Summary
- update resume-session tip to use `opencode --continue` and `opencode --c`
- align tip wording with actual CLI behavior

## After
<img width="996" height="488" alt="image" src="https://github.com/user-attachments/assets/9625ff3e-88cf-455c-a33a-1f743ad94dc6" />

## Before

<img width="1114" height="609" alt="image" src="https://github.com/user-attachments/assets/4136f462-55ef-4db3-80ad-317a47724ddb" />

