### PR TITLE
fix: correct dot prefix display in directory names for RTL text rendering issue #9579

### DIFF
--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -105,7 +105,7 @@ export const SessionReview = (props: SessionReviewProps) => {
                         <FileIcon node={{ path: diff.file, type: "file" }} />
                         <div data-slot="session-review-file-name-container">
                           <Show when={diff.file.includes("/")}>
-                            <span data-slot="session-review-directory">{getDirectory(diff.file)}&lrm;</span>
+                            <span data-slot="session-review-directory">{`\u202A${getDirectory(diff.file)}\u202C`}</span>
                           </Show>
                           <span data-slot="session-review-filename">{getFilename(diff.file)}</span>
                           <Show when={props.onViewFile}>

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -610,7 +610,7 @@ export function SessionTurn(
                                         <div data-slot="session-turn-file-path">
                                           <Show when={diff.file.includes("/")}>
                                             <span data-slot="session-turn-directory">
-                                              {getDirectory(diff.file)}&lrm;
+                                              {`\u202A${getDirectory(diff.file)}\u202C`}
                                             </span>
                                           </Show>
                                           <span data-slot="session-turn-filename">{getFilename(diff.file)}</span>


### PR DESCRIPTION
Fixes file path display bug where dot prefixes from directory names (e.g., `.opencode/`) were incorrectly appearing on filenames in the Session changes panel.

**Problem:** 
- Expected: `.opencode/commands/README.md`
- Actual: `opencode/commands/.README.md` (dot moved from directory to filename)

**Root Cause:**
CSS `direction: rtl` (used for left-truncation of long paths) triggers Unicode Bidirectional Algorithm, which treats dots as neutral characters and reorders them visually.

**Solution:**
Wrapped directory paths with Unicode Left-to-Right Embedding (`\u202A`) and Pop Directional Formatting (`\u202C`) to isolate the directory text and prevent character reordering while preserving left-truncation behavior.

**Files Changed:**
- `packages/ui/src/components/session-review.tsx` - Session Review panel
- `packages/ui/src/components/session-turn.tsx` - Session Turn display

Closes #9579