### PR TITLE
feat: expose skills as slash commands

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -345,8 +345,9 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = [...command.slashes()]
 
     for (const serverCommand of sync.data.command) {
+      const suffix = serverCommand.mcp ? " (MCP)" : serverCommand.skill ? " (Skill)" : ""
       results.push({
-        display: "/" + serverCommand.name + (serverCommand.mcp ? " (MCP)" : ""),
+        display: "/" + serverCommand.name + suffix,
         description: serverCommand.description,
         onSelect: () => {
           const newText = "/" + serverCommand.name + " "

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -6,6 +6,7 @@ import { Identifier } from "../id/id"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
 import { MCP } from "../mcp"
+import { Skill } from "../skill/skill"
 
 export namespace Command {
   export const Event = {
@@ -27,6 +28,7 @@ export namespace Command {
       agent: z.string().optional(),
       model: z.string().optional(),
       mcp: z.boolean().optional(),
+      skill: z.boolean().optional(),
       // workaround for zod not supporting async functions natively so we use getters
       // https://zod.dev/v4/changelog?id=zfunction
       template: z.promise(z.string()).or(z.string()),
@@ -115,6 +117,18 @@ export namespace Command {
           })
         },
         hints: prompt.arguments?.map((_, i) => `$${i + 1}`) ?? [],
+      }
+    }
+
+    for (const skill of await Skill.all()) {
+      result[skill.name] = {
+        name: skill.name,
+        skill: true,
+        description: skill.description,
+        get template() {
+          return Bun.file(skill.location).text()
+        },
+        hints: ["$ARGUMENTS"],
       }
     }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1605,6 +1605,22 @@ NOTE: At any point in time through this workflow you should feel free to ask the
   export async function command(input: CommandInput) {
     log.info("command", input)
     const command = await Command.get(input.command)
+
+    if (command.skill) {
+      const skillPrompt = input.arguments
+        ? `Use the skill tool to load the "${input.command}" skill, then follow its instructions to handle: ${input.arguments}`
+        : `Use the skill tool to load the "${input.command}" skill and follow its instructions.`
+
+      return prompt({
+        sessionID: input.sessionID,
+        messageID: input.messageID,
+        model: input.model ? Provider.parseModel(input.model) : await lastModel(input.sessionID),
+        agent: input.agent ?? (await Agent.defaultAgent()),
+        parts: [{ type: "text", text: skillPrompt }],
+        variant: input.variant,
+      })
+    }
+
     const agentName = command.agent ?? input.agent ?? (await Agent.defaultAgent())
 
     const raw = input.arguments.match(argsRegex) ?? []

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -45,7 +45,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
       const skill = await Skill.get(params.name)
 
       if (!skill) {
-        const available = await Skill.all().then((x) => Object.keys(x).join(", "))
+        const available = await Skill.all().then((x) => x.map((s) => s.name).join(", "))
         throw new Error(`Skill "${params.name}" not found. Available skills: ${available || "none"}`)
       }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2077,6 +2077,7 @@ export type Command = {
   agent?: string
   model?: string
   mcp?: boolean
+  skill?: boolean
   template: string
   subtask?: boolean
   hints: Array<string>


### PR DESCRIPTION
 Summary
- Add skill loading to Command.list() so skills appear as /skill-name commands
- Skill commands invoke the skill tool to show 'Loaded skill: X' in UI
- Add (Skill) suffix in autocomplete dropdown to distinguish from MCP commands
- Fix skill tool error message to show actual skill names instead of array indices
- Regenerate SDK types with skill?: boolean field

 What does this PR do?
Allows users to invoke skills directly via slash commands (e.g., `/my-skill`) instead of manually calling the skill tool. When a skill command is invoked, it automatically loads the skill and follows its instructions.
**Before:** Users had to know about the skill tool and call it manually
**After:** Skills appear in autocomplete with `(Skill)` suffix and can be invoked like any other command

 How did you verify your code works?
- Created test skills in `.opencode/skill/` directory
- Verified skills appear in TUI autocomplete with `(Skill)` suffix
- Confirmed `/skill-name` invocation triggers the skill tool and shows "Loaded skill: X" in UI
- Tested with arguments: `/skill-name some arguments` passes arguments correctly
