### PR TITLE
fix(session): handle ModelNotFoundError gracefully in prompt loop

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -730,8 +730,14 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async (stream) => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
+          try {
+            const msg = await SessionPrompt.prompt({ ...body, sessionID })
+            stream.write(JSON.stringify(msg))
+          } catch (e) {
+            // Error event is already published in SessionPrompt.loop for ModelNotFoundError
+            // Log the error but don't re-throw to prevent unhandled exception stack traces
+            log.error("prompt failed", { sessionID, error: e })
+          }
         })
       },
     )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -310,14 +310,40 @@ export namespace SessionPrompt {
           history: msgs,
         })
 
-      const model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID)
+      let model: Provider.Model
+      try {
+        model = await Provider.getModel(lastUser.model.providerID, lastUser.model.modelID)
+      } catch (e) {
+        if (Provider.ModelNotFoundError.isInstance(e)) {
+          const { providerID, modelID, suggestions } = e.data
+          const hint = suggestions?.length ? ` Did you mean: ${suggestions.join(", ")}?` : ""
+          Bus.publish(Session.Event.Error, {
+            sessionID,
+            error: new NamedError.Unknown({ message: `Model not found: ${providerID}/${modelID}.${hint}` }).toObject(),
+          })
+        }
+        throw e
+      }
       const task = tasks.pop()
 
       // pending subtask
       // TODO: centralize "invoke tool" logic
       if (task?.type === "subtask") {
         const taskTool = await TaskTool.init()
-        const taskModel = task.model ? await Provider.getModel(task.model.providerID, task.model.modelID) : model
+        let taskModel: Provider.Model
+        try {
+          taskModel = task.model ? await Provider.getModel(task.model.providerID, task.model.modelID) : model
+        } catch (e) {
+          if (Provider.ModelNotFoundError.isInstance(e)) {
+            const { providerID, modelID, suggestions } = e.data
+            const hint = suggestions?.length ? ` Did you mean: ${suggestions.join(", ")}?` : ""
+            Bus.publish(Session.Event.Error, {
+              sessionID,
+              error: new NamedError.Unknown({ message: `Model not found: ${providerID}/${modelID}.${hint}` }).toObject(),
+            })
+          }
+          throw e
+        }
         const assistantMessage = (await Session.updateMessage({
           id: Identifier.ascending("message"),
           role: "assistant",


### PR DESCRIPTION
When using a non-existent provider/model, the application now:
- Publishes Session.Event.Error to notify clients properly
- Displays a friendly error message instead of stack trace
- Prevents UI disruption in TUI/Web mode

Changes:
- Add try-catch for Provider.getModel() in loop function
- Add try-catch for subtask model retrieval
- Handle errors gracefully in session prompt route

Fixes UI disruption when using custom providers like oh-my-opencode's sisypus

### What does this PR do?

### How did you verify your code works?                                                                                  
  - [√] Run `opencode run -m "sisypus/test-model" "hello"`                                   
  - [√] Verify clean error message: `Error: Model not found: sisypus/test-model.`            
  - [√] Verify no stack trace is displayed       

Fixes #10631                                                                               
                                                                                                  
