### PR TITLE
fix(app): remove terminal button border to align with close button

### DIFF
--- a/packages/app/src/components/session/session-sortable-terminal-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-terminal-tab.tsx
@@ -106,6 +106,7 @@ export function SortableTerminalTab(props: { terminal: LocalPTY; onClose?: () =>
     <div use:sortable classList={{ "h-full": true, "opacity-0": sortable.isActiveDraggable }}>
       <div class="relative h-full">
         <Tabs.Trigger
+          classes={{ button: "border-0" }}
           value={props.terminal.id}
           onClick={focus}
           onMouseDown={(e) => e.preventDefault()}


### PR DESCRIPTION
### What does this PR do?

Align terminal text button with close button, by setting the border to 0px.

Before:

<img width="188" height="91" alt="image" src="https://github.com/user-attachments/assets/55373b1e-114c-488d-a762-401da477bb74" />

After:

<img width="188" height="91" alt="image" src="https://github.com/user-attachments/assets/7f45958e-37e2-4150-8545-43863d0f8ad6" />

### How did you verify your code works?

bun run --cwd packages/app dev