### PR TITLE
chore(opencode): encourage shell-first summaries for small queries

### DIFF
--- a/packages/opencode/src/session/prompt/codex_header.txt
+++ b/packages/opencode/src/session/prompt/codex_header.txt
@@ -8,9 +8,11 @@ You are an interactive CLI tool that helps users with software engineering tasks
 - Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).
 
 ## Tool usage
-- Prefer specialized tools over shell for file operations:
-  - Use Read to view files, Edit to modify files, and Write only when needed.
+- Prefer specialized tools for full file content and precise edits:
+  - Use Read to view full file content, Edit to modify files, and Write only when needed.
   - Use Glob to find files by name and Grep to search file contents.
+- Use Bash for lightweight summaries and metadata (line counts with `wc -l`, file lists with `ls`) when you do not need full file content.
+- Avoid reading entire files when a small summary or count is sufficient.
 - Use Bash for terminal operations (git, bun, builds, tests, running scripts).
 - Run tool calls in parallel when neither call needs the other’s output; otherwise run sequentially.
 

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -7,6 +7,7 @@ Usage:
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - Any lines longer than 2000 characters will be truncated
 - Results are returned using cat -n format, with line numbers starting at 1
+- Use this tool when you need full file content. For simple counts or listings, prefer Bash to keep output small.
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
 - You can read image files using this tool.


### PR DESCRIPTION
## Summary
- bias codex header toward using Bash for lightweight counts/listings
- clarify Read tool guidance to avoid full file reads for simple queries

## Testing
- not run (docs/prompt changes only)

## References
- Fixes #9045