### PR TITLE
feat(opencode): trigger compaction earlier and add multi-file read

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -35,11 +35,13 @@ export namespace SessionCompaction {
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output
     const output = Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
     const usable = input.model.limit.input || context - output
-    return count > usable
+    const threshold = Math.floor(usable * EARLY_COMPACT_RATIO)
+    return count > threshold
   }
 
   export const PRUNE_MINIMUM = 20_000
   export const PRUNE_PROTECT = 40_000
+  export const EARLY_COMPACT_RATIO = 0.9
 
   const PRUNE_PROTECTED_TOOLS = ["skill"]
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -24,9 +24,15 @@ export const ReadTool = Tool.define("read", {
     })
     .refine((value) => value.filePath || (value.filePaths && value.filePaths.length > 0), {
       message: "filePath or filePaths is required",
+    })
+    .refine((value) => !(value.filePath && value.filePaths && value.filePaths.length > 0), {
+      message: "Use filePath or filePaths, not both",
     }),
   async execute(params, ctx) {
-    const paths = params.filePaths?.length ? params.filePaths : params.filePath ? [params.filePath] : []
+    const hasPath = Boolean(params.filePath)
+    const hasPaths = Boolean(params.filePaths?.length)
+    if (hasPath && hasPaths) throw new Error("Use filePath or filePaths, not both")
+    const paths = hasPaths ? params.filePaths! : hasPath ? [params.filePath!] : []
     if (paths.length === 0) throw new Error("filePath or filePaths is required")
 
     const limit = params.limit ?? DEFAULT_READ_LIMIT
@@ -154,10 +160,7 @@ export const ReadTool = Tool.define("read", {
       return readOne(paths[0])
     }
 
-    const results = []
-    for (const value of paths) {
-      results.push(await readOne(value))
-    }
+    const results = await Promise.all(paths.map((value) => readOne(value)))
 
     const output = results.map((result) => result.output).join("\n\n")
     const preview = results.map((result) => result.metadata.preview).join("\n\n")

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -15,123 +15,166 @@ const MAX_BYTES = 50 * 1024
 
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
-  parameters: z.object({
-    filePath: z.string().describe("The path to the file to read"),
-    offset: z.coerce.number().describe("The line number to start reading from (0-based)").optional(),
-    limit: z.coerce.number().describe("The number of lines to read (defaults to 2000)").optional(),
-  }),
+  parameters: z
+    .object({
+      filePath: z.string().describe("The path to the file to read").optional(),
+      filePaths: z.array(z.string()).describe("Paths to files to read").optional(),
+      offset: z.coerce.number().describe("The line number to start reading from (0-based)").optional(),
+      limit: z.coerce.number().describe("The number of lines to read (defaults to 2000)").optional(),
+    })
+    .refine((value) => value.filePath || (value.filePaths && value.filePaths.length > 0), {
+      message: "filePath or filePaths is required",
+    }),
   async execute(params, ctx) {
-    let filepath = params.filePath
-    if (!path.isAbsolute(filepath)) {
-      filepath = path.join(process.cwd(), filepath)
-    }
-    const title = path.relative(Instance.worktree, filepath)
-
-    await assertExternalDirectory(ctx, filepath, {
-      bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
-    })
-
-    await ctx.ask({
-      permission: "read",
-      patterns: [filepath],
-      always: ["*"],
-      metadata: {},
-    })
-
-    const file = Bun.file(filepath)
-    if (!(await file.exists())) {
-      const dir = path.dirname(filepath)
-      const base = path.basename(filepath)
-
-      const dirEntries = fs.readdirSync(dir)
-      const suggestions = dirEntries
-        .filter(
-          (entry) =>
-            entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
-        )
-        .map((entry) => path.join(dir, entry))
-        .slice(0, 3)
-
-      if (suggestions.length > 0) {
-        throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
-      }
-
-      throw new Error(`File not found: ${filepath}`)
-    }
-
-    // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
-    const isImage =
-      file.type.startsWith("image/") && file.type !== "image/svg+xml" && file.type !== "image/vnd.fastbidsheet"
-    const isPdf = file.type === "application/pdf"
-    if (isImage || isPdf) {
-      const mime = file.type
-      const msg = `${isImage ? "Image" : "PDF"} read successfully`
-      return {
-        title,
-        output: msg,
-        metadata: {
-          preview: msg,
-          truncated: false,
-        },
-        attachments: [
-          {
-            id: Identifier.ascending("part"),
-            sessionID: ctx.sessionID,
-            messageID: ctx.messageID,
-            type: "file",
-            mime,
-            url: `data:${mime};base64,${Buffer.from(await file.bytes()).toString("base64")}`,
-          },
-        ],
-      }
-    }
-
-    const isBinary = await isBinaryFile(filepath, file)
-    if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
+    const paths = params.filePaths?.length ? params.filePaths : params.filePath ? [params.filePath] : []
+    if (paths.length === 0) throw new Error("filePath or filePaths is required")
 
     const limit = params.limit ?? DEFAULT_READ_LIMIT
     const offset = params.offset || 0
-    const lines = await file.text().then((text) => text.split("\n"))
 
-    const raw: string[] = []
-    let bytes = 0
-    let truncatedByBytes = false
-    for (let i = offset; i < Math.min(lines.length, offset + limit); i++) {
-      const line = lines[i].length > MAX_LINE_LENGTH ? lines[i].substring(0, MAX_LINE_LENGTH) + "..." : lines[i]
-      const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
-      if (bytes + size > MAX_BYTES) {
-        truncatedByBytes = true
-        break
+    const readOne = async (value: string) => {
+      const filepath = path.isAbsolute(value) ? value : path.join(process.cwd(), value)
+      const title = path.relative(Instance.worktree, filepath)
+
+      await assertExternalDirectory(ctx, filepath, {
+        bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
+      })
+
+      await ctx.ask({
+        permission: "read",
+        patterns: [filepath],
+        always: ["*"],
+        metadata: {},
+      })
+
+      const file = Bun.file(filepath)
+      if (!(await file.exists())) {
+        const dir = path.dirname(filepath)
+        const base = path.basename(filepath)
+
+        const dirEntries = fs.readdirSync(dir)
+        const suggestions = dirEntries
+          .filter(
+            (entry) =>
+              entry.toLowerCase().includes(base.toLowerCase()) || base.toLowerCase().includes(entry.toLowerCase()),
+          )
+          .map((entry) => path.join(dir, entry))
+          .slice(0, 3)
+
+        if (suggestions.length > 0) {
+          throw new Error(`File not found: ${filepath}\n\nDid you mean one of these?\n${suggestions.join("\n")}`)
+        }
+
+        throw new Error(`File not found: ${filepath}`)
       }
-      raw.push(line)
-      bytes += size
+
+      // Exclude SVG (XML-based) and vnd.fastbidsheet (.fbs extension, commonly FlatBuffers schema files)
+      const isImage =
+        file.type.startsWith("image/") && file.type !== "image/svg+xml" && file.type !== "image/vnd.fastbidsheet"
+      const isPdf = file.type === "application/pdf"
+      if (isImage || isPdf) {
+        const mime = file.type
+        const msg = `${isImage ? "Image" : "PDF"} read successfully`
+        return {
+          title,
+          output: msg,
+          metadata: {
+            preview: msg,
+            truncated: false,
+          },
+          attachments: [
+            {
+              id: Identifier.ascending("part"),
+              sessionID: ctx.sessionID,
+              messageID: ctx.messageID,
+              type: "file" as const,
+              mime,
+              url: `data:${mime};base64,${Buffer.from(await file.bytes()).toString("base64")}`,
+            },
+          ],
+        }
+      }
+
+      const isBinary = await isBinaryFile(filepath, file)
+      if (isBinary) throw new Error(`Cannot read binary file: ${filepath}`)
+
+      const lines = await file.text().then((text) => text.split("\n"))
+
+      const raw: string[] = []
+      let bytes = 0
+      let truncatedByBytes = false
+      for (let i = offset; i < Math.min(lines.length, offset + limit); i++) {
+        const line = lines[i].length > MAX_LINE_LENGTH ? lines[i].substring(0, MAX_LINE_LENGTH) + "..." : lines[i]
+        const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+        if (bytes + size > MAX_BYTES) {
+          truncatedByBytes = true
+          break
+        }
+        raw.push(line)
+        bytes += size
+      }
+
+      const content = raw.map((line, index) => {
+        return `${(index + offset + 1).toString().padStart(5, "0")}| ${line}`
+      })
+      const preview = raw.slice(0, 20).join("\n")
+
+      let output = "<file>\n"
+      output += content.join("\n")
+
+      const totalLines = lines.length
+      const lastReadLine = offset + raw.length
+      const hasMoreLines = totalLines > lastReadLine
+      const truncated = hasMoreLines || truncatedByBytes
+
+      if (truncatedByBytes) {
+        output += `\n\n(Output truncated at ${MAX_BYTES} bytes. Use 'offset' parameter to read beyond line ${lastReadLine})`
+      } else if (hasMoreLines) {
+        output += `\n\n(File has more lines. Use 'offset' parameter to read beyond line ${lastReadLine})`
+      } else {
+        output += `\n\n(End of file - total ${totalLines} lines)`
+      }
+      output += "\n</file>"
+
+      // just warms the lsp client
+      LSP.touchFile(filepath, false)
+      FileTime.read(ctx.sessionID, filepath)
+
+      return {
+        title,
+        output,
+        metadata: {
+          preview,
+          truncated,
+        },
+      }
     }
 
-    const content = raw.map((line, index) => {
-      return `${(index + offset + 1).toString().padStart(5, "0")}| ${line}`
-    })
-    const preview = raw.slice(0, 20).join("\n")
-
-    let output = "<file>\n"
-    output += content.join("\n")
-
-    const totalLines = lines.length
-    const lastReadLine = offset + raw.length
-    const hasMoreLines = totalLines > lastReadLine
-    const truncated = hasMoreLines || truncatedByBytes
-
-    if (truncatedByBytes) {
-      output += `\n\n(Output truncated at ${MAX_BYTES} bytes. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    } else if (hasMoreLines) {
-      output += `\n\n(File has more lines. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    } else {
-      output += `\n\n(End of file - total ${totalLines} lines)`
+    if (paths.length === 1) {
+      return readOne(paths[0])
     }
-    output += "\n</file>"
 
-    // just warms the lsp client
-    LSP.touchFile(filepath, false)
-    FileTime.read(ctx.sessionID, filepath)
+    const results = []
+    for (const value of paths) {
+      results.push(await readOne(value))
+    }
+
+    const output = results.map((result) => result.output).join("\n\n")
+    const preview = results.map((result) => result.metadata.preview).join("\n\n")
+    const truncated = results.some((result) => result.metadata.truncated)
+    const title = results.map((result) => result.title).join(", ")
+    const attachments = results.flatMap((result) => result.attachments ?? [])
+
+    if (attachments.length === 0) {
+      return {
+        title,
+        output,
+        metadata: {
+          preview,
+          truncated,
+        },
+      }
+    }
 
     return {
       title,
@@ -140,6 +183,7 @@ export const ReadTool = Tool.define("read", {
         preview,
         truncated,
       },
+      attachments,
     }
   },
 })

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -2,7 +2,7 @@ Reads a file from the local filesystem. You can access any file directly by usin
 Assume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
 
 Usage:
-- The filePath parameter must be an absolute path, not a relative path
+- The filePath or filePaths parameters must be absolute paths, not relative paths
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - Any lines longer than 2000 characters will be truncated
@@ -10,3 +10,4 @@ Usage:
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
 - You can read image files using this tool.
+- Use `filePaths` to read multiple files in one call; the response includes one `<file>` block per path.

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -3,6 +3,7 @@ Assume this tool is able to read all files on the machine. If the User provides 
 
 Usage:
 - The filePath or filePaths parameters must be absolute paths, not relative paths
+- Use either `filePath` or `filePaths`, not both
 - By default, it reads up to 2000 lines starting from the beginning of the file
 - You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 - Any lines longer than 2000 characters will be truncated
@@ -10,4 +11,4 @@ Usage:
 - You have the capability to call multiple tools in a single response. It is always better to speculatively read multiple files as a batch that are potentially useful.
 - If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
 - You can read image files using this tool.
-- Use `filePaths` to read multiple files in one call; the response includes one `<file>` block per path.
+- Use `filePaths` to read multiple files in one call; the response includes one `<file>` block per path in the same order, and `offset`/`limit` apply to each file.

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -52,6 +52,18 @@ describe("session.compaction.isOverflow", () => {
     })
   })
 
+  test("returns true when token count exceeds early compaction threshold", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const model = createModel({ context: 100_000, output: 10_000 })
+        const tokens = { input: 80_000, output: 1_001, reasoning: 0, cache: { read: 0, write: 0 } }
+        expect(await SessionCompaction.isOverflow({ tokens, model })).toBe(true)
+      },
+    })
+  })
+
   test("returns false when token count within usable context", async () => {
     await using tmp = await tmpdir()
     await Instance.provide({

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -51,29 +51,6 @@ describe("tool.read external_directory permission", () => {
     })
   })
 
-  test("reads multiple files with filePaths", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "first.txt"), "first content")
-        await Bun.write(path.join(dir, "second.txt"), "second content")
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute(
-          {
-            filePaths: [path.join(tmp.path, "first.txt"), path.join(tmp.path, "second.txt")],
-          },
-          ctx,
-        )
-        expect(result.output).toContain("first content")
-        expect(result.output).toContain("second content")
-      },
-    })
-  })
-
   test("asks for external_directory permission when reading absolute path outside project", async () => {
     await using outerTmp = await tmpdir({
       init: async (dir) => {
@@ -142,6 +119,129 @@ describe("tool.read external_directory permission", () => {
         await read.execute({ filePath: path.join(tmp.path, "internal.txt") }, testCtx)
         const extDirReq = requests.find((r) => r.permission === "external_directory")
         expect(extDirReq).toBeUndefined()
+      },
+    })
+  })
+})
+
+describe("tool.read filePaths", () => {
+  test("combines output in order and builds title", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "first.txt"), "first content")
+        await Bun.write(path.join(dir, "second.txt"), "second content")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const first = path.join(tmp.path, "first.txt")
+        const second = path.join(tmp.path, "second.txt")
+        const result = await read.execute({ filePaths: [first, second] }, ctx)
+        const firstIndex = result.output.indexOf("first content")
+        const secondIndex = result.output.indexOf("second content")
+        const blocks = result.output.match(/<file>/g) ?? []
+        const title = `${path.relative(Instance.worktree, first)}, ${path.relative(Instance.worktree, second)}`
+        expect(result.title).toBe(title)
+        expect(firstIndex).toBeGreaterThan(-1)
+        expect(secondIndex).toBeGreaterThan(-1)
+        expect(firstIndex).toBeLessThan(secondIndex)
+        expect(blocks.length).toBe(2)
+      },
+    })
+  })
+
+  test("applies offset and limit to each file", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const firstLines = ["a0", "a1", "a2"].join("\n")
+        const secondLines = ["b0", "b1", "b2"].join("\n")
+        await Bun.write(path.join(dir, "first.txt"), firstLines)
+        await Bun.write(path.join(dir, "second.txt"), secondLines)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const first = path.join(tmp.path, "first.txt")
+        const second = path.join(tmp.path, "second.txt")
+        const result = await read.execute({ filePaths: [first, second], offset: 1, limit: 1 }, ctx)
+        expect(result.output).toContain("a1")
+        expect(result.output).toContain("b1")
+        expect(result.output).not.toContain("a0")
+        expect(result.output).not.toContain("b0")
+        expect(result.output).not.toContain("a2")
+        expect(result.output).not.toContain("b2")
+      },
+    })
+  })
+
+  test("throws when filePaths is empty", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePaths: [] }, ctx)).rejects.toThrow("filePath or filePaths is required")
+      },
+    })
+  })
+
+  test("throws when filePath and filePaths are both provided", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "first.txt"), "first content")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const first = path.join(tmp.path, "first.txt")
+        await expect(read.execute({ filePath: first, filePaths: [first] }, ctx)).rejects.toThrow(
+          "Use filePath or filePaths, not both",
+        )
+      },
+    })
+  })
+
+  test("throws when filePaths contains missing file", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const missing = path.join(tmp.path, "missing.txt")
+        await expect(read.execute({ filePaths: [missing] }, ctx)).rejects.toThrow("File not found")
+      },
+    })
+  })
+
+  test("combines attachments for images and pdfs", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const png = Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+          "base64",
+        )
+        const pdf = Buffer.from("%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF\n")
+        await Bun.write(path.join(dir, "image.png"), png)
+        await Bun.write(path.join(dir, "file.pdf"), pdf)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute(
+          { filePaths: [path.join(tmp.path, "image.png"), path.join(tmp.path, "file.pdf")] },
+          ctx,
+        )
+        expect(result.output).toContain("Image read successfully")
+        expect(result.output).toContain("PDF read successfully")
+        expect(result.attachments?.length).toBe(2)
       },
     })
   })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -51,6 +51,29 @@ describe("tool.read external_directory permission", () => {
     })
   })
 
+  test("reads multiple files with filePaths", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "first.txt"), "first content")
+        await Bun.write(path.join(dir, "second.txt"), "second content")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute(
+          {
+            filePaths: [path.join(tmp.path, "first.txt"), path.join(tmp.path, "second.txt")],
+          },
+          ctx,
+        )
+        expect(result.output).toContain("first content")
+        expect(result.output).toContain("second content")
+      },
+    })
+  })
+
   test("asks for external_directory permission when reading absolute path outside project", async () => {
     await using outerTmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
## Summary
- trigger session compaction earlier to avoid overflow at high context usage
- add multi-file read validation and update read tool guidance
- expand read and compaction tests to cover filePaths edge cases and early threshold

## Testing
- `bun test test/tool/read.test.ts`
- `bun test test/session/compaction.test.ts`

## References
- Fixes #9045