### PR TITLE
fix(ui): preserve filename casing in edit/write tool titles

### DIFF
--- a/packages/ui/src/components/message-part.css
+++ b/packages/ui/src/components/message-part.css
@@ -230,6 +230,9 @@
 
   [data-slot="message-part-title"] {
     flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-family: var(--font-family-sans);
     font-size: var(--font-size-base);
     font-style: normal;
@@ -237,7 +240,14 @@
     line-height: var(--line-height-large);
     letter-spacing: var(--letter-spacing-normal);
     color: var(--text-base);
+  }
+
+  [data-slot="message-part-title-text"] {
     text-transform: capitalize;
+  }
+
+  [data-slot="message-part-title-filename"] {
+    /* No text-transform - preserve original filename casing */
   }
 
   [data-slot="message-part-path"] {

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1025,7 +1025,8 @@ ToolRegistry.register({
           <div data-component="edit-trigger">
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
-                {i18n.t("ui.messagePart.title.edit")} {filename()}
+                <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.edit")}</span>
+                <span data-slot="message-part-title-filename">{filename()}</span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">
@@ -1077,7 +1078,8 @@ ToolRegistry.register({
           <div data-component="write-trigger">
             <div data-slot="message-part-title-area">
               <div data-slot="message-part-title">
-                {i18n.t("ui.messagePart.title.write")} {filename()}
+                <span data-slot="message-part-title-text">{i18n.t("ui.messagePart.title.write")}</span>
+                <span data-slot="message-part-title-filename">{filename()}</span>
               </div>
               <Show when={props.input.filePath?.includes("/")}>
                 <div data-slot="message-part-path">


### PR DESCRIPTION
## Summary
- Separates title text from filename in edit/write tool triggers
- CSS `text-transform: capitalize` now only applies to action label (Edit/Write), not the filename
- Fixes incorrect display of filenames like "myFile.tsx" being shown as "Myfile.tsx"

Fixes #9751

## Changes
- Modified `packages/ui/src/components/message-part.tsx`: Split title into separate `<span>` elements for title text and filename
- Modified `packages/ui/src/components/message-part.css`: Added new CSS selectors for title-text (with capitalize) and title-filename (without capitalize)

## Test plan
- [ ] Open a session with edit/write tool usage
- [ ] Verify filenames display with original casing (e.g., "myFile.tsx" not "Myfile.tsx")
- [ ] Verify action labels still show capitalized (e.g., "Edit", "Write")

🤖 Generated with [Claude Code](https://claude.com/claude-code)