### PR TITLE
feat(app): add open project button to directory dialog

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -2,9 +2,10 @@ import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { List } from "@opencode-ai/ui/list"
+import { Button } from "@opencode-ai/ui/button"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
-import { createMemo } from "solid-js"
+import { createMemo, createSignal, Show } from "solid-js"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
@@ -20,6 +21,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const sdk = useGlobalSDK()
   const dialog = useDialog()
   const language = useLanguage()
+  const [searchQuery, setSearchQuery] = createSignal("")
 
   const home = createMemo(() => sync.data.path.home)
 
@@ -173,14 +175,37 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     dialog.close()
   }
 
+  function resolvePath() {
+    const query = searchQuery()
+    const input = scoped(query)
+    if (!input) return
+
+    const raw = normalizeDriveRoot(query.trim())
+    const isPath = raw.startsWith("~") || !!rootOf(raw) || raw.includes("/")
+
+    if (isPath) {
+      resolve(join(input.directory, input.path))
+    }
+  }
+
   return (
     <Dialog title={props.title ?? language.t("command.project.open")}>
       <List
         search={{ placeholder: language.t("dialog.directory.search.placeholder"), autofocus: true }}
-        emptyMessage={language.t("dialog.directory.empty")}
+        emptyMessage={
+          <div class="flex flex-col gap-2 items-center justify-center py-4">
+            <span class="text-text-weak">{language.t("dialog.directory.empty")}</span>
+            <Show when={searchQuery().includes("/") || searchQuery().includes("\\") || searchQuery().startsWith("~")}>
+              <Button variant="secondary" onClick={() => resolvePath()}>
+                Open "{searchQuery()}"
+              </Button>
+            </Show>
+          </div>
+        }
         loadingMessage={language.t("common.loading")}
         items={directories}
         key={(x) => x}
+        onSearch={setSearchQuery}
         onSelect={(path) => {
           if (!path) return
           resolve(path)

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -24,10 +24,11 @@ export interface ListSearchProps {
 export interface ListProps<T> extends FilteredListProps<T> {
   class?: string
   children: (item: T) => JSX.Element
-  emptyMessage?: string
+  emptyMessage?: string | JSX.Element
   loadingMessage?: string
   onKeyEvent?: (event: KeyboardEvent, item: T | undefined) => void
   onMove?: (item: T | undefined) => void
+  onSearch?: (query: string) => void
   activeIcon?: IconProps["name"]
   filter?: string
   search?: ListSearchProps | boolean
@@ -84,6 +85,7 @@ export function List<T>(props: ListProps<T> & { ref?: (ref: ListRef) => void }) 
     const current = internalFilter()
     if (prev !== current) {
       onInput(current)
+      props.onSearch?.(current)
     }
     return current
   }, "")


### PR DESCRIPTION
## Summary
This PR adds a feature to the "Open Project" dialog that allows users to explicitly open a directory path if it's not found in the search results.

<img width="2864" height="1450" alt="image" src="https://github.com/user-attachments/assets/17c620f2-6f36-49a6-ad1a-d6f2375a755c" />


## Motivation
The current project search functionality has limitations where it only indexes files up to a specific nested level. This makes it impossible to find and open projects that are deeply nested or outside the scanned depth, effectively making them inaccessible via the UI search.

This change provides a fallback mechanism: if a user explicitly types a valid path (Unix or Windows style), they can open it directly even if the search indexer hasn't found it.

## Changes
- Adds logic to detect if the search query looks like a path (contains `/`, `\` or starts with `~`).
- Displays an "Open [path]" button when no search results are found but a valid path is entered.
- Updates `List` component to support custom empty messages.
- Ensures the project is added to the sidebar when a new session is started.

## Verification
- Verified that typing a path like `~/Dev/my-project` or `C:\Dev\my-project` displays an "Open" button when no results are found.
- Verified that clicking the button opens the project.
- Verified type safety with `bun typecheck`.

Partially fixes https://github.com/anomalyco/opencode/issues/7577
Partially fixes https://github.com/anomalyco/opencode/issues/7111