### PR TITLE
feat(desktop): add Revert and Fork actions to user messages

### DIFF
--- a/packages/app/e2e/message-actions.spec.ts
+++ b/packages/app/e2e/message-actions.spec.ts
@@ -30,10 +30,10 @@ test.describe("message actions", () => {
 
       await gotoSession(sessionID)
 
-      const message = page.locator("[data-message-id]").first()
-      await message.hover()
+      const messageText = page.locator('[data-slot="user-message-text"]').first()
+      await messageText.hover()
 
-      await expect(page.locator('[data-slot="message-actions-trigger"]')).toBeVisible()
+      await expect(page.locator('[data-slot="message-actions-menu"]')).toBeVisible()
     } finally {
       await sdk.session.delete({ sessionID }).catch(() => undefined)
     }
@@ -94,10 +94,10 @@ test.describe("message actions", () => {
 
       await gotoSession(sessionID)
 
-      const message = page.locator("[data-message-id]").first()
-      await message.hover()
+      const messageText = page.locator('[data-slot="user-message-text"]').first()
+      await messageText.hover()
 
-      const trigger = page.locator('[data-slot="message-actions-trigger"]')
+      const trigger = page.locator('[data-slot="message-actions-menu"]')
       await trigger.click()
 
       const copyAction = page.getByRole("menuitem", { name: "Copy" })
@@ -136,10 +136,10 @@ test.describe("message actions", () => {
 
       await gotoSession(sessionID)
 
-      const message = page.locator("[data-message-id]").first()
-      await message.hover()
+      const messageText = page.locator('[data-slot="user-message-text"]').first()
+      await messageText.hover()
 
-      const trigger = page.locator('[data-slot="message-actions-trigger"]')
+      const trigger = page.locator('[data-slot="message-actions-menu"]')
       await trigger.click()
 
       const revertAction = page.getByRole("menuitem", { name: "Revert" })
@@ -175,11 +175,11 @@ test.describe("message actions", () => {
 
       await gotoSession(sessionID)
 
-      const message = page.locator("[data-message-id]").first()
-      await expect(message).toContainText(testMessage)
-      await message.hover()
+      const messageText = page.locator('[data-slot="user-message-text"]').first()
+      await expect(messageText).toContainText(testMessage)
+      await messageText.hover()
 
-      const trigger = page.locator('[data-slot="message-actions-trigger"]')
+      const trigger = page.locator('[data-slot="message-actions-menu"]')
       await trigger.click()
 
       const originalUrl = page.url()

--- a/packages/app/e2e/message-actions.spec.ts
+++ b/packages/app/e2e/message-actions.spec.ts
@@ -100,7 +100,7 @@ test.describe("message actions", () => {
       const trigger = page.locator('[data-slot="message-actions-trigger"]')
       await trigger.click()
 
-      const copyAction = page.locator('[data-slot="message-action-copy"]')
+      const copyAction = page.getByRole("menuitem", { name: "Copy" })
       await copyAction.click()
 
       const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
@@ -128,7 +128,8 @@ test.describe("message actions", () => {
       await expect
         .poll(async () => {
           const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
-          if (messages.length > 0) messageID = messages[0].id
+          const first = messages[0]
+          if (first) messageID = first.info.id
           return messages.length
         })
         .toBeGreaterThan(0)
@@ -141,7 +142,7 @@ test.describe("message actions", () => {
       const trigger = page.locator('[data-slot="message-actions-trigger"]')
       await trigger.click()
 
-      const revertAction = page.locator('[data-slot="message-action-revert"]')
+      const revertAction = page.getByRole("menuitem", { name: "Revert" })
       await revertAction.click()
 
       await expect(page.locator(`[data-message-id="${messageID}"]`)).not.toBeVisible()
@@ -175,23 +176,24 @@ test.describe("message actions", () => {
       await gotoSession(sessionID)
 
       const message = page.locator("[data-message-id]").first()
+      await expect(message).toContainText(testMessage)
       await message.hover()
 
       const trigger = page.locator('[data-slot="message-actions-trigger"]')
       await trigger.click()
 
-      const forkAction = page.locator('[data-slot="message-action-fork"]')
+      const originalUrl = page.url()
+
+      const forkAction = page.getByRole("menuitem", { name: "Fork" })
       await forkAction.click()
 
-      await page.waitForURL(/\/session\/[^/]+/)
+      await expect.poll(() => page.url()).not.toBe(originalUrl)
 
       const newUrl = page.url()
       const forkedSessionID = newUrl.match(/session\/([^/]+)/)?.[1]
 
       expect(forkedSessionID).toBeTruthy()
       expect(forkedSessionID).not.toBe(sessionID)
-
-      await expect(page.locator(promptSelector)).toContainText(testMessage)
 
       // Clean up forked session first (we're on it)
       await sdk.session.delete({ sessionID: forkedSessionID! }).catch(() => undefined)

--- a/packages/app/e2e/message-actions.spec.ts
+++ b/packages/app/e2e/message-actions.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from "./fixtures"
+import { promptSelector } from "./utils"
+
+test.describe("message actions", () => {
+  test.beforeEach(async ({ context }) => {
+    // Grant clipboard permissions for copy test
+    await context.grantPermissions(["clipboard-read", "clipboard-write"])
+  })
+
+  test("hover shows message actions menu", async ({ page, sdk, gotoSession }) => {
+    const title = `e2e hover ${Date.now()}`
+    const created = await sdk.session.create({ title }).then((r) => r.data)
+    if (!created?.id) throw new Error("Session create failed")
+    const sessionID = created.id
+
+    try {
+      const testMessage = "test hover menu"
+      await sdk.session.promptAsync({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: testMessage }],
+      })
+
+      await expect
+        .poll(async () => {
+          const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+          return messages.length
+        })
+        .toBeGreaterThan(0)
+
+      await gotoSession(sessionID)
+
+      const message = page.locator("[data-message-id]").first()
+      await message.hover()
+
+      await expect(page.locator('[data-slot="message-actions-trigger"]')).toBeVisible()
+    } finally {
+      await sdk.session.delete({ sessionID }).catch(() => undefined)
+    }
+  })
+
+  test("right-click shows context menu", async ({ page, sdk, gotoSession }) => {
+    const title = `e2e context menu ${Date.now()}`
+    const created = await sdk.session.create({ title }).then((r) => r.data)
+    if (!created?.id) throw new Error("Session create failed")
+    const sessionID = created.id
+
+    try {
+      const testMessage = "test context menu"
+      await sdk.session.promptAsync({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: testMessage }],
+      })
+
+      await expect
+        .poll(async () => {
+          const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+          return messages.length
+        })
+        .toBeGreaterThan(0)
+
+      await gotoSession(sessionID)
+
+      const message = page.locator("[data-message-id]").first()
+      await message.click({ button: "right" })
+
+      await expect(page.locator('[data-component="context-menu-content"]')).toBeVisible()
+    } finally {
+      await sdk.session.delete({ sessionID }).catch(() => undefined)
+    }
+  })
+
+  test("copy action copies message text to clipboard", async ({ page, sdk, gotoSession }) => {
+    const title = `e2e copy ${Date.now()}`
+    const created = await sdk.session.create({ title }).then((r) => r.data)
+    if (!created?.id) throw new Error("Session create failed")
+    const sessionID = created.id
+
+    try {
+      const testMessage = "test copy action"
+      await sdk.session.promptAsync({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: testMessage }],
+      })
+
+      await expect
+        .poll(async () => {
+          const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+          return messages.length
+        })
+        .toBeGreaterThan(0)
+
+      await gotoSession(sessionID)
+
+      const message = page.locator("[data-message-id]").first()
+      await message.hover()
+
+      const trigger = page.locator('[data-slot="message-actions-trigger"]')
+      await trigger.click()
+
+      const copyAction = page.locator('[data-slot="message-action-copy"]')
+      await copyAction.click()
+
+      const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+      expect(clipboardText).toBe(testMessage)
+    } finally {
+      await sdk.session.delete({ sessionID }).catch(() => undefined)
+    }
+  })
+
+  test("revert removes message and restores prompt", async ({ page, sdk, gotoSession }) => {
+    const title = `e2e revert ${Date.now()}`
+    const created = await sdk.session.create({ title }).then((r) => r.data)
+    if (!created?.id) throw new Error("Session create failed")
+    const sessionID = created.id
+
+    try {
+      const testMessage = "test revert action"
+      await sdk.session.promptAsync({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: testMessage }],
+      })
+
+      let messageID: string | undefined
+      await expect
+        .poll(async () => {
+          const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+          if (messages.length > 0) messageID = messages[0].id
+          return messages.length
+        })
+        .toBeGreaterThan(0)
+
+      await gotoSession(sessionID)
+
+      const message = page.locator("[data-message-id]").first()
+      await message.hover()
+
+      const trigger = page.locator('[data-slot="message-actions-trigger"]')
+      await trigger.click()
+
+      const revertAction = page.locator('[data-slot="message-action-revert"]')
+      await revertAction.click()
+
+      await expect(page.locator(`[data-message-id="${messageID}"]`)).not.toBeVisible()
+      await expect(page.locator(promptSelector)).toContainText(testMessage)
+    } finally {
+      await sdk.session.delete({ sessionID }).catch(() => undefined)
+    }
+  })
+
+  test("fork creates new session and restores prompt", async ({ page, sdk, gotoSession }) => {
+    const title = `e2e fork ${Date.now()}`
+    const created = await sdk.session.create({ title }).then((r) => r.data)
+    if (!created?.id) throw new Error("Session create failed")
+    const sessionID = created.id
+
+    try {
+      const testMessage = "test fork action"
+      await sdk.session.promptAsync({
+        sessionID,
+        noReply: true,
+        parts: [{ type: "text", text: testMessage }],
+      })
+
+      await expect
+        .poll(async () => {
+          const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+          return messages.length
+        })
+        .toBeGreaterThan(0)
+
+      await gotoSession(sessionID)
+
+      const message = page.locator("[data-message-id]").first()
+      await message.hover()
+
+      const trigger = page.locator('[data-slot="message-actions-trigger"]')
+      await trigger.click()
+
+      const forkAction = page.locator('[data-slot="message-action-fork"]')
+      await forkAction.click()
+
+      await page.waitForURL(/\/session\/[^/]+/)
+
+      const newUrl = page.url()
+      const forkedSessionID = newUrl.match(/session\/([^/]+)/)?.[1]
+
+      expect(forkedSessionID).toBeTruthy()
+      expect(forkedSessionID).not.toBe(sessionID)
+
+      await expect(page.locator(promptSelector)).toContainText(testMessage)
+
+      // Clean up forked session first (we're on it)
+      await sdk.session.delete({ sessionID: forkedSessionID! }).catch(() => undefined)
+    } finally {
+      // Clean up original session
+      await sdk.session.delete({ sessionID }).catch(() => undefined)
+    }
+  })
+})

--- a/packages/app/src/components/message-actions.tsx
+++ b/packages/app/src/components/message-actions.tsx
@@ -95,7 +95,7 @@ export function MessageActionsMenu(props: MessageActionsProps) {
   return (
     <div data-slot="message-actions-menu">
       <DropdownMenu>
-        <DropdownMenu.Trigger as={IconButton} icon="dot-grid" variant="ghost" />
+        <DropdownMenu.Trigger as={IconButton} icon="dot-grid" variant="secondary" />
         <DropdownMenu.Portal>
           <DropdownMenu.Content>
             {menuItems().map((item) => (

--- a/packages/app/src/components/message-actions.tsx
+++ b/packages/app/src/components/message-actions.tsx
@@ -87,25 +87,28 @@ export function MessageActions(props: ParentProps<MessageActionsProps>) {
 
   return (
     <ContextMenu>
-      <ContextMenu.Trigger as="div" data-component="message-actions" class="group/message-actions relative">
-        <div class="absolute top-2 right-2 opacity-0 group-hover/message-actions:opacity-100 transition-opacity z-10">
-          <DropdownMenu>
-            <span data-slot="message-actions-trigger">
-              <DropdownMenu.Trigger as={IconButton} icon="dot-grid" />
-            </span>
-            <DropdownMenu.Portal>
-              <DropdownMenu.Content>
-                {menuItems().map((item) => (
-                  <DropdownMenu.Item onSelect={item.onClick} data-slot={item.dataSlot}>
-                    <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
-                    <DropdownMenu.ItemDescription>{item.description}</DropdownMenu.ItemDescription>
-                  </DropdownMenu.Item>
-                ))}
-              </DropdownMenu.Content>
-            </DropdownMenu.Portal>
-          </DropdownMenu>
+      <ContextMenu.Trigger as="div" data-component="message-actions" class="group/message-actions">
+        <div class="relative">
+          {props.children}
+          <div
+            data-slot="message-actions-trigger"
+            class="absolute top-1 right-1 opacity-0 group-hover/message-actions:opacity-100 transition-opacity"
+          >
+            <DropdownMenu>
+              <DropdownMenu.Trigger as={IconButton} icon="dot-grid" variant="ghost" />
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content>
+                  {menuItems().map((item) => (
+                    <DropdownMenu.Item onSelect={item.onClick} data-slot={item.dataSlot}>
+                      <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
+                      <DropdownMenu.ItemDescription>{item.description}</DropdownMenu.ItemDescription>
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu>
+          </div>
         </div>
-        {props.children}
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content data-component="context-menu-content">

--- a/packages/app/src/components/message-actions.tsx
+++ b/packages/app/src/components/message-actions.tsx
@@ -15,7 +15,7 @@ interface MessageActionsProps {
   messageID: string
 }
 
-export function MessageActions(props: ParentProps<MessageActionsProps>) {
+function useMessageActions(props: MessageActionsProps) {
   const sync = useSync()
   const sdk = useSDK()
   const prompt = usePrompt()
@@ -85,30 +85,40 @@ export function MessageActions(props: ParentProps<MessageActionsProps>) {
     },
   ]
 
+  return { menuItems }
+}
+
+/** Dropdown menu trigger for message actions (Revert, Fork, Copy) */
+export function MessageActionsMenu(props: MessageActionsProps) {
+  const { menuItems } = useMessageActions(props)
+
+  return (
+    <div data-slot="message-actions-menu">
+      <DropdownMenu>
+        <DropdownMenu.Trigger as={IconButton} icon="dot-grid" variant="ghost" />
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content>
+            {menuItems().map((item) => (
+              <DropdownMenu.Item onSelect={item.onClick} data-slot={item.dataSlot}>
+                <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
+                <DropdownMenu.ItemDescription>{item.description}</DropdownMenu.ItemDescription>
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+/** Context menu wrapper for message actions (right-click menu) */
+export function MessageActions(props: ParentProps<MessageActionsProps>) {
+  const { menuItems } = useMessageActions(props)
+
   return (
     <ContextMenu>
-      <ContextMenu.Trigger as="div" data-component="message-actions" class="group/message-actions">
-        <div class="relative">
-          {props.children}
-          <div
-            data-slot="message-actions-trigger"
-            class="absolute top-1 right-1 opacity-0 group-hover/message-actions:opacity-100 transition-opacity"
-          >
-            <DropdownMenu>
-              <DropdownMenu.Trigger as={IconButton} icon="dot-grid" variant="ghost" />
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content>
-                  {menuItems().map((item) => (
-                    <DropdownMenu.Item onSelect={item.onClick} data-slot={item.dataSlot}>
-                      <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
-                      <DropdownMenu.ItemDescription>{item.description}</DropdownMenu.ItemDescription>
-                    </DropdownMenu.Item>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu>
-          </div>
-        </div>
+      <ContextMenu.Trigger as="div" data-component="message-actions">
+        {props.children}
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content data-component="context-menu-content">

--- a/packages/app/src/components/message-actions.tsx
+++ b/packages/app/src/components/message-actions.tsx
@@ -1,0 +1,121 @@
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
+import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { useSDK } from "@/context/sdk"
+import { useSync } from "@/context/sync"
+import { usePrompt } from "@/context/prompt"
+import { useNavigate } from "@solidjs/router"
+import { extractPromptFromParts } from "@/utils/prompt"
+import { base64Encode } from "@opencode-ai/util/encode"
+import type { TextPart } from "@opencode-ai/sdk/v2/client"
+import type { ParentProps } from "solid-js"
+
+interface MessageActionsProps {
+  sessionID: string
+  messageID: string
+}
+
+export function MessageActions(props: ParentProps<MessageActionsProps>) {
+  const sync = useSync()
+  const sdk = useSDK()
+  const prompt = usePrompt()
+  const navigate = useNavigate()
+
+  const sessionStatus = () => sync.data.session_status[props.sessionID] ?? { type: "idle" }
+  const parts = () => sync.data.part[props.messageID] ?? []
+
+  const handleRevert = async () => {
+    const msgParts = parts()
+    if (!msgParts.length) return
+
+    if (sessionStatus().type !== "idle") {
+      await sdk.client.session.abort({ sessionID: props.sessionID }).catch(() => {})
+    }
+
+    await sdk.client.session.revert({ sessionID: props.sessionID, messageID: props.messageID })
+
+    const restored = extractPromptFromParts(msgParts, { directory: sdk.directory })
+    prompt.set(restored)
+  }
+
+  const handleFork = async () => {
+    const msgParts = parts()
+    if (!msgParts.length) return
+
+    const result = await sdk.client.session.fork({ sessionID: props.sessionID, messageID: props.messageID })
+    if (!result.data?.id) return
+
+    const restored = extractPromptFromParts(msgParts, { directory: sdk.directory })
+
+    navigate(`/${base64Encode(sdk.directory)}/session/${result.data.id}`)
+
+    requestAnimationFrame(() => {
+      prompt.set(restored)
+    })
+  }
+
+  const handleCopy = async () => {
+    const text = parts()
+      .filter((p): p is TextPart => p.type === "text" && !p.synthetic && !p.ignored)
+      .map((p) => p.text)
+      .join("")
+
+    if (!text) return
+
+    await navigator.clipboard.writeText(text)
+  }
+
+  const menuItems = () => [
+    {
+      label: "Revert",
+      description: "undo messages and file changes",
+      onClick: handleRevert,
+      dataSlot: "message-action-revert",
+    },
+    {
+      label: "Fork",
+      description: "create a new session",
+      onClick: handleFork,
+      dataSlot: "message-action-fork",
+    },
+    {
+      label: "Copy",
+      description: "message text to clipboard",
+      onClick: handleCopy,
+      dataSlot: "message-action-copy",
+    },
+  ]
+
+  return (
+    <ContextMenu>
+      <ContextMenu.Trigger as="div" data-component="message-actions" class="group/message-actions relative">
+        <div class="absolute top-2 right-2 opacity-0 group-hover/message-actions:opacity-100 transition-opacity z-10">
+          <DropdownMenu>
+            <DropdownMenu.Trigger as={IconButton} icon="dots-horizontal" data-slot="message-actions-trigger" />
+            <DropdownMenu.Portal>
+              <DropdownMenu.Content>
+                {menuItems().map((item) => (
+                  <DropdownMenu.Item onSelect={item.onClick} data-slot={item.dataSlot}>
+                    <DropdownMenu.ItemLabel>{item.label}</DropdownMenu.ItemLabel>
+                    <DropdownMenu.ItemDescription>{item.description}</DropdownMenu.ItemDescription>
+                  </DropdownMenu.Item>
+                ))}
+              </DropdownMenu.Content>
+            </DropdownMenu.Portal>
+          </DropdownMenu>
+        </div>
+        {props.children}
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content data-component="context-menu-content">
+          {menuItems().map((item) => (
+            <ContextMenu.Item onSelect={item.onClick} data-slot={item.dataSlot}>
+              <ContextMenu.ItemLabel>{item.label}</ContextMenu.ItemLabel>
+              <ContextMenu.ItemDescription>{item.description}</ContextMenu.ItemDescription>
+            </ContextMenu.Item>
+          ))}
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu>
+  )
+}

--- a/packages/app/src/components/message-actions.tsx
+++ b/packages/app/src/components/message-actions.tsx
@@ -38,19 +38,18 @@ export function MessageActions(props: ParentProps<MessageActionsProps>) {
     prompt.set(restored)
   }
 
-  const handleFork = async () => {
+  const handleFork = () => {
     const msgParts = parts()
     if (!msgParts.length) return
 
-    const result = await sdk.client.session.fork({ sessionID: props.sessionID, messageID: props.messageID })
-    if (!result.data?.id) return
-
     const restored = extractPromptFromParts(msgParts, { directory: sdk.directory })
 
-    navigate(`/${base64Encode(sdk.directory)}/session/${result.data.id}`)
-
-    requestAnimationFrame(() => {
-      prompt.set(restored)
+    sdk.client.session.fork({ sessionID: props.sessionID, messageID: props.messageID }).then((result) => {
+      if (!result.data?.id) return
+      navigate(`/${base64Encode(sdk.directory)}/session/${result.data.id}`)
+      setTimeout(() => {
+        prompt.set(restored)
+      }, 500)
     })
   }
 
@@ -91,7 +90,9 @@ export function MessageActions(props: ParentProps<MessageActionsProps>) {
       <ContextMenu.Trigger as="div" data-component="message-actions" class="group/message-actions relative">
         <div class="absolute top-2 right-2 opacity-0 group-hover/message-actions:opacity-100 transition-opacity z-10">
           <DropdownMenu>
-            <DropdownMenu.Trigger as={IconButton} icon="dots-horizontal" data-slot="message-actions-trigger" />
+            <span data-slot="message-actions-trigger">
+              <DropdownMenu.Trigger as={IconButton} icon="dot-grid" />
+            </span>
             <DropdownMenu.Portal>
               <DropdownMenu.Content>
                 {menuItems().map((item) => (

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -7,7 +7,7 @@ import { selectionFromLines, useFile, type SelectedLineRange } from "@/context/f
 import { createStore } from "solid-js/store"
 import { PromptInput } from "@/components/prompt-input"
 import { SessionContextUsage } from "@/components/session-context-usage"
-import { MessageActions } from "@/components/message-actions"
+import { MessageActions, MessageActionsMenu } from "@/components/message-actions"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -1377,6 +1377,7 @@ export default function Page() {
                                       onStepsExpandedToggle={() =>
                                         setStore("expanded", message.id, (open: boolean | undefined) => !open)
                                       }
+                                      actions={<MessageActionsMenu sessionID={params.id!} messageID={message.id} />}
                                       classes={{
                                         root: "min-w-0 w-full relative",
                                         content: "flex flex-col justify-between !overflow-visible",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -7,6 +7,7 @@ import { selectionFromLines, useFile, type SelectedLineRange } from "@/context/f
 import { createStore } from "solid-js/store"
 import { PromptInput } from "@/components/prompt-input"
 import { SessionContextUsage } from "@/components/session-context-usage"
+import { MessageActions } from "@/components/message-actions"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -1359,29 +1360,31 @@ export default function Page() {
                               }
 
                               return (
-                                <div
-                                  id={anchor(message.id)}
-                                  data-message-id={message.id}
-                                  classList={{
-                                    "min-w-0 w-full max-w-full": true,
-                                    "md:max-w-200": !showTabs(),
-                                  }}
-                                >
-                                  <SessionTurn
-                                    sessionID={params.id!}
-                                    messageID={message.id}
-                                    lastUserMessageID={lastUserMessage()?.id}
-                                    stepsExpanded={store.expanded[message.id] ?? false}
-                                    onStepsExpandedToggle={() =>
-                                      setStore("expanded", message.id, (open: boolean | undefined) => !open)
-                                    }
-                                    classes={{
-                                      root: "min-w-0 w-full relative",
-                                      content: "flex flex-col justify-between !overflow-visible",
-                                      container: "w-full px-4 md:px-6",
+                                <MessageActions sessionID={params.id!} messageID={message.id}>
+                                  <div
+                                    id={anchor(message.id)}
+                                    data-message-id={message.id}
+                                    classList={{
+                                      "min-w-0 w-full max-w-full": true,
+                                      "md:max-w-200": !showTabs(),
                                     }}
-                                  />
-                                </div>
+                                  >
+                                    <SessionTurn
+                                      sessionID={params.id!}
+                                      messageID={message.id}
+                                      lastUserMessageID={lastUserMessage()?.id}
+                                      stepsExpanded={store.expanded[message.id] ?? false}
+                                      onStepsExpandedToggle={() =>
+                                        setStore("expanded", message.id, (open: boolean | undefined) => !open)
+                                      }
+                                      classes={{
+                                        root: "min-w-0 w-full relative",
+                                        content: "flex flex-col justify-between !overflow-visible",
+                                        container: "w-full px-4 md:px-6",
+                                      }}
+                                    />
+                                  </div>
+                                </MessageActions>
                               )
                             }}
                           </For>

--- a/packages/ui/src/components/context-menu.css
+++ b/packages/ui/src/components/context-menu.css
@@ -1,0 +1,125 @@
+[data-component="context-menu-content"],
+[data-component="context-menu-sub-content"] {
+  min-width: 8rem;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent);
+  background-clip: padding-box;
+  background-color: var(--surface-raised-stronger-non-alpha);
+  padding: 4px;
+  box-shadow: var(--shadow-md);
+  z-index: 50;
+  transform-origin: var(--kb-menu-content-transform-origin);
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
+
+  &[data-closed] {
+    animation: context-menu-close 0.15s ease-out;
+  }
+
+  &[data-expanded] {
+    animation: context-menu-open 0.15s ease-out;
+  }
+}
+
+[data-component="context-menu-content"],
+[data-component="context-menu-sub-content"] {
+  [data-slot="context-menu-item"],
+  [data-slot="context-menu-checkbox-item"],
+  [data-slot="context-menu-radio-item"],
+  [data-slot="context-menu-sub-trigger"] {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    cursor: default;
+    user-select: none;
+    outline: none;
+
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-small);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    letter-spacing: var(--letter-spacing-normal);
+    color: var(--text-strong);
+
+    &[data-highlighted] {
+      background: var(--surface-raised-base-hover);
+    }
+
+    &[data-disabled] {
+      color: var(--text-weak);
+      pointer-events: none;
+    }
+  }
+
+  [data-slot="context-menu-sub-trigger"] {
+    &[data-expanded] {
+      background: var(--surface-raised-base-hover);
+    }
+  }
+
+  [data-slot="context-menu-item-indicator"] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+  }
+
+  [data-slot="context-menu-item-label"] {
+    flex: 1;
+  }
+
+  [data-slot="context-menu-item-description"] {
+    font-size: var(--font-size-x-small);
+    color: var(--text-weak);
+  }
+
+  [data-slot="context-menu-separator"] {
+    height: 1px;
+    margin: 4px -4px;
+    border-top-color: var(--border-weak-base);
+  }
+
+  [data-slot="context-menu-group-label"] {
+    padding: 4px 8px;
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-x-small);
+    font-weight: var(--font-weight-medium);
+    line-height: var(--line-height-large);
+    letter-spacing: var(--letter-spacing-normal);
+    color: var(--text-weak);
+  }
+
+  [data-slot="context-menu-arrow"] {
+    fill: var(--surface-raised-stronger-non-alpha);
+  }
+}
+
+@keyframes context-menu-open {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes context-menu-close {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+}

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,0 +1,290 @@
+import { ContextMenu as Kobalte } from "@kobalte/core/context-menu"
+import { splitProps } from "solid-js"
+import type { ComponentProps, ParentProps } from "solid-js"
+
+export interface ContextMenuProps extends ComponentProps<typeof Kobalte> {}
+export interface ContextMenuTriggerProps extends ComponentProps<typeof Kobalte.Trigger> {}
+export interface ContextMenuPortalProps extends ComponentProps<typeof Kobalte.Portal> {}
+export interface ContextMenuContentProps extends ComponentProps<typeof Kobalte.Content> {}
+export interface ContextMenuArrowProps extends ComponentProps<typeof Kobalte.Arrow> {}
+export interface ContextMenuSeparatorProps extends ComponentProps<typeof Kobalte.Separator> {}
+export interface ContextMenuGroupProps extends ComponentProps<typeof Kobalte.Group> {}
+export interface ContextMenuGroupLabelProps extends ComponentProps<typeof Kobalte.GroupLabel> {}
+export interface ContextMenuItemProps extends ComponentProps<typeof Kobalte.Item> {}
+export interface ContextMenuItemLabelProps extends ComponentProps<typeof Kobalte.ItemLabel> {}
+export interface ContextMenuItemDescriptionProps extends ComponentProps<typeof Kobalte.ItemDescription> {}
+export interface ContextMenuItemIndicatorProps extends ComponentProps<typeof Kobalte.ItemIndicator> {}
+export interface ContextMenuRadioGroupProps extends ComponentProps<typeof Kobalte.RadioGroup> {}
+export interface ContextMenuRadioItemProps extends ComponentProps<typeof Kobalte.RadioItem> {}
+export interface ContextMenuCheckboxItemProps extends ComponentProps<typeof Kobalte.CheckboxItem> {}
+export interface ContextMenuSubProps extends ComponentProps<typeof Kobalte.Sub> {}
+export interface ContextMenuSubTriggerProps extends ComponentProps<typeof Kobalte.SubTrigger> {}
+export interface ContextMenuSubContentProps extends ComponentProps<typeof Kobalte.SubContent> {}
+
+function ContextMenuRoot(props: ContextMenuProps) {
+  return <Kobalte {...props} data-component="context-menu" />
+}
+
+function ContextMenuTrigger(props: ParentProps<ContextMenuTriggerProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.Trigger
+      {...rest}
+      data-slot="context-menu-trigger"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.Trigger>
+  )
+}
+
+function ContextMenuPortal(props: ContextMenuPortalProps) {
+  return <Kobalte.Portal {...props} />
+}
+
+function ContextMenuContent(props: ParentProps<ContextMenuContentProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.Content
+      {...rest}
+      data-component="context-menu-content"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.Content>
+  )
+}
+
+function ContextMenuArrow(props: ContextMenuArrowProps) {
+  const [local, rest] = splitProps(props, ["class", "classList"])
+  return (
+    <Kobalte.Arrow
+      {...rest}
+      data-slot="context-menu-arrow"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    />
+  )
+}
+
+function ContextMenuSeparator(props: ContextMenuSeparatorProps) {
+  const [local, rest] = splitProps(props, ["class", "classList"])
+  return (
+    <Kobalte.Separator
+      {...rest}
+      data-slot="context-menu-separator"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    />
+  )
+}
+
+function ContextMenuGroup(props: ParentProps<ContextMenuGroupProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.Group
+      {...rest}
+      data-slot="context-menu-group"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.Group>
+  )
+}
+
+function ContextMenuGroupLabel(props: ParentProps<ContextMenuGroupLabelProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.GroupLabel
+      {...rest}
+      data-slot="context-menu-group-label"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.GroupLabel>
+  )
+}
+
+function ContextMenuItem(props: ParentProps<ContextMenuItemProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.Item
+      {...rest}
+      data-slot="context-menu-item"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.Item>
+  )
+}
+
+function ContextMenuItemLabel(props: ParentProps<ContextMenuItemLabelProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.ItemLabel
+      {...rest}
+      data-slot="context-menu-item-label"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.ItemLabel>
+  )
+}
+
+function ContextMenuItemDescription(props: ParentProps<ContextMenuItemDescriptionProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.ItemDescription
+      {...rest}
+      data-slot="context-menu-item-description"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.ItemDescription>
+  )
+}
+
+function ContextMenuItemIndicator(props: ParentProps<ContextMenuItemIndicatorProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.ItemIndicator
+      {...rest}
+      data-slot="context-menu-item-indicator"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.ItemIndicator>
+  )
+}
+
+function ContextMenuRadioGroup(props: ParentProps<ContextMenuRadioGroupProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.RadioGroup
+      {...rest}
+      data-slot="context-menu-radio-group"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.RadioGroup>
+  )
+}
+
+function ContextMenuRadioItem(props: ParentProps<ContextMenuRadioItemProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.RadioItem
+      {...rest}
+      data-slot="context-menu-radio-item"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.RadioItem>
+  )
+}
+
+function ContextMenuCheckboxItem(props: ParentProps<ContextMenuCheckboxItemProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.CheckboxItem
+      {...rest}
+      data-slot="context-menu-checkbox-item"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.CheckboxItem>
+  )
+}
+
+function ContextMenuSub(props: ContextMenuSubProps) {
+  return <Kobalte.Sub {...props} />
+}
+
+function ContextMenuSubTrigger(props: ParentProps<ContextMenuSubTriggerProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.SubTrigger
+      {...rest}
+      data-slot="context-menu-sub-trigger"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.SubTrigger>
+  )
+}
+
+function ContextMenuSubContent(props: ParentProps<ContextMenuSubContentProps>) {
+  const [local, rest] = splitProps(props, ["class", "classList", "children"])
+  return (
+    <Kobalte.SubContent
+      {...rest}
+      data-component="context-menu-sub-content"
+      classList={{
+        ...(local.classList ?? {}),
+        [local.class ?? ""]: !!local.class,
+      }}
+    >
+      {local.children}
+    </Kobalte.SubContent>
+  )
+}
+
+export const ContextMenu = Object.assign(ContextMenuRoot, {
+  Trigger: ContextMenuTrigger,
+  Portal: ContextMenuPortal,
+  Content: ContextMenuContent,
+  Arrow: ContextMenuArrow,
+  Separator: ContextMenuSeparator,
+  Group: ContextMenuGroup,
+  GroupLabel: ContextMenuGroupLabel,
+  Item: ContextMenuItem,
+  ItemLabel: ContextMenuItemLabel,
+  ItemDescription: ContextMenuItemDescription,
+  ItemIndicator: ContextMenuItemIndicator,
+  RadioGroup: ContextMenuRadioGroup,
+  RadioItem: ContextMenuRadioItem,
+  CheckboxItem: ContextMenuCheckboxItem,
+  Sub: ContextMenuSub,
+  SubTrigger: ContextMenuSubTrigger,
+  SubContent: ContextMenuSubContent,
+})

--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -80,15 +80,19 @@
     padding: 8px 12px;
     border-radius: 4px;
 
-    [data-slot="user-message-copy-wrapper"] {
+    [data-slot="user-message-actions"] {
       position: absolute;
       top: 7px;
       right: 7px;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 4px;
       opacity: 0;
       transition: opacity 0.15s ease;
     }
 
-    &:hover [data-slot="user-message-copy-wrapper"] {
+    &:hover [data-slot="user-message-actions"] {
       opacity: 1;
     }
   }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -89,6 +89,7 @@ function DiagnosticsDisplay(props: { diagnostics: Diagnostic[] }): JSX.Element {
 export interface MessageProps {
   message: MessageType
   parts: PartType[]
+  actions?: JSX.Element
 }
 
 export interface MessagePartProps {
@@ -271,7 +272,9 @@ export function Message(props: MessageProps) {
   return (
     <Switch>
       <Match when={props.message.role === "user" && props.message}>
-        {(userMessage) => <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} />}
+        {(userMessage) => (
+          <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} actions={props.actions} />
+        )}
       </Match>
       <Match when={props.message.role === "assistant" && props.message}>
         {(assistantMessage) => (
@@ -295,7 +298,7 @@ export function AssistantMessageDisplay(props: { message: AssistantMessage; part
   return <For each={filteredParts()}>{(part) => <Part part={part} message={props.message} />}</For>
 }
 
-export function UserMessageDisplay(props: { message: UserMessage; parts: PartType[] }) {
+export function UserMessageDisplay(props: { message: UserMessage; parts: PartType[]; actions?: JSX.Element }) {
   const dialog = useDialog()
   const [copied, setCopied] = createSignal(false)
   const [expanded, setExpanded] = createSignal(false)
@@ -406,7 +409,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
           >
             <Icon name="chevron-down" size="small" />
           </button>
-          <div data-slot="user-message-copy-wrapper">
+          <div data-slot="user-message-actions">
             <Tooltip value={copied() ? "Copied!" : "Copy"} placement="top" gutter={8}>
               <IconButton
                 icon={copied() ? "check" : "copy"}
@@ -417,6 +420,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
                 }}
               />
             </Tooltip>
+            {props.actions}
           </div>
         </div>
       </Show>

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -12,7 +12,19 @@ import { useDiffComponent } from "../context/diff"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 
 import { Binary } from "@opencode-ai/util/binary"
-import { createEffect, createMemo, createSignal, For, Match, on, onCleanup, ParentProps, Show, Switch } from "solid-js"
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  JSX,
+  Match,
+  on,
+  onCleanup,
+  ParentProps,
+  Show,
+  Switch,
+} from "solid-js"
 import { DiffChanges } from "./diff-changes"
 import { Message, Part } from "./message-part"
 import { Markdown } from "./markdown"
@@ -126,6 +138,7 @@ export function SessionTurn(
     stepsExpanded?: boolean
     onStepsExpandedToggle?: () => void
     onUserInteracted?: () => void
+    actions?: JSX.Element
     classes?: {
       root?: string
       content?: string
@@ -505,7 +518,7 @@ export function SessionTurn(
                     <div data-slot="session-turn-sticky" ref={setStickyRef}>
                       {/* User Message */}
                       <div data-slot="session-turn-message-content">
-                        <Message message={msg()} parts={stickyParts()} />
+                        <Message message={msg()} parts={stickyParts()} actions={props.actions} />
                       </div>
 
                       {/* Trigger (sticky) */}

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -17,6 +17,7 @@
 @import "../components/diff.css" layer(components);
 @import "../components/diff-changes.css" layer(components);
 @import "../components/dropdown-menu.css" layer(components);
+@import "../components/context-menu.css" layer(components);
 @import "../components/dialog.css" layer(components);
 @import "../components/file-icon.css" layer(components);
 @import "../components/hover-card.css" layer(components);


### PR DESCRIPTION
### What does this PR do?
Fixes #9661
Adds Revert and Fork message actions to the desktop/web app, bringing feature parity with the CLI TUI.
- **Hover menu**: Three-dot button appears next to copy button with Revert/Fork/Copy options
- **Right-click menu**: Context menu on user messages with the same actions

 ### Screenshots
 
 Hover Button
| Before | After |
|--------|-------|
|  <img width="579" height="123" alt="before-button" src="https://github.com/user-attachments/assets/0ffedb17-e1f6-41e5-b2a7-e0e9fa0737d1" /> | <img width="782" height="173" alt="after-buttons" src="https://github.com/user-attachments/assets/bc06e903-f03f-41c5-af82-8b381afb4524" />



 Right-Click Menu
| Before | After |
|--------|-------|
| <img width="574" height="171" alt="before-rc" src="https://github.com/user-attachments/assets/2f3268b0-17c4-471b-ba48-b15e3cb2e7bb" /> | <img width="714" height="186" alt="after-rc" src="https://github.com/user-attachments/assets/64fc4ba4-2e52-4b60-a165-21fd51fd49d0" /> |

 Changes
- `packages/app/src/components/message-actions.tsx` - New MessageActions and MessageActionsMenu components
- `packages/ui/src/components/context-menu.tsx` - New ContextMenu component (wraps Kobalte)
- `packages/ui/src/components/message-part.tsx` - Added `actions` prop to render custom action buttons
- `packages/ui/src/components/session-turn.tsx` - Pass actions through to Message component
- `packages/app/e2e/message-actions.spec.ts` - E2E tests for all actions

### How did you verify your code works?

- [x] Hover shows menu button
- [x] Menu opens with Revert/Fork/Copy options
- [x] Right-click shows context menu
- [x] Revert removes message and restores prompt
- [x] Fork creates new session and navigates to it
- [x] Copy copies message text to clipboard
- [x] All 5 E2E tests pass
