### PR TITLE
fix(app): workspaces padding wonkiness

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1173,7 +1173,7 @@ export default function Layout(props: ParentProps) {
 
     return (
       <Dialog title={language.t("workspace.delete.title")} fit>
-        <div class="flex flex-col gap-4 px-2.5 pb-3">
+        <div class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
           <div class="flex flex-col gap-1">
             <span class="text-14-regular text-text-strong">
               {language.t("workspace.delete.confirm", { name: name() })}
@@ -1253,7 +1253,7 @@ export default function Layout(props: ParentProps) {
 
     return (
       <Dialog title={language.t("workspace.reset.title")} fit>
-        <div class="flex flex-col gap-4 px-2.5 pb-3">
+        <div class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
           <div class="flex flex-col gap-1">
             <span class="text-14-regular text-text-strong">
               {language.t("workspace.reset.confirm", { name: name() })}
@@ -1830,7 +1830,7 @@ export default function Layout(props: ParentProps) {
                     size="large"
                     onClick={(e: MouseEvent) => {
                       loadMore()
-                      ;(e.currentTarget as HTMLButtonElement).blur()
+                        ;(e.currentTarget as HTMLButtonElement).blur()
                     }}
                   >
                     {language.t("common.loadMore")}
@@ -2015,7 +2015,7 @@ export default function Layout(props: ParentProps) {
                 size="large"
                 onClick={(e: MouseEvent) => {
                   loadMore()
-                  ;(e.currentTarget as HTMLButtonElement).blur()
+                    ;(e.currentTarget as HTMLButtonElement).blur()
                 }}
               >
                 {language.t("common.loadMore")}


### PR DESCRIPTION
### What does this PR do?

Adds padding to body of workspace modals

Before: 
<img width="696" height="236" alt="Image" src="https://github.com/user-attachments/assets/4acb9887-c0b1-4854-a04f-f55b220d5e1b" />

<img width="673" height="192" alt="Image" src="https://github.com/user-attachments/assets/306706d4-b3aa-4385-86bf-3fcec37f37d4" />

After: 
<img width="683" height="241" alt="Screenshot 2026-01-20 at 11 14 25 PM" src="https://github.com/user-attachments/assets/2c8e1f98-ab72-4341-8084-250d5cd0e81f" />

<img width="685" height="214" alt="Screenshot 2026-01-20 at 11 14 36 PM" src="https://github.com/user-attachments/assets/c7a3c71d-eb8c-45fc-8d4b-0beb029feced" />


### How did you verify your code works?

Ran it & recorded above screenshots

Closes: https://github.com/anomalyco/opencode/issues/9771
