### PR TITLE
chore(deps): update GitLab packages for better self-hosted instance support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -284,7 +284,7 @@
         "@ai-sdk/vercel": "1.0.31",
         "@ai-sdk/xai": "2.0.51",
         "@clack/prompts": "1.0.0-alpha.1",
-        "@gitlab/gitlab-ai-provider": "3.1.2",
+        "@gitlab/gitlab-ai-provider": "3.1.3",
         "@hono/standard-validator": "0.1.5",
         "@hono/zod-validator": "catalog:",
         "@modelcontextprotocol/sdk": "1.25.2",
@@ -922,7 +922,7 @@
 
     "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
 
-    "@gitlab/gitlab-ai-provider": ["@gitlab/gitlab-ai-provider@3.1.2", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=2.0.0", "@ai-sdk/provider-utils": ">=3.0.0" } }, "sha512-p0NZhZJSavWDX9r/Px/mOK2YIC803GZa8iRzcg3f1C6S0qfea/HBTe4/NWvT2+2kWIwhCePGuI4FN2UFiUWXUg=="],
+    "@gitlab/gitlab-ai-provider": ["@gitlab/gitlab-ai-provider@3.1.3", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=2.0.0", "@ai-sdk/provider-utils": ">=3.0.0" } }, "sha512-ikumi4PZN/S0f+j/5rb5dBRtORyT41Pl/tj8vHhnpFtpYcxXsaNv2RvCKBVf2/PovvSz2pYMOcpujIU4MdGfyQ=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -70,7 +70,7 @@
     "@ai-sdk/vercel": "1.0.31",
     "@ai-sdk/xai": "2.0.51",
     "@clack/prompts": "1.0.0-alpha.1",
-    "@gitlab/gitlab-ai-provider": "3.1.2",
+    "@gitlab/gitlab-ai-provider": "3.1.3",
     "@hono/standard-validator": "0.1.5",
     "@hono/zod-validator": "catalog:",
     "@modelcontextprotocol/sdk": "1.25.2",

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -15,7 +15,7 @@ import { CopilotAuthPlugin } from "./copilot"
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
 
-  const BUILTIN = ["opencode-anthropic-auth@0.0.9", "@gitlab/opencode-gitlab-auth@1.3.0"]
+  const BUILTIN = ["opencode-anthropic-auth@0.0.9", "@gitlab/opencode-gitlab-auth@1.3.2"]
 
   // Built-in plugins that are directly imported (not installed from npm)
   const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin]


### PR DESCRIPTION
### What does this PR do?

### Summary

Update `@gitlab/gitlab-ai-provider` and `@gitlab/opencode-gitlab-auth` packages to fix authentication with self-hosted GitLab instances.

#### Changes
 @gitlab/gitlab-ai-provider
- Fix authentication when using AI Gateway as an Anthropic proxy
- Set `apiKey: null` on Anthropic client to prevent environment variable override
- Filter out `x-api-key` header to use Bearer token authentication instead
- Replace console.log with noop to avoid breaking TUI output

 @gitlab/opencode-gitlab-auth  
- OAuth authorize flow now respects `GITLAB_INSTANCE_URL` environment variable
- Enables authentication with self-hosted GitLab instances without requiring UI prompts

### Why?
When connecting opencode to a self-hosted GitLab instance with Duo enabled:
1. The Anthropic SDK was incorrectly sending `x-api-key` header instead of using Bearer token auth expected by AI Gateway proxy
2. The OAuth flow was ignoring `GITLAB_INSTANCE_URL` env var and always redirecting to gitlab.com
 Testing

### How did you verify your code works?

1. Deployed a self-hosted GitLab instance with Duo enabled
2. Set environment variables:
   - `GITLAB_INSTANCE_URL=https://your-gitlab-instance.com`

Related issue: https://github.com/anomalyco/opencode/issues/8655