### PR TITLE
fix(tui): prevent sidebar height from overflowing.

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -73,6 +73,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
       <box
         backgroundColor={theme.backgroundPanel}
         width={42}
+        height="100%"
         paddingTop={1}
         paddingBottom={1}
         paddingLeft={2}


### PR DESCRIPTION
### What does this PR do?
- fixes height of the sidebar to "100%", preventing sidebar from overflowing, specially on smaller screens.
- this issue surfaced after this PR (https://github.com/anomalyco/opencode/pull/7288) as it converts sidebar to an overlay for smaller screens

### How did you verify your code works?
- tested fixe against the latest version (1.1.27) by following the steps in #9686 
- fixed version screenshots attached below

**window fullscreen:**
<img width="2565" height="1604" alt="fixed_full" src="https://github.com/user-attachments/assets/8380608d-725d-49b9-ab89-d41a5ce7dba3" />

**window normal/half:**
<img width="2565" height="1604" alt="fixed_half" src="https://github.com/user-attachments/assets/6214d28a-4462-4a6b-8bf3-f2c4b722249c" />

fixes #9686 
