### PR TITLE
chore: Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,7 +114,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.publish.outputs.tag }}
 
-      - uses: apple-actions/import-codesign-certs@v2
+      - uses: apple-actions/import-codesign-certs@v6
         if: ${{ runner.os == 'macOS' }}
         with:
           keychain: build


### PR DESCRIPTION
Fixes #10466

## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `apple-actions/import-codesign-certs` | [`v2`](https://github.com/apple-actions/import-codesign-certs/releases/tag/v2) | [`v6`](https://github.com/apple-actions/import-codesign-certs/releases/tag/v6) | [Release](https://github.com/apple-actions/import-codesign-certs/releases/tag/v6) | publish.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
