### PR TITLE
feat(opencode): add configurable shell resolution with plugin support

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -880,6 +880,7 @@ export namespace Config {
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
+      shell: z.string().optional().describe("Shell to use for command execution"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -880,7 +880,12 @@ export namespace Config {
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
-      shell: z.string().optional().describe("Shell to use for command execution"),
+      shell: z
+        .string()
+        .optional()
+        .describe(
+          'Absolute path to the shell binary to use for command execution. This value takes priority over the $SHELL environment variable and any shell resolved via plugin hooks. Example: "/bin/bash" or "/usr/bin/zsh"',
+        ),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -95,7 +95,7 @@ export namespace Pty {
 
   export async function create(input: CreateInput) {
     const id = Identifier.create("pty", false)
-    const command = input.command || Shell.preferred()
+    const command = input.command || (await Shell.preferred())
     const args = input.args || []
     if (command.endsWith("sh")) {
       args.push("-l")

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1430,7 +1430,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       },
     }
     await Session.updatePart(part)
-    const shell = Shell.preferred()
+    const shell = await Shell.preferred()
     const shellName = (
       process.platform === "win32" ? path.win32.basename(shell, ".exe") : path.basename(shell)
     ).toLowerCase()

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -1,7 +1,8 @@
 import { Flag } from "@/flag/flag"
-import { lazy } from "@/util/lazy"
 import path from "path"
 import { spawn, type ChildProcess } from "child_process"
+import { Config } from "@/config/config"
+import { Plugin } from "@/plugin"
 
 const SIGKILL_TIMEOUT_MS = 200
 
@@ -53,15 +54,27 @@ export namespace Shell {
     return "/bin/sh"
   }
 
-  export const preferred = lazy(() => {
-    const s = process.env.SHELL
-    if (s) return s
-    return fallback()
-  })
+  async function fromConfigOrPlugin() {
+    const config = await Config.get().catch(() => undefined)
+    if (config?.shell) return config.shell
 
-  export const acceptable = lazy(() => {
+    const result = { shell: "" }
+    await Plugin.trigger("shell.resolve", { platform: process.platform }, result)
+    return result.shell || undefined
+  }
+
+  export async function preferred() {
+    const override = await fromConfigOrPlugin()
+    if (override) return override
+    return process.env.SHELL || fallback()
+  }
+
+  export async function acceptable() {
+    const override = await fromConfigOrPlugin()
+    if (override) return override
+
     const s = process.env.SHELL
     if (s && !BLACKLIST.has(process.platform === "win32" ? path.win32.basename(s) : path.basename(s))) return s
     return fallback()
-  })
+  }
 }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -52,7 +52,7 @@ const parser = lazy(async () => {
 
 // TODO: we may wanna rename this tool so it works better on other shells
 export const BashTool = Tool.define("bash", async () => {
-  const shell = Shell.acceptable()
+  const shell = await Shell.acceptable()
   log.info("bash tool using shell", { shell })
 
   return {

--- a/packages/opencode/test/shell/shell.test.ts
+++ b/packages/opencode/test/shell/shell.test.ts
@@ -1,0 +1,80 @@
+import { expect, test, mock } from "bun:test"
+import { Shell } from "../../src/shell/shell"
+import { Config } from "../../src/config/config"
+import { Plugin } from "../../src/plugin"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+test("Shell.preferred resolves from config", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      shell: "/custom/shell",
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const shell = await Shell.preferred()
+      expect(shell).toBe("/custom/shell")
+    },
+  })
+})
+
+test("Shell.acceptable resolves from config", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      shell: "/custom/acceptable/shell",
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const shell = await Shell.acceptable()
+      expect(shell).toBe("/custom/acceptable/shell")
+    },
+  })
+})
+
+test("Shell.preferred resolves from plugin", async () => {
+  const originalTrigger = Plugin.trigger
+  Plugin.trigger = mock(async (name, input, output) => {
+    if (name === "shell.resolve") {
+      output.shell = "/plugin/resolved/shell"
+    }
+  })
+
+  try {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shell = await Shell.preferred()
+        expect(shell).toBe("/plugin/resolved/shell")
+        expect(Plugin.trigger).toHaveBeenCalledWith("shell.resolve", expect.anything(), expect.anything())
+      },
+    })
+  } finally {
+    Plugin.trigger = originalTrigger
+  }
+})
+
+test("Shell.preferred falls back to environment/system", async () => {
+  const originalEnvShell = process.env.SHELL
+  process.env.SHELL = "/env/shell"
+
+  try {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shell = await Shell.preferred()
+        expect(shell).toBe("/env/shell")
+      },
+    })
+  } finally {
+    process.env.SHELL = originalEnvShell
+  }
+})

