### PR TITLE
fix: resolve homebrew upgrade requiring multiple runs (#5375)

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -148,10 +148,19 @@ export namespace Installation {
         break
       case "brew": {
         const formula = await getBrewFormula()
-        cmd = $`brew upgrade ${formula}`.env({
-          HOMEBREW_NO_AUTO_UPDATE: "1",
-          ...process.env,
-        })
+        const isTap = formula.includes("/")
+
+        if (isTap) {
+          cmd = $`brew tap anomalyco/tap && cd "$(brew --repo anomalyco/tap)" && git pull --ff-only && brew upgrade ${formula}`.env({
+            HOMEBREW_NO_AUTO_UPDATE: "1",
+            ...process.env,
+          })
+        } else {
+          cmd = $`brew upgrade ${formula}`.env({
+            HOMEBREW_NO_AUTO_UPDATE: "1",
+            ...process.env,
+          })
+        }
         break
       }
       case "choco":
@@ -188,7 +197,14 @@ export namespace Installation {
 
     if (detectedMethod === "brew") {
       const formula = await getBrewFormula()
-      if (formula === "opencode") {
+      const isTap = formula.includes("/")
+
+      if (isTap) {
+        const infoJson = await $`brew info --json=v2 ${formula}`.quiet().text()
+        const info = JSON.parse(infoJson)
+        const version = info.formulae?.[0]?.versions?.stable
+        return version
+      } else {
         return fetch("https://formulae.brew.sh/api/formula/opencode.json")
           .then((res) => {
             if (!res.ok) throw new Error(res.statusText)

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -148,19 +148,20 @@ export namespace Installation {
         break
       case "brew": {
         const formula = await getBrewFormula()
-        const isTap = formula.includes("/")
-
-        if (isTap) {
-          cmd = $`brew tap anomalyco/tap && cd "$(brew --repo anomalyco/tap)" && git pull --ff-only && brew upgrade ${formula}`.env({
-            HOMEBREW_NO_AUTO_UPDATE: "1",
-            ...process.env,
-          })
-        } else {
-          cmd = $`brew upgrade ${formula}`.env({
-            HOMEBREW_NO_AUTO_UPDATE: "1",
-            ...process.env,
-          })
+        if (formula.includes("/")) {
+          cmd =
+            $`brew tap anomalyco/tap && cd "$(brew --repo anomalyco/tap)" && git pull --ff-only && brew upgrade ${formula}`.env(
+              {
+                HOMEBREW_NO_AUTO_UPDATE: "1",
+                ...process.env,
+              },
+            )
+          break
         }
+        cmd = $`brew upgrade ${formula}`.env({
+          HOMEBREW_NO_AUTO_UPDATE: "1",
+          ...process.env,
+        })
         break
       }
       case "choco":
@@ -197,21 +198,19 @@ export namespace Installation {
 
     if (detectedMethod === "brew") {
       const formula = await getBrewFormula()
-      const isTap = formula.includes("/")
-
-      if (isTap) {
+      if (formula.includes("/")) {
         const infoJson = await $`brew info --json=v2 ${formula}`.quiet().text()
         const info = JSON.parse(infoJson)
         const version = info.formulae?.[0]?.versions?.stable
+        if (!version) throw new Error(`Could not detect version for tap formula: ${formula}`)
         return version
-      } else {
-        return fetch("https://formulae.brew.sh/api/formula/opencode.json")
-          .then((res) => {
-            if (!res.ok) throw new Error(res.statusText)
-            return res.json()
-          })
-          .then((data: any) => data.versions.stable)
       }
+      return fetch("https://formulae.brew.sh/api/formula/opencode.json")
+        .then((res) => {
+          if (!res.ok) throw new Error(res.statusText)
+          return res.json()
+        })
+        .then((data: any) => data.versions.stable)
     }
 
     if (detectedMethod === "npm" || detectedMethod === "bun" || detectedMethod === "pnpm") {


### PR DESCRIPTION
Fixes #5375 

The root cause was that for tap-installed formulas, version detection could fall back to a stale source and Homebrew’s auto-update behavior was being suppressed, so users wouldn’t always see the latest tap changes on the first run.

### What does this PR do?

- **Remove HOMEBREW_NO_AUTO_UPDATE:** Let brew auto-update taps before  
  upgrading (default behavior)

- **Fix version detection for tap formulas:** Use `brew info --json=v2`  
  for tap formulas instead of falling back to npm registry
  
### UPDATE:
  - Removing HOMEBREW_NO_AUTO_UPDATE updates all taps which is un-wanted.
  - Instead, we Manually `git pull` only the "anomalyco/tap" tap repo
  - Then run `brew upgrade` for the "anomalyco/tap/opencode"


### How did you verify your code works?
Running the command `bun run dev upgrade --print-logs`
