### PR TITLE
fix(ui): prevent copy buttons from stealing focus from prompt input

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -425,6 +425,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
               <IconButton
                 icon={copied() ? "check" : "copy"}
                 variant="secondary"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={(event) => {
                   event.stopPropagation()
                   handleCopy()
@@ -701,6 +702,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
               <IconButton
                 icon={copied() ? "check" : "copy"}
                 variant="secondary"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={handleCopy}
                 aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
               />

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -626,6 +626,7 @@ export function SessionTurn(
                                   <IconButton
                                     icon={copied() ? "check" : "copy"}
                                     variant="secondary"
+                                    onMouseDown={(e) => e.preventDefault()}
                                     onClick={(event) => {
                                       event.stopPropagation()
                                       handleCopy()


### PR DESCRIPTION
Closes #10083 

### What does this PR do?
Fixes bug where pressing on copy button to copy chat message would cause the prompt input to unfocus, unless user clicks within the session again

### How did you verify your code works?
Tested locally
