### PR TITLE
fix: ensure @opencode-ai/plugin is installed in cache environment

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -11,6 +11,7 @@ import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
+import { Installation } from "../installation"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -42,6 +43,13 @@ export namespace Plugin {
       const init = await plugin(input)
       hooks.push(init)
     }
+
+    // Ensure @opencode-ai/plugin is available in the cache environment
+    await BunProc.install("@opencode-ai/plugin", Installation.isLocal() ? "latest" : Installation.VERSION).catch(
+      (err) => {
+        log.error("failed to install @opencode-ai/plugin", { error: err })
+      },
+    )
 
     const plugins = [...(config.plugin ?? [])]
     if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {


### PR DESCRIPTION
### What does this PR do?
Fixes #5860

### How did you verify your code works?
1. If you have opencode-google-antigravity-auth installed, it may break between opencode updates (it did for me)
2. With this patch opencode will automatically install the opencode-ai/plugin, if it's missing.  (you can simulate the missing module with `rm -rf /home/deftdawg/.cache/opencode/node_modules/@opencode-ai/plugin`)
3. When `@opencode-ai/plugin`, `opencode` will silently crash with a blank screen... You can see the full error... `opencode run hello --print-logs`
4. testing the fix, switch to this branch and `nix build .#opencode` (or however you build on your distro)
5. `./result/bin/opencode run hello --print-logs` # this will work and install the module fixing the issue.
