### PR TITLE
fix: change models.dev refresh log from info to debug

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -105,9 +105,7 @@ export namespace ModelsDev {
 
   export async function refresh() {
     const file = Bun.file(filepath)
-    log.info("refreshing", {
-      file,
-    })
+    log.debug("refreshing")
     const result = await fetch(`${url()}/api.json`, {
       headers: {
         "User-Agent": Installation.USER_AGENT,


### PR DESCRIPTION
### What does this PR do?

Changes the `log.info("refreshing", { file })` call to `log.debug("refreshing")` in the models.dev refresh function.

This removes unnecessary INFO-level log noise during startup:
```
INFO  2026-01-25T06:06:04 +69ms service=models.dev file={} refreshing
```

<img width="575" height="63" alt="Screenshot 2026-01-25 at 3 10 52 PM" src="https://github.com/user-attachments/assets/45eb74b8-7243-4603-8242-5ff09b7292e9" />

The diagnostic capability is preserved for local development where log level defaults to DEBUG.

Closes https://github.com/anomalyco/opencode/issues/10506

### How did you verify your code works?

- Verified log level behavior: production uses INFO (hides debug), local dev uses DEBUG (shows debug)
- Confirmed existing pattern: `config.ts` uses `log.debug()` for similar operational logs