### PR TITLE
tweak(session title): change prompt to have the response with user language

### DIFF
--- a/packages/opencode/src/agent/prompt/title.txt
+++ b/packages/opencode/src/agent/prompt/title.txt
@@ -12,6 +12,7 @@ Your output must be:
 </task>
 
 <rules>
+- you MUST use the same language as the user message you are summarizing
 - Title must be grammatically correct and read naturally - no word salad
 - Never include tool names in the title (e.g. "read tool", "bash tool", "edit tool")
 - Focus on the main topic or question the user needs to retrieve

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -91,7 +91,7 @@ export namespace SessionSummary {
           {
             role: "user" as const,
             content: `
-              The following is the text to summarize. Make sure to use the same language as the user message you are summarizing in your response.
+              The following is the text to summarize:
               <text>
               ${textPart?.text ?? ""}
               </text>

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -91,7 +91,7 @@ export namespace SessionSummary {
           {
             role: "user" as const,
             content: `
-              The following is the text to summarize:
+              The following is the text to summarize. Make sure to use the same language as the user message you are summarizing in your response.
               <text>
               ${textPart?.text ?? ""}
               </text>


### PR DESCRIPTION
Change session title prompt to have the response using the user's language (used in the summarized message)