### PR TITLE
feat: use incremental port assignment instead of random ports

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -546,7 +546,20 @@ export namespace Server {
         return undefined
       }
     }
-    const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
+
+    let server: ReturnType<typeof Bun.serve> | undefined
+    const startPort = opts.port === 0 ? 4096 : opts.port
+    const maxAttempts = 10
+
+    // Try incremental ports starting from the specified/default port
+    for (let i = 0; i < maxAttempts; i++) {
+      server = tryServe(startPort + i)
+      if (server) break
+    }
+
+    // Fall back to OS-assigned port if all attempts fail
+    if (!server) server = tryServe(0)
+
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
     _url = server.url


### PR DESCRIPTION
## Summary

When the default port 4096 is occupied, the server now tries incremental ports (4097, 4098, etc.) instead of falling back to a random OS-assigned port.

## Changes

- Modified server port selection logic in `packages/opencode/src/server/server.ts`
- Server now tries up to 10 incremental ports before falling back to OS-assigned port
- Works for both default port (4096) and custom ports via `--port` flag

## Verification

Tested with multiple server instances:

**Default port behavior:**
- Server 1: Port 4096 ✓
- Server 2: Port 4097 ✓
- Server 3: Port 4098 ✓

**Custom port behavior (--port 5000):**
- Server 1: Port 5000 ✓
- Server 2: Port 5001 ✓
- Server 3: Port 5002 ✓

Verified with `lsof` that each server listens on the expected incremental port.

Fixes #10357