### PR TITLE
docs: add warning about Claude Pro/Max subscription support

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -279,7 +279,7 @@ For custom inference profiles, use the model and provider name in the key and se
    ```
 
 :::info
-Using your Claude Pro/Max subscription is not officially supported in Opencode. We've received [reports](https://x.com/trq212/status/2009689809875591565) of some users having their subscriptions blocked while using it with OpenCode.
+Using your Claude Pro/Max subscription in OpenCode is not officially supported by [Anthropic](https://anthropic.com).
 :::
 
 ##### Using API keys

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -254,12 +254,6 @@ For custom inference profiles, use the model and provider name in the key and se
 
 ### Anthropic
 
-We recommend signing up for [Claude Pro](https://www.anthropic.com/news/claude-pro) or [Max](https://www.anthropic.com/max).
-
-:::info
-We've received reports of some users having their subscriptions blocked while using it with OpenCode.
-:::
-
 1. Once you've signed up, run the `/connect` command and select Anthropic.
 
    ```txt
@@ -283,6 +277,10 @@ We've received reports of some users having their subscriptions blocked while us
    ```txt
    /models
    ```
+
+:::info
+Using your Claude Pro/Max subscription is not officially supported in Opencode. We've received [reports](https://x.com/trq212/status/2009689809875591565) of some users having their subscriptions blocked while using it with OpenCode.
+:::
 
 ##### Using API keys
 


### PR DESCRIPTION
## Summary

- Remove recommendation to sign up for Claude Pro/Max
- Add info block noting that Pro/Max subscriptions are not officially supported by Anthropic
- Reference [user report](https://x.com/trq212/status/2009689809875591565) of subscription being blocked