### PR TITLE
fix(app): expose context pane on mobile web

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1015,8 +1015,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             </div>
           </Show>
         </div>
-        <div class="relative p-3 flex items-center justify-between gap-2">
-          <div class="flex items-center gap-2 min-w-0 flex-1">
+        <div class="relative py-3 px-1 md:px-3 flex items-center justify-between">
+          <div class="flex items-center justify-start gap-0 md:gap-2 [&_[data-component=button]]:px-0.5 [&_[data-component=button]]:md:px-2 [&_[data-slot=select-select-trigger]]:px-0.5 [&_[data-slot=select-select-trigger]]:md:px-2">
             <Switch>
               <Match when={store.mode === "shell"}>
                 <div class="flex items-center gap-2 px-2 h-6">

--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -1,4 +1,4 @@
-import { Match, Show, Switch, createMemo } from "solid-js"
+import { Match, Show, Switch, createMemo, createSignal, onCleanup } from "solid-js"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { ProgressCircle } from "@opencode-ai/ui/progress-circle"
 import { Button } from "@opencode-ai/ui/button"
@@ -13,11 +13,17 @@ interface SessionContextUsageProps {
   variant?: "button" | "indicator"
 }
 
+const isTouch = () => window.matchMedia("(hover: none)").matches
+
 export function SessionContextUsage(props: SessionContextUsageProps) {
   const sync = useSync()
   const params = useParams()
   const layout = useLayout()
   const language = useLanguage()
+  const [touchTooltip, setTouchTooltip] = createSignal(false)
+  let tooltipTimer: number | undefined
+
+  onCleanup(() => clearTimeout(tooltipTimer))
 
   const variant = createMemo(() => props.variant ?? "button")
   const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
@@ -42,10 +48,30 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
   const openContext = () => {
     if (!params.id) return
     if (!view().reviewPanel.opened()) view().reviewPanel.open()
-    layout.fileTree.open()
     layout.fileTree.setTab("all")
+    layout.fileTree.open()
+    view().mobileTab.set("context")
     tabs().open("context")
     tabs().setActive("context")
+  }
+
+  const handleClick = () => {
+    if (variant() === "indicator") return
+    if (isTouch() && !touchTooltip()) {
+      setTouchTooltip(true)
+      clearTimeout(tooltipTimer)
+      tooltipTimer = window.setTimeout(() => setTouchTooltip(false), 3000)
+      return
+    }
+    setTouchTooltip(false)
+    openContext()
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    // On touch devices, we control the tooltip state ourselves via handleClick
+    // Ignore Kobalte's attempts to close it
+    if (isTouch()) return
+    setTouchTooltip(open)
   }
 
   const circle = () => (
@@ -79,7 +105,12 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
 
   return (
     <Show when={params.id}>
-      <Tooltip value={tooltipValue()} placement="top">
+      <Tooltip
+        value={tooltipValue()}
+        placement="top"
+        open={touchTooltip() || undefined}
+        onOpenChange={handleOpenChange}
+      >
         <Switch>
           <Match when={variant() === "indicator"}>{circle()}</Match>
           <Match when={true}>
@@ -87,7 +118,7 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
               type="button"
               variant="ghost"
               class="size-6"
-              onClick={openContext}
+              onClick={handleClick}
               aria-label={language.t("context.usage.view")}
             >
               {circle()}

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -334,14 +334,14 @@ export function SessionContextTab(props: SessionContextTabProps) {
 
   return (
     <div
-      class="@container h-full overflow-y-auto no-scrollbar pb-10"
+      class="@container h-full overflow-y-auto no-scrollbar md:pb-10 pb-[calc(var(--prompt-height,6rem)+32px)]"
       ref={(el) => {
         scroll = el
         restoreScroll()
       }}
       onScroll={handleScroll}
     >
-      <div class="px-6 pt-4 flex flex-col gap-10">
+      <div class="px-4 md:px-6 pt-4 flex flex-col gap-10">
         <div class="grid grid-cols-1 @[32rem]:grid-cols-2 gap-4">
           <For each={stats()}>{(stat) => <Stat label={stat.label} value={stat.value} />}</For>
         </div>

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -172,6 +172,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         mobileSidebar: {
           opened: false,
         },
+        mobileTab: "session" as "session" | "changes" | "context",
         sessionTabs: {} as Record<string, SessionTabs>,
         sessionView: {} as Record<string, SessionView>,
         handoff: {
@@ -723,6 +724,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
               if (same(current.reviewOpen, open)) return
               setStore("sessionView", session, "reviewOpen", open)
+            },
+          },
+          mobileTab: {
+            value: createMemo(() => store.mobileTab),
+            set(tab: "session" | "changes" | "context") {
+              setStore("mobileTab", tab)
             },
           },
         }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -565,7 +565,6 @@ export default function Page() {
     expanded: {} as Record<string, boolean>,
     messageId: undefined as string | undefined,
     turnStart: 0,
-    mobileTab: "session" as "session" | "changes",
     changes: "session" as "session" | "turn",
     newSessionWorktree: "main",
     promptHeight: 0,
@@ -888,7 +887,8 @@ export default function Page() {
       .filter((tab) => tab !== "context" && tab !== "review"),
   )
 
-  const mobileChanges = createMemo(() => !isDesktop() && store.mobileTab === "changes")
+  const mobileChanges = createMemo(() => !isDesktop() && view().mobileTab.value() === "changes")
+  const mobileContext = createMemo(() => !isDesktop() && view().mobileTab.value() === "context")
   const reviewTab = createMemo(() => isDesktop() && !layout.fileTree.opened())
 
   const fileTreeTab = () => layout.fileTree.tab()
@@ -1220,7 +1220,7 @@ export default function Page() {
 
     const wants = isDesktop()
       ? desktopFileTreeOpen() || (desktopReviewOpen() && activeTab() === "review")
-      : store.mobileTab === "changes"
+      : view().mobileTab.value() === "changes"
     if (!wants) return
     if (sync.data.session_diff[id] !== undefined) return
     if (sync.status === "loading") return
@@ -1534,14 +1534,31 @@ export default function Page() {
     <div class="relative bg-background-base size-full overflow-hidden flex flex-col">
       <SessionHeader />
       <div class="flex-1 min-h-0 flex flex-col md:flex-row">
-        <SessionMobileTabs
-          open={!isDesktop() && !!params.id}
-          hasReview={hasReview()}
-          reviewCount={reviewCount()}
-          onSession={() => setStore("mobileTab", "session")}
-          onChanges={() => setStore("mobileTab", "changes")}
-          t={language.t as (key: string, vars?: Record<string, string | number | boolean>) => string}
-        />
+        {/* Mobile tab bar - only shown on mobile when there's a session */}
+        <Show when={!isDesktop() && params.id}>
+          <Tabs
+            class="h-auto"
+            value={view().mobileTab.value()}
+            onChange={(value) => view().mobileTab.set(value as "session" | "changes" | "context")}
+          >
+            <Tabs.List>
+              <Tabs.Trigger value="session" class="w-1/3" classes={{ button: "w-full" }}>
+                {language.t("session.tab.session")}
+              </Tabs.Trigger>
+              <Tabs.Trigger value="changes" class="w-1/3" classes={{ button: "w-full" }}>
+                <Switch>
+                  <Match when={hasReview()}>
+                    {language.t("session.review.filesChanged", { count: reviewCount() })}
+                  </Match>
+                  <Match when={true}>{language.t("session.review.change.other")}</Match>
+                </Switch>
+              </Tabs.Trigger>
+              <Tabs.Trigger value="context" class="w-1/3 !border-r-0" classes={{ button: "w-full" }}>
+                {language.t("session.tab.context")}
+              </Tabs.Trigger>
+            </Tabs.List>
+          </Tabs>
+        </Show>
 
         {/* Session panel */}
         <div
@@ -1559,79 +1576,93 @@ export default function Page() {
             <Switch>
               <Match when={params.id}>
                 <Show when={activeMessage()}>
-                  <MessageTimeline
-                    mobileChanges={mobileChanges()}
-                    mobileFallback={reviewContent({
-                      diffStyle: "unified",
-                      classes: {
-                        root: "pb-[calc(var(--prompt-height,8rem)+32px)]",
-                        header: "px-4",
-                        container: "px-4",
-                      },
-                      loadingClass: "px-4 py-4 text-text-weak",
-                      emptyClass: "h-full px-4 pb-30 flex flex-col items-center justify-center text-center gap-6",
-                    })}
-                    scroll={ui.scroll}
-                    onResumeScroll={resumeScroll}
-                    setScrollRef={setScrollRef}
-                    onScheduleScrollState={scheduleScrollState}
-                    onAutoScrollHandleScroll={autoScroll.handleScroll}
-                    onMarkScrollGesture={markScrollGesture}
-                    hasScrollGesture={hasScrollGesture}
-                    isDesktop={isDesktop()}
-                    onScrollSpyScroll={scrollSpy.onScroll}
-                    onAutoScrollInteraction={autoScroll.handleInteraction}
-                    showHeader={!!(info()?.title || info()?.parentID)}
-                    centered={centered()}
-                    title={info()?.title}
-                    parentID={info()?.parentID}
-                    openTitleEditor={openTitleEditor}
-                    closeTitleEditor={closeTitleEditor}
-                    saveTitleEditor={saveTitleEditor}
-                    titleRef={(el) => {
-                      titleRef = el
-                    }}
-                    titleState={title}
-                    onTitleDraft={(value) => setTitle("draft", value)}
-                    onTitleMenuOpen={(open) => setTitle("menuOpen", open)}
-                    onTitlePendingRename={(value) => setTitle("pendingRename", value)}
-                    onNavigateParent={() => {
-                      navigate(`/${params.dir}/session/${info()?.parentID}`)
-                    }}
-                    sessionID={params.id!}
-                    onArchiveSession={(sessionID) => void archiveSession(sessionID)}
-                    onDeleteSession={(sessionID) => dialog.show(() => <DialogDeleteSession sessionID={sessionID} />)}
-                    t={language.t as (key: string, vars?: Record<string, string | number | boolean>) => string}
-                    setContentRef={(el) => {
-                      content = el
-                      autoScroll.contentRef(el)
+                  <Switch>
+                    <Match when={mobileContext()}>
+                      <div class="relative h-full overflow-hidden">
+                        <SessionContextTab
+                          messages={messages}
+                          visibleUserMessages={visibleUserMessages}
+                          view={view}
+                          info={info}
+                        />
+                      </div>
+                    </Match>
+                    <Match when={true}>
+                      <MessageTimeline
+                        mobileChanges={mobileChanges()}
+                        mobileFallback={reviewContent({
+                          diffStyle: "unified",
+                          classes: {
+                            root: "pb-[calc(var(--prompt-height,8rem)+32px)]",
+                            header: "px-4",
+                            container: "px-4",
+                          },
+                          loadingClass: "px-4 py-4 text-text-weak",
+                          emptyClass: "h-full px-4 pb-30 flex flex-col items-center justify-center text-center gap-6",
+                        })}
+                        scroll={ui.scroll}
+                        onResumeScroll={resumeScroll}
+                        setScrollRef={setScrollRef}
+                        onScheduleScrollState={scheduleScrollState}
+                        onAutoScrollHandleScroll={autoScroll.handleScroll}
+                        onMarkScrollGesture={markScrollGesture}
+                        hasScrollGesture={hasScrollGesture}
+                        isDesktop={isDesktop()}
+                        onScrollSpyScroll={scrollSpy.onScroll}
+                        onAutoScrollInteraction={autoScroll.handleInteraction}
+                        showHeader={!!(info()?.title || info()?.parentID)}
+                        centered={centered()}
+                        title={info()?.title}
+                        parentID={info()?.parentID}
+                        openTitleEditor={openTitleEditor}
+                        closeTitleEditor={closeTitleEditor}
+                        saveTitleEditor={saveTitleEditor}
+                        titleRef={(el) => {
+                          titleRef = el
+                        }}
+                        titleState={title}
+                        onTitleDraft={(value) => setTitle("draft", value)}
+                        onTitleMenuOpen={(open) => setTitle("menuOpen", open)}
+                        onTitlePendingRename={(value) => setTitle("pendingRename", value)}
+                        onNavigateParent={() => {
+                          navigate(`/${params.dir}/session/${info()?.parentID}`)
+                        }}
+                        sessionID={params.id!}
+                        onArchiveSession={(sessionID) => void archiveSession(sessionID)}
+                        onDeleteSession={(sessionID) => dialog.show(() => <DialogDeleteSession sessionID={sessionID} />)}
+                        t={language.t as (key: string, vars?: Record<string, string | number | boolean>) => string}
+                        setContentRef={(el) => {
+                          content = el
+                          autoScroll.contentRef(el)
 
-                      const root = scroller
-                      if (root) scheduleScrollState(root)
-                    }}
-                    turnStart={store.turnStart}
-                    onRenderEarlier={() => setStore("turnStart", 0)}
-                    historyMore={historyMore()}
-                    historyLoading={historyLoading()}
-                    onLoadEarlier={() => {
-                      const id = params.id
-                      if (!id) return
-                      setStore("turnStart", 0)
-                      sync.session.history.loadMore(id)
-                    }}
-                    renderedUserMessages={renderedUserMessages()}
-                    anchor={anchor}
-                    onRegisterMessage={scrollSpy.register}
-                    onUnregisterMessage={scrollSpy.unregister}
-                    onFirstTurnMount={() => {
-                      const id = params.id
-                      if (!id) return
-                      navMark({ dir: params.dir, to: id, name: "session:first-turn-mounted" })
-                    }}
-                    lastUserMessageID={lastUserMessage()?.id}
-                    expanded={store.expanded}
-                    onToggleExpanded={(id) => setStore("expanded", id, (open: boolean | undefined) => !open)}
-                  />
+                          const root = scroller
+                          if (root) scheduleScrollState(root)
+                        }}
+                        turnStart={store.turnStart}
+                        onRenderEarlier={() => setStore("turnStart", 0)}
+                        historyMore={historyMore()}
+                        historyLoading={historyLoading()}
+                        onLoadEarlier={() => {
+                          const id = params.id
+                          if (!id) return
+                          setStore("turnStart", 0)
+                          sync.session.history.loadMore(id)
+                        }}
+                        renderedUserMessages={renderedUserMessages()}
+                        anchor={anchor}
+                        onRegisterMessage={scrollSpy.register}
+                        onUnregisterMessage={scrollSpy.unregister}
+                        onFirstTurnMount={() => {
+                          const id = params.id
+                          if (!id) return
+                          navMark({ dir: params.dir, to: id, name: "session:first-turn-mounted" })
+                        }}
+                        lastUserMessageID={lastUserMessage()?.id}
+                        expanded={store.expanded}
+                        onToggleExpanded={(id) => setStore("expanded", id, (open: boolean | undefined) => !open)}
+                      />
+                    </Match>
+                  </Switch>
                 </Show>
               </Match>
               <Match when={true}>

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -9,6 +9,8 @@ export interface TooltipProps extends ComponentProps<typeof KobalteTooltip> {
   contentStyle?: JSX.CSSProperties
   inactive?: boolean
   forceOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }
 
 export interface TooltipKeybindProps extends Omit<TooltipProps, "value"> {
@@ -32,7 +34,7 @@ export function TooltipKeybind(props: TooltipKeybindProps) {
 }
 
 export function Tooltip(props: TooltipProps) {
-  const [open, setOpen] = createSignal(false)
+  const [internalOpen, setInternalOpen] = createSignal(false)
   const [local, others] = splitProps(props, [
     "children",
     "class",
@@ -40,7 +42,18 @@ export function Tooltip(props: TooltipProps) {
     "contentStyle",
     "inactive",
     "forceOpen",
+    "open",
+    "onOpenChange",
   ])
+
+  const open = () => local.open ?? internalOpen()
+  const setOpen = (value: boolean) => {
+    if (local.onOpenChange) {
+      local.onOpenChange(value)
+    } else {
+      setInternalOpen(value)
+    }
+  }
 
   const c = children(() => local.children)
 


### PR DESCRIPTION
fixes #10443 

_note: recommend reviewing with [`?w=1` github review whitespace parameter](https://github.com/anomalyco/opencode/pull/10457/changes?w=1)_

### What does this PR do?

* enable viewing context details on mobile web
* introduce third mobile tab state for context panel
* workaround tooltip ignoring touch events
* two-tap pattern for opening context tab from tooltip
* tighten spacing between interactive elements in prompt bar on mobile

### How did you verify your code works?

tested on device running the locally-built web app client:

#### before
https://github.com/user-attachments/assets/08175e16-aa1c-4b02-af1b-22784e0814da

#### after
https://github.com/user-attachments/assets/2ef71eb1-584e-4611-8fee-ad4b7e2d39cb

