### PR TITLE
feat(provider): support responses api for `@ai-sdk/openai-compatible` providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1033,6 +1033,12 @@ export namespace Provider {
           name: model.providerID,
           ...options,
         })
+        if (model.api.npm.includes("@ai-sdk/openai-compatible") && model.options["responsesApiSupported"] === true) {
+          log.debug(`using responses api for ${model.id}`)
+          // the copilot openai compatible override is the only who exposes the responses api
+          // not even upstream @ai-sk/openai-compatible does
+          loaded.languageModel = createGitHubCopilotOpenAICompatible({name: model.providerID, ...options}).responses
+        }
         s.sdk.set(key, loaded)
         return loaded as SDK
       }

--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-language-model.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-responses-language-model.ts
@@ -194,7 +194,7 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV2 {
     }
 
     const openaiOptions = await parseProviderOptions({
-      provider: "openai",
+      provider: this.config.provider.replace(".responses", ""),
       providerOptions,
       schema: openaiResponsesProviderOptionsSchema,
     })


### PR DESCRIPTION
### What does this PR do?

it supports the responses api for providers using `@ai-sdk/openai-compatible`. I used your wrapper for github copilot provider which exposes the `.responses` api. could not do it natively because `@ai-sdk` does not supports it, see https://github.com/vercel/ai/issues/11970

I plan to add documentation about the new parameters once the approach is approved

closes #9628

### How did you verify your code works?

set breakpoint in the lines changed and verifying the override for `languageModel` was working

```sh
bun run --inspect=ws://localhost:6499/ --cwd packages/opencode ./src/index.ts serve --port 4096
opencode attach http://localhost:4096
```

then tried the model several times and worked ok

config used

```jsonc
{
  "provider": {
    "customprovider": {
      "npm": "@ai-sdk/openai-compatible",
      "options": {
        "baseURL": "<URL>/litellm",
        "headers": {
          "client": "opencode",
        },
        "litellmProxy": true,
      },
      "models": {
        "customprovider/gpt-5-codex": {
          "name": "OpenAI GPT 5 codex",
          "options": {
            "responsesApiSupported": true,
            "store": false,
          },
        },
      }
    }
  }
}
```

the `store: false` is needed to avoid sending `item_reference` messages, here
https://github.com/anomalyco/opencode/blob/2e53697da01d1417845567296774166350e786f1/packages/opencode/src/provider/sdk/openai-compatible/src/responses/convert-to-openai-responses-input.ts#L173

https://github.com/anomalyco/opencode/blob/2e53697da01d1417845567296774166350e786f1/packages/opencode/src/provider/sdk/openai-compatible/src/responses/convert-to-openai-responses-input.ts#L199

otherwise you will get the error _Zero Data Retention Organizations are incompatible with the Responses API_. see https://github.com/openai/openai-agents-python/issues/605 for context
