### PR TITLE
fix: allow gpt-5.1-codex model in codex auth pluginFixes

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -355,7 +355,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         if (auth.type !== "oauth") return {}
 
         // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set(["gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-codex"])
+        const allowedModels = new Set(["gpt-5.1-codex-max", "gpt-5.1-codex-mini", "gpt-5.2", "gpt-5.2-codex", "gpt-5.1-codex"])
         for (const modelId of Object.keys(provider.models)) {
           if (!allowedModels.has(modelId)) {
             delete provider.models[modelId]


### PR DESCRIPTION
Fixes #10135

### What does this PR do?
Adds \`gpt-5.1-codex\` to the allowed models list in the Codex auth plugin.

### How did you verify your code works?
Created a reproduction test case to verify the model was previously filtered out and is now preserved.