### PR TITLE
fix(snapshot): handle git add failures with --ignore-errors fallback

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -65,7 +65,22 @@ export namespace Snapshot {
       await $`git --git-dir ${git} config core.autocrlf false`.quiet().nothrow()
       log.info("initialized")
     }
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+    // Try to add all files, with fallback for problematic files (e.g., Windows reserved names like 'nul')
+    const addResult = await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`
+      .quiet()
+      .cwd(Instance.directory)
+      .nothrow()
+    if (addResult.exitCode !== 0) {
+      log.warn("git add failed, retrying with --ignore-errors", {
+        exitCode: addResult.exitCode,
+        stderr: addResult.stderr.toString(),
+      })
+      // Retry with --ignore-errors to skip problematic files and continue
+      await $`git --git-dir ${git} --work-tree ${Instance.worktree} add --ignore-errors .`
+        .quiet()
+        .cwd(Instance.directory)
+        .nothrow()
+    }
     const hash = await $`git --git-dir ${git} --work-tree ${Instance.worktree} write-tree`
       .quiet()
       .cwd(Instance.directory)


### PR DESCRIPTION
## Problem

When `git add .` fails during snapshot initialization (e.g., due to Windows reserved filenames like `nul`, `con`, `aux`, `prn`), the snapshot silently returns the **empty tree hash** (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`).

This causes:
- All diff calculations to be based on empty tree
- `undo` command only reverts conversation, **not code changes**
- `revert` functionality completely non-functional
- No error message shown to user

### Reproduction Steps
1. Create a file named `nul` in a project directory (Windows)
2. Start opencode and make code changes
3. Try to undo - conversation reverts but files remain unchanged

### Log Evidence
```
INFO service=snapshot hash=4b825dc642cb6eb9a060e54bf8d69288fbee4904 cwd=E:\project git=...
```
The hash `4b825dc642cb6eb9a060e54bf8d69288fbee4904` is Git's well-known empty tree hash.

## Solution

- Check `git add` exit code and log warnings on failure
- Retry with `--ignore-errors` flag to skip problematic files
- This allows snapshot tracking to work for all other files even when some files can't be added

## Changes

- `packages/opencode/src/snapshot/index.ts`: Modified `track()` function to handle `git add` failures gracefully

## Testing

Tested on Windows with a file named `nul` that previously broke snapshot initialization. After the fix, snapshot correctly tracks all other files and undo/revert works as expected.