### PR TITLE
feat(app): add focus styling to input fields, add search icon to file/command search

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -148,7 +148,7 @@ export function DialogSelectFile() {
         search={{
           placeholder: language.t("palette.search.placeholder"),
           autofocus: true,
-          hideIcon: true,
+          hideIcon: false,
           class: "pl-3 pr-2 !mb-0",
         }}
         emptyMessage={language.t("palette.empty")}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1459,8 +1459,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         onSubmit={handleSubmit}
         classList={{
           "group/prompt-input": true,
-          "bg-surface-raised-stronger-non-alpha shadow-xs-border relative": true,
-          "rounded-md overflow-clip focus-within:shadow-xs-border": true,
+          "bg-surface-raised-stronger-non-alpha shadow-xs-border-base relative": true,
+          "rounded-md overflow-clip focus-within:shadow-xs-border-weak-focus": true,
           "border-icon-info-active border-dashed": store.dragging,
           [props.class ?? ""]: !!props.class,
         }}

--- a/packages/app/src/components/settings-keybinds.tsx
+++ b/packages/app/src/components/settings-keybinds.tsx
@@ -365,8 +365,11 @@ export const SettingsKeybinds: Component = () => {
             </Button>
           </div>
 
-          <div class="flex items-center gap-2 px-3 h-9 rounded-lg bg-surface-base">
-            <Icon name="magnifying-glass" class="text-icon-weak-base flex-shrink-0" />
+          <div class="flex items-center gap-2 px-3 h-9 rounded-lg bg-surface-base group/search focus-within:shadow-xs-border-weak-focus transition-shadow">
+            <Icon
+              name="magnifying-glass"
+              class="text-icon-weak-base group-focus-within/search:text-text-weak flex-shrink-0"
+            />
             <TextField
               variant="ghost"
               type="text"

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -208,11 +208,20 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
   return (
     <div data-component="list" classList={{ [props.class ?? ""]: !!props.class }}>
       <Show when={!!props.search}>
-        <div data-slot="list-search-wrapper">
-          <div data-slot="list-search" classList={{ [searchProps().class ?? ""]: !!searchProps().class }}>
+        <div data-slot="list-search-wrapper" class="pt-px">
+          <div
+            data-slot="list-search"
+            classList={{
+              [searchProps().class ?? ""]: !!searchProps().class,
+              "focus-within:shadow-xs-border-weak-focus group/list-search transition-shadow": true,
+            }}
+          >
             <div data-slot="list-search-container">
               <Show when={!searchProps().hideIcon}>
-                <Icon name="magnifying-glass" />
+                <Icon
+                  name="magnifying-glass"
+                  class="text-icon-weak-base group-focus-within/list-search:text-text-weak"
+                />
               </Show>
               <TextField
                 autofocus={searchProps().autofocus}

--- a/packages/ui/src/styles/tailwind/index.css
+++ b/packages/ui/src/styles/tailwind/index.css
@@ -65,6 +65,7 @@
   --shadow-xs-border-base: var(--shadow-xs-border-base);
   --shadow-xs-border-select: var(--shadow-xs-border-select);
   --shadow-xs-border-focus: var(--shadow-xs-border-focus);
+  --shadow-xs-border-weak-focus: var(--shadow-xs-border-weak-focus);
 
   --animate-pulse: var(--animate-pulse);
 }

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -73,6 +73,9 @@
     0 0 0 1px var(--border-base, rgba(11, 6, 0, 0.2)), 0 1px 2px -1px rgba(19, 16, 16, 0.25),
     0 1px 2px 0 rgba(19, 16, 16, 0.08), 0 1px 3px 0 rgba(19, 16, 16, 0.12), 0 0 0 2px var(--background-weak, #f1f0f0),
     0 0 0 3px var(--border-selected, rgba(0, 74, 255, 0.99));
+  --shadow-xs-border-weak-focus:
+    0 0 0 1px var(--border-active, var(--smoke-light-alpha-9)), 0 1px 2px -1px rgba(19, 16, 16, 0.04),
+    0 1px 2px 0 rgba(19, 16, 16, 0.06), 0 1px 3px 0 rgba(19, 16, 16, 0.08);
   --shadow-lg-border-base:
     0 0 0 1px var(--border-weak-base, rgba(0, 0, 0, 0.07)), 0 36px 80px 0 rgba(0, 0, 0, 0.03),
     0 13.141px 29.201px 0 rgba(0, 0, 0, 0.04), 0 6.38px 14.177px 0 rgba(0, 0, 0, 0.05),


### PR DESCRIPTION
### What does this PR do?

1. Add focus styling for input fields: 
- prompt input,
- select file/command input
- settings' keybind search inputs

2. Add magnifying glass icon to select file/command input for consistency
3. Change color of icon in settings' keybind search input when the input is focused



### How did you verify your code works?
Ran locally, compared to ensure style is consistent, and that themes are respected

## Before

https://github.com/user-attachments/assets/c5f53f9d-a1d6-40e5-a8a8-a6ca3d32e64a

## After

https://github.com/user-attachments/assets/f34fb4eb-1caa-4052-a989-78e7df723d62

