### PR TITLE
fix: parse Kimi K2 Thinking tool calls with special tokens

### DIFF
--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -173,7 +173,7 @@ export async function handler(
 
     // Handle non-streaming response
     if (!isStream) {
-      const responseConverter = createResponseConverter(providerInfo.format, opts.format)
+      const responseConverter = createResponseConverter(providerInfo.format, opts.format, modelInfo.toolCallFormat)
       const json = await res.json()
       const body = JSON.stringify(responseConverter(json))
       logger.metric({ response_length: body.length })
@@ -193,7 +193,7 @@ export async function handler(
     }
 
     // Handle streaming response
-    const streamConverter = createStreamPartConverter(providerInfo.format, opts.format)
+    const streamConverter = createStreamPartConverter(providerInfo.format, opts.format, modelInfo.toolCallFormat)
     const usageParser = providerInfo.createUsageParser()
     const binaryDecoder = providerInfo.createBinaryStreamDecoder()
     const stream = new ReadableStream({
@@ -251,8 +251,15 @@ export async function handler(
                 usageParser.parse(part)
 
                 if (providerInfo.format !== opts.format) {
-                  part = streamConverter(part)
-                  c.enqueue(encoder.encode(part + "\n\n"))
+                  const converted = streamConverter(part)
+                  if (converted === null) continue
+                  if (Array.isArray(converted)) {
+                    for (const item of converted) {
+                      c.enqueue(encoder.encode(item + "\n\n"))
+                    }
+                  } else {
+                    c.enqueue(encoder.encode(converted + "\n\n"))
+                  }
                 }
               }
 

--- a/packages/console/app/src/routes/zen/util/provider/kimi.ts
+++ b/packages/console/app/src/routes/zen/util/provider/kimi.ts
@@ -1,0 +1,213 @@
+/**
+ * Kimi K2 Thinking model tool call parser
+ *
+ * Kimi K2 Thinking uses special tokens for tool calls:
+ * - <|tool_calls_section_begin|> / <|tool_calls_section_end|> wraps all tool calls
+ * - <|tool_call_begin|> / <|tool_call_end|> wraps each tool call
+ * - <|tool_call_argument_begin|> separates tool ID from arguments
+ *
+ * Tool ID format: "functions.{func_name}:{idx}"
+ *
+ * Example:
+ * <|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{"city":"Beijing"}<|tool_call_end|><|tool_calls_section_end|>
+ */
+
+export interface KimiToolCall {
+  id: string
+  type: "function"
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+const TOOL_CALLS_SECTION_BEGIN = "<|tool_calls_section_begin|>"
+const TOOL_CALLS_SECTION_END = "<|tool_calls_section_end|>"
+
+const TOOL_CALL_PATTERN =
+  /<\|tool_call_begin\|>\s*(?<id>[\w\.:\-]+)\s*<\|tool_call_argument_begin\|>\s*(?<arguments>[\s\S]*?)\s*<\|tool_call_end\|>/g
+
+/**
+ * Check if content contains Kimi K2 special tool call tokens
+ */
+export function hasKimiToolCalls(content: string | null | undefined): boolean {
+  if (!content) return false
+  return content.includes(TOOL_CALLS_SECTION_BEGIN)
+}
+
+/**
+ * Extract tool calls from Kimi K2 Thinking format
+ *
+ * @param content - Raw content that may contain Kimi tool call tokens
+ * @returns Array of parsed tool calls in OpenAI format
+ */
+export function extractKimiToolCalls(content: string): KimiToolCall[] {
+  if (!hasKimiToolCalls(content)) return []
+
+  const toolCalls: KimiToolCall[] = []
+
+  // Reset regex state
+  TOOL_CALL_PATTERN.lastIndex = 0
+
+  let match
+  while ((match = TOOL_CALL_PATTERN.exec(content)) !== null) {
+    const { id, arguments: args } = match.groups!
+
+    // Parse function name from ID format: "functions.get_weather:0"
+    const name = parseKimiFunctionName(id)
+    if (!name) continue
+
+    toolCalls.push({
+      id,
+      type: "function",
+      function: {
+        name,
+        arguments: args.trim(),
+      },
+    })
+  }
+
+  return toolCalls
+}
+
+/**
+ * Parse function name from Kimi tool call ID
+ *
+ * ID format: "functions.{func_name}:{idx}"
+ * Example: "functions.get_weather:0" -> "get_weather"
+ */
+function parseKimiFunctionName(id: string): string | null {
+  if (!id) return null
+
+  // Handle format: functions.name:idx
+  const parts = id.split(".")
+  if (parts.length < 2) return null
+
+  const nameWithIdx = parts.slice(1).join(".")
+  const name = nameWithIdx.split(":")[0]
+
+  return name || null
+}
+
+/**
+ * Remove Kimi tool call tokens from content, leaving only regular text
+ *
+ * @param content - Raw content with potential Kimi tokens
+ * @returns Content with tool call sections removed
+ */
+export function stripKimiToolCallTokens(content: string): string {
+  if (!hasKimiToolCalls(content)) return content
+
+  // Remove entire tool_calls_section
+  const sectionPattern = /<\|tool_calls_section_begin\|>[\s\S]*?<\|tool_calls_section_end\|>/g
+  return content.replace(sectionPattern, "").trim()
+}
+
+/**
+ * Process Kimi K2 response content - extract tool calls and clean content
+ *
+ * @param content - Raw content from Kimi K2 Thinking model
+ * @returns Object with cleaned content and extracted tool calls
+ */
+export function processKimiContent(content: string | null | undefined): {
+  content: string
+  toolCalls: KimiToolCall[]
+} {
+  if (!content) {
+    return { content: "", toolCalls: [] }
+  }
+
+  const toolCalls = extractKimiToolCalls(content)
+  const cleanedContent = stripKimiToolCallTokens(content)
+
+  return {
+    content: cleanedContent,
+    toolCalls,
+  }
+}
+
+export interface KimiStreamState {
+  buffer: string
+  emittedToolCallIndices: Set<number>
+  isInToolCallSection: boolean
+}
+
+export function createKimiStreamParser() {
+  const state: KimiStreamState = {
+    buffer: "",
+    emittedToolCallIndices: new Set(),
+    isInToolCallSection: false,
+  }
+
+  return {
+    append(content: string): {
+      textToEmit: string
+      toolCalls: Array<KimiToolCall & { index: number }>
+      isComplete: boolean
+    } {
+      state.buffer += content
+
+      const result: {
+        textToEmit: string
+        toolCalls: Array<KimiToolCall & { index: number }>
+        isComplete: boolean
+      } = {
+        textToEmit: "",
+        toolCalls: [],
+        isComplete: false,
+      }
+
+      if (!state.isInToolCallSection && state.buffer.includes(TOOL_CALLS_SECTION_BEGIN)) {
+        state.isInToolCallSection = true
+        const idx = state.buffer.indexOf(TOOL_CALLS_SECTION_BEGIN)
+        result.textToEmit = state.buffer.substring(0, idx)
+        state.buffer = state.buffer.substring(idx)
+      }
+
+      if (!state.isInToolCallSection) {
+        result.textToEmit = state.buffer
+        state.buffer = ""
+        return result
+      }
+
+      if (state.buffer.includes(TOOL_CALLS_SECTION_END)) {
+        result.isComplete = true
+        const toolCalls = extractKimiToolCalls(state.buffer)
+        toolCalls.forEach((tc, idx) => {
+          if (!state.emittedToolCallIndices.has(idx)) {
+            state.emittedToolCallIndices.add(idx)
+            result.toolCalls.push({ ...tc, index: idx })
+          }
+        })
+        state.buffer = ""
+        return result
+      }
+
+      TOOL_CALL_PATTERN.lastIndex = 0
+      const matches = [...state.buffer.matchAll(TOOL_CALL_PATTERN)]
+      matches.forEach((match, idx) => {
+        if (!state.emittedToolCallIndices.has(idx)) {
+          const { id, arguments: args } = match.groups!
+          const name = id.split(".")[1]?.split(":")[0]
+          if (name) {
+            state.emittedToolCallIndices.add(idx)
+            result.toolCalls.push({
+              id,
+              type: "function",
+              function: { name, arguments: args.trim() },
+              index: idx,
+            })
+          }
+        }
+      })
+
+      return result
+    },
+
+    reset() {
+      state.buffer = ""
+      state.emittedToolCallIndices.clear()
+      state.isInToolCallSection = false
+    },
+  }
+}

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -1,4 +1,5 @@
 import { ProviderHelper, CommonRequest, CommonResponse, CommonChunk } from "./provider"
+import { hasKimiToolCalls, processKimiContent, createKimiStreamParser, type KimiToolCall } from "./kimi"
 
 type Usage = {
   prompt_tokens?: number
@@ -211,7 +212,7 @@ export function toOaCompatibleRequest(body: CommonRequest) {
   }
 }
 
-export function fromOaCompatibleResponse(resp: any): CommonResponse {
+export function fromOaCompatibleResponse(resp: any, toolCallFormat?: "kimi"): CommonResponse {
   if (!resp || typeof resp !== "object") return resp
 
   if (!Array.isArray((resp as any).choices)) return resp
@@ -223,9 +224,20 @@ export function fromOaCompatibleResponse(resp: any): CommonResponse {
   if (!message) return resp
 
   const content: any[] = []
+  let kimiToolCalls: KimiToolCall[] = []
 
   if (typeof message.content === "string" && message.content.length > 0) {
-    content.push({ type: "text", text: message.content })
+    // Parse Kimi tool calls if explicitly configured OR auto-detected in content
+    const shouldParseKimi = toolCallFormat === "kimi" || hasKimiToolCalls(message.content)
+    if (shouldParseKimi && hasKimiToolCalls(message.content)) {
+      const processed = processKimiContent(message.content)
+      if (processed.content.length > 0) {
+        content.push({ type: "text", text: processed.content })
+      }
+      kimiToolCalls = processed.toolCalls
+    } else {
+      content.push({ type: "text", text: message.content })
+    }
   }
 
   if (Array.isArray(message.tool_calls)) {
@@ -247,7 +259,23 @@ export function fromOaCompatibleResponse(resp: any): CommonResponse {
     }
   }
 
+  for (const tc of kimiToolCalls) {
+    let input
+    try {
+      input = JSON.parse(tc.function.arguments)
+    } catch {
+      input = tc.function.arguments
+    }
+    content.push({
+      type: "tool_use",
+      id: tc.id,
+      name: tc.function.name,
+      input,
+    })
+  }
+
   const stopReason = (() => {
+    if (kimiToolCalls.length > 0) return "tool_calls"
     const reason = choice.finish_reason
     if (reason === "stop") return "stop"
     if (reason === "tool_calls") return "tool_calls"
@@ -543,4 +571,85 @@ export function toOaCompatibleChunk(chunk: CommonChunk): string {
   }
 
   return `data: ${JSON.stringify(result)}`
+}
+
+export function createKimiAwareChunkParser() {
+  const kimiParser = createKimiStreamParser()
+  let pendingToolCallChunks: CommonChunk[] = []
+
+  return {
+    parse(chunk: string): CommonChunk[] {
+      const baseResult = fromOaCompatibleChunk(chunk)
+      if (typeof baseResult === "string") return []
+
+      const results: CommonChunk[] = []
+      const contentDelta = baseResult.choices[0]?.delta?.content
+
+      if (contentDelta) {
+        const parsed = kimiParser.append(contentDelta)
+
+        if (parsed.textToEmit) {
+          results.push({
+            ...baseResult,
+            choices: [
+              {
+                index: 0,
+                delta: { content: parsed.textToEmit },
+                finish_reason: null,
+              },
+            ],
+          })
+        }
+
+        for (const tc of parsed.toolCalls) {
+          results.push({
+            ...baseResult,
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: tc.index,
+                      id: tc.id,
+                      type: "function",
+                      function: {
+                        name: tc.function.name,
+                        arguments: tc.function.arguments,
+                      },
+                    },
+                  ],
+                },
+                finish_reason: null,
+              },
+            ],
+          })
+        }
+
+        if (parsed.isComplete && results.length === 0) {
+          results.push({
+            ...baseResult,
+            choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+          })
+        }
+
+        return results
+      }
+
+      if (baseResult.choices[0]?.delta?.tool_calls) {
+        return [baseResult]
+      }
+
+      if (baseResult.choices[0]?.finish_reason) {
+        return [baseResult]
+      }
+
+      return [baseResult]
+    },
+
+    reset() {
+      kimiParser.reset()
+      pendingToolCallChunks = []
+    },
+  }
 }

--- a/packages/console/app/src/routes/zen/util/provider/provider.ts
+++ b/packages/console/app/src/routes/zen/util/provider/provider.ts
@@ -22,6 +22,7 @@ import {
   toOaCompatibleChunk,
   toOaCompatibleRequest,
   toOaCompatibleResponse,
+  createKimiAwareChunkParser,
 } from "./openai-compatible"
 
 export type UsageInfo = {
@@ -176,16 +177,35 @@ export function createBodyConverter(from: ZenData.Format, to: ZenData.Format) {
   }
 }
 
-export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Format) {
+export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Format, toolCallFormat?: "kimi") {
+  let kimiParser: ReturnType<typeof createKimiAwareChunkParser> | null =
+    toolCallFormat === "kimi" ? createKimiAwareChunkParser() : null
+
   return (part: any): any => {
-    if (from === to) return part
+    if (from === to && !kimiParser && !part.includes?.("<|tool_call")) return part
+
+    if (from === "oa-compat" && part.includes?.("<|tool_call")) {
+      kimiParser ??= createKimiAwareChunkParser()
+    }
+
+    if (kimiParser && from === "oa-compat") {
+      const chunks = kimiParser.parse(part)
+      if (chunks.length === 0) return null
+
+      const results = chunks.map((chunk) => {
+        if (to === "anthropic") return toAnthropicChunk(chunk)
+        if (to === "openai") return toOpenaiChunk(chunk)
+        return toOaCompatibleChunk(chunk)
+      })
+
+      return results.length === 1 ? results[0] : results
+    }
 
     let raw: CommonChunk | string
     if (from === "anthropic") raw = fromAnthropicChunk(part)
     else if (from === "openai") raw = fromOpenaiChunk(part)
     else raw = fromOaCompatibleChunk(part)
 
-    // If result is a string (error case), pass it through
     if (typeof raw === "string") return raw
 
     if (to === "anthropic") return toAnthropicChunk(raw)
@@ -194,14 +214,14 @@ export function createStreamPartConverter(from: ZenData.Format, to: ZenData.Form
   }
 }
 
-export function createResponseConverter(from: ZenData.Format, to: ZenData.Format) {
+export function createResponseConverter(from: ZenData.Format, to: ZenData.Format, toolCallFormat?: "kimi") {
   return (response: any): any => {
-    if (from === to) return response
+    if (from === to && !toolCallFormat) return response
 
     let raw: CommonResponse
     if (from === "anthropic") raw = fromAnthropicResponse(response)
     else if (from === "openai") raw = fromOpenaiResponse(response)
-    else raw = fromOaCompatibleResponse(response)
+    else raw = fromOaCompatibleResponse(response, toolCallFormat)
 
     if (to === "anthropic") return toAnthropicResponse(raw)
     if (to === "openai") return toOpenaiResponse(raw)

--- a/packages/console/core/src/model.ts
+++ b/packages/console/core/src/model.ts
@@ -39,6 +39,7 @@ export namespace ZenData {
     trial: TrialSchema.optional(),
     rateLimit: z.number().optional(),
     fallbackProvider: z.string().optional(),
+    toolCallFormat: z.enum(["kimi"]).optional(),
     providers: z.array(
       z.object({
         id: z.string(),


### PR DESCRIPTION
Kimi K2 Thinking model uses special tokens for tool calls instead of standard OpenAI format:
<|tool_calls_section_begin|><|tool_call_begin|>functions.name:idx<|tool_call_argument_begin|>{...}<|tool_call_end|><|tool_calls_section_end|>

This PR adds:
- kimi.ts: Parser for Kimi special token format
- Support for toolCallFormat flag in ZenData model schema
- Auto-detection fallback when flag is not set
- Both streaming and non-streaming response handling

The parser activates when:
1. Model has toolCallFormat: "kimi" in config, OR
2. Response content contains <|tool_call tokens (auto-detect)

Fixes #9878

PR also: https://github.com/anomalyco/models.dev/pull/705