### PR TITLE
fix(enterprise): add message navigation to share page desktop view

### DIFF
--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -20,6 +20,7 @@ import { createStore } from "solid-js/store"
 import z from "zod"
 import NotFound from "../[...404]"
 import { Tabs } from "@opencode-ai/ui/tabs"
+import { MessageNav } from "@opencode-ai/ui/message-nav"
 import { preloadMultiFileDiff, PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
 import { Diff as SSRDiff } from "@opencode-ai/ui/diff-ssr"
 import { clientOnly } from "@solidjs/start"
@@ -362,6 +363,15 @@ export default function () {
                                     {title()}
                                   </div>
                                   <div class="flex items-start justify-start h-full min-h-0">
+                                    <Show when={messages().length > 1}>
+                                      <MessageNav
+                                        class="sticky top-0 shrink-0 py-2 pl-4"
+                                        messages={messages()}
+                                        current={activeMessage()}
+                                        size="compact"
+                                        onMessageSelect={setActiveMessage}
+                                      />
+                                    </Show>
                                     <SessionTurn
                                       sessionID={data().sessionID}
                                       messageID={store.messageId ?? firstUserMessage()!.id!}


### PR DESCRIPTION
### What does this PR do?

Fixes #10032

Adds the `MessageNav` component to the share page's desktop viewport, allowing users to navigate between messages in multi-turn conversations.

**Problem:** On desktop viewports, the share page only showed a single message (the first user message) with no way to access other messages. Users discovered the messages were present in the data but the UI didn't provide navigation.

**Solution:** Added the existing `MessageNav` component (already used in the main app) to the desktop view. It appears on the left side of the session content when there are multiple messages, showing compact tick marks that expand to a detailed list on hover.

### How did you verify your code works?

- `bun run --cwd packages/enterprise typecheck` passes
- `bun run --cwd packages/enterprise build` completes successfully
- Reviewed the `MessageNav` component behavior in the main app to confirm it provides the expected functionality

---
🤖 Generated with [Claude Code](https://claude.ai/code)