### PR TITLE
fix(web): add favicon.ico reference for Google crawlers

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -38,6 +38,14 @@ export default defineConfig({
           tag: "link",
           attrs: {
             rel: "icon",
+            href: "/favicon.ico",
+            sizes: "32x32",
+          },
+        },
+        {
+          tag: "link",
+          attrs: {
+            rel: "icon",
             href: "/favicon-v2.ico",
             sizes: "32x32",
           },


### PR DESCRIPTION
## Summary
Adds `/favicon.ico` to the head config so Google crawlers can find it at the standard location.

Follows up on #9492 - the v2 favicon cache bust is in place, but we also need the standard `/favicon.ico` path for Google's favicon crawler.

## Changes
- Added `/favicon.ico` link tag to Starlight head config (alongside the existing v2 references)