### PR TITLE
docs: document MCP OAuth redirect URI for pre-registered clients

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -214,6 +214,8 @@ If you have client credentials from the MCP server provider, you can configure t
 }
 ```
 
+OpenCode listens at `http://127.0.0.1:19876/mcp/oauth/callback` for the OAuth callback. Configure your pre-registered client to allow that redirect URI.
+
 ---
 
 ### Authenticating


### PR DESCRIPTION
### What does this PR do?

Clarify that pre-registered OAuth apps must allow the exact local loopback callback URL

### How did you verify your code works?

I didn't change the code, so I haven't run any tests. This is a minor doc enhancement. I haven't found any guidelines regarding formatting so I'm guessing there is no formatting to be done on the doc.