### PR TITLE
feat: for openrouter session uses cost from metadata

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -20,6 +20,7 @@ import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
 
 import type { Provider } from "@/provider/provider"
+import type { JSONObject } from "@ai-sdk/provider"
 import { PermissionNext } from "@/permission/next"
 import { Global } from "@/global"
 
@@ -409,6 +410,58 @@ export namespace Session {
     return part
   })
 
+  function extractProviderCost(metadata?: ProviderMetadata): number | null {
+    if (!metadata) return null
+
+    if (typeof metadata.openrouter?.usage == "object") {
+      const usage = metadata.openrouter?.usage as JSONObject;
+      if (typeof usage.cost == "number") {
+        return usage.cost;
+      }
+    }
+
+    return null
+  }
+
+  type UsageTokens = {
+      input: number;
+      output: number;
+      reasoning: number;
+      cache: {
+          write: number;
+          read: number;
+      };
+  }
+
+  const getCost = fn(z.object({
+    model: z.custom<Provider.Model>(),
+    tokens: z.custom<UsageTokens>(),
+    metadata: z.custom<ProviderMetadata>().optional(),
+  }), (input) => {
+    const {tokens, metadata} = input;
+    const providerCost = extractProviderCost(metadata);
+    if (providerCost) {
+      return providerCost;
+    }
+
+    // Approximated cost
+    const costInfo =
+        input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
+          ? input.model.cost.experimentalOver200K
+          : input.model.cost;
+    const appoximatedCost = new Decimal(0)
+        .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
+        .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
+        // TODO: update models.dev to have better pricing model, for now:
+        // charge reasoning tokens at the same rate as output tokens
+        .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
+        .toNumber();
+
+    return Number.isFinite(appoximatedCost) ? appoximatedCost : 0;
+  })
+
   export const getUsage = fn(
     z.object({
       model: z.custom<Provider.Model>(),
@@ -441,23 +494,13 @@ export namespace Session {
         },
       }
 
-      const costInfo =
-        input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
-          ? input.model.cost.experimentalOver200K
-          : input.model.cost
       return {
-        cost: safe(
-          new Decimal(0)
-            .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
-            // TODO: update models.dev to have better pricing model, for now:
-            // charge reasoning tokens at the same rate as output tokens
-            .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
-            .toNumber(),
-        ),
         tokens,
+        cost: getCost({
+          model: input.model,
+          tokens: tokens,
+          metadata: input.metadata
+        }),
       }
     },
   )


### PR DESCRIPTION
### What does this PR do?

It takes cost of the message from provider's metadata for openrouter.
If there is no cost in metadata, it calculates it in an old way based on price and used tokens.

### How did you verify your code works?

1) Added `log.info("***** use metadata cost: ${usage.cost}")` to packages/opencode/src/session/index.ts:419
2) `bun dev web`
3) opened a project, sent message to chat
4) Found `INFO  2026-01-19T22:41:13 +0ms service=session ***** use metadata cost: 0.00073491` in logs (~/.local/share/opencode/log/dev.log)
5) Verified cost in web: <img width="258" height="236" alt="image" src="https://github.com/user-attachments/assets/93e49ab3-0696-44b2-9a4f-a80b775e9062" />

