### PR TITLE
fix: Don't unnecessarily wrap lines and introduce an unneeded empty line (resolves #9489)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -337,6 +337,7 @@ function Option(props: {
         fg={props.active ? fg : props.current ? theme.primary : theme.text}
         attributes={props.active ? TextAttributes.BOLD : undefined}
         overflow="hidden"
+        wrapMode="none"
         paddingLeft={3}
       >
         {Locale.truncate(props.title, 61)}


### PR DESCRIPTION
Set the `noWrap` property in this file so as not to wrap unnecessarily and introduce an unneeded empty line. 

Resolves #9489

### Before

<img width="764" height="612" alt="dev" src="https://github.com/user-attachments/assets/94905852-5e3f-441c-a76b-3e7689a9dbdb" />

### After 

<img width="765" height="617" alt="no-wrap" src="https://github.com/user-attachments/assets/18903489-ef5a-40e1-8dd9-b9fb503f5ac5" />
