### PR TITLE
feat(cli): add cli model validation

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -11,6 +11,7 @@ import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2"
 import { Server } from "../../server/server"
 import { Provider } from "../../provider/provider"
 import { Agent } from "../../agent/agent"
+import { FormatError } from "../error"
 
 const TOOL: Record<string, [string, string]> = {
   todowrite: ["Todo", UI.Style.TEXT_WARNING_BOLD],
@@ -251,21 +252,47 @@ export const RunCommand = cmd({
         return args.agent
       })()
 
+      const {validatedModelString, validatedModelObject} = await (async () => {
+        if (args.model === undefined || args.model === null) {
+          return { validatedModelString: undefined, validatedModelObject: undefined }
+        }
+
+        const trimmed = args.model.trim()
+        if (!trimmed) {
+          UI.println(UI.Style.TEXT_DANGER_BOLD + "✕", UI.Style.TEXT_NORMAL, `model argument cannot be empty`)
+          process.exit(1)
+        }
+
+        const parsed = Provider.parseModel(trimmed)
+        return Provider.getModel(parsed.providerID, parsed.modelID)
+          .then(() => ({
+            validatedModelString: trimmed,
+            validatedModelObject: { providerID: parsed.providerID, modelID: parsed.modelID },
+          }))
+          .catch((e) => {
+            if (Provider.ModelNotFoundError.isInstance(e)) {
+              const formatted = FormatError(e)
+              if (formatted) UI.println(formatted)
+              process.exit(1)
+            }
+            throw e
+          })
+      })()
+
       if (args.command) {
         await sdk.session.command({
           sessionID,
           agent: resolvedAgent,
-          model: args.model,
+          model: validatedModelString,
           command: args.command,
           arguments: message,
           variant: args.variant,
         })
       } else {
-        const modelParam = args.model ? Provider.parseModel(args.model) : undefined
         await sdk.session.prompt({
           sessionID,
           agent: resolvedAgent,
-          model: modelParam,
+          model: validatedModelObject,
           variant: args.variant,
           parts: [...fileParts, { type: "text", text: message }],
         })


### PR DESCRIPTION
Closes #9582

### What does this PR do?
Adds early CLI validation for the `--model` argument that:
- Validates model format (provider/model)
- Checks provider & model exist before backend call
- Shows fuzzy suggestions for typos
- Exits with code 1 on validation error

### How did you verify your code works?
Tested 6 scenarios with compiled executable:
```sh
# Test 1: Valid model
opencode run --model "opencode/gpt-5-nano" -> proceeds normally

# Test 2: Empty string
opencode run --model "" -> ✕ model argument cannot be empty\

# Test 3: Whitespace only
opencode run --model "   " -> ✕ model argument cannot be empty

# Test 4: Invalid provider
opencode run --model "opencode-typo/gpt-4" -> Model not found: opencode-typo/gpt-4 
Try: `opencode models` to list available models
Or check your config (opencode.json) provider/model names

# Test 5: Invalid model (typo)
opencode run --model "opencode/claude-sonet-4" -> Model not found: opencode/claude-sonet-4
Did you mean: claude-sonnet-4, claude-sonnet-4-5

# Test 6: No --model flag
opencode run -> proceeds normally with default model
```
