### PR TITLE
fix: clarify agent locations in TUI tip - Issue #10343

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -91,7 +91,7 @@ const TIPS = [
   "Add {highlight}.md{/highlight} files to {highlight}.opencode/command/{/highlight} to define reusable custom prompts",
   "Use {highlight}$ARGUMENTS{/highlight}, {highlight}$1{/highlight}, {highlight}$2{/highlight} in custom commands for dynamic input",
   "Use backticks in commands to inject shell output (e.g., {highlight}`git status`{/highlight})",
-  "Add {highlight}.md{/highlight} files to {highlight}.opencode/agent/{/highlight} for specialized AI personas",
+  "Add {highlight}.md{/highlight} files to {highlight}.opencode/agent/{/highlight} or {highlight}~/.config/opencode/agent/{/highlight} for custom AI personas",
   "Configure per-agent permissions for {highlight}edit{/highlight}, {highlight}bash{/highlight}, and {highlight}webfetch{/highlight} tools",
   'Use patterns like {highlight}"git *": "allow"{/highlight} for granular bash permissions',
   'Set {highlight}"rm -rf *": "deny"{/highlight} to block destructive commands',


### PR DESCRIPTION
## Problem
The TUI tip suggested agents can only be placed in `.opencode/agent/`, but agents can also be added globally in `~/.config/opencode/agent/`.

## Solution
Updated tip to show both locations:

```typescript
// Before:
"Add {highlight}.md{/highlight} files to {highlight}.opencode/agent/{/highlight} for specialized AI personas"

// After:
"Add {highlight}.md{/highlight} files to {highlight}.opencode/agent/{/highlight} or {highlight}~/.config/opencode/agent/{/highlight} for custom AI personas"
```

## Impact
Users now know they can create agents at both:
- **Project level**: `.opencode/agent/` (project-specific)
- **Global level**: `~/.config/opencode/agent/` (available in all projects)

## Testing
- Verified with existing test suite (752/759 tests passing)
- Visual verification of tip in TUI

Fixes #10343