### PR TITLE
fix: detect musl vs glibc for Alpine Linux npm install

### DIFF
--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -44,7 +44,29 @@ let arch = archMap[os.arch()]
 if (!arch) {
   arch = os.arch()
 }
-const base = "opencode-" + platform + "-" + arch
+
+// Detect musl vs glibc on Linux
+let libc = ""
+if (platform === "linux") {
+  try {
+    const lddVersion = childProcess.execSync("ldd --version 2>&1", { encoding: "utf8" })
+    if (lddVersion.toLowerCase().includes("musl")) {
+      libc = "-musl"
+    }
+  } catch (e) {
+    // ldd failed, try alternative detection
+    try {
+      const muslFiles = fs.readdirSync("/lib").filter((f) => f.startsWith("ld-musl-"))
+      if (muslFiles.length > 0) {
+        libc = "-musl"
+      }
+    } catch (e) {
+      // Ignore, default to glibc
+    }
+  }
+}
+
+const base = "opencode-" + platform + "-" + arch + libc
 const binary = platform === "windows" ? "opencode.exe" : "opencode"
 
 function findBinary(startDir) {


### PR DESCRIPTION
## Summary

Fixes #9571 

When installing `opencode-ai` via npm on Alpine Linux, the installation fails because the wrapper script and postinstall script don't detect musl vs glibc, causing them to look for the wrong binary package.

## Changes

- Add musl/glibc detection to `packages/opencode/bin/opencode` wrapper script
- Add musl/glibc detection to `packages/opencode/script/postinstall.mjs`
- Uses the same detection logic already present in `packages/opencode/script/publish-registries.ts`

## Root Cause

Both scripts only detected platform and architecture but not the libc variant, producing package names like `opencode-linux-x64` instead of `opencode-linux-x64-musl` for Alpine.

## Testing

**Before (Alpine):**
```bash
podman run --rm alpine:latest sh -c "apk add nodejs npm && npm install -g opencode-ai && opencode --version"
# Error: spawnSync /usr/local/lib/node_modules/opencode-ai/node_modules/opencode-linux-x64/bin/opencode ENOENT
```

**After (with fix):**
- Tested musl detection on Alpine: correctly detects `-musl` suffix
- Tested on glibc system: correctly uses no suffix (default glibc)
- Detection logic matches existing `publish-registries.ts` implementation

## Related

The musl packages already exist on npm:
- `opencode-linux-x64-musl@1.1.26`
- `opencode-linux-arm64-musl@1.1.26`
- `opencode-linux-x64-baseline-musl@1.1.26`