### PR TITLE
feat: ctrl+m keybinding to display description of command in TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -1,17 +1,19 @@
-import type { BoxRenderable, TextareaRenderable, KeyEvent, ScrollBoxRenderable } from "@opentui/core"
-import fuzzysort from "fuzzysort"
-import { firstBy } from "remeda"
-import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
-import { createStore } from "solid-js/store"
-import { useSDK } from "@tui/context/sdk"
-import { useSync } from "@tui/context/sync"
-import { useTheme, selectedForeground } from "@tui/context/theme"
+import { Locale } from "@/util/locale"
+import type { BoxRenderable, KeyEvent, ScrollBoxRenderable, TextareaRenderable } from "@opentui/core"
+import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/solid"
 import { SplitBorder } from "@tui/component/border"
 import { useCommandDialog } from "@tui/component/dialog-command"
-import { useTerminalDimensions } from "@opentui/solid"
-import { Locale } from "@/util/locale"
-import type { PromptInfo } from "./history"
+import { useKeybind } from "@tui/context/keybind"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
+import { selectedForeground, useTheme } from "@tui/context/theme"
+import fuzzysort from "fuzzysort"
+import { firstBy } from "remeda"
+import { Index, Show, createEffect, createMemo, createResource, createSignal, onCleanup, onMount } from "solid-js"
+import { createStore } from "solid-js/store"
 import { useFrecency } from "./frecency"
