### PR TITLE
fix(app): markdown rendering with morphdom for better dom functions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -423,6 +423,7 @@
         "marked": "catalog:",
         "marked-katex-extension": "5.1.6",
         "marked-shiki": "catalog:",
+        "morphdom": "2.7.8",
         "remeda": "catalog:",
         "shiki": "catalog:",
         "solid-js": "catalog:",
@@ -3101,6 +3102,8 @@
     "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
 
     "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
+
+    "morphdom": ["morphdom@2.7.8", "", {}, "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,6 +56,7 @@
     "marked": "catalog:",
     "marked-katex-extension": "5.1.6",
     "marked-shiki": "catalog:",
+    "morphdom": "2.7.8",
     "remeda": "catalog:",
     "shiki": "catalog:",
     "solid-js": "catalog:",


### PR DESCRIPTION
### What does this PR do?

Fixes scroll jumping/flickering that occurred when streaming markdown content with code blocks. 

Adam (@adamdotdevin) What I did is 
- Replace `innerHTML` with `morphdom` for incremental DOM updates
- Configure morphdom to preserve copy button wrappers (data-component="markdown-code") and buttons (data-slot="markdown-copy-button")
- Debounce setupCodeCopy() by 150ms so it only runs after content settles, not on every streaming update (for better ux uk)

Watch this videos for see the diff: 

Issue:
Video: https://www.youtube.com/watch?v=rn7zQlxb1yU
(make sure you watch this video before 24 hours of pr created otherwise it will get deleted xD)


Solution:
Video: https://www.youtube.com/watch?v=B3NQV7KJp3o
(make sure you watch this video before 24 hours of pr created otherwise it will get deleted xD)


- 
### How did you verify your code works?

  - [x] Tested streaming responses with multiple code blocks
  - [x] Verified scroll follows content smoothly without jumping
  - [x] Verified copy buttons appear and work correctly after streaming completes
  - [x] Verified user scroll-up pauses auto-scroll, scroll-to-bottom resumes it


@adamdotdevin ready for merge!
solves issue: #10372 