### PR TITLE
feat: add /stats dialog with token usage statistics

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -13,6 +13,7 @@ import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
+import { DialogStats } from "@tui/component/dialog-stats"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
@@ -444,6 +445,17 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogStatus />)
+      },
+      category: "System",
+    },
+    {
+      title: "View stats",
+      value: "opencode.stats",
+      slash: {
+        name: "stats",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogStats />)
       },
       category: "System",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/activity-heatmap.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/activity-heatmap.tsx
@@ -1,0 +1,199 @@
+import { For, createMemo, Show } from "solid-js"
+import { useTheme, tint } from "@tui/context/theme"
+import type { StatsAggregator } from "@/stats/aggregator"
+
+export type HeatmapViewMode = "7d" | "30d" | "1y"
+
+export interface ActivityHeatmapProps {
+  dailyStats: StatsAggregator.DailyStats[]
+  viewMode: HeatmapViewMode
+}
+
+// Get all dates for the heatmap grid
+function generateDateGrid(viewMode: HeatmapViewMode): string[][] {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  
+  let totalDays: number
+  switch (viewMode) {
+    case "7d":
+      totalDays = 7
+      break
+    case "30d":
+      totalDays = 30
+      break
+    case "1y":
+      totalDays = 365
+      break
+  }
+
+  // Find the start date (align to Sunday for week start)
+  const endDate = new Date(today)
+  const startDate = new Date(today)
+  startDate.setDate(startDate.getDate() - totalDays + 1)
+  
+  // For 30d and 1y views, align to start of week (Sunday)
+  if (viewMode !== "7d") {
+    const dayOfWeek = startDate.getDay()
+    startDate.setDate(startDate.getDate() - dayOfWeek)
+  }
+
+  // Generate grid: 7 rows (days of week) x N columns (weeks)
+  const weeks: string[][] = []
+  const current = new Date(startDate)
+  
+  while (current <= endDate) {
+    const week: string[] = []
+    for (let day = 0; day < 7; day++) {
+      if (current <= endDate && current >= startDate) {
+        week.push(current.toISOString().split("T")[0])
+      } else {
+        week.push("") // Empty cell for padding
+      }
+      current.setDate(current.getDate() + 1)
+    }
+    weeks.push(week)
+  }
+
+  return weeks
+}
+
+// Get intensity level (0-4) based on token count
+function getIntensityLevel(tokens: number, maxTokens: number): number {
+  if (tokens === 0 || maxTokens === 0) return 0
+  const ratio = tokens / maxTokens
+  if (ratio < 0.25) return 1
+  if (ratio < 0.50) return 2
+  if (ratio < 0.75) return 3
+  return 4
+}
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+const MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+export function ActivityHeatmap(props: ActivityHeatmapProps) {
+  const { theme } = useTheme()
+
+  // Create a map for quick lookup
+  const statsMap = createMemo(() => {
+    const map = new Map<string, number>()
+    for (const stat of props.dailyStats) {
+      map.set(stat.date, stat.tokens.total)
+    }
+    return map
+  })
+
+  // Find max tokens for intensity calculation
+  const maxTokens = createMemo(() => {
+    return Math.max(...props.dailyStats.map(s => s.tokens.total), 1)
+  })
+
+  // Generate the date grid
+  const grid = createMemo(() => generateDateGrid(props.viewMode))
+
+  // Get color based on intensity
+  const getColor = (level: number) => {
+    switch (level) {
+      case 0: return theme.borderSubtle
+      case 1: return tint(theme.background, theme.primary, 0.25)
+      case 2: return tint(theme.background, theme.primary, 0.5)
+      case 3: return tint(theme.background, theme.primary, 0.75)
+      case 4: return theme.primary
+      default: return theme.borderSubtle
+    }
+  }
+
+  // Get month labels for the grid
+  const monthLabels = createMemo(() => {
+    const labels: { month: string; position: number }[] = []
+    const weeks = grid()
+    let lastMonth = -1
+    
+    for (let weekIdx = 0; weekIdx < weeks.length; weekIdx++) {
+      const week = weeks[weekIdx]
+      // Check first non-empty date in week
+      for (const dateStr of week) {
+        if (dateStr) {
+          const month = new Date(dateStr).getMonth()
+          if (month !== lastMonth) {
+            labels.push({ month: MONTH_LABELS[month], position: weekIdx })
+            lastMonth = month
+          }
+          break
+        }
+      }
+    }
+    return labels
+  })
+
+  // Cell character based on view mode
+  const cellChar = () => props.viewMode === "1y" ? "▪" : "█"
+
+  return (
+    <box flexDirection="column" gap={0}>
+      {/* Month labels row (only for 30d and 1y views) */}
+      <Show when={props.viewMode !== "7d"}>
+        <box flexDirection="row" paddingLeft={4}>
+          <For each={monthLabels()}>
+            {(label, idx) => {
+              const nextPos = monthLabels()[idx() + 1]?.position ?? grid().length
+              const width = nextPos - label.position
+              return (
+                <text 
+                  fg={theme.textMuted} 
+                  width={width * (props.viewMode === "1y" ? 1 : 2)}
+                >
+                  {label.month}
+                </text>
+              )
+            }}
+          </For>
+        </box>
+      </Show>
+
+      {/* Grid with day labels */}
+      <box flexDirection="column">
+        <For each={[0, 1, 2, 3, 4, 5, 6]}>
+          {(dayIdx) => (
+            <box flexDirection="row" gap={0}>
+              {/* Day label */}
+              <text fg={theme.textMuted} width={4}>
+                {dayIdx % 2 === 1 ? DAY_LABELS[dayIdx].substring(0, 3) : "   "}
+              </text>
+              
+              {/* Cells for this day across all weeks */}
+              <For each={grid()}>
+                {(week) => {
+                  const dateStr = week[dayIdx] || ""
+                  const tokens = dateStr ? (statsMap().get(dateStr) || 0) : 0
+                  const level = getIntensityLevel(tokens, maxTokens())
+                  const color = getColor(level)
+                  
+                  return (
+                    <text 
+                      fg={dateStr ? color : theme.background}
+                      width={props.viewMode === "1y" ? 1 : 2}
+                    >
+                      {dateStr ? cellChar() : " "}
+                    </text>
+                  )
+                }}
+              </For>
+            </box>
+          )}
+        </For>
+      </box>
+
+      {/* Legend */}
+      <box flexDirection="row" gap={1} paddingTop={1} paddingLeft={4}>
+        <text fg={theme.textMuted}>Less</text>
+        <For each={[0, 1, 2, 3, 4]}>
+          {(level) => (
+            <text fg={getColor(level)}>{cellChar()}</text>
+          )}
+        </For>
+        <text fg={theme.textMuted}>More</text>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-stats.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-stats.tsx
@@ -1,0 +1,235 @@
+import { TextAttributes } from "@opentui/core"
+import { useTheme } from "@tui/context/theme"
+import { useKeyboard } from "@opentui/solid"
+import { For, Show, createSignal, onMount, createMemo } from "solid-js"
+import { StatsAggregator } from "@/stats/aggregator"
+import { ActivityHeatmap, type HeatmapViewMode } from "./activity-heatmap"
+import { useDialog } from "@tui/ui/dialog"
+import "opentui-spinner/solid"
+
+export function DialogStats() {
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  
+  const [viewMode, setViewMode] = createSignal<HeatmapViewMode>("30d")
+  const [loading, setLoading] = createSignal(true)
+  const [stats7, setStats7] = createSignal<StatsAggregator.AggregatedStats | null>(null)
+  const [stats30, setStats30] = createSignal<StatsAggregator.AggregatedStats | null>(null)
+  const [stats365, setStats365] = createSignal<StatsAggregator.AggregatedStats | null>(null)
+
+  // Load stats
+  const loadStats = async () => {
+    setLoading(true)
+    try {
+      const [s7, s30, s365] = await Promise.all([
+        StatsAggregator.aggregate({ days: 7 }),
+        StatsAggregator.aggregate({ days: 30 }),
+        StatsAggregator.aggregate({ days: 365 }),
+      ])
+      
+      setStats7(s7)
+      setStats30(s30)
+      setStats365(s365)
+    } catch (e) {
+      // Stats loading failed - show empty state
+      console.error("Failed to load stats:", e)
+    }
+    setLoading(false)
+  }
+
+  onMount(loadStats)
+
+  // Get current stats based on view mode
+  const currentStats = createMemo(() => {
+    switch (viewMode()) {
+      case "7d": return stats7()
+      case "30d": return stats30()
+      case "1y": return stats365()
+    }
+  })
+
+  // Keyboard handling
+  useKeyboard((evt) => {
+    if (evt.name === "escape") {
+      dialog.clear()
+    }
+    // Shift+R to cycle view modes
+    if (evt.shift && evt.name === "r") {
+      setViewMode((current) => {
+        switch (current) {
+          case "7d": return "30d"
+          case "30d": return "1y"
+          case "1y": return "7d"
+        }
+      })
+    }
+  })
+
+  const formatNumber = StatsAggregator.formatNumber
+
+  // Model usage sorted by total tokens
+  const sortedModels = createMemo(() => {
+    const s = stats30()
+    if (!s) return []
+    return Object.entries(s.modelUsage)
+      .sort(([, a], [, b]) => (b.tokens.input + b.tokens.output) - (a.tokens.input + a.tokens.output))
+      .slice(0, 5) // Top 5 models
+  })
+
+  const totalModelTokens = createMemo(() => {
+    return sortedModels().reduce((sum, [, usage]) => sum + usage.tokens.input + usage.tokens.output, 0)
+  })
+
+  return (
+    <box 
+      flexDirection="column" 
+      paddingLeft={2} 
+      paddingRight={2} 
+      paddingBottom={1}
+      gap={1}
+    >
+      {/* Header */}
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Token Usage Statistics
+        </text>
+        <box flexDirection="row" gap={2}>
+          <text fg={theme.textMuted}>
+            {viewMode() === "7d" ? "7 Days" : viewMode() === "30d" ? "30 Days" : "1 Year"}
+          </text>
+          <text fg={theme.textMuted}>shift+r: view</text>
+          <text fg={theme.textMuted}>esc: close</text>
+        </box>
+      </box>
+
+      <Show when={!loading()} fallback={
+        <box flexDirection="row" justifyContent="center" padding={2}>
+          <spinner frames={["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]} interval={80} color={theme.primary} />
+          <text fg={theme.textMuted}> Loading statistics...</text>
+        </box>
+      }>
+        {/* Activity Heatmap */}
+        <box flexDirection="column">
+          <text fg={theme.text} attributes={TextAttributes.BOLD}>
+            Activity ({viewMode() === "7d" ? "Last 7 Days" : viewMode() === "30d" ? "Last 30 Days" : "Last Year"})
+          </text>
+          <Show when={currentStats()}>
+            {(s) => (
+              <ActivityHeatmap 
+                dailyStats={s().dailyStats} 
+                viewMode={viewMode()}
+              />
+            )}
+          </Show>
+        </box>
+
+        {/* Summary Cards - Side by Side */}
+        <box flexDirection="row" gap={2}>
+          {/* 7 Day Summary */}
+          <box flexDirection="column" flexGrow={1}>
+            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+              7 Days
+            </text>
+            <Show when={stats7()}>
+              {(s) => (
+                <box flexDirection="column">
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Input:</text>
+                    <text fg={theme.text}>{formatNumber(s().totalTokens.input)}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Output:</text>
+                    <text fg={theme.text}>{formatNumber(s().totalTokens.output)}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Cache:</text>
+                    <text fg={theme.text}>{formatNumber(s().totalTokens.cache.read + s().totalTokens.cache.write)}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Sessions:</text>
+                    <text fg={theme.text}>{s().totalSessions}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Cost:</text>
+                    <text fg={theme.success}>${s().totalCost.toFixed(2)}</text>
+                  </box>
+                </box>
+              )}
+            </Show>
+          </box>
+
+          {/* 30 Day Summary */}
+          <box flexDirection="column" flexGrow={1}>
+            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+              30 Days
+            </text>
+            <Show when={stats30()}>
+              {(s) => (
+                <box flexDirection="column">
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Input:</text>
+                    <text fg={theme.text}>{formatNumber(s().totalTokens.input)}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Output:</text>
+                    <text fg={theme.text}>{formatNumber(s().totalTokens.output)}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Cache:</text>
+                    <text fg={theme.text}>{formatNumber(s().totalTokens.cache.read + s().totalTokens.cache.write)}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Sessions:</text>
+                    <text fg={theme.text}>{s().totalSessions}</text>
+                  </box>
+                  <box flexDirection="row" justifyContent="space-between">
+                    <text fg={theme.textMuted}>Cost:</text>
+                    <text fg={theme.success}>${s().totalCost.toFixed(2)}</text>
+                  </box>
+                </box>
+              )}
+            </Show>
+          </box>
+        </box>
+
+        {/* Model Usage */}
+        <Show when={sortedModels().length > 0}>
+          <box flexDirection="column">
+            <text fg={theme.text} attributes={TextAttributes.BOLD}>
+              Model Usage (30 Days)
+            </text>
+            <For each={sortedModels()}>
+              {([model, usage]) => {
+                const tokens = usage.tokens.input + usage.tokens.output
+                const percentage = totalModelTokens() > 0 ? (tokens / totalModelTokens()) * 100 : 0
+                const barLength = Math.max(1, Math.floor(percentage / 5)) // 20 char max bar
+                
+                return (
+                  <box flexDirection="row" gap={1}>
+                    <text fg={theme.text} width={30}>
+                      {model.length > 28 ? model.substring(0, 26) + ".." : model}
+                    </text>
+                    <text fg={theme.primary}>
+                      {"█".repeat(barLength)}{"░".repeat(20 - barLength)}
+                    </text>
+                    <text fg={theme.textMuted} width={6}>
+                      {percentage.toFixed(0)}%
+                    </text>
+                    <text fg={theme.text}>
+                      {formatNumber(tokens)}
+                    </text>
+                  </box>
+                )
+              }}
+            </For>
+          </box>
+        </Show>
+
+        {/* Footer */}
+        <box flexDirection="row" justifyContent="flex-end">
+          <text fg={theme.textMuted}>All Projects</text>
+        </box>
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -651,6 +651,7 @@ export namespace Config {
       scrollbar_toggle: z.string().optional().default("none").describe("Toggle session scrollbar"),
       username_toggle: z.string().optional().default("none").describe("Toggle username visibility"),
       status_view: z.string().optional().default("<leader>s").describe("View status"),
+      stats_view: z.string().optional().default("<leader>S").describe("View token usage statistics"),
       session_export: z.string().optional().default("<leader>x").describe("Export session to editor"),
       session_new: z.string().optional().default("<leader>n").describe("Create a new session"),
       session_list: z.string().optional().default("<leader>l").describe("List all sessions"),

--- a/packages/opencode/src/stats/aggregator.ts
+++ b/packages/opencode/src/stats/aggregator.ts
@@ -1,0 +1,293 @@
+import { Session } from "../session"
+import { Storage } from "../storage/storage"
+import type { Project } from "../project/project"
+
+export namespace StatsAggregator {
+  export interface DailyStats {
+    date: string // YYYY-MM-DD format
+    tokens: {
+      input: number
+      output: number
+      reasoning: number
+      total: number
+    }
+    sessions: number
+    messages: number
+    cost: number
+  }
+
+  export interface ModelUsage {
+    messages: number
+    tokens: {
+      input: number
+      output: number
+    }
+    cost: number
+  }
+
+  export interface AggregatedStats {
+    totalSessions: number
+    totalMessages: number
+    totalCost: number
+    totalTokens: {
+      input: number
+      output: number
+      reasoning: number
+      cache: {
+        read: number
+        write: number
+      }
+    }
+    toolUsage: Record<string, number>
+    modelUsage: Record<string, ModelUsage>
+    dateRange: {
+      earliest: number
+      latest: number
+    }
+    days: number
+    costPerDay: number
+    tokensPerSession: number
+    medianTokensPerSession: number
+    // NEW: Daily breakdown for heatmap
+    dailyStats: DailyStats[]
+  }
+
+  export interface AggregateOptions {
+    days?: number
+    projectFilter?: string // project ID to filter by, undefined = all projects
+  }
+
+  async function getAllSessions(): Promise<Session.Info[]> {
+    const sessions: Session.Info[] = []
+    const projectKeys = await Storage.list(["project"])
+    const projects = await Promise.all(projectKeys.map((key) => Storage.read<Project.Info>(key)))
+
+    for (const project of projects) {
+      if (!project) continue
+      const sessionKeys = await Storage.list(["session", project.id])
+      const projectSessions = await Promise.all(sessionKeys.map((key) => Storage.read<Session.Info>(key)))
+      for (const session of projectSessions) {
+        if (session) {
+          sessions.push(session)
+        }
+      }
+    }
+    return sessions
+  }
+
+  function formatDate(timestamp: number): string {
+    const date = new Date(timestamp)
+    return date.toISOString().split("T")[0]
+  }
+
+  export async function aggregate(options: AggregateOptions = {}): Promise<AggregatedStats> {
+    const { days, projectFilter } = options
+    const sessions = await getAllSessions()
+    const MS_IN_DAY = 24 * 60 * 60 * 1000
+
+    const cutoffTime = (() => {
+      if (days === undefined) return 0
+      if (days === 0) {
+        const now = new Date()
+        now.setHours(0, 0, 0, 0)
+        return now.getTime()
+      }
+      return Date.now() - days * MS_IN_DAY
+    })()
+
+    const windowDays = (() => {
+      if (days === undefined) return undefined
+      if (days === 0) return 1
+      return days
+    })()
+
+    let filteredSessions = cutoffTime > 0 
+      ? sessions.filter((session) => session.time.updated >= cutoffTime) 
+      : sessions
+
+    if (projectFilter !== undefined) {
+      filteredSessions = filteredSessions.filter((session) => session.projectID === projectFilter)
+    }
+
+    // Initialize daily stats map
+    const dailyStatsMap: Map<string, DailyStats> = new Map()
+
+    const stats: AggregatedStats = {
+      totalSessions: filteredSessions.length,
+      totalMessages: 0,
+      totalCost: 0,
+      totalTokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+      toolUsage: {},
+      modelUsage: {},
+      dateRange: { earliest: Date.now(), latest: Date.now() },
+      days: 0,
+      costPerDay: 0,
+      tokensPerSession: 0,
+      medianTokensPerSession: 0,
+      dailyStats: [],
+    }
+
+    if (filteredSessions.length === 0) {
+      stats.days = windowDays ?? 0
+      return stats
+    }
+
+    let earliestTime = Date.now()
+    let latestTime = 0
+    const sessionTotalTokens: number[] = []
+
+    const BATCH_SIZE = 20
+    for (let i = 0; i < filteredSessions.length; i += BATCH_SIZE) {
+      const batch = filteredSessions.slice(i, i + BATCH_SIZE)
+
+      const batchPromises = batch.map(async (session) => {
+        const messages = await Session.messages({ sessionID: session.id })
+
+        let sessionCost = 0
+        let sessionTokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
+        let sessionToolUsage: Record<string, number> = {}
+        let sessionModelUsage: Record<string, ModelUsage> = {}
+        
+        // Track daily stats for this session
+        const sessionDate = formatDate(session.time.updated)
+
+        for (const message of messages) {
+          if (message.info.role === "assistant") {
+            sessionCost += message.info.cost || 0
+
+            const modelKey = `${message.info.providerID}/${message.info.modelID}`
+            if (!sessionModelUsage[modelKey]) {
+              sessionModelUsage[modelKey] = {
+                messages: 0,
+                tokens: { input: 0, output: 0 },
+                cost: 0,
+              }
+            }
+            sessionModelUsage[modelKey].messages++
+            sessionModelUsage[modelKey].cost += message.info.cost || 0
+
+            if (message.info.tokens) {
+              sessionTokens.input += message.info.tokens.input || 0
+              sessionTokens.output += message.info.tokens.output || 0
+              sessionTokens.reasoning += message.info.tokens.reasoning || 0
+              sessionTokens.cache.read += message.info.tokens.cache?.read || 0
+              sessionTokens.cache.write += message.info.tokens.cache?.write || 0
+
+              sessionModelUsage[modelKey].tokens.input += message.info.tokens.input || 0
+              sessionModelUsage[modelKey].tokens.output +=
+                (message.info.tokens.output || 0) + (message.info.tokens.reasoning || 0)
+            }
+          }
+
+          for (const part of message.parts) {
+            if (part.type === "tool" && part.tool) {
+              sessionToolUsage[part.tool] = (sessionToolUsage[part.tool] || 0) + 1
+            }
+          }
+        }
+
+        return {
+          sessionDate,
+          messageCount: messages.length,
+          sessionCost,
+          sessionTokens,
+          sessionTotalTokens: sessionTokens.input + sessionTokens.output + sessionTokens.reasoning,
+          sessionToolUsage,
+          sessionModelUsage,
+          earliestTime: cutoffTime > 0 ? session.time.updated : session.time.created,
+          latestTime: session.time.updated,
+        }
+      })
+
+      const batchResults = await Promise.all(batchPromises)
+
+      for (const result of batchResults) {
+        earliestTime = Math.min(earliestTime, result.earliestTime)
+        latestTime = Math.max(latestTime, result.latestTime)
+        sessionTotalTokens.push(result.sessionTotalTokens)
+
+        stats.totalMessages += result.messageCount
+        stats.totalCost += result.sessionCost
+        stats.totalTokens.input += result.sessionTokens.input
+        stats.totalTokens.output += result.sessionTokens.output
+        stats.totalTokens.reasoning += result.sessionTokens.reasoning
+        stats.totalTokens.cache.read += result.sessionTokens.cache.read
+        stats.totalTokens.cache.write += result.sessionTokens.cache.write
+
+        // Aggregate daily stats
+        const dateKey = result.sessionDate
+        if (!dailyStatsMap.has(dateKey)) {
+          dailyStatsMap.set(dateKey, {
+            date: dateKey,
+            tokens: { input: 0, output: 0, reasoning: 0, total: 0 },
+            sessions: 0,
+            messages: 0,
+            cost: 0,
+          })
+        }
+        const daily = dailyStatsMap.get(dateKey)!
+        daily.tokens.input += result.sessionTokens.input
+        daily.tokens.output += result.sessionTokens.output
+        daily.tokens.reasoning += result.sessionTokens.reasoning
+        daily.tokens.total += result.sessionTotalTokens
+        daily.sessions += 1
+        daily.messages += result.messageCount
+        daily.cost += result.sessionCost
+
+        for (const [tool, count] of Object.entries(result.sessionToolUsage)) {
+          stats.toolUsage[tool] = (stats.toolUsage[tool] || 0) + count
+        }
+
+        for (const [model, usage] of Object.entries(result.sessionModelUsage)) {
+          if (!stats.modelUsage[model]) {
+            stats.modelUsage[model] = {
+              messages: 0,
+              tokens: { input: 0, output: 0 },
+              cost: 0,
+            }
+          }
+          stats.modelUsage[model].messages += usage.messages
+          stats.modelUsage[model].tokens.input += usage.tokens.input
+          stats.modelUsage[model].tokens.output += usage.tokens.output
+          stats.modelUsage[model].cost += usage.cost
+        }
+      }
+    }
+
+    const rangeDays = Math.max(1, Math.ceil((latestTime - earliestTime) / MS_IN_DAY))
+    const effectiveDays = windowDays ?? rangeDays
+    stats.dateRange = { earliest: earliestTime, latest: latestTime }
+    stats.days = effectiveDays
+    stats.costPerDay = stats.totalCost / effectiveDays
+    const totalTokens = stats.totalTokens.input + stats.totalTokens.output + stats.totalTokens.reasoning
+    stats.tokensPerSession = filteredSessions.length > 0 ? totalTokens / filteredSessions.length : 0
+    
+    sessionTotalTokens.sort((a, b) => a - b)
+    const mid = Math.floor(sessionTotalTokens.length / 2)
+    stats.medianTokensPerSession =
+      sessionTotalTokens.length === 0
+        ? 0
+        : sessionTotalTokens.length % 2 === 0
+          ? (sessionTotalTokens[mid - 1] + sessionTotalTokens[mid]) / 2
+          : sessionTotalTokens[mid]
+
+    // Convert daily stats map to sorted array
+    stats.dailyStats = Array.from(dailyStatsMap.values()).sort((a, b) => a.date.localeCompare(b.date))
+
+    return stats
+  }
+
+  export function formatNumber(num: number): string {
+    if (num >= 1000000) {
+      return (num / 1000000).toFixed(1) + "M"
+    } else if (num >= 1000) {
+      return (num / 1000).toFixed(1) + "K"
+    }
+    return num.toString()
+  }
+}

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -803,6 +803,10 @@ export type KeybindsConfig = {
    */
   status_view?: string
   /**
+   * View token usage statistics
+   */
+  stats_view?: string
+  /**
    * Export session to editor
    */
   session_export?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -982,6 +982,10 @@ export type KeybindsConfig = {
    */
   status_view?: string
   /**
+   * View token usage statistics
+   */
+  stats_view?: string
+  /**
    * Export session to editor
    */
   session_export?: string


### PR DESCRIPTION
Closes #6767

## Summary

Implements the `/stats` command feature request with comprehensive token usage statistics:

- **GitHub-style activity heatmap** showing daily usage intensity (7 rows × weeks columns)
- **3 view modes**: 7 days, 30 days, 1 year (cycle with Shift+R)
- **Side-by-side token summaries** for 7-day and 30-day periods
- **Model usage breakdown** with visual bar charts showing token distribution by model

This addresses the feature request for visual statistics similar to Claude Code.

## Changes

| File | Description |
|------|-------------|
| `packages/opencode/src/stats/aggregator.ts` | Stats aggregation module with daily breakdown for heatmap data |
| `packages/opencode/src/cli/cmd/tui/component/activity-heatmap.tsx` | GitHub-style contribution graph component using `tint()` for color intensity |
| `packages/opencode/src/cli/cmd/tui/component/dialog-stats.tsx` | Main stats dialog with all UI sections |
| `packages/opencode/src/cli/cmd/tui/app.tsx` | Added `/stats` slash command registration |
| `packages/sdk/js/src/gen/types.gen.ts` | Added `stats_view` keybind type |
| `packages/sdk/js/src/v2/gen/types.gen.ts` | Added `stats_view` keybind type |

## Usage

Type `/stats` in the OpenCode TUI to open the statistics dialog.

## Features Implemented (from #6767)

- [x] Activity Heatmap - GitHub-style contribution graph showing usage intensity
- [x] Usage Metrics - Total tokens used with input/output/cache breakdown
- [x] Model usage tracking - Shows which models are being used most
- [x] Session count and cost estimates
- [ ] Active days and streaks (future enhancement)
- [ ] Peak coding hours (future enhancement)
- [ ] Fun comparisons (future enhancement)