### PR TITLE
fix(ui): remove portal spacer and fix terminal toggle padding

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -212,9 +212,9 @@ export function SessionHeader() {
                   title="Toggle terminal"
                   keybind={command.keybind("terminal.toggle")}
                 >
-                  <Button
+              <Button
                     variant="ghost"
-                    class="group/terminal-toggle size-6 p-0"
+                    class="group/terminal-toggle size-8 rounded-md"
                     onClick={() => view().terminal.toggle()}
                   >
                     <div class="relative flex items-center justify-center size-4 [&>*]:absolute [&>*]:inset-0">

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -105,10 +105,8 @@ export function Titlebar() {
         </TooltipKeybind>
         <div id="opencode-titlebar-left" class="flex items-center gap-3 min-w-0 px-2" />
         <div class="flex-1 h-full" data-tauri-drag-region />
-        <div id="opencode-titlebar-right" class="flex items-center gap-3 shrink-0" />
-        <Show when={reserve()}>
-          <div class="w-[120px] h-full shrink-0" data-tauri-drag-region />
-        </Show>
+        <div id="opencode-titlebar-right" class="flex items-center gap-3 shrink-0 flex-1 justify-end" />
+
       </div>
       <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
         <div id="opencode-titlebar-center" class="pointer-events-auto" />


### PR DESCRIPTION
Fixes #9712 
Fixes #9713 

### What does this PR do?
Removed the right-edge portal spacer behavior so no trailing space appears next to Share button
Updated the terminal toggle button to size-8 with rounded corners to align with other buttons in the UI

### How did you verify your code works?

Open a session : confirm there is no trailing space next to the Share button.
Compare the terminal toggle with the other buttons in the app and ensure button padding is consistent

#### Spacing comparsion
Before:
<img width="1919" height="70" alt="image" src="https://github.com/user-attachments/assets/c2df1666-6f44-4569-8f8a-1ab572c43f35" />

After:
<img width="1920" height="73" alt="image" src="https://github.com/user-attachments/assets/a562644f-1335-418f-a472-cba3c5db889f" />


#### Button comparsion

Before:
<img width="128" height="59" alt="image" src="https://github.com/user-attachments/assets/af29ca58-03f5-4151-87be-bf3327fbe682" />

After:
<img width="120" height="58" alt="image" src="https://github.com/user-attachments/assets/bfdbfb56-674a-48fb-890d-a2d045b84f17" />

