### PR TITLE
chore: reduce models.dev refresh log level to debug

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -105,7 +105,7 @@ export namespace ModelsDev {
 
   export async function refresh() {
     const file = Bun.file(filepath)
-    log.info("refreshing", {
+    log.debug("refreshing", {
       file,
     })
     const result = await fetch(`${url()}/api.json`, {


### PR DESCRIPTION
## Summary
- Change `log.info("refreshing", ...)` to `log.debug(...)` in `models.ts`

## Problem
On every startup, an INFO level log appears:
```
INFO  2026-01-25T07:13:12 +132ms service=models.dev file={} refreshing
```

This clutters the console output and provides no actionable information to users.

## Solution
Reduced the log level from INFO to DEBUG, so it only appears when explicitly debugging.