### PR TITLE
feat(tui): use ellipsis in middle of file path instead of truncating for modified files list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -13,8 +13,7 @@ import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 
 const SIDEBAR_WIDTH = 42
-const SIDEBAR_PADDING = 2 + 2 + 1 // left + right + inner scrollbox
-const SIDEBAR_CONTENT_WIDTH = SIDEBAR_WIDTH - SIDEBAR_PADDING
+const SIDEBAR_FILE_WIDTH = SIDEBAR_WIDTH - 2 - 2 - 1 - 1 // left + right padding + inner scrollbox + file row gap
 
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const sync = useSync()
@@ -245,7 +244,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                       const stats = [item.additions && `+${item.additions}`, item.deletions && `-${item.deletions}`]
                         .filter(Boolean)
                         .join(" ")
-                      const fileWidth = SIDEBAR_CONTENT_WIDTH - 2 - stats.length
+                      const fileWidth = SIDEBAR_FILE_WIDTH - stats.length
                       return (
                         <box flexDirection="row" gap={1} justifyContent="space-between">
                           <text fg={theme.textMuted} wrapMode="none">

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -12,6 +12,10 @@ import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 
+const SIDEBAR_WIDTH = 42
+const SIDEBAR_PADDING = 2 + 2 + 1 // left + right + inner scrollbox
+const SIDEBAR_CONTENT_WIDTH = SIDEBAR_WIDTH - SIDEBAR_PADDING
+
 export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const sync = useSync()
   const { theme } = useTheme()
@@ -72,7 +76,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     <Show when={session()}>
       <box
         backgroundColor={theme.backgroundPanel}
-        width={42}
+        width={SIDEBAR_WIDTH}
         height="100%"
         paddingTop={1}
         paddingBottom={1}
@@ -238,10 +242,14 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 <Show when={diff().length <= 2 || expanded.diff}>
                   <For each={diff() || []}>
                     {(item) => {
+                      const stats = [item.additions && `+${item.additions}`, item.deletions && `-${item.deletions}`]
+                        .filter(Boolean)
+                        .join(" ")
+                      const fileWidth = SIDEBAR_CONTENT_WIDTH - 2 - stats.length
                       return (
                         <box flexDirection="row" gap={1} justifyContent="space-between">
                           <text fg={theme.textMuted} wrapMode="none">
-                            {item.file}
+                            {Locale.truncateMiddle(item.file, fileWidth)}
                           </text>
                           <box flexDirection="row" gap={1} flexShrink={0}>
                             <Show when={item.additions}>


### PR DESCRIPTION
Closes https://github.com/anomalyco/opencode/issues/9592

### What does this PR do?

I [watched this video](https://www.youtube.com/watch?v=1fZTOjd_bOQ) a couple of days ago where Scott Jenson talks about early on macOS where they moved the ellipsis in the middle of the file instead of the end to not trim critical information.
<img width="1279" height="828" alt="image" src="https://github.com/user-attachments/assets/b00468fc-0835-45a6-9e4a-f5ae5dd8b625" />


I found myself needing this in opencode, because when paths get long, the actual filename get truncated so the modified files list is less useful.

### How did you verify your code works?

After/before:

<img width="1374" height="878" alt="image" src="https://github.com/user-attachments/assets/428425c1-8438-4d5b-9319-46f351be67df" />
