### PR TITLE
fix: handle non-array MCP tool result.content to prevent TypeError

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -767,7 +767,8 @@ export namespace SessionPrompt {
         const textParts: string[] = []
         const attachments: MessageV2.FilePart[] = []
 
-        for (const contentItem of result.content) {
+        const contentArray = Array.isArray(result.content) ? result.content : []
+        for (const contentItem of contentArray) {
           if (contentItem.type === "text") {
             textParts.push(contentItem.text)
           } else if (contentItem.type === "image") {


### PR DESCRIPTION
## Summary

Fixes `TypeError: {} is not iterable` error when MCP tools (like Claude's built-in `discard` and `extract` context management tools) return results with non-array `content` values.

## Problem

In `packages/opencode/src/session/prompt.ts:770`, the code iterates over `result.content` assuming it's always an array:

```typescript
for (const contentItem of result.content) {
```

When an MCP tool returns `content` as `undefined`, `{}`, or any non-array value, this throws:
```
TypeError: {} is not iterable
```

## Solution

Added an `Array.isArray()` guard to safely handle non-array content:

```typescript
const contentArray = Array.isArray(result.content) ? result.content : []
for (const contentItem of contentArray) {
```

## Testing

Reproduced the error using Claude's built-in `discard` and `extract` tools, verified the fix prevents the error while maintaining correct behavior for standard MCP tool results.