### PR TITLE
fix(snapshot): support non-ASCII filenames in undo/revert

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -85,7 +85,7 @@ export namespace Snapshot {
     const git = gitdir()
     await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
     const result =
-      await $`git -c core.autocrlf=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
+      await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
         .quiet()
         .cwd(Instance.directory)
         .nothrow()
@@ -196,7 +196,7 @@ export namespace Snapshot {
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
     const git = gitdir()
     const result: FileDiff[] = []
-    for await (const line of $`git -c core.autocrlf=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
+    for await (const line of $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
       .quiet()
       .cwd(Instance.directory)
       .nothrow()


### PR DESCRIPTION
## Summary

Fix undo/revert not working for files with non-ASCII characters in their names (e.g., Chinese, Japanese, Korean filenames).

## Problem

On Windows (and potentially other systems), when using `/undo` to revert changes to files with non-ASCII filenames, the files are not actually reverted. English-named files work correctly, but files like `公共函数.cpp` (Chinese) fail silently.

### Root Cause

The `git diff --name-only` command used in `Snapshot.patch()` returns non-ASCII filenames as octal-escaped strings with quotes when `core.quotepath` is enabled (the default):

```
"\345\205\254\345\205\261\345\207\275\346\225\260.cpp"
```

Instead of:
```
公共函数.cpp
```

This escaped path is then stored in the patch data and later passed to `git checkout`, which fails because no file with that literal escaped name exists.

### Evidence from logs

```
service=snapshot file=D:\sword-net-3\"\345\205\254\345\205\261\345\207\275\346\225\260.cpp" hash=... reverting
```

vs working English file:
```
service=snapshot file=D:\sword-net-3\pch.cpp hash=... reverting
```

## Solution

Add `-c core.quotepath=false` to git diff commands to output non-ASCII filenames literally without escaping.

## Changes

- `Snapshot.patch()`: Add `-c core.quotepath=false` to `git diff --name-only`
- `Snapshot.diffFull()`: Add `-c core.quotepath=false` to `git diff --numstat`

## Testing

Tested on Windows 11 with Chinese filename (`公共函数.cpp`):
- Before: `/undo` only reverts English-named files, Chinese-named files unchanged
- After: `/undo` correctly reverts all files regardless of filename encoding

## Checklist

- [x] Minimal, focused change
- [x] Tested on Windows with non-ASCII filenames
- [x] No breaking changes