### PR TITLE
chore: add CONTRIBUTING.md to instructions

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -4,7 +4,7 @@
   // "enterprise": {
   //   "url": "https://enterprise.dev.opencode.ai",
   // },
-  "instructions": ["STYLE_GUIDE.md"],
+  "instructions": ["STYLE_GUIDE.md", "CONTRIBUTING.md"],
   "provider": {
     "opencode": {
       "options": {},


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` to the instructions array in `.opencode/opencode.jsonc`
- This ensures contributors see both the style guide and contributing guidelines