### PR TITLE
fix: replace rg with fd to search empty directory

### DIFF
--- a/packages/opencode/src/file/fd.ts
+++ b/packages/opencode/src/file/fd.ts
@@ -119,10 +119,12 @@ export namespace Fd {
 
   export async function* list(input: {
     cwd: string
+    follow?: boolean
     hidden?: boolean
   }) {
 
     const args = [await fdExcutablePath(), "--exclude", ".git"]
+    if (input.follow !== false) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
 
 

--- a/packages/opencode/src/file/fd.ts
+++ b/packages/opencode/src/file/fd.ts
@@ -1,0 +1,172 @@
+import fs from "fs/promises"
+import path from "path"
+import z from "zod"
+import { Global } from "../global"
+import { NamedError } from "@opencode-ai/util/error"
+import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
+
+export namespace Fd {
+  const DownloadFailedError = NamedError.create(
+    "FdDownloadFailedError",
+    z.object({
+      url: z.string(),
+      status: z.number(),
+    }),
+  )
+  const ExtractionFailedError = NamedError.create(
+    "FdExtractionFailedError",
+    z.object({
+      filepath: z.string(),
+      stderr: z.string(),
+    }),
+  )
+
+  const PLATFORM = {
+    "arm64-darwin": { filename: "aarch64-apple-darwin", extension: "tar.gz" },
+    "arm64-win32": { filename: "aarch64-pc-windows-msvc", extension: "zip" },
+    "arm64-linux": { filename: "aarch64-unknown-linux-gnu", extension: "tar.gz" },
+    "x64-darwin": { filename: "x86_64-apple-darwin", extension: "tar.gz" },
+    "x64-win32": { filename: "x86_64-pc-windows-gnu", extension: "zip" },
+    "x64-linux": { filename: "x86_64-unknown-linux-gnu", extension: "tar.gz" },
+  }
+
+  async function downloadFd() {
+    const version = "v10.3.0"
+    const platformKey = `${process.arch}-${process.platform}` as keyof typeof PLATFORM
+    const platform = PLATFORM[platformKey]
+
+    const filename = `fd-${version}-${platform.filename}.${platform.extension}`
+    const url = `https://github.com/sharkdp/fd/releases/download/${version}/${filename}`
+
+    const response = await fetch(url)
+    if (!response.ok) throw new DownloadFailedError({ url, status: response.status })
+
+    const buffer = await response.arrayBuffer()
+    const archivePath = path.join(Global.Path.bin, filename)
+    await Bun.write(archivePath, buffer)
+
+
+    if (platform.extension === "tar.gz") {
+      const args = ["tar", "-xzf", archivePath, "--strip-components=1"]
+
+      if (platformKey.endsWith("-darwin")) args.push("--include=*/fd")
+      if (platformKey.endsWith("-linux")) args.push("--wildcards", "*/fd")
+
+      const proc = Bun.spawn(args, {
+        cwd: Global.Path.bin,
+        stderr: "pipe",
+        stdout: "pipe",
+      })
+
+      await proc.exited
+      if (proc.exitCode !== 0) {
+        throw new ExtractionFailedError({
+          filepath: archivePath,
+          stderr: await Bun.readableStreamToText(proc.stderr),
+        })
+      }
+    }
+
+    if (platform.extension === "zip") {
+      const zipFileReader = new ZipReader(new BlobReader(new Blob([await Bun.file(archivePath).arrayBuffer()])))
+      const entries = await zipFileReader.getEntries()
+      let fdEntry: any
+      for (const entry of entries) {
+        if (entry.filename.endsWith("fd.exe")) {
+          fdEntry = entry
+          break
+        }
+      }
+
+      if (!fdEntry) {
+        throw new ExtractionFailedError({
+          filepath: archivePath,
+          stderr: "fd.exe not found in zip archive",
+        })
+      }
+
+      const fdBlob = await fdEntry.getData(new BlobWriter())
+      if (!fdBlob) {
+        throw new ExtractionFailedError({
+          filepath: archivePath,
+          stderr: "Failed to extract fd.exe from zip archive",
+        })
+      }
+      await Bun.write(path.join(Global.Path.bin, "fd.exe"), await fdBlob.arrayBuffer())
+      await zipFileReader.close()
+    }
+
+    await fs.unlink(archivePath)
+    if (!platformKey.endsWith("-win32")) {
+      await fs.chmod(path.join(Global.Path.bin, "fd"), 0o755)
+    }
+  }
+
+
+  export async function fdExcutablePath() {
+    let filepath = Bun.which("fd")
+    if (filepath) return filepath
+
+    filepath = path.join(Global.Path.bin, "fd" + (process.platform === "win32" ? ".exe" : ""))
+
+    if (await Bun.file(filepath).exists()) {
+      return filepath
+    }
+
+    await downloadFd()
+    return filepath
+  }
+
+  export async function* list(input: {
+    cwd: string
+    hidden?: boolean
+  }) {
+
+    const args = [await fdExcutablePath(), "--exclude", ".git"]
+    if (input.hidden !== false) args.push("--hidden")
+
+
+    // Bun.spawn should throw this, but it incorrectly reports that the executable does not exist.
+    // See https://github.com/oven-sh/bun/issues/24012
+    if (!(await fs.stat(input.cwd).catch(() => undefined))?.isDirectory()) {
+      throw Object.assign(new Error(`No such file or directory: '${input.cwd}'`), {
+        code: "ENOENT",
+        errno: -2,
+        path: input.cwd,
+      })
+    }
+
+
+    const proc = Bun.spawn(args, {
+      cwd: input.cwd,
+      stdout: "pipe",
+      stderr: "ignore",
+      maxBuffer: 1024 * 1024 * 20,
+    })
+
+    const reader = proc.stdout.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ""
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        // Handle both Unix (\n) and Windows (\r\n) line endings
+        const lines = buffer.split(/\r?\n/)
+        buffer = lines.pop() || ""
+
+        for (const line of lines) {
+          if (line) yield line
+        }
+      }
+
+      if (buffer) yield buffer
+    } finally {
+      reader.releaseLock()
+      await proc.exited
+    }
+  }
+}

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -167,8 +167,13 @@ export namespace File {
         return
       }
 
