### PR TITLE
fix(codex): write refresh tokens to openai auth (#10010)

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -399,7 +399,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
               const tokens = await refreshAccessToken(currentAuth.refresh)
               const newAccountId = extractAccountId(tokens) || authWithAccount.accountId
               await input.client.auth.set({
-                path: { id: "codex" },
+                path: { id: "openai" },
                 body: {
                   type: "oauth",
                   refresh: tokens.refresh_token,


### PR DESCRIPTION
## Summary
Update the Codex OAuth refresh flow to write refreshed tokens back to the `openai` auth entry, preventing duplicate `codex` credentials and keeping `auth list` consistent.

Fixes #10010

## Changes
- Store refreshed Codex OAuth tokens under `openai` instead of `codex`

## AI Assistance
- **Tools**: OpenCode + openai/gpt-5.2-codex
- **Testing**: `bun turbo typecheck`
- **Review**: Human operator reviewed changes

## Notes
- No additional tests run beyond typecheck