### PR TITLE
fix: make 'Learn More' link functional in theme settings

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -5,6 +5,7 @@ import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme"
 import { useLanguage } from "@/context/language"
 import { useSettings, monoFontFamily } from "@/context/settings"
 import { playSound, SOUND_OPTIONS } from "@/utils/sound"
+import { Link } from "./link"
 
 export const SettingsGeneral: Component = () => {
   const theme = useTheme()
@@ -107,9 +108,9 @@ export const SettingsGeneral: Component = () => {
               description={
                 <>
                   {language.t("settings.general.row.theme.description")}{" "}
-                  <a href="#" class="text-text-interactive-base">
+                  <Link href="https://opencode.ai/docs/themes/">
                     {language.t("common.learnMore")}
-                  </a>
+                  </Link>
                 </>
               }
             >


### PR DESCRIPTION
fixes #10074 

### What does this PR do?
The "Learn More" button for themes wasnt redirecting anywhere. I have fixed it to direct to the proper opencode documentation for themes.
### How did you verify your code works?
Check by running locally

Before

https://github.com/user-attachments/assets/2836a7de-7cc3-4061-9e23-17e7b00c1edc

After


https://github.com/user-attachments/assets/694d34bd-5228-4e0b-8077-fa13135bc392

