### PR TITLE
docs(tool): clarify question tool label character limits

### DIFF
--- a/packages/opencode/src/tool/question.txt
+++ b/packages/opencode/src/tool/question.txt
@@ -7,4 +7,6 @@ Use this tool when you need to ask the user questions during execution. This all
 Usage notes:
 - When `custom` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
 - Answers are returned as arrays of labels; set `multiple: true` to allow selecting more than one
-- If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label
+- If you recommend a specific option, make that the first option in the list and add " *" at the end of the label (e.g., "Use TypeScript *")
+- Labels must be concise: 1-5 words, max 30 characters
+- Headers must be very short: max 30 characters


### PR DESCRIPTION
### What does this PR do?

Fixes #10283

Updates the question tool description to prevent LLMs from exceeding the 30-character label limit:

1. **Adds explicit character limits** - Labels (30 chars) and headers (30 chars) now documented
2. **Changes recommendation suffix** - From `(Recommended)` (13 chars) to ` *` (2 chars)
3. **Adds example** - Shows the pattern: `"Use TypeScript *"`

### How did you verify your code works?

This is a documentation-only change to `question.txt`. The fix addresses the root cause of validation errors where LLMs create labels like "Use existing patterns (Recommended)" (36 chars) which exceed the 30-character limit.