### PR TITLE
feat(tui): add switch to last session keybind (ctrl-x o)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -297,6 +297,18 @@ function App() {
       },
     },
     {
+      title: "Switch to last session",
+      value: "session.last",
+      keybind: "session_last",
+      category: "Session",
+      suggested: !!route.previous,
+      onSelect: () => {
+        if (!route.previous) return
+        route.navigate({ type: "session", sessionID: route.previous })
+        dialog.clear()
+      },
+    },
+    {
       title: "New session",
       suggested: route.data.type === "session",
       value: "session.new",

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -26,12 +26,18 @@ export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
           },
     )
 
+    let previous: string | undefined
+
     return {
       get data() {
         return store
       },
+      get previous() {
+        return previous
+      },
       navigate(route: Route) {
         console.log("navigate", route)
+        if (store.type === "session") previous = store.sessionID
         setStore(route)
       },
     }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -640,6 +640,7 @@ export namespace Config {
       session_export: z.string().optional().default("<leader>x").describe("Export session to editor"),
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),
       session_list: z.string().optional().default("<leader>l").describe("List all sessions"),
+      session_last: z.string().optional().default("<leader>o").describe("Switch to last session"),
       session_timeline: z.string().optional().default("<leader>g").describe("Show session timeline"),
       session_fork: z.string().optional().default("none").describe("Fork session from message"),
       session_rename: z.string().optional().default("ctrl+r").describe("Rename session"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -971,6 +971,10 @@ export type KeybindsConfig = {
    */
   session_list?: string
   /**
+   * Switch to last session
+   */
+  session_last?: string
+  /**
    * Show session timeline
    */
   session_timeline?: string

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -21,6 +21,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "session_export": "<leader>x",
     "session_new": "<leader>n",
     "session_list": "<leader>l",
+    "session_last": "<leader>o",
     "session_timeline": "<leader>g",
     "session_fork": "none",
     "session_rename": "none",


### PR DESCRIPTION
## Summary

- Add `session_last` keybinding (`<leader>o` / `ctrl-x o`) to quickly switch to the previously viewed session
- Track previous session ID in route context (ephemeral, in-memory)
- Similar to Emacs's `C-x o` for switching windows

Closes #9526

## Changes

- `packages/opencode/src/config/config.ts` - Add `session_last` keybinding definition
- `packages/opencode/src/cli/cmd/tui/context/route.tsx` - Track previous session ID
- `packages/opencode/src/cli/cmd/tui/app.tsx` - Add "Switch to last session" command
- `packages/web/src/content/docs/keybinds.mdx` - Document the new keybinding
- `packages/sdk/js/src/v2/gen/types.gen.ts` - Regenerated SDK types