### PR TITLE
fix(desktop): dialog not closing when clicking overlay during heavy r…

### DIFF
--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -53,7 +53,7 @@ function init() {
             }}
           >
             <Kobalte.Portal>
-              <Kobalte.Overlay data-component="dialog-overlay" />
+              <Kobalte.Overlay data-component="dialog-overlay" onClick={close} />
               {element()}
             </Kobalte.Portal>
           </Kobalte>


### PR DESCRIPTION
### What does this PR do?
This PR adds a call to the "close" function on the setting dialog overlay to prevent the settings screen from being stuck. Fixes #10138 and #10137
### How did you verify your code works?

I tested this by following the steps mentioned in the listed issues on the desktop client.

 In the first video, you can see that the call to "openChangeDialog" doesn't work after the theme change, causing the dialog to remain open indefinitely. In the second video, you can see that the dialog is closed properly and the "overlay click" is logged in the console.

https://github.com/user-attachments/assets/d60a6b00-ffc6-4e9d-b408-c4ee1df3f942


https://github.com/user-attachments/assets/f7aa9351-399b-44b5-84c7-88fdbdcd1d7f

