### PR TITLE
feat(app): add app version display to settings

### DIFF
--- a/packages/app/src/components/dialog-settings.tsx
+++ b/packages/app/src/components/dialog-settings.tsx
@@ -3,6 +3,7 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { Icon } from "@opencode-ai/ui/icon"
 import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
 import { SettingsGeneral } from "./settings-general"
 import { SettingsKeybinds } from "./settings-keybinds"
 import { SettingsPermissions } from "./settings-permissions"
@@ -14,6 +15,7 @@ import { SettingsMcp } from "./settings-mcp"
 
 export const DialogSettings: Component = () => {
   const language = useLanguage()
+  const platform = usePlatform()
 
   return (
     <Dialog size="x-large">
@@ -23,22 +25,35 @@ export const DialogSettings: Component = () => {
             style={{
               display: "flex",
               "flex-direction": "column",
-              gap: "12px",
+              "justify-content": "space-between",
+              height: "100%",
               width: "100%",
-              "padding-top": "12px",
-              "padding-bottom": "12px",
             }}
           >
-            <Tabs.SectionTitle>{language.t("settings.section.desktop")}</Tabs.SectionTitle>
-            <div style={{ display: "flex", "flex-direction": "column", gap: "6px", width: "100%" }}>
-              <Tabs.Trigger value="general">
-                <Icon name="sliders" />
-                {language.t("settings.tab.general")}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="shortcuts">
-                <Icon name="keyboard" />
-                {language.t("settings.tab.shortcuts")}
-              </Tabs.Trigger>
+            <div
+              style={{
+                display: "flex",
+                "flex-direction": "column",
+                gap: "12px",
+                width: "100%",
+                "padding-top": "12px",
+              }}
+            >
+              <Tabs.SectionTitle>{language.t("settings.section.desktop")}</Tabs.SectionTitle>
+              <div style={{ display: "flex", "flex-direction": "column", gap: "6px", width: "100%" }}>
+                <Tabs.Trigger value="general">
+                  <Icon name="sliders" />
+                  {language.t("settings.tab.general")}
+                </Tabs.Trigger>
+                <Tabs.Trigger value="shortcuts">
+                  <Icon name="keyboard" />
+                  {language.t("settings.tab.shortcuts")}
+                </Tabs.Trigger>
+              </div>
+            </div>
+            <div class="flex flex-col gap-1 pl-1 py-1 text-12-medium text-text-weak">
+              <span>OpenCode Desktop</span>
+              <span class="text-11-regular">v{platform.version}</span>
             </div>
           </div>
           {/* <Tabs.SectionTitle>Server</Tabs.SectionTitle> */}


### PR DESCRIPTION
### What does this PR do?
Adds app version display to the settings dialog. The version is positioned at the bottom of the sidebar (in the settings categories column) and shows:

First row: "OpenCode Desktop"
Second row: Current version (e.g., "v1.1.32")
Uses platform.version from the context to dynamically display the version from packages/app/package.json.


### How did you verify your code works?
Tested on a separate branch with an older version pulled from upstream. The version number correctly displayed whatever version was set in the platform context, confirming:

Dynamic version loading works
The UI renders correctly at the bottom of the sidebar
Styling matches the existing settings tab components

## Screenshot
<img width="353" height="637" alt="image" src="https://github.com/user-attachments/assets/486cff9a-7d83-47f7-ba06-5bfc86ec4fff" />


