### PR TITLE
fix(tui): guard against undefined in DialogSelect onMove callback

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -149,7 +149,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   function moveTo(next: number, center = false) {
     setStore("selected", next)
-    props.onMove?.(selected()!)
+    const option = selected()
+    if (option) props.onMove?.(option)
     if (!scroll) return
     const target = scroll.getChildren().find((child) => {
       return child.id === JSON.stringify(selected()?.value)


### PR DESCRIPTION
Fixes anomalyco/opencode#10461

### What does this PR do?

Prevents TypeError when filtered list is empty and user navigates, affecting /fork, timeline, and theme picker dialogs.

### How did you verify your code works?

Tried it locally with opencode dev before and after fix was applied to verify that it actually fixed the issue.
