### PR TITLE
fix(timeline): errors when no timeline message options

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
@@ -26,12 +26,14 @@ export function DialogThemeList() {
       options={options}
       current={initial}
       onMove={(opt) => {
-        theme.set(opt.value)
+        if (opt) theme.set(opt.value)
       }}
       onSelect={(opt) => {
-        theme.set(opt.value)
-        confirmed = true
-        dialog.clear()
+        if (opt) {
+          theme.set(opt.value)
+          confirmed = true
+          dialog.clear()
+        }
       }}
       ref={(r) => {
         ref = r

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -60,5 +60,5 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
     return result
   })
 
-  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="Fork from message" options={options()} />
+  return <DialogSelect onMove={(option) => option && props.onMove(option.value)} title="Fork from message" options={options()} />
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-timeline.tsx
@@ -43,5 +43,5 @@ export function DialogTimeline(props: {
     return result
   })
 
-  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="Timeline" options={options()} />
+  return <DialogSelect onMove={(option) => option && props.onMove(option.value)} title="Timeline" options={options()} />
 }


### PR DESCRIPTION
### What does this PR do?

check if option is defined, fixes #10130 , found out that this also happens in theme and fork message so added fixes for those too. fixes #8873 as well

when using timeline jump to message and there are no message results, opencode errors, error message:
[11:13:12] [ERROR] Error: undefined is not an object (evaluating 'option.value')
    TypeError: undefined is not an object (evaluating 'option.value')
        at onMove (src/cli/cmd/tui/routes/session/dialog-timeline.tsx:44:36)
        at moveTo (src/cli/cmd/tui/ui/dialog-select.tsx:96:11)
        at <anonymous> (src/cli/cmd/tui/ui/dialog-select.tsx:78:9)

### How did you verify your code works?
tested it locally