### PR TITLE
fix(tui): prevent crash when theme search returns no results

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -149,7 +149,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   function moveTo(next: number, center = false) {
     setStore("selected", next)
-    props.onMove?.(selected()!)
+    const option = selected()
+    if (option) props.onMove?.(option)
     if (!scroll) return
     const target = scroll.getChildren().find((child) => {
       return child.id === JSON.stringify(selected()?.value)


### PR DESCRIPTION
### What does this PR do?

Fixes #10488

When searching for themes in the TUI that don't exist, the DialogSelect component would crash with ```undefined is not an object (evaluating 'opt.value')```. This happened because the onMove callback was being called even when the filtered options list was empty

### Before
![beforee](https://github.com/user-attachments/assets/23ab38a9-394f-49d8-ab52-77943d5180e1)


### After
![afteree](https://github.com/user-attachments/assets/d8688fb3-90e0-4906-a02d-ed07913e1a51)



The fix adds a safety check in the moveTo function to only call onMove when there's actually a valid option selected.

### How did you verify your code works?
1. Run bun dev in the TUI
2. Use /theme command
3. Search for a theme that doesn't exist
4. The dialog should show "No results found" without crashing

This is a minimal bug fix that follows the existing code patterns and doesn't change any external behavior.

