### PR TITLE
feat(app): always show Toggle-Review button 

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -47,7 +47,6 @@ export function SessionHeader() {
 
   const currentSession = createMemo(() => sync.data.session.find((s) => s.id === params.id))
   const shareEnabled = createMemo(() => sync.data.config.share !== "disabled")
-  const showReview = createMemo(() => !!currentSession()?.summary?.files)
   const showShare = createMemo(() => shareEnabled() && !!currentSession())
   const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
   const view = createMemo(() => layout.view(sessionKey()))
@@ -176,13 +175,7 @@ export function SessionHeader() {
               {/*   <SessionMcpIndicator /> */}
               {/* </div> */}
               <div class="flex items-center gap-1">
-                <div
-                  class="hidden md:block shrink-0"
-                  classList={{
-                    "opacity-0 pointer-events-none": !showReview(),
-                  }}
-                  aria-hidden={!showReview()}
-                >
+                <div class="hidden md:block shrink-0">
                   <TooltipKeybind
                     title={language.t("command.review.toggle")}
                     keybind={command.keybind("review.toggle")}


### PR DESCRIPTION
### What does this PR do?

Updates the "Toggle Review" button in the header to always be visible. 
<img width="448" height="230" alt="image" src="https://github.com/user-attachments/assets/f8a2d7d5-2695-47f7-926b-35f10db3c05d" />


Before:

https://github.com/user-attachments/assets/b36f11f6-b230-4e15-9bbb-ff95e8040de0


After:


https://github.com/user-attachments/assets/89ca207a-843a-4461-9f92-b72b3e0397b4



### How did you verify your code works?
Ran it and tested toggling review with and without file dif 

Closes: https://github.com/anomalyco/opencode/issues/9943
