### PR TITLE
feat(desktop): add hardware acceleration toggle for Windows

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -1,9 +1,10 @@
-import { Component, createMemo, type JSX } from "solid-js"
+import { Component, createMemo, createSignal, Show, type JSX, onMount } from "solid-js"
 import { Select } from "@opencode-ai/ui/select"
 import { Switch } from "@opencode-ai/ui/switch"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme"
 import { useLanguage } from "@/context/language"
 import { useSettings, monoFontFamily } from "@/context/settings"
+import { usePlatform } from "@/context/platform"
 import { playSound, SOUND_OPTIONS } from "@/utils/sound"
 import { Link } from "./link"
 
@@ -30,6 +31,7 @@ export const SettingsGeneral: Component = () => {
   const theme = useTheme()
   const language = useLanguage()
   const settings = useSettings()
+  const platform = usePlatform()
 
   const themeOptions = createMemo(() =>
     Object.entries(theme.themes()).map(([id, def]) => ({ id, name: def.name ?? id })),
@@ -309,6 +311,11 @@ export const SettingsGeneral: Component = () => {
             </SettingsRow>
           </div>
         </div>
+
+        {/* Advanced Section - only show on Windows desktop */}
+        <Show when={platform.os === "windows" && platform.getDisableHardwareAcceleration}>
+          <AdvancedSection />
+        </Show>
       </div>
     </div>
   )
@@ -328,6 +335,56 @@ const SettingsRow: Component<SettingsRowProps> = (props) => {
         <span class="text-12-regular text-text-weak">{props.description}</span>
       </div>
       <div class="flex-shrink-0">{props.children}</div>
+    </div>
+  )
+}
+
+const AdvancedSection: Component = () => {
+  const platform = usePlatform()
+  const language = useLanguage()
+  const [disableGpu, setDisableGpu] = createSignal(false)
+  const [needsRestart, setNeedsRestart] = createSignal(false)
+
+  onMount(async () => {
+    if (platform.getDisableHardwareAcceleration) {
+      const value = await platform.getDisableHardwareAcceleration()
+      setDisableGpu(value)
+    }
+  })
+
+  const handleToggle = async (checked: boolean) => {
+    if (platform.setDisableHardwareAcceleration) {
+      await platform.setDisableHardwareAcceleration(checked)
+      setDisableGpu(checked)
+      setNeedsRestart(true)
+    }
+  }
+
+  return (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.advanced")}</h3>
+
+      <div class="bg-surface-raised-base px-4 rounded-lg">
+        <SettingsRow
+          title={language.t("settings.general.advanced.disableHardwareAcceleration.title")}
+          description={language.t("settings.general.advanced.disableHardwareAcceleration.description")}
+        >
+          <div class="flex items-center gap-2">
+            <Show when={needsRestart()}>
+              <button
+                class="text-12-regular text-text-info hover:underline"
+                onClick={() => platform.restart?.()}
+              >
+                Restart now
+              </button>
+            </Show>
+            <Switch
+              checked={disableGpu()}
+              onChange={handleToggle}
+            />
+          </div>
+        </SettingsRow>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/context/platform.tsx
+++ b/packages/app/src/context/platform.tsx
@@ -49,6 +49,12 @@ export type Platform = {
 
   /** Parse markdown to HTML using native parser (desktop only, returns unprocessed code blocks) */
   parseMarkdown?(markdown: string): Promise<string>
+
+  /** Get hardware acceleration disabled setting (Windows desktop only) */
+  getDisableHardwareAcceleration?(): Promise<boolean>
+
+  /** Set hardware acceleration disabled setting (Windows desktop only) */
+  setDisableHardwareAcceleration?(disabled: boolean): Promise<void>
 }
 
 export const { use: usePlatform, provider: PlatformProvider } = createSimpleContext({

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -527,6 +527,11 @@ export const dict = {
   "settings.general.section.notifications": "System notifications",
   "settings.general.section.updates": "Updates",
   "settings.general.section.sounds": "Sound effects",
+  "settings.general.section.advanced": "Advanced",
+
+  "settings.general.advanced.disableHardwareAcceleration.title": "Disable hardware acceleration",
+  "settings.general.advanced.disableHardwareAcceleration.description":
+    "Disable GPU acceleration. May fix crashes or visual issues. Requires restart.",
 
   "settings.general.row.language.title": "Language",
   "settings.general.row.language.description": "Change the display language for OpenCode",

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ use crate::window_customizer::PinchZoomDisablePlugin;
 
 const SETTINGS_STORE: &str = "opencode.settings.dat";
 const DEFAULT_SERVER_URL_KEY: &str = "defaultServerUrl";
+const DISABLE_HARDWARE_ACCEL_KEY: &str = "disableHardwareAcceleration";
 
 #[derive(Clone, serde::Serialize)]
 struct ServerReadyData {
@@ -130,6 +131,36 @@ async fn set_default_server_url(app: AppHandle, url: Option<String>) -> Result<(
             store.delete(DEFAULT_SERVER_URL_KEY);
         }
     }
+
+    store
+        .save()
+        .map_err(|e| format!("Failed to save settings: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(windows)]
+#[tauri::command]
+fn get_disable_hardware_acceleration(app: AppHandle) -> Result<bool, String> {
+    let store = app
+        .store(SETTINGS_STORE)
+        .map_err(|e| format!("Failed to open settings store: {}", e))?;
+
+    let value = store.get(DISABLE_HARDWARE_ACCEL_KEY);
+    match value {
+        Some(v) => Ok(v.as_bool().unwrap_or(false)),
+        None => Ok(false),
+    }
+}
+
+#[cfg(windows)]
+#[tauri::command]
+async fn set_disable_hardware_acceleration(app: AppHandle, disabled: bool) -> Result<(), String> {
+    let store = app
+        .store(SETTINGS_STORE)
+        .map_err(|e| format!("Failed to open settings store: {}", e))?;
+
+    store.set(DISABLE_HARDWARE_ACCEL_KEY, serde_json::Value::Bool(disabled));
 
     store
         .save()
@@ -282,14 +313,32 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(PinchZoomDisablePlugin)
         .plugin(tauri_plugin_decorum::init())
-        .invoke_handler(tauri::generate_handler![
-            kill_sidecar,
-            install_cli,
-            ensure_server_ready,
-            get_default_server_url,
-            set_default_server_url,
-            markdown::parse_markdown_command
-        ])
+        .invoke_handler({
+            #[cfg(windows)]
+            {
+                tauri::generate_handler![
+                    kill_sidecar,
+                    install_cli,
+                    ensure_server_ready,
+                    get_default_server_url,
+                    set_default_server_url,
+                    get_disable_hardware_acceleration,
+                    set_disable_hardware_acceleration,
+                    markdown::parse_markdown_command
+                ]
+            }
+            #[cfg(not(windows))]
+            {
+                tauri::generate_handler![
+                    kill_sidecar,
+                    install_cli,
+                    ensure_server_ready,
+                    get_default_server_url,
+                    set_default_server_url,
+                    markdown::parse_markdown_command
+                ]
+            }
+        })
         .setup(move |app| {
             let app = app.handle().clone();
 
@@ -312,6 +361,16 @@ pub fn run() {
                 .find(|w| w.label == "main")
                 .expect("main window config missing");
 
+            // Check if hardware acceleration is disabled (Windows only)
+            #[cfg(windows)]
+            let disable_gpu = {
+                let store = app.store(SETTINGS_STORE).ok();
+                store
+                    .and_then(|s| s.get(DISABLE_HARDWARE_ACCEL_KEY))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            };
+
             let window_builder = WebviewWindowBuilder::from_config(&app, config)
                 .expect("Failed to create window builder from config")
                 .inner_size(size.width as f64, size.height as f64)
@@ -321,6 +380,15 @@ pub fn run() {
                       window.__OPENCODE__.updaterEnabled = {updater_enabled};
                     "#
                 ));
+
+            // Apply GPU disable flag on Windows if setting is enabled
+            #[cfg(windows)]
+            let window_builder = if disable_gpu {
+                println!("Hardware acceleration disabled via settings");
+                window_builder.additional_browser_args("--disable-gpu")
+            } else {
+                window_builder
+            };
 
             #[cfg(target_os = "macos")]
             let window_builder = window_builder

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -320,6 +320,18 @@ const createPlatform = (password: Accessor<string | null>): Platform => ({
   parseMarkdown: async (markdown: string) => {
     return invoke<string>("parse_markdown_command", { markdown })
   },
+
+  // Windows-only: hardware acceleration toggle
+  ...(ostype() === "windows"
+    ? {
+        getDisableHardwareAcceleration: async () => {
+          return invoke<boolean>("get_disable_hardware_acceleration").catch(() => false)
+        },
+        setDisableHardwareAcceleration: async (disabled: boolean) => {
+          await invoke("set_disable_hardware_acceleration", { disabled })
+        },
+      }
+    : {}),
 })
 
 createMenu()


### PR DESCRIPTION
## Summary

Adds a setting to disable hardware acceleration on Windows.

## Problem

I experienced an issue where OpenCode stops responding while video is playing in Chromium-based browsers (Chrome, Edge). Adding this toggle so users can try disabling GPU acceleration if they have similar issues.

## Solution

- Added "Disable hardware acceleration" toggle in Settings > General > Advanced (Windows only)
- Passes `--disable-gpu` flag to WebView2 at startup
- Requires app restart to take effect

## Changes

- `packages/desktop/src-tauri/src/lib.rs` - Read setting at startup, pass browser args
- `packages/desktop/src/index.tsx` - Platform methods for get/set
- `packages/app/src/context/platform.tsx` - Type definitions
- `packages/app/src/components/settings-general.tsx` - UI toggle
- `packages/app/src/i18n/en.ts` - Translations

---

**Note:** Apologies for the earlier mess - branch had unrelated commits and description incorrectly referenced memory leak issues. Cleaned up now.

Fixes #10424