### PR TITLE
fix: update pre-push hook to allow caret version differences

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,20 @@
 #!/bin/sh
+set -e
 # Check if bun version matches package.json
-EXPECTED_VERSION=$(grep '"packageManager"' package.json | sed 's/.*"bun@\([^"]*\)".*/\1/')
-CURRENT_VERSION=$(bun --version)
-if [ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]; then
-  echo "Error: Bun version $CURRENT_VERSION does not match expected version $EXPECTED_VERSION from package.json"
-  exit 1
-fi
+# keep in sync with packages/script/src/index.ts semver qualifier
+bun -e '
+import { semver } from "bun";
+const pkg = await Bun.file("package.json").json();
+const expectedBunVersion = pkg.packageManager?.split("@")[1];
+if (!expectedBunVersion) {
+  throw new Error("packageManager field not found in root package.json");
+}
+const expectedBunVersionRange = `^${expectedBunVersion}`;
+if (!semver.satisfies(process.versions.bun, expectedBunVersionRange)) {
+  throw new Error(`This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`);
+}
+if (process.versions.bun !== expectedBunVersion) {
+  console.warn(`Warning: Bun version ${process.versions.bun} differs from expected ${expectedBunVersion}`);
+}
+'
 bun typecheck


### PR DESCRIPTION
previous PRs (#9597 then #9682) to relax the bun version requirement missed this

partially fixes issue discussed in #9834