### PR TITLE
feat: pass plan metadata in question event for plugin access

### DIFF
--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -36,6 +36,7 @@ export namespace Question {
       id: Identifier.schema("question"),
       sessionID: Identifier.schema("session"),
       questions: z.array(Info).describe("Questions to ask"),
+      metadata: z.record(z.string(), z.any()).optional().describe("Additional metadata for plugins"),
       tool: z
         .object({
           messageID: z.string(),
@@ -97,6 +98,7 @@ export namespace Question {
   export async function ask(input: {
     sessionID: string
     questions: Info[]
+    metadata?: Record<string, unknown>
     tool?: { messageID: string; callID: string }
   }): Promise<Answer[]> {
     const s = await state()
@@ -109,6 +111,7 @@ export namespace Question {
         id,
         sessionID: input.sessionID,
         questions: input.questions,
+        metadata: input.metadata,
         tool: input.tool,
       }
       s.pending[id] = {

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -22,7 +22,11 @@ export const PlanExitTool = Tool.define("plan_exit", {
   parameters: z.object({}),
   async execute(_params, ctx) {
     const session = await Session.get(ctx.sessionID)
-    const plan = path.relative(Instance.worktree, Session.plan(session))
+    const absolutePlanPath = Session.plan(session)
+    const plan = path.relative(Instance.worktree, absolutePlanPath)
+    const planContent = await Bun.file(absolutePlanPath)
+      .text()
+      .catch(() => "")
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
       questions: [
@@ -36,6 +40,11 @@ export const PlanExitTool = Tool.define("plan_exit", {
           ],
         },
       ],
+      metadata: {
+        planPath: absolutePlanPath,
+        planRelativePath: plan,
+        planContent,
+      },
       tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
     })
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -584,6 +584,12 @@ export type QuestionRequest = {
    * Questions to ask
    */
   questions: Array<QuestionInfo>
+  /**
+   * Additional metadata for plugins
+   */
+  metadata?: {
+    [key: string]: unknown
+  }
   tool?: {
     messageID: string
     callID: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -7359,6 +7359,14 @@
               "$ref": "#/components/schemas/QuestionInfo"
             }
           },
+          "metadata": {
+            "description": "Additional metadata for plugins",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {}
+          },
           "tool": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
## Summary

When `plan_exit` is called, plugins listening to the `question.asked` event now receive the plan content and path via a new `metadata` field. This enables plugins (like Plannotator) to intercept the plan approval dialog and show custom UI for plan review.

## Changes

- Add optional `metadata` field to `QuestionRequest` schema
- Update `Question.ask()` to accept and pass through metadata  
- `plan_exit` tool includes `planPath`, `planRelativePath`, and `planContent` in metadata

## Example Plugin Usage

```typescript
event: async ({ event }) => {
  if (event.type !== "question.asked") return
  if (event.properties.questions?.[0]?.header !== "Build Agent") return

  const { planPath, planContent } = event.properties.metadata ?? {}
  if (planContent) {
    // Show custom plan review UI
  }
}
```

## Breaking Changes

None - metadata is optional and existing code is unaffected.
