### PR TITLE
fix(pty): Add UTF-8 defaults for Windows PTY

### DIFF
--- a/packages/app/public/site.webmanifest
+++ b/packages/app/public/site.webmanifest
@@ -1,1 +1,21 @@
-../../ui/src/assets/favicon/site.webmanifest
+{
+  "name": "OpenCode",
+  "short_name": "OpenCode",
+  "icons": [
+    {
+      "src": "/web-app-manifest-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/web-app-manifest-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -8,6 +8,7 @@ import type { WSContext } from "hono/ws"
 import { Instance } from "../project/instance"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
+import path from "path"
 
 export namespace Pty {
   const log = Log.create({ service: "pty" })
@@ -96,9 +97,22 @@ export namespace Pty {
   export async function create(input: CreateInput) {
     const id = Identifier.create("pty", false)
     const command = input.command || Shell.preferred()
-    const args = input.args || []
+    let args = input.args || []
     if (command.endsWith("sh")) {
       args.push("-l")
+    }
+    if (process.platform === "win32" && args.length === 0) {
+      const base = path.win32.basename(command).toLowerCase()
+      if (base === "cmd.exe" || base === "cmd") {
+        args = ["/k", "chcp 65001>nul"]
+      } else if (base === "powershell.exe" || base === "pwsh.exe") {
+        args = [
+          "-NoLogo",
+          "-NoExit",
+          "-Command",
+          "[Console]::OutputEncoding=[Text.UTF8Encoding]::UTF8; [Console]::InputEncoding=[Text.UTF8Encoding]::UTF8",
+        ]
+      }
     }
 
     const cwd = input.cwd || Instance.directory
@@ -108,6 +122,12 @@ export namespace Pty {
       TERM: "xterm-256color",
       OPENCODE_TERMINAL: "1",
     } as Record<string, string>
+    if (process.platform === "win32") {
+      env.LANG = env.LANG || "en_US.UTF-8"
+      env.LC_ALL = env.LC_ALL || "en_US.UTF-8"
+      env.PYTHONUTF8 = env.PYTHONUTF8 || "1"
+      env.PYTHONIOENCODING = env.PYTHONIOENCODING || "utf-8"
+    }
     log.info("creating session", { id, cmd: command, args, cwd })
 
     const spawn = await pty()


### PR DESCRIPTION
## Summary

Fix CJK (Chinese, Japanese, Korean) character display issues in Windows terminals by adding proper UTF-8 encoding defaults.

## Problem

Windows terminals don't have UTF-8 encoding enabled by default, causing CJK characters to display as gibberish or question marks. This affects:
- Terminal output with CJK characters
- Python scripts with CJK strings
- Git operations with CJK filenames
- Any CLI tool outputting CJK text

## Solution

This PR adds platform-specific UTF-8 defaults for Windows:

### Environment Variables
- `LANG=en_US.UTF-8` - Sets locale for Unix-style tools
- `LC_ALL=en_US.UTF-8` - Overrides all locale categories
- `PYTHONUTF8=1` - Enables UTF-8 mode for Python 3.7+
- `PYTHONIOENCODING=utf-8` - Sets Python stdin/stdout/stderr encoding

### Shell Startup Arguments
- **CMD.exe**: Runs `chcp 65001` to set code page to UTF-8
- **PowerShell**: Sets OutputEncoding and InputEncoding to UTF-8

## Testing

Tested on Windows with:
- ✅ Terminal displaying Chinese characters correctly
- ✅ Python scripts printing CJK text without errors
- ✅ Git operations with CJK filenames
- ✅ CMD and PowerShell shells

## Impact

- **Platform**: Windows only (no impact on macOS/Linux)
- **Backwards Compatible**: Yes (only sets defaults, can be overridden via env parameter)
- **User-Visible**: Yes (fixes CJK display issues)

## Related Issues

This PR addresses the root cause of several Windows encoding issues:
- Fixes #10414 - OpenCode crashes with garbled console output on Windows
- Fixes #10486 - Chinese characters appearing incorrectly
- Fixes #9814 - Garbled characters after launching on Windows
- Fixes #9793 - Chinese characters displaying as garbled text (命令行模式下中文显示突然全部变成乱码)
- Related to #10265 - Ctrl+C terminal garbage issue
- Related to #10341 - Scoop Windows garbled output issue

Closes #10491