### PR TITLE
fix(ui): use focus-visible instead of focus to prevent sticky hover effect on click

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -131,7 +131,7 @@ export function SessionHeader() {
           <Portal mount={mount()}>
             <button
               type="button"
-              class="hidden md:flex w-[320px] p-1 pl-1.5 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-raised-base transition-colors cursor-default hover:bg-surface-raised-base-hover focus:bg-surface-raised-base-hover active:bg-surface-raised-base-active"
+              class="hidden md:flex w-[320px] p-1 pl-1.5 items-center gap-2 justify-between rounded-md border border-border-weak-base bg-surface-raised-base transition-colors cursor-default hover:bg-surface-raised-base-hover focus-visible:bg-surface-raised-base-hover active:bg-surface-raised-base-active"
               onClick={() => command.trigger("file.open")}
               aria-label={language.t("session.header.searchFiles")}
             >

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1654,7 +1654,7 @@ export default function Layout(props: ParentProps) {
       <div
         data-session-id={props.session.id}
         class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-3
-               hover:bg-surface-raised-base-hover focus-within:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
+               hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
       >
         <Show
           when={hoverEnabled()}
@@ -1771,7 +1771,7 @@ export default function Layout(props: ParentProps) {
     )
 
     return (
-      <div class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover focus-within:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active">
+      <div class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-3 hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active">
         <Show
           when={!tooltip()}
           fallback={

--- a/packages/ui/src/components/button.css
+++ b/packages/ui/src/components/button.css
@@ -46,7 +46,7 @@
     &:hover:not(:disabled) {
       background-color: var(--surface-raised-base-hover);
     }
-    &:focus:not(:disabled) {
+    &:focus-visible:not(:disabled) {
       background-color: var(--surface-raised-base-hover);
     }
     &:active:not(:disabled) {

--- a/packages/ui/src/components/icon-button.css
+++ b/packages/ui/src/components/icon-button.css
@@ -90,8 +90,8 @@
       /*   color: var(--icon-hover); */
       /* } */
     }
-    &:focus:not(:disabled) {
-      background-color: var(--surface-focus);
+    &:focus-visible:not(:disabled) {
+      background-color: var(--surface-raised-base-hover);
     }
     &:active:not(:disabled) {
       background-color: var(--surface-raised-base-active);

--- a/packages/ui/src/components/list.css
+++ b/packages/ui/src/components/list.css
@@ -40,11 +40,8 @@
       transition: opacity 0.15s ease;
 
       &:hover:not(:disabled),
+      &:focus-visible:not(:disabled),
       &:active:not(:disabled) {
-        background-color: transparent;
-        opacity: 0.7;
-      }
-      &:focus-visible:not(:disabled) {
         background-color: transparent;
         opacity: 0.7;
       }
@@ -94,11 +91,8 @@
       transition: opacity 0.15s ease;
 
       &:hover:not(:disabled),
+      &:focus-visible:not(:disabled),
       &:active:not(:disabled) {
-        background-color: transparent;
-        opacity: 0.7;
-      }
-      &:focus-visible:not(:disabled) {
         background-color: transparent;
         opacity: 0.7;
       }

--- a/packages/ui/src/components/list.css
+++ b/packages/ui/src/components/list.css
@@ -40,8 +40,11 @@
       transition: opacity 0.15s ease;
 
       &:hover:not(:disabled),
-      &:focus:not(:disabled),
       &:active:not(:disabled) {
+        background-color: transparent;
+        opacity: 0.7;
+      }
+      &:focus-visible:not(:disabled) {
         background-color: transparent;
         opacity: 0.7;
       }
@@ -91,8 +94,11 @@
       transition: opacity 0.15s ease;
 
       &:hover:not(:disabled),
-      &:focus:not(:disabled),
       &:active:not(:disabled) {
+        background-color: transparent;
+        opacity: 0.7;
+      }
+      &:focus-visible:not(:disabled) {
         background-color: transparent;
         opacity: 0.7;
       }

--- a/packages/ui/src/components/select.css
+++ b/packages/ui/src/components/select.css
@@ -31,7 +31,7 @@
       }
     }
 
-    &:not([data-expanded]):focus {
+    &:not([data-expanded]):focus-visible {
       &[data-variant="secondary"] {
         background-color: var(--button-secondary-base);
       }


### PR DESCRIPTION


### What does this PR do?

fixes the sticky hover effect bug where clicking on toggle/button components caused the hover background to persist until clicking elsewhere. The issue was caused by :focus styles being identical to :hover styles when an element receives focus on click, the focus styling stayed even after the mouse left. changed to :focus-visible which only applies for keyboard navigation, not mouse clicks.


it was staying like this forever:
<img width="73" height="33" alt="image" src="https://github.com/user-attachments/assets/957229c4-5226-425e-b7bf-b55539960a00" />
<img width="82" height="54" alt="image" src="https://github.com/user-attachments/assets/6c1779ab-01f8-4d87-88bf-155a0ea235c4" />



### How did you verify your code works?

- [x] clicked ghost buttons, select dropdowns, and session list items
- [x] moved mouse away and confirmed background returns to normal immediately
- [x] tested keyboard navigation (Tab) to confirm focus styling still appears for accessibility
