### PR TITLE
fix(app): terminal no longer hangs on exit or ctrl + D and closes the pane

### DIFF
--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -38,6 +38,21 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, sess
     }),
   )
 
+  sdk.event.on("pty.exited", (event) => {
+    const id = event.properties.id
+    if (!store.all.some((x) => x.id === id)) return
+    batch(() => {
+      setStore(
+        "all",
+        store.all.filter((x) => x.id !== id),
+      )
+      if (store.active === id) {
+        const remaining = store.all.filter((x) => x.id !== id)
+        setStore("active", remaining[0]?.id)
+      }
+    })
+  })
+
   return {
     ready,
     all: createMemo(() => Object.values(store.all)),

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -386,6 +386,19 @@ export default function Page() {
 
   createEffect(
     on(
+      () => terminal.all().length,
+      (count, prevCount) => {
+        if (prevCount !== undefined && prevCount > 0 && count === 0) {
+          if (view().terminal.opened()) {
+            view().terminal.toggle()
+          }
+        }
+      },
+    ),
+  )
+
+  createEffect(
+    on(
       () => visibleUserMessages().at(-1)?.id,
       (lastId, prevLastId) => {
         if (lastId && prevLastId && lastId > prevLastId) {

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -147,6 +147,9 @@ export namespace Pty {
       log.info("session exited", { id, exitCode })
       session.info.status = "exited"
       Bus.publish(Event.Exited, { id, exitCode })
+      for (const ws of session.subscribers) {
+        ws.close()
+      }
       state().delete(id)
     })
     Bus.publish(Event.Created, { info })


### PR DESCRIPTION


### What does this PR do?
fixes terminal hanging for 5-10 seconds when user types exit or Ctrl+D. Previously, the terminal would become unresponsive and eventually respawn a new terminal.

https://github.com/user-attachments/assets/9351e991-c482-4052-9602-ce6788a0f24b




### How did you verify your code works?

 1. Opened terminal with `Ctrl+`
  2. Typed exit → terminal tab closes immediately and pane toggles closed (no hang)
  3. Tested Ctrl+D → same immediate close behavior
  4. With multiple terminals: closed one → others remain, pane stays open
  5. Closed last terminal → pane closes automatically
  6. Pressed `Ctrl+` again → pane opens, new terminal auto-creates as expected

its very annoying to have this issue :)