### PR TITLE
chore(opencode): Use Bun.semver instead of node-semver

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -376,7 +376,6 @@
       "name": "@opencode-ai/script",
       "devDependencies": {
         "@types/bun": "catalog:",
-        "@types/semver": "catalog:",
       },
     },
     "packages/sdk/js": {
@@ -1854,8 +1853,6 @@
     "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
     "@types/scheduler": ["@types/scheduler@0.26.0", "", {}, "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA=="],
-
-    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
     "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -3,8 +3,7 @@
   "name": "@opencode-ai/script",
   "license": "MIT",
   "devDependencies": {
-    "@types/bun": "catalog:",
-    "@types/semver": "catalog:"
+    "@types/bun": "catalog:"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -1,6 +1,5 @@
-import { $ } from "bun"
+import { $, semver } from "bun"
 import path from "path"
-import { satisfies } from "semver"
 
 const rootPkgPath = path.resolve(import.meta.dir, "../../../package.json")
 const rootPkg = await Bun.file(rootPkgPath).json()
@@ -13,7 +12,7 @@ if (!expectedBunVersion) {
 // relax version requirement
 const expectedBunVersionRange = `^${expectedBunVersion}`
 
-if (!satisfies(process.versions.bun, expectedBunVersionRange)) {
+if (!semver.satisfies(process.versions.bun, expectedBunVersionRange)) {
   throw new Error(`This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`)
 }
 


### PR DESCRIPTION
### What does this PR do?

Use `Bun.semver` instead of `node-semver` in Bun contexts (clear because there was Bun.$). Saw it when looking at #9682 and thinking that you could have a simpler dependency tree :)

https://bun.com/blog/bun-v1.0.11#bun-semver-is-a-fast-builtin-semver-parser
