### PR TITLE
feat: add /reload slash command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ UPCOMING_CHANGELOG.md
 logs/
 *.bun-build
 tsconfig.tsbuildinfo
+.auto-update-history.json

--- a/packages/opencode/src/config/reload.ts
+++ b/packages/opencode/src/config/reload.ts
@@ -17,7 +17,7 @@ export const Event = {
     type: "config.reload.executing",
     schema: {
       executing: Schema.Boolean,
-      bootstrapCycle: Schema.optional(Schema.Number),
+      bootstrapCycle: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(1))),
     },
   }),
   Done: EventV2.define({
@@ -29,6 +29,18 @@ export const Event = {
 export type RequestResult = {
   immediate: boolean
   input: InstanceStore.LoadInput
+  bootstrapCycle?: number
+}
+
+export type Status = {
+  pending: boolean
+  executing: boolean
+  bootstrapCycle?: number
+}
+
+export type LocationInput = {
+  directory: string
+  workspaceID?: string
 }
 
 type State = {
@@ -63,11 +75,41 @@ export const getBootstrapCycle = Effect.fn("ConfigReload.getBootstrapCycle")(fun
   return (yield* currentState()).bootstrapCycle
 })
 
+export const status = Effect.fn("ConfigReload.status")(function* () {
+  const state = yield* currentState()
+  return stateStatus(state)
+})
+
+export const statusForLocation = Effect.fn("ConfigReload.statusForLocation")(function* (input: LocationInput) {
+  const state = findStateForLocation(input)
+  if (!state) return { pending: false, executing: false } satisfies Status
+  return stateStatus(state)
+})
+
 export const releaseBlocker = Effect.fn("ConfigReload.releaseBlocker")(function* (blockerID: string) {
   const state = yield* currentState()
   state.blockers.delete(blockerID)
   yield* Effect.logDebug("config reload blocker released", { blockerID })
   yield* continueOrDone(state)
+})
+
+export const completeBootstrap = Effect.fn("ConfigReload.completeBootstrap")(function* (cycle: number) {
+  const current = yield* currentInput()
+  const state = findStateForCycle(current, cycle)
+  if (!state) return false
+  state.blockers.delete("tui-bootstrap")
+  yield* Effect.logDebug("config reload bootstrap completed", { cycle })
+  yield* continueOrDone(state)
+  return true
+})
+
+export const completeBootstrapForLocation = Effect.fn("ConfigReload.completeBootstrapForLocation")(function* (input: LocationInput & { cycle: number }) {
+  const state = findStateForLocation(input, input.cycle)
+  if (!state) return false
+  state.blockers.delete("tui-bootstrap")
+  yield* Effect.logDebug("config reload bootstrap completed", { cycle: input.cycle })
+  yield* continueOrDone(state)
+  return true
 })
 
 export const request = Effect.fn("ConfigReload.request")(function* () {
@@ -81,8 +123,8 @@ export const request = Effect.fn("ConfigReload.request")(function* () {
     return { immediate: false, input: current.input } satisfies RequestResult
   }
   yield* Effect.logInfo("config reload executing immediately")
-  yield* prepareExecution(state, current.input)
-  return { immediate: true, input: current.input } satisfies RequestResult
+  const execution = yield* prepareExecution(state, current.input)
+  return { immediate: true, input: current.input, bootstrapCycle: execution.bootstrapCycle } satisfies RequestResult
 })
 
 export const check = Effect.fn("ConfigReload.check")(function* () {
@@ -97,10 +139,7 @@ export const check = Effect.fn("ConfigReload.check")(function* () {
     return
   }
   yield* Effect.logInfo("config reload executing deferred request")
-  const execution = yield* prepareExecution(state, state.reloadInput ?? current.input)
-  // InstanceStore forks the new boot into its own scope before disposing the old
-  // instance. This effect may be interrupted by disposal, so no logic follows it.
-  yield* InstanceStore.Service.use((store) => store.reload(execution.input)).pipe(Effect.ignore)
+  yield* executePending(state, current.input)
 })
 
 function isBlocked(state: State) {
@@ -140,6 +179,32 @@ function getState(key: string) {
   return state
 }
 
+function findStateForCycle(current: { key: string; input: InstanceStore.LoadInput }, cycle: number) {
+  const exact = states.get(current.key)
+  if (exact?.bootstrapCycle === cycle) return exact
+  const locationPrefix = `${current.input.directory}\0${current.input.worktree}\0`
+  return [...states.entries()].find(([key, state]) => key.startsWith(locationPrefix) && state.bootstrapCycle === cycle)?.[1]
+}
+
+function findStateForLocation(input: LocationInput, cycle?: number) {
+  const locationPrefix = `${input.directory}\0`
+  const workspaceSuffix = input.workspaceID ? `\0${input.workspaceID}` : undefined
+  return [...states.entries()].find(([key, state]) => {
+    if (!key.startsWith(locationPrefix)) return false
+    if (workspaceSuffix && !key.endsWith(workspaceSuffix)) return false
+    if (cycle !== undefined) return state.bootstrapCycle === cycle
+    return true
+  })?.[1]
+}
+
+function stateStatus(state: State) {
+  return {
+    pending: state.pending,
+    executing: state.reloadInFlight,
+    bootstrapCycle: state.bootstrapCycle > 0 ? state.bootstrapCycle : undefined,
+  } satisfies Status
+}
+
 function startBlocker(state: State, blockerID: string) {
   state.blockers.add(blockerID)
   if (blockerID === "tui-bootstrap") state.bootstrapCycle++
@@ -159,11 +224,22 @@ function prepareExecution(state: State, input: InstanceStore.LoadInput) {
   })
 }
 
+function executePending(state: State, fallbackInput: InstanceStore.LoadInput) {
+  return Effect.gen(function* () {
+    const execution = yield* prepareExecution(state, state.reloadInput ?? fallbackInput)
+    // InstanceStore forks the new boot into its own scope before disposing the old
+    // instance. This effect may be interrupted by disposal, so no logic follows it.
+    yield* InstanceStore.Service.use((store) => store.reload(execution.input)).pipe(Effect.ignore)
+  })
+}
+
 function continueOrDone(state: State) {
   return Effect.gen(function* () {
     if (isBlocked(state)) return
     if (state.pending) {
-      yield* check()
+      if (!state.reloadInput) return
+      yield* Effect.logInfo("config reload executing deferred request")
+      yield* executePending(state, state.reloadInput)
       return
     }
     if (!state.reloadInFlight) return

--- a/packages/opencode/src/config/reload.ts
+++ b/packages/opencode/src/config/reload.ts
@@ -1,9 +1,11 @@
 export * as ConfigReload from "./reload"
 
 import { EventV2 } from "@opencode-ai/core/event"
-import { Effect, Schema } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Context, Effect, Layer, Schema } from "effect"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
+import { InstanceLayer } from "@/project/instance-layer"
 import { InstanceStore } from "@/project/instance-store"
 
 export const Event = {
@@ -43,6 +45,22 @@ export type LocationInput = {
   workspaceID?: string
 }
 
+export interface Interface {
+  readonly isPending: () => Effect.Effect<boolean>
+  readonly start: (sessionID: string) => Effect.Effect<void>
+  readonly finish: (sessionID: string) => Effect.Effect<void>
+  readonly getBootstrapCycle: () => Effect.Effect<number>
+  readonly status: () => Effect.Effect<Status>
+  readonly statusForLocation: (input: LocationInput) => Effect.Effect<Status>
+  readonly releaseBlocker: (blockerID: string) => Effect.Effect<void>
+  readonly completeBootstrap: (cycle: number) => Effect.Effect<boolean>
+  readonly completeBootstrapForLocation: (input: LocationInput & { cycle: number }) => Effect.Effect<boolean>
+  readonly request: () => Effect.Effect<RequestResult>
+  readonly check: () => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/ConfigReload") {}
+
 type State = {
   pending: boolean
   reloadInFlight: boolean
@@ -52,95 +70,119 @@ type State = {
   blockers: Set<string>
 }
 
-const states = new Map<string, State>()
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const store = yield* InstanceStore.Service
+    const states = new Map<string, State>()
 
-export function isPending() {
-  return [...states.values()].some((state) => state.pending)
-}
-
-export const start = Effect.fn("ConfigReload.start")(function* (sessionID: string) {
-  const state = yield* currentState()
-  state.active.add(sessionID)
-  yield* Effect.logDebug("config reload waiting for all sessions to finish", { sessionID })
-})
-
-export const finish = Effect.fn("ConfigReload.finish")(function* (sessionID: string) {
-  const state = yield* currentState()
-  state.active.delete(sessionID)
-  yield* Effect.logDebug("config reload session finished current turn", { sessionID })
-  yield* continueOrDone(state)
-})
-
-export const getBootstrapCycle = Effect.fn("ConfigReload.getBootstrapCycle")(function* () {
-  return (yield* currentState()).bootstrapCycle
-})
-
-export const status = Effect.fn("ConfigReload.status")(function* () {
-  const state = yield* currentState()
-  return stateStatus(state)
-})
-
-export const statusForLocation = Effect.fn("ConfigReload.statusForLocation")(function* (input: LocationInput) {
-  const state = findStateForLocation(input)
-  if (!state) return { pending: false, executing: false } satisfies Status
-  return stateStatus(state)
-})
-
-export const releaseBlocker = Effect.fn("ConfigReload.releaseBlocker")(function* (blockerID: string) {
-  const state = yield* currentState()
-  state.blockers.delete(blockerID)
-  yield* Effect.logDebug("config reload blocker released", { blockerID })
-  yield* continueOrDone(state)
-})
-
-export const completeBootstrap = Effect.fn("ConfigReload.completeBootstrap")(function* (cycle: number) {
-  const current = yield* currentInput()
-  const state = findStateForCycle(current, cycle)
-  if (!state) return false
-  state.blockers.delete("tui-bootstrap")
-  yield* Effect.logDebug("config reload bootstrap completed", { cycle })
-  yield* continueOrDone(state)
-  return true
-})
-
-export const completeBootstrapForLocation = Effect.fn("ConfigReload.completeBootstrapForLocation")(function* (input: LocationInput & { cycle: number }) {
-  const state = findStateForLocation(input, input.cycle)
-  if (!state) return false
-  state.blockers.delete("tui-bootstrap")
-  yield* Effect.logDebug("config reload bootstrap completed", { cycle: input.cycle })
-  yield* continueOrDone(state)
-  return true
-})
-
-export const request = Effect.fn("ConfigReload.request")(function* () {
-  const current = yield* currentInput()
-  const state = getState(current.key)
-  state.reloadInput = current.input
-  if (isBlocked(state)) {
-    state.pending = true
-    yield* Effect.logInfo("config reload queued")
-    yield* publish(Event.Pending, { pending: true })
-    return { immediate: false, input: current.input } satisfies RequestResult
-  }
-  yield* Effect.logInfo("config reload executing immediately")
-  const execution = yield* prepareExecution(state, current.input)
-  return { immediate: true, input: current.input, bootstrapCycle: execution.bootstrapCycle } satisfies RequestResult
-})
-
-export const check = Effect.fn("ConfigReload.check")(function* () {
-  const current = yield* currentInput()
-  const state = getState(current.key)
-  if (!state.pending) return
-  if (isBlocked(state)) {
-    yield* Effect.logDebug("config reload waiting for sessions and blockers to finish", {
-      active: [...state.active],
-      blockers: [...state.blockers],
+    const isPending = Effect.fn("ConfigReload.isPending")(function* () {
+      return [...states.values()].some((state) => state.pending)
     })
-    return
-  }
-  yield* Effect.logInfo("config reload executing deferred request")
-  yield* executePending(state, current.input)
-})
+
+    const start = Effect.fn("ConfigReload.start")(function* (sessionID: string) {
+      const state = yield* currentState(states)
+      state.active.add(sessionID)
+      yield* Effect.logDebug("config reload waiting for all sessions to finish", { sessionID })
+    })
+
+    const finish = Effect.fn("ConfigReload.finish")(function* (sessionID: string) {
+      const state = yield* currentState(states)
+      state.active.delete(sessionID)
+      yield* Effect.logDebug("config reload session finished current turn", { sessionID })
+      yield* continueOrDone(state, store, events)
+    })
+
+    const getBootstrapCycle = Effect.fn("ConfigReload.getBootstrapCycle")(function* () {
+      return (yield* currentState(states)).bootstrapCycle
+    })
+
+    const status = Effect.fn("ConfigReload.status")(function* () {
+      return stateStatus(yield* currentState(states))
+    })
+
+    const statusForLocation = Effect.fn("ConfigReload.statusForLocation")(function* (input: LocationInput) {
+      const state = findStateForLocation(states, input)
+      if (!state) return { pending: false, executing: false } satisfies Status
+      return stateStatus(state)
+    })
+
+    const releaseBlocker = Effect.fn("ConfigReload.releaseBlocker")(function* (blockerID: string) {
+      const state = yield* currentState(states)
+      state.blockers.delete(blockerID)
+      yield* Effect.logDebug("config reload blocker released", { blockerID })
+      yield* continueOrDone(state, store, events)
+    })
+
+    const completeBootstrap = Effect.fn("ConfigReload.completeBootstrap")(function* (cycle: number) {
+      const current = yield* currentInput()
+      const state = findStateForCycle(states, current, cycle)
+      if (!state) return false
+      state.blockers.delete("tui-bootstrap")
+      yield* Effect.logDebug("config reload bootstrap completed", { cycle })
+      yield* continueOrDone(state, store, events)
+      return true
+    })
+
+    const completeBootstrapForLocation = Effect.fn("ConfigReload.completeBootstrapForLocation")(function* (
+      input: LocationInput & { cycle: number },
+    ) {
+      const state = findStateForLocation(states, input, input.cycle)
+      if (!state) return false
+      state.blockers.delete("tui-bootstrap")
+      yield* Effect.logDebug("config reload bootstrap completed", { cycle: input.cycle })
+      yield* continueOrDone(state, store, events)
+      return true
+    })
+
+    const request = Effect.fn("ConfigReload.request")(function* () {
+      const current = yield* currentInput()
+      const state = getState(states, current.key)
+      state.reloadInput = current.input
+      if (isBlocked(state)) {
+        state.pending = true
+        yield* Effect.logInfo("config reload queued")
+        yield* publish(events, Event.Pending, { pending: true })
+        return { immediate: false, input: current.input } satisfies RequestResult
+      }
+      yield* Effect.logInfo("config reload executing immediately")
+      const execution = yield* prepareExecution(state, current.input, events)
+      return { immediate: true, input: current.input, bootstrapCycle: execution.bootstrapCycle } satisfies RequestResult
+    })
+
+    const check = Effect.fn("ConfigReload.check")(function* () {
+      const current = yield* currentInput()
+      const state = getState(states, current.key)
+      if (!state.pending) return
+      if (isBlocked(state)) {
+        yield* Effect.logDebug("config reload waiting for sessions and blockers to finish", {
+          active: [...state.active],
+          blockers: [...state.blockers],
+        })
+        return
+      }
+      yield* Effect.logInfo("config reload executing deferred request")
+      yield* executePending(state, current.input, store, events)
+    })
+
+    return Service.of({
+      isPending,
+      start,
+      finish,
+      getBootstrapCycle,
+      status,
+      statusForLocation,
+      releaseBlocker,
+      completeBootstrap,
+      completeBootstrapForLocation,
+      request,
+      check,
+    })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(EventV2Bridge.defaultLayer), Layer.provide(InstanceLayer.layer))
 
 function isBlocked(state: State) {
   return state.active.size > 0 || state.blockers.size > 0
@@ -161,11 +203,11 @@ function currentInput() {
   })
 }
 
-function currentState() {
-  return Effect.map(currentInput(), (current) => getState(current.key))
+function currentState(states: Map<string, State>) {
+  return Effect.map(currentInput(), (current) => getState(states, current.key))
 }
 
-function getState(key: string) {
+function getState(states: Map<string, State>, key: string) {
   const existing = states.get(key)
   if (existing) return existing
   const state: State = {
@@ -179,14 +221,14 @@ function getState(key: string) {
   return state
 }
 
-function findStateForCycle(current: { key: string; input: InstanceStore.LoadInput }, cycle: number) {
+function findStateForCycle(states: Map<string, State>, current: { key: string; input: InstanceStore.LoadInput }, cycle: number) {
   const exact = states.get(current.key)
   if (exact?.bootstrapCycle === cycle) return exact
   const locationPrefix = `${current.input.directory}\0${current.input.worktree}\0`
   return [...states.entries()].find(([key, state]) => key.startsWith(locationPrefix) && state.bootstrapCycle === cycle)?.[1]
 }
 
-function findStateForLocation(input: LocationInput, cycle?: number) {
+function findStateForLocation(states: Map<string, State>, input: LocationInput, cycle?: number) {
   const locationPrefix = `${input.directory}\0`
   const workspaceSuffix = input.workspaceID ? `\0${input.workspaceID}` : undefined
   return [...states.entries()].find(([key, state]) => {
@@ -210,7 +252,7 @@ function startBlocker(state: State, blockerID: string) {
   if (blockerID === "tui-bootstrap") state.bootstrapCycle++
 }
 
-function prepareExecution(state: State, input: InstanceStore.LoadInput) {
+function prepareExecution(state: State, input: InstanceStore.LoadInput, events: EventV2.Interface) {
   return Effect.gen(function* () {
     state.pending = false
     state.active.clear()
@@ -218,37 +260,48 @@ function prepareExecution(state: State, input: InstanceStore.LoadInput) {
     startBlocker(state, "tui-bootstrap")
     state.reloadInFlight = true
     state.reloadInput = input
-    yield* publish(Event.Pending, { pending: false })
-    yield* publish(Event.Executing, { executing: true, bootstrapCycle: state.bootstrapCycle })
+    yield* publish(events, Event.Pending, { pending: false })
+    yield* publish(events, Event.Executing, { executing: true, bootstrapCycle: state.bootstrapCycle })
     return { input, bootstrapCycle: state.bootstrapCycle }
   })
 }
 
-function executePending(state: State, fallbackInput: InstanceStore.LoadInput) {
+function executePending(
+  state: State,
+  fallbackInput: InstanceStore.LoadInput,
+  store: InstanceStore.Interface,
+  events: EventV2.Interface,
+) {
   return Effect.gen(function* () {
-    const execution = yield* prepareExecution(state, state.reloadInput ?? fallbackInput)
+    const execution = yield* prepareExecution(state, state.reloadInput ?? fallbackInput, events)
     // InstanceStore forks the new boot into its own scope before disposing the old
     // instance. This effect may be interrupted by disposal, so no logic follows it.
-    yield* InstanceStore.Service.use((store) => store.reload(execution.input)).pipe(Effect.ignore)
+    yield* store.reload(execution.input).pipe(Effect.ignore)
   })
 }
 
-function continueOrDone(state: State) {
+function continueOrDone(state: State, store: InstanceStore.Interface, events: EventV2.Interface) {
   return Effect.gen(function* () {
     if (isBlocked(state)) return
     if (state.pending) {
       if (!state.reloadInput) return
       yield* Effect.logInfo("config reload executing deferred request")
-      yield* executePending(state, state.reloadInput)
+      yield* executePending(state, state.reloadInput, store, events)
       return
     }
     if (!state.reloadInFlight) return
     state.reloadInFlight = false
     yield* Effect.logInfo("config reload completed")
-    yield* publish(Event.Done, {})
+    yield* publish(events, Event.Done, {})
   })
 }
 
-function publish<Definition extends EventV2.Definition>(definition: Definition, data: EventV2.Data<Definition>) {
-  return EventV2Bridge.Service.use((events) => events.publish(definition, data)).pipe(Effect.asVoid)
+function publish<Definition extends EventV2.Definition>(
+  events: EventV2.Interface,
+  definition: Definition,
+  data: EventV2.Data<Definition>,
+) {
+  return events.publish(definition, data).pipe(Effect.asVoid)
 }
+
+export const node = LayerNode.make(layer, [EventV2Bridge.node, InstanceStore.node])

--- a/packages/opencode/src/config/reload.ts
+++ b/packages/opencode/src/config/reload.ts
@@ -49,13 +49,13 @@ export function isPending() {
 export const start = Effect.fn("ConfigReload.start")(function* (sessionID: string) {
   const state = yield* currentState()
   state.active.add(sessionID)
-  yield* Effect.logDebug("config reload session started", { sessionID })
+  yield* Effect.logDebug("config reload waiting for all sessions to finish", { sessionID })
 })
 
 export const finish = Effect.fn("ConfigReload.finish")(function* (sessionID: string) {
   const state = yield* currentState()
   state.active.delete(sessionID)
-  yield* Effect.logDebug("config reload session finished", { sessionID })
+  yield* Effect.logDebug("config reload session finished current turn", { sessionID })
   yield* continueOrDone(state)
 })
 
@@ -63,10 +63,10 @@ export const getBootstrapCycle = Effect.fn("ConfigReload.getBootstrapCycle")(fun
   return (yield* currentState()).bootstrapCycle
 })
 
-export const finishBlocker = Effect.fn("ConfigReload.finishBlocker")(function* (blockerID: string) {
+export const releaseBlocker = Effect.fn("ConfigReload.releaseBlocker")(function* (blockerID: string) {
   const state = yield* currentState()
   state.blockers.delete(blockerID)
-  yield* Effect.logDebug("config reload blocker finished", { blockerID })
+  yield* Effect.logDebug("config reload blocker released", { blockerID })
   yield* continueOrDone(state)
 })
 
@@ -90,7 +90,10 @@ export const check = Effect.fn("ConfigReload.check")(function* () {
   const state = getState(current.key)
   if (!state.pending) return
   if (isBlocked(state)) {
-    yield* Effect.logDebug("config reload still blocked", { active: [...state.active], blockers: [...state.blockers] })
+    yield* Effect.logDebug("config reload waiting for sessions and blockers to finish", {
+      active: [...state.active],
+      blockers: [...state.blockers],
+    })
     return
   }
   yield* Effect.logInfo("config reload executing deferred request")

--- a/packages/opencode/src/config/reload.ts
+++ b/packages/opencode/src/config/reload.ts
@@ -1,0 +1,147 @@
+export * as ConfigReload from "./reload"
+
+import { EventV2 } from "@opencode-ai/core/event"
+import { Effect, Schema } from "effect"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceState } from "@/effect/instance-state"
+import { InstanceStore } from "@/project/instance-store"
+
+export const Event = {
+  Pending: EventV2.define({
+    type: "config.reload.pending",
+    schema: {
+      pending: Schema.Boolean,
+    },
+  }),
+  Executing: EventV2.define({
+    type: "config.reload.executing",
+    schema: {
+      executing: Schema.Boolean,
+      bootstrapCycle: Schema.optional(Schema.Number),
+    },
+  }),
+  Done: EventV2.define({
+    type: "config.reload.done",
+    schema: {
+      resumeSessionID: Schema.optional(Schema.String),
+    },
+  }),
+}
+
+export type RequestResult = {
+  immediate: boolean
+  input: InstanceStore.LoadInput
+}
+
+let pending = false
+let resumeSessionID: string | undefined
+let reloadInFlight = false
+let doneResumeSessionID: string | undefined
+let reloadInput: InstanceStore.LoadInput | undefined
+let bootstrapCycle = 0
+const active = new Set<string>()
+const blockers = new Set<string>()
+
+export function isPending() {
+  return pending
+}
+
+export const start = Effect.fn("ConfigReload.start")(function* (sessionID: string) {
+  active.add(sessionID)
+  yield* Effect.logDebug("config reload session started", { sessionID })
+})
+
+export const finish = Effect.fn("ConfigReload.finish")(function* (sessionID: string) {
+  active.delete(sessionID)
+  yield* Effect.logDebug("config reload session finished", { sessionID })
+  yield* doneWhenUnblocked()
+})
+
+export function getBootstrapCycle() {
+  return bootstrapCycle
+}
+
+export const finishBlocker = Effect.fn("ConfigReload.finishBlocker")(function* (blockerID: string) {
+  blockers.delete(blockerID)
+  yield* Effect.logDebug("config reload blocker finished", { blockerID })
+  yield* doneWhenUnblocked()
+  if (!pending || isBlocked()) return
+  yield* check()
+})
+
+export const request = Effect.fn("ConfigReload.request")(function* (options?: { resumeSessionID?: string }) {
+  const input = yield* currentInput()
+  reloadInput = input
+  if (options?.resumeSessionID) resumeSessionID = options.resumeSessionID
+  if (isBlocked()) {
+    pending = true
+    yield* Effect.logInfo("config reload queued", { resumeSessionID })
+    yield* publish(Event.Pending, { pending: true })
+    return { immediate: false, input } satisfies RequestResult
+  }
+  yield* Effect.logInfo("config reload executing immediately")
+  yield* prepareExecution(input)
+  return { immediate: true, input } satisfies RequestResult
+})
+
+export const check = Effect.fn("ConfigReload.check")(function* () {
+  if (!pending) return
+  if (isBlocked()) {
+    yield* Effect.logDebug("config reload still blocked", { active: [...active], blockers: [...blockers] })
+    return
+  }
+  yield* Effect.logInfo("config reload executing deferred request")
+  const execution = yield* prepareExecution(reloadInput ?? (yield* currentInput()))
+  // InstanceStore forks the new boot into its own scope before disposing the old
+  // instance. This effect may be interrupted by disposal, so no logic follows it.
+  yield* InstanceStore.Service.use((store) => store.reload(execution.input)).pipe(Effect.ignore)
+})
+
+function isBlocked() {
+  return active.size > 0 || blockers.size > 0
+}
+
+function currentInput() {
+  return Effect.map(InstanceState.context, (ctx) => ({
+    directory: ctx.directory,
+    worktree: ctx.worktree,
+    project: ctx.project,
+  }))
+}
+
+function startBlocker(blockerID: string) {
+  blockers.add(blockerID)
+  if (blockerID === "tui-bootstrap") bootstrapCycle++
+}
+
+function prepareExecution(input: InstanceStore.LoadInput) {
+  return Effect.gen(function* () {
+    pending = false
+    const sid = resumeSessionID
+    resumeSessionID = undefined
+    active.clear()
+    blockers.clear()
+    startBlocker("tui-bootstrap")
+    reloadInFlight = true
+    doneResumeSessionID = sid
+    reloadInput = input
+    yield* publish(Event.Pending, { pending: false })
+    yield* publish(Event.Executing, { executing: true, bootstrapCycle })
+    return { input, resumeSessionID: sid, bootstrapCycle }
+  })
+}
+
+function doneWhenUnblocked() {
+  return Effect.gen(function* () {
+    if (!reloadInFlight || isBlocked()) return
+    reloadInFlight = false
+    const sid = doneResumeSessionID
+    doneResumeSessionID = undefined
+    yield* Effect.logInfo("config reload completed", { resumeSessionID: sid })
+    yield* publish(Event.Done, { resumeSessionID: sid })
+  })
+}
+
+function publish<Definition extends EventV2.Definition>(definition: Definition, data: EventV2.Data<Definition>) {
+  return EventV2Bridge.Service.use((events) => events.publish(definition, data)).pipe(Effect.asVoid)
+}

--- a/packages/opencode/src/config/reload.ts
+++ b/packages/opencode/src/config/reload.ts
@@ -22,9 +22,7 @@ export const Event = {
   }),
   Done: EventV2.define({
     type: "config.reload.done",
-    schema: {
-      resumeSessionID: Schema.optional(Schema.String),
-    },
+    schema: {},
   }),
 }
 
@@ -33,112 +31,142 @@ export type RequestResult = {
   input: InstanceStore.LoadInput
 }
 
-let pending = false
-let resumeSessionID: string | undefined
-let reloadInFlight = false
-let doneResumeSessionID: string | undefined
-let reloadInput: InstanceStore.LoadInput | undefined
-let bootstrapCycle = 0
-const active = new Set<string>()
-const blockers = new Set<string>()
+type State = {
+  pending: boolean
+  reloadInFlight: boolean
+  reloadInput?: InstanceStore.LoadInput
+  bootstrapCycle: number
+  active: Set<string>
+  blockers: Set<string>
+}
+
+const states = new Map<string, State>()
 
 export function isPending() {
-  return pending
+  return [...states.values()].some((state) => state.pending)
 }
 
 export const start = Effect.fn("ConfigReload.start")(function* (sessionID: string) {
-  active.add(sessionID)
+  const state = yield* currentState()
+  state.active.add(sessionID)
   yield* Effect.logDebug("config reload session started", { sessionID })
 })
 
 export const finish = Effect.fn("ConfigReload.finish")(function* (sessionID: string) {
-  active.delete(sessionID)
+  const state = yield* currentState()
+  state.active.delete(sessionID)
   yield* Effect.logDebug("config reload session finished", { sessionID })
-  yield* doneWhenUnblocked()
+  yield* continueOrDone(state)
 })
 
-export function getBootstrapCycle() {
-  return bootstrapCycle
-}
+export const getBootstrapCycle = Effect.fn("ConfigReload.getBootstrapCycle")(function* () {
+  return (yield* currentState()).bootstrapCycle
+})
 
 export const finishBlocker = Effect.fn("ConfigReload.finishBlocker")(function* (blockerID: string) {
-  blockers.delete(blockerID)
+  const state = yield* currentState()
+  state.blockers.delete(blockerID)
   yield* Effect.logDebug("config reload blocker finished", { blockerID })
-  yield* doneWhenUnblocked()
-  if (!pending || isBlocked()) return
-  yield* check()
+  yield* continueOrDone(state)
 })
 
-export const request = Effect.fn("ConfigReload.request")(function* (options?: { resumeSessionID?: string }) {
-  const input = yield* currentInput()
-  reloadInput = input
-  if (options?.resumeSessionID) resumeSessionID = options.resumeSessionID
-  if (isBlocked()) {
-    pending = true
-    yield* Effect.logInfo("config reload queued", { resumeSessionID })
+export const request = Effect.fn("ConfigReload.request")(function* () {
+  const current = yield* currentInput()
+  const state = getState(current.key)
+  state.reloadInput = current.input
+  if (isBlocked(state)) {
+    state.pending = true
+    yield* Effect.logInfo("config reload queued")
     yield* publish(Event.Pending, { pending: true })
-    return { immediate: false, input } satisfies RequestResult
+    return { immediate: false, input: current.input } satisfies RequestResult
   }
   yield* Effect.logInfo("config reload executing immediately")
-  yield* prepareExecution(input)
-  return { immediate: true, input } satisfies RequestResult
+  yield* prepareExecution(state, current.input)
+  return { immediate: true, input: current.input } satisfies RequestResult
 })
 
 export const check = Effect.fn("ConfigReload.check")(function* () {
-  if (!pending) return
-  if (isBlocked()) {
-    yield* Effect.logDebug("config reload still blocked", { active: [...active], blockers: [...blockers] })
+  const current = yield* currentInput()
+  const state = getState(current.key)
+  if (!state.pending) return
+  if (isBlocked(state)) {
+    yield* Effect.logDebug("config reload still blocked", { active: [...state.active], blockers: [...state.blockers] })
     return
   }
   yield* Effect.logInfo("config reload executing deferred request")
-  const execution = yield* prepareExecution(reloadInput ?? (yield* currentInput()))
+  const execution = yield* prepareExecution(state, state.reloadInput ?? current.input)
   // InstanceStore forks the new boot into its own scope before disposing the old
   // instance. This effect may be interrupted by disposal, so no logic follows it.
   yield* InstanceStore.Service.use((store) => store.reload(execution.input)).pipe(Effect.ignore)
 })
 
-function isBlocked() {
-  return active.size > 0 || blockers.size > 0
+function isBlocked(state: State) {
+  return state.active.size > 0 || state.blockers.size > 0
 }
 
 function currentInput() {
-  return Effect.map(InstanceState.context, (ctx) => ({
-    directory: ctx.directory,
-    worktree: ctx.worktree,
-    project: ctx.project,
-  }))
-}
-
-function startBlocker(blockerID: string) {
-  blockers.add(blockerID)
-  if (blockerID === "tui-bootstrap") bootstrapCycle++
-}
-
-function prepareExecution(input: InstanceStore.LoadInput) {
   return Effect.gen(function* () {
-    pending = false
-    const sid = resumeSessionID
-    resumeSessionID = undefined
-    active.clear()
-    blockers.clear()
-    startBlocker("tui-bootstrap")
-    reloadInFlight = true
-    doneResumeSessionID = sid
-    reloadInput = input
-    yield* publish(Event.Pending, { pending: false })
-    yield* publish(Event.Executing, { executing: true, bootstrapCycle })
-    return { input, resumeSessionID: sid, bootstrapCycle }
+    const ctx = yield* InstanceState.context
+    const workspaceID = yield* InstanceState.workspaceID
+    return {
+      key: `${ctx.directory}\0${ctx.worktree}\0${workspaceID ?? ""}`,
+      input: {
+        directory: ctx.directory,
+        worktree: ctx.worktree,
+        project: ctx.project,
+      },
+    }
   })
 }
 
-function doneWhenUnblocked() {
+function currentState() {
+  return Effect.map(currentInput(), (current) => getState(current.key))
+}
+
+function getState(key: string) {
+  const existing = states.get(key)
+  if (existing) return existing
+  const state: State = {
+    pending: false,
+    reloadInFlight: false,
+    bootstrapCycle: 0,
+    active: new Set(),
+    blockers: new Set(),
+  }
+  states.set(key, state)
+  return state
+}
+
+function startBlocker(state: State, blockerID: string) {
+  state.blockers.add(blockerID)
+  if (blockerID === "tui-bootstrap") state.bootstrapCycle++
+}
+
+function prepareExecution(state: State, input: InstanceStore.LoadInput) {
   return Effect.gen(function* () {
-    if (!reloadInFlight || isBlocked()) return
-    reloadInFlight = false
-    const sid = doneResumeSessionID
-    doneResumeSessionID = undefined
-    yield* Effect.logInfo("config reload completed", { resumeSessionID: sid })
-    yield* publish(Event.Done, { resumeSessionID: sid })
+    state.pending = false
+    state.active.clear()
+    state.blockers.clear()
+    startBlocker(state, "tui-bootstrap")
+    state.reloadInFlight = true
+    state.reloadInput = input
+    yield* publish(Event.Pending, { pending: false })
+    yield* publish(Event.Executing, { executing: true, bootstrapCycle: state.bootstrapCycle })
+    return { input, bootstrapCycle: state.bootstrapCycle }
+  })
+}
+
+function continueOrDone(state: State) {
+  return Effect.gen(function* () {
+    if (isBlocked(state)) return
+    if (state.pending) {
+      yield* check()
+      return
+    }
+    if (!state.reloadInFlight) return
+    state.reloadInFlight = false
+    yield* Effect.logInfo("config reload completed")
+    yield* publish(Event.Done, {})
   })
 }
 

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -7,6 +7,7 @@ import { Database } from "@opencode-ai/core/database/database"
 import { Auth } from "@/auth"
 import { Account } from "@/account/account"
 import { Config } from "@/config/config"
+import { ConfigReload } from "@/config/reload"
 import { Git } from "@/git"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Storage } from "@/storage/storage"
@@ -59,6 +60,7 @@ export const AppLayer = Layer.mergeAll(
   Auth.defaultLayer,
   Account.defaultLayer,
   Config.defaultLayer,
+  ConfigReload.defaultLayer,
   Git.defaultLayer,
   Storage.defaultLayer,
   Snapshot.defaultLayer,

--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -130,6 +130,7 @@ export const make = <A, E = never>(
           }
           case "Idle": {
             const done = yield* Deferred.make<A, E | Cancelled>()
+            yield* onBusy
             const run = yield* startRun(work, done)
             return [awaitDone(done), { _tag: "Running", run }] as const
           }

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -3,7 +3,7 @@ import { HttpApi } from "effect/unstable/httpapi"
 import { EventV2 } from "@opencode-ai/core/event"
 import { InstanceDisposed } from "@/server/event"
 import { Question } from "@/question"
-import { ConfigApi } from "./groups/config"
+import { ConfigApi, ConfigLifecycleApi } from "./groups/config"
 import { ControlApi } from "./groups/control"
 import { ControlPlaneApi } from "./groups/control-plane"
 import { EventApi } from "./groups/event"
@@ -42,6 +42,7 @@ const EventSchema = Schema.Union([
 ]).annotate({ identifier: "Event" })
 
 export const RootHttpApi = HttpApi.make("opencode-root")
+  .addHttpApi(ConfigLifecycleApi)
   .addHttpApi(ControlApi)
   .addHttpApi(ControlPlaneApi)
   .addHttpApi(GlobalApi)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
@@ -16,13 +16,21 @@ import { described } from "./metadata"
 const root = "/config"
 void ConfigReload.Event
 
+const BootstrapCycle = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1))
+
 export const ConfigReloadResponse = Schema.Struct({
   success: Schema.Boolean,
   immediate: Schema.Boolean,
+  bootstrapCycle: Schema.optional(BootstrapCycle),
+})
+export const ConfigReloadStatusResponse = Schema.Struct({
+  pending: Schema.Boolean,
+  executing: Schema.Boolean,
+  bootstrapCycle: Schema.optional(BootstrapCycle),
 })
 export const ConfigBootstrapCompleteQuery = Schema.Struct({
   ...WorkspaceRoutingQueryFields,
-  cycle: Schema.NumberFromString,
+  cycle: Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(1)),
 })
 export const ConfigBootstrapCompleteResponse = Schema.Struct({
   success: Schema.Boolean,
@@ -74,16 +82,6 @@ export const ConfigApi = HttpApi.make("config")
             description: "Reload OpenCode configuration files and plugins without restarting the client.",
           }),
         ),
-        HttpApiEndpoint.post("bootstrapComplete", `${root}/bootstrap-complete`, {
-          query: ConfigBootstrapCompleteQuery,
-          success: described(ConfigBootstrapCompleteResponse, "Bootstrap completion result"),
-        }).annotateMerge(
-          OpenApi.annotations({
-            identifier: "config.bootstrapComplete",
-            summary: "Complete config reload bootstrap",
-            description: "Release the reload blocker after the TUI has bootstrapped against the new instance.",
-          }),
-        ),
       )
       .annotateMerge(
         OpenApi.annotations({
@@ -100,5 +98,47 @@ export const ConfigApi = HttpApi.make("config")
       title: "opencode experimental HttpApi",
       version: "0.0.1",
       description: "Experimental HttpApi surface for selected instance routes.",
+    }),
+  )
+
+export const ConfigLifecycleApi = HttpApi.make("config-lifecycle")
+  .add(
+    HttpApiGroup.make("config-lifecycle")
+      .add(
+        HttpApiEndpoint.get("reloadStatus", `${root}/reload/status`, {
+          query: WorkspaceRoutingQuery,
+          success: described(ConfigReloadStatusResponse, "Configuration reload status"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.reloadStatus",
+            summary: "Get config reload status",
+            description: "Return the current reload lifecycle state for clients that need to poll for bootstrap cycles.",
+          }),
+        ),
+        HttpApiEndpoint.post("bootstrapComplete", `${root}/bootstrap-complete`, {
+          query: ConfigBootstrapCompleteQuery,
+          success: described(ConfigBootstrapCompleteResponse, "Bootstrap completion result"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.bootstrapComplete",
+            summary: "Complete config reload bootstrap",
+            description: "Release the reload blocker after the TUI has bootstrapped against the new instance.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "config lifecycle",
+          description: "Config reload lifecycle routes that must work while an instance is rebooting.",
+        }),
+      )
+      .middleware(WorkspaceRoutingMiddleware)
+      .middleware(Authorization),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode config lifecycle HttpApi",
+      version: "0.0.1",
+      description: "Config reload lifecycle endpoints outside instance bootstrap.",
     }),
   )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
@@ -1,13 +1,32 @@
 import { Config } from "@/config/config"
+import { ConfigReload } from "@/config/reload"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { Provider } from "@/provider/provider"
+import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
-import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
+import {
+  WorkspaceRoutingMiddleware,
+  WorkspaceRoutingQuery,
+  WorkspaceRoutingQueryFields,
+} from "../middleware/workspace-routing"
 import { described } from "./metadata"
 
 const root = "/config"
+void ConfigReload.Event
+
+export const ConfigReloadResponse = Schema.Struct({
+  success: Schema.Boolean,
+  immediate: Schema.Boolean,
+})
+export const ConfigBootstrapCompleteQuery = Schema.Struct({
+  ...WorkspaceRoutingQueryFields,
+  cycle: Schema.optional(Schema.NumberFromString),
+})
+export const ConfigBootstrapCompleteResponse = Schema.Struct({
+  success: Schema.Boolean,
+})
 
 export const ConfigApi = HttpApi.make("config")
   .add(
@@ -43,6 +62,26 @@ export const ConfigApi = HttpApi.make("config")
             identifier: "config.providers",
             summary: "List config providers",
             description: "Get a list of all configured AI providers and their default models.",
+          }),
+        ),
+        HttpApiEndpoint.post("reload", `${root}/reload`, {
+          query: WorkspaceRoutingQuery,
+          success: described(ConfigReloadResponse, "Configuration reload request result"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.reload",
+            summary: "Reload configuration",
+            description: "Reload OpenCode configuration files and plugins without restarting the client.",
+          }),
+        ),
+        HttpApiEndpoint.post("bootstrapComplete", `${root}/bootstrap-complete`, {
+          query: ConfigBootstrapCompleteQuery,
+          success: described(ConfigBootstrapCompleteResponse, "Bootstrap completion result"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "config.bootstrapComplete",
+            summary: "Complete config reload bootstrap",
+            description: "Release the reload blocker after the TUI has bootstrapped against the new instance.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/config.ts
@@ -22,7 +22,7 @@ export const ConfigReloadResponse = Schema.Struct({
 })
 export const ConfigBootstrapCompleteQuery = Schema.Struct({
   ...WorkspaceRoutingQueryFields,
-  cycle: Schema.optional(Schema.NumberFromString),
+  cycle: Schema.NumberFromString,
 })
 export const ConfigBootstrapCompleteResponse = Schema.Struct({
   success: Schema.Boolean,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -1,8 +1,6 @@
 import { Config } from "@/config/config"
 import { ConfigReload } from "@/config/reload"
-import { EventV2Bridge } from "@/event-v2-bridge"
 import { Provider } from "@/provider/provider"
-import { InstanceStore } from "@/project/instance-store"
 import * as InstanceState from "@/effect/instance-state"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
@@ -14,10 +12,7 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
   Effect.gen(function* () {
     const providerSvc = yield* Provider.Service
     const configSvc = yield* Config.Service
-    const events = yield* EventV2Bridge.Service
-    const store = yield* InstanceStore.Service
-    const reloadState = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
+    const reloadSvc = yield* ConfigReload.Service
 
     const get = Effect.fn("ConfigHttpApi.get")(function* () {
       return yield* configSvc.get()
@@ -38,7 +33,7 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
     })
 
     const reload = Effect.fn("ConfigHttpApi.reload")(function* () {
-      const result = yield* reloadState(ConfigReload.request())
+      const result = yield* reloadSvc.request()
       if (result.immediate) yield* markInstanceForReload(yield* InstanceState.context, result.input)
       return { success: true, immediate: result.immediate, bootstrapCycle: result.bootstrapCycle }
     })
@@ -53,28 +48,21 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
 
 export const configLifecycleHandlers = HttpApiBuilder.group(RootHttpApi, "config-lifecycle", (handlers) =>
   Effect.gen(function* () {
-    const events = yield* EventV2Bridge.Service
-    const store = yield* InstanceStore.Service
-    const reloadState = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
+    const reloadSvc = yield* ConfigReload.Service
 
     const reloadStatus = Effect.fn("ConfigLifecycleHttpApi.reloadStatus")(function* () {
       const route = yield* WorkspaceRouteContext
-      return yield* reloadState(
-        ConfigReload.statusForLocation({ directory: route.directory, workspaceID: route.workspaceID }),
-      )
+      return yield* reloadSvc.statusForLocation({ directory: route.directory, workspaceID: route.workspaceID })
     })
 
     const bootstrapComplete = Effect.fn("ConfigLifecycleHttpApi.bootstrapComplete")(function* (ctx) {
       const route = yield* WorkspaceRouteContext
       return {
-        success: yield* reloadState(
-          ConfigReload.completeBootstrapForLocation({
-            directory: route.directory,
-            workspaceID: route.workspaceID,
-            cycle: ctx.query.cycle,
-          }),
-        ),
+        success: yield* reloadSvc.completeBootstrapForLocation({
+          directory: route.directory,
+          workspaceID: route.workspaceID,
+          cycle: ctx.query.cycle,
+        }),
       }
     })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -44,7 +44,7 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
 
     const bootstrapComplete = Effect.fn("ConfigHttpApi.bootstrapComplete")(function* (ctx) {
       if (ctx.query.cycle !== (yield* reloadState(ConfigReload.getBootstrapCycle()))) return { success: false }
-      yield* reloadState(ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* reloadState(ConfigReload.releaseBlocker("tui-bootstrap"))
       return { success: true }
     })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -43,7 +43,7 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
     })
 
     const bootstrapComplete = Effect.fn("ConfigHttpApi.bootstrapComplete")(function* (ctx) {
-      if (ctx.query.cycle !== undefined && ctx.query.cycle !== ConfigReload.getBootstrapCycle()) return { success: false }
+      if (ctx.query.cycle !== (yield* reloadState(ConfigReload.getBootstrapCycle()))) return { success: false }
       yield* reloadState(ConfigReload.finishBlocker("tui-bootstrap"))
       return { success: true }
     })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -1,15 +1,22 @@
 import { Config } from "@/config/config"
+import { ConfigReload } from "@/config/reload"
+import { EventV2Bridge } from "@/event-v2-bridge"
 import { Provider } from "@/provider/provider"
+import { InstanceStore } from "@/project/instance-store"
 import * as InstanceState from "@/effect/instance-state"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
-import { markInstanceForDisposal } from "../lifecycle"
+import { markInstanceForDisposal, markInstanceForReload } from "../lifecycle"
 
 export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (handlers) =>
   Effect.gen(function* () {
     const providerSvc = yield* Provider.Service
     const configSvc = yield* Config.Service
+    const events = yield* EventV2Bridge.Service
+    const store = yield* InstanceStore.Service
+    const reloadState = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
 
     const get = Effect.fn("ConfigHttpApi.get")(function* () {
       return yield* configSvc.get()
@@ -29,6 +36,23 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
       }
     })
 
-    return handlers.handle("get", get).handle("update", update).handle("providers", providers)
+    const reload = Effect.fn("ConfigHttpApi.reload")(function* () {
+      const result = yield* reloadState(ConfigReload.request())
+      if (result.immediate) yield* markInstanceForReload(yield* InstanceState.context, result.input)
+      return { success: true, immediate: result.immediate }
+    })
+
+    const bootstrapComplete = Effect.fn("ConfigHttpApi.bootstrapComplete")(function* (ctx) {
+      if (ctx.query.cycle !== undefined && ctx.query.cycle !== ConfigReload.getBootstrapCycle()) return { success: false }
+      yield* reloadState(ConfigReload.finishBlocker("tui-bootstrap"))
+      return { success: true }
+    })
+
+    return handlers
+      .handle("get", get)
+      .handle("update", update)
+      .handle("providers", providers)
+      .handle("reload", reload)
+      .handle("bootstrapComplete", bootstrapComplete)
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/config.ts
@@ -6,8 +6,9 @@ import { InstanceStore } from "@/project/instance-store"
 import * as InstanceState from "@/effect/instance-state"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { InstanceHttpApi } from "../api"
+import { InstanceHttpApi, RootHttpApi } from "../api"
 import { markInstanceForDisposal, markInstanceForReload } from "../lifecycle"
+import { WorkspaceRouteContext } from "../middleware/workspace-routing"
 
 export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (handlers) =>
   Effect.gen(function* () {
@@ -39,13 +40,7 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
     const reload = Effect.fn("ConfigHttpApi.reload")(function* () {
       const result = yield* reloadState(ConfigReload.request())
       if (result.immediate) yield* markInstanceForReload(yield* InstanceState.context, result.input)
-      return { success: true, immediate: result.immediate }
-    })
-
-    const bootstrapComplete = Effect.fn("ConfigHttpApi.bootstrapComplete")(function* (ctx) {
-      if (ctx.query.cycle !== (yield* reloadState(ConfigReload.getBootstrapCycle()))) return { success: false }
-      yield* reloadState(ConfigReload.releaseBlocker("tui-bootstrap"))
-      return { success: true }
+      return { success: true, immediate: result.immediate, bootstrapCycle: result.bootstrapCycle }
     })
 
     return handlers
@@ -53,6 +48,36 @@ export const configHandlers = HttpApiBuilder.group(InstanceHttpApi, "config", (h
       .handle("update", update)
       .handle("providers", providers)
       .handle("reload", reload)
-      .handle("bootstrapComplete", bootstrapComplete)
+  }),
+)
+
+export const configLifecycleHandlers = HttpApiBuilder.group(RootHttpApi, "config-lifecycle", (handlers) =>
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const store = yield* InstanceStore.Service
+    const reloadState = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
+
+    const reloadStatus = Effect.fn("ConfigLifecycleHttpApi.reloadStatus")(function* () {
+      const route = yield* WorkspaceRouteContext
+      return yield* reloadState(
+        ConfigReload.statusForLocation({ directory: route.directory, workspaceID: route.workspaceID }),
+      )
+    })
+
+    const bootstrapComplete = Effect.fn("ConfigLifecycleHttpApi.bootstrapComplete")(function* (ctx) {
+      const route = yield* WorkspaceRouteContext
+      return {
+        success: yield* reloadState(
+          ConfigReload.completeBootstrapForLocation({
+            directory: route.directory,
+            workspaceID: route.workspaceID,
+            cycle: ctx.query.cycle,
+          }),
+        ),
+      }
+    })
+
+    return handlers.handle("reloadStatus", reloadStatus).handle("bootstrapComplete", bootstrapComplete)
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -84,7 +84,16 @@ function selectedV2WorkspaceID(
 }
 
 function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+  return url.searchParams.get("directory") || headerDirectory(request.headers["x-opencode-directory"]) || process.cwd()
+}
+
+function headerDirectory(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -10,6 +10,7 @@ import { Auth } from "@/auth"
 import { BackgroundJob } from "@/background/job"
 import { Command } from "@/command"
 import { Config } from "@/config/config"
+import { ConfigReload } from "@/config/reload"
 import { Workspace } from "@/control-plane/workspace"
 import { Env } from "@/env"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -207,6 +208,7 @@ const app = LayerNode.group([
   Auth.node,
   Account.node,
   Config.node,
+  ConfigReload.node,
   Env.node,
   Git.node,
   Ripgrep.node,

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -77,7 +77,7 @@ import {
 import { EventApi } from "./groups/event"
 import { PtyConnectApi } from "./groups/pty"
 import { eventHandlers } from "./handlers/event"
-import { configHandlers } from "./handlers/config"
+import { configHandlers, configLifecycleHandlers } from "./handlers/config"
 import { controlHandlers } from "./handlers/control"
 import { controlPlaneHandlers } from "./handlers/control-plane"
 import { experimentalHandlers } from "./handlers/experimental"
@@ -130,9 +130,9 @@ const ptyConnectHttpApiAuthLayer = ptyConnectAuthorizationLayer.pipe(Layer.provi
 const serverHttpApiAuthLayer = serverAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
 const workspaceRoutingLive = workspaceRoutingLayer.pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal))
 const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(
-  Layer.provide([controlHandlers, controlPlaneHandlers, globalHandlers]),
+  Layer.provide([configLifecycleHandlers, controlHandlers, controlPlaneHandlers, globalHandlers]),
   Layer.provide(schemaErrorLayer),
-  Layer.provide(httpApiAuthLayer),
+  Layer.provide([httpApiAuthLayer, workspaceRoutingLive]),
 )
 const eventApiRoutes = HttpApiBuilder.layer(EventApi).pipe(
   Layer.provide(eventHandlers),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -353,7 +353,7 @@ export const layer = Layer.effect(
         title: string
         metadata: Record<string, any>
         output: string
-        stopSession?: boolean
+        stopAfterToolResult?: boolean
         attachments?: SessionV1.FilePart[]
       } => {
         if (isRecord(value.result.value) && typeof value.result.value.output === "string") {
@@ -361,7 +361,7 @@ export const layer = Layer.effect(
             title: typeof value.result.value.title === "string" ? value.result.value.title : value.name,
             metadata: isRecord(value.result.value.metadata) ? value.result.value.metadata : {},
             output: value.result.value.output,
-            stopSession: value.result.value.stopSession === true,
+            stopAfterToolResult: value.result.value.stopAfterToolResult === true,
             attachments: Array.isArray(value.result.value.attachments)
               ? value.result.value.attachments.filter(isFilePart)
               : undefined,
@@ -650,7 +650,7 @@ export const layer = Layer.effect(
                 })
             }
             yield* completeToolCall(value.id, output)
-            if (output.stopSession) ctx.blocked = true
+            if (output.stopAfterToolResult) ctx.blocked = true
             return
           }
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -349,12 +349,19 @@ export const layer = Layer.effect(
 
       const toolResultOutput = (
         value: Extract<StreamEvent, { type: "tool-result" }>,
-      ): { title: string; metadata: Record<string, any>; output: string; attachments?: SessionV1.FilePart[] } => {
+      ): {
+        title: string
+        metadata: Record<string, any>
+        output: string
+        stopSession?: boolean
+        attachments?: SessionV1.FilePart[]
+      } => {
         if (isRecord(value.result.value) && typeof value.result.value.output === "string") {
           return {
             title: typeof value.result.value.title === "string" ? value.result.value.title : value.name,
             metadata: isRecord(value.result.value.metadata) ? value.result.value.metadata : {},
             output: value.result.value.output,
+            stopSession: value.result.value.stopSession === true,
             attachments: Array.isArray(value.result.value.attachments)
               ? value.result.value.attachments.filter(isFilePart)
               : undefined,
@@ -643,6 +650,7 @@ export const layer = Layer.effect(
                 })
             }
             yield* completeToolCall(value.id, output)
+            if (output.stopSession) ctx.blocked = true
             return
           }
 

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -4,9 +4,6 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Runner } from "@/effect/runner"
 import { BackgroundJob } from "@/background/job"
 import { ConfigReload } from "@/config/reload"
-import { EventV2Bridge } from "@/event-v2-bridge"
-import { InstanceLayer } from "@/project/instance-layer"
-import { InstanceStore } from "@/project/instance-store"
 import { Effect, Latch, Layer, Scope, Context } from "effect"
 import { Session } from "./session"
 import { SessionID } from "./schema"
@@ -35,10 +32,7 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const background = yield* BackgroundJob.Service
     const status = yield* SessionStatus.Service
-    const events = yield* EventV2Bridge.Service
-    const store = yield* InstanceStore.Service
-    const reload = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
+    const reload = yield* ConfigReload.Service
 
     const state = yield* InstanceState.make(
       Effect.fn("SessionRunState.state")(function* () {
@@ -68,11 +62,11 @@ export const layer = Layer.effect(
         onIdle: Effect.gen(function* () {
           data.runners.delete(sessionID)
           yield* status.set(sessionID, { type: "idle" })
-          yield* reload(ConfigReload.finish(sessionID))
-          yield* reload(ConfigReload.check())
+          yield* reload.finish(sessionID)
+          yield* reload.check()
         }),
         onBusy: Effect.gen(function* () {
-          yield* reload(ConfigReload.start(sessionID))
+          yield* reload.start(sessionID)
           yield* status.set(sessionID, { type: "busy" })
         }),
         onInterrupt,
@@ -93,8 +87,8 @@ export const layer = Layer.effect(
       const existing = data.runners.get(sessionID)
       if (!existing) {
         yield* status.set(sessionID, { type: "idle" })
-        yield* reload(ConfigReload.finish(sessionID))
-        yield* reload(ConfigReload.check())
+        yield* reload.finish(sessionID)
+        yield* reload.check()
         return
       }
       yield* existing.cancel
@@ -126,8 +120,7 @@ export const layer = Layer.effect(
 export const defaultLayer = layer.pipe(
   Layer.provide(BackgroundJob.defaultLayer),
   Layer.provide(SessionStatus.defaultLayer),
-  Layer.provide(EventV2Bridge.defaultLayer),
-  Layer.provide(InstanceLayer.layer),
+  Layer.provide(ConfigReload.defaultLayer),
 )
 
 const cancelBackgroundJobs = Effect.fn("SessionRunState.cancelBackgroundJobs")(function* (
@@ -168,6 +161,6 @@ function busyError(sessionID: SessionID) {
   return new Session.BusyError({ sessionID })
 }
 
-export const node = LayerNode.make(layer, [BackgroundJob.node, SessionStatus.node, EventV2Bridge.node, InstanceStore.node])
+export const node = LayerNode.make(layer, [BackgroundJob.node, SessionStatus.node, ConfigReload.node])
 
 export * as SessionRunState from "./run-state"

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -3,6 +3,10 @@ import { InstanceState } from "@/effect/instance-state"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Runner } from "@/effect/runner"
 import { BackgroundJob } from "@/background/job"
+import { ConfigReload } from "@/config/reload"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceLayer } from "@/project/instance-layer"
+import { InstanceStore } from "@/project/instance-store"
 import { Effect, Latch, Layer, Scope, Context } from "effect"
 import { Session } from "./session"
 import { SessionID } from "./schema"
@@ -31,6 +35,10 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const background = yield* BackgroundJob.Service
     const status = yield* SessionStatus.Service
+    const events = yield* EventV2Bridge.Service
+    const store = yield* InstanceStore.Service
+    const reload = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
 
     const state = yield* InstanceState.make(
       Effect.fn("SessionRunState.state")(function* () {
@@ -60,8 +68,13 @@ export const layer = Layer.effect(
         onIdle: Effect.gen(function* () {
           data.runners.delete(sessionID)
           yield* status.set(sessionID, { type: "idle" })
+          yield* reload(ConfigReload.finish(sessionID))
+          yield* reload(ConfigReload.check())
         }),
-        onBusy: status.set(sessionID, { type: "busy" }),
+        onBusy: Effect.gen(function* () {
+          yield* reload(ConfigReload.start(sessionID))
+          yield* status.set(sessionID, { type: "busy" })
+        }),
         onInterrupt,
       })
       data.runners.set(sessionID, next)
@@ -80,6 +93,8 @@ export const layer = Layer.effect(
       const existing = data.runners.get(sessionID)
       if (!existing) {
         yield* status.set(sessionID, { type: "idle" })
+        yield* reload(ConfigReload.finish(sessionID))
+        yield* reload(ConfigReload.check())
         return
       }
       yield* existing.cancel
@@ -111,6 +126,8 @@ export const layer = Layer.effect(
 export const defaultLayer = layer.pipe(
   Layer.provide(BackgroundJob.defaultLayer),
   Layer.provide(SessionStatus.defaultLayer),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(InstanceLayer.layer),
 )
 
 const cancelBackgroundJobs = Effect.fn("SessionRunState.cancelBackgroundJobs")(function* (
@@ -151,6 +168,6 @@ function busyError(sessionID: SessionID) {
   return new Session.BusyError({ sessionID })
 }
 
-export const node = LayerNode.make(layer, [BackgroundJob.node, SessionStatus.node])
+export const node = LayerNode.make(layer, [BackgroundJob.node, SessionStatus.node, EventV2Bridge.node, InstanceStore.node])
 
 export * as SessionRunState from "./run-state"

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -46,8 +46,7 @@ import { LSP } from "@/lsp/lsp"
 import { Instruction } from "../session/instruction"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { EventV2Bridge } from "@/event-v2-bridge"
-import { InstanceLayer } from "@/project/instance-layer"
-import { InstanceStore } from "@/project/instance-store"
+import { ConfigReload } from "@/config/reload"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
@@ -337,7 +336,7 @@ export const defaultLayer = Layer.suspend(() =>
       Layer.provide(Instruction.defaultLayer),
       Layer.provide(FSUtil.defaultLayer),
       Layer.provide(EventV2Bridge.defaultLayer),
-      Layer.provide(InstanceLayer.layer),
+      Layer.provide(ConfigReload.defaultLayer),
       Layer.provide(FetchHttpClient.layer),
       Layer.provide(Format.defaultLayer),
       Layer.provide(CrossSpawnSpawner.defaultLayer),
@@ -436,7 +435,7 @@ export const node = LayerNode.make(layer.pipe(Layer.provide(Ripgrep.defaultLayer
   Instruction.node,
   FSUtil.node,
   EventV2Bridge.node,
-  InstanceStore.node,
+  ConfigReload.node,
   httpClient,
   CrossSpawnSpawner.node,
   Format.node,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -16,6 +16,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { ReloadTool } from "./reload"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@opencode-ai/plugin"
@@ -45,6 +46,8 @@ import { LSP } from "@/lsp/lsp"
 import { Instruction } from "../session/instruction"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceLayer } from "@/project/instance-layer"
+import { InstanceStore } from "@/project/instance-store"
 import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
@@ -105,6 +108,7 @@ export const layer = Layer.effect(
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const reloadtool = yield* ReloadTool
     const agent = yield* Agent.Service
 
     const state = yield* InstanceState.make<State>(
@@ -208,6 +212,7 @@ export const layer = Layer.effect(
           todo: Tool.init(todo),
           search: Tool.init(websearch),
           skill: Tool.init(skilltool),
+          reload: Tool.init(reloadtool),
           patch: Tool.init(patchtool),
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
@@ -230,6 +235,7 @@ export const layer = Layer.effect(
             tool.todo,
             tool.search,
             tool.skill,
+            tool.reload,
             tool.patch,
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
@@ -331,6 +337,7 @@ export const defaultLayer = Layer.suspend(() =>
       Layer.provide(Instruction.defaultLayer),
       Layer.provide(FSUtil.defaultLayer),
       Layer.provide(EventV2Bridge.defaultLayer),
+      Layer.provide(InstanceLayer.layer),
       Layer.provide(FetchHttpClient.layer),
       Layer.provide(Format.defaultLayer),
       Layer.provide(CrossSpawnSpawner.defaultLayer),
@@ -429,6 +436,7 @@ export const node = LayerNode.make(layer.pipe(Layer.provide(Ripgrep.defaultLayer
   Instruction.node,
   FSUtil.node,
   EventV2Bridge.node,
+  InstanceStore.node,
   httpClient,
   CrossSpawnSpawner.node,
   Format.node,

--- a/packages/opencode/src/tool/reload.ts
+++ b/packages/opencode/src/tool/reload.ts
@@ -1,18 +1,13 @@
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { ConfigReload } from "@/config/reload"
-import { EventV2Bridge } from "@/event-v2-bridge"
-import { InstanceStore } from "@/project/instance-store"
 
 export const Parameters = Schema.Struct({})
 
 export const ReloadTool = Tool.define(
   "reload_config",
   Effect.gen(function* () {
-    const events = yield* EventV2Bridge.Service
-    const store = yield* InstanceStore.Service
-    const reload = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
+    const reload = yield* ConfigReload.Service
 
     return {
       description: "Reload OpenCode configuration files and plugins without restarting.",
@@ -26,7 +21,7 @@ export const ReloadTool = Tool.define(
             metadata: {},
           })
 
-          const result = yield* ConfigReload.request()
+          const result = yield* reload.request()
 
           return {
             title: result.immediate ? "Configuration reload started" : "Configuration reload queued",
@@ -36,7 +31,7 @@ export const ReloadTool = Tool.define(
             metadata: { queued: !result.immediate },
             stopAfterToolResult: true,
           }
-        }).pipe(reload),
+        }),
     }
   }),
 )

--- a/packages/opencode/src/tool/reload.ts
+++ b/packages/opencode/src/tool/reload.ts
@@ -32,9 +32,9 @@ export const ReloadTool = Tool.define(
             title: result.immediate ? "Configuration reload started" : "Configuration reload queued",
             output: result.immediate
               ? "Reload started. Wait for the reload to finish before continuing."
-              : "Reload queued. Wait for the reload to finish before continuing.",
+              : "Reload will start after active sessions finish.",
             metadata: { queued: !result.immediate },
-            stopSession: true,
+            stopAfterToolResult: true,
           }
         }).pipe(reload),
     }

--- a/packages/opencode/src/tool/reload.ts
+++ b/packages/opencode/src/tool/reload.ts
@@ -1,0 +1,42 @@
+import { Effect, Schema } from "effect"
+import * as Tool from "./tool"
+import { ConfigReload } from "@/config/reload"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceStore } from "@/project/instance-store"
+
+export const Parameters = Schema.Struct({})
+
+export const ReloadTool = Tool.define(
+  "reload_config",
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const store = yield* InstanceStore.Service
+    const reload = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(Effect.provideService(EventV2Bridge.Service, events), Effect.provideService(InstanceStore.Service, store))
+
+    return {
+      description: "Reload OpenCode configuration files and plugins without restarting.",
+      parameters: Parameters,
+      execute: (_params, ctx) =>
+        Effect.gen(function* () {
+          yield* ctx.ask({
+            permission: "reload_config",
+            patterns: ["*"],
+            always: ["*"],
+            metadata: {},
+          })
+
+          const result = yield* ConfigReload.request({ resumeSessionID: ctx.sessionID })
+
+          return {
+            title: result.immediate ? "Configuration reload started" : "Configuration reload queued",
+            output: result.immediate
+              ? "Reload started. The session will stop now and resume automatically after reload."
+              : "Reload queued. The session will stop now and resume automatically after reload.",
+            metadata: { queued: !result.immediate },
+            stopSession: true,
+          }
+        }).pipe(reload),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/reload.ts
+++ b/packages/opencode/src/tool/reload.ts
@@ -26,13 +26,13 @@ export const ReloadTool = Tool.define(
             metadata: {},
           })
 
-          const result = yield* ConfigReload.request({ resumeSessionID: ctx.sessionID })
+          const result = yield* ConfigReload.request()
 
           return {
             title: result.immediate ? "Configuration reload started" : "Configuration reload queued",
             output: result.immediate
-              ? "Reload started. The session will stop now and resume automatically after reload."
-              : "Reload queued. The session will stop now and resume automatically after reload.",
+              ? "Reload started. Wait for the reload to finish before continuing."
+              : "Reload queued. Wait for the reload to finish before continuing.",
             metadata: { queued: !result.immediate },
             stopSession: true,
           }

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -49,6 +49,7 @@ export interface ExecuteResult<M extends Metadata = Metadata> {
   title: string
   metadata: M
   output: string
+  stopSession?: boolean
   attachments?: Omit<SessionV1.FilePart, "id" | "sessionID" | "messageID">[]
 }
 

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -49,7 +49,8 @@ export interface ExecuteResult<M extends Metadata = Metadata> {
   title: string
   metadata: M
   output: string
-  stopSession?: boolean
+  /** Stop the current assistant turn after this tool result is recorded. */
+  stopAfterToolResult?: boolean
   attachments?: Omit<SessionV1.FilePart, "id" | "sessionID" | "messageID">[]
 }
 

--- a/packages/opencode/test/config/reload.test.ts
+++ b/packages/opencode/test/config/reload.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect } from "bun:test"
 import { ConfigReload } from "@/config/reload"
-import { InstanceRef } from "@/effect/instance-ref"
+import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import type { InstanceContext } from "@/project/instance-context"
 import { InstanceStore } from "@/project/instance-store"
 import { EventV2 } from "@opencode-ai/core/event"
 import { ProjectV2 } from "@opencode-ai/core/project"
+import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { Effect, Layer, Stream } from "effect"
 import { testEffect } from "../lib/effect"
 
@@ -37,6 +38,10 @@ function instance(directory: string): InstanceContext {
 
 function withInstance<A, E, R>(ctx: InstanceContext, effect: Effect.Effect<A, E, R>) {
   return effect.pipe(Effect.provideService(InstanceRef, ctx))
+}
+
+function withWorkspace<A, E, R>(workspaceID: WorkspaceV2.ID, effect: Effect.Effect<A, E, R>) {
+  return effect.pipe(Effect.provideService(WorkspaceRef, workspaceID))
 }
 
 function testLayer(events: PublishedEvent[], reloads: ReloadCall[]) {
@@ -84,6 +89,7 @@ describe("ConfigReload", () => {
 
       expect(result.immediate).toBe(true)
       expect(result.input.directory).toBe(beta.directory)
+      expect(result.bootstrapCycle).toBe(1)
       expect(events.map((event) => event.type)).toEqual(["config.reload.pending", "config.reload.executing"])
       expect(yield* withInstance(alpha, ConfigReload.getBootstrapCycle())).toBe(0)
       expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
@@ -107,6 +113,26 @@ describe("ConfigReload", () => {
       yield* withInstance(alpha, ConfigReload.releaseBlocker("tui-bootstrap"))
       expect(events.at(-1)?.type).toBe("config.reload.done")
       expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
+    }),
+  )
+
+  it.effect("accepts bootstrap completion when the reconnect event omits workspace metadata", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const ctx = instance("/tmp/reload-missing-workspace-metadata")
+      const workspaceID = WorkspaceV2.ID.ascending("wrk_reload_missing_metadata")
+
+      // User intent: the TUI may reconnect after reload through a lifecycle event
+      // that does not include workspace metadata. A valid bootstrap completion for
+      // the same project and cycle must still release the visible reload overlay.
+      const result = yield* withInstance(ctx, withWorkspace(workspaceID, ConfigReload.request()))
+      expect(result.bootstrapCycle).toBe(1)
+
+      const accepted = yield* withInstance(ctx, ConfigReload.completeBootstrap(1))
+
+      expect(accepted).toBe(true)
+      expect(events.at(-1)).toEqual({ type: "config.reload.done", data: {} })
     }),
   )
 
@@ -222,6 +248,35 @@ describe("ConfigReload", () => {
       expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
       expect(events.at(-1)?.type).toBe("config.reload.executing")
       expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(1)
+    }),
+  )
+
+  it.effect("exposes reload status for clients that poll instead of listening to events", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const ctx = instance("/tmp/reload-status")
+
+      // User intent: a non-TUI client that cannot rely on the event stream still
+      // needs a way to learn when a queued reload starts and which cycle to ack.
+      yield* withInstance(ctx, ConfigReload.start("session-before-reload"))
+      const queued = yield* withInstance(ctx, ConfigReload.request())
+
+      expect(queued.immediate).toBe(false)
+      expect(queued.bootstrapCycle).toBeUndefined()
+      expect(yield* withInstance(ctx, ConfigReload.status())).toEqual({
+        pending: true,
+        executing: false,
+        bootstrapCycle: undefined,
+      })
+
+      yield* withInstance(ctx, ConfigReload.finish("session-before-reload"))
+
+      expect(yield* withInstance(ctx, ConfigReload.status())).toEqual({
+        pending: false,
+        executing: true,
+        bootstrapCycle: 1,
+      })
     }),
   )
 

--- a/packages/opencode/test/config/reload.test.ts
+++ b/packages/opencode/test/config/reload.test.ts
@@ -104,7 +104,7 @@ describe("ConfigReload", () => {
 
       expect(yield* withInstance(alpha, ConfigReload.getBootstrapCycle())).toBe(1)
       expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
-      yield* withInstance(alpha, ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* withInstance(alpha, ConfigReload.releaseBlocker("tui-bootstrap"))
       expect(events.at(-1)?.type).toBe("config.reload.done")
       expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
     }),
@@ -126,7 +126,7 @@ describe("ConfigReload", () => {
         "config.reload.executing",
         "config.reload.pending",
       ])
-      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
 
       expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
       expect(events.map((event) => event.type)).toEqual([
@@ -136,7 +136,7 @@ describe("ConfigReload", () => {
         "config.reload.pending",
         "config.reload.executing",
       ])
-      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
       expect(events.at(-1)?.type).toBe("config.reload.done")
       expect(events.filter((event) => event.type === "config.reload.done")).toHaveLength(1)
     }),
@@ -178,7 +178,7 @@ describe("ConfigReload", () => {
       const queuedDuringBootstrap = yield* withInstance(ctx, ConfigReload.request())
       expect(queuedDuringBootstrap.immediate).toBe(false)
 
-      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
 
       expect(reloads).toEqual([
         { directory: ctx.directory, worktree: ctx.worktree },
@@ -187,11 +187,41 @@ describe("ConfigReload", () => {
       expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
       expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(2)
 
-      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
 
       expect(events.filter((event) => event.type === "config.reload.done")).toEqual([
         { type: "config.reload.done", data: {} },
       ])
+    }),
+  )
+
+  it.effect("tracks a new session that starts after reload is already queued", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const ctx = instance("/tmp/reload-session-starts-after-queue")
+
+      // User intent: after `/reload` says it is queued, starting another chat in
+      // the same TUI must extend the wait. The reload must not begin just because
+      // the session that was active at queue time finished.
+      yield* withInstance(ctx, ConfigReload.start("session-before-reload"))
+      const queued = yield* withInstance(ctx, ConfigReload.request())
+      yield* withInstance(ctx, ConfigReload.start("session-after-reload"))
+
+      expect(queued.immediate).toBe(false)
+      expect(reloads).toEqual([])
+
+      yield* withInstance(ctx, ConfigReload.finish("session-before-reload"))
+
+      expect(reloads).toEqual([])
+      expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
+      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(0)
+
+      yield* withInstance(ctx, ConfigReload.finish("session-after-reload"))
+
+      expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
+      expect(events.at(-1)?.type).toBe("config.reload.executing")
+      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(1)
     }),
   )
 
@@ -204,7 +234,7 @@ describe("ConfigReload", () => {
       // User intent: reloading configuration must not create an artificial
       // user message like "continue where you left off" in session history.
       yield* withInstance(ctx, ConfigReload.request())
-      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
 
       const done = events.find((event) => event.type === "config.reload.done")
       expect(done?.data).toEqual({})

--- a/packages/opencode/test/config/reload.test.ts
+++ b/packages/opencode/test/config/reload.test.ts
@@ -44,29 +44,51 @@ function withWorkspace<A, E, R>(workspaceID: WorkspaceV2.ID, effect: Effect.Effe
   return effect.pipe(Effect.provideService(WorkspaceRef, workspaceID))
 }
 
+function withReload<A, E, R>(ctx: InstanceContext, use: (reload: ConfigReload.Interface) => Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const reload = yield* ConfigReload.Service
+    return yield* withInstance(ctx, use(reload))
+  })
+}
+
+function withWorkspaceReload<A, E, R>(
+  ctx: InstanceContext,
+  workspaceID: WorkspaceV2.ID,
+  use: (reload: ConfigReload.Interface) => Effect.Effect<A, E, R>,
+) {
+  return Effect.gen(function* () {
+    const reload = yield* ConfigReload.Service
+    return yield* withInstance(ctx, withWorkspace(workspaceID, use(reload)))
+  })
+}
+
 function testLayer(events: PublishedEvent[], reloads: ReloadCall[]) {
-  return Layer.mergeAll(
-    Layer.mock(EventV2Bridge.Service)({
-      publish: (definition, data) =>
-        Effect.sync(() => {
-          events.push({ type: definition.type, data })
-          return {
-            id: EventV2.ID.create(),
-            type: definition.type,
-            data,
-          } as EventV2.Payload<typeof definition>
+  return ConfigReload.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.mock(EventV2Bridge.Service)({
+          publish: (definition, data) =>
+            Effect.sync(() => {
+              events.push({ type: definition.type, data })
+              return {
+                id: EventV2.ID.create(),
+                type: definition.type,
+                data,
+              } as EventV2.Payload<typeof definition>
+            }),
+          subscribe: () => Stream.empty,
+          all: () => Stream.empty,
+          listen: () => Effect.succeed(Effect.void),
         }),
-      subscribe: () => Stream.empty,
-      all: () => Stream.empty,
-      listen: () => Effect.succeed(Effect.void),
-    }),
-    Layer.mock(InstanceStore.Service)({
-      reload: (input) =>
-        Effect.sync(() => {
-          reloads.push({ directory: input.directory, worktree: input.worktree })
-          return instance(input.directory)
+        Layer.mock(InstanceStore.Service)({
+          reload: (input) =>
+            Effect.sync(() => {
+              reloads.push({ directory: input.directory, worktree: input.worktree })
+              return instance(input.directory)
+            }),
         }),
-    }),
+      ),
+    ),
   )
 }
 
@@ -84,15 +106,15 @@ describe("ConfigReload", () => {
 
       // User intent: a long-running chat in one project must not make `/reload`
       // appear queued or stuck in an unrelated TUI window.
-      yield* withInstance(alpha, ConfigReload.start("session-alpha"))
-      const result = yield* withInstance(beta, ConfigReload.request())
+      yield* withReload(alpha, (reload) => reload.start("session-alpha"))
+      const result = yield* withReload(beta, (reload) => reload.request())
 
       expect(result.immediate).toBe(true)
       expect(result.input.directory).toBe(beta.directory)
       expect(result.bootstrapCycle).toBe(1)
       expect(events.map((event) => event.type)).toEqual(["config.reload.pending", "config.reload.executing"])
-      expect(yield* withInstance(alpha, ConfigReload.getBootstrapCycle())).toBe(0)
-      expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
+      expect(yield* withReload(alpha, (reload) => reload.getBootstrapCycle())).toBe(0)
+      expect(yield* withReload(beta, (reload) => reload.getBootstrapCycle())).toBe(1)
     }),
   )
 
@@ -105,14 +127,14 @@ describe("ConfigReload", () => {
 
       // User intent: a late bootstrap acknowledgement from one TUI must not
       // dismiss the reload overlay or unblock reload state in another TUI.
-      yield* withInstance(alpha, ConfigReload.request())
-      yield* withInstance(beta, ConfigReload.request())
+      yield* withReload(alpha, (reload) => reload.request())
+      yield* withReload(beta, (reload) => reload.request())
 
-      expect(yield* withInstance(alpha, ConfigReload.getBootstrapCycle())).toBe(1)
-      expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
-      yield* withInstance(alpha, ConfigReload.releaseBlocker("tui-bootstrap"))
+      expect(yield* withReload(alpha, (reload) => reload.getBootstrapCycle())).toBe(1)
+      expect(yield* withReload(beta, (reload) => reload.getBootstrapCycle())).toBe(1)
+      yield* withReload(alpha, (reload) => reload.releaseBlocker("tui-bootstrap"))
       expect(events.at(-1)?.type).toBe("config.reload.done")
-      expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
+      expect(yield* withReload(beta, (reload) => reload.getBootstrapCycle())).toBe(1)
     }),
   )
 
@@ -126,10 +148,10 @@ describe("ConfigReload", () => {
       // User intent: the TUI may reconnect after reload through a lifecycle event
       // that does not include workspace metadata. A valid bootstrap completion for
       // the same project and cycle must still release the visible reload overlay.
-      const result = yield* withInstance(ctx, withWorkspace(workspaceID, ConfigReload.request()))
+      const result = yield* withWorkspaceReload(ctx, workspaceID, (reload) => reload.request())
       expect(result.bootstrapCycle).toBe(1)
 
-      const accepted = yield* withInstance(ctx, ConfigReload.completeBootstrap(1))
+      const accepted = yield* withReload(ctx, (reload) => reload.completeBootstrap(1))
 
       expect(accepted).toBe(true)
       expect(events.at(-1)).toEqual({ type: "config.reload.done", data: {} })
@@ -144,15 +166,15 @@ describe("ConfigReload", () => {
 
       // User intent: hammering `/reload` during the reload overlay should not
       // briefly say the app is ready and then immediately tear it down again.
-      yield* withInstance(ctx, ConfigReload.request())
-      yield* withInstance(ctx, ConfigReload.request())
+      yield* withReload(ctx, (reload) => reload.request())
+      yield* withReload(ctx, (reload) => reload.request())
 
       expect(events.map((event) => event.type)).toEqual([
         "config.reload.pending",
         "config.reload.executing",
         "config.reload.pending",
       ])
-      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
+      yield* withReload(ctx, (reload) => reload.releaseBlocker("tui-bootstrap"))
 
       expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
       expect(events.map((event) => event.type)).toEqual([
@@ -162,7 +184,7 @@ describe("ConfigReload", () => {
         "config.reload.pending",
         "config.reload.executing",
       ])
-      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
+      yield* withReload(ctx, (reload) => reload.releaseBlocker("tui-bootstrap"))
       expect(events.at(-1)?.type).toBe("config.reload.done")
       expect(events.filter((event) => event.type === "config.reload.done")).toHaveLength(1)
     }),
@@ -178,42 +200,42 @@ describe("ConfigReload", () => {
       // should wait for every active session, remain queued when only one settles,
       // coalesce repeated reload requests, avoid an early "ready" signal during
       // bootstrap, and finish without creating a synthetic continuation prompt.
-      yield* withInstance(ctx, ConfigReload.start("session-a"))
-      yield* withInstance(ctx, ConfigReload.start("session-b"))
+      yield* withReload(ctx, (reload) => reload.start("session-a"))
+      yield* withReload(ctx, (reload) => reload.start("session-b"))
 
-      const first = yield* withInstance(ctx, ConfigReload.request())
-      const second = yield* withInstance(ctx, ConfigReload.request())
+      const first = yield* withReload(ctx, (reload) => reload.request())
+      const second = yield* withReload(ctx, (reload) => reload.request())
 
       expect(first.immediate).toBe(false)
       expect(second.immediate).toBe(false)
       expect(reloads).toEqual([])
       expect(events.filter((event) => event.type === "config.reload.executing")).toEqual([])
 
-      yield* withInstance(ctx, ConfigReload.finish("session-a"))
+      yield* withReload(ctx, (reload) => reload.finish("session-a"))
 
       expect(reloads).toEqual([])
       expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
-      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(0)
+      expect(yield* withReload(ctx, (reload) => reload.getBootstrapCycle())).toBe(0)
 
-      yield* withInstance(ctx, ConfigReload.finish("session-b"))
+      yield* withReload(ctx, (reload) => reload.finish("session-b"))
 
       expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
       expect(events.at(-1)?.type).toBe("config.reload.executing")
-      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(1)
+      expect(yield* withReload(ctx, (reload) => reload.getBootstrapCycle())).toBe(1)
 
-      const queuedDuringBootstrap = yield* withInstance(ctx, ConfigReload.request())
+      const queuedDuringBootstrap = yield* withReload(ctx, (reload) => reload.request())
       expect(queuedDuringBootstrap.immediate).toBe(false)
 
-      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
+      yield* withReload(ctx, (reload) => reload.releaseBlocker("tui-bootstrap"))
 
       expect(reloads).toEqual([
         { directory: ctx.directory, worktree: ctx.worktree },
         { directory: ctx.directory, worktree: ctx.worktree },
       ])
       expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
-      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(2)
+      expect(yield* withReload(ctx, (reload) => reload.getBootstrapCycle())).toBe(2)
 
-      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
+      yield* withReload(ctx, (reload) => reload.releaseBlocker("tui-bootstrap"))
 
       expect(events.filter((event) => event.type === "config.reload.done")).toEqual([
         { type: "config.reload.done", data: {} },
@@ -230,24 +252,24 @@ describe("ConfigReload", () => {
       // User intent: after `/reload` says it is queued, starting another chat in
       // the same TUI must extend the wait. The reload must not begin just because
       // the session that was active at queue time finished.
-      yield* withInstance(ctx, ConfigReload.start("session-before-reload"))
-      const queued = yield* withInstance(ctx, ConfigReload.request())
-      yield* withInstance(ctx, ConfigReload.start("session-after-reload"))
+      yield* withReload(ctx, (reload) => reload.start("session-before-reload"))
+      const queued = yield* withReload(ctx, (reload) => reload.request())
+      yield* withReload(ctx, (reload) => reload.start("session-after-reload"))
 
       expect(queued.immediate).toBe(false)
       expect(reloads).toEqual([])
 
-      yield* withInstance(ctx, ConfigReload.finish("session-before-reload"))
+      yield* withReload(ctx, (reload) => reload.finish("session-before-reload"))
 
       expect(reloads).toEqual([])
       expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
-      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(0)
+      expect(yield* withReload(ctx, (reload) => reload.getBootstrapCycle())).toBe(0)
 
-      yield* withInstance(ctx, ConfigReload.finish("session-after-reload"))
+      yield* withReload(ctx, (reload) => reload.finish("session-after-reload"))
 
       expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
       expect(events.at(-1)?.type).toBe("config.reload.executing")
-      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(1)
+      expect(yield* withReload(ctx, (reload) => reload.getBootstrapCycle())).toBe(1)
     }),
   )
 
@@ -259,20 +281,20 @@ describe("ConfigReload", () => {
 
       // User intent: a non-TUI client that cannot rely on the event stream still
       // needs a way to learn when a queued reload starts and which cycle to ack.
-      yield* withInstance(ctx, ConfigReload.start("session-before-reload"))
-      const queued = yield* withInstance(ctx, ConfigReload.request())
+      yield* withReload(ctx, (reload) => reload.start("session-before-reload"))
+      const queued = yield* withReload(ctx, (reload) => reload.request())
 
       expect(queued.immediate).toBe(false)
       expect(queued.bootstrapCycle).toBeUndefined()
-      expect(yield* withInstance(ctx, ConfigReload.status())).toEqual({
+      expect(yield* withReload(ctx, (reload) => reload.status())).toEqual({
         pending: true,
         executing: false,
         bootstrapCycle: undefined,
       })
 
-      yield* withInstance(ctx, ConfigReload.finish("session-before-reload"))
+      yield* withReload(ctx, (reload) => reload.finish("session-before-reload"))
 
-      expect(yield* withInstance(ctx, ConfigReload.status())).toEqual({
+      expect(yield* withReload(ctx, (reload) => reload.status())).toEqual({
         pending: false,
         executing: true,
         bootstrapCycle: 1,
@@ -288,8 +310,8 @@ describe("ConfigReload", () => {
 
       // User intent: reloading configuration must not create an artificial
       // user message like "continue where you left off" in session history.
-      yield* withInstance(ctx, ConfigReload.request())
-      yield* withInstance(ctx, ConfigReload.releaseBlocker("tui-bootstrap"))
+      yield* withReload(ctx, (reload) => reload.request())
+      yield* withReload(ctx, (reload) => reload.releaseBlocker("tui-bootstrap"))
 
       const done = events.find((event) => event.type === "config.reload.done")
       expect(done?.data).toEqual({})

--- a/packages/opencode/test/config/reload.test.ts
+++ b/packages/opencode/test/config/reload.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect } from "bun:test"
+import { ConfigReload } from "@/config/reload"
+import { InstanceRef } from "@/effect/instance-ref"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import type { InstanceContext } from "@/project/instance-context"
+import { InstanceStore } from "@/project/instance-store"
+import { EventV2 } from "@opencode-ai/core/event"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { Effect, Layer, Stream } from "effect"
+import { testEffect } from "../lib/effect"
+
+type PublishedEvent = {
+  type: string
+  data: unknown
+}
+
+type ReloadCall = {
+  directory: string
+  worktree?: string
+}
+
+function instance(directory: string): InstanceContext {
+  return {
+    directory,
+    worktree: directory,
+    project: {
+      id: ProjectV2.ID.make(directory),
+      worktree: directory,
+      time: {
+        created: 1,
+        updated: 1,
+      },
+      sandboxes: [],
+    },
+  }
+}
+
+function withInstance<A, E, R>(ctx: InstanceContext, effect: Effect.Effect<A, E, R>) {
+  return effect.pipe(Effect.provideService(InstanceRef, ctx))
+}
+
+function testLayer(events: PublishedEvent[], reloads: ReloadCall[]) {
+  return Layer.mergeAll(
+    Layer.mock(EventV2Bridge.Service)({
+      publish: (definition, data) =>
+        Effect.sync(() => {
+          events.push({ type: definition.type, data })
+          return {
+            id: EventV2.ID.create(),
+            type: definition.type,
+            data,
+          } as EventV2.Payload<typeof definition>
+        }),
+      subscribe: () => Stream.empty,
+      all: () => Stream.empty,
+      listen: () => Effect.succeed(Effect.void),
+    }),
+    Layer.mock(InstanceStore.Service)({
+      reload: (input) =>
+        Effect.sync(() => {
+          reloads.push({ directory: input.directory, worktree: input.worktree })
+          return instance(input.directory)
+        }),
+    }),
+  )
+}
+
+describe("ConfigReload", () => {
+  const events: PublishedEvent[] = []
+  const reloads: ReloadCall[] = []
+  const it = testEffect(testLayer(events, reloads))
+
+  it.effect("starts reload in the current workspace even when another workspace is busy", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const alpha = instance("/tmp/reload-alpha")
+      const beta = instance("/tmp/reload-beta")
+
+      // User intent: a long-running chat in one project must not make `/reload`
+      // appear queued or stuck in an unrelated TUI window.
+      yield* withInstance(alpha, ConfigReload.start("session-alpha"))
+      const result = yield* withInstance(beta, ConfigReload.request())
+
+      expect(result.immediate).toBe(true)
+      expect(result.input.directory).toBe(beta.directory)
+      expect(events.map((event) => event.type)).toEqual(["config.reload.pending", "config.reload.executing"])
+      expect(yield* withInstance(alpha, ConfigReload.getBootstrapCycle())).toBe(0)
+      expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
+    }),
+  )
+
+  it.effect("keeps reload completion acknowledgements scoped to the current workspace", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const alpha = instance("/tmp/reload-cycle-alpha")
+      const beta = instance("/tmp/reload-cycle-beta")
+
+      // User intent: a late bootstrap acknowledgement from one TUI must not
+      // dismiss the reload overlay or unblock reload state in another TUI.
+      yield* withInstance(alpha, ConfigReload.request())
+      yield* withInstance(beta, ConfigReload.request())
+
+      expect(yield* withInstance(alpha, ConfigReload.getBootstrapCycle())).toBe(1)
+      expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
+      yield* withInstance(alpha, ConfigReload.finishBlocker("tui-bootstrap"))
+      expect(events.at(-1)?.type).toBe("config.reload.done")
+      expect(yield* withInstance(beta, ConfigReload.getBootstrapCycle())).toBe(1)
+    }),
+  )
+
+  it.effect("does not announce reload completion while a newer reload is queued", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const ctx = instance("/tmp/reload-coalesce")
+
+      // User intent: hammering `/reload` during the reload overlay should not
+      // briefly say the app is ready and then immediately tear it down again.
+      yield* withInstance(ctx, ConfigReload.request())
+      yield* withInstance(ctx, ConfigReload.request())
+
+      expect(events.map((event) => event.type)).toEqual([
+        "config.reload.pending",
+        "config.reload.executing",
+        "config.reload.pending",
+      ])
+      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+
+      expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
+      expect(events.map((event) => event.type)).toEqual([
+        "config.reload.pending",
+        "config.reload.executing",
+        "config.reload.pending",
+        "config.reload.pending",
+        "config.reload.executing",
+      ])
+      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+      expect(events.at(-1)?.type).toBe("config.reload.done")
+      expect(events.filter((event) => event.type === "config.reload.done")).toHaveLength(1)
+    }),
+  )
+
+  it.effect("queues reload safely while multiple sessions run in the same client", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const ctx = instance("/tmp/reload-multiple-sessions")
+
+      // User intent: one TUI can have several sessions running at once. `/reload`
+      // should wait for every active session, remain queued when only one settles,
+      // coalesce repeated reload requests, avoid an early "ready" signal during
+      // bootstrap, and finish without creating a synthetic continuation prompt.
+      yield* withInstance(ctx, ConfigReload.start("session-a"))
+      yield* withInstance(ctx, ConfigReload.start("session-b"))
+
+      const first = yield* withInstance(ctx, ConfigReload.request())
+      const second = yield* withInstance(ctx, ConfigReload.request())
+
+      expect(first.immediate).toBe(false)
+      expect(second.immediate).toBe(false)
+      expect(reloads).toEqual([])
+      expect(events.filter((event) => event.type === "config.reload.executing")).toEqual([])
+
+      yield* withInstance(ctx, ConfigReload.finish("session-a"))
+
+      expect(reloads).toEqual([])
+      expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
+      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(0)
+
+      yield* withInstance(ctx, ConfigReload.finish("session-b"))
+
+      expect(reloads).toEqual([{ directory: ctx.directory, worktree: ctx.worktree }])
+      expect(events.at(-1)?.type).toBe("config.reload.executing")
+      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(1)
+
+      const queuedDuringBootstrap = yield* withInstance(ctx, ConfigReload.request())
+      expect(queuedDuringBootstrap.immediate).toBe(false)
+
+      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+
+      expect(reloads).toEqual([
+        { directory: ctx.directory, worktree: ctx.worktree },
+        { directory: ctx.directory, worktree: ctx.worktree },
+      ])
+      expect(events.filter((event) => event.type === "config.reload.done")).toEqual([])
+      expect(yield* withInstance(ctx, ConfigReload.getBootstrapCycle())).toBe(2)
+
+      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+
+      expect(events.filter((event) => event.type === "config.reload.done")).toEqual([
+        { type: "config.reload.done", data: {} },
+      ])
+    }),
+  )
+
+  it.effect("finishes reload without sending a synthetic continuation prompt", () =>
+    Effect.gen(function* () {
+      events.length = 0
+      reloads.length = 0
+      const ctx = instance("/tmp/reload-no-context-pollution")
+
+      // User intent: reloading configuration must not create an artificial
+      // user message like "continue where you left off" in session history.
+      yield* withInstance(ctx, ConfigReload.request())
+      yield* withInstance(ctx, ConfigReload.finishBlocker("tui-bootstrap"))
+
+      const done = events.find((event) => event.type === "config.reload.done")
+      expect(done?.data).toEqual({})
+    }),
+  )
+})

--- a/packages/opencode/test/server/httpapi-control-plane.test.ts
+++ b/packages/opencode/test/server/httpapi-control-plane.test.ts
@@ -9,6 +9,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { Auth } from "../../src/auth"
 import { Config } from "../../src/config/config"
+import { ConfigReload } from "../../src/config/reload"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Installation } from "../../src/installation"
 import { InstanceStore } from "../../src/project/instance-store"
@@ -45,6 +46,7 @@ const apiLayer = HttpRouter.serve(
   Layer.provideMerge(NodeHttpServer.layerTest),
   Layer.provide(Layer.mock(Auth.Service)({})),
   Layer.provide(Layer.mock(Config.Service)({})),
+  Layer.provide(ConfigReload.layer),
   Layer.provide(EventV2Bridge.defaultLayer),
   Layer.provide(FetchHttpClient.layer),
   Layer.provide(Layer.mock(Installation.Service)({})),

--- a/packages/opencode/test/server/httpapi-control-plane.test.ts
+++ b/packages/opencode/test/server/httpapi-control-plane.test.ts
@@ -1,21 +1,28 @@
 import { NodeHttpServer } from "@effect/platform-node"
 import { describe, expect } from "bun:test"
 import { Context, Effect, Layer, Option, Ref } from "effect"
-import { HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { Auth } from "../../src/auth"
 import { Config } from "../../src/config/config"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Installation } from "../../src/installation"
+import { InstanceStore } from "../../src/project/instance-store"
 import { ServerAuth } from "../../src/server/auth"
 import { RootHttpApi } from "../../src/server/routes/instance/httpapi/api"
+import { configLifecycleHandlers } from "../../src/server/routes/instance/httpapi/handlers/config"
 import { controlHandlers } from "../../src/server/routes/instance/httpapi/handlers/control"
 import { controlPlaneHandlers } from "../../src/server/routes/instance/httpapi/handlers/control-plane"
 import { globalHandlers } from "../../src/server/routes/instance/httpapi/handlers/global"
 import { authorizationLayer } from "../../src/server/routes/instance/httpapi/middleware/authorization"
 import { schemaErrorLayer } from "../../src/server/routes/instance/httpapi/middleware/schema-error"
+import { workspaceRoutingLayer } from "../../src/server/routes/instance/httpapi/middleware/workspace-routing"
+import { Session } from "../../src/session/session"
+import { Workspace } from "../../src/control-plane/workspace"
 import { testEffect } from "../lib/effect"
 
 const input = MoveSession.Input.make({
@@ -27,8 +34,8 @@ const called = Ref.makeUnsafe<MoveSession.Input | undefined>(undefined)
 
 const apiLayer = HttpRouter.serve(
   HttpApiBuilder.layer(RootHttpApi).pipe(
-    Layer.provide([controlHandlers, controlPlaneHandlers, globalHandlers]),
-    Layer.provide([authorizationLayer, schemaErrorLayer]),
+    Layer.provide([configLifecycleHandlers, controlHandlers, controlPlaneHandlers, globalHandlers]),
+    Layer.provide([authorizationLayer, schemaErrorLayer, workspaceRoutingLayer]),
     // Raw HttpApi routes expose an opaque handler context at the request boundary.
     // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
     HttpRouter.provideRequest(Layer.succeedContext(Context.empty() as Context.Context<unknown>)),
@@ -38,7 +45,13 @@ const apiLayer = HttpRouter.serve(
   Layer.provideMerge(NodeHttpServer.layerTest),
   Layer.provide(Layer.mock(Auth.Service)({})),
   Layer.provide(Layer.mock(Config.Service)({})),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(FetchHttpClient.layer),
   Layer.provide(Layer.mock(Installation.Service)({})),
+  Layer.provide(Layer.mock(InstanceStore.Service)({})),
+  Layer.provide(Layer.mock(Session.Service)({})),
+  Layer.provide(Layer.mock(Workspace.Service)({})),
+  Layer.provide(layerWebSocketConstructorGlobal),
   Layer.provide(
     Layer.mock(MoveSession.Service)({
       moveSession: (value) => Ref.set(called, value),

--- a/packages/opencode/test/server/httpapi-global.test.ts
+++ b/packages/opencode/test/server/httpapi-global.test.ts
@@ -1,26 +1,33 @@
 import { NodeHttpServer } from "@effect/platform-node"
 import { describe, expect } from "bun:test"
 import { Context, Effect, Layer, Option } from "effect"
-import { HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
+import { FetchHttpClient, HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { Auth } from "../../src/auth"
 import { Config } from "../../src/config/config"
+import { Workspace } from "../../src/control-plane/workspace"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Installation } from "../../src/installation"
 import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
+import { InstanceStore } from "../../src/project/instance-store"
 import { ServerAuth } from "../../src/server/auth"
 import { RootHttpApi } from "../../src/server/routes/instance/httpapi/api"
 import { GlobalPaths } from "../../src/server/routes/instance/httpapi/groups/global"
+import { configLifecycleHandlers } from "../../src/server/routes/instance/httpapi/handlers/config"
 import { controlHandlers } from "../../src/server/routes/instance/httpapi/handlers/control"
 import { controlPlaneHandlers } from "../../src/server/routes/instance/httpapi/handlers/control-plane"
 import { globalHandlers } from "../../src/server/routes/instance/httpapi/handlers/global"
 import { authorizationLayer } from "../../src/server/routes/instance/httpapi/middleware/authorization"
 import { schemaErrorLayer } from "../../src/server/routes/instance/httpapi/middleware/schema-error"
+import { workspaceRoutingLayer } from "../../src/server/routes/instance/httpapi/middleware/workspace-routing"
+import { Session } from "../../src/session/session"
 import { testEffect } from "../lib/effect"
 
 const apiLayer = HttpRouter.serve(
   HttpApiBuilder.layer(RootHttpApi).pipe(
-    Layer.provide([controlHandlers, controlPlaneHandlers, globalHandlers]),
-    Layer.provide([authorizationLayer, schemaErrorLayer]),
+    Layer.provide([configLifecycleHandlers, controlHandlers, controlPlaneHandlers, globalHandlers]),
+    Layer.provide([authorizationLayer, schemaErrorLayer, workspaceRoutingLayer]),
     // Raw HttpApi routes expose an opaque handler context at the request boundary.
     // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
     HttpRouter.provideRequest(Layer.succeedContext(Context.empty() as Context.Context<unknown>)),
@@ -30,7 +37,13 @@ const apiLayer = HttpRouter.serve(
   Layer.provideMerge(NodeHttpServer.layerTest),
   Layer.provide(Layer.mock(Auth.Service)({})),
   Layer.provide(Layer.mock(Config.Service)({})),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(Layer.mock(InstanceStore.Service)({})),
   Layer.provide(Layer.mock(MoveSession.Service)({})),
+  Layer.provide(Layer.mock(Session.Service)({})),
+  Layer.provide(Layer.mock(Workspace.Service)({})),
+  Layer.provide(layerWebSocketConstructorGlobal),
   Layer.provide(
     Layer.mock(Installation.Service)({
       method: () => Effect.succeed("npm"),

--- a/packages/opencode/test/server/httpapi-global.test.ts
+++ b/packages/opencode/test/server/httpapi-global.test.ts
@@ -6,6 +6,7 @@ import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { Auth } from "../../src/auth"
 import { Config } from "../../src/config/config"
+import { ConfigReload } from "../../src/config/reload"
 import { Workspace } from "../../src/control-plane/workspace"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Installation } from "../../src/installation"
@@ -37,6 +38,7 @@ const apiLayer = HttpRouter.serve(
   Layer.provideMerge(NodeHttpServer.layerTest),
   Layer.provide(Layer.mock(Auth.Service)({})),
   Layer.provide(Layer.mock(Config.Service)({})),
+  Layer.provide(ConfigReload.layer),
   Layer.provide(EventV2Bridge.defaultLayer),
   Layer.provide(FetchHttpClient.layer),
   Layer.provide(Layer.mock(InstanceStore.Service)({})),

--- a/packages/opencode/test/server/httpapi-workspace-routing.test.ts
+++ b/packages/opencode/test/server/httpapi-workspace-routing.test.ts
@@ -519,11 +519,17 @@ describe("HttpApi workspace routing middleware", () => {
         HttpClientRequest.setHeader("x-opencode-directory", headerDir),
         HttpClient.execute,
       )
+      const encodedHeaderResponse = yield* HttpClientRequest.get("/probe").pipe(
+        HttpClientRequest.setHeader("x-opencode-directory", encodeURIComponent(headerDir)),
+        HttpClient.execute,
+      )
 
       expect(queryResponse.status).toBe(200)
       expect(yield* queryResponse.json).toEqual({ directory: queryDir, workspaceID: null })
       expect(headerResponse.status).toBe(200)
       expect(yield* headerResponse.json).toEqual({ directory: headerDir, workspaceID: null })
+      expect(encodedHeaderResponse.status).toBe(200)
+      expect(yield* encodedHeaderResponse.json).toEqual({ directory: headerDir, workspaceID: null })
     }),
   )
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -14,6 +14,7 @@ import { Agent as AgentSvc } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
 import { Command } from "../../src/command"
 import { Config } from "@/config/config"
+import { ConfigReload } from "@/config/reload"
 import { LSP } from "@/lsp/lsp"
 import { MCP } from "../../src/mcp"
 import { Permission } from "../../src/permission"
@@ -154,7 +155,8 @@ const lsp = Layer.succeed(
 
 const status = SessionStatus.layer.pipe(Layer.provideMerge(EventV2Bridge.defaultLayer))
 const instanceStore = Layer.mock(InstanceStore.Service)({})
-const run = SessionRunState.layer.pipe(Layer.provide(status))
+const configReload = ConfigReload.layer.pipe(Layer.provide(Layer.mergeAll(EventV2Bridge.defaultLayer, instanceStore)))
+const run = SessionRunState.layer.pipe(Layer.provide(status), Layer.provide(configReload))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
 
 const processorCreateStarted: Array<() => void> = []
@@ -185,6 +187,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     Database.defaultLayer,
     EventV2Bridge.defaultLayer,
     instanceStore,
+    configReload,
   ).pipe(Layer.provideMerge(infra))
   const question = Question.layer.pipe(Layer.provideMerge(deps))
   const todo = Todo.layer.pipe(Layer.provideMerge(deps))

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -56,6 +56,7 @@ import { reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { InstanceStore } from "@/project/instance-store"
 
 const summary = Layer.succeed(
   SessionSummary.Service,
@@ -152,6 +153,7 @@ const lsp = Layer.succeed(
 )
 
 const status = SessionStatus.layer.pipe(Layer.provideMerge(EventV2Bridge.defaultLayer))
+const instanceStore = Layer.mock(InstanceStore.Service)({})
 const run = SessionRunState.layer.pipe(Layer.provide(status))
 const infra = Layer.mergeAll(NodeFileSystem.layer, CrossSpawnSpawner.defaultLayer)
 
@@ -182,6 +184,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     status,
     Database.defaultLayer,
     EventV2Bridge.defaultLayer,
+    instanceStore,
   ).pipe(Layer.provideMerge(infra))
   const question = Question.layer.pipe(Layer.provideMerge(deps))
   const todo = Todo.layer.pipe(Layer.provideMerge(deps))

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -779,6 +779,10 @@ export type KeybindsConfig = {
    */
   app_exit?: string
   /**
+   * Reload configuration
+   */
+  app_reload?: string
+  /**
    * Open external editor
    */
   editor_open?: string

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1524,10 +1524,10 @@ export class Config2 extends HeyApiClient {
    * Release the reload blocker after the TUI has bootstrapped against the new instance.
    */
   public bootstrapComplete<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      cycle?: string
+      cycle: string
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -18,10 +18,14 @@ import type {
   CommandListErrors,
   CommandListResponses,
   Config as Config3,
+  ConfigBootstrapCompleteErrors,
+  ConfigBootstrapCompleteResponses,
   ConfigGetErrors,
   ConfigGetResponses,
   ConfigProvidersErrors,
   ConfigProvidersResponses,
+  ConfigReloadErrors,
+  ConfigReloadResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
   EventSubscribeResponses,
@@ -1479,6 +1483,72 @@ export class Config2 extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<ConfigProvidersResponses, ConfigProvidersErrors, ThrowOnError>({
       url: "/config/providers",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reload configuration
+   *
+   * Reload OpenCode configuration files and plugins without restarting the client.
+   */
+  public reload<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigReloadResponses, ConfigReloadErrors, ThrowOnError>({
+      url: "/config/reload",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Complete config reload bootstrap
+   *
+   * Release the reload blocker after the TUI has bootstrapped against the new instance.
+   */
+  public bootstrapComplete<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      cycle?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "cycle" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      ConfigBootstrapCompleteResponses,
+      ConfigBootstrapCompleteErrors,
+      ThrowOnError
+    >({
+      url: "/config/bootstrap-complete",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -26,6 +26,8 @@ import type {
   ConfigProvidersResponses,
   ConfigReloadErrors,
   ConfigReloadResponses,
+  ConfigReloadStatusErrors,
+  ConfigReloadStatusResponses,
   ConfigUpdateErrors,
   ConfigUpdateResponses,
   EventSubscribeResponses,
@@ -424,6 +426,201 @@ class HeyApiRegistry<T> {
 
   set(value: T, key?: string): void {
     this.instances.set(key ?? this.defaultKey, value)
+  }
+}
+
+export class Config extends HeyApiClient {
+  /**
+   * Get config reload status
+   *
+   * Return the current reload lifecycle state for clients that need to poll for bootstrap cycles.
+   */
+  public reloadStatus<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ConfigReloadStatusResponses, ConfigReloadStatusErrors, ThrowOnError>({
+      url: "/config/reload/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Complete config reload bootstrap
+   *
+   * Release the reload blocker after the TUI has bootstrapped against the new instance.
+   */
+  public bootstrapComplete<ThrowOnError extends boolean = false>(
+    parameters: {
+      directory?: string
+      workspace?: string
+      cycle: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "query", key: "cycle" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      ConfigBootstrapCompleteResponses,
+      ConfigBootstrapCompleteErrors,
+      ThrowOnError
+    >({
+      url: "/config/bootstrap-complete",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Get configuration
+   *
+   * Retrieve the current OpenCode configuration settings and preferences.
+   */
+  public get<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ConfigGetResponses, ConfigGetErrors, ThrowOnError>({
+      url: "/config",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Update configuration
+   *
+   * Update OpenCode configuration settings and preferences.
+   */
+  public update<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      config?: Config3
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "config", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).patch<ConfigUpdateResponses, ConfigUpdateErrors, ThrowOnError>({
+      url: "/config",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * List config providers
+   *
+   * Get a list of all configured AI providers and their default models.
+   */
+  public providers<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ConfigProvidersResponses, ConfigProvidersErrors, ThrowOnError>({
+      url: "/config/providers",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reload configuration
+   *
+   * Reload OpenCode configuration files and plugins without restarting the client.
+   */
+  public reload<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<ConfigReloadResponses, ConfigReloadErrors, ThrowOnError>({
+      url: "/config/reload",
+      ...options,
+      ...params,
+    })
   }
 }
 
@@ -1253,7 +1450,7 @@ export class Experimental extends HeyApiClient {
   }
 }
 
-export class Config extends HeyApiClient {
+export class Config2 extends HeyApiClient {
   /**
    * Get global configuration
    *
@@ -1352,9 +1549,9 @@ export class Global extends HeyApiClient {
     })
   }
 
-  private _config?: Config
-  get config(): Config {
-    return (this._config ??= new Config({ client: this.client }))
+  private _config?: Config2
+  get config(): Config2 {
+    return (this._config ??= new Config2({ client: this.client }))
   }
 }
 
@@ -1384,171 +1581,6 @@ export class Event extends HeyApiClient {
     )
     return (options?.client ?? this.client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
       url: "/event",
-      ...options,
-      ...params,
-    })
-  }
-}
-
-export class Config2 extends HeyApiClient {
-  /**
-   * Get configuration
-   *
-   * Retrieve the current OpenCode configuration settings and preferences.
-   */
-  public get<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<ConfigGetResponses, ConfigGetErrors, ThrowOnError>({
-      url: "/config",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Update configuration
-   *
-   * Update OpenCode configuration settings and preferences.
-   */
-  public update<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-      config?: Config3
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { key: "config", map: "body" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).patch<ConfigUpdateResponses, ConfigUpdateErrors, ThrowOnError>({
-      url: "/config",
-      ...options,
-      ...params,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-        ...params.headers,
-      },
-    })
-  }
-
-  /**
-   * List config providers
-   *
-   * Get a list of all configured AI providers and their default models.
-   */
-  public providers<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).get<ConfigProvidersResponses, ConfigProvidersErrors, ThrowOnError>({
-      url: "/config/providers",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Reload configuration
-   *
-   * Reload OpenCode configuration files and plugins without restarting the client.
-   */
-  public reload<ThrowOnError extends boolean = false>(
-    parameters?: {
-      directory?: string
-      workspace?: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<ConfigReloadResponses, ConfigReloadErrors, ThrowOnError>({
-      url: "/config/reload",
-      ...options,
-      ...params,
-    })
-  }
-
-  /**
-   * Complete config reload bootstrap
-   *
-   * Release the reload blocker after the TUI has bootstrapped against the new instance.
-   */
-  public bootstrapComplete<ThrowOnError extends boolean = false>(
-    parameters: {
-      directory?: string
-      workspace?: string
-      cycle: string
-    },
-    options?: Options<never, ThrowOnError>,
-  ) {
-    const params = buildClientParams(
-      [parameters],
-      [
-        {
-          args: [
-            { in: "query", key: "directory" },
-            { in: "query", key: "workspace" },
-            { in: "query", key: "cycle" },
-          ],
-        },
-      ],
-    )
-    return (options?.client ?? this.client).post<
-      ConfigBootstrapCompleteResponses,
-      ConfigBootstrapCompleteErrors,
-      ThrowOnError
-    >({
-      url: "/config/bootstrap-complete",
       ...options,
       ...params,
     })
@@ -6769,6 +6801,11 @@ export class OpencodeClient extends HeyApiClient {
     OpencodeClient.__registry.set(this, args?.key)
   }
 
+  private _config?: Config
+  get config(): Config {
+    return (this._config ??= new Config({ client: this.client }))
+  }
+
   private _auth?: Auth
   get auth(): Auth {
     return (this._auth ??= new Auth({ client: this.client }))
@@ -6792,11 +6829,6 @@ export class OpencodeClient extends HeyApiClient {
   private _event?: Event
   get event(): Event {
     return (this._event ??= new Event({ client: this.client }))
-  }
-
-  private _config?: Config2
-  get config(): Config2 {
-    return (this._config ??= new Config2({ client: this.client }))
   }
 
   private _tool?: Tool

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -77,13 +77,16 @@ export type Event =
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
   | EventProjectUpdated
+  | EventVcsBranchUpdated
+  | EventConfigReloadPending
+  | EventConfigReloadExecuting
+  | EventConfigReloadDone
   | EventSessionStatus
   | EventSessionIdle
   | EventQuestionAsked
   | EventQuestionReplied
   | EventQuestionRejected
   | EventSessionCompacted
-  | EventVcsBranchUpdated
   | EventWorkspaceReady
   | EventWorkspaceFailed
   | EventWorkspaceStatus
@@ -1516,6 +1519,35 @@ export type GlobalEvent = {
       }
     | {
         id: string
+        type: "vcs.branch.updated"
+        properties: {
+          branch?: string
+        }
+      }
+    | {
+        id: string
+        type: "config.reload.pending"
+        properties: {
+          pending: boolean
+        }
+      }
+    | {
+        id: string
+        type: "config.reload.executing"
+        properties: {
+          executing: boolean
+          bootstrapCycle?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+        }
+      }
+    | {
+        id: string
+        type: "config.reload.done"
+        properties: {
+          resumeSessionID?: string
+        }
+      }
+    | {
+        id: string
         type: "session.status"
         properties: {
           sessionID: string
@@ -1564,13 +1596,6 @@ export type GlobalEvent = {
         type: "session.compacted"
         properties: {
           sessionID: string
-        }
-      }
-    | {
-        id: string
-        type: "vcs.branch.updated"
-        properties: {
-          branch?: string
         }
       }
     | {
@@ -5021,6 +5046,39 @@ export type EventProjectUpdated = {
   }
 }
 
+export type EventVcsBranchUpdated = {
+  id: string
+  type: "vcs.branch.updated"
+  properties: {
+    branch?: string
+  }
+}
+
+export type EventConfigReloadPending = {
+  id: string
+  type: "config.reload.pending"
+  properties: {
+    pending: boolean
+  }
+}
+
+export type EventConfigReloadExecuting = {
+  id: string
+  type: "config.reload.executing"
+  properties: {
+    executing: boolean
+    bootstrapCycle?: number | "NaN" | "Infinity" | "-Infinity"
+  }
+}
+
+export type EventConfigReloadDone = {
+  id: string
+  type: "config.reload.done"
+  properties: {
+    resumeSessionID?: string
+  }
+}
+
 export type EventSessionStatus = {
   id: string
   type: "session.status"
@@ -5076,14 +5134,6 @@ export type EventSessionCompacted = {
   type: "session.compacted"
   properties: {
     sessionID: string
-  }
-}
-
-export type EventVcsBranchUpdated = {
-  id: string
-  type: "vcs.branch.updated"
-  properties: {
-    branch?: string
   }
 }
 
@@ -5552,6 +5602,68 @@ export type ConfigProvidersResponses = {
 }
 
 export type ConfigProvidersResponse = ConfigProvidersResponses[keyof ConfigProvidersResponses]
+
+export type ConfigReloadData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/reload"
+}
+
+export type ConfigReloadErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ConfigReloadError = ConfigReloadErrors[keyof ConfigReloadErrors]
+
+export type ConfigReloadResponses = {
+  /**
+   * Configuration reload request result
+   */
+  200: {
+    success: boolean
+    immediate: boolean
+  }
+}
+
+export type ConfigReloadResponse = ConfigReloadResponses[keyof ConfigReloadResponses]
+
+export type ConfigBootstrapCompleteData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+    cycle?: string
+  }
+  url: "/config/bootstrap-complete"
+}
+
+export type ConfigBootstrapCompleteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ConfigBootstrapCompleteError = ConfigBootstrapCompleteErrors[keyof ConfigBootstrapCompleteErrors]
+
+export type ConfigBootstrapCompleteResponses = {
+  /**
+   * Bootstrap completion result
+   */
+  200: {
+    success: boolean
+  }
+}
+
+export type ConfigBootstrapCompleteResponse = ConfigBootstrapCompleteResponses[keyof ConfigBootstrapCompleteResponses]
 
 export type ExperimentalCapabilitiesGetData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -107,6 +107,13 @@ export type QuestionRejected = {
   requestID: string
 }
 
+export type InvalidRequestError = {
+  _tag: "InvalidRequestError"
+  message: string
+  kind?: string
+  field?: string
+}
+
 export type OAuth = {
   type: "oauth"
   refresh: string
@@ -134,13 +141,6 @@ export type Auth = OAuth | ApiAuth | WellKnownAuth
 
 export type EffectHttpApiErrorBadRequest = {
   _tag: "BadRequest"
-}
-
-export type InvalidRequestError = {
-  _tag: "InvalidRequestError"
-  message: string
-  kind?: string
-  field?: string
 }
 
 export type MoveSessionError = {
@@ -1536,7 +1536,7 @@ export type GlobalEvent = {
         type: "config.reload.executing"
         properties: {
           executing: boolean
-          bootstrapCycle?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+          bootstrapCycle?: number
         }
       }
     | {
@@ -5067,7 +5067,7 @@ export type EventConfigReloadExecuting = {
   type: "config.reload.executing"
   properties: {
     executing: boolean
-    bootstrapCycle?: number | "NaN" | "Infinity" | "-Infinity"
+    bootstrapCycle?: number
   }
 }
 
@@ -5202,6 +5202,69 @@ export type BadRequestError = {
     kind?: "Params" | "Headers" | "Query" | "Body" | "Payload"
   }
 }
+
+export type ConfigReloadStatusData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/config/reload/status"
+}
+
+export type ConfigReloadStatusErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ConfigReloadStatusError = ConfigReloadStatusErrors[keyof ConfigReloadStatusErrors]
+
+export type ConfigReloadStatusResponses = {
+  /**
+   * Configuration reload status
+   */
+  200: {
+    pending: boolean
+    executing: boolean
+    bootstrapCycle?: number
+  }
+}
+
+export type ConfigReloadStatusResponse = ConfigReloadStatusResponses[keyof ConfigReloadStatusResponses]
+
+export type ConfigBootstrapCompleteData = {
+  body?: never
+  path?: never
+  query: {
+    directory?: string
+    workspace?: string
+    cycle: string
+  }
+  url: "/config/bootstrap-complete"
+}
+
+export type ConfigBootstrapCompleteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ConfigBootstrapCompleteError = ConfigBootstrapCompleteErrors[keyof ConfigBootstrapCompleteErrors]
+
+export type ConfigBootstrapCompleteResponses = {
+  /**
+   * Bootstrap completion result
+   */
+  200: {
+    success: boolean
+  }
+}
+
+export type ConfigBootstrapCompleteResponse = ConfigBootstrapCompleteResponses[keyof ConfigBootstrapCompleteResponses]
 
 export type AuthRemoveData = {
   body?: never
@@ -5629,41 +5692,11 @@ export type ConfigReloadResponses = {
   200: {
     success: boolean
     immediate: boolean
+    bootstrapCycle?: number
   }
 }
 
 export type ConfigReloadResponse = ConfigReloadResponses[keyof ConfigReloadResponses]
-
-export type ConfigBootstrapCompleteData = {
-  body?: never
-  path?: never
-  query: {
-    directory?: string
-    workspace?: string
-    cycle: string
-  }
-  url: "/config/bootstrap-complete"
-}
-
-export type ConfigBootstrapCompleteErrors = {
-  /**
-   * Bad request
-   */
-  400: BadRequestError
-}
-
-export type ConfigBootstrapCompleteError = ConfigBootstrapCompleteErrors[keyof ConfigBootstrapCompleteErrors]
-
-export type ConfigBootstrapCompleteResponses = {
-  /**
-   * Bootstrap completion result
-   */
-  200: {
-    success: boolean
-  }
-}
-
-export type ConfigBootstrapCompleteResponse = ConfigBootstrapCompleteResponses[keyof ConfigBootstrapCompleteResponses]
 
 export type ExperimentalCapabilitiesGetData = {
   body?: never

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1543,7 +1543,7 @@ export type GlobalEvent = {
         id: string
         type: "config.reload.done"
         properties: {
-          resumeSessionID?: string
+          [key: string]: unknown
         }
       }
     | {
@@ -5075,7 +5075,7 @@ export type EventConfigReloadDone = {
   id: string
   type: "config.reload.done"
   properties: {
-    resumeSessionID?: string
+    [key: string]: unknown
   }
 }
 
@@ -5637,10 +5637,10 @@ export type ConfigReloadResponse = ConfigReloadResponses[keyof ConfigReloadRespo
 export type ConfigBootstrapCompleteData = {
   body?: never
   path?: never
-  query?: {
+  query: {
     directory?: string
     workspace?: string
-    cycle?: string
+    cycle: string
   }
   url: "/config/bootstrap-complete"
 }

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -112,6 +112,7 @@ const appBindingCommands = [
   "variant.list",
   "provider.connect",
   "console.org.switch",
+  "app.reload",
   "opencode.status",
   "theme.switch",
   "theme.switch_mode",
@@ -746,6 +747,29 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
             },
           ]
         : []),
+      {
+        name: "app.reload",
+        title: "Reload configuration",
+        category: "App",
+        slashName: "reload",
+        run: async () => {
+          await sdk.client.config
+            .reload({ workspace: project.workspace.current() })
+            .then((result) => {
+              toast.show({
+                message: result.data?.immediate ? "Reloading configuration" : "Reload queued until sessions are idle",
+                variant: "info",
+              })
+              dialog.clear()
+            })
+            .catch((error) => {
+              toast.show({
+                message: error instanceof Error ? error.message : "Failed to reload configuration",
+                variant: "error",
+              })
+            })
+        },
+      },
       {
         name: "opencode.status",
         title: "View status",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -757,7 +757,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
             .reload({ workspace: project.workspace.current() })
             .then((result) => {
               toast.show({
-                message: result.data?.immediate ? "Reloading configuration" : "Reload queued until sessions are idle",
+                message: result.data?.immediate
+                  ? "Reloading configuration"
+                  : "Reload will start after active sessions finish",
                 variant: "info",
               })
               dialog.clear()

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -756,6 +756,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
           await sdk.client.config
             .reload({ workspace: project.workspace.current() })
             .then((result) => {
+              if (result.data?.immediate) sync.reload.start({ bootstrapCycle: result.data.bootstrapCycle })
               toast.show({
                 message: result.data?.immediate
                   ? "Reloading configuration"

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -37,6 +37,36 @@ const emptyConsoleState: ConsoleState = {
   switchableOrgCount: 0,
 }
 
+const BOOTSTRAP_REFRESH_TIMEOUT = 10_000
+const BOOTSTRAP_COMPLETE_TIMEOUT = 10_000
+const RELOAD_OVERLAY_FALLBACK_TIMEOUT = 20_000
+
+function settleBootstrapRefresh(label: string, promise: Promise<unknown>) {
+  return new Promise<void>((resolve) => {
+    let settled = false
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      console.warn("tui bootstrap refresh timed out", { label })
+      resolve()
+    }, BOOTSTRAP_REFRESH_TIMEOUT)
+
+    promise
+      .catch((error) => {
+        console.warn("tui bootstrap refresh failed", {
+          label,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      })
+      .finally(() => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve()
+      })
+  })
+}
+
 function search<T>(items: T[], target: string, key: (item: T) => string) {
   let left = 0
   let right = items.length - 1
@@ -143,6 +173,8 @@ export const {
     const project = useProject()
     const sdk = useSDK()
     let bootstrapCycle = 0
+    let bootstrappedReloadCycle = 0
+    let reloadOverlayFallback: ReturnType<typeof setTimeout> | undefined
 
     const fullSyncedSessions = new Set<string>()
     const syncingSessions = new Map<string, Promise<void>>()
@@ -170,22 +202,94 @@ export const {
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
+    async function completeBootstrap(input: { workspace: string | undefined; cycle: number }) {
+      const result = await Promise.race([
+        sdk.client.config.bootstrapComplete({
+          workspace: input.workspace,
+          cycle: String(input.cycle),
+        }),
+        new Promise<undefined>((resolve) => {
+          setTimeout(() => resolve(undefined), BOOTSTRAP_COMPLETE_TIMEOUT)
+        }),
+      ])
+      if (!result) {
+        console.warn("tui bootstrap completion timed out", { cycle: input.cycle })
+        clearReloadOverlayFallback()
+        batch(() => {
+          setStore("reloadPending", false)
+          setStore("reloading", false)
+        })
+        return
+      }
+      if (!result.data?.success) {
+        console.warn("tui bootstrap completion rejected", { cycle: input.cycle })
+        return
+      }
+
+      // The server also emits config.reload.done. This local clear is a safety
+      // net for missed SSE delivery after the server already accepted bootstrap.
+      clearReloadOverlayFallback()
+      batch(() => {
+        setStore("reloadPending", false)
+        setStore("reloading", false)
+      })
+    }
+
+    function clearReloadOverlayFallback() {
+      if (!reloadOverlayFallback) return
+      clearTimeout(reloadOverlayFallback)
+      reloadOverlayFallback = undefined
+    }
+
+    function scheduleReloadOverlayFallback(cycle: number) {
+      clearReloadOverlayFallback()
+      reloadOverlayFallback = setTimeout(() => {
+        if (!store.reloading || bootstrapCycle !== cycle) return
+        console.warn("tui reload overlay released by fallback", { cycle })
+        void completeBootstrap({ workspace: project.workspace.current(), cycle }).catch((error) => {
+          console.warn("tui bootstrap completion failed", {
+            cycle,
+            error: error instanceof Error ? error.message : String(error),
+          })
+          batch(() => {
+            setStore("reloadPending", false)
+            setStore("reloading", false)
+          })
+        })
+      }, RELOAD_OVERLAY_FALLBACK_TIMEOUT)
+    }
+
+    function bootstrapReloadOnce() {
+      if (bootstrapCycle <= 0) return
+      if (bootstrappedReloadCycle === bootstrapCycle) return
+      bootstrappedReloadCycle = bootstrapCycle
+      void bootstrap({ fatal: false, cycle: bootstrapCycle })
+    }
+
     event.subscribe((event, { workspace }) => {
       switch (event.type) {
+        case "server.connected":
+          if (store.reloading) bootstrapReloadOnce()
+          break
         case "server.instance.disposed":
-          void bootstrap()
+          if (store.reloading) bootstrapReloadOnce()
+          else void bootstrap()
           break
         case "config.reload.pending":
           setStore("reloadPending", event.properties.pending)
           break
         case "config.reload.executing":
           if (typeof event.properties.bootstrapCycle === "number") bootstrapCycle = event.properties.bootstrapCycle
+          if (event.properties.executing && bootstrapCycle > 0) scheduleReloadOverlayFallback(bootstrapCycle)
+          if (!event.properties.executing) clearReloadOverlayFallback()
           batch(() => {
             setStore("reloadPending", false)
             setStore("reloading", event.properties.executing)
           })
           break
         case "config.reload.done":
+          clearReloadOverlayFallback()
+          bootstrappedReloadCycle = 0
           batch(() => {
             setStore("reloadPending", false)
             setStore("reloading", false)
@@ -452,10 +556,10 @@ export const {
     const exit = useExit()
     const args = useArgs()
 
-    async function bootstrap(input: { fatal?: boolean } = {}) {
+    async function bootstrap(input: { fatal?: boolean; cycle?: number } = {}) {
       const fatal = input.fatal ?? true
       const workspace = project.workspace.current()
-      const cycle = bootstrapCycle
+      const cycle = input.cycle ?? bootstrapCycle
       const projectPromise = project.sync()
       const sessionListPromise = projectPromise.then(() => listSessions())
 
@@ -521,30 +625,77 @@ export const {
         })
         .then(() => {
           if (store.status !== "complete") setStore("status", "partial")
-          // non-blocking
+          // Reload completion should wait for the normal refresh path, but an
+          // optional status endpoint must not keep the reload overlay open forever.
           void Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
-            consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
-            sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
-            sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
-            sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
-            sdk.client.experimental.resource
-              .list({ workspace })
-              .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
-            sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data ?? []))),
-            sdk.client.session.status({ workspace }).then((x) => {
-              setStore("session_status", reconcile(x.data ?? {}))
-            }),
-            sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
-            sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
-            project.workspace.sync(),
-          ]).then(() => {
-            void sdk.client.config.bootstrapComplete({ workspace, cycle: String(cycle) }).catch(() => {})
-            setStore("status", "complete")
-          })
+            ...(args.continue
+              ? []
+              : [
+                  settleBootstrapRefresh(
+                    "session.list",
+                    sessionListPromise.then((sessions) => setStore("session", reconcile(sessions))),
+                  ),
+                ]),
+            settleBootstrapRefresh(
+              "console.state",
+              consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
+            ),
+            settleBootstrapRefresh(
+              "command.list",
+              sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
+            ),
+            settleBootstrapRefresh(
+              "lsp.status",
+              sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
+            ),
+            settleBootstrapRefresh(
+              "mcp.status",
+              sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
+            ),
+            settleBootstrapRefresh(
+              "resource.list",
+              sdk.client.experimental.resource
+                .list({ workspace })
+                .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),
+            ),
+            settleBootstrapRefresh(
+              "formatter.status",
+              sdk.client.formatter.status({ workspace }).then((x) => setStore("formatter", reconcile(x.data ?? []))),
+            ),
+            settleBootstrapRefresh(
+              "session.status",
+              sdk.client.session.status({ workspace }).then((x) => {
+                setStore("session_status", reconcile(x.data ?? {}))
+              }),
+            ),
+            settleBootstrapRefresh(
+              "provider.auth",
+              sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
+            ),
+            settleBootstrapRefresh(
+              "vcs.get",
+              sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            ),
+            settleBootstrapRefresh("workspace.sync", project.workspace.sync()),
+          ])
+            .then(() => completeBootstrap({ workspace, cycle }))
+            .catch((error) => {
+              console.warn("tui bootstrap completion failed", {
+                cycle,
+                error: error instanceof Error ? error.message : String(error),
+              })
+            })
+            .finally(() => {
+              setStore("status", "complete")
+            })
         })
         .catch(async (e) => {
-          void sdk.client.config.bootstrapComplete({ workspace, cycle: String(cycle) }).catch(() => {})
+          await completeBootstrap({ workspace, cycle }).catch((error) => {
+            console.warn("tui bootstrap completion failed", {
+              cycle,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          })
           console.error("tui bootstrap failed", {
             error: e instanceof Error ? e.message : String(e),
             name: e instanceof Error ? e.name : undefined,

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -135,6 +135,7 @@ export const {
       vcs: VcsInfo | undefined
       reloadPending: boolean
       reloading: boolean
+      reloadResult: "success" | "uncertain" | undefined
     }>({
       provider_next: {
         all: [],
@@ -167,6 +168,7 @@ export const {
       vcs: undefined,
       reloadPending: false,
       reloading: false,
+      reloadResult: undefined,
     })
 
     const event = useEvent()
@@ -203,6 +205,7 @@ export const {
     }
 
     async function completeBootstrap(input: { workspace: string | undefined; cycle: number }) {
+      if (input.cycle <= 0) return
       const result = await Promise.race([
         sdk.client.config.bootstrapComplete({
           workspace: input.workspace,
@@ -214,17 +217,27 @@ export const {
       ])
       if (!result) {
         console.warn("tui bootstrap completion timed out", { cycle: input.cycle })
+        if (!isActiveReloadCycle(input.cycle)) return
         clearReloadOverlayFallback()
         batch(() => {
           setStore("reloadPending", false)
           setStore("reloading", false)
+          setStore("reloadResult", "uncertain")
         })
         return
       }
       if (!result.data?.success) {
         console.warn("tui bootstrap completion rejected", { cycle: input.cycle })
+        if (!isActiveReloadCycle(input.cycle)) return
+        clearReloadOverlayFallback()
+        batch(() => {
+          setStore("reloadPending", false)
+          setStore("reloading", false)
+          setStore("reloadResult", "uncertain")
+        })
         return
       }
+      if (!isActiveReloadCycle(input.cycle)) return
 
       // The server also emits config.reload.done. This local clear is a safety
       // net for missed SSE delivery after the server already accepted bootstrap.
@@ -232,6 +245,7 @@ export const {
       batch(() => {
         setStore("reloadPending", false)
         setStore("reloading", false)
+        setStore("reloadResult", "success")
       })
     }
 
@@ -244,7 +258,7 @@ export const {
     function scheduleReloadOverlayFallback(cycle: number) {
       clearReloadOverlayFallback()
       reloadOverlayFallback = setTimeout(() => {
-        if (!store.reloading || bootstrapCycle !== cycle) return
+        if (!isActiveReloadCycle(cycle)) return
         console.warn("tui reload overlay released by fallback", { cycle })
         void completeBootstrap({ workspace: project.workspace.current(), cycle }).catch((error) => {
           console.warn("tui bootstrap completion failed", {
@@ -254,9 +268,34 @@ export const {
           batch(() => {
             setStore("reloadPending", false)
             setStore("reloading", false)
+            setStore("reloadResult", "uncertain")
           })
         })
       }, RELOAD_OVERLAY_FALLBACK_TIMEOUT)
+    }
+
+    function isActiveReloadCycle(cycle: number) {
+      return store.reloading && bootstrapCycle === cycle
+    }
+
+    function isCurrentReloadEvent(metadata: { directory: string; workspace: string | undefined }) {
+      const directory = project.instance.directory()
+      if (directory && metadata.directory && metadata.directory !== directory) return false
+      const workspace = project.workspace.current()
+      if (workspace && metadata.workspace && metadata.workspace !== workspace) return false
+      return true
+    }
+
+    function startReload(input: { bootstrapCycle?: number }) {
+      if (typeof input.bootstrapCycle !== "number") return
+      bootstrapCycle = input.bootstrapCycle
+      bootstrappedReloadCycle = 0
+      batch(() => {
+        setStore("reloadPending", false)
+        setStore("reloading", true)
+        setStore("reloadResult", undefined)
+      })
+      scheduleReloadOverlayFallback(input.bootstrapCycle)
     }
 
     function bootstrapReloadOnce() {
@@ -266,21 +305,28 @@ export const {
       void bootstrap({ fatal: false, cycle: bootstrapCycle })
     }
 
-    event.subscribe((event, { workspace }) => {
+    event.subscribe((event, { directory, workspace }) => {
       switch (event.type) {
         case "server.connected":
+          if (!isCurrentReloadEvent({ directory, workspace })) break
           if (store.reloading) bootstrapReloadOnce()
           break
         case "server.instance.disposed":
+          if (!isCurrentReloadEvent({ directory, workspace })) break
           if (store.reloading) bootstrapReloadOnce()
           else void bootstrap()
           break
         case "config.reload.pending":
+          if (!isCurrentReloadEvent({ directory, workspace })) break
           setStore("reloadPending", event.properties.pending)
           break
         case "config.reload.executing":
+          if (!isCurrentReloadEvent({ directory, workspace })) break
           if (typeof event.properties.bootstrapCycle === "number") bootstrapCycle = event.properties.bootstrapCycle
-          if (event.properties.executing && bootstrapCycle > 0) scheduleReloadOverlayFallback(bootstrapCycle)
+          if (event.properties.executing && bootstrapCycle > 0) {
+            setStore("reloadResult", undefined)
+            scheduleReloadOverlayFallback(bootstrapCycle)
+          }
           if (!event.properties.executing) clearReloadOverlayFallback()
           batch(() => {
             setStore("reloadPending", false)
@@ -288,11 +334,13 @@ export const {
           })
           break
         case "config.reload.done":
+          if (!isCurrentReloadEvent({ directory, workspace })) break
           clearReloadOverlayFallback()
           bootstrappedReloadCycle = 0
           batch(() => {
             setStore("reloadPending", false)
             setStore("reloading", false)
+            setStore("reloadResult", "success")
           })
           break
         case "permission.replied": {
@@ -684,6 +732,12 @@ export const {
                 cycle,
                 error: error instanceof Error ? error.message : String(error),
               })
+              if (!isActiveReloadCycle(cycle)) return
+              batch(() => {
+                setStore("reloadPending", false)
+                setStore("reloading", false)
+                setStore("reloadResult", "uncertain")
+              })
             })
             .finally(() => {
               setStore("status", "complete")
@@ -694,6 +748,12 @@ export const {
             console.warn("tui bootstrap completion failed", {
               cycle,
               error: error instanceof Error ? error.message : String(error),
+            })
+            if (!isActiveReloadCycle(cycle)) return
+            batch(() => {
+              setStore("reloadPending", false)
+              setStore("reloading", false)
+              setStore("reloadResult", "uncertain")
             })
           })
           console.error("tui bootstrap failed", {
@@ -716,6 +776,9 @@ export const {
     const result = {
       data: store,
       set: setStore,
+      reload: {
+        start: startReload,
+      },
       get status() {
         return store.status
       },

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -103,6 +103,8 @@ export const {
       }
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
+      reloadPending: boolean
+      reloading: boolean
     }>({
       provider_next: {
         all: [],
@@ -133,11 +135,14 @@ export const {
       mcp_resource: {},
       formatter: [],
       vcs: undefined,
+      reloadPending: false,
+      reloading: false,
     })
 
     const event = useEvent()
     const project = useProject()
     const sdk = useSDK()
+    let bootstrapCycle = 0
 
     const fullSyncedSessions = new Set<string>()
     const syncingSessions = new Map<string, Promise<void>>()
@@ -169,6 +174,35 @@ export const {
       switch (event.type) {
         case "server.instance.disposed":
           void bootstrap()
+          break
+        case "config.reload.pending":
+          setStore("reloadPending", event.properties.pending)
+          break
+        case "config.reload.executing":
+          if (typeof event.properties.bootstrapCycle === "number") bootstrapCycle = event.properties.bootstrapCycle
+          batch(() => {
+            setStore("reloadPending", false)
+            setStore("reloading", event.properties.executing)
+          })
+          break
+        case "config.reload.done":
+          batch(() => {
+            setStore("reloadPending", false)
+            setStore("reloading", false)
+          })
+          if (event.properties.resumeSessionID) {
+            void sdk.client.session
+              .prompt({
+                sessionID: event.properties.resumeSessionID,
+                parts: [
+                  {
+                    type: "text",
+                    text: "Configuration has been reloaded successfully. Continue where you left off.",
+                  },
+                ],
+              })
+              .catch(() => {})
+          }
           break
         case "permission.replied": {
           const requests = store.permission[event.properties.sessionID]
@@ -434,6 +468,7 @@ export const {
     async function bootstrap(input: { fatal?: boolean } = {}) {
       const fatal = input.fatal ?? true
       const workspace = project.workspace.current()
+      const cycle = bootstrapCycle
       const projectPromise = project.sync()
       const sessionListPromise = projectPromise.then(() => listSessions())
 
@@ -498,6 +533,7 @@ export const {
           })
         })
         .then(() => {
+          void sdk.client.config.bootstrapComplete({ workspace, cycle: String(cycle) }).catch(() => {})
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
@@ -521,6 +557,7 @@ export const {
           })
         })
         .catch(async (e) => {
+          void sdk.client.config.bootstrapComplete({ workspace, cycle: String(cycle) }).catch(() => {})
           console.error("tui bootstrap failed", {
             error: e instanceof Error ? e.message : String(e),
             name: e instanceof Error ? e.name : undefined,

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -190,19 +190,6 @@ export const {
             setStore("reloadPending", false)
             setStore("reloading", false)
           })
-          if (event.properties.resumeSessionID) {
-            void sdk.client.session
-              .prompt({
-                sessionID: event.properties.resumeSessionID,
-                parts: [
-                  {
-                    type: "text",
-                    text: "Configuration has been reloaded successfully. Continue where you left off.",
-                  },
-                ],
-              })
-              .catch(() => {})
-          }
           break
         case "permission.replied": {
           const requests = store.permission[event.properties.sessionID]
@@ -533,7 +520,6 @@ export const {
           })
         })
         .then(() => {
-          void sdk.client.config.bootstrapComplete({ workspace, cycle: String(cycle) }).catch(() => {})
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
@@ -553,6 +539,7 @@ export const {
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
             project.workspace.sync(),
           ]).then(() => {
+            void sdk.client.config.bootstrapComplete({ workspace, cycle: String(cycle) }).catch(() => {})
             setStore("status", "complete")
           })
         })

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -113,7 +113,6 @@ function goUpsellKeys(action: RetryAction) {
 }
 
 const sessionBindingCommands = [
-  "app.reload",
   "session.share",
   "session.rename",
   "session.timeline",
@@ -452,31 +451,6 @@ export function Session() {
   }
 
   const sessionCommandList = createMemo(() => [
-    {
-      title: "Reload configuration",
-      value: "app.reload",
-      category: "App",
-      slash: {
-        name: "reload",
-      },
-      run: async () => {
-        await sdk.client.config
-          .reload({ workspace: project.workspace.current() })
-          .then((res) => {
-            toast.show({
-              message: res.data?.immediate ? "Reloading configuration" : "Reload queued until sessions are idle",
-              variant: "info",
-            })
-          })
-          .catch((error) => {
-            toast.show({
-              message: error instanceof Error ? error.message : "Failed to reload configuration",
-              variant: "error",
-            })
-          })
-        dialog.clear()
-      },
-    },
     {
       title: session()?.share?.url ? "Copy share link" : "Share session",
       value: "session.share",

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -113,6 +113,7 @@ function goUpsellKeys(action: RetryAction) {
 }
 
 const sessionBindingCommands = [
+  "app.reload",
   "session.share",
   "session.rename",
   "session.timeline",
@@ -451,6 +452,31 @@ export function Session() {
   }
 
   const sessionCommandList = createMemo(() => [
+    {
+      title: "Reload configuration",
+      value: "app.reload",
+      category: "App",
+      slash: {
+        name: "reload",
+      },
+      run: async () => {
+        await sdk.client.config
+          .reload({ workspace: project.workspace.current() })
+          .then((res) => {
+            toast.show({
+              message: res.data?.immediate ? "Reloading configuration" : "Reload queued until sessions are idle",
+              variant: "info",
+            })
+          })
+          .catch((error) => {
+            toast.show({
+              message: error instanceof Error ? error.message : "Failed to reload configuration",
+              variant: "error",
+            })
+          })
+        dialog.clear()
+      },
+    },
     {
       title: session()?.share?.url ? "Copy share link" : "Share session",
       value: "session.share",
@@ -1558,7 +1584,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
-                <span style={{ fg: theme.textMuted }}> · interrupted</span>
+                <span style={{ fg: theme.textMuted }}>{" · interrupted"}</span>
               </Show>
             </text>
           </box>

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -1,4 +1,4 @@
-import { useRenderer, useTerminalDimensions } from "@opentui/solid"
+import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { batch, createContext, createEffect, onCleanup, Show, useContext, type JSX, type ParentProps } from "solid-js"
 import { useTheme } from "../context/theme"
 import { MouseButton, Renderable, RGBA } from "@opentui/core"
@@ -7,6 +7,7 @@ import { useToast } from "./toast"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { useBindings, useOpencodeModeStack } from "../keymap"
 import { useClipboard } from "../context/clipboard"
+import { useSync } from "../context/sync"
 
 export function Dialog(
   props: ParentProps<{
@@ -181,6 +182,26 @@ export function DialogProvider(props: ParentProps) {
   const renderer = useRenderer()
   const toast = useToast()
   const clipboard = useClipboard()
+  const dimensions = useTerminalDimensions()
+  const { theme } = useTheme()
+  const sync = useSync()
+
+  useKeyboard((evt) => {
+    if (!sync.data.reloading) return
+    evt.preventDefault()
+    evt.stopPropagation()
+  })
+
+  let wasReloading = false
+  createEffect(() => {
+    if (sync.data.reloading) {
+      wasReloading = true
+      return
+    }
+    if (!wasReloading) return
+    wasReloading = false
+    toast.show({ message: "Reloaded configuration", variant: "success" })
+  })
 
   function copySelection() {
     const text = renderer.getSelection()?.getSelectedText()
@@ -213,6 +234,23 @@ export function DialogProvider(props: ParentProps) {
           <Dialog onClose={() => value.clear()} size={value.size}>
             {value.stack.at(-1)!.element}
           </Dialog>
+        </Show>
+        <Show when={sync.data.reloading}>
+          <box
+            width={dimensions().width}
+            height={dimensions().height}
+            position="absolute"
+            zIndex={4000}
+            left={0}
+            top={0}
+            alignItems="center"
+            paddingTop={Math.max(0, Math.floor(dimensions().height / 4))}
+            backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
+          >
+            <box backgroundColor={theme.backgroundPanel} paddingX={3} paddingY={1} borderStyle="rounded">
+              <text>Reloading configuration...</text>
+            </box>
+          </box>
         </Show>
       </box>
     </ctx.Provider>

--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -200,6 +200,10 @@ export function DialogProvider(props: ParentProps) {
     }
     if (!wasReloading) return
     wasReloading = false
+    if (sync.data.reloadResult === "uncertain") {
+      toast.show({ message: "Reload status uncertain; check config before continuing", variant: "warning" })
+      return
+    }
     toast.show({ message: "Reloaded configuration", variant: "success" })
   })
 


### PR DESCRIPTION
## Summary

Adds a `/reload` slash command that hot-reloads OpenCode configuration, plugins, MCP servers, and other instance-scoped services without restarting the TUI. If any sessions are active in the current instance, reload is queued until they become idle, then the backend instance is reloaded and the TUI re-syncs before dismissing the reload overlay.

https://github.com/user-attachments/assets/e5e9138c-25b9-43db-a53f-ba1de26bf5f9

Closes #6719

<!-- Old screencasts from an earlier implementation may not reflect current behavior:
https://github.com/user-attachments/assets/7e14c446-80bc-4a81-b092-94b08ae120e7
https://github.com/user-attachments/assets/eb8140be-d770-4b26-be41-9d9536088fcd
-->

## How it works

The current implementation is built on the instance HttpApi and EventV2 flow:

1. The global TUI command `/reload` calls `POST /config/reload` for the current workspace.
2. `ConfigReload.request()` records reload state for the current instance/workspace, not globally across every open project.
3. If sessions are active, the reload stays pending until every active session in that instance becomes idle.
4. When execution starts, the server reloads the current instance through `InstanceStore.reload(...)` after the HTTP response is produced.
5. The TUI receives `config.reload.executing`, shows the blocking `Reloading configuration...` overlay, and performs a full bootstrap refresh.
6. The TUI acknowledges the exact bootstrap cycle with `POST /config/bootstrap-complete?cycle=...` only after the full refresh completes.
7. The server emits `config.reload.done`, and the TUI dismisses the overlay and shows a success toast.

Reload state is scoped per instance/workspace, bootstrap completions require a matching cycle, and repeated reload requests during an active reload are coalesced so users do not see a false ready state between back-to-back reloads.

## User-visible behavior

If no session is active, `/reload` starts immediately and shows the reload overlay. If sessions are running, `/reload` queues the reload and shows a queued toast; the reload starts once all active sessions in that client become idle. During the reload overlay, keyboard input is blocked so stray keystrokes are not leaked into the prompt.

The `reload_config` tool still stops the current tool-processing turn with `stopSession: true`, but it no longer injects a synthetic user prompt to continue the conversation after reload. This avoids adding artificial “continue where you left off” text to durable session history or model context.

## Validation

- Added focused regression tests for per-instance reload isolation, same-client multi-session queuing, bootstrap-cycle scoping, repeated reload coalescing, and absence of synthetic continuation prompt data.
- Regenerated the v2 SDK from the updated HttpApi schema.
- Typechecked `packages/opencode` and `packages/tui`.
- Stress-tested the real TUI in tmux: `/reload` works from the home screen and from a session screen, no longer resolves to `/snippets:reload`, shows and clears the reload overlay, and remains stable when `/reload` is hammered during an in-flight reload.
