### PR TITLE
fix(web): add & fix the download button

### DIFF
--- a/packages/console/app/src/component/header.tsx
+++ b/packages/console/app/src/component/header.tsx
@@ -170,22 +170,18 @@ export function Header(props: { zen?: boolean; hideGetStarted?: boolean }) {
             </Switch>
           </li>
           <Show when={!props.hideGetStarted}>
-            {" "}
             <li>
-              {" "}
               <A href="/download" data-slot="cta-button">
-                {" "}
                 <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  {" "}
                   <path
                     d="M12.1875 9.75L9.00001 12.9375L5.8125 9.75M9.00001 2.0625L9 12.375M14.4375 15.9375H3.5625"
                     stroke="currentColor"
                     stroke-width="1.5"
                     stroke-linecap="square"
-                  />{" "}
-                </svg>{" "}
-                Free{" "}
-              </A>{" "}
+                  />
+                </svg>
+                Free
+              </A>
             </li>
           </Show>
         </ul>

--- a/packages/console/app/src/routes/changelog/index.css
+++ b/packages/console/app/src/routes/changelog/index.css
@@ -106,10 +106,13 @@
           [data-slot="cta-button"] {
             background: var(--color-background-strong);
             color: var(--color-text-inverted);
-            padding: 8px 16px;
+            padding: 8px 16px 8px 10px;
             border-radius: 4px;
             font-weight: 500;
             text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 8px;
 
             @media (max-width: 55rem) {
               display: none;

--- a/packages/console/app/src/routes/changelog/index.tsx
+++ b/packages/console/app/src/routes/changelog/index.tsx
@@ -97,7 +97,7 @@ export default function Changelog() {
       <Meta name="description" content="OpenCode release notes and changelog" />
 
       <div data-component="container">
-        <Header hideGetStarted />
+        <Header />
 
         <div data-component="content">
           <section data-component="changelog-hero">


### PR DESCRIPTION
### What does this PR do?

Added the desktop/cli download button to the changelog page.

<img width="634" height="317" alt="image" src="https://github.com/user-attachments/assets/5028d618-f48a-4eb2-9adb-d213af0500a6" />


### How did you verify your code works?

I used my eyes