### PR TITLE
fix(provider): deep merge providerOptions in applyCaching

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1,5 +1,5 @@
 import type { APICallError, ModelMessage } from "ai"
-import { unique } from "remeda"
+import { mergeDeep, unique } from "remeda"
 import type { JSONSchema } from "zod/v4/core"
 import type { Provider } from "./provider"
 import type { ModelsDev } from "./models"
@@ -186,18 +186,12 @@ export namespace ProviderTransform {
       if (shouldUseContentOptions) {
         const lastContent = msg.content[msg.content.length - 1]
         if (lastContent && typeof lastContent === "object") {
-          lastContent.providerOptions = {
-            ...lastContent.providerOptions,
-            ...providerOptions,
-          }
+          lastContent.providerOptions = mergeDeep(lastContent.providerOptions ?? {}, providerOptions)
           continue
         }
       }
 
-      msg.providerOptions = {
-        ...msg.providerOptions,
-        ...providerOptions,
-      }
+      msg.providerOptions = mergeDeep(msg.providerOptions ?? {}, providerOptions)
     }
 
     return msgs


### PR DESCRIPTION
## Summary

Fixes #10241

Previously, `applyCaching` used shallow spreading (`{...a, ...b}`) to merge `providerOptions`, which would completely overwrite nested keys like `openaiCompatible`. This caused options set by `normalizeMessages` (e.g., `reasoning_content` for interleaved models) to be lost when `applyCaching` ran.

## Changes

- Import `mergeDeep` from remeda
- Replace shallow spread with `mergeDeep()` for both message-level and content-level providerOptions

Now using remeda's `mergeDeep` to properly preserve existing nested properties while adding cache control options.

## Test Plan

- [x] Existing provider transform tests pass (75 tests)
- [x] TypeScript type checking passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)