### PR TITLE
fix(app): support ctrl-n/p in lists

### DIFF
--- a/packages/ui/src/hooks/use-filtered-list.tsx
+++ b/packages/ui/src/hooks/use-filtered-list.tsx
@@ -82,6 +82,15 @@ export function useFilteredList<T>(props: FilteredListProps<T>) {
       const selectedIndex = flat().findIndex((x) => props.key(x) === list.active())
       const selected = flat()[selectedIndex]
       if (selected) props.onSelect?.(selected, selectedIndex)
+    } else if (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+      if (event.key === "n" || event.key === "p") {
+        event.preventDefault()
+        const navEvent = new KeyboardEvent("keydown", {
+          key: event.key === "n" ? "ArrowDown" : "ArrowUp",
+          bubbles: true,
+        })
+        list.onKeyDown(navEvent)
+      }
     } else {
       // Skip list navigation for text editing shortcuts (e.g., Option+Arrow, Option+Backspace on macOS)
       if (event.altKey || event.metaKey) return


### PR DESCRIPTION
### What does this PR do?
Adds ctrl+n/p keyboard navigation to lists (ex: command palette). ctrl+n moves down, ctrl+p moves up.

### How did you verify your code works? 
1. Run app locally
2. Open command palette
3. Verify ctrl+n moves selection down, ctrl+p moves up
4. Verify arrow keys and Enter still work