### PR TITLE
fix: Persist loaded model and mode on ACP session load

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -512,8 +512,13 @@ export namespace ACP {
         const lastUser = messages?.findLast((m) => m.info.role === "user")?.info
         if (lastUser?.role === "user") {
           result.models.currentModelId = `${lastUser.model.providerID}/${lastUser.model.modelID}`
+          this.sessionManager.setModel(sessionId, {
+            providerID: lastUser.model.providerID,
+            modelID: lastUser.model.modelID,
+          })
           if (result.modes.availableModes.some((m) => m.id === lastUser.agent)) {
             result.modes.currentModeId = lastUser.agent
+            this.sessionManager.setMode(sessionId, lastUser.agent)
           }
         }
 


### PR DESCRIPTION
Fixes https://github.com/anomalyco/opencode/issues/9828

Fixes my pervious https://github.com/anomalyco/opencode/pull/7809 by also using set model and set mode to change the actual model and mode of the loaded session (verified working this time)