### PR TITLE
fix(opencode): preserve tool input from running state for MCP tool results

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -176,7 +176,7 @@ export namespace SessionProcessor {
                       ...match,
                       state: {
                         status: "completed",
-                        input: value.input,
+                        input: value.input ?? match.state.input,
                         output: value.output.output,
                         metadata: value.output.metadata,
                         title: value.output.title,
@@ -200,7 +200,7 @@ export namespace SessionProcessor {
                       ...match,
                       state: {
                         status: "error",
-                        input: value.input,
+                        input: value.input ?? match.state.input,
                         error: (value.error as any).toString(),
                         time: {
                           start: match.state.time.start,


### PR DESCRIPTION
### What does this PR do?

Fixes MCP tool results failing schema validation when the tool doesn't return `input` in the response.

When processing `tool-result` and `tool-error` events, `value.input` can be undefined for some MCP tools (e.g., chrome-devtools `take_screenshot`). This causes Zod schema validation to fail because `ToolStateCompleted.input` requires a record.

The fix preserves the input from the running tool state (`match.state.input`) when `value.input` is undefined.

Fixes #9666

### How did you verify your code works?

1. Configured chrome-devtools MCP with `take_screenshot` tool
2. Before fix: calling screenshot without `filePath` fails with schema validation error
3. After fix: screenshot completes successfully, input preserved from tool-call phase