### PR TITLE
fix(desktop): change project path tooltip position to bottom

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1957,7 +1957,7 @@ export default function Layout(props: ParentProps) {
                         />
 
                         <Tooltip
-                          placement={sidebarProps.mobile ? "bottom" : "top"}
+                          placement="bottom"
                           gutter={2}
                           value={project()?.worktree}
                           class="shrink-0"


### PR DESCRIPTION
- Changed tooltip placement for project path in sidebar from "top" to "bottom" as we were collapsing the tooltip with project name and we have extra space in bottom. it might be better @adamdotdevin 

before: 

<img width="326" height="220" alt="image" src="https://github.com/user-attachments/assets/9e5d1621-7c4c-4bb7-a015-362ded6bef3f" />

after : 

<img width="328" height="134" alt="image" src="https://github.com/user-attachments/assets/80687d31-4283-4e18-8231-32c714701a22" />
