### PR TITLE
feat(app): add oauth link copy shortcut

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -5,6 +5,7 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import type { IconName } from "@opencode-ai/ui/icons/provider"
+import { Keybind } from "@opencode-ai/ui/keybind"
 import { List, type ListRef } from "@opencode-ai/ui/list"
 import { ProviderIcon } from "@opencode-ai/ui/provider-icon"
 import { Spinner } from "@opencode-ai/ui/spinner"
@@ -97,6 +98,12 @@ export function DialogConnectProvider(props: { provider: string }) {
 
   let listRef: ListRef | undefined
   function handleKey(e: KeyboardEvent) {
+    if (e.key.toLowerCase() === "c" && store.authorization?.url) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+      e.preventDefault()
+      copyAuthorizationUrl(store.authorization.url)
+      return
+    }
     if (e.key === "Enter" && e.target instanceof HTMLInputElement) {
       return
     }
@@ -123,6 +130,23 @@ export function DialogConnectProvider(props: { provider: string }) {
       title: language.t("provider.connect.toast.connected.title", { provider: provider().name }),
       description: language.t("provider.connect.toast.connected.description", { provider: provider().name }),
     })
+  }
+
+  function copyAuthorizationUrl(url: string) {
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        showToast({
+          variant: "success",
+          title: language.t("session.share.copy.copied"),
+        })
+      })
+      .catch(() => {
+        showToast({
+          variant: "error",
+          title: language.t("toast.session.share.copyFailed.title"),
+        })
+      })
   }
 
   function goBack() {
@@ -337,10 +361,20 @@ export function DialogConnectProvider(props: { provider: string }) {
                       <div class="flex flex-col gap-6">
                         <div class="text-14-regular text-text-base">
                           {language.t("provider.connect.oauth.code.visit.prefix")}
-                          <Link href={store.authorization!.url}>
+                          <Link
+                            href={store.authorization!.url}
+                            onContextMenu={(event) => {
+                              event.preventDefault()
+                              copyAuthorizationUrl(store.authorization!.url)
+                            }}
+                          >
                             {language.t("provider.connect.oauth.code.visit.link")}
                           </Link>
                           {language.t("provider.connect.oauth.code.visit.suffix", { provider: provider().name })}
+                        </div>
+                        <div class="text-12-regular text-text-weak flex items-center gap-2">
+                          <Keybind>c</Keybind>
+                          <span>copy authorization link</span>
                         </div>
                         <form onSubmit={handleSubmit} class="flex flex-col items-start gap-4">
                           <TextField
@@ -395,10 +429,20 @@ export function DialogConnectProvider(props: { provider: string }) {
                       <div class="flex flex-col gap-6">
                         <div class="text-14-regular text-text-base">
                           {language.t("provider.connect.oauth.auto.visit.prefix")}
-                          <Link href={store.authorization!.url}>
+                          <Link
+                            href={store.authorization!.url}
+                            onContextMenu={(event) => {
+                              event.preventDefault()
+                              copyAuthorizationUrl(store.authorization!.url)
+                            }}
+                          >
                             {language.t("provider.connect.oauth.auto.visit.link")}
                           </Link>
                           {language.t("provider.connect.oauth.auto.visit.suffix", { provider: provider().name })}
+                        </div>
+                        <div class="text-12-regular text-text-weak flex items-center gap-2">
+                          <Keybind>c</Keybind>
+                          <span>copy authorization link</span>
                         </div>
                         <TextField
                           label={language.t("provider.connect.oauth.auto.confirmationCode")}


### PR DESCRIPTION
## Summary

- Adds right-click and `c` shortcut to copy OAuth authorization links in the provider connect dialog
- Displays the shared keybind pill under the visit link prompt

## Notes

- Confirmation code already remains copyable via the existing field

Anthropic preview (similar for chatgpt pro/plus and copilot screens):
<img width="1326" height="794" alt="image" src="https://github.com/user-attachments/assets/eba682b1-75c1-4465-ab6a-bfcced1ace1f" />
