### PR TITLE
feat(app): allow users to select directory text on new session

### DIFF
--- a/packages/app/src/components/session/session-new-view.tsx
+++ b/packages/app/src/components/session/session-new-view.tsx
@@ -53,7 +53,7 @@ export function NewSessionView(props: NewSessionViewProps) {
       <div class="text-20-medium text-text-weaker">{language.t("command.session.new")}</div>
       <div class="flex justify-center items-center gap-3">
         <Icon name="folder" size="small" />
-        <div class="text-12-medium text-text-weak">
+        <div class="text-12-medium text-text-weak select-text">
           {getDirectory(projectRoot())}
           <span class="text-text-strong">{getFilename(projectRoot())}</span>
         </div>


### PR DESCRIPTION
### What does this PR do?

Makes the directory text selectable so that it can be copied

<img width="518" height="379" alt="Screenshot 2026-01-20 at 9 59 23 PM" src="https://github.com/user-attachments/assets/b9346e7c-b426-4065-a0c2-f58e2b3b055e" />


### How did you verify your code works?

Ran it locally:

https://github.com/user-attachments/assets/291b879b-6cf1-4adf-97c5-5aa55ae78a5d



Closes: https://github.com/anomalyco/opencode/issues/9759
