### PR TITLE
docs(docs):add introduction draft

### DIFF
--- a/packages/docs/index.mdx
+++ b/packages/docs/index.mdx
@@ -1,56 +1,36 @@
 ---
 title: "Introduction"
-description: "Welcome to the new home for your documentation"
+description: "OpenCode is the open source AI coding agent for the terminal."
 ---
 
-## Setting up
+## What is OpenCode
 
-Get your documentation site up and running in minutes.
+OpenCode is an open source AI coding agent focused on the terminal experience.
+It runs locally, supports multiple model providers, and offers both a TUI and API-based workflows.
+You can use it to explore codebases, make changes, run tests, and automate common engineering tasks.
 
-<Card title="Start here" icon="rocket" href="/quickstart" horizontal>
-  Follow our three step quickstart guide.
+## Quick start
+
+<Card title="Install OpenCode" icon="rocket" href="https://opencode.ai/install" horizontal>
+  One command installation for macOS, Linux, and Windows.
 </Card>
 
-## Make it yours
-
-Design a docs site that looks great and empowers your users.
-
 <Columns cols={2}>
-  <Card title="Edit locally" icon="pen-to-square" href="/development">
-    Edit your docs locally and preview them in real time.
+  <Card title="Run the TUI" icon="terminal" href="/quickstart">
+    Launch OpenCode and start a session in minutes.
   </Card>
-  <Card title="Customize your site" icon="palette" href="/essentials/settings">
-    Customize the design and colors of your site to match your brand.
-  </Card>
-  <Card title="Set up navigation" icon="map" href="/essentials/navigation">
-    Organize your docs to help users find what they need and succeed with your product.
-  </Card>
-  <Card title="API documentation" icon="terminal" href="/api-reference/introduction">
-    Auto-generate API documentation from OpenAPI specifications.
+  <Card title="Local development" icon="wrench" href="/development">
+    Preview docs locally and learn the basics.
   </Card>
 </Columns>
 
-## Create beautiful pages
-
-Everything you need to create world-class documentation.
+## Community & source
 
 <Columns cols={2}>
-  <Card title="Write with MDX" icon="pen-fancy" href="/essentials/markdown">
-    Use MDX to style your docs pages.
+  <Card title="GitHub" icon="github" href="https://github.com/anomalyco/opencode">
+    Issues, roadmap, and pull requests live here.
   </Card>
-  <Card title="Code samples" icon="code" href="/essentials/code">
-    Add sample code to demonstrate how to use your product.
-  </Card>
-  <Card title="Images" icon="image" href="/essentials/images">
-    Display images and other media.
-  </Card>
-  <Card title="Reusable snippets" icon="recycle" href="/essentials/reusable-snippets">
-    Write once and reuse across your docs.
+  <Card title="Discord" icon="comments" href="https://opencode.ai/discord">
+    Ask questions, share tips, and get help from the community.
   </Card>
 </Columns>
-
-## Need inspiration?
-
-<Card title="See complete examples" icon="stars" href="https://mintlify.com/customers">
-  Browse our showcase of exceptional documentation sites.
-</Card>


### PR DESCRIPTION
### What does this PR do?
Adds an English OpenCode introduction page draft in `opencode/packages/docs/index.mdx' for docs homepage content.
### How did you verify your code works?
Not applicable (documentation content only; no runtime behavior).