### PR TITLE
chore: revert "Update flake.lock"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768569498,
-        "narHash": "sha256-bB6Nt99Cj8Nu5nIUq0GLmpiErIT5KFshMQJGMZwgqUo=",
+        "lastModified": 1768302833,
+        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "be5afa0fcb31f0a96bf9ecba05a516c66fcd8114",
+        "rev": "61db79b0c6b838d9894923920b612048e1201926",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This reverts commit 7621c5cafbc5f853806bf8a9c95ebaa727bda15f.

more care should be taken when updating the pinned nixpkgs - previous bad CI did so without even checking if opencode still built

new CI avoids this problem, however this commit from the old CI made it onto a branch that was only merged recently

Note: there appear to be some other branches with bad nixpkgs committed by the old CI (e.g. sqlite@49a196c6f390b7c983eccae3d7a1845ee1b09648) hopefully we won't need to fight this for too long
