### PR TITLE
fix(tui): auto-scroll textarea cursor when typing long prompts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -781,6 +781,10 @@ export function Prompt(props: PromptProps) {
                 setStore("prompt", "input", value)
                 autocomplete.onInput(value)
                 syncExtmarksWithPromptParts()
+                // Force layout update and render to keep cursor visible when typing
+                // beyond the visible area (matches pattern in onPaste handler)
+                input.getLayoutNode().markDirty()
+                renderer.requestRender()
               }}
               keyBindings={textareaKeybindings()}
               onKeyDown={async (e) => {


### PR DESCRIPTION
### What does this PR do?

Fixes the textarea cursor not auto-scrolling when typing long prompts that exceed the visible area (maxHeight of 6 lines).

When typing beyond the visible area, the cursor would move but the viewport wouldn't follow, leaving the text invisible and causing black/empty spaces to appear.

### How did you verify your code works?

The fix adds `markDirty()` and `requestRender()` calls to the `onContentChange` handler, matching the pattern already used in:
- `onPaste` handler (lines 926-929)
- `TuiEvent.PromptAppend` handler (lines 98-100)

This ensures the layout is recalculated and the viewport syncs with cursor position on every keystroke.

---
Fixes #10401

🤖 Generated with Claude Code