### PR TITLE
feat: Support ACP audience by mapping to ignore and synthetic

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -696,6 +696,7 @@ export namespace ACP {
                   content: {
                     type: "text",
                     text: part.text,
+                    ...(part.synthetic && { annotations: { audience: ["assistant"] } }),
                   },
                 },
               })
@@ -968,14 +969,16 @@ export namespace ACP {
       const agent = session.modeId ?? (await AgentModule.defaultAgent())
 
       const parts: Array<
-        { type: "text"; text: string } | { type: "file"; url: string; filename: string; mime: string }
+        { type: "text"; text: string; synthetic?: boolean } | { type: "file"; url: string; filename: string; mime: string }
       > = []
       for (const part of params.prompt) {
         switch (part.type) {
           case "text":
+            const hidden = part.annotations?.audience?.length === 1 && part.annotations.audience[0] === "assistant"
             parts.push({
               type: "text" as const,
               text: part.text,
+              ...(hidden && { synthetic: true }),
             })
             break
           case "image": {

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -12,6 +12,7 @@ import {
   type PermissionOption,
   type PlanEntry,
   type PromptRequest,
+  type Role,
   type SetSessionModelRequest,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
@@ -687,7 +688,12 @@ export namespace ACP {
               break
           }
         } else if (part.type === "text") {
-          if (part.text && !part.ignored) {
+          if (part.text) {
+            const audience: Role[] | undefined = part.synthetic
+              ? ["assistant"]
+              : part.ignored
+                ? ["user"]
+                : undefined
             await this.connection
               .sessionUpdate({
                 sessionId,
@@ -696,7 +702,7 @@ export namespace ACP {
                   content: {
                     type: "text",
                     text: part.text,
-                    ...(part.synthetic && { annotations: { audience: ["assistant"] } }),
+                    ...(audience && { annotations: { audience } }),
                   },
                 },
               })
@@ -969,16 +975,19 @@ export namespace ACP {
       const agent = session.modeId ?? (await AgentModule.defaultAgent())
 
       const parts: Array<
-        { type: "text"; text: string; synthetic?: boolean } | { type: "file"; url: string; filename: string; mime: string }
+        { type: "text"; text: string; synthetic?: boolean; ignored?: boolean } | { type: "file"; url: string; filename: string; mime: string }
       > = []
       for (const part of params.prompt) {
         switch (part.type) {
           case "text":
-            const hidden = part.annotations?.audience?.length === 1 && part.annotations.audience[0] === "assistant"
+            const audience = part.annotations?.audience
+            const forAssistant = audience?.length === 1 && audience[0] === "assistant"
+            const forUser = audience?.length === 1 && audience[0] === "user"
             parts.push({
               type: "text" as const,
               text: part.text,
-              ...(hidden && { synthetic: true }),
+              ...(forAssistant && { synthetic: true }),
+              ...(forUser && { ignored: true }),
             })
             break
           case "image": {


### PR DESCRIPTION
Closes https://github.com/anomalyco/opencode/issues/9589

This PR does the 2 way translation between ACP audience roles, and opencode ignore and synthetic fields:
- An ACP assistant only message should only be shown to the agent - maps to opencode synthetic
- An ACP user only message should only be shown to the user - maps to opencode ignored