### PR TITLE
feat: add persistent memory file system

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -13,6 +13,7 @@ import { LocalProvider, useLocal } from "@tui/context/local"
 import { DialogModel, useConnected } from "@tui/component/dialog-model"
 import { DialogMcp } from "@tui/component/dialog-mcp"
 import { DialogStatus } from "@tui/component/dialog-status"
+import { DialogMemory } from "@tui/component/dialog-memory"
 import { DialogThemeList } from "@tui/component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
@@ -444,6 +445,17 @@ function App() {
       },
       onSelect: () => {
         dialog.replace(() => <DialogStatus />)
+      },
+      category: "System",
+    },
+    {
+      title: "View memory",
+      value: "opencode.memory",
+      slash: {
+        name: "memory",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogMemory />)
       },
       category: "System",
     },

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-memory.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-memory.tsx
@@ -1,0 +1,159 @@
+import { TextAttributes } from "@opentui/core"
+import { useTheme } from "../context/theme"
+import { For, Show, createResource, createSignal, onMount } from "solid-js"
+import { useSync } from "@tui/context/sync"
+import { useDialog } from "@tui/ui/dialog"
+import { useTerminalDimensions } from "@opentui/solid"
+import path from "path"
+import os from "os"
+
+export function DialogMemory() {
+  const { theme } = useTheme()
+  const sync = useSync()
+  const dialog = useDialog()
+  const dimensions = useTerminalDimensions()
+
+  // Signal to trigger re-fetch when dialog opens
+  const [fetchTrigger, setFetchTrigger] = createSignal(0)
+
+  // Set dialog to xlarge size on mount and trigger fresh fetch
+  onMount(() => {
+    dialog.setSize("xlarge")
+    setFetchTrigger((n) => n + 1)
+  })
+
+  // Read config directly from disk each time
+  const [memoryFiles] = createResource(fetchTrigger, async () => {
+    const projectDir = sync.data.path.directory || process.cwd()
+    const configPath = path.join(projectDir, "opencode.json")
+
+    // Read config directly from disk
+    const configFile = Bun.file(configPath)
+    if (!(await configFile.exists())) {
+      return []
+    }
+
+    let config: { memory?: string[] }
+    try {
+      config = await configFile.json()
+    } catch {
+      return []
+    }
+
+    const memory = config.memory
+    if (!memory || memory.length === 0) {
+      return []
+    }
+
+    const resolvedPaths: string[] = []
+
+    for (let memoryPath of memory) {
+      // Handle ~/ paths
+      if (memoryPath.startsWith("~/")) {
+        memoryPath = path.join(os.homedir(), memoryPath.slice(2))
+      }
+      // Handle relative paths (resolve from project directory)
+      else if (!path.isAbsolute(memoryPath)) {
+        memoryPath = path.join(projectDir, memoryPath)
+      }
+      // Normalize the path
+      memoryPath = path.normalize(memoryPath)
+      resolvedPaths.push(memoryPath)
+    }
+
+    const results: Array<{ path: string; content: string | null; error?: string }> = []
+
+    for (const memoryPath of resolvedPaths) {
+      try {
+        const file = Bun.file(memoryPath)
+        if (await file.exists()) {
+          const content = await file.text()
+          results.push({ path: memoryPath, content: content || "(empty)" })
+        }
+        // Skip non-existent files - don't add them to results
+      } catch (e) {
+        // Only show errors for files that exist but failed to read
+        results.push({ path: memoryPath, content: null, error: String(e) })
+      }
+    }
+
+    return results
+  })
+
+  // Calculate max height for scrollbox (75% of terminal height)
+  const maxHeight = () => Math.floor(dimensions().height * 0.75)
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Memory Files
+        </text>
+        <text fg={theme.textMuted}>esc</text>
+      </box>
+
+      <Show when={memoryFiles.loading}>
+        <text fg={theme.textMuted}>Loading...</text>
+      </Show>
+
+      <Show when={!memoryFiles.loading && memoryFiles()}>
+        <Show
+          when={memoryFiles()!.length > 0}
+          fallback={
+            <text fg={theme.textMuted}>
+              No memory files configured. You can tell the model to create some.
+            </text>
+          }
+        >
+          <scrollbox
+            maxHeight={maxHeight()}
+            viewportOptions={{
+              paddingRight: 1,
+            }}
+            verticalScrollbarOptions={{
+              paddingLeft: 1,
+              visible: true,
+              trackOptions: {
+                backgroundColor: theme.backgroundElement,
+                foregroundColor: theme.border,
+              },
+            }}
+          >
+            <For each={memoryFiles()!}>
+              {(file) => (
+                <box gap={0} paddingBottom={1}>
+                  <box flexDirection="row" gap={1}>
+                    <text
+                      flexShrink={0}
+                      style={{
+                        fg: file.content !== null ? theme.success : theme.error,
+                      }}
+                    >
+                      •
+                    </text>
+                    <text fg={theme.text} attributes={TextAttributes.BOLD}>
+                      {path.basename(file.path)}
+                    </text>
+                    <text fg={theme.textMuted}>{file.path}</text>
+                  </box>
+                  <Show when={file.content !== null}>
+                    <box paddingLeft={2}>
+                      <text fg={theme.textMuted} wrapMode="word">
+                        {file.content}
+                      </text>
+                    </box>
+                  </Show>
+                  <Show when={file.error}>
+                    <box paddingLeft={2}>
+                      <text fg={theme.error}>{file.error}</text>
+                    </box>
+                  </Show>
+                </box>
+              )}
+            </For>
+          </scrollbox>
+        </Show>
+      </Show>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -8,13 +8,24 @@ import { useToast } from "./toast"
 
 export function Dialog(
   props: ParentProps<{
-    size?: "medium" | "large"
+    size?: "medium" | "large" | "xlarge"
     onClose: () => void
   }>,
 ) {
   const dimensions = useTerminalDimensions()
   const { theme } = useTheme()
   const renderer = useRenderer()
+
+  const width = () => {
+    if (props.size === "xlarge") return Math.min(160, dimensions().width - 4)
+    if (props.size === "large") return 80
+    return 60
+  }
+
+  const paddingTop = () => {
+    if (props.size === "xlarge") return Math.floor(dimensions().height * 0.1)
+    return Math.floor(dimensions().height / 4)
+  }
 
   return (
     <box
@@ -26,7 +37,7 @@ export function Dialog(
       height={dimensions().height}
       alignItems="center"
       position="absolute"
-      paddingTop={dimensions().height / 4}
+      paddingTop={paddingTop()}
       left={0}
       top={0}
       backgroundColor={RGBA.fromInts(0, 0, 0, 150)}
@@ -36,7 +47,7 @@ export function Dialog(
           if (renderer.getSelection()) return
           e.stopPropagation()
         }}
-        width={props.size === "large" ? 80 : 60}
+        width={width()}
         maxWidth={dimensions().width - 2}
         backgroundColor={theme.backgroundPanel}
         paddingTop={1}
@@ -53,7 +64,7 @@ function init() {
       element: JSX.Element
       onClose?: () => void
     }[],
-    size: "medium" as "medium" | "large",
+    size: "medium" as "medium" | "large" | "xlarge",
   })
 
   useKeyboard((evt) => {
@@ -119,7 +130,7 @@ function init() {
     get size() {
       return store.size
     },
-    setSize(size: "medium" | "large") {
+    setSize(size: "medium" | "large" | "xlarge") {
       setStore("size", size)
     },
   }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1030,6 +1030,7 @@ export namespace Config {
           },
         ),
       instructions: z.array(z.string()).optional().describe("Additional instruction files or patterns to include"),
+      memory: z.array(z.string()).optional().describe("Paths to MEMORY.md files that are read before every message and can be written to by the model"),
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
       tools: z.record(z.string(), z.boolean()).optional(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -598,7 +598,7 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
-        system: [...(await SystemPrompt.environment(model)), ...(await SystemPrompt.custom())],
+        system: [...(await SystemPrompt.environment(model)), ...(await SystemPrompt.custom()), ...(await SystemPrompt.memory())],
         messages: [
           ...MessageV2.toModelMessages(sessionMessages, model),
           ...(isLastStep

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -20,6 +20,26 @@ import { Flag } from "@/flag/flag"
 
 const log = Log.create({ service: "system-prompt" })
 
+// Store resolved memory paths for the write tool to use
+let resolvedMemoryPaths: string[] = []
+
+export function getMemoryPaths(): string[] {
+  return resolvedMemoryPaths
+}
+
+export function addMemoryPath(resolvedPath: string): void {
+  if (!resolvedMemoryPaths.includes(resolvedPath)) {
+    resolvedMemoryPaths.push(resolvedPath)
+  }
+}
+
+export function removeMemoryPath(resolvedPath: string): void {
+  const index = resolvedMemoryPaths.indexOf(resolvedPath)
+  if (index !== -1) {
+    resolvedMemoryPaths.splice(index, 1)
+  }
+}
+
 async function resolveRelativeInstruction(instruction: string): Promise<string[]> {
   if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
     return Filesystem.globUp(instruction, Instance.directory, Instance.worktree).catch(() => [])
@@ -148,5 +168,107 @@ export namespace SystemPrompt {
         .then((x) => (x ? "Instructions from: " + url + "\n" + x : "")),
     )
     return Promise.all([...foundFiles, ...foundUrls]).then((result) => result.filter(Boolean))
+  }
+
+  /**
+   * Reads MEMORY.md files before every message.
+   * Unlike custom() which runs once at session start, this runs before each API call.
+   * The model can also write to these files using the memory_write tool.
+   * Always returns memory instructions so the model knows about memory_create.
+   */
+  export async function memory(): Promise<string[]> {
+    const config = await Config.get()
+    
+    const instructions = [
+      "# Memory System",
+      "",
+      "You have access to a persistent memory system that survives across chat sessions.",
+      "",
+      "## Tools",
+      "- `memory_create`: Create a new memory file for a directory or purpose. Use this when the user asks to remember information about a specific part of the project, or when you discover important context that should persist.",
+      "- `memory_write`: Write or append content to an existing memory file.",
+      "",
+      "## When to create memory files",
+      "- When the user explicitly asks to create a memory file or remember something persistently",
+      "- When you discover important project conventions, patterns, or decisions that would be useful in future sessions",
+      "- When working on a specific subdirectory that has its own context worth remembering",
+      "",
+      "## Naming convention",
+      "- Name files based on the directory or purpose: `api_memory.md`, `frontend_memory.md`, `project_memory.md`",
+      "- Use lowercase with underscores",
+      "- Always use .md extension",
+      "",
+    ]
+
+    if (!config.memory || config.memory.length === 0) {
+      resolvedMemoryPaths = []
+      return [
+        [
+          ...instructions,
+          "## Current status",
+          "No memory files are configured yet. Use `memory_create` to create your first memory file.",
+        ].join("\n"),
+      ]
+    }
+
+    const resolvedPaths: string[] = []
+    
+    for (let memoryPath of config.memory) {
+      // Handle ~/ paths
+      if (memoryPath.startsWith("~/")) {
+        memoryPath = path.join(os.homedir(), memoryPath.slice(2))
+      }
+      // Handle relative paths (resolve from project directory)
+      else if (!path.isAbsolute(memoryPath)) {
+        memoryPath = path.join(Instance.directory, memoryPath)
+      }
+      // Normalize the path
+      memoryPath = path.normalize(memoryPath)
+      resolvedPaths.push(memoryPath)
+    }
+
+    // Store resolved paths for the memory_write tool
+    resolvedMemoryPaths = resolvedPaths
+
+    // Read all memory files
+    const results: string[] = []
+    for (const memoryPath of resolvedPaths) {
+      try {
+        const file = Bun.file(memoryPath)
+        if (await file.exists()) {
+          const content = await file.text()
+          if (content.trim()) {
+            results.push(
+              `<memory-file path="${memoryPath}">\n${content}\n</memory-file>`
+            )
+          }
+        }
+      } catch (e) {
+        log.warn(`Failed to read memory file: ${memoryPath}`, { error: e })
+      }
+    }
+
+    if (results.length > 0) {
+      return [
+        [
+          ...instructions,
+          "## Current memory files",
+          "The following memory files are available. Use `memory_write` to update them.",
+          "",
+          ...results,
+        ].join("\n"),
+      ]
+    }
+
+    return [
+      [
+        ...instructions,
+        "## Current status",
+        `${resolvedPaths.length} memory path(s) configured but no files exist yet. Use \`memory_write\` to create content in them, or \`memory_create\` for a new location.`,
+        "",
+        "Configured paths:",
+        ...resolvedPaths.map(p => `- ${p}`),
+      ].join("\n"),
+    ]
   }
 }

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -171,7 +171,7 @@ export namespace SystemPrompt {
   }
 
   /**
-   * Reads MEMORY.md files before every message.
+   * Reads files configured in the memory array before every message.
    * Unlike custom() which runs once at session start, this runs before each API call.
    * The model can also write to these files using the memory_write tool.
    * Always returns memory instructions so the model knows about memory_create.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -264,7 +264,7 @@ export namespace SystemPrompt {
       [
         ...instructions,
         "## Current status",
-        `${resolvedPaths.length} memory path(s) configured but no files exist yet. Use \`memory_write\` to create content in them, or \`memory_create\` for a new location.`,
+        `${resolvedPaths.length} memory path(s) configured but no files exist yet. Use \`memory_write\` to create content in them or to create a new location.`,
         "",
         "Configured paths:",
         ...resolvedPaths.map(p => `- ${p}`),

--- a/packages/opencode/src/tool/memory.ts
+++ b/packages/opencode/src/tool/memory.ts
@@ -1,0 +1,197 @@
+import z from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { addMemoryPath, removeMemoryPath } from "../session/system"
+import { modify, applyEdits, parse } from "jsonc-parser"
+import { Instance } from "../project/instance"
+import os from "os"
+
+// Helper to refresh config cache after memory modifications
+async function refreshConfig() {
+  await Instance.dispose()
+}
+
+type ToolResult = { title: string; metadata: Record<string, any>; output: string }
+
+function error(title: string, message: string): ToolResult {
+  return { title, metadata: {}, output: `Error: ${message}` }
+}
+
+function resolvePath(inputPath: string): string {
+  let resolved = inputPath
+  if (resolved.startsWith("~/")) {
+    resolved = path.join(os.homedir(), resolved.slice(2))
+  } else if (!path.isAbsolute(resolved)) {
+    resolved = path.join(Instance.directory, resolved)
+  }
+  return path.normalize(resolved)
+}
+
+function toConfigPath(absolutePath: string): string {
+  if (absolutePath.startsWith(Instance.directory)) {
+    return "./" + path.relative(Instance.directory, absolutePath).replace(/\\/g, "/")
+  } else if (absolutePath.startsWith(os.homedir())) {
+    return "~/" + path.relative(os.homedir(), absolutePath).replace(/\\/g, "/")
+  }
+  return absolutePath
+}
+
+async function findConfigFile(): Promise<string> {
+  const candidates = [
+    path.join(Instance.directory, "opencode.jsonc"),
+    path.join(Instance.directory, "opencode.json"),
+    path.join(Instance.directory, ".opencode", "opencode.jsonc"),
+    path.join(Instance.directory, ".opencode", "opencode.json"),
+  ]
+  for (const candidate of candidates) {
+    if (await Bun.file(candidate).exists()) return candidate
+  }
+  return path.join(Instance.directory, "opencode.json")
+}
+
+async function getMemoryFromConfig(): Promise<{ configPath: string; configText: string; memory: string[] }> {
+  const configPath = await findConfigFile()
+  const configFile = Bun.file(configPath)
+  const configText = (await configFile.exists()) ? await configFile.text() : "{}"
+  const config = parse(configText) || {}
+  const memory: string[] = config.memory || []
+  return { configPath, configText, memory }
+}
+
+async function addToConfig(filePath: string): Promise<{ configPath: string; configEntry: string }> {
+  const { configPath, configText, memory } = await getMemoryFromConfig()
+  const configEntry = toConfigPath(filePath)
+
+  if (!memory.includes(configEntry)) {
+    const edits = modify(configText, ["memory"], [...memory, configEntry], {
+      formattingOptions: { tabSize: 2, insertSpaces: true },
+    })
+    await Bun.write(configPath, applyEdits(configText, edits))
+    addMemoryPath(filePath)
+    await refreshConfig()
+  }
+
+  return { configPath, configEntry }
+}
+
+export const MemoryWriteTool = Tool.define("memory_write", {
+  description: `Save information to a memory file that persists across sessions. Use when the user wants to remember something, store project context, or save preferences. Creates the file if it doesn't exist. Always show the user the file path after writing.`,
+  parameters: z.object({
+    filePath: z.string().describe("Path to the memory file (e.g., './MEMORY.md' or './docs/notes.md')"),
+    content: z.string().describe("Content to write"),
+    mode: z
+      .enum(["overwrite", "append"])
+      .default("append")
+      .describe("'append' adds to existing content, 'overwrite' replaces it"),
+  }),
+  async execute(params): Promise<ToolResult> {
+    try {
+      const resolved = resolvePath(params.filePath)
+      const fs = await import("fs/promises")
+      await fs.mkdir(path.dirname(resolved), { recursive: true }).catch(() => {})
+
+      let finalContent = params.content
+      const file = Bun.file(resolved)
+      const exists = await file.exists()
+
+      if (params.mode === "append" && exists) {
+        const existing = await file.text()
+        const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : ""
+        finalContent = existing + sep + params.content
+      }
+
+      await Bun.write(resolved, finalContent)
+      const { configEntry } = await addToConfig(resolved)
+
+      return {
+        title: path.basename(resolved),
+        metadata: { filePath: resolved, mode: params.mode, created: !exists },
+        output: `${exists ? "Updated" : "Created"} memory file: ${configEntry}`,
+      }
+    } catch (e) {
+      return error("Write failed", String(e))
+    }
+  },
+})
+
+export const MemoryDeleteTool = Tool.define("memory_delete", {
+  description: `Delete a memory file permanently. Use when the user wants to remove a memory file they no longer need. Always show the user the deleted file path.`,
+  parameters: z.object({
+    filePath: z.string().describe("Path to the memory file to delete"),
+  }),
+  async execute(params): Promise<ToolResult> {
+    try {
+      const resolved = resolvePath(params.filePath)
+      const { configPath, configText, memory } = await getMemoryFromConfig()
+
+      const configEntry = memory.find((entry) => path.normalize(resolvePath(entry)) === resolved)
+      if (!configEntry) return error("Not configured", `"${params.filePath}" is not a configured memory file.`)
+
+      const newMemory = memory.filter((p) => p !== configEntry)
+      const edits = modify(configText, ["memory"], newMemory.length ? newMemory : undefined, {
+        formattingOptions: { tabSize: 2, insertSpaces: true },
+      })
+      await Bun.write(configPath, applyEdits(configText, edits))
+      removeMemoryPath(resolved)
+      await refreshConfig()
+
+      const fs = await import("fs/promises")
+      await fs.unlink(resolved).catch(() => {})
+
+      return {
+        title: path.basename(resolved),
+        metadata: { filePath: resolved, configEntry },
+        output: `Deleted memory file: ${configEntry}`,
+      }
+    } catch (e) {
+      return error("Delete failed", String(e))
+    }
+  },
+})
+
+export const MemoryRenameTool = Tool.define("memory_rename", {
+  description: `Rename or move a memory file to a new location. Use when the user wants to reorganize or rename their memory files. Always show the user the old and new file paths.`,
+  parameters: z.object({
+    oldPath: z.string().describe("Current path to the memory file"),
+    newPath: z.string().describe("New path for the memory file"),
+  }),
+  async execute(params): Promise<ToolResult> {
+    const oldResolved = resolvePath(params.oldPath)
+    const newResolved = resolvePath(params.newPath)
+
+    if (await Bun.file(newResolved).exists()) {
+      return error("Path exists", `File already exists at "${newResolved}"`)
+    }
+    if (!(await Bun.file(oldResolved).exists())) {
+      return error("Source not found", `File not found at "${oldResolved}"`)
+    }
+
+    try {
+      const { configPath, configText, memory } = await getMemoryFromConfig()
+
+      const oldConfigEntry = memory.find((entry) => path.normalize(resolvePath(entry)) === oldResolved)
+      if (!oldConfigEntry) return error("Not configured", `"${params.oldPath}" is not a configured memory file.`)
+
+      const fs = await import("fs/promises")
+      await fs.mkdir(path.dirname(newResolved), { recursive: true }).catch(() => {})
+      await fs.rename(oldResolved, newResolved)
+
+      const newConfigEntry = toConfigPath(newResolved)
+      const newMemory = memory.map((p) => (p === oldConfigEntry ? newConfigEntry : p))
+      const edits = modify(configText, ["memory"], newMemory, { formattingOptions: { tabSize: 2, insertSpaces: true } })
+      await Bun.write(configPath, applyEdits(configText, edits))
+
+      removeMemoryPath(oldResolved)
+      addMemoryPath(newResolved)
+      await refreshConfig()
+
+      return {
+        title: path.basename(newResolved),
+        metadata: { oldPath: oldResolved, newPath: newResolved },
+        output: `Renamed: ${oldConfigEntry} -> ${newConfigEntry}`,
+      }
+    } catch (e) {
+      return error("Rename failed", String(e))
+    }
+  },
+})

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -11,6 +11,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { MemoryWriteTool, MemoryDeleteTool, MemoryRenameTool } from "./memory"
 import type { Agent } from "../agent/agent"
 import { Tool } from "./tool"
 import { Instance } from "../project/instance"
@@ -113,6 +114,8 @@ export namespace ToolRegistry {
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),
+      ...(config.memory && config.memory.length > 0 ? [MemoryDeleteTool, MemoryRenameTool] : []),
+      MemoryWriteTool,
       ...custom,
     ]
   }


### PR DESCRIPTION
- Add config.memory array for specifying memory file paths
- Memory files are read and injected into system prompt before every message
- Add memory_write tool to create/update memory files
- Add memory_delete tool to remove memory files
- Add memory_rename tool to rename/move memory files
- Add /memory command to view all memory files in TUI
- Support ~/,  relative, and absolute paths
- Tools automatically update config when creating new files