### PR TITLE
fix(opencode): relax bun version requirement

### DIFF
--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -10,8 +10,11 @@ if (!expectedBunVersion) {
   throw new Error("packageManager field not found in root package.json")
 }
 
-if (!satisfies(process.versions.bun, expectedBunVersion)) {
-  throw new Error(`This script requires bun@${expectedBunVersion}, but you are using bun@${process.versions.bun}`)
+// relax version requirement
+const expectedBunVersionRange = `^${expectedBunVersion}`
+
+if (!satisfies(process.versions.bun, expectedBunVersionRange)) {
+  throw new Error(`This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`)
 }
 
 const env = {


### PR DESCRIPTION
fixes failing CI - semver needs the caret range qualifier to actually relax the dependency

fixes: #9583