### PR TITLE
docs: Fix typo

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -157,10 +157,10 @@ Configure agents in your `opencode.json` config file:
 
 You can also define agents using markdown files. Place them in:
 
-- Global: `~/.config/opencode/agents/`
-- Per-project: `.opencode/agents/`
+- Global: `~/.config/opencode/agent/`
+- Per-project: `.opencode/agent/`
 
-```markdown title="~/.config/opencode/agents/review.md"
+```markdown title="~/.config/opencode/agent/review.md"
 ---
 description: Reviews code for quality and best practices
 mode: subagent
@@ -419,7 +419,7 @@ You can override these permissions per agent.
 
 You can also set permissions in Markdown agents.
 
-```markdown title="~/.config/opencode/agents/review.md"
+```markdown title="~/.config/opencode/agent/review.md"
 ---
 description: Code review without edits
 mode: subagent
@@ -637,7 +637,7 @@ Do you have an agent you'd like to share? [Submit a PR](https://github.com/anoma
 
 ### Documentation agent
 
-```markdown title="~/.config/opencode/agents/docs-writer.md"
+```markdown title="~/.config/opencode/agent/docs-writer.md"
 ---
 description: Writes and maintains project documentation
 mode: subagent
@@ -659,7 +659,7 @@ Focus on:
 
 ### Security auditor
 
-```markdown title="~/.config/opencode/agents/security-auditor.md"
+```markdown title="~/.config/opencode/agent/security-auditor.md"
 ---
 description: Performs security audits and identifies vulnerabilities
 mode: subagent


### PR DESCRIPTION
When I use the command `opencode agent create` the `agent.md` file is created under `agent` folder instead of `agents` so I updated the docs to match the current behavior.

<img width="721" height="361" alt="Screenshot 2026-01-20 at 2 07 46 PM" src="https://github.com/user-attachments/assets/89cb379c-0427-4301-8f38-2cbd7dcff114" />


Updated paths for agent markdown files from 'agents' to 'agent'.


### What does this PR do?
Fix a typo I found
