### PR TITLE
fix(acp): rename setSessionModel to unstable_setSessionModel

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1084,7 +1084,7 @@ export namespace ACP {
       }
     }
 
-    async setSessionModel(params: SetSessionModelRequest) {
+    async unstable_setSessionModel(params: SetSessionModelRequest) {
       const session = this.sessionManager.get(params.sessionId)
 
       const model = Provider.parseModel(params.modelId)

--- a/packages/opencode/test/acp/agent-interface.test.ts
+++ b/packages/opencode/test/acp/agent-interface.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+import { ACP } from "../../src/acp/agent"
+import type { Agent as ACPAgent } from "@agentclientprotocol/sdk"
+
+/**
+ * Type-level test: This line will fail to compile if ACP.Agent
+ * doesn't properly implement the ACPAgent interface.
+ *
+ * The SDK checks for methods like `agent.unstable_setSessionModel` at runtime
+ * and throws "Method not found" if they're missing. TypeScript allows optional
+ * interface methods to be omitted, but the SDK still expects them.
+ *
+ * @see https://github.com/agentclientprotocol/typescript-sdk/commit/7072d3f
+ */
+type _AssertAgentImplementsACPAgent = ACP.Agent extends ACPAgent ? true : never
+const _typeCheck: _AssertAgentImplementsACPAgent = true
+
+/**
+ * Runtime verification that optional methods the SDK expects are actually implemented.
+ * The SDK's router checks `if (!agent.methodName)` and throws MethodNotFound if missing.
+ */
+describe("acp.agent interface compliance", () => {
+  // Extract method names from the ACPAgent interface type
+  type ACPAgentMethods = keyof ACPAgent
+
+  // Methods that the SDK's router explicitly checks for at runtime
+  const sdkCheckedMethods: ACPAgentMethods[] = [
+    // Required
+    "initialize",
+    "newSession",
+    "prompt",
+    "cancel",
+    // Optional but checked by SDK router
+    "loadSession",
+    "setSessionMode",
+    "authenticate",
+    // Unstable - SDK checks these with unstable_ prefix
+    "unstable_listSessions",
+    "unstable_forkSession",
+    "unstable_resumeSession",
+    "unstable_setSessionModel",
+  ]
+
+  test("Agent implements all SDK-checked methods", () => {
+    for (const method of sdkCheckedMethods) {
+      expect(typeof ACP.Agent.prototype[method as keyof typeof ACP.Agent.prototype], `Missing method: ${method}`).toBe(
+        "function",
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #9941

- Rename `setSessionModel` → `unstable_setSessionModel` to match ACP SDK v0.12.0+ interface
- Add unit test to catch future SDK interface changes at compile time

## Root Cause

The ACP TypeScript SDK v0.12.0 renamed this method in [commit 7072d3f](https://github.com/agentclientprotocol/typescript-sdk/commit/7072d3f0aae8df8da4f772b3960268f3e7c43364). The SDK's router checks `if (!agent.unstable_setSessionModel)` and throws "Method not found" when missing.

## References

- SDK commit: https://github.com/agentclientprotocol/typescript-sdk/commit/7072d3f
- Same fix in Qwen Code: https://github.com/QwenLM/qwen-code/pull/1521