### PR TITLE
feat(app): add number shortcuts to switch projects

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -802,6 +802,26 @@ export default function Layout(props: ParentProps) {
       },
     ]
 
+    if (platform.platform === "desktop") {
+      const shortcuts = layout.projects
+        .list()
+        .slice(0, 9)
+        .map((project, index) => {
+          const slot = index + 1
+          const name = project.name || getFilename(project.worktree)
+          return {
+            id: `project.switch.${project.worktree}`,
+            title: `Switch to ${name}`,
+            description: `Project ${slot}`,
+            category: "Project",
+            keybind: `mod+${slot}`,
+            onSelect: () => navigateToProject(project.worktree),
+          }
+        })
+
+      commands.push(...shortcuts)
+    }
+
     for (const [id, definition] of availableThemeEntries()) {
       commands.push({
         id: `theme.set.${id}`,


### PR DESCRIPTION
## Summary
- add desktop-only project switch commands bound to mod+1..9
- map shortcuts to the first nine projects in sidebar order for quick navigation

Fixes #9600