### PR TITLE
fix(app): mobile horizontal scrolling due to session stat btn

### DIFF
--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -88,9 +88,6 @@
     }
   }
 
-  [data-slot="session-turn-response-trigger"] {
-    width: fit-content;
-  }
 
   [data-slot="session-turn-message-header"] {
     display: flex;
@@ -483,7 +480,7 @@
   }
 
   [data-slot="session-turn-collapsible-trigger-content"] {
-    width: fit-content;
+    max-width: 100%;
     display: flex;
     align-items: center;
     gap: 8px;
@@ -512,6 +509,11 @@
 
   [data-slot="session-turn-retry-attempt"] {
     color: var(--text-weak);
+  }
+
+  [data-slot="session-turn-status-text"] {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   [data-slot="session-turn-details-text"] {

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -593,10 +593,16 @@ export function SessionTurn(
                                 <span data-slot="session-turn-retry-attempt">(#{retry()?.attempt})</span>
                               </Match>
                               <Match when={working()}>
-                                {store.status ?? i18n.t("ui.sessionTurn.status.consideringNextSteps")}
+                                <span data-slot="session-turn-status-text">
+                                  {store.status ?? i18n.t("ui.sessionTurn.status.consideringNextSteps")}
+                                </span>
                               </Match>
-                              <Match when={props.stepsExpanded}>{i18n.t("ui.sessionTurn.steps.hide")}</Match>
-                              <Match when={!props.stepsExpanded}>{i18n.t("ui.sessionTurn.steps.show")}</Match>
+                              <Match when={props.stepsExpanded}>
+                                <span data-slot="session-turn-status-text">{i18n.t("ui.sessionTurn.steps.hide")}</span>
+                              </Match>
+                              <Match when={!props.stepsExpanded}>
+                                <span data-slot="session-turn-status-text">{i18n.t("ui.sessionTurn.steps.show")}</span>
+                              </Match>
                             </Switch>
                             <span aria-hidden="true">·</span>
                             <span aria-live="off">{store.duration}</span>


### PR DESCRIPTION
### What does this PR do?
Adds ellipsis to session-status-turn button so that it doesn't overflow and cause scrolling on mobile. 

Ex of mobile scroll: 
<img width="811" height="837" alt="Screenshot 2026-01-24 at 11 01 34 PM" src="https://github.com/user-attachments/assets/ef7e6bfb-b929-47ce-8ce0-18b9b40171f3" />

Before: 

https://github.com/user-attachments/assets/3989dacf-e7f8-43e0-8c02-9aad95ac00ca


After:

https://github.com/user-attachments/assets/eab75744-0a04-4bea-a760-dd25ad18f4b2


### How did you verify your code works?
Tested

Fixes: https://github.com/anomalyco/opencode/issues/10485