### PR TITLE
fix(tui): add weight to fuzzy search to maintain title priority

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -72,15 +72,23 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   let input: InputRenderable
 
   const filtered = createMemo(() => {
-    if (props.skipFilter) {
-      return props.options.filter((x) => x.disabled !== true)
-    }
+    if (props.skipFilter) return props.options.filter((x) => x.disabled !== true)
     const needle = store.filter.toLowerCase()
-    const result = pipe(
+    const options = pipe(
       props.options,
       filter((x) => x.disabled !== true),
-      (x) => (!needle ? x : fuzzysort.go(needle, x, { keys: ["title", "category"] }).map((x) => x.obj)),
     )
+    if (!needle) return options
+
+    // prioritize title matches (weight: 2) over category matches (weight: 1).
+    // users typically search by the item name, and not its category.
+    const result = fuzzysort
+      .go(needle, options, {
+        keys: ["title", "category"],
+        scoreFn: (r) => r[0].score * 2 + r[1].score,
+      })
+      .map((x) => x.obj)
+
     return result
   })
 


### PR DESCRIPTION
### What does this PR do?

Fix TUI's command search filtering to maintain proper result prioritization throughout typing by adding weights to fuzzy search scoring where title matches are weighted 2x more than category matches, this helps title matches consistently appear before category matches.

### How did you verify your code works?
followed the reproduction steps mentioned in #10102 and verified options with "session" in their title appear consistently at the top of the results and above options with only category "session"

screen recording of the fix below:

https://github.com/user-attachments/assets/dded3462-94ef-4b89-a22c-1582aec7d50e

fixes #10102 