### PR TITLE
fix(tests): Prevent tests from overwriting auth.json (#10370)

### DIFF
--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -5,7 +5,6 @@ import path from "path"
 import fs from "fs/promises"
 import fsSync from "fs"
 import { afterAll } from "bun:test"
-const { Global } = await import("../src/global")
 
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
@@ -22,6 +21,8 @@ process.env["XDG_DATA_HOME"] = path.join(dir, "share")
 process.env["XDG_CACHE_HOME"] = path.join(dir, "cache")
 process.env["XDG_CONFIG_HOME"] = path.join(dir, "config")
 process.env["XDG_STATE_HOME"] = path.join(dir, "state")
+
+const { Global } = await import("../src/global")
 
 // Pre-fetch models.json so tests don't need the macro fallback
 // Also write the cache version file to prevent global/index.ts from clearing the cache

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -24,6 +24,13 @@ process.env["XDG_STATE_HOME"] = path.join(dir, "state")
 
 const { Global } = await import("../src/global")
 
+if (!Global.Path.data.startsWith(dir)) {
+  throw new Error(
+    `Test isolation failed: Global.Path.data="${Global.Path.data}" expected prefix "${dir}". ` +
+      "Ensure XDG env vars are set before importing from src/.",
+  )
+}
+
 // Pre-fetch models.json so tests don't need the macro fallback
 // Also write the cache version file to prevent global/index.ts from clearing the cache
 const cacheDir = path.join(dir, "cache", "opencode")


### PR DESCRIPTION
## Problem
Tests overwrite the user's auth.json because the test preload imports Global before XDG test env vars are set, so xdg-basedir resolves to the real home directory.

## Solution
- Defer the Global import until after the test XDG/OPENCODE_TEST_HOME env vars are set
- Fail fast if Global.Path.data resolves outside the temp test directory

## Notes
- Closes #10370
- AI Assistance: OpenCode + gpt-5.2-codex
- Testing: `bun turbo typecheck` (pre-push hook)
- Review: Human operator reviewed