### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768302833,
-        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
+        "lastModified": 1768393167,
+        "narHash": "sha256-n2063BRjHde6DqAz2zavhOOiLUwA3qXt7jQYHyETjX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61db79b0c6b838d9894923920b612048e1201926",
+        "rev": "2f594d5af95d4fdac67fba60376ec11e482041cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Using bun 1.3.5 from nixpkgs, opencode appears to not build a binary compatible with base M series CPUs. (some sort of issue with baseline bun vs with extensions perhaps? the baffling thing is that my M1 macbook pro cannot build opencode but builds work in CI which [use M1 processors for macos-latest](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) - perhaps its a base vs pro vs max issue?

Recent work allows bun version relaxation and as such, it is appropriate to bump flake.lock to a nixpkgs checkout containing bun 1.3.6 - allowing opencode's dev branch to be built for all supported platforms*

*tested x86_64-linux and aarch64-darwin locally

fixes #9285