### PR TITLE
feat: Use platform paste key for tips.tsx

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -2,6 +2,8 @@ import { createMemo, createSignal, For } from "solid-js"
 import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"
 
 const themeCount = Object.keys(DEFAULT_THEMES).length
+const isMac = process.platform === "darwin"
+const pasteKey = isMac ? "Cmd+V" : "Ctrl+V"
 const themeTip = `Use {highlight}/theme{/highlight} or {highlight}Ctrl+X T{/highlight} to switch between ${themeCount} built-in themes`
 
 type TipPart = { text: string; highlight: boolean }
@@ -56,7 +58,7 @@ const TIPS = [
   "Use {highlight}/redo{/highlight} to restore previously undone messages and file changes",
   "Run {highlight}/share{/highlight} to create a public link to your conversation at opencode.ai",
   "Drag and drop images into the terminal to add them as context",
-  "Press {highlight}Ctrl+V{/highlight} to paste images from your clipboard into the prompt",
+  `Press {highlight}${pasteKey}{/highlight} to paste images from your clipboard into the prompt`,
   "Press {highlight}Ctrl+X E{/highlight} or {highlight}/editor{/highlight} to compose messages in your external editor",
   "Run {highlight}/init{/highlight} to auto-generate project rules based on your codebase",
   "Run {highlight}/models{/highlight} or {highlight}Ctrl+X M{/highlight} to see and switch between available AI models",


### PR DESCRIPTION
### Summary
This PR updates the Tips component to display the correct keyboard shortcut for pasting images based on the user's operating system.

### Changes
- Added platform detection using process.platform.
- Introduced pasteKey constant that dynamically sets the shortcut:
  - macOS: Displays Cmd+V
  - Windows/Linux: Displays Ctrl+V (default)
- Updated the specific tip string to use the dynamic {highlight}${pasteKey}{/highlight} variable.

### How did you verify your code works?

<img width="732" height="100" alt="image" src="https://github.com/user-attachments/assets/563f5cc4-4d2a-43c0-93a9-51cdc0d71ebf" />


closes https://github.com/anomalyco/opencode/issues/10082