+import type { PromptInfo } from "./history"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -80,12 +82,14 @@ export function Autocomplete(props: {
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
   const frecency = useFrecency()
+  const keybind = useKeybind()
 
   const [store, setStore] = createStore({
     index: 0,
     selected: 0,
     visible: false as AutocompleteRef["visible"],
     input: "keyboard" as "keyboard" | "mouse",
+    showDescriptionModal: false,
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -527,6 +531,13 @@ export function Autocomplete(props: {
         }
       },
       onKeyDown(e: KeyEvent) {
+        if (store.showDescriptionModal) {
+          if (e.name === "q" || e.name === "escape") {
+            setStore("showDescriptionModal", false)
+            e.preventDefault()
+            return
+          }
+        }
         if (store.visible) {
           const name = e.name?.toLowerCase()
           const ctrlOnly = e.ctrl && !e.meta && !e.shift
@@ -565,6 +576,14 @@ export function Autocomplete(props: {
             e.preventDefault()
             return
           }
+          if (keybind.match("autocomplete_show_description", e)) {
+            const selected = options()[store.selected]
+            if (selected?.description) {
+              setStore("showDescriptionModal", true)
+              e.preventDefault()
+              return
+            }
+          }
         }
         if (!store.visible) {
           if (e.name === "@") {
@@ -593,61 +612,91 @@ export function Autocomplete(props: {
   let scroll: ScrollBoxRenderable
 
   return (
-    <box
-      visible={store.visible !== false}
-      position="absolute"
-      top={position().y - height()}
-      left={position().x}
-      width={position().width}
-      zIndex={100}
-      {...SplitBorder}
-      borderColor={theme.border}
-    >
-      <scrollbox
-        ref={(r: ScrollBoxRenderable) => (scroll = r)}
-        backgroundColor={theme.backgroundMenu}
-        height={height()}
-        scrollbarOptions={{ visible: false }}
-      >
-        <Index
-          each={options()}
-          fallback={
-            <box paddingLeft={1} paddingRight={1}>
-              <text fg={theme.textMuted}>No matching items</text>
-            </box>
-          }
-        >
-          {(option, index) => (
-            <box
-              paddingLeft={1}
-              paddingRight={1}
-              backgroundColor={index === store.selected ? theme.primary : undefined}
-              flexDirection="row"
-              onMouseMove={() => {
-                setStore("input", "mouse")
-              }}
-              onMouseOver={() => {
-                if (store.input !== "mouse") return
-                moveTo(index)
-              }}
-              onMouseDown={() => {
-                setStore("input", "mouse")
-                moveTo(index)
-              }}
-              onMouseUp={() => select()}
-            >
-              <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>
-                {option().display}
+    <>
+      <Show when={store.showDescriptionModal}>
+          <box
+            position="absolute"
+            left={dimensions().width/4-5}
+            top={1}
+            width={dimensions().width/4}
+            height={dimensions().height/4}
+            paddingLeft={3}
+            paddingRight={3}
+            paddingTop={2}
+            paddingBottom={2}
+            {...SplitBorder}
+            borderColor={theme.border}
+            backgroundColor={theme.backgroundMenu}
+          >
+            <box flexDirection="row" justifyContent="space-between" marginBottom={1}>
+              <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                {options()[store.selected]?.display?.trimEnd() ?? ""}
               </text>
-              <Show when={option().description}>
-                <text fg={index === store.selected ? selectedForeground(theme) : theme.textMuted} wrapMode="none">
-                  {option().description}
-                </text>
-              </Show>
+              <text fg={theme.textMuted}>q / esc</text>
             </box>
-          )}
-        </Index>
-      </scrollbox>
-    </box>
+            <scrollbox maxHeight={Math.floor(dimensions().height * 0.6)} scrollbarOptions={{ visible: false }}>
+              <text fg={theme.text} wrapMode="word">
+                {options()[store.selected]?.description ?? ""}
+              </text>
+            </scrollbox>
+          </box>
+      </Show>
+      <box
+        visible={store.visible !== false}
+        position="absolute"
+        top={position().y - height()}
+        left={position().x}
+        width={position().width}
+        zIndex={100}
+        {...SplitBorder}
+        borderColor={theme.border}
+      >
+        <scrollbox
+          ref={(r: ScrollBoxRenderable) => (scroll = r)}
+          backgroundColor={theme.backgroundMenu}
+          height={height()}
+          scrollbarOptions={{ visible: false }}
+        >
+          <Index
+            each={options()}
+            fallback={
+              <box paddingLeft={1} paddingRight={1}>
+                <text fg={theme.textMuted}>No matching items</text>
+              </box>
+            }
+          >
+            {(option, index) => (
+              <box
+                backgroundColor={index === store.selected ? theme.primary : undefined}
+                flexDirection="row"
+                onMouseMove={() => {
+                  setStore("input", "mouse")
+                }}
+                onMouseOver={() => {
+                  if (store.input !== "mouse") return
+                  moveTo(index)
+                }}
+                onMouseDown={() => {
+                  setStore("input", "mouse")
+                  moveTo(index)
+                }}
+                onMouseUp={() => select()}
+              >
+                <text fg={index === store.selected ? selectedForeground(theme) : theme.text} flexShrink={0}>
+                  {option().display}
+                </text>
+                {
+                  option().description ? (
+                    <text fg={index === store.selected ? selectedForeground(theme) : theme.textMuted} wrapMode="none">
+                      {Locale.truncateFirstLine(option().description || "")}
+                    </text>
+                  ) : null
+                }
+              </box>
+            )}
+          </Index>
+        </scrollbox>
+      </box>
+    </>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -616,7 +616,7 @@ export function Autocomplete(props: {
       <Show when={store.showDescriptionModal}>
           <box
             position="absolute"
-            left={dimensions().width/4-5}
+            left={dimensions().width/4}
             top={1}
             width={dimensions().width/4}
             height={dimensions().height/4}

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,36 +1,36 @@
-import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, t, dim, fg } from "@opentui/core"
-import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, Show, Switch, Match } from "solid-js"
-import "opentui-spinner/solid"
-import { useLocal } from "@tui/context/local"
-import { useTheme } from "@tui/context/theme"
-import { EmptyBorder } from "@tui/component/border"
-import { useSDK } from "@tui/context/sdk"
-import { useRoute } from "@tui/context/route"
-import { useSync } from "@tui/context/sync"
 import { Identifier } from "@/id/id"
-import { createStore, produce } from "solid-js/store"
-import { useKeybind } from "@tui/context/keybind"
-import { usePromptHistory, type PromptInfo } from "./history"
-import { usePromptStash } from "./stash"
-import { DialogStash } from "../dialog-stash"
-import { type AutocompleteRef, Autocomplete } from "./autocomplete"
-import { useCommandDialog } from "../dialog-command"
-import { useRenderer } from "@opentui/solid"
-import { Editor } from "@tui/util/editor"
-import { useExit } from "../../context/exit"
-import { Clipboard } from "../../util/clipboard"
-import type { FilePart } from "@opencode-ai/sdk/v2"
-import { TuiEvent } from "../../event"
+import { formatDuration } from "@/util/format"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
-import { formatDuration } from "@/util/format"
-import { createColors, createFrames } from "../../ui/spinner.ts"
+import type { FilePart } from "@opencode-ai/sdk/v2"
+import { BoxRenderable, MouseEvent, PasteEvent, TextareaRenderable } from "@opentui/core"
+import { useRenderer } from "@opentui/solid"
+import { EmptyBorder } from "@tui/component/border"
+import { useKeybind } from "@tui/context/keybind"
+import { useLocal } from "@tui/context/local"
+import { useRoute } from "@tui/context/route"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
+import { useTheme } from "@tui/context/theme"
 import { useDialog } from "@tui/ui/dialog"
-import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
-import { DialogAlert } from "../../ui/dialog-alert"
-import { useToast } from "../../ui/toast"
+import { Editor } from "@tui/util/editor"
+import "opentui-spinner/solid"
+import { createEffect, createMemo, createSignal, Match, onCleanup, onMount, Show, Switch, type JSX } from "solid-js"
+import { createStore, produce } from "solid-js/store"
+import { useExit } from "../../context/exit"
 import { useKV } from "../../context/kv"
+import { TuiEvent } from "../../event"
+import { DialogAlert } from "../../ui/dialog-alert"
+import { createColors, createFrames } from "../../ui/spinner.ts"
+import { useToast } from "../../ui/toast"
+import { Clipboard } from "../../util/clipboard"
+import { useCommandDialog } from "../dialog-command"
+import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
+import { DialogStash } from "../dialog-stash"
 import { useTextareaKeybindings } from "../textarea-keybindings"
+import { Autocomplete, type AutocompleteRef } from "./autocomplete"
+import { usePromptHistory, type PromptInfo } from "./history"
+import { usePromptStash } from "./stash"
 
 export type PromptProps = {
   sessionID?: string
@@ -1075,6 +1075,9 @@ export function Prompt(props: PromptProps) {
             <box gap={2} flexDirection="row">
               <Switch>
                 <Match when={store.mode === "normal"}>
+                  <text fg={theme.text}>
+                    {keybind.print("autocomplete_show_description")} <span style={{ fg: theme.textMuted }}>description</span>
+                  </text>
                   <Show when={local.model.variant.list().length > 0}>
                     <text fg={theme.text}>
                       {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>variants</span>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1,17 +1,10 @@
-import { Log } from "../util/log"
-import path from "path"
-import { pathToFileURL } from "url"
-import os from "os"
-import z from "zod"
-import { Filesystem } from "../util/filesystem"
-import { ModelsDev } from "../provider/models"
-import { mergeDeep, pipe, unique } from "remeda"
-import { Global } from "../global"
-import fs from "fs/promises"
-import { lazy } from "../util/lazy"
+import { BunProc } from "@/bun"
+import { Bus } from "@/bus"
+import { GlobalBus } from "@/bus/global"
+import { Installation } from "@/installation"
 import { NamedError } from "@opencode-ai/util/error"
-import { Flag } from "../flag/flag"
-import { Auth } from "../auth"
+import { existsSync } from "fs"
+import fs from "fs/promises"
 import {
   type ParseError as JsoncParseError,
   applyEdits,
@@ -19,15 +12,22 @@ import {
   parse as parseJsonc,
   printParseErrorCode,
 } from "jsonc-parser"
-import { Instance } from "../project/instance"
+import os from "os"
+import path from "path"
+import { mergeDeep, pipe, unique } from "remeda"
+import { pathToFileURL } from "url"
+import z from "zod"
+import { Auth } from "../auth"
+import { Flag } from "../flag/flag"
+import { Global } from "../global"
 import { LSPServer } from "../lsp/server"
-import { BunProc } from "@/bun"
-import { Installation } from "@/installation"
-import { ConfigMarkdown } from "./markdown"
-import { existsSync } from "fs"
-import { Bus } from "@/bus"
-import { GlobalBus } from "@/bus/global"
+import { Instance } from "../project/instance"
+import { ModelsDev } from "../provider/models"
 import { Event } from "../server/event"
+import { Filesystem } from "../util/filesystem"
+import { lazy } from "../util/lazy"
+import { Log } from "../util/log"
+import { ConfigMarkdown } from "./markdown"
 
 export namespace Config {
   const log = Log.create({ service: "config" })
@@ -703,6 +703,7 @@ export namespace Config {
       agent_cycle: z.string().optional().default("tab").describe("Next agent"),
       agent_cycle_reverse: z.string().optional().default("shift+tab").describe("Previous agent"),
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),
+      autocomplete_show_description: z.string().optional().default("ctrl+m").describe("Show full description in autocomplete"),
       input_clear: z.string().optional().default("ctrl+c").describe("Clear input field"),
       input_paste: z.string().optional().default("ctrl+v").describe("Paste from clipboard"),
       input_submit: z.string().optional().default("return").describe("Submit input"),

--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -78,4 +78,19 @@ export namespace Locale {
     const template = count === 1 ? singular : plural
     return template.replace("{}", count.toString())
   }
+
+  export function truncateFirstLine(str: string, maxLength?: number): string {
+    const firstLineEnd = str.indexOf("\n")
+    const firstLine = firstLineEnd === -1 ? str : str.slice(0, firstLineEnd)
+
+    if (!maxLength) {
+      return firstLine
+    }
+
+    if (firstLine.length <= maxLength) {
+      return firstLine
+    }
+
+    return firstLine.slice(0, maxLength - 1) + "…"
+  }
 }

--- a/packages/opencode/test/util/locale.test.ts
+++ b/packages/opencode/test/util/locale.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { Locale } from "../../src/util/locale"
+
+describe("util.locale", () => {
+  describe("truncateFirstLine", () => {
+    test("returns single line text without truncation when no maxLength", () => {
+      const result = Locale.truncateFirstLine("Hello world")
+      expect(result).toEqual("Hello world")
+    })
+
+    test("extracts first line from multiline text without maxLength", () => {
+      const result = Locale.truncateFirstLine("First line\nSecond line\nThird line")
+      expect(result).toEqual("First line")
+    })
+
+    test("returns empty string for empty input", () => {
+      const result = Locale.truncateFirstLine("")
+      expect(result).toEqual("")
+    })
+
+    test("returns single line when text is shorter than maxLength", () => {
+      const result = Locale.truncateFirstLine("Short", 10)
+      expect(result).toEqual("Short")
+    })
+
+    test("returns multiline text first line when shorter than maxLength", () => {
+      const result = Locale.truncateFirstLine("Short\nSecond line", 10)
+      expect(result).toEqual("Short")
+    })
+
+    test("truncates first line when it exceeds maxLength", () => {
+      const result = Locale.truncateFirstLine("This is a very long line", 10)
+      expect(result).toEqual("This is a…")
+    })
+
+    test("truncates first line of multiline text when it exceeds maxLength", () => {
+      const result = Locale.truncateFirstLine("This is a very long line\nSecond line", 10)
+      expect(result).toEqual("This is a…")
+    })
+
+    test("handles text exactly at maxLength", () => {
+      const result = Locale.truncateFirstLine("Exactly10!", 10)
+      expect(result).toEqual("Exactly10!")
+    })
+
+    test("handles multiline text with first line exactly at maxLength", () => {
+      const result = Locale.truncateFirstLine("Exactly10!\nSecond line", 10)
+      expect(result).toEqual("Exactly10!")
+    })
+
+    test("handles maxLength of 1", () => {
+      const result = Locale.truncateFirstLine("Hello", 1)
+      expect(result).toEqual("…")
+    })
+
+    test("handles text with only newline character", () => {
+      const result = Locale.truncateFirstLine("\n")
+      expect(result).toEqual("")
+    })
+
+    test("handles text with multiple consecutive newlines", () => {
+      const result = Locale.truncateFirstLine("First\n\n\nFourth")
+      expect(result).toEqual("First")
+    })
+
+    test("preserves spaces in first line", () => {
+      const result = Locale.truncateFirstLine("  spaced text  \nSecond line")
+      expect(result).toEqual("  spaced text  ")
+    })
+
+    test("handles unicode characters correctly with maxLength", () => {
+      const result = Locale.truncateFirstLine("Hello 🌍🌎🌏", 8)
+      expect(result).toEqual("Hello 🌍…")
+    })
+
+    test("handles text with carriage return and newline", () => {
+      const result = Locale.truncateFirstLine("First line\r\nSecond line")
+      expect(result).toEqual("First line\r")
+    })
+  })
+})

--- a/packages/opencode/test/util/locale.test.ts
+++ b/packages/opencode/test/util/locale.test.ts
@@ -68,11 +68,6 @@ describe("util.locale", () => {
       expect(result).toEqual("  spaced text  ")
     })
 
-    test("handles unicode characters correctly with maxLength", () => {
-      const result = Locale.truncateFirstLine("Hello 🌍🌎🌏", 8)
-      expect(result).toEqual("Hello 🌍…")
-    })
-
     test("handles text with carriage return and newline", () => {
       const result = Locale.truncateFirstLine("First line\r\nSecond line")
       expect(result).toEqual("First line\r")

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4,20 +4,6 @@ export type ClientOptions = {
   baseUrl: `${string}://${string}` | (string & {})
 }
 
-export type EventInstallationUpdated = {
-  type: "installation.updated"
-  properties: {
-    version: string
-  }
-}
-
-export type EventInstallationUpdateAvailable = {
-  type: "installation.update-available"
-  properties: {
-    version: string
-  }
-}
-
 export type Project = {
   id: string
   worktree: string
@@ -51,6 +37,20 @@ export type EventServerInstanceDisposed = {
   type: "server.instance.disposed"
   properties: {
     directory: string
+  }
+}
+
+export type EventInstallationUpdated = {
+  type: "installation.updated"
+  properties: {
+    version: string
+  }
+}
+
+export type EventInstallationUpdateAvailable = {
+  type: "installation.update-available"
+  properties: {
+    version: string
   }
 }
 
@@ -882,10 +882,10 @@ export type EventWorktreeFailed = {
 }
 
 export type Event =
-  | EventInstallationUpdated
-  | EventInstallationUpdateAvailable
   | EventProjectUpdated
   | EventServerInstanceDisposed
+  | EventInstallationUpdated
+  | EventInstallationUpdateAvailable
   | EventServerConnected
   | EventGlobalDisposed
   | EventLspClientDiagnostics
@@ -1141,6 +1141,10 @@ export type KeybindsConfig = {
    * Cycle model variants
    */
   variant_cycle?: string
+  /**
+   * Show full description in autocomplete
+   */
+  autocomplete_show_description?: string
   /**
    * Clear input field
    */

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8636,6 +8636,11 @@
             "default": "ctrl+t",
             "type": "string"
           },
+          "autocomplete_show_description": {
+            "description": "Show full description in autocomplete",
+            "default": "ctrl+m",
+            "type": "string"
+          },
           "input_clear": {
             "description": "Clear input field",
             "default": "ctrl+c",

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -52,6 +52,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "model_cycle_favorite": "none",
     "model_cycle_favorite_reverse": "none",
     "variant_cycle": "ctrl+t",
+    "autocomplete_show_description": "ctrl+m",
     "command_list": "ctrl+p",
     "agent_list": "<leader>a",
     "agent_cycle": "tab",


### PR DESCRIPTION
Proposition to add a keybinding: `ctrl+m` that shows the entire description of a command in the normal view.

<img width="2330" height="750" alt="Screenshot 2026-01-23 at 10 17 41 AM" src="https://github.com/user-attachments/assets/d47e9220-f117-4cf4-b8b0-d24466c13a00" />

Close the description modal by pressing q or esc. I propose to add it on the side, but we can put it anywhere else.

My thinking is that on some personal commands and other community commands I have seen big descriptions and that causes the user to always check the files on disk. I want to integrate an easy way to check the description without leaving the context of my terminal screen.
