### PR TITLE
fix(app): open terminal pane when creating new terminal

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -509,7 +509,10 @@ export default function Page() {
       description: language.t("command.terminal.new.description"),
       category: language.t("command.category.terminal"),
       keybind: "ctrl+alt+t",
-      onSelect: () => terminal.new(),
+      onSelect: () => {
+        if (terminal.all().length > 0) terminal.new()
+        view().terminal.open()
+      },
     },
     {
       id: "steps.toggle",


### PR DESCRIPTION
Fixes #9906

## Problem

Running the new terminal command (`Ctrl+Alt+T`) creates a tab but doesn't open the terminal pane. Users must manually open the pane to see the new tab.

## Solution

Open the terminal pane when the command is invoked. If no terminals exist, let the existing auto-create effect handle creating the first terminal to avoid duplicates.

## Now

![(NOW) fix_terminal-new-opens-pane](https://github.com/user-attachments/assets/0af92f11-9cbf-4638-b9b6-fe13477443aa)
