### PR TITLE
fix: clarify LSP diagnostics output and add config to disable them

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1029,6 +1029,14 @@ export namespace Config {
             error: "For custom LSP servers, 'extensions' array is required.",
           },
         ),
+      diagnostics: z
+        .object({
+          disabled: z
+            .boolean()
+            .optional()
+            .describe("Disable LSP diagnostics output in edit/write tool results (default: false)"),
+        })
+        .optional(),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -14,6 +14,7 @@ import { Bus } from "../bus"
 import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
+import { Config } from "../config/config"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectory } from "./external-directory"
 
@@ -125,11 +126,12 @@ export const EditTool = Tool.define("edit", {
     const normalizedFilePath = Filesystem.normalizePath(filePath)
     const issues = diagnostics[normalizedFilePath] ?? []
     const errors = issues.filter((item) => item.severity === 1)
-    if (errors.length > 0) {
+    const cfg = await Config.get()
+    if (errors.length > 0 && cfg.lsp !== false && !cfg.diagnostics?.disabled) {
       const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
       const suffix =
         errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
-      output += `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filePath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+      output += `\n\nNote: the edit was applied successfully. The following pre-existing or new LSP diagnostics were detected in this file (informational only — not caused by a failed edit):\n<diagnostics file="${filePath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
     }
 
     return {

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -9,6 +9,7 @@ import { File } from "../file"
 import { FileTime } from "../file/time"
 import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
+import { Config } from "../config/config"
 import { trimDiff } from "./edit"
 import { assertExternalDirectory } from "./external-directory"
 
@@ -51,20 +52,23 @@ export const WriteTool = Tool.define("write", {
     await LSP.touchFile(filepath, true)
     const diagnostics = await LSP.diagnostics()
     const normalizedFilepath = Filesystem.normalizePath(filepath)
-    let projectDiagnosticsCount = 0
-    for (const [file, issues] of Object.entries(diagnostics)) {
-      const errors = issues.filter((item) => item.severity === 1)
-      if (errors.length === 0) continue
-      const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
-      const suffix =
-        errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
-      if (file === normalizedFilepath) {
-        output += `\n\nLSP errors detected in this file, please fix:\n<diagnostics file="${filepath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
-        continue
+    const cfg = await Config.get()
+    if (cfg.lsp !== false && !cfg.diagnostics?.disabled) {
+      let projectDiagnosticsCount = 0
+      for (const [file, issues] of Object.entries(diagnostics)) {
+        const errors = issues.filter((item) => item.severity === 1)
+        if (errors.length === 0) continue
+        const limited = errors.slice(0, MAX_DIAGNOSTICS_PER_FILE)
+        const suffix =
+          errors.length > MAX_DIAGNOSTICS_PER_FILE ? `\n... and ${errors.length - MAX_DIAGNOSTICS_PER_FILE} more` : ""
+        if (file === normalizedFilepath) {
+          output += `\n\nNote: the file was written successfully. The following pre-existing or new LSP diagnostics were detected in this file (informational only — not caused by a failed write):\n<diagnostics file="${filepath}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
+          continue
+        }
+        if (projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
+        projectDiagnosticsCount++
+        output += `\n\nLSP diagnostics detected in other files (informational only):\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
       }
-      if (projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
-      projectDiagnosticsCount++
-      output += `\n\nLSP errors detected in other files:\n<diagnostics file="${file}">\n${limited.map(LSP.Diagnostic.pretty).join("\n")}${suffix}\n</diagnostics>`
     }
 
     return {


### PR DESCRIPTION
## Summary

- Reword diagnostic messages in edit/write tool output to make it unambiguous that the operation succeeded, preventing agents from misinterpreting diagnostics as failed edits
- Add a `diagnostics.disabled` config option so users can opt out of diagnostic output in tool results entirely

## Problem

When an edit or write operation succeeds but triggers LSP diagnostics, the previous output only showed `"LSP errors detected in this file, please fix:"`. This imperative wording caused agents to believe the operation failed, leading to unnecessary retries or infinite loops.

## Changes

1. **Wording fix** (`edit.ts`, `write.ts`): Changed output from `"LSP errors detected in this file, please fix:"` to `"Note: the edit was applied successfully. The following pre-existing or new LSP diagnostics were detected in this file (informational only — not caused by a failed edit):"` 
2. **Config option** (`config.ts`): Added `diagnostics.disabled` boolean option. When set to `true` in `opencode.json`, diagnostic output is completely suppressed from edit/write tool results:
   ```json
   {
     "diagnostics": {
       "disabled": true
     }
   }
   ```
3. Both tools now also skip diagnostic output when `lsp: false` is set (consistent with existing config)

## Testing

- Verified `tsc --noEmit` passes with no type errors
- Full `turbo typecheck` passes across all packages
- Manual testing: `bun dev` with edits triggering LSP diagnostics shows new wording

Fixes #9102