### PR TITLE
fix(app): clear session hover state on navigation

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1488,6 +1488,7 @@ export default function Layout(props: ParentProps) {
         class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 ${props.dense ? "py-0.5" : "py-1"}`}
         onMouseEnter={() => prefetchSession(props.session, "high")}
         onFocus={() => prefetchSession(props.session, "high")}
+        onClick={() => setHoverSession(undefined)}
       >
         <div class="flex items-center gap-1 w-full">
           <div


### PR DESCRIPTION
Fixes #10035

## Summary
Fixes a UX issue where the session steps tooltip (hover card) persists after clicking a session in the sidebar. This change ensures the hover state is cleared immediately upon navigation, preventing the tooltip from remaining visible when the user enters the session.

https://github.com/user-attachments/assets/f51d0966-c83d-4763-b4db-b5a9ff29b6b0


## Changes
- `packages/app/src/pages/layout.tsx`: Added `onClick` handler to reset `hoverSession` state when a session item is clicked.

## Non-goals
- Changes to focus behavior in the new session conversation panel are out of scope. (Current behavior: entering a key types in the prompt, even if the input visual highlight is subtle).

## Verification
- Validated locally: Clicking a session in the sidebar now immediately dismisses the hover tooltip.