### PR TITLE
docs: Update agents.mdx / models section w/ correct provider/model-id format

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -325,14 +325,13 @@ If you don’t specify a model, primary agents use the [model globally configure
 {
   "agent": {
     "plan": {
-      "model": "anthropic/claude-haiku-4-20250514"
+      "model": "opencode/openai/gpt-5.1-codex"
     }
   }
 }
 ```
 
-The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen), you would use `opencode/gpt-5.1-codex` for GPT 5.1 Codex.
-
+The model ID in your OpenCode config uses the format `provider/model-id`. For example, if you're using [OpenCode Zen](/docs/zen) to connect to GPT 5.1 Codex, you would use `opencode/openai/gpt-5.1-codex` for GPT 5.1 Codex, whereas if you are connecting to that same model via OpenAI auth, you would use `openai/openai/gpt-5.1-codex`. 
 ---
 
 ### Tools


### PR DESCRIPTION
Previous version incorrectly stated "The model ID in your OpenCode config uses the format provider/model-id. For example, if you’re using OpenCode Zen, you would use opencode/gpt-5.1-codex for GPT 5.1 Codex." 

This commit corrects the provider/model-id format and examples. The provider indeed prefixes the model-id, but it's the full model-id, not just the part to the right of the slash, e.g. 

opencode/openai/gpt-5.1-codex
openai/openai/gpt-5.1-codex

### What does this PR do?
corrects incorrect/confusing documentation 

### How did you verify your code works?
tested in opencode.json 