### PR TITLE
fix(app): normalize path separators for session diff filtering on Windows

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -40,7 +40,7 @@ export namespace SessionSummary {
         .flatMap((x) => x.parts)
         .filter((x) => x.type === "patch")
         .flatMap((x) => x.files)
-        .map((x) => path.relative(Instance.worktree, x)),
+        .map((x) => path.relative(Instance.worktree, x).replaceAll("\\", "/")),
     )
     const diffs = await computeDiff({ messages: input.messages }).then((x) =>
       x.filter((x) => {


### PR DESCRIPTION
fixes #9921 

### What does this PR do?

Normalizes path separators when comparing file paths in the session diff filtering logic. On Windows, path.relative() returns paths with backslashes (\), but Git always outputs paths with forward slashes (/). This mismatch caused modified files to be filtered out of the session review on Windows.

The fix:
Added .replaceAll("\\", "/") to normalize Windows backslashes to forward slashes before comparing against Git's output.

### How did you verify your code works?
On Windows, started a new session, tested modify file, delete file and create file operations.

## Before
Opencode review cannot see some files have been changed
<img width="1325" height="582" alt="image" src="https://github.com/user-attachments/assets/23889e9b-d024-4b76-ab71-c6177bb5a0f6" />

## After
Fixed
<img width="1384" height="769" alt="image" src="https://github.com/user-attachments/assets/d59aa91c-0b9e-42eb-ac55-8de5cc52b75e" />