-      const set = new Set<string>()
-      for await (const file of Fd.list({ cwd: Instance.directory })) {
+      for await (let file of Fd.list({ cwd: Instance.directory })) {
+        if (process.platform == "win32") {
+          // On a regular Windows PC, fd returns paths with backslashes '\\',
+          // but on Windows in GitHub Actions, it seems to return paths with forward slashes '/'
+          // (which causes the test to fail), we just replace '/' here simply.
+          file = file.replaceAll('/', '\\')
+        }
         if (file.endsWith("/") || file.endsWith("\\")) {
           result.dirs.push(file)
         } else {

--- a/packages/opencode/src/file/index.ts
+++ b/packages/opencode/src/file/index.ts
@@ -7,11 +7,12 @@ import path from "path"
 import fs from "fs"
 import ignore from "ignore"
 import { Log } from "../util/log"
-import { Filesystem } from "../util/filesystem"
+// import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
-import { Ripgrep } from "./ripgrep"
+// import { Ripgrep } from "./ripgrep"
 import fuzzysort from "fuzzysort"
 import { Global } from "../global"
+import { Fd } from "./fd"
 
 export namespace File {
   const log = Log.create({ service: "file" })
@@ -167,17 +168,11 @@ export namespace File {
       }
 
       const set = new Set<string>()
-      for await (const file of Ripgrep.files({ cwd: Instance.directory })) {
-        result.files.push(file)
-        let current = file
-        while (true) {
-          const dir = path.dirname(current)
-          if (dir === ".") break
-          if (dir === current) break
-          current = dir
-          if (set.has(dir)) continue
-          set.add(dir)
-          result.dirs.push(dir + "/")
+      for await (const file of Fd.list({ cwd: Instance.directory })) {
+        if (file.endsWith("/") || file.endsWith("\\")) {
+          result.dirs.push(file)
+        } else {
+          result.files.push(file)
         }
       }
       cache = result


### PR DESCRIPTION
### What does this PR do?
Fixes #10637 and #11827

### How did you verify your code works?
#### Why is it wrong now?
When we type '@', it will trigger File.search, which use ripgrep to retrieve all the files and directorys.   
>  packages/opencode/src/file/index.ts

The command be excuted is `rg --files ...` eventually, and it only list files, we later use these files to extrapolate  the directorys. The key point is that `rg` only list files.

#### How I resolved it?
Use [fd](https://github.com/sharkdp/fd) to replace rg

#### I have verified it in
- OS: macOS 15.6 / win11
- OpenCode: 1.1.36