### PR TITLE
chore: follow conventional commit in nix CI

### DIFF
--- a/.github/workflows/update-nix-hashes.yml
+++ b/.github/workflows/update-nix-hashes.yml
@@ -128,7 +128,7 @@ jobs:
           echo "Changes detected:"
           echo "$STATUS"
           git add "${FILES[@]}"
-          git commit -m "Update $TITLE"
+          git commit -m "chore: update nix node_modules hashes"
 
           BRANCH="${TARGET_BRANCH:-${GITHUB_REF_NAME}}"
           git pull --rebase --autostash origin "$BRANCH"


### PR DESCRIPTION
follow conventional commit in nix CI for updating node_modules hashes
