### PR TITLE
fix: add space toggle hint to tool selection prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -134,7 +134,7 @@ const AgentCreateCommand = cmd({
           selectedTools = cliTools ? cliTools.split(",").map((t) => t.trim()) : AVAILABLE_TOOLS
         } else {
           const result = await prompts.multiselect({
-            message: "Select tools to enable",
+            message: "Select tools to enable (Space to toggle)",
             options: AVAILABLE_TOOLS.map((tool) => ({
               label: tool,
               value: tool,


### PR DESCRIPTION
## Summary
- Adds "(Space to toggle)" hint to the tool selection prompt when creating a custom agent, making the UI more discoverable for users

Fixes #9537 

Before:
<img width="307" height="286" alt="Screenshot 2026-01-19 at 7 38 34 PM" src="https://github.com/user-attachments/assets/983d37e6-f76f-4f90-b16b-73ae2e71d318" />


After:
<img width="452" height="309" alt="Screenshot 2026-01-19 at 7 55 18 PM" src="https://github.com/user-attachments/assets/69e4aa7b-99b4-449f-8438-4d8df91d56dd" />
