### PR TITLE
fix(app): enable dialog dismiss on model selector (dialog.tsx)

### DIFF
--- a/packages/ui/src/components/dialog.css
+++ b/packages/ui/src/components/dialog.css
@@ -20,6 +20,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 
   [data-slot="dialog-container"] {
     position: relative;
@@ -41,6 +42,7 @@
       max-height: 100%;
       min-height: 280px;
       overflow: auto;
+      pointer-events: auto;
 
       /* Hide scrollbar */
       scrollbar-width: none;

--- a/packages/ui/src/context/dialog.tsx
+++ b/packages/ui/src/context/dialog.tsx
@@ -53,7 +53,7 @@ function init() {
             }}
           >
             <Kobalte.Portal>
-              <Kobalte.Overlay data-component="dialog-overlay" />
+              <Kobalte.Overlay data-component="dialog-overlay" onClick={close} />
               {element()}
             </Kobalte.Portal>
           </Kobalte>


### PR DESCRIPTION
### What does this PR do?

on clicking outside of this dialog modal it should be closing just like all of the dialogs we have. :) 

<img width="956" height="757" alt="image" src="https://github.com/user-attachments/assets/01975d74-53b7-4ce2-8b67-0b162744c4be" />


now it works on pressing esc or clicking outside.... @adamdotdevin mind looking at the code ? 