### PR TITLE
docs: add ecosystem entries for ELF, Ralph Wiggum, and Switch-Omo-Config

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -46,6 +46,9 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                       |
+| [opencode-elf](https://github.com/mark-hingston/opencode-elf)                                      | Emergent Learning Framework - learns from past successes/failures to improve AI coding         |
+| [opencode-ralph](https://github.com/rot13maxi/opencode-ralph)                                      | Ralph Wiggum plugin for iterative self-referential AI development loops (native plugin)        |
+| [@th0rgal/ralph-wiggum](https://github.com/Th0rgal/open-ralph-wiggum)                              | Multi-agent Ralph Wiggum CLI wrapper for Claude Code, Codex, and OpenCode                      |
 
 ---
 
@@ -64,6 +67,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Switch-Omo-Config](https://github.com/AnPod/Switch-Omo-Config)                            | Shell script utility to switch oh-my-opencode configuration profiles                      |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds four new community projects to the OpenCode ecosystem page:

### Plugins

- **[opencode-elf](https://github.com/mark-hingston/opencode-elf)** - Emergent Learning Framework that learns from past successes/failures to improve AI coding through golden rules, heuristics, and context injection
- **[opencode-ralph](https://github.com/rot13maxi/opencode-ralph)** - Native Ralph Wiggum plugin implementing iterative self-referential AI development loops (ported from Claude Code's official plugin)
- **[@th0rgal/ralph-wiggum](https://github.com/Th0rgal/open-ralph-wiggum)** - Multi-agent CLI wrapper supporting Claude Code, Codex, and OpenCode with task tracking, status monitoring, and mid-loop context injection

### Projects

- **[Switch-Omo-Config](https://github.com/AnPod/Switch-Omo-Config)** - Shell script utility for switching oh-my-opencode configuration profiles (useful for users with multiple oh-my-opencode setups)

---

All projects are actively maintained and have been tested with current OpenCode versions.