--- a/packages/opencode/test/shell/shell.test.ts
+++ b/packages/opencode/test/shell/shell.test.ts
@@ -1,10 +1,8 @@
 import { expect, test, mock } from "bun:test"
 import { Shell } from "../../src/shell/shell"
-import { Config } from "../../src/config/config"
 import { Plugin } from "../../src/plugin"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
-import path from "path"
 
 test("Shell.preferred resolves from config", async () => {
   await using tmp = await tmpdir({
@@ -44,6 +42,7 @@ test("Shell.preferred resolves from plugin", async () => {
     if (name === "shell.resolve") {
       output.shell = "/plugin/resolved/shell"
     }
+    return output
   })
 
   try {
@@ -54,6 +53,29 @@ test("Shell.preferred resolves from plugin", async () => {
         const shell = await Shell.preferred()
         expect(shell).toBe("/plugin/resolved/shell")
         expect(Plugin.trigger).toHaveBeenCalledWith("shell.resolve", expect.anything(), expect.anything())
+      },
+    })
+  } finally {
+    Plugin.trigger = originalTrigger
+  }
+})
+
+test("Shell.acceptable resolves from plugin", async () => {
+  const originalTrigger = Plugin.trigger
+  Plugin.trigger = mock(async (name, input, output) => {
+    if (name === "shell.resolve") {
+      output.shell = "/plugin/resolved/shell"
+    }
+    return output
+  })
+
+  try {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shell = await Shell.acceptable()
+        expect(shell).toBe("/plugin/resolved/shell")
       },
     })
   } finally {
@@ -72,6 +94,27 @@ test("Shell.preferred falls back to environment/system", async () => {
       fn: async () => {
         const shell = await Shell.preferred()
         expect(shell).toBe("/env/shell")
+      },
+    })
+  } finally {
+    process.env.SHELL = originalEnvShell
+  }
+})
+
+test("Shell.acceptable falls back when SHELL is blacklisted", async () => {
+  const originalEnvShell = process.env.SHELL
+  process.env.SHELL = "/usr/bin/fish"
+
+  try {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shell = await Shell.acceptable()
+        // Should NOT return fish since it's blacklisted
+        expect(shell).not.toBe("/usr/bin/fish")
+        // Should return a fallback shell
+        expect(shell).toBeTruthy()
       },
     })
   } finally {

--- a/packages/opencode/test/shell/shell.test.ts
+++ b/packages/opencode/test/shell/shell.test.ts
@@ -121,3 +121,49 @@ test("Shell.acceptable falls back when SHELL is blacklisted", async () => {
     process.env.SHELL = originalEnvShell
   }
 })
+
+test("Config takes priority over plugin", async () => {
+  const originalTrigger = Plugin.trigger
+  Plugin.trigger = mock(async (name, input, output) => {
+    if (name === "shell.resolve") {
+      output.shell = "/plugin/shell"
+    }
+    return output
+  })
+
+  try {
+    await using tmp = await tmpdir({
+      config: {
+        shell: "/config/shell",
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const shell = await Shell.preferred()
+        // Config should win over plugin
+        expect(shell).toBe("/config/shell")
+      },
+    })
+  } finally {
+    Plugin.trigger = originalTrigger
+  }
+})
+
+test("Config can override blacklist for Shell.acceptable", async () => {
+  // fish is normally blacklisted, but config should allow explicit override
+  await using tmp = await tmpdir({
+    config: {
+      shell: "/usr/bin/fish",
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const shell = await Shell.acceptable()
+      // Config explicitly sets fish, so it should be allowed despite blacklist
+      expect(shell).toBe("/usr/bin/fish")
+    },
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -173,6 +173,7 @@ export interface Hooks {
     output: { temperature: number; topP: number; topK: number; options: Record<string, any> },
   ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  "shell.resolve"?: (input: { platform: string }, output: { shell: string }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
     output: { parts: Part[] },

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -173,6 +173,19 @@ export interface Hooks {
     output: { temperature: number; topP: number; topK: number; options: Record<string, any> },
   ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  /**
+   * Called when resolving which shell to use for command execution.
+   *
+   * This hook participates in the shell resolution priority chain and allows
+   * plugins to override the default shell selection based on the current
+   * platform or runtime environment.
+   *
+   * Example use cases:
+   * - Selecting a different shell when running inside a container or VM
+   * - Routing commands to a remote shell for specific platforms
+   * - Enforcing a particular shell (e.g., `bash`, `zsh`, `powershell`) for
+   *   consistency across environments
+   */
   "shell.resolve"?: (input: { platform: string }, output: { shell: string }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1586,6 +1586,10 @@ export type Config = {
    * Theme name to use for the interface
    */
   theme?: string
+  /**
+   * Shell to use for command execution
+   */
+  shell?: string
   keybinds?: KeybindsConfig
   logLevel?: LogLevel
   /**

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1587,7 +1587,7 @@ export type Config = {
    */
   theme?: string
   /**
-   * Shell to use for command execution
+   * Absolute path to the shell binary to use for command execution. This value takes priority over the $SHELL environment variable and any shell resolved via plugin hooks. Example: "/bin/bash" or "/usr/bin/zsh"
    */
   shell?: string
   keybinds?: KeybindsConfig

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9313,6 +9313,10 @@
             "description": "Theme name to use for the interface",
             "type": "string"
           },
+          "shell": {
+            "description": "Shell to use for command execution",
+            "type": "string"
+          },
           "keybinds": {
             "$ref": "#/components/schemas/KeybindsConfig"
           },

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9314,7 +9314,7 @@
             "type": "string"
           },
           "shell": {
-            "description": "Shell to use for command execution",
+            "description": "Absolute path to the shell binary to use for command execution. This value takes priority over the $SHELL environment variable and any shell resolved via plugin hooks. Example: \"/bin/bash\" or \"/usr/bin/zsh\"",
             "type": "string"
           },
           "keybinds": {


### PR DESCRIPTION
## Summary

Adds a first-class way to control which shell OpenCode uses when executing commands. Users (and plugin authors) can now override shell resolution explicitly instead of relying on `$SHELL` and platform defaults.

Fixes #4702

### Problem

Today, the bash tool’s shell selection is implicit: OpenCode primarily relies on `$SHELL` and then falls back to OS defaults. That’s fine for simple local setups, but it breaks down whenever *“my login shell”* is not the same as *“the shell OpenCode should execute commands with.”* `$SHELL` is global, can point at non-POSIX shells, and is often misleading in containerized/remote/dev environments (#8396), forcing users into brittle workarounds (wrapper scripts, aliases, or forks) just to control command execution. 

This shows up in several common scenarios:

- **Sandboxed execution / safer “allow” mode:** Teams want to route commands through a controlled entrypoint (e.g., a wrapper that runs `docker run` with a read-only filesystem) so they can set `"bash": "allow"` without approving every command while still reducing risk. #4702
- **Non-POSIX login shells:** Developers using Fish/Nushell as their default shell still need OpenCode to run Bash/Zsh for agent-generated scripts and tooling compatibility. #8716
- **Per-project consistency:** Repos may require a specific shell (e.g., `/bin/bash` for CI parity or `/bin/zsh` for team conventions) independent of the user’s interactive environment.
- **Remote & ephemeral environments:** In nix-shell, devcontainers, SSH sessions, or remote IDEs, `$SHELL` can reflect the host/login context rather than the environment where commands should run leading to surprising behavior and “works on my machine” inconsistencies.
- **Enterprise policy & compliance:** Orgs often need to standardize execution through an approved shell entrypoint (auditing, environment bootstrapping, restricted PATH), which must be configurable without asking every developer to change their global shell.

### Solution

Shell resolution is now explicit and extensible, while preserving existing behavior by default. OpenCode resolves the shell using the following priority order:

1. **Config override**  set `"shell": "/bin/zsh"` (or a wrapper) in `opencode.json`
2. **Plugin hook** `shell.resolve` can dynamically choose a shell per workspace/environment
3. **Environment** `$SHELL` (existing behavior)
4. **Fallback**  system default (existing behavior)

This keeps backward compatibility for current users, but unlocks predictable, per-project and policy-driven shell behavior for advanced setups.
