### PR TITLE
fix(opencode): handle bare git repos and worktrees created from them, FIX #10643

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -54,125 +54,167 @@ export namespace Project {
     log.info("fromDirectory", { directory })
 
     const { id, sandbox, worktree, vcs } = await iife(async () => {
-      const matches = Filesystem.up({ targets: [".git"], start: directory })
-      const git = await matches.next().then((x) => x.value)
-      await matches.return()
-      if (git) {
-        let sandbox = path.dirname(git)
+      const gitBinary = Bun.which("git")
 
-        const gitBinary = Bun.which("git")
+      const findDotGit = async () => {
+        const matches = Filesystem.up({ targets: [".git"], start: directory })
+        const dotGit = await matches.next().then((x) => x.value)
+        await matches.return()
+        return dotGit
+      }
 
-        // cached id calculation
-        let id = await Bun.file(path.join(git, "opencode"))
+      // read cached id
+      const readId = async (commonDir: string) =>
+        Bun.file(path.join(commonDir, "opencode"))
           .text()
           .then((x) => x.trim())
           .catch(() => undefined)
 
-        if (!gitBinary) {
+      const writeId = async (commonDir: string, id: string) =>
+        Bun.file(path.join(commonDir, "opencode"))
+          .write(id)
+          .catch(() => undefined)
+
+      // generate id from root commit
+      const generateId = async (cwd: string) => {
+        const roots = await $`git rev-list --max-parents=0 --all`
+          .quiet()
+          .nothrow()
+          .cwd(cwd)
+          .text()
+          .then((x) =>
+            x
+              .split("\n")
+              .filter(Boolean)
+              .map((x) => x.trim())
+              .toSorted(),
+          )
+          .catch(() => undefined)
+        return roots?.[0]
+      }
+
+      const globalFallback = (vcs?: "git") => ({
+        id: "global",
+        sandbox: "/",
+        worktree: "/",
+        vcs: vcs ?? Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
+      })
+
+      // No git binary - fallback to .git directory search
+      if (!gitBinary) {
+        const dotGit = await findDotGit()
+        if (dotGit) {
+          const sandbox = path.dirname(dotGit)
+          const id = await readId(dotGit)
           return {
             id: id ?? "global",
-            worktree: sandbox,
             sandbox: sandbox,
+            worktree: sandbox,
             vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
           }
         }
+        return globalFallback()
+      }
 
-        // generate id from root commit
-        if (!id) {
-          const roots = await $`git rev-list --max-parents=0 --all`
+      const insideGitWorktree = await $`git rev-parse --is-inside-work-tree`
+        .quiet()
+        .nothrow()
+        .cwd(directory)
+        .text()
+        .then((x) => x.trim() === "true")
+        .catch(() => false)
+
+      // Inside a git worktree (normal repo or worktree from repo / bare-repo)
+      if (insideGitWorktree) {
+        const sandbox = await iife(async () => {
+          const top = await $`git rev-parse --show-toplevel`
             .quiet()
             .nothrow()
-            .cwd(sandbox)
+            .cwd(directory)
             .text()
-            .then((x) =>
-              x
-                .split("\n")
-                .filter(Boolean)
-                .map((x) => x.trim())
-                .toSorted(),
-            )
+            .then((x) => x.trim())
             .catch(() => undefined)
+          if (top) return top
 
-          if (!roots) {
-            return {
-              id: "global",
-              worktree: sandbox,
-              sandbox: sandbox,
-              vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
-            }
-          }
+          const dotGit = await findDotGit()
+          if (!dotGit) return undefined
+          return path.dirname(dotGit)
+        })
+        if (!sandbox) return globalFallback()
 
-          id = roots[0]
-          if (id) {
-            void Bun.file(path.join(git, "opencode"))
-              .write(id)
-              .catch(() => undefined)
-          }
-        }
-
-        if (!id) {
-          return {
-            id: "global",
-            worktree: sandbox,
-            sandbox: sandbox,
-            vcs: "git",
-          }
-        }
-
-        const top = await $`git rev-parse --show-toplevel`
+        // Get the common git directory (for storing opencode id file)
+        // - normal repo: returns .git directory
+        // - linked worktree: returns the main repo's .git or bare repo path
+        const commonDir = await $`git rev-parse --git-common-dir`
           .quiet()
           .nothrow()
           .cwd(sandbox)
           .text()
           .then((x) => path.resolve(sandbox, x.trim()))
           .catch(() => undefined)
+        if (!commonDir) return globalFallback()
 
-        if (!top) {
-          return {
-            id,
-            sandbox,
-            worktree: sandbox,
-            vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
-          }
+        let id = await readId(commonDir)
+        if (!id) {
+          id = await generateId(sandbox)
+          if (id) await writeId(commonDir, id)
         }
 
-        sandbox = top
-
-        const worktree = await $`git rev-parse --git-common-dir`
+        // For normal repos: commonDir is .git, worktree is sandbox (parent of .git)
+        // For linked worktrees: commonDir is main repo's .git or bare repo path
+        // Use commonDir's parent as worktree for normal repos, or commonDir itself for bare repos
+        const bare = await $`git rev-parse --is-bare-repository`
           .quiet()
           .nothrow()
-          .cwd(sandbox)
+          .cwd(commonDir)
           .text()
-          .then((x) => {
-            const dirname = path.dirname(x.trim())
-            if (dirname === ".") return sandbox
-            return dirname
-          })
-          .catch(() => undefined)
+          .then((x) => x.trim() === "true")
+          .catch(() => false)
 
-        if (!worktree) {
-          return {
-            id,
-            sandbox,
-            worktree: sandbox,
-            vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
-          }
-        }
+        const worktree = bare ? commonDir : path.dirname(commonDir)
 
         return {
-          id,
-          sandbox,
-          worktree,
+          id: id ?? "global",
+          sandbox: sandbox,
+          worktree: worktree,
           vcs: "git",
         }
       }
 
-      return {
-        id: "global",
-        worktree: "/",
-        sandbox: "/",
-        vcs: Info.shape.vcs.parse(Flag.OPENCODE_FAKE_VCS),
+      // Inside a bare repo
+      const insideGitBareRepo = await $`git rev-parse --is-bare-repository`
+        .quiet()
+        .nothrow()
+        .cwd(directory)
+        .text()
+        .then((x) => x.trim() === "true")
+        .catch(() => false)
+
+      if (insideGitBareRepo) {
+        const commonDir = await $`git rev-parse --git-common-dir`
+          .quiet()
+          .nothrow()
+          .cwd(directory)
+          .text()
+          .then((x) => path.resolve(directory, x.trim()))
+          .catch(() => undefined)
+        if (!commonDir) return globalFallback()
+
+        let id = await readId(commonDir)
+        if (!id) {
+          id = await generateId(commonDir)
+          if (id) await writeId(commonDir, id)
+        }
+
+        return {
+          id: id ?? "global",
+          sandbox: commonDir,
+          worktree: commonDir,
+          vcs: "git",
+        }
       }
+
+      return globalFallback()
     })
 
     let existing = await Storage.read<Info>(["project", id]).catch(() => undefined)

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -89,6 +89,74 @@ describe("Project.fromDirectory with worktrees", () => {
   })
 })
 
+describe("Project.fromDirectory with bare repo", () => {
+  test("should handle git bare repo with no commits", async () => {
+    await using tmp = await tmpdir()
+    const bare = path.join(tmp.path, "bare.git")
+    await $`git init --bare ${bare}`.quiet()
+
+    const { project } = await Project.fromDirectory(bare)
+
+    expect(project).toBeDefined()
+    expect(project.id).toBe("global")
+    expect(project.vcs).toBe("git")
+    expect(project.worktree).toBe(bare)
+
+    const file = path.join(bare, "opencode")
+    const exists = await Bun.file(file).exists()
+    expect(exists).toBe(false)
+  })
+
+  test("should handle git bare repo with commits", async () => {
+    await using tmp = await tmpdir()
+    const bare = path.join(tmp.path, "bare.git")
+    await $`git init --bare ${bare}`.quiet()
+
+    const worktreePath = path.join(tmp.path, "worktree")
+    await $`git worktree add ${worktreePath} -b test`.cwd(bare).quiet()
+    await $`git commit --allow-empty -m "root commit ${worktreePath}"`.cwd(worktreePath).quiet()
+
+    const { project, sandbox } = await Project.fromDirectory(bare)
+
+    expect(project).toBeDefined()
+    expect(project.id).not.toBe("global")
+    expect(project.vcs).toBe("git")
+    expect(project.worktree).toBe(bare)
+    expect(sandbox).toBe(bare)
+    expect(project.sandboxes).toBeEmpty()
+
+    const file = path.join(bare, "opencode")
+    const exists = await Bun.file(file).exists()
+    expect(exists).toBe(true)
+
+    await $`git worktree remove ${worktreePath}`.cwd(bare).quiet()
+  })
+})
+
+describe("Project.fromDirectory with worktrees created from bare repo", () => {
+  test("should set worktree to bare repo when called from a worktree", async () => {
+    await using tmp = await tmpdir()
+    const bare = path.join(tmp.path, "bare.git")
+    await $`git init --bare ${bare}`.quiet()
+
+    const worktreePath = path.join(tmp.path, "worktree")
+    await $`git worktree add ${worktreePath} -b test`.cwd(bare).quiet()
+    await $`git commit --allow-empty -m "root commit ${worktreePath}"`.cwd(worktreePath).quiet()
+
+    const { project, sandbox } = await Project.fromDirectory(worktreePath)
+
+    expect(project).toBeDefined()
+    expect(project.id).not.toBe("global")
+    expect(project.vcs).toBe("git")
+    expect(project.worktree).toBe(bare)
+    expect(sandbox).toBe(worktreePath)
+    expect(project.sandboxes).toContain(worktreePath)
+    expect(project.sandboxes).not.toContain(bare)
+
+    await $`git worktree remove ${worktreePath}`.cwd(bare).quiet()
+  })
+})
+
 describe("Project.discover", () => {
   test("should discover favicon.png in root", async () => {
     await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
### What does this PR do?

Worktree path is resolved incorrectly for bare repos, which makes later git operations run in a non‑repo directory.

FIX #10643

Detect bare repos with `git rev-parse --is-bare-repository` and set worktree to `git rev-parse --git-common-dir` when bare. Store the opencode id in the `common-dir`.

This makes bare repos work at a basic level. Some features still rely on a normal worktree, but the bare repo is now detected, and basic chat and code edits work.

### How did you verify your code works?

I tested locally and added basic test cases.
