### PR TITLE
fix(anthropic): ensure reasoning blocks precede tool_use in assistant messages

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -63,6 +63,25 @@ export namespace ProviderTransform {
           return { ...msg, content: filtered }
         })
         .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
+        .map((msg) => {
+          // Anthropic requires reasoning blocks to precede tool_use blocks in assistant messages
+          if (msg.role === "assistant" && Array.isArray(msg.content)) {
+            const priority = (type: string) => {
+              switch (type) {
+                case "reasoning":
+                  return 0
+                case "text":
+                  return 1
+                case "tool-call":
+                  return 2
+                default:
+                  return 3
+              }
+            }
+            msg.content.sort((a, b) => priority(a.type) - priority(b.type))
+          }
+          return msg
+        })
     }
 
     if (model.api.id.includes("claude")) {


### PR DESCRIPTION
Fixes #9364

## Problem
When using Claude models with Extended Thinking enabled, multi-turn conversations with tool use fail with:
```
messages.X.content.0.type: Expected 'thinking' or 'redacted_thinking', but found 'tool_use'
```

## Root Cause
The `normalizeMessages` function filters empty content but does not reorder parts to ensure `reasoning` blocks come before `tool-call` blocks in assistant messages.

## Solution
Added sorting logic for assistant messages in the Anthropic-specific block. Parts are now ordered by priority:
- `reasoning`: 0 (first)
- `text`: 1
- `tool-call`: 2
- everything else: 3

This ensures compliance with Anthropic's Extended Thinking API requirements.

## References
- https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
- Related: #2599, #3077