### PR TITLE
docs: opencode-lldb-debug - new eco addition

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -46,6 +46,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                       |
+| [opencode-lldb-debug](https://github.com/heavenly/opencode-lldb)                                   | Exposing LLDB as a tool to opencode - automating your job away further                         |
 
 ---
 


### PR DESCRIPTION
### What does this PR do?
Hello,
I added a new listing to the ecosystem, a small plugin I created, exposing the user's LLDB debugger as a tool for opencode to utilize.

### How did you verify your code works?
I tested it on my local Rust projects.