### PR TITLE
feat: add custom sounds support for desktop

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -1,15 +1,19 @@
-import { Component, createMemo, type JSX } from "solid-js"
+import { Component, createMemo, Show, type JSX } from "solid-js"
 import { Select } from "@opencode-ai/ui/select"
 import { Switch } from "@opencode-ai/ui/switch"
+import { Button } from "@opencode-ai/ui/button"
+import { Icon } from "@opencode-ai/ui/icon"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme"
 import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
 import { useSettings, monoFontFamily } from "@/context/settings"
-import { playSound, SOUND_OPTIONS } from "@/utils/sound"
+import { playSound, SOUND_OPTIONS, isCustomSound, soundSrc, getSoundLabel } from "@/utils/sound"
 import { Link } from "./link"
 
 export const SettingsGeneral: Component = () => {
   const theme = useTheme()
   const language = useLanguage()
+  const platform = usePlatform()
   const settings = useSettings()
 
   const themeOptions = createMemo(() =>

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -552,11 +552,14 @@ export const dict = {
   "settings.general.notifications.errors.description": "Show system notification when an error occurs",
 
   "settings.general.sounds.agent.title": "Agent",
-  "settings.general.sounds.agent.description": "Play sound when the agent is complete or needs attention",
+  "settings.general.sounds.agent.description": "Play sound when agent is complete or needs attention",
   "settings.general.sounds.permissions.title": "Permissions",
   "settings.general.sounds.permissions.description": "Play sound when a permission is required",
   "settings.general.sounds.errors.title": "Errors",
   "settings.general.sounds.errors.description": "Play sound when an error occurs",
+  "settings.general.sounds.custom.error.invalid": "Please select a valid audio file",
+  "settings.general.sounds.custom.error.tooLarge": "File is larger than 5MB",
+  "settings.general.sounds.custom.error.tooLargeConfirm": "This file is larger than 5MB. Continue?",
 
   "settings.shortcuts.title": "Keyboard shortcuts",
   "settings.shortcuts.reset.button": "Reset to defaults",

--- a/packages/app/src/utils/custom-sounds.ts
+++ b/packages/app/src/utils/custom-sounds.ts
@@ -1,0 +1,15 @@
+export const MAX_FILE_SIZE = 5 * 1024 * 1024
+
+export const ALLOWED_AUDIO_EXTENSIONS = ["mp3", "wav", "aac", "aiff", "ogg", "flac", "m4a", "wma"]
+
+export function getFileExtension(path: string): string {
+  return path.split(".").pop()?.toLowerCase() ?? ""
+}
+
+export function isAudioFile(path: string): boolean {
+  return ALLOWED_AUDIO_EXTENSIONS.includes(getFileExtension(path))
+}
+
+export function getFilename(path: string): string {
+  return path.split(/[/\\]/).pop() ?? ""
+}

--- a/packages/app/src/utils/sound.ts
+++ b/packages/app/src/utils/sound.ts
@@ -97,8 +97,26 @@ export type SoundID = SoundOption["id"]
 
 const soundById = Object.fromEntries(SOUND_OPTIONS.map((s) => [s.id, s.src])) as Record<SoundID, string>
 
+export function isCustomSound(id: string | undefined): boolean {
+  return id?.startsWith("custom:") ?? false
+}
+
+export function getSoundLabel(id: string): string {
+  if (isCustomSound(id)) {
+    return id.slice("custom:".length)
+  }
+  const option = SOUND_OPTIONS.find((s) => s.id === id)
+  return option?.label ?? id
+}
+
 export function soundSrc(id: string | undefined) {
   if (!id) return
+  
+  if (isCustomSound(id)) {
+    const filename = id.slice("custom:".length)
+    return `sounds/${filename}`
+  }
+  
   if (!(id in soundById)) return
   return soundById[id as SoundID]
 }

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -891,11 +891,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -906,7 +927,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3025,6 +3046,7 @@ name = "opencode-desktop"
 version = "0.0.0"
 dependencies = [
  "comrak",
+ "dirs 5.0.1",
  "futures",
  "gtk",
  "listeners",
@@ -3037,6 +3059,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-decorum",
  "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-http",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
@@ -3791,6 +3814,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4661,7 +4695,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4711,7 +4745,7 @@ checksum = "87d6f8cafe6a75514ce5333f115b7b1866e8e68d9672bf4ca89fc0f35697ea9d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5007,7 +5041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27cbc31740f4d507712550694749572ec0e43bdd66992db7599b89fbfd6b167b"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5524,7 +5558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d5572781bee8e3f994d7467084e1b1fd7a93ce66bd480f8156ba89dee55a2b"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2 0.6.3",
@@ -6264,6 +6298,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6627,7 +6670,7 @@ dependencies = [
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -30,6 +30,8 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-http = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-fs = "2"
+dirs = "5"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -29,6 +29,13 @@
     "window-state:default",
     "os:default",
     "notification:default",
+    "fs:allow-copy-file",
+    "fs:allow-create",
+    "fs:allow-exists",
+    "fs:allow-read-file",
+    "fs:allow-remove",
+    "fs:allow-write-file",
+    "fs:allow-mkdir",
     {
       "identifier": "http:default",
       "allow": [{ "url": "http://*" }, { "url": "https://*" }, { "url": "http://*:*/*" }]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod cli;
 #[cfg(windows)]
 mod job_object;
 mod markdown;
+mod sounds;
 mod window_customizer;
 
 use cli::{install_cli, sync_cli};
@@ -288,7 +289,11 @@ pub fn run() {
             ensure_server_ready,
             get_default_server_url,
             set_default_server_url,
-            markdown::parse_markdown_command
+            markdown::parse_markdown_command,
+            sounds::copy_sound_file,
+            sounds::cleanup_old_sounds,
+            sounds::sound_file_exists,
+            sounds::get_file_size,
         ])
         .setup(move |app| {
             let app = app.handle().clone();

--- a/packages/desktop/src-tauri/src/sounds.rs
+++ b/packages/desktop/src-tauri/src/sounds.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::path::Path;
+
+#[tauri::command]
+async fn copy_sound_file(src: String, filename: String, category: String) -> Result<String, String> {
+    let config_dir = dirs::config_dir().ok_or("Failed to get config dir")?;
+    let sounds_dir = config_dir.join("opencode").join("sounds").join(&category);
+    
+    fs::create_dir_all(&sounds_dir).map_err(|e| e.to_string())?;
+    
+    let dest = sounds_dir.join(&filename);
+    fs::copy(&src, &dest).map_err(|e| e.to_string())?;
+    
+    Ok(dest.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+async fn cleanup_old_sounds(category: String, keep_file: String) -> Result<(), String> {
+    let config_dir = dirs::config_dir().ok_or("Failed to get config dir")?;
+    let sounds_dir = config_dir.join("opencode").join("sounds").join(&category);
+    
+    if sounds_dir.exists() {
+        for entry in fs::read_dir(&sounds_dir).map_err(|e| e.to_string())? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            if entry.file_name() != keep_file {
+                fs::remove_file(entry.path()).map_err(|e| e.to_string())?;
+            }
+        }
+    }
+    
+    Ok(())
+}
+
+#[tauri::command]
+async fn sound_file_exists(path: String) -> Result<bool, String> {
+    Ok(Path::new(&path).exists())
+}
+
+#[tauri::command]
+async fn get_file_size(path: String) -> Result<u64, String> {
+    let metadata = fs::metadata(&path).map_err(|e| e.to_string())?;
+    Ok(metadata.len())
+}


### PR DESCRIPTION
- Add ability to upload and use custom audio files for sounds
- Add file upload buttons in settings for agent, permissions, and error sounds
- Implement custom sound file management with cleanup of old sounds
- Add file size validation (5MB limit) with confirmation prompt
- Add Tauri commands for file operations (copy, cleanup, exists, size)
- Add translations for custom sound error messages
- Update Cargo dependencies with dirs and tauri-plugin-fs
- Add file system capabilities for custom sound management

### What does this PR do?

### How did you verify your code works?
