### PR TITLE
fix(opencode): Allow compatible Bun versions in packageManager field

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -375,6 +375,7 @@
       "name": "@opencode-ai/script",
       "devDependencies": {
         "@types/bun": "catalog:",
+        "@types/semver": "catalog:",
       },
     },
     "packages/sdk/js": {
@@ -515,6 +516,7 @@
     "@types/bun": "1.3.5",
     "@types/luxon": "3.7.1",
     "@types/node": "22.13.9",
+    "@types/semver": "7.7.1",
     "@typescript/native-preview": "7.0.0-dev.20251207.1",
     "ai": "5.0.119",
     "diff": "8.0.2",
@@ -1849,6 +1851,8 @@
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
     "@types/scheduler": ["@types/scheduler@0.26.0", "", {}, "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA=="],
+
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@tsconfig/bun": "catalog:",
         "husky": "9.1.7",
         "prettier": "3.6.2",
+        "semver": "^7.6.0",
         "sst": "3.17.23",
         "turbo": "2.5.6",
       },

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-80+b7FwUy4mRWTzEjPrBWuR5Um67I1Rn4U/n/s/lBjs=",
+    "x86_64-linux": "sha256-AbPldHboLnT/sRYYEBKBx0EsQtA3uIOn85sl3rsg56s=",
     "aarch64-linux": "sha256-xH/Grwh3b+HWsUkKN8LMcyMaMcmnIJYlgp38WJCat5E=",
     "aarch64-darwin": "sha256-Izv6PE9gNaeYYfcqDwjTU/WYtD1y+j65annwvLzkMD8=",
     "x86_64-darwin": "sha256-EG1Z0uAeyFiOeVsv0Sz1sa8/mdXuw/uvbYYrkFR3EAg="

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@^1.3.5",
+  "packageManager": "bun@1.3.5",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.5",
+  "packageManager": "bun@^1.3.5",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "typecheck": "bun turbo typecheck",
@@ -66,6 +66,7 @@
     "@tsconfig/bun": "catalog:",
     "husky": "9.1.7",
     "prettier": "3.6.2",
+    "semver": "^7.6.0",
     "sst": "3.17.23",
     "turbo": "2.5.6"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
       "@kobalte/core": "0.13.11",
       "@types/luxon": "3.7.1",
       "@types/node": "22.13.9",
+      "@types/semver": "7.7.1",
       "@tsconfig/node22": "22.0.2",
       "@tsconfig/bun": "1.0.9",
       "@cloudflare/workers-types": "4.20251008.0",

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -3,7 +3,8 @@
   "name": "@opencode-ai/script",
   "license": "MIT",
   "devDependencies": {
-    "@types/bun": "catalog:"
+    "@types/bun": "catalog:",
+    "@types/semver": "catalog:"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -1,5 +1,6 @@
 import { $ } from "bun"
 import path from "path"
+import { satisfies } from "semver"
 
 const rootPkgPath = path.resolve(import.meta.dir, "../../../package.json")
 const rootPkg = await Bun.file(rootPkgPath).json()
@@ -9,7 +10,7 @@ if (!expectedBunVersion) {
   throw new Error("packageManager field not found in root package.json")
 }
 
-if (process.versions.bun !== expectedBunVersion) {
+if (!satisfies(process.versions.bun, expectedBunVersion)) {
   throw new Error(`This script requires bun@${expectedBunVersion}, but you are using bun@${process.versions.bun}`)
 }
 


### PR DESCRIPTION
Fixes #9583

Fixes build failure with Bun 1.3.6 by using semver ranges and updating build hashes.

**Problem:**  
OpenCode build fails because packageManager specifies bun@1.3.5, but Nix provides 1.3.6.

**Solution:**  
- Update packageManager to ^1.3.5 to allow compatible versions.
- Modify the build script to use semver.satisfies() for range checking.
- Update nix/hashes.json with new node_modules hash.

**Compatibility:**  
Bun 1.3.6 is fully backward compatible (confirmed via changelog review). No breaking changes affect the build script.

**Testing:**  
Verified with local NixOS rebuild; build succeeds with Bun 1.3.6.

**Note:** PR #9618 provides an alternative fix by pinning exactly to bun@1.3.6 instead of using semver ranges.