### PR TITLE
fix(desktop): macos headlights not centered in titlebar

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -84,7 +84,7 @@ export function Titlebar() {
         onMouseDown={drag}
       >
         <Show when={mac()}>
-          <div class="w-[72px] h-full shrink-0" data-tauri-drag-region />
+          <div class="w-20 h-full shrink-0" data-tauri-drag-region />
           <div class="xl:hidden w-10 shrink-0 flex items-center justify-center">
             <IconButton icon="menu" variant="ghost" class="size-8 rounded-md" onClick={layout.mobileSidebar.toggle} />
           </div>

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
         "zoomHotkeysEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 12.0, "y": 18.0 }
+        "trafficLightPosition": { "x": 12.0, "y": 22.0 }
       }
     ],
     "withGlobalTauri": true,

--- a/packages/desktop/src-tauri/tauri.prod.conf.json
+++ b/packages/desktop/src-tauri/tauri.prod.conf.json
@@ -14,7 +14,7 @@
         "zoomHotkeysEnabled": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 12.0, "y": 18.0 }
+        "trafficLightPosition": { "x": 12.0, "y": 22.0 }
       }
     ],
     "withGlobalTauri": true,


### PR DESCRIPTION
### What does this PR do?
Fixes macos headlight titlebar centering and adds space between the "toggle sidebar" button and the headlights.

### How did you verify your code works?
Verified on desktop.

Before:
<img width="1503" height="87" alt="Screenshot 2026-01-20 at 8 12 42 PM" src="https://github.com/user-attachments/assets/92f7e460-242b-4b45-94a7-7ea083356b14" />


After:
<img width="1512" height="95" alt="Screenshot 2026-01-20 at 8 10 04 PM" src="https://github.com/user-attachments/assets/460f147c-9477-4c35-9800-30e3696f89b8" />

