### PR TITLE
fix(session): enhance compatibility with Anthropic SDK for token usage

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -426,11 +426,22 @@ export namespace Session {
       metadata: z.custom<ProviderMetadata>().optional(),
     }),
     (input) => {
-      const cachedInputTokens = input.usage.cachedInputTokens ?? 0
+      const baseInputTokens = input.usage.inputTokens ?? 0
+      const baseCachedTokens = input.usage.cachedInputTokens ?? 0
+
+      // The ai-sdk anthropic only read input_tokens and cache_read_input_tokens from message_start block
+      // But a lot of compatible providers only return real tokens in message_delta block
+      // Try to read from the metadata anthropic usage.
+      const anthUsageMeta = input.metadata?.["anthropic"]?.["usage"]
+      const anthUsage = anthUsageMeta && typeof anthUsageMeta === "object" ? (anthUsageMeta as Record<string, unknown>) : undefined
+      const pick = (value: unknown, fallback: number) =>
+        typeof value === "number" && Number.isFinite(value) ? value : fallback
+      const inputTokens = anthUsage ? pick(anthUsage["input_tokens"], baseInputTokens) : baseInputTokens
+      const cachedInputTokens = anthUsage ? pick(anthUsage["cache_read_input_tokens"], baseCachedTokens) : baseCachedTokens
+
       const excludesCachedTokens = !!(input.metadata?.["anthropic"] || input.metadata?.["bedrock"])
-      const adjustedInputTokens = excludesCachedTokens
-        ? (input.usage.inputTokens ?? 0)
-        : (input.usage.inputTokens ?? 0) - cachedInputTokens
+      const adjustedInputTokens = excludesCachedTokens ? inputTokens : inputTokens - cachedInputTokens
+
       const safe = (value: number) => {
         if (!Number.isFinite(value)) return 0
         return value

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -235,6 +235,30 @@ describe("session.getUsage", () => {
     expect(result.tokens.cache.read).toBe(200)
   })
 
+  test("reads anthropic usage from metadata", () => {
+    const model = createModel({ context: 100_000, output: 32_000 })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 500,
+        totalTokens: 500,
+        cachedInputTokens: 0,
+      },
+      metadata: {
+        anthropic: {
+          usage: {
+            input_tokens: 700,
+            cache_read_input_tokens: 50,
+          },
+        },
+      },
+    })
+
+    expect(result.tokens.input).toBe(700)
+    expect(result.tokens.cache.read).toBe(50)
+  })
+
   test("handles reasoning tokens", () => {
     const model = createModel({ context: 100_000, output: 32_000 })
     const result = Session.getUsage({


### PR DESCRIPTION
### What does this PR do?
fix: https://github.com/anomalyco/opencode/issues/7481

The ai-sdk anthropic only read input_tokens and cache_read_input_tokens from message_start block, but a lot of compatible providers only return real tokens in message_delta block, try to read from the metadata anthropic usage.

Since the main branch of the ai-sdk anthropic package has already adopted the v3 protocol, and the usage object in v3 is incompatible with v2, we have decided to fix it on the opencode side.

https://github.com/vercel/ai/blob/%40ai-sdk/anthropic%402.0.57/packages/anthropic/src/anthropic-messages-language-model.ts#L1389

### How did you verify your code works?
1. unit test
2. build opencode, perform integration testing