### PR TITLE
fix(tui): Use selectedForeground for question prompt tab text visibility (resolves #10334)

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -3,7 +3,7 @@ import { createMemo, For, Show } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
-import { tint, useTheme } from "../../context/theme"
+import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../component/border"
@@ -272,7 +272,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                     backgroundColor={isActive() ? theme.accent : theme.backgroundElement}
                     onMouseUp={() => selectTab(index())}
                   >
-                    <text fg={isActive() ? theme.selectedListItemText : isAnswered() ? theme.text : theme.textMuted}>
+                    <text fg={isActive() ? selectedForeground(theme, theme.accent) : isAnswered() ? theme.text : theme.textMuted}>
                       {q.header}
                     </text>
                   </box>
@@ -285,7 +285,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               backgroundColor={confirm() ? theme.accent : theme.backgroundElement}
               onMouseUp={() => selectTab(questions().length)}
             >
-              <text fg={confirm() ? theme.selectedListItemText : theme.textMuted}>Confirm</text>
+              <text fg={confirm() ? selectedForeground(theme, theme.accent) : theme.textMuted}>Confirm</text>
             </box>
           </box>
         </Show>


### PR DESCRIPTION
### What does this PR do?

For the `question` tool, implements a similar fix to that in these previously merged PRs resolving similar issues in other locations:

PR #4572 (resolved issue #4369)
PR #7251 (resolved issue #7251)

### How did you verify your code works?

Manual before/after testing.

#### Before

<img width="648" height="396" alt="before" src="https://github.com/user-attachments/assets/70f4212b-8ce7-4719-b1ad-a32a7038adf3" />

#### After

<img width="723" height="379" alt="after" src="https://github.com/user-attachments/assets/e4cf96a2-625a-4aaa-b45e-7de10abefd1f" />

#### Note

Disregard the branch name, it's vestigial.

Resolves #10334.