### PR TITLE
feat(nix): relax bun versioning

### DIFF
--- a/nix/opencode.nix
+++ b/nix/opencode.nix
@@ -25,6 +25,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
+  patches = [
+    ./patches/relax-bun-version-check.patch
+  ];
+
   configurePhase = ''
     runHook preConfigure
 

--- a/nix/patches/relax-bun-version-check.patch
+++ b/nix/patches/relax-bun-version-check.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/script/src/index.ts b/packages/script/src/index.ts
+index 9d3c6821c..44ed9c21b 100644
+--- a/packages/script/src/index.ts
++++ b/packages/script/src/index.ts
+@@ -11,7 +11,7 @@ if (!expectedBunVersion) {
+ }
+ 
+ if (!satisfies(process.versions.bun, expectedBunVersion)) {
+-  throw new Error(`This script requires bun@${expectedBunVersion}, but you are using bun@${process.versions.bun}`)
++  console.warn(`This script requires bun@${expectedBunVersion}, but you are using bun@${process.versions.bun}`)
+ }
+ 
+ const env = {


### PR DESCRIPTION
### What does this PR do?
It's meant to relax bun versioning, especially for users importing opencode via a flake directly - skipping the nixpkgs repo. Nixpkgs already has fixed this on their side.

### How did you verify your code works?
just ran `nix build` and i no longer get issues