### PR TITLE
fix(ui): prevent Enter key action during IME composition

### DIFF
--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -133,7 +133,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
     const index = selected ? all.indexOf(selected) : -1
     props.onKeyEvent?.(e, selected)
 
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.isComposing) {
       e.preventDefault()
       if (selected) handleSelect(selected, index)
     } else {

--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -77,7 +77,7 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
   }
 
   const onKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter") {
+    if (event.key === "Enter" && !event.isComposing) {
       event.preventDefault()
       const selectedIndex = flat().findIndex((x) => props.key(x) === list.active())
       const selected = flat()[selectedIndex]


### PR DESCRIPTION
- Add isComposing check to avoid triggering selection during IME input confirmation
- Closes #9563 

### What does this PR do?
Fixes a bug where pressing Enter to confirm IME (Input Method Editor) composition also triggers list item selection.

### How did you verify your code works?
1. run `bun dev -- --port 4096` in the root folder
2. run `bun run --cwd packages/app dev` in the root folder in another terminal, open the local web app
3. use Chinese to search models
4. pressing Enter during composition only confirm IME text