### PR TITLE
refactor(tui): theme switching & loading reactivity

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-theme-list.tsx
@@ -1,11 +1,11 @@
 import { DialogSelect, type DialogSelectRef } from "../ui/dialog-select"
 import { useTheme } from "../context/theme"
 import { useDialog } from "../ui/dialog"
-import { onCleanup, onMount } from "solid-js"
+import { onCleanup } from "solid-js"
 
 export function DialogThemeList() {
   const theme = useTheme()
-  const options = Object.keys(theme.all())
+  const options = () => Object.keys(theme.all())
     .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))
     .map((value) => ({
       title: value,
@@ -23,7 +23,7 @@ export function DialogThemeList() {
   return (
     <DialogSelect
       title="Themes"
-      options={options}
+      options={options()}
       current={initial}
       onMove={(opt) => {
         theme.set(opt.value)

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -73,6 +73,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
       path: Path
+      config_generation: number
     }>({
       provider_next: {
         all: [],
@@ -100,6 +101,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       formatter: [],
       vcs: undefined,
       path: { state: "", config: "", worktree: "", directory: "" },
+      config_generation: 0,
     })
 
     const sdk = useSDK()
@@ -393,6 +395,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               setStore("provider_next", reconcile(providerList))
               setStore("agent", reconcile(agents))
               setStore("config", reconcile(config))
+              setStore("config_generation", (g) => g + 1)
               if (sessions !== undefined) setStore("session", reconcile(sessions))
             })
           })

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -1,9 +1,10 @@
-import { SyntaxStyle, RGBA, type TerminalColors } from "@opentui/core"
+import { SyntaxStyle, RGBA, type TerminalColors, CliRenderer } from "@opentui/core"
 import path from "path"
-import { createEffect, createMemo, onMount } from "solid-js"
+import { createEffect, createMemo, createResource, on } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
 import { Glob } from "../../../../util/glob"
+import { useToast } from "../ui/toast"
 import aura from "./theme/aura.json" with { type: "json" }
 import ayu from "./theme/ayu.json" with { type: "json" }
 import catppuccin from "./theme/catppuccin.json" with { type: "json" }
@@ -39,7 +40,7 @@ import zenburn from "./theme/zenburn.json" with { type: "json" }
 import carbonfox from "./theme/carbonfox.json" with { type: "json" }
 import { useKV } from "./kv"
 import { useRenderer } from "@opentui/solid"
-import { createStore, produce } from "solid-js/store"
+import { createStore } from "solid-js/store"
 import { Global } from "@/global"
 import { Filesystem } from "@/util/filesystem"
 
@@ -174,6 +175,11 @@ export const DEFAULT_THEMES: Record<string, ThemeJson> = {
   carbonfox,
 }
 
+const FALLBACK_THEME_KEY = "opencode"
+const SYSTEM_THEME_KEY = "system"
+
+type ThemeStore = Record<string, ThemeJson>
+
 function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   const defs = theme.defs ?? {}
   function resolveColor(c: ColorValue): RGBA {
@@ -282,78 +288,151 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   init: (props: { mode: "dark" | "light" }) => {
     const sync = useSync()
     const kv = useKV()
+
+    const requested = sync.data.config.theme
+      || (kv.get("theme") as string | undefined)
+      || FALLBACK_THEME_KEY
+
     const [store, setStore] = createStore({
-      themes: DEFAULT_THEMES,
+      themes: { ...DEFAULT_THEMES },
       mode: kv.get("theme_mode", props.mode),
-      active: (sync.data.config.theme ?? kv.get("theme", "opencode")) as string,
+      requested, active: requested,
       ready: false,
     })
 
-    createEffect(() => {
-      const theme = sync.data.config.theme
-      if (theme) setStore("active", theme)
-    })
+    const createLoader = (loader: () => Promise<ThemeStore>) => {
+      const [loaded, { refetch: reload }] =
+        createResource(async () => {
+          const themes = await loader();
+          setStore("themes", themes)
+          return themes
+        })
 
-    function init() {
-      resolveSystemTheme()
-      getCustomThemes()
-        .then((custom) => {
-          setStore(
-            produce((draft) => {
-              Object.assign(draft.themes, custom)
-            }),
-          )
-        })
-        .catch(() => {
-          setStore("active", "opencode")
-        })
-        .finally(() => {
-          if (store.active !== "system") {
-            setStore("ready", true)
-          }
-        })
+      return {
+        loaded,
+        reload,
+      }
     }
 
-    onMount(init)
-
-    function resolveSystemTheme() {
-      console.log("resolveSystemTheme")
-      renderer
-        .getPalette({
-          size: 16,
-        })
-        .then((colors) => {
-          console.log(colors.palette)
-          if (!colors.palette[0]) {
-            if (store.active === "system") {
-              setStore(
-                produce((draft) => {
-                  draft.active = "opencode"
-                  draft.ready = true
-                }),
-              )
-            }
-            return
-          }
-          setStore(
-            produce((draft) => {
-              draft.themes.system = generateSystem(colors, store.mode)
-              if (store.active === "system") {
-                draft.ready = true
-              }
-            }),
-          )
-        })
-    }
+    const customLoader = createLoader(loadCustomThemes)
 
     const renderer = useRenderer()
-    process.on("SIGUSR2", async () => {
-      renderer.clearPaletteCache()
-      init()
+    const systemLoader = createLoader(async () => {
+      const colors = await detectSystemColors(renderer)
+      const theme = generateSystemTheme(colors, store.mode)
+      return { [SYSTEM_THEME_KEY]: theme }
     })
 
+    const getStatus = (key: string) => {
+      const customState = customLoader.loaded.state
+      const systemState = systemLoader.loaded.state
+
+      if (key in DEFAULT_THEMES) {
+        return "succeeded"
+      }
+
+      if (key === SYSTEM_THEME_KEY) {
+        switch (systemState) {
+          case "ready":
+            return "succeeded"
+          case "errored":
+            return "errored"
+          default:
+            return "pending"
+        }
+      }
+
+      switch (customState) {
+        case "ready": {
+          const themes = customLoader.loaded.latest
+          const theme = themes[key]
+
+          if (!theme) return "errored"
+          return "succeeded"
+        }
+        case "errored":
+          return "errored"
+        default:
+          return "pending"
+      }
+    }
+
+    const requestedStatus = createMemo(
+      () => {
+        const key = store.requested
+        const status = getStatus(key)
+        return { key, status }
+      },
+      undefined,
+      {
+        equals: (prev, next) => (
+          next.key === prev.key &&
+          next.status === prev.status
+        )
+      }
+    )
+
+    const toast = useToast()
+    createEffect(on(
+      requestedStatus,
+      ({ key, status }) => {
+        console.debug("theme", "requested", { key, status })
+
+        const promote = (override?: string) => {
+          const active = override ?? key
+          console.debug("theme", "active", { key: active })
+
+          setStore({
+            ready: true,
+            active,
+          })
+        }
+
+        switch (status) {
+          case "pending": {
+            return
+          }
+          case "succeeded": {
+            promote()
+            return
+          }
+          case "errored": {
+            toast.show({
+              message: `Theme ${key} may not have resolved correctly`,
+              variant: "warning", duration: 3000,
+            })
+
+            if (key in store.themes) {
+              promote()
+              return
+            }
+
+            if (!store.ready) {
+              promote(FALLBACK_THEME_KEY)
+              return
+            }
+
+            return
+          }
+        }
+      }
+    ))
+
+    createEffect(on(
+      () => sync.data.config_generation,
+      () => {
+        renderer.clearPaletteCache()
+        systemLoader.reload()
+        customLoader.reload()
+
+        const key = sync.data.config.theme || store.active
+        setStore("requested", key)
+      },
+      { defer: true }
+    ))
+
     const values = createMemo(() => {
-      return resolveTheme(store.themes[store.active] ?? store.themes.opencode, store.mode)
+      return resolveTheme((store.themes[store.active] ?? store.themes[FALLBACK_THEME_KEY]), store.mode)
     })
 
     const syntax = createMemo(() => generateSyntax(values()))
@@ -382,7 +461,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         kv.set("theme_mode", mode)
       },
       set(theme: string) {
-        setStore("active", theme)
+        setStore("requested", theme)
         kv.set("theme", theme)
       },
       get ready() {
@@ -392,7 +471,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   },
 })
 
-async function getCustomThemes() {
+async function loadCustomThemes() {
   const directories = [
     Global.Path.config,
     ...(await Array.fromAsync(
@@ -425,7 +504,14 @@ export function tint(base: RGBA, overlay: RGBA, alpha: number): RGBA {
   return RGBA.fromInts(Math.round(r * 255), Math.round(g * 255), Math.round(b * 255))
 }
 
-function generateSystem(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
+async function detectSystemColors(renderer: CliRenderer) {
+  const colors = await renderer.getPalette({ size: 16 })
+  if (colors.palette[0]) return colors
+
+  throw new Error("System color detection failed")
+}
+
+function generateSystemTheme(colors: TerminalColors, mode: "dark" | "light"): ThemeJson {
   const bg = RGBA.fromHex(colors.defaultBackground ?? colors.palette[0]!)
   const fg = RGBA.fromHex(colors.defaultForeground ?? colors.palette[7]!)
   const transparent = RGBA.fromInts(0, 0, 0, 0)


### PR DESCRIPTION
### Issues
- **Prepares for** #6322
  - _Shown in GIF below_

### Refactor
Remodels theme resolution reactivity with respect to this tuple:
- The user's requested theme
- The loading status of relevant async resources

This change also prepares for a feature, **system-like custom themes**, shown in this video:

<img src="https://github.com/user-attachments/assets/e5384fac-27f9-4a87-9940-783b5c1951d3" alt="tui-theme" width="480" />

### Fixes
- Theme picker list now updates on reload
- Warning toasts on errored
  - These toasts could easily be removed

### Performance
The theme context now readies **10x faster** (30ms → 3ms) in by-far the most common case: using one of the default themes. The speedup is achieved by not waiting on resources irrelevant to the requested theme before marking it as ready.
_Timed using this [patch](https://github.com/user-attachments/files/24698744/ready-timing.patch) that calls `console.time` inside `createSimpleContext`._

#### After = 3.558ms
```
...
[17:05:25] [LOG] '%s: %s' 'context:Theme' '3.558ms'
...
```

#### Before = 31.264ms
```
...
[17:04:19] [LOG] '%s: %s' 'context:Theme' '31.264ms'
...
```

### Implementation
- 2x `createResource`s
  - Custom theme loading
  - System palette detection
- These in turn are accessed in a `createMemo` returning this tuple:
  - The user's requested theme
  - The loading status of relevant async resources
- 2x `createEffect`s
  - One to update the requested theme when the config generation increments
  - Another to promote and re-resolve the theme when our memoized tuple changes