### PR TITLE
fix(app): cursor on resize

### DIFF
--- a/packages/ui/src/components/resize-handle.css
+++ b/packages/ui/src/components/resize-handle.css
@@ -19,7 +19,7 @@
     inset-inline-end: 0;
     width: 8px;
     transform: translateX(50%);
-    cursor: ew-resize;
+    cursor: col-resize;
 
     &::after {
       width: 3px;
@@ -34,7 +34,7 @@
     inset-block-start: 0;
     height: 8px;
     transform: translateY(-50%);
-    cursor: ns-resize;
+    cursor: row-resize;
 
     &::after {
       height: 3px;


### PR DESCRIPTION
### What does this PR do?

use native cursor for resizingggggg...

<img width="286" height="161" alt="Screenshot 2026-01-24 at 3 02 22 AM" src="https://github.com/user-attachments/assets/3eeb8f4f-3bd4-4bb8-b784-0b5c4db423da" />

<img width="555" height="340" alt="Screenshot 2026-01-24 at 3 06 18 AM" src="https://github.com/user-attachments/assets/3959126f-3411-40a7-a4e5-fd441d375764" />
