### PR TITLE
fix: harmonize primary button hover and icon-button hover

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -170,12 +170,18 @@ export function SessionHeader() {
                     triggerAs={Button}
                     triggerProps={{
                       variant: "secondary",
-                      class: "rounded-sm w-[60px] h-[24px]",
+                      class: "rounded-sm w-[60px] h-[24px] hover:bg-surface-raised-base-hover",
                       classList: { "rounded-r-none": shareUrl() !== undefined },
                       style: { scale: 1 },
                     }}
                     trigger={language.t("session.share.action.share")}
                   >
+                    <input
+                      type="text"
+                      autofocus
+                      style="position:absolute; left:-10000px; width:1px; height:1px; opacity:0;"
+                      aria-hidden="true"
+                    />
                     <div class="flex flex-col gap-2">
                       <Show
                         when={shareUrl()}

--- a/packages/ui/src/components/button.css
+++ b/packages/ui/src/components/button.css
@@ -20,8 +20,11 @@
       color: var(--icon-invert-base);
     }
 
+    /* Clear, darker hover fill for primary button */
     &:hover:not(:disabled) {
-      background-color: var(--icon-strong-hover);
+      /* Subtler darken on hover to avoid overly dark button */
+      background-color: color-mix(in oklab, var(--button-primary-base) 75%, black 25%);
+      transition: background-color 100ms ease;
     }
     &:focus:not(:disabled) {
       background-color: var(--icon-strong-focus);

--- a/packages/ui/src/components/icon-button.css
+++ b/packages/ui/src/components/icon-button.css
@@ -24,7 +24,8 @@
     }
 
     &:hover:not(:disabled) {
-      background-color: var(--icon-strong-hover);
+      /* Align hover color with primary button hover to keep consistency */
+      background-color: color-mix(in oklab, var(--button-primary-base) 75%, black 25%);
     }
     &:focus:not(:disabled) {
       background-color: var(--icon-strong-focus);


### PR DESCRIPTION
## What does this PR do?
- Fixes bug where "publish on web" hover effect did not work unless user clicks inside the popover
- Makes primary button hover effect clearer 

## How did you verify your code works?
ran locally

## Before
https://github.com/user-attachments/assets/78ac22e8-2704-4bb5-a469-cdd93076f16e

## After
https://github.com/user-attachments/assets/d15caa33-4955-4ff0-8165-bb74f592bcd5

