### PR TITLE
fix(provider): add thinking presets for Google Vertex Anthropic

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -420,7 +420,9 @@ export namespace ProviderTransform {
         )
 
       case "@ai-sdk/anthropic":
-        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
+      // https://v5.ai-sdk.dev/providers/ai-sdk-providers/anthropic
+      case "@ai-sdk/google-vertex/anthropic":
+        // https://v5.ai-sdk.dev/providers/ai-sdk-providers/google-vertex#anthropic-provider
         return {
           high: {
             thinking: {
@@ -643,7 +645,7 @@ export namespace ProviderTransform {
     const modelCap = modelLimit || globalLimit
     const standardLimit = Math.min(modelCap, globalLimit)
 
-    if (npm === "@ai-sdk/anthropic") {
+    if (npm === "@ai-sdk/anthropic" || npm === "@ai-sdk/google-vertex/anthropic") {
       const thinking = options?.["thinking"]
       const budgetTokens = typeof thinking?.["budgetTokens"] === "number" ? thinking["budgetTokens"] : 0
       const enabled = thinking?.["type"] === "enabled"


### PR DESCRIPTION
## Summary
- Adds `@ai-sdk/google-vertex/anthropic` to the `thinkingPresets` switch statement
- Updates `adjustMaxTokens` to handle thinking budget calculations for Vertex Anthropic

This enables reasoning/thinking support for Claude models accessed through Google Vertex AI.

Fixes #9894

## Changes
- Add `@ai-sdk/google-vertex/anthropic` case to `thinkingPresets()` (uses same config as `@ai-sdk/anthropic`)
- Add `@ai-sdk/google-vertex/anthropic` to `adjustMaxTokens()` condition for proper token budgeting

## Test plan
- [x] Existing tests pass (`bun test --grep transform` - 75 tests pass)
- [x] Type check passes (`bun run typecheck`)
- [ ] Manual testing with Claude models on Vertex AI with reasoning enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)