### PR TITLE
docs: fix permission event name (permission.asked not permission.updated)

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -170,8 +170,8 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 #### Permission Events
 
+- `permission.asked`
 - `permission.replied`
-- `permission.updated`
 
 #### Server Events
 


### PR DESCRIPTION
## Summary

- Fix incorrect permission event name in plugin documentation

## Details

The documentation lists `permission.updated` as a permission event, but testing shows the actual event name is `permission.asked`.

**Before:**
```
Permission Events
- permission.replied
- permission.updated
```

**After:**
```
Permission Events
- permission.asked
- permission.replied
```

## How this was discovered

Created a plugin that logs all events to debug notification behavior:

```javascript
event: async ({ event }) => {
  await appendFile("/tmp/debug.log", `${event.type}\n`)
}
```

When triggering a permission prompt, the log shows:
```
permission.asked    <- when permission prompt appears
permission.replied  <- when user responds
```

`permission.updated` never appears - that event doesn't exist.

## Working example

```javascript
export const NotificationPlugin = async ({ $ }) => {
  return {
    event: async ({ event }) => {
      // This works:
      if (event.type === "permission.asked") {
        await $\`osascript -e 'display notification "Permission required!" with title "OpenCode"'\`
      }
    },
  }
}
```