### PR TITLE
fix(ui): align 'upgrade' command with brand guidelines

### DIFF
--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -6,8 +6,8 @@ export namespace UI {
   const LOGO = [
     [`                    `, `             ▄     `],
     [`█▀▀█ █▀▀█ █▀▀█ █▀▀▄ `, `█▀▀▀ █▀▀█ █▀▀█ █▀▀█`],
-    [`█░░█ █░░█ █▀▀▀ █░░█ `, `█░░░ █░░█ █░░█ █▀▀▀`],
-    [`▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀  ▀ `, `▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀`],
+    [`█░░█ █░░█ █^^^ █░░█ `, `█░░░ █░░█ █░░█ █^^^`],
+    [`▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀~~▀ `, `▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀`],
   ]
 
   export const CancelledError = NamedError.create("UICancelledError", z.void())
@@ -47,13 +47,25 @@ export namespace UI {
   }
 
   export function logo(pad?: string) {
+    const leftReset = "\x1b[0m\x1B[38;5;244m";
+    const rightReset = "\x1b[0m";
     const result = []
     for (const row of LOGO) {
       if (pad) result.push(pad)
-      result.push(Bun.color("gray", "ansi"))
-      result.push(row[0])
-      result.push("\x1b[0m")
-      result.push(row[1])
+      result.push(leftReset)
+
+      let left = row[0]
+      left = left.replace(/░/g, `\x1b[30m█${leftReset}`)
+      left = left.replace(/\^/g, `\x1b[40m▀${leftReset}`)
+      left = left.replace(/_/g, "\x1b[48;5;240m ")
+      left = left.replace(/~/g, `\x1b[30m▀${leftReset}`)
+      result.push(left)
+
+      result.push(rightReset)
+      let right = row[1]
+      right = right.replace(/\^/g, `\x1b[48;5;239m▀${rightReset}`)
+
+      result.push(right);
       result.push(EOL)
     }
     return result.join("").trimEnd()


### PR DESCRIPTION
### What does this PR do?

(Fixes https://github.com/anomalyco/opencode/issues/9695) It aligns the logo shown when using the `opencode upgrade` command to align with the logo used in the main TUI.

|Before|After|
|-|-|
|<img width="528" height="227" alt="Screenshot 2026-01-20 at 22 13 34" src="https://github.com/user-attachments/assets/d0a7be55-6a94-4c34-bb39-b2c90e21f322" />|<img width="744" height="256" alt="Screenshot 2026-01-20 at 22 03 14" src="https://github.com/user-attachments/assets/a63a7a2a-3b1c-4a11-87a7-9028d70400e8" />|

### How did you verify your code works?

I ran `bun dev upgrade`