### PR TITLE
feat(opencode): support plugins on `opencodePlugins` export

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -77,11 +77,12 @@ export namespace Plugin {
         if (!plugin) continue
       }
       const mod = await import(plugin)
+      const exp = (mod as { opencodePlugins?: typeof mod }).opencodePlugins ?? mod
       // Prevent duplicate initialization when plugins export the same function
       // as both a named export and default export (e.g., `export const X` and `export default X`).
       // Object.entries(mod) would return both entries pointing to the same function reference.
       const seen = new Set<PluginInstance>()
-      for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+      for (const [_name, fn] of Object.entries<PluginInstance>(exp)) {
         if (seen.has(fn)) continue
         seen.add(fn)
         const init = await fn(input)

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -139,6 +139,38 @@ export const MyPlugin: Plugin = async ({ project, client, $, directory, worktree
 
 ---
 
+### Plugin exports
+
+By default, OpenCode treats all exported functions from a plugin module as plugin functions. For multi-purpose packages, you can explicitly mark opencode-specific exports by exporting an `opencodePlugins` object. If found, plugins will be loaded from here instead of the top level exports.
+
+```ts title="multi-purpose-package.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+// Main export for other purposes
+export const otherFunction = () => {
+  /* ... */
+}
+
+// Explicit opencode plugins as named exports
+export const opencodePlugins = {
+  myTool: async ({ client }) => {
+    return {
+      tool: {
+        myTool: tool({
+          description: "A custom tool",
+          args: { foo: tool.schema.string() },
+          async execute(args) {
+            return `Hello ${args.foo}!`
+          },
+        }),
+      },
+    }
+  },
+}
+```
+
+---
+
 ### Events
 
 Plugins can subscribe to events as seen below in the Examples section. Here is a list of the different events available.


### PR DESCRIPTION
### What does this PR do?

Resolves #10583. Currently npm-based plugins effectively *must* be opencode plugins and little else, as opencode will attempt to load the main module & execute factory functions producing plugins.

This pr checks first for an `opencodePlugins` export on the main module,  and loads plugins from there if found.

### How did you verify your code works?

Tested with `@superbfowle/bash-history-mcp-test`, which is based off of https://github.com/rektide/bash-history-mcp/tree/opencode-support-next / nitsanavni/bash-history-mcp#2 , attempting to add `opencode` support to `bash-history-mcp`.

My first pass at trying to do this was quite gnarly, and only worked because `index.ts` didn't export anything. https://github.com/nitsanavni/bash-history-mcp/pull/1/files#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R78-R95

The second PR requires no messing around, was much cleaner to write. 

### Notes

I spent some time trying to add support loading from non-main files, as mentioned in #10583. But trying to get support for `package.json#exports` was not going well and I gave up. This PR only adds support for `opencodePlugins` exports on the main module, which is at least something.