### PR TITLE
fix(app): fix numbered list rendering in web markdown

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -2,6 +2,14 @@
 
 - NEVER try to restart the app, or the server process, EVER.
 
+## Local Dev
+
+- `opencode dev web` proxies `https://app.opencode.ai`, so local UI/CSS changes will not show there.
+- For local UI changes, run the backend and app dev servers separately.
+- Backend (from `packages/opencode`): `bun run --conditions=browser ./src/index.ts serve --port 4096`
+- App (from `packages/app`): `bun dev -- --port 4444`
+- Open `http://localhost:4444` to verify UI changes (it targets the backend at `http://localhost:4096`).
+
 ## SolidJS
 
 - Always prefer `createStore` over multiple `createSignal` calls

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -6,6 +6,26 @@
   }
 }
 
+[data-component="markdown"] ul {
+  list-style: disc outside;
+  padding-left: 1.5rem;
+}
+
+[data-component="markdown"] ol {
+  list-style: decimal outside;
+  padding-left: 1.5rem;
+}
+
+[data-component="markdown"] li > p:first-child {
+  display: inline;
+  margin: 0;
+}
+
+[data-component="markdown"] li > p + p {
+  display: block;
+  margin-top: 0.5rem;
+}
+
 *[data-tauri-drag-region] {
   app-region: drag;
 }


### PR DESCRIPTION
## Summary
- Fix numbered/bulleted lists in web markdown rendering where numbers appeared on separate lines from content
- The issue was caused by `<p>` tags inside `<li>` elements (loose lists from marked) combined with `list-style-position: inside`
- Added CSS to make first paragraph inline with list markers
- Updated AGENTS.md with local dev workflow for testing UI changes

## Details
`opencode dev web` proxies from `app.opencode.ai`, so local CSS changes don't show. To test local UI changes:
- Backend: `bun run --conditions=browser ./src/index.ts serve --port 4096` (from `packages/opencode`)
- App: `bun dev -- --port 4444` (from `packages/app`)