### PR TITLE
docs: add opencode-recall to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -46,6 +46,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                       |
+| [opencode-recall](https://github.com/SleepingBag945/opencode-recall)                               | Optimize token usage with reversible tool output pruning, plus on-demand restore and explore   |
 
 ---
 


### PR DESCRIPTION
Add opencode-recall plugin entry to the Ecosystem page.

### What does this PR do?
- Adds opencode-recall to the Plugins list in `ecosystem.mdx`.

### How did you verify your code works?
- N/A (documentation-only change)