### PR TITLE
fix(app): center checkbox indicator in provider selection

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -187,7 +187,7 @@ export function DialogConnectProvider(props: { provider: string }) {
                   {(i) => (
                     <div class="w-full flex items-center gap-x-2">
                       <div class="w-4 h-2 rounded-[1px] bg-input-base shadow-xs-border-base flex items-center justify-center">
-                        <div class="w-2.5 h-0.5 bg-icon-strong-base hidden" data-slot="list-item-extra-icon" />
+                        <div class="w-2.5 h-0.5 ml-0 bg-icon-strong-base hidden" data-slot="list-item-extra-icon" />
                       </div>
                       <span>{methodLabel(i)}</span>
                     </div>


### PR DESCRIPTION
### What does this PR do?

center indicator:
<img width="235" height="105" alt="image" src="https://github.com/user-attachments/assets/be5b3b72-be1e-4906-97eb-e8d770d575c7" />


### How did you verify your code works?
