### PR TITLE
feat: Add promptCacheKey for Venice provider

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -598,6 +598,11 @@ export namespace ProviderTransform {
         result["reasoningSummary"] = "auto"
       }
     }
+
+    if (input.model.providerID === "venice") {
+      result["promptCacheKey"] = input.sessionID
+    }
+
     return result
   }
 


### PR DESCRIPTION
Closes #9914 

### What does this PR do?
- Include sessionID in cache key when provider is Venice

### How did you verify your code works?
- I ran Opencode locally and captured the payload to see that the field was present.
