### PR TITLE
feat(app): Expand model picker options

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -145,9 +145,12 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           available(),
           filter((x) => Math.abs(DateTime.fromISO(x.release_date).diffNow().as("months")) < 6),
           groupBy((x) => x.provider.id),
-          mapValues((models) =>
-            pipe(
-              models,
+          mapValues((models) => {
+            const isCodex = (model: { family?: string; id: string }) => model.family?.includes("codex") || model.id.includes("codex")
+            const codex = models.filter((model) => isCodex(model))
+            const nonCodex = models.filter((model) => !isCodex(model))
+            const deduped = pipe(
+              nonCodex,
               groupBy((x) => x.family),
               values(),
               (groups) =>
@@ -155,8 +158,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
                   const first = firstBy(g, [(x) => x.release_date, "desc"])
                   return first ? [{ modelID: first.id, providerID: first.provider.id }] : []
                 }),
-            ),
-          ),
+            )
+            return [
+              ...deduped,
+              ...codex.map((model) => ({
+                modelID: model.id,
+                providerID: model.provider.id,
+              })),
+            ]
+          }),
           values(),
           flat(),
         ),


### PR DESCRIPTION
### What does this PR do?

- This PR expands the model picker options by excluding codex models from the family dedupe: non-Codex models remain deduped, while all Codex variants are listed.

- Result: OAuth users can select more codex models, like what OpenAI offers in their official IDE plugin.

Fixes #10560 

### How did you verify your code works?
Verified in the desktop app model picker
<img width="293" height="360" alt="image" src="https://github.com/user-attachments/assets/79fb503a-5e24-4ef9-9976-52815d9ea0da" />
Compared to codex IDE plugin
<img width="293" height="360" alt="image" src="https://github.com/user-attachments/assets/b567179e-0143-4b51-ad7f-0ef00825887a" />
