### PR TITLE
fix(serve): add signal handlers for graceful shutdown on Windows

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -18,6 +18,19 @@ export const ServeCommand = cmd({
     const server = Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
+    const shutdown = async (signal: string) => {
+      console.log(`Received ${signal}, shutting down...`)
+      await server.stop()
+      process.exit(0)
+    }
+
+    process.on("SIGINT", () => shutdown("SIGINT"))
+    process.on("SIGTERM", () => shutdown("SIGTERM"))
+    // SIGBREAK is Windows-specific (Ctrl+Break)
+    if (process.platform === "win32") {
+      process.on("SIGBREAK", () => shutdown("SIGBREAK"))
+    }
+
     await new Promise(() => {})
     await server.stop()
   },

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -278,6 +278,7 @@ export namespace Server {
       idleTimeout: 0,
       fetch: app.fetch,
       websocket: websocket,
+      reusePort: true,
     } as const
     const tryServe = (port: number) => {
       try {


### PR DESCRIPTION
## Summary

Fixes #9859 - Adds signal handlers for graceful shutdown in `opencode serve` to prevent ghost port bindings on Windows when the process is terminated by external tools like openralph/opencode-ralph.

## Changes

- **`packages/opencode/src/cli/cmd/serve.ts`**: Added signal handlers for `SIGINT`, `SIGTERM`, and `SIGBREAK` (Windows-only) that call `server.stop()` before exiting
- **`packages/opencode/src/server/server.ts`**: Added `reusePort: true` to `Bun.serve()` for defense-in-depth, allowing immediate port reuse even after abnormal termination

## Root Cause

The `opencode serve` command lacked signal handlers to catch termination signals. When plugins like openralph send SIGTERM to terminate the server, the process would die immediately without calling `server.stop()`, causing:
1. TCP listener not closed properly
2. Port binding persists as a "ghost" on Windows
3. Server restart fails until port times out (2-5 minutes) or system reboot

## Solution

1. **Signal handlers**: Register handlers for SIGINT, SIGTERM, and SIGBREAK (Windows Ctrl+Break) that gracefully shut down the server
2. **reusePort**: Enable `SO_REUSEPORT` on the server socket, allowing immediate port reuse as a fallback for edge cases
