### PR TITLE
fix: (web UI / API) show sandbox sessions created in project subdirectories 

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -518,7 +518,6 @@ export default function Layout(props: ParentProps) {
       for (const dir of dirs) {
         const [dirStore] = globalSync.child(dir)
         const dirSessions = dirStore.session
-          .filter((session) => session.directory === dirStore.path.directory)
           .filter((session) => !session.parentID && !session.time?.archived)
           .toSorted(sortSessions)
         result.push(...dirSessions)
@@ -526,10 +525,7 @@ export default function Layout(props: ParentProps) {
       return result
     }
     const [projectStore] = globalSync.child(project.worktree)
-    return projectStore.session
-      .filter((session) => session.directory === projectStore.path.directory)
-      .filter((session) => !session.parentID && !session.time?.archived)
-      .toSorted(sortSessions)
+    return projectStore.session.filter((session) => !session.parentID && !session.time?.archived).toSorted(sortSessions)
   })
 
   type PrefetchQueue = {
@@ -1454,10 +1450,7 @@ export default function Layout(props: ParentProps) {
     const [menuOpen, setMenuOpen] = createSignal(false)
     const slug = createMemo(() => base64Encode(props.directory))
     const sessions = createMemo(() =>
-      workspaceStore.session
-        .filter((session) => session.directory === workspaceStore.path.directory)
-        .filter((session) => !session.parentID && !session.time?.archived)
-        .toSorted(sortSessions),
+      workspaceStore.session.filter((session) => !session.parentID && !session.time?.archived).toSorted(sortSessions),
     )
     const local = createMemo(() => props.directory === props.project.worktree)
     const workspaceValue = createMemo(() => {
@@ -1632,7 +1625,6 @@ export default function Layout(props: ParentProps) {
     const sessions = (directory: string) => {
       const [data] = globalSync.child(directory)
       return data.session
-        .filter((session) => session.directory === data.path.directory)
         .filter((session) => !session.parentID && !session.time?.archived)
         .toSorted(sortSessions)
         .slice(0, 2)
@@ -1641,7 +1633,6 @@ export default function Layout(props: ParentProps) {
     const projectSessions = () => {
       const [data] = globalSync.child(props.project.worktree)
       return data.session
-        .filter((session) => session.directory === data.path.directory)
         .filter((session) => !session.parentID && !session.time?.archived)
         .toSorted(sortSessions)
         .slice(0, 2)
@@ -1736,10 +1727,7 @@ export default function Layout(props: ParentProps) {
     const [workspaceStore, setWorkspaceStore] = globalSync.child(props.project.worktree)
     const slug = createMemo(() => base64Encode(props.project.worktree))
     const sessions = createMemo(() =>
-      workspaceStore.session
-        .filter((session) => session.directory === workspaceStore.path.directory)
-        .filter((session) => !session.parentID && !session.time?.archived)
-        .toSorted(sortSessions),
+      workspaceStore.session.filter((session) => !session.parentID && !session.time?.archived).toSorted(sortSessions),
     )
     const loading = createMemo(() => workspaceStore.status !== "complete" && sessions().length === 0)
     const hasMore = createMemo(() => workspaceStore.sessionTotal > workspaceStore.session.length)

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -56,7 +56,13 @@ export const SessionRoutes = lazy(() =>
         const term = query.search?.toLowerCase()
         const sessions: Session.Info[] = []
         for await (const session of Session.list()) {
-          if (query.directory !== undefined && session.directory !== query.directory) continue
+          const normalizedSessionDir = Filesystem.normalize(session.directory)
+          if (
+            normalizedQueryDir !== undefined &&
+            normalizedSessionDir !== normalizedQueryDir &&
+            !Filesystem.contains(normalizedQueryDir, normalizedSessionDir)
+          )
+            continue
           if (query.roots && session.parentID) continue
           if (query.start !== undefined && session.time.updated < query.start) continue
           if (term !== undefined && !session.title.toLowerCase().includes(term)) continue


### PR DESCRIPTION
Related to #9366 

## Web UI does not show sessions that are created in a project's subdirectory

If you start opencode in a subdirectory of a project - it will set `session.directory` to that pwd. Allowing a different `external_directory` permission setup.

The web UI doesn't currently show these, so you're unable to access these sessions via web (they are shown in TUI), 

## Fix:

- Compare on API side (`GET /session`) via `contains` instead of a direct match
- Remove filtering on web side
