### PR TITLE
docs: add Anthropic subscription warning and update feature list to highlight GitHub Copilot

### DIFF
--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -192,7 +192,7 @@ export default function Home() {
               <li>
                 <span>[*]</span>
                 <div>
-                  <strong>Claude Pro</strong> Log in with Anthropic to use your Claude Pro or Max account
+                  <strong>GitHub Copilot</strong> Log in with GitHub to use your Copilot account
                 </div>
               </li>
               <li>

--- a/packages/console/app/src/routes/temp.tsx
+++ b/packages/console/app/src/routes/temp.tsx
@@ -89,7 +89,7 @@ export default function Home() {
               <strong>Shareable links</strong> Share a link to any sessions for reference or to debug
             </li>
             <li>
-              <strong>Claude Pro</strong> Log in with Anthropic to use your Claude Pro or Max account
+              <strong>GitHub Copilot</strong> Log in with GitHub to use your Copilot account
             </li>
             <li>
               <strong>ChatGPT Plus/Pro</strong> Log in with OpenAI to use your ChatGPT Plus or Pro account

--- a/packages/web/src/components/Lander.astro
+++ b/packages/web/src/components/Lander.astro
@@ -77,7 +77,7 @@ if (image) {
         <li><b>LSP enabled</b>: Automatically loads the right LSPs for the LLM.</li>
         <li><b>Multi-session</b>: Start multiple agents in parallel on the same project.</li>
         <li><b>Shareable links</b>: Share a link to any sessions for reference or to debug.</li>
-        <li><b>Claude Pro</b>: Log in with Anthropic to use your Claude Pro or Max account.</li>
+        <li><b>GitHub Copilot</b>: Log in with GitHub to use your Copilot account.</li>
         <li><b>ChatGPT Plus/Pro</b>: Log in with OpenAI to use your ChatGPT Plus or Pro account.</li>
         <li><b>Use any model</b>: Supports 75+ LLM providers through <a href="https://models.dev">Models.dev</a>, including local models.</li>
       </ul>

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -235,6 +235,10 @@ To use Amazon Bedrock with OpenCode:
 
 We recommend signing up for [Claude Pro](https://www.anthropic.com/news/claude-pro) or [Max](https://www.anthropic.com/max).
 
+:::info
+We've received reports of some users having their subscriptions blocked while using it with OpenCode.
+:::
+
 1. Once you've signed up, run the `/connect` command and select Anthropic.
 
    ```txt


### PR DESCRIPTION
## Summary
- Added info warning box to Anthropic provider docs about reports of subscription blocking
- Updated feature list on homepage/lander pages to replace "Claude Pro" with "GitHub Copilot" integration

## Changes
- `packages/web/src/content/docs/providers.mdx`: Added warning about subscription blocking under Anthropic section
- `packages/web/src/components/Lander.astro`: Updated feature list entry
- `packages/console/app/src/routes/index.tsx`: Updated feature list entry  
- `packages/console/app/src/routes/temp.tsx`: Updated feature list entry