### PR TITLE
fix(app): terminal improvements - focus, rename, error state, CSP

### DIFF
--- a/packages/app/src/components/session/session-sortable-terminal-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-terminal-tab.tsx
@@ -1,14 +1,22 @@
 import type { JSX } from "solid-js"
+import { createSignal, Show } from "solid-js"
 import { createSortable } from "@thisbeyond/solid-dnd"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tabs } from "@opencode-ai/ui/tabs"
+import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
+import { Icon } from "@opencode-ai/ui/icon"
 import { useTerminal, type LocalPTY } from "@/context/terminal"
 import { useLanguage } from "@/context/language"
 
-export function SortableTerminalTab(props: { terminal: LocalPTY }): JSX.Element {
+export function SortableTerminalTab(props: { terminal: LocalPTY; onClose?: () => void }): JSX.Element {
   const terminal = useTerminal()
   const language = useLanguage()
   const sortable = createSortable(props.terminal.id)
+  const [editing, setEditing] = createSignal(false)
+  const [title, setTitle] = createSignal(props.terminal.title)
+  const [menuOpen, setMenuOpen] = createSignal(false)
+  const [menuPosition, setMenuPosition] = createSignal({ x: 0, y: 0 })
+  const [blurEnabled, setBlurEnabled] = createSignal(false)
 
   const label = () => {
     language.locale()
@@ -19,20 +27,138 @@ export function SortableTerminalTab(props: { terminal: LocalPTY }): JSX.Element 
     if (props.terminal.title) return props.terminal.title
     return language.t("terminal.title")
   }
+
+  const close = () => {
+    const count = terminal.all().length
+    terminal.close(props.terminal.id)
+    if (count === 1) {
+      props.onClose?.()
+    }
+  }
+
+  const focus = () => {
+    if (editing()) return
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur()
+    }
+    const wrapper = document.getElementById(`terminal-wrapper-${props.terminal.id}`)
+    const element = wrapper?.querySelector('[data-component="terminal"]') as HTMLElement
+    if (!element) return
+
+    const textarea = element.querySelector("textarea") as HTMLTextAreaElement
+    if (textarea) {
+      textarea.focus()
+      return
+    }
+    element.focus()
+    element.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }))
+  }
+
+  const edit = (e?: Event) => {
+    if (e) {
+      e.stopPropagation()
+      e.preventDefault()
+    }
+
+    setBlurEnabled(false)
+    setTitle(props.terminal.title)
+    setEditing(true)
+    setTimeout(() => {
+      const input = document.getElementById(`terminal-title-input-${props.terminal.id}`) as HTMLInputElement
+      if (!input) return
+      input.focus()
+      input.select()
+      setTimeout(() => setBlurEnabled(true), 100)
+    }, 10)
+  }
+
+  const save = () => {
+    if (!blurEnabled()) return
+
+    const value = title().trim()
+    if (value && value !== props.terminal.title) {
+      terminal.update({ id: props.terminal.id, title: value })
+    }
+    setEditing(false)
+  }
+
+  const keydown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      save()
+      return
+    }
+    if (e.key === "Escape") {
+      e.preventDefault()
+      setEditing(false)
+    }
+  }
+
+  const menu = (e: MouseEvent) => {
+    e.preventDefault()
+    setMenuPosition({ x: e.clientX, y: e.clientY })
+    setMenuOpen(true)
+  }
+
   return (
     // @ts-ignore
     <div use:sortable classList={{ "h-full": true, "opacity-0": sortable.isActiveDraggable }}>
       <div class="relative h-full">
         <Tabs.Trigger
           value={props.terminal.id}
+          onClick={focus}
+          onMouseDown={(e) => e.preventDefault()}
+          onContextMenu={menu}
           closeButton={
-            terminal.all().length > 1 && (
-              <IconButton icon="close" variant="ghost" onClick={() => terminal.close(props.terminal.id)} />
-            )
+            <IconButton
+              icon="close"
+              variant="ghost"
+              onClick={(e) => {
+                e.stopPropagation()
+                close()
+              }}
+            />
           }
         >
-          {label()}
+          <span onDblClick={edit} style={{ visibility: editing() ? "hidden" : "visible" }}>
+            {label()}
+          </span>
         </Tabs.Trigger>
+        <Show when={editing()}>
+          <div class="absolute inset-0 flex items-center px-3 bg-muted z-10 pointer-events-auto">
+            <input
+              id={`terminal-title-input-${props.terminal.id}`}
+              type="text"
+              value={title()}
+              onInput={(e) => setTitle(e.currentTarget.value)}
+              onBlur={save}
+              onKeyDown={keydown}
+              onMouseDown={(e) => e.stopPropagation()}
+              class="bg-transparent border-none outline-none text-sm min-w-0 flex-1"
+            />
+          </div>
+        </Show>
+        <DropdownMenu open={menuOpen()} onOpenChange={setMenuOpen}>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content
+              style={{
+                position: "fixed",
+                left: `${menuPosition().x}px`,
+                top: `${menuPosition().y}px`,
+              }}
+            >
+              <DropdownMenu.Item onSelect={edit}>
+                <Icon name="edit" class="w-4 h-4 mr-2" />
+                Rename
+              </DropdownMenu.Item>
+              <DropdownMenu.Item onSelect={close}>
+                <Icon name="close" class="w-4 h-4 mr-2" />
+                Close
+              </DropdownMenu.Item>
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu>
       </div>
     </div>
   )

--- a/packages/app/src/context/terminal.tsx
+++ b/packages/app/src/context/terminal.tsx
@@ -13,6 +13,7 @@ export type LocalPTY = {
   cols?: number
   buffer?: string
   scrollY?: number
+  error?: boolean
 }
 
 const WORKSPACE_KEY = "__workspace__"
@@ -107,14 +108,15 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, sess
         .then((pty) => {
           const id = pty.data?.id
           if (!id) return
-          setStore("all", [
-            ...store.all,
-            {
-              id,
-              title: pty.data?.title ?? "Terminal",
-              titleNumber: nextNumber,
-            },
-          ])
+          const newTerminal = {
+            id,
+            title: pty.data?.title ?? "Terminal",
+            titleNumber: nextNumber,
+          }
+          setStore("all", (all) => {
+            const newAll = [...all, newTerminal]
+            return newAll
+          })
           setStore("active", id)
         })
         .catch((e) => {
@@ -122,7 +124,10 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, sess
         })
     },
     update(pty: Partial<LocalPTY> & { id: string }) {
-      setStore("all", (x) => x.map((x) => (x.id === pty.id ? { ...x, ...pty } : x)))
+      const index = store.all.findIndex((x) => x.id === pty.id)
+      if (index !== -1) {
+        setStore("all", index, (existing) => ({ ...existing, ...pty }))
+      }
       sdk.client.pty
         .update({
           ptyID: pty.id,
@@ -157,18 +162,29 @@ function createTerminalSession(sdk: ReturnType<typeof useSDK>, dir: string, sess
     open(id: string) {
       setStore("active", id)
     },
+    next() {
+      const index = store.all.findIndex((x) => x.id === store.active)
+      if (index === -1) return
+      const nextIndex = (index + 1) % store.all.length
+      setStore("active", store.all[nextIndex]?.id)
+    },
+    previous() {
+      const index = store.all.findIndex((x) => x.id === store.active)
+      if (index === -1) return
+      const prevIndex = index === 0 ? store.all.length - 1 : index - 1
+      setStore("active", store.all[prevIndex]?.id)
+    },
     async close(id: string) {
       batch(() => {
-        setStore(
-          "all",
-          store.all.filter((x) => x.id !== id),
-        )
+        const filtered = store.all.filter((x) => x.id !== id)
         if (store.active === id) {
           const index = store.all.findIndex((f) => f.id === id)
-          const previous = store.all[Math.max(0, index - 1)]
-          setStore("active", previous?.id)
+          const next = index > 0 ? index - 1 : 0
+          setStore("active", filtered[next]?.id)
         }
+        setStore("all", filtered)
       })
+
       await sdk.client.pty.remove({ ptyID: id }).catch((e) => {
         console.error("Failed to close terminal", e)
       })
@@ -244,6 +260,8 @@ export const { use: useTerminal, provider: TerminalProvider } = createSimpleCont
       open: (id: string) => workspace().open(id),
       close: (id: string) => workspace().close(id),
       move: (id: string, to: number) => workspace().move(id, to),
+      next: () => workspace().next(),
+      previous: () => workspace().previous(),
     }
   },
 })

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -499,6 +499,7 @@ export namespace Server {
         )
         .all("/*", async (c) => {
           const path = c.req.path
+
           const response = await proxy(`https://app.opencode.ai${path}`, {
             ...c.req,
             headers: {
@@ -508,7 +509,7 @@ export namespace Server {
           })
           response.headers.set(
             "Content-Security-Policy",
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' data:",
           )
           return response
         }) as unknown as Hono,


### PR DESCRIPTION
## Summary
- **Terminal focus fix** - Keyboard input now goes to terminal instead of chat (focuses ghostty's internal textarea)
- **Terminal rename** - Double-click tab or right-click → Rename (with overlay input approach)
- **Terminal error state** - Shows dismissable "Connection Lost" message when connection fails
- **CSP update** - Added `wasm-unsafe-eval` to `script-src` and `data:` to `connect-src` for ghostty WASM
- **OPENCODE_TERMINAL=1 env var** - Added for PTY sessions to detect opencode terminal context
- **Terminal navigation** - Added `next()` and `previous()` methods to terminal context

## Issues Fixed
- Fixes #9420 - CSP blocking WASM/data: URI
- Fixes #7578 - Terminal not working (input goes to chat)
- Fixes #9023 - Aggressive auto-focus prevents terminal interaction
- Fixes #7116 - Can't rename ghostty tab
- Fixes #6004 - Terminal freezes on shell exit (partially - server-side fix was in #9506)

## Files Changed
- `packages/app/src/components/session/session-sortable-terminal-tab.tsx` - Rename functionality
- `packages/app/src/components/terminal.tsx` - Simplified WebSocket close handling
- `packages/app/src/context/terminal.tsx` - Added error field, improved close() logic, navigation
- `packages/app/src/pages/session.tsx` - Terminal focus effect, error UI, disabled chat autofocus
- `packages/opencode/src/pty/index.ts` - Added OPENCODE_TERMINAL=1 env var
- `packages/opencode/src/server/server.ts` - Updated CSP for WASM

## Testing
Tested manually with `bun dev` for both backend and frontend.