### PR TITLE
fix(batch): update batch tool definition to outline correct value for max tool calls

### DIFF
--- a/packages/opencode/src/tool/batch.txt
+++ b/packages/opencode/src/tool/batch.txt
@@ -6,7 +6,7 @@ Payload Format (JSON array):
 [{"tool": "read", "parameters": {"filePath": "src/index.ts", "limit": 350}},{"tool": "grep", "parameters": {"pattern": "Session\\.updatePart", "include": "src/**/*.ts"}},{"tool": "bash", "parameters": {"command": "git status", "description": "Shows working tree status"}}]
 
 Notes:
-- 1–20 tool calls per batch
+- 1–25 tool calls per batch
 - All calls start in parallel; ordering NOT guaranteed
 - Partial failures do not stop other tool calls
 - Do NOT use the batch tool within another batch tool.


### PR DESCRIPTION
Fixes #9519

## What does this PR do?

Tiny fix to keep `batch` tool documentation consistent with the code.

#9275 increased the batch tool's max limit from 10 to 25 in `batch.ts`, but the documentation in `batch.txt` incorrectly says "1–20" instead of "1–25".

https://github.com/anomalyco/opencode/blob/aa4b06e16548d5a1a5e8c32376987f6aa70c9844/packages/opencode/src/tool/batch.ts#L36-L37

## How did you verify your code works?

Docs update.