### PR TITLE
fix(app): cleanup pty.exited event listener on unmount

### DIFF
--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -38,7 +38,7 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, sess
     }),
   )
 
-  sdk.event.on("pty.exited", (event) => {
+  const unsub = sdk.event.on("pty.exited", (event) => {
     const id = event.properties.id
     if (!store.all.some((x) => x.id === id)) return
     batch(() => {
@@ -52,6 +52,7 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, sess
       }
     })
   })
+  onCleanup(unsub)
 
   return {
     ready,


### PR DESCRIPTION
### What does this PR do?
as you have asked @adamdotdevin i got better version of unmount on pty.exited :) we dont have to do it with ws.close :) this works better :) 
### How did you verify your code works?
