### PR TITLE
fix(app): Always close hovercard when view-sessions clicked

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2156,8 +2156,8 @@ export default function Layout(props: ParentProps) {
                 class="flex w-full text-left justify-start text-text-base px-2 hover:bg-transparent active:bg-transparent"
                 onClick={() => {
                   layout.sidebar.open()
+                  setOpen(false)
                   if (selected()) {
-                    setOpen(false)
                     return
                   }
                   navigateToProject(props.project.worktree)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where clicking "View all sessions" on unopen projects doesn't close hovercard. 

Before: 

https://github.com/user-attachments/assets/80ed711e-31bc-4456-8541-a1d77f41e6b5

After:

https://github.com/user-attachments/assets/e70df4e2-d5b2-49a7-8d70-3a2cd3094ebc


After:

### How did you verify your code works?
tested, see above

Fixes: https://github.com/anomalyco/opencode/issues/10325
