### PR TITLE
fix: ensure cache dir has package.json before bun install

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import { Global } from "../global"
 import { Log } from "../util/log"
 import path from "path"
+import fs from "fs/promises"
 import { Filesystem } from "../util/filesystem"
 import { NamedError } from "@opencode-ai/util/error"
 import { readableStreamToText } from "bun"
@@ -64,6 +65,14 @@ export namespace BunProc {
   export async function install(pkg: string, version = "latest") {
     // Use lock to ensure only one install at a time
     using _ = await Lock.write("bun-install")
+
+    // Ensure cache directory exists with a package.json so bun doesn't traverse up
+    // to find a parent workspace (e.g., if user has package.json in home directory)
+    await fs.mkdir(Global.Path.cache, { recursive: true })
+    const pkgJsonPath = path.join(Global.Path.cache, "package.json")
+    if (!(await Filesystem.exists(pkgJsonPath))) {
+      await Bun.write(pkgJsonPath, "{}")
+    }
 
     const mod = path.join(Global.Path.cache, "node_modules", pkg)
     const pkgjson = Bun.file(path.join(Global.Path.cache, "package.json"))


### PR DESCRIPTION
### What does this PR do?
Fixes plugin installation failure when user has a `package.json` in their home directory
When running `bun add --cwd <cache-dir> <package>`, Bun traverses up from the target directory looking for a workspace root (a directory with `package.json`). If the user has a `package.json` in their home directory (e.g., `~/.git` repo with `package.json`), Bun installs packages there instead of in the cache directory.
This causes the subsequent `import()` to fail with `ERR_MODULE_NOT_FOUND` because the packages aren't where OpenCode expects them.

Error example:
ERROR ... message=Cannot find module 'C:\Users\...\.cache\opencode\node_modules\opencode-anthropic-auth' from 'B/~BUN/root/src/index.js'

### Solution
Create the cache directory and an empty `package.json` before running `bun add`. This ensures Bun recognizes the cache directory as the
workspace root and installs packages there.

### How did you verify your code works?
Verified by:
1. Removing the cache directory
2. Having a `package.json` in the home directory
3. Running the install - packages now correctly install to the cache directory