### PR TITLE
fix: permission prompt should ignore keyboard events while dialog stack len > 0

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -14,6 +14,7 @@ import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
 import { Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 import { Global } from "@/global"
+import { useDialog } from "../../ui/dialog"
 
 type PermissionStage = "permission" | "always" | "reject"
 
@@ -304,8 +305,11 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
   const textareaKeybindings = useTextareaKeybindings()
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
+  const dialog = useDialog()
 
   useKeyboard((evt) => {
+    if (dialog.stack.length > 0) return
+
     if (evt.name === "escape" || keybind.match("app_exit", evt)) {
       evt.preventDefault()
       props.onCancel()
@@ -384,8 +388,11 @@ function Prompt<const T extends Record<string, string>>(props: {
   })
   const diffKey = Keybind.parse("ctrl+f")[0]
   const narrow = createMemo(() => dimensions().width < 80)
+  const dialog = useDialog()
 
   useKeyboard((evt) => {
+    if (dialog.stack.length > 0) return
+
     if (evt.name === "left" || evt.name == "h") {
       evt.preventDefault()
       const idx = keys.indexOf(store.selected)


### PR DESCRIPTION
### What does this PR do?
- Fixes #10286 (using exact same pattern as https://github.com/anomalyco/opencode/blob/af5e405391efa8ca16fe81159422457e858c3a20/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx#L122-L126)

### How did you verify your code works?
Manually tested all combinations of permission prompt being open, including the subagent rejection prompt, then opening the command palette, using keys that the permission prompts would react to, potentially changing settings or opening other dialogs such as the "connect a provider".