### PR TITLE
fix(app): respect navigator.languages priority for locale  (#9996)

### DIFF
--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -54,6 +54,7 @@ function detectLocale(): Locale {
     if (language.toLowerCase().startsWith("pl")) return "pl"
     if (language.toLowerCase().startsWith("ru")) return "ru"
     if (language.toLowerCase().startsWith("ar")) return "ar"
+    if (language.toLowerCase().startsWith("en")) return "en"
   }
 
   return "en"


### PR DESCRIPTION
### What does this PR do?
Resolves #9996. English locale detection in the web UI could fall through to a later supported locale (ru/fr/etc) even when `navigator.languages` prefers `en*`, because `en` was not explicitly matched.


### How did you verify your code works?
Verification:
- Started API server: `bun dev serve`
- Started app dev server: `bun run --cwd packages/app dev`
- Confirmed `navigator.languages` like ['en-US','en-GB','nl','fr'] resolves to English.
- Manually tested in Chrome 143.0.7499.194, Safari 26.2, and Firefox 148.0b2.
