### PR TITLE
fix(tool): handle invalid session_ids gracefully and fix test initialization

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -61,8 +61,10 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const session = await iife(async () => {
         if (params.session_id) {
-          const found = await Session.get(params.session_id).catch(() => {})
-          if (found) return found
+          try {
+            const found = await Session.get(params.session_id)
+            if (found) return found
+          } catch {}
         }
 
         return await Session.create({

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { TaskTool } from "../../src/tool/task"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Identifier } from "../../src/id/id"
+import { Tool } from "../../src/tool/tool"
+
+const projectRoot = path.join(__dirname, "../..")
+
+describe("tool.task", () => {
+  test("handles invalid session_id gracefully", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+        const messageID = Identifier.ascending("message")
+        
+        await Session.updateMessage({
+          id: messageID,
+          sessionID: session.id,
+          role: "assistant",
+          parentID: Identifier.ascending("message"),
+          modelID: "dummy-model",
+          providerID: "dummy-provider",
+          mode: "auto",
+          agent: "primary",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 }
+          },
+          time: { created: Date.now() }
+        })
+
+        const ctx: Tool.Context = {
+          sessionID: session.id,
+          messageID: messageID,
+          agent: "primary",
+          abort: AbortSignal.any([]),
+          metadata: () => {},
+          ask: async () => {},
+        }
+
+        let error: Error | undefined
+        try {
+          const task = await TaskTool.init({ agent: { name: "primary" } as any })
+          await task.execute(
+            {
+              description: "test subtask",
+              prompt: "do something",
+              subagent_type: "explore",
+              session_id: "invalid_id_format",
+            },
+            ctx,
+          )
+        } catch (e) {
+          error = e as Error
+        }
+        expect(error).toBeDefined()
+        expect(error?.message).not.toContain("Invalid string: must start with")
+      }
+    })
+  })
+})


### PR DESCRIPTION
Fixes [#9950
](https://github.com/anomalyco/opencode/issues/9950)

### What does this PR do?
- Adds a `try/catch` around `Session.get()` in the task tool to gracefully handle invalid session IDs instead of crashing.
- Adds test/tool/task.test.ts to test the task tool and verify the graceful error handling.

### How did you verify your code works?
Ran bun test packages/opencode/test/tool/task.test.ts and verified the new test passes.