### PR TITLE
fix: include _noop tool in activeTools for LiteLLM proxy compatibility

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -208,7 +208,7 @@ export namespace LLM {
       topP: params.topP,
       topK: params.topK,
       providerOptions: ProviderTransform.providerOptions(input.model, params.options),
-      activeTools: Object.keys(tools).filter((x) => x !== "invalid" && x !== "_noop"),
+      activeTools: Object.keys(tools).filter((x) => x !== "invalid"),
       tools,
       maxOutputTokens,
       abortSignal: input.abort,


### PR DESCRIPTION
## Summary
- Fix compaction failing with LiteLLM proxies when message history contains tool calls

## Problem
When using `/compact` on sessions with LiteLLM proxy providers, the request fails with:
```
litellm.UnsupportedParamsError: Bedrock doesn't support tool calling without `tools=` param specified
```

## Root Cause
The `_noop` dummy tool was being added correctly to satisfy LiteLLM's requirement, but it was filtered out from `activeTools` on line 211 of `llm.ts`, so it was never actually sent in the API request.

## Fix
Remove `_noop` from the `activeTools` filter so it gets included in requests when needed.