### PR TITLE
fix(provider): retry OpenAI Responses API on 404 errors

### DIFF
--- a/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-error.ts
+++ b/packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-error.ts
@@ -16,7 +16,19 @@ export const openaiErrorDataSchema = z.object({
 
 export type OpenAIErrorData = z.infer<typeof openaiErrorDataSchema>
 
+// Status codes that should trigger automatic retry
+const RETRYABLE_STATUS_CODES = new Set([
+  404, // OpenAI Responses API can return 404 for transient "Item not found" errors
+  408, // Request Timeout
+  429, // Too Many Requests / Rate Limited
+  500, // Internal Server Error
+  502, // Bad Gateway
+  503, // Service Unavailable
+  504, // Gateway Timeout
+])
+
 export const openaiFailedResponseHandler: any = createJsonErrorResponseHandler({
   errorSchema: openaiErrorDataSchema,
   errorToMessage: (data) => data.error.message,
+  isRetryable: (response) => RETRYABLE_STATUS_CODES.has(response.status),
 })


### PR DESCRIPTION
## Summary
- Add `isRetryable` callback to `openaiFailedResponseHandler` to mark transient errors as retryable
- OpenAI's Responses API can return 404 for transient "Item not found" errors
- Enables automatic retry through the existing `SessionProcessor` retry mechanism

Retryable status codes: 404, 408, 429, 500, 502, 503, 504

Fixes #10505

## Changes
- `packages/opencode/src/provider/sdk/openai-compatible/src/responses/openai-error.ts` - Added `RETRYABLE_STATUS_CODES` set and `isRetryable` callback

## Test plan
- [ ] Verify OpenAI 404 errors are retried automatically
- [ ] Verify other retryable status codes (429, 500, etc.) trigger retry
- [ ] Verify non-retryable errors (400, 401, 403) do not retry

🤖 Generated with [Claude Code](https://claude.ai/claude-code)