### PR TITLE
feat: add remote subagent protocol

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -368,6 +368,13 @@ export function Autocomplete(props: {
     }))
   })
 
+  const isRemoteDomain = (text: string): boolean => {
+    // Match: localhost, localhost:3000, example.com, example.com:8080
+    // Optionally followed by /agent-name
+    const domainPattern = /^(localhost(:\d+)?|[\w.-]+\.\w+(:\d+)?)(\/[\w-]+)?$/
+    return domainPattern.test(text)
+  }
+
   const options = createMemo((prev: AutocompleteOption[] | undefined) => {
     const filesValue = files()
     const agentsValue = agents()
@@ -404,7 +411,28 @@ export function Autocomplete(props: {
       },
     })
 
-    return result.map((arr) => arr.obj)
+    const options = result.map((arr) => arr.obj)
+
+    if (store.visible === "@" && currentFilter && isRemoteDomain(currentFilter)) {
+      const remoteOption: AutocompleteOption = {
+        display: "@" + currentFilter + " (remote)",
+        description: "Invoke remote agent",
+        onSelect: () => {
+          insertPart(currentFilter, {
+            type: "agent",
+            name: "@" + currentFilter,
+            source: {
+              start: 0,
+              end: 0,
+              value: "",
+            },
+          })
+        },
+      }
+      options.unshift(remoteOption)
+    }
+
+    return options
   })
 
   createEffect(() => {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1088,6 +1088,12 @@ export namespace Config {
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
         })
         .optional(),
+      remoteAgents: z
+        .object({
+          domains: z.array(z.string()).optional().describe("List of trusted domains for remote agents"),
+        })
+        .optional()
+        .describe("Configuration for remote subagents accessible via @domain.com syntax"),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/remote/discovery.ts
+++ b/packages/opencode/src/remote/discovery.ts
@@ -1,0 +1,92 @@
+import { z } from "zod"
+
+export namespace RemoteDiscovery {
+  export const AgentInfo = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    endpoint: z.string(),
+  })
+  export type AgentInfo = z.infer<typeof AgentInfo>
+
+  export const DiscoveryDocument = z.object({
+    version: z.string(),
+    agents: z.array(AgentInfo),
+  })
+  export type DiscoveryDocument = z.infer<typeof DiscoveryDocument>
+
+  const cache = new Map<string, { doc: DiscoveryDocument; expiresAt: number }>()
+  const CACHE_TTL = 5 * 60 * 1000 // 5 minutes
+
+  export function parseAgentRef(ref: string): { domain: string; agentName: string } | null {
+    if (!ref.startsWith("@")) return null
+
+    const rest = ref.slice(1)
+
+    // Check if it looks like a domain (has a dot or is localhost with optional port)
+    // Domain pattern: localhost, localhost:3000, example.com, example.com:8080
+    const domainPattern = /^(localhost(:\d+)?|[\w.-]+\.\w+(:\d+)?)$/
+
+    // Check for agent name after slash: @domain.com/agent or @localhost:3000/agent
+    const slashIndex = rest.indexOf("/")
+    if (slashIndex !== -1) {
+      const domain = rest.slice(0, slashIndex)
+      const agentName = rest.slice(slashIndex + 1) || "default"
+      if (!domainPattern.test(domain)) return null
+      return { domain, agentName }
+    }
+
+    // Just @domain.com or @localhost:3000 (default agent)
+    if (!domainPattern.test(rest)) return null
+    return { domain: rest, agentName: "default" }
+  }
+
+  export async function discover(domain: string): Promise<DiscoveryDocument> {
+    const cached = cache.get(domain)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.doc
+    }
+
+    const protocol = domain.startsWith("localhost") ? "http" : "https"
+    const url = `${protocol}://${domain}/.well-known/agents/agents.json`
+
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10000),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch agent discovery from ${url}: ${response.status} ${response.statusText}`)
+    }
+
+    const data = await response.json()
+    const parsed = DiscoveryDocument.safeParse(data)
+
+    if (!parsed.success) {
+      throw new Error(`Invalid agent discovery document from ${url}: ${parsed.error.message}`)
+    }
+
+    cache.set(domain, { doc: parsed.data, expiresAt: Date.now() + CACHE_TTL })
+    return parsed.data
+  }
+
+  export async function getAgent(domain: string, agentName: string): Promise<AgentInfo & { domain: string }> {
+    const doc = await discover(domain)
+    const agent = doc.agents.find((a) => a.name === agentName)
+    if (!agent) {
+      throw new Error(`Agent "${agentName}" not found on ${domain}. Available: ${doc.agents.map((a) => a.name).join(", ")}`)
+    }
+    return { ...agent, domain }
+  }
+
+  export function buildEndpointUrl(domain: string, endpoint: string): string {
+    const protocol = domain.startsWith("localhost") ? "http" : "https"
+    if (endpoint.startsWith("http://") || endpoint.startsWith("https://")) {
+      return endpoint
+    }
+    return `${protocol}://${domain}${endpoint}`
+  }
+
+  export function clearCache() {
+    cache.clear()
+  }
+}

--- a/packages/opencode/src/remote/index.ts
+++ b/packages/opencode/src/remote/index.ts
@@ -1,0 +1,3 @@
+export { RemoteDiscovery } from "./discovery"
+export { RemoteStream } from "./stream"
+export { RemoteTrust } from "./trust"

--- a/packages/opencode/src/remote/stream.ts
+++ b/packages/opencode/src/remote/stream.ts
@@ -1,0 +1,313 @@
+import { z } from "zod"
+import { Session } from "../session"
+import { MessageV2 } from "../session/message-v2"
+import { Identifier } from "../id/id"
+import { RemoteDiscovery } from "./discovery"
+import { Instance } from "../project/instance"
+import { Bus } from "../bus"
+
+export namespace RemoteStream {
+  export const PromptRequest = z.object({
+    session_id: z.string().optional(),
+    prompt: z.string(),
+    attachments: z
+      .array(
+        z.object({
+          type: z.literal("file"),
+          path: z.string(),
+          content: z.string(),
+        }),
+      )
+      .optional(),
+  })
+  export type PromptRequest = z.infer<typeof PromptRequest>
+
+  export const PromptResponse = z.object({
+    session_id: z.string(),
+    stream_url: z.string(),
+  })
+  export type PromptResponse = z.infer<typeof PromptResponse>
+
+  export type StreamEvent =
+    | { type: "text"; delta: string }
+    | { type: "reasoning"; delta: string }
+    | { type: "tool_start"; id: string; name: string; input: unknown }
+    | { type: "tool_result"; id: string; status: "completed" | "error"; output: string; error?: string }
+    | { type: "step_start"; step_id: string }
+    | { type: "step_finish"; step_id: string; tokens?: { input: number; output: number } }
+    | { type: "error"; message: string; code: string }
+    | { type: "done"; stop_reason: string }
+
+  interface StreamContext {
+    session: Session.Info
+    messageID: string
+    parentMessageID: string
+    abort: AbortSignal
+    onToolUpdate?: (summary: ToolSummary[]) => void
+  }
+
+  interface ToolSummary {
+    id: string
+    tool: string
+    state: { status: string; title?: string }
+  }
+
+  export async function invoke(
+    domain: string,
+    agentInfo: RemoteDiscovery.AgentInfo,
+    prompt: string,
+    ctx: StreamContext,
+  ): Promise<MessageV2.WithParts> {
+    const endpointUrl = RemoteDiscovery.buildEndpointUrl(domain, agentInfo.endpoint)
+    const promptUrl = `${endpointUrl}/prompt`
+
+    const promptResponse = await fetch(promptUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt } satisfies PromptRequest),
+      signal: ctx.abort,
+    })
+
+    if (!promptResponse.ok) {
+      throw new Error(`Remote agent prompt failed: ${promptResponse.status} ${promptResponse.statusText}`)
+    }
+
+    const promptData = PromptResponse.parse(await promptResponse.json())
+    const streamUrl = RemoteDiscovery.buildEndpointUrl(domain, promptData.stream_url)
+
+    const assistantMsg: MessageV2.Assistant = {
+      id: ctx.messageID,
+      sessionID: ctx.session.id,
+      role: "assistant",
+      time: { created: Date.now() },
+      parentID: ctx.parentMessageID,
+      modelID: "remote",
+      providerID: domain,
+      mode: "remote",
+      agent: `${domain}:${agentInfo.name}`,
+      path: {
+        cwd: Instance.worktree,
+        root: Instance.worktree,
+      },
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    }
+    await Session.updateMessage(assistantMsg)
+
+    let currentTextPart: MessageV2.TextPart | undefined
+    let currentReasoningPart: MessageV2.ReasoningPart | undefined
+    const toolParts = new Map<string, MessageV2.ToolPart>()
+    const toolSummary: ToolSummary[] = []
+
+    const response = await fetch(streamUrl, {
+      headers: { Accept: "text/event-stream" },
+      signal: ctx.abort,
+    })
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Remote agent stream failed: ${response.status} ${response.statusText}`)
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split("\n")
+        buffer = lines.pop() || ""
+
+        let currentEvent = ""
+        let currentData = ""
+
+        for (const line of lines) {
+          if (line.startsWith("event: ")) {
+            currentEvent = line.slice(7).trim()
+          } else if (line.startsWith("data: ")) {
+            currentData = line.slice(6)
+          } else if (line === "" && currentEvent && currentData) {
+            const event = parseEvent(currentEvent, currentData)
+            if (event) {
+              const result = await handleEvent(event, {
+                session: ctx.session,
+                messageID: ctx.messageID,
+                currentTextPart,
+                currentReasoningPart,
+                toolParts,
+                toolSummary,
+                onToolUpdate: ctx.onToolUpdate,
+              })
+              if (result.textPart !== undefined) currentTextPart = result.textPart
+              if (result.reasoningPart !== undefined) currentReasoningPart = result.reasoningPart
+            }
+            currentEvent = ""
+            currentData = ""
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    if (currentTextPart && currentTextPart.time) {
+      currentTextPart.time.end = Date.now()
+      await Session.updatePart({ part: currentTextPart, delta: "" })
+    }
+
+    assistantMsg.time.completed = Date.now()
+    await Session.updateMessage(assistantMsg)
+
+    return MessageV2.get({ sessionID: ctx.session.id, messageID: ctx.messageID })
+  }
+
+  function parseEvent(eventType: string, data: string): StreamEvent | null {
+    try {
+      const parsed = JSON.parse(data)
+      return { type: eventType, ...parsed } as StreamEvent
+    } catch {
+      return null
+    }
+  }
+
+  interface EventHandlerContext {
+    session: Session.Info
+    messageID: string
+    currentTextPart: MessageV2.TextPart | undefined
+    currentReasoningPart: MessageV2.ReasoningPart | undefined
+    toolParts: Map<string, MessageV2.ToolPart>
+    toolSummary: ToolSummary[]
+    onToolUpdate?: (summary: ToolSummary[]) => void
+  }
+
+  interface EventHandlerResult {
+    textPart?: MessageV2.TextPart | undefined
+    reasoningPart?: MessageV2.ReasoningPart | undefined
+  }
+
+  async function handleEvent(event: StreamEvent, ctx: EventHandlerContext): Promise<EventHandlerResult> {
+    const result: EventHandlerResult = {}
+
+    switch (event.type) {
+      case "text": {
+        if (!ctx.currentTextPart) {
+          const part: MessageV2.TextPart = {
+            id: Identifier.ascending("part"),
+            messageID: ctx.messageID,
+            sessionID: ctx.session.id,
+            type: "text",
+            text: event.delta,
+            time: { start: Date.now() },
+          }
+          result.textPart = part
+          await Session.updatePart({ part, delta: event.delta })
+        } else {
+          ctx.currentTextPart.text += event.delta
+          result.textPart = ctx.currentTextPart
+          await Session.updatePart({ part: ctx.currentTextPart, delta: event.delta })
+        }
+        break
+      }
+
+      case "reasoning": {
+        if (!ctx.currentReasoningPart) {
+          const part: MessageV2.ReasoningPart = {
+            id: Identifier.ascending("part"),
+            messageID: ctx.messageID,
+            sessionID: ctx.session.id,
+            type: "reasoning",
+            text: event.delta,
+            time: { start: Date.now() },
+          }
+          result.reasoningPart = part
+          await Session.updatePart({ part, delta: event.delta })
+        } else {
+          ctx.currentReasoningPart.text += event.delta
+          result.reasoningPart = ctx.currentReasoningPart
+          await Session.updatePart({ part: ctx.currentReasoningPart, delta: event.delta })
+        }
+        break
+      }
+
+      case "tool_start": {
+        const inputObj = typeof event.input === "object" && event.input !== null ? (event.input as Record<string, unknown>) : {}
+        const part: MessageV2.ToolPart = {
+          id: Identifier.ascending("part"),
+          messageID: ctx.messageID,
+          sessionID: ctx.session.id,
+          type: "tool",
+          callID: event.id,
+          tool: event.name,
+          state: {
+            status: "running",
+            input: inputObj as Record<string, any>,
+            time: { start: Date.now() },
+          },
+        }
+        ctx.toolParts.set(event.id, part)
+        await Session.updatePart(part)
+
+        ctx.toolSummary.push({
+          id: part.id,
+          tool: event.name,
+          state: { status: "running" },
+        })
+        ctx.onToolUpdate?.(ctx.toolSummary)
+        break
+      }
+
+      case "tool_result": {
+        const part = ctx.toolParts.get(event.id)
+        if (part && part.state.status === "running") {
+          const now = Date.now()
+          if (event.status === "completed") {
+            part.state = {
+              status: "completed",
+              input: part.state.input,
+              output: event.output,
+              title: "Completed",
+              metadata: {},
+              time: { start: part.state.time.start, end: now },
+            }
+          } else {
+            part.state = {
+              status: "error",
+              input: part.state.input,
+              error: event.error || event.output,
+              time: { start: part.state.time.start, end: now },
+            }
+          }
+          await Session.updatePart(part)
+
+          const summaryIdx = ctx.toolSummary.findIndex((t) => t.id === part.id)
+          if (summaryIdx >= 0) {
+            ctx.toolSummary[summaryIdx].state = {
+              status: part.state.status,
+              title: part.state.status === "completed" ? (part.state as MessageV2.ToolStateCompleted).title : undefined,
+            }
+            ctx.onToolUpdate?.(ctx.toolSummary)
+          }
+        }
+        break
+      }
+
+      case "error": {
+        throw new Error(`Remote agent error: ${event.message} (${event.code})`)
+      }
+
+      case "done": {
+        break
+      }
+    }
+
+    return result
+  }
+}

--- a/packages/opencode/src/remote/trust.ts
+++ b/packages/opencode/src/remote/trust.ts
@@ -1,0 +1,29 @@
+import { Config } from "../config/config"
+
+export namespace RemoteTrust {
+  const sessionTrusted = new Set<string>()
+
+  export async function isTrusted(domain: string): Promise<boolean> {
+    if (sessionTrusted.has(domain)) return true
+
+    const config = await Config.get()
+    const configuredDomains = config.remoteAgents?.domains ?? []
+    return configuredDomains.includes(domain)
+  }
+
+  export function trustForSession(domain: string): void {
+    sessionTrusted.add(domain)
+  }
+
+  export function revokeSessionTrust(domain: string): void {
+    sessionTrusted.delete(domain)
+  }
+
+  export function clearSessionTrust(): void {
+    sessionTrusted.clear()
+  }
+
+  export function getSessionTrustedDomains(): string[] {
+    return Array.from(sessionTrusted)
+  }
+}

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,6 +11,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { RemoteDiscovery, RemoteStream, RemoteTrust } from "../remote"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -40,6 +41,12 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     parameters,
     async execute(params: z.infer<typeof parameters>, ctx) {
       const config = await Config.get()
+
+      // Check if this is a remote agent reference
+      const remoteRef = RemoteDiscovery.parseAgentRef(params.subagent_type)
+      if (remoteRef) {
+        return executeRemoteAgent(params, ctx, remoteRef)
+      }
 
       // Skip permission check when user explicitly invoked via @ or command subtask
       if (!ctx.extra?.bypassAgentCheck) {
@@ -186,3 +193,89 @@ export const TaskTool = Tool.define("task", async (ctx) => {
     },
   }
 })
+
+async function executeRemoteAgent(
+  params: z.infer<typeof parameters>,
+  ctx: Tool.Context,
+  remoteRef: { domain: string; agentName: string },
+) {
+  const { domain, agentName } = remoteRef
+
+  // Check trust
+  const isTrusted = await RemoteTrust.isTrusted(domain)
+  if (!isTrusted) {
+    await ctx.ask({
+      permission: "remote_agent",
+      patterns: [domain],
+      always: [],
+      metadata: {
+        domain,
+        agentName,
+        description: params.description,
+      },
+    })
+    RemoteTrust.trustForSession(domain)
+  }
+
+  // Discover and get agent info
+  const agentInfo = await RemoteDiscovery.getAgent(domain, agentName)
+
+  // Create session for tracking
+  const session = await Session.create({
+    parentID: ctx.sessionID,
+    title: `${params.description} (@${domain}${agentName !== "default" ? ":" + agentName : ""} remote)`,
+    permission: [],
+  })
+
+  ctx.metadata({
+    title: params.description,
+    metadata: {
+      sessionId: session.id,
+      remote: { domain, agent: agentName },
+    },
+  })
+
+  const messageID = Identifier.ascending("message")
+
+  const result = await RemoteStream.invoke(domain, agentInfo, params.prompt, {
+    session,
+    messageID,
+    parentMessageID: ctx.messageID,
+    abort: ctx.abort,
+    onToolUpdate: (summary) => {
+      ctx.metadata({
+        title: params.description,
+        metadata: {
+          summary: [...summary],
+          sessionId: session.id,
+          remote: { domain, agent: agentName },
+        },
+      })
+    },
+  })
+
+  const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
+  const output =
+    text + "\n\n" + ["<task_metadata>", `session_id: ${session.id}`, `remote: ${domain}/${agentName}`, "</task_metadata>"].join("\n")
+
+  const summary = result.parts
+    .filter((x): x is MessageV2.ToolPart => x.type === "tool")
+    .map((part) => ({
+      id: part.id,
+      tool: part.tool,
+      state: {
+        status: part.state.status,
+        title: part.state.status === "completed" ? part.state.title : undefined,
+      },
+    }))
+
+  return {
+    title: params.description,
+    metadata: {
+      summary,
+      sessionId: session.id,
+      remote: { domain, agent: agentName },
+    },
+    output,
+  }
+}

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -3,7 +3,9 @@ Launch a new agent to handle complex, multistep tasks autonomously.
 Available agent types and the tools they have access to:
 {agents}
 
-When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.
+Remote agents can also be invoked using the @domain.com or @domain.com/agent syntax (e.g., @localhost:3000 or @example.com/code-review). Remote agents execute on external servers and stream their results back.
+
+When using the Task tool, you must specify a subagent_type parameter to select which agent type to use. For remote agents, include the full @domain syntax (e.g., subagent_type: "@localhost:3000" or "@example.com/code-review").
 
 When to use the Task tool:
 - When you are instructed to execute custom slash commands. Use the Task tool with the slash command invocation as the entire prompt. The slash command can take arguments. For example: Task(description="Check the file", prompt="/check-file path/to/file.py")


### PR DESCRIPTION
## Summary

Add support for invoking remote subagents via `@domain.com` or `@domain.com/agent` syntax. Remote subagents are fully self-contained services with their own LLM, tools, and execution environment that stream activity back to opencode for display.

* Example remote agent implementation: https://github.com/adriancooney/remote-subagent-example
* Example transcript: https://gist.github.com/adriancooney/1a655e333723aa94f27c3b79f9b70f0a#file-opencode-transcript-md

This is missing a very important component: authentication. Before investing time into exploring different solutions, I wanted to see if there's an appetite at all for something like this.

To test:

1. Open opencode
2. Type `@remote-subagent-example.vercel.app cowsay`
3. Validate sub-agent was called and output returned.


https://github.com/user-attachments/assets/5026ca1c-599f-4d86-98b7-1ef34e4360c0


### Features

- **Discovery**: Agents are discovered via `/.well-known/agents/agents.json`
- **Streaming**: HTTP POST + SSE for real-time text, reasoning, and tool events
- **Trust**: Session-scoped domain trust with optional config-based permanent trust
- **Integration**: Remote agents display like local subagents in the TUI

### Protocol

See the draft RFCs in the companion example project:
- [RFC 001: Agent Discovery](https://gist.github.com/adriancooney/1a655e333723aa94f27c3b79f9b70f0a#file-001-agent-discovery-md)
- [RFC 002: Agent Communication](https://gist.github.com/adriancooney/1a655e333723aa94f27c3b79f9b70f0a#file-002-agent-communication-md)
- [RFC 003: OpenCode Integration](https://gist.github.com/adriancooney/1a655e333723aa94f27c3b79f9b70f0a#file-003-opencode-integration-md)

### Changes

| File | Description |
|------|-------------|
| `src/remote/discovery.ts` | Discovery protocol client, parses @domain/agent refs |
| `src/remote/stream.ts` | SSE consumer, maps events to MessageV2.Part |
| `src/remote/trust.ts` | Domain trust management |
| `src/tool/task.ts` | Branch to remote execution for @domain refs |
| `src/config/config.ts` | Add `remoteAgents.domains` config option |
| `autocomplete.tsx` | Show remote domains in autocomplete |

### Usage

```
@localhost:3000 list files in current directory
@example.com/code-review review this function
```

### Configuration

```json
{
  "remoteAgents": {
    "domains": ["localhost:3000", "agents.example.com"]
  }
}
```