### PR TITLE
fix(tool): use default agent fallback in plan_exit when build is disabled

### DIFF
--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -7,6 +7,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Provider } from "../provider/provider"
 import { Instance } from "../project/instance"
+import { Agent } from "../agent/agent"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 import ENTER_DESCRIPTION from "./plan-enter.txt"
 
@@ -23,15 +24,19 @@ export const PlanExitTool = Tool.define("plan_exit", {
   async execute(_params, ctx) {
     const session = await Session.get(ctx.sessionID)
     const plan = path.relative(Instance.worktree, Session.plan(session))
+
+    // Get the default primary agent (falls back if "build" is disabled)
+    const targetAgent = await Agent.defaultAgent()
+
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
       questions: [
         {
-          question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
-          header: "Build Agent",
+          question: `Plan at ${plan} is complete. Would you like to switch to the ${targetAgent} agent and start implementing?`,
+          header: "Exit Plan Mode",
           custom: false,
           options: [
-            { label: "Yes", description: "Switch to build agent and start implementing the plan" },
+            { label: "Yes", description: `Switch to ${targetAgent} agent and start implementing the plan` },
             { label: "No", description: "Stay with plan agent to continue refining the plan" },
           ],
         },
@@ -51,7 +56,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
       time: {
         created: Date.now(),
       },
-      agent: "build",
+      agent: targetAgent,
       model,
     }
     await Session.updateMessage(userMsg)
@@ -65,8 +70,8 @@ export const PlanExitTool = Tool.define("plan_exit", {
     } satisfies MessageV2.TextPart)
 
     return {
-      title: "Switching to build agent",
-      output: "User approved switching to build agent. Wait for further instructions.",
+      title: `Switching to ${targetAgent} agent`,
+      output: `User approved switching to ${targetAgent} agent. Wait for further instructions.`,
       metadata: {},
     }
   },


### PR DESCRIPTION
### What does this PR do?

Fixes the `plan_exit` tool throwing an error when the build agent is disabled via config (`agent.build.disable: true`).

**Problem:** The tool hardcoded `agent: "build"` without checking if the build agent was available, causing an error when trying to switch to a disabled agent.

**Solution:** Use `Agent.defaultAgent()` to dynamically find an available primary agent instead of hardcoding "build". This leverages the existing fallback logic that finds the first available primary visible agent.

Fixes #9822

### How did you verify your code works?

- [x] TypeScript compilation passes (`bun run tsgo --noEmit` in packages/opencode)
- [x] Code review of `Agent.defaultAgent()` shows it properly falls back to available primary agents
- [ ] Manual testing with `agent.build.disable: true` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)