### PR TITLE
fix(tui): preserve agent state after compaction

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,3 +1,4 @@
-plans/
-bun.lock
+node_modules
 package.json
+bun.lock
+.gitignore

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -130,16 +130,16 @@ export function Prompt(props: PromptProps) {
     interrupt: 0,
   })
 
-  // Initialize agent/model/variant from last user message when session changes
-  let syncedSessionID: string | undefined
+  // Initialize agent/model/variant from last user message when it changes.
+  // This handles both initial session load AND compaction (where a new user
+  // message is created with the current agent state).
+  let syncedMessageID: string | undefined
   createEffect(() => {
-    const sessionID = props.sessionID
     const msg = lastUserMessage()
+    if (!msg) return
 
-    if (sessionID !== syncedSessionID) {
-      if (!sessionID || !msg) return
-
-      syncedSessionID = sessionID
+    if (msg.id !== syncedMessageID) {
+      syncedMessageID = msg.id
 
       // Only set agent if it's a primary agent (not a subagent)
       const isPrimaryAgent = local.agent.list().some((x) => x.name === msg.agent)

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -7,7 +7,8 @@ export function getFilename(path: string | undefined) {
 
 export function getDirectory(path: string | undefined) {
   if (!path) return ""
-  const parts = path.split("/")
+  const trimmed = path.replace(/[\/\\]+$/, "")
+  const parts = trimmed.split(/[\/\\]/)
   return parts.slice(0, parts.length - 1).join("/") + "/"
 }
 


### PR DESCRIPTION
Track lastUserMessage().id changes instead of session ID changes when
syncing agent state. Previously, compaction would create a new user
message with the current agent mode (e.g., "plan"), but since the
session ID stayed the same, the agent state was never synced from it.

Fixes #8349