### PR TITLE
fix(tui): preserve pasted slash commands with arguments

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-util.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete-util.ts
@@ -1,0 +1,28 @@
+/**
+ * Determines whether the slash command text should be cleared when hiding the autocomplete.
+ *
+ * The text should only be cleared when the user abandons a partial slash command
+ * (e.g., types "/gc" then moves cursor elsewhere without selecting).
+ *
+ * The text should NOT be cleared when:
+ * - The text contains arguments (has whitespace) - e.g., "/gcd:plan-phase 2"
+ * - The text was pasted with a complete command and arguments
+ *
+ * @param visible - The current autocomplete mode ("/" for slash commands, "@" for mentions, false if hidden)
+ * @param text - The current input text
+ * @returns true if the text should be cleared, false otherwise
+ */
+export function shouldClearSlashCommand(visible: "/" | "@" | false, text: string): boolean {
+  // Only consider clearing for slash command mode
+  if (visible !== "/") return false
+
+  // Text must start with /
+  if (!text.startsWith("/")) return false
+
+  // If text contains whitespace, it has arguments - don't clear
+  // This handles pasted commands like "/gcd:plan-phase 2"
+  if (/\s/.test(text)) return false
+
+  // Clear partial commands without arguments (e.g., "/gc" abandoned)
+  return true
+}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -12,6 +12,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { Locale } from "@/util/locale"
 import type { PromptInfo } from "./history"
 import { useFrecency } from "./frecency"
+import { shouldClearSlashCommand } from "./autocomplete-util"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -471,7 +472,7 @@ export function Autocomplete(props: {
 
   function hide() {
     const text = props.input().plainText
-    if (store.visible === "/" && !text.endsWith(" ") && text.startsWith("/")) {
+    if (shouldClearSlashCommand(store.visible, text)) {
       const cursor = props.input().logicalCursor
       props.input().deleteRange(0, 0, cursor.row, cursor.col)
       // Sync the prompt store immediately since onContentChange is async

--- a/packages/opencode/test/cli/tui/autocomplete.test.ts
+++ b/packages/opencode/test/cli/tui/autocomplete.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+import { shouldClearSlashCommand } from "../../../src/cli/cmd/tui/component/prompt/autocomplete-util"
+
+describe("shouldClearSlashCommand", () => {
+  describe("slash command mode", () => {
+    test("clears partial command without arguments", () => {
+      expect(shouldClearSlashCommand("/", "/gc")).toBe(true)
+      expect(shouldClearSlashCommand("/", "/help")).toBe(true)
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase")).toBe(true)
+    })
+
+    test("does not clear command with single argument", () => {
+      expect(shouldClearSlashCommand("/", "/help topic")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase 2")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/run test")).toBe(false)
+    })
+
+    test("does not clear command with multiple arguments", () => {
+      expect(shouldClearSlashCommand("/", "/cmd arg1 arg2")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/cmd arg1 arg2 arg3")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase 2 extra")).toBe(false)
+    })
+
+    test("does not clear command with trailing space (selected from autocomplete)", () => {
+      expect(shouldClearSlashCommand("/", "/help ")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase ")).toBe(false)
+    })
+
+    test("does not clear text that doesn't start with /", () => {
+      expect(shouldClearSlashCommand("/", "hello")).toBe(false)
+      expect(shouldClearSlashCommand("/", "")).toBe(false)
+      expect(shouldClearSlashCommand("/", "gc")).toBe(false)
+    })
+
+    test("clears just the slash character", () => {
+      expect(shouldClearSlashCommand("/", "/")).toBe(true)
+    })
+  })
+
+  describe("mention mode (@)", () => {
+    test("never clears in mention mode", () => {
+      expect(shouldClearSlashCommand("@", "/help")).toBe(false)
+      expect(shouldClearSlashCommand("@", "/gc")).toBe(false)
+      expect(shouldClearSlashCommand("@", "@file")).toBe(false)
+    })
+  })
+
+  describe("hidden mode (false)", () => {
+    test("never clears when autocomplete is hidden", () => {
+      expect(shouldClearSlashCommand(false, "/help")).toBe(false)
+      expect(shouldClearSlashCommand(false, "/gc")).toBe(false)
+      expect(shouldClearSlashCommand(false, "anything")).toBe(false)
+    })
+  })
+
+  describe("pasted command scenarios", () => {
+    test("preserves pasted command with arguments (the main bug fix)", () => {
+      // This was the original bug: pasting "/gcd:plan-phase 2" would get deleted
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase 2")).toBe(false)
+    })
+
+    test("preserves pasted command with complex arguments", () => {
+      expect(shouldClearSlashCommand("/", "/search query with spaces")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/run npm install --save")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/edit file.ts line 42")).toBe(false)
+    })
+
+    test("preserves command even with multiple spaces", () => {
+      expect(shouldClearSlashCommand("/", "/cmd  double-space")).toBe(false)
+      expect(shouldClearSlashCommand("/", "/cmd   triple")).toBe(false)
+    })
+  })
+
+  describe("edge cases", () => {
+    test("handles empty string", () => {
+      expect(shouldClearSlashCommand("/", "")).toBe(false)
+    })
+
+    test("handles whitespace only", () => {
+      expect(shouldClearSlashCommand("/", " ")).toBe(false)
+      expect(shouldClearSlashCommand("/", "  ")).toBe(false)
+    })
+
+    test("handles slash with only whitespace", () => {
+      // "/ " means user typed / then space - has space so don't clear
+      expect(shouldClearSlashCommand("/", "/ ")).toBe(false)
+    })
+
+    test("handles commands with special characters", () => {
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase")).toBe(true) // no args
+      expect(shouldClearSlashCommand("/", "/gcd:plan-phase 2")).toBe(false) // with args
+      expect(shouldClearSlashCommand("/", "/some_command")).toBe(true) // no args
+      expect(shouldClearSlashCommand("/", "/some_command arg")).toBe(false) // with args
+    })
+
+    test("handles newlines in arguments", () => {
+      expect(shouldClearSlashCommand("/", "/cmd arg1\narg2")).toBe(false)
+    })
+
+    test("handles tabs as whitespace", () => {
+      expect(shouldClearSlashCommand("/", "/cmd\targ")).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Fixes #9880

## Problem

Pasting a slash command with arguments (e.g., `/gcd:plan-phase 2`) clears the input instead of injecting the prompt.

## Cause

The `hide()` function in autocomplete clears text when it starts with `/` and doesn't end with space, but doesn't check if arguments are already present.

## Fix

Check for any whitespace in the text. If present, preserve it (command has arguments).

## Verification

- Added 17 unit tests covering partial commands, commands with args, pasted commands, edge cases
- `bun test test/cli/tui/autocomplete.test.ts` passes