### PR TITLE
fix(app): Fix plan mode btn keyboard a11y issues

### DIFF
--- a/packages/ui/src/components/select.css
+++ b/packages/ui/src/components/select.css
@@ -36,7 +36,7 @@
         background-color: var(--button-secondary-base);
       }
       &[data-variant="ghost"] {
-        background-color: transparent;
+        background-color: var(--surface-raised-base-hover);
       }
       &[data-variant="primary"] {
         background-color: var(--icon-strong-base);

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -39,13 +39,13 @@ export function Tooltip(props: TooltipProps) {
   onMount(() => {
     const childElements = c()
     if (childElements instanceof HTMLElement) {
-      childElements.addEventListener("focus", () => setOpen(true))
-      childElements.addEventListener("blur", () => setOpen(false))
+      childElements.addEventListener("focusin", () => setOpen(true))
+      childElements.addEventListener("focusout", () => setOpen(false))
     } else if (Array.isArray(childElements)) {
       for (const child of childElements) {
         if (child instanceof HTMLElement) {
-          child.addEventListener("focus", () => setOpen(true))
-          child.addEventListener("blur", () => setOpen(false))
+          child.addEventListener("focusin", () => setOpen(true))
+          child.addEventListener("focusout", () => setOpen(false))
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
FIxes plan mode btn's missing: 
- hover style
- tooltip

on keyboard focus


### Before: 

https://github.com/user-attachments/assets/60443c46-c186-486f-959b-8998c7844074

### After: 

https://github.com/user-attachments/assets/2a5b77d7-aa8c-40ec-a7bc-5ef97d5c1db7

### Bonus `:focus` issue fixed by this pr 

#### Before: 

https://github.com/user-attachments/assets/99f1d8ac-d239-4e1b-9746-f04a48951baf


#### After: 

https://github.com/user-attachments/assets/57486328-d1c1-441c-ad7d-f174bb823bfa





### How did you verify your code works?

Fixes: https://github.com/anomalyco/opencode/issues/10329