### PR TITLE
docs: Update plugin loading documentation

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -48,8 +48,11 @@ Reference the entry point in `opencode.json` config.
 Config files are discovered in multiple places.
 
 - Global config (`~/.config/opencode/opencode.json`)
-- Project config (`opencode.json`)
 - Hidden project config (`.opencode/opencode.json`)
+
+Config files in these places are not discovered, at least the plugins are not loaded:
+
+- Project config (`opencode.json`)
 
 #### Dependencies
 

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -11,7 +11,7 @@ For examples, check out the [plugins](/docs/ecosystem#plugins) created by the co
 
 ## Use a plugin
 
-There are two ways to load plugins.
+There are three ways to load plugins.
 
 ---
 
@@ -23,6 +23,40 @@ Place JavaScript or TypeScript files in the plugin directory.
 - `~/.config/opencode/plugins/` - Global plugins
 
 Files in these directories are automatically loaded at startup.
+#### bug awareness
+If the plugin needs dependencies then the dependency resolution might not work correctly.
+*workaround*: Reference the plugin entry point explicitly in `opencode.json`.
+
+#### another limitation
+The entry point of the plugins have to be always directly in the `plugins` directory, entry points of subdirectories in the `plugins` directory won't be discovered.
+*workaround*: Reference the plugin entry point explicitly in `opencode.json`.
+
+---
+
+### From global files referenced in config
+
+Place JavaScript or TypeScript files anywhere on the disk.
+Reference the entry point in `opencode.json` config.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["file:///absolute/path/to/plugin/entry_point"]
+}
+```
+
+Config files are discovered in multiple places.
+
+- Global config (`~/.config/opencode/opencode.json`)
+- Project config (`opencode.json`)
+- Hidden project config (`.opencode/opencode.json`)
+
+#### Dependencies
+
+If the plugin needs external dependencies, they should be installed in `node_modules` of the plugin directory using a `package.json` in the plugin directory and `bun install` in the plugin directory.
+You can try to declare the plugin dependencies in `package.json` of the `.opencode` folder to skip the `bun install` step but this is not always working because of dependency plath resolution, especially if the plugin is bundled.
+You can also try to use the `package.json` of the project directly but this has not been tested and is maybe not officially supported.
+Just try what works and hope for the best.
 
 ---
 

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -49,9 +49,6 @@ Config files are discovered in multiple places.
 
 - Global config (`~/.config/opencode/opencode.json`)
 - Hidden project config (`.opencode/opencode.json`)
-
-Config files in these places are not discovered, at least the plugins are not loaded:
-
 - Project config (`opencode.json`)
 
 #### Dependencies


### PR DESCRIPTION
Closes #10556

Expanded documentation on loading plugins, including new methods and limitations.

### What does this PR do?
Improve docs on plugin loading.

### How did you verify your code works?
#### workspace with `.opencode`
```bash title="setup_workspace_with_dot_opencode.sh"
#!/usr/bin/env bash

# Script to create test workspace by cloning opencode-pty repository
ROOT_DIR="$(pwd)"
OPENCODE_PTY="$ROOT_DIR/opencode-pty"
WORKSPACE="$ROOT_DIR/opencode_workspace"
OPENCODE_CONFIG="$WORKSPACE/.opencode/opencode.json"
OPENCODE_LOG="$WORKSPACE/opencode.log"
rm -rf "$OPENCODE_PTY"
rm -rf "$WORKSPACE"
git clone https://github.com/shekohex/opencode-pty
cd "$OPENCODE_PTY"
bun install
echo 'console.log("opencode-pty plugin loaded");' >> index.ts
cd "$ROOT_DIR"
mkdir "$WORKSPACE"
mkdir "$WORKSPACE/.opencode"

# Create opencode.json config file in workspace/.opencode
cat <<'EOF' > "$OPENCODE_CONFIG"
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": ["file://__OPENCODE_PTY__/index.ts"]
}
EOF
sed -i "s|__OPENCODE_PTY__|$OPENCODE_PTY|g" "$OPENCODE_CONFIG"

# Run opencode in debug wait mode in background and print PID
cd "$WORKSPACE"
opencode debug wait &
pid=$!
trap "kill $pid" EXIT
echo $pid
tree -L 3 "$ROOT_DIR"
sleep 5
```
#### output
```console
Cloning into 'opencode-pty'...
bun install v1.3.6 (d530ed99)

+ @types/bun@1.3.1
+ @opencode-ai/plugin@1.1.3
+ @opencode-ai/sdk@1.1.3
+ bun-pty@0.4.2
+ typescript@5.9.3

11 packages installed [27.00ms]
43568
/tmp/opencode-pty-bug
├── opencode-pty
│   ├── AGENTS.md
│   ├── bun.lock
│   ├── flake.lock
│   ├── flake.nix
│   ├── index.ts
│   ├── LICENSE
│   ├── nix
│   │   ├── bun.nix
│   │   └── README.bun2nix.md
│   ├── node_modules
│   │   ├── bun-pty
│   │   ├── bun-types
│   │   ├── csstype
│   │   ├── @opencode-ai
│   │   ├── @types
│   │   ├── typescript
│   │   ├── undici-types
│   │   └── zod
│   ├── package.json
│   ├── README.md
│   ├── release.sh
│   ├── src
│   │   ├── plugin
│   │   └── plugin.ts
│   └── tsconfig.json
├── opencode_workspace
├── setup_opencode_workspace.sh
└── setup_workspace_with_dot_opencode.sh

15 directories, 15 files
opencode-pty plugin loaded
```
#### workspace without `.opencode`
```bash title="setup_opencode_workspace.sh"
#!/usr/bin/env bash

# Script to create test workspace by cloning opencode-pty repository
ROOT_DIR="$(pwd)"
OPENCODE_PTY="$ROOT_DIR/opencode-pty"
WORKSPACE="$ROOT_DIR/opencode_workspace"
OPENCODE_LOG="$WORKSPACE/opencode.log"
rm -rf "$OPENCODE_PTY"
rm -rf "$WORKSPACE"
git clone https://github.com/shekohex/opencode-pty
cd "$OPENCODE_PTY"
bun install
echo 'console.log("opencode-pty plugin loaded");' >> index.ts
cd "$ROOT_DIR"
mkdir "$WORKSPACE"

# Create opencode.json config file in workspace
cat <<'EOF' > "$WORKSPACE/opencode.json"
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": ["file://__OPENCODE_PTY__/index.ts"]
}
EOF
sed -i "s|__OPENCODE_PTY__|$OPENCODE_PTY|g" "$WORKSPACE/opencode.json"

# Run opencode in debug wait mode in background and print PID
cd "$WORKSPACE"
echo "starting opencode in workspapce $(pwd)"
opencode debug wait > "$OPENCODE_LOG" &
pid=$!
trap "kill $pid" EXIT
echo "pid of opencode: $pid"
echo "content of $WORKSPACE/opencode.json"
cat "$WORKSPACE/opencode.json"
echo "content of $OPENCODE_PTY/index.ts"
cat "$OPENCODE_PTY/index.ts"
tree -L 3 "$ROOT_DIR"
sleep 5
echo "content of $OPENCODE_LOG"
cat "$OPENCODE_LOG"
```
#### output
```console
Cloning into 'opencode-pty'...
bun install v1.3.6 (d530ed99)

+ @types/bun@1.3.1
+ @opencode-ai/plugin@1.1.3
+ @opencode-ai/sdk@1.1.3
+ bun-pty@0.4.2
+ typescript@5.9.3

11 packages installed [21.00ms]
starting opencode in workspapce /tmp/opencode-pty-bug/opencode_workspace
pid of opencode: 130033
content of /tmp/opencode-pty-bug/opencode_workspace/opencode.json
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": ["file:///tmp/opencode-pty-bug/opencode-pty/index.ts"]
}
content of /tmp/opencode-pty-bug/opencode-pty/index.ts
export {
  PTYPlugin
} from "./src/plugin.ts";
console.log("opencode-pty plugin loaded");
/tmp/opencode-pty-bug
├── opencode-pty
│   ├── AGENTS.md
│   ├── bun.lock
│   ├── flake.lock
│   ├── flake.nix
│   ├── index.ts
│   ├── LICENSE
│   ├── nix
│   │   ├── bun.nix
│   │   └── README.bun2nix.md
│   ├── node_modules
│   │   ├── bun-pty
│   │   ├── bun-types
│   │   ├── csstype
│   │   ├── @opencode-ai
│   │   ├── @types
│   │   ├── typescript
│   │   ├── undici-types
│   │   └── zod
│   ├── package.json
│   ├── README.md
│   ├── release.sh
│   ├── src
│   │   ├── plugin
│   │   └── plugin.ts
│   └── tsconfig.json
├── opencode_workspace
│   ├── opencode.json
│   └── opencode.log
├── setup_opencode_workspace.sh
└── setup_workspace_with_dot_opencode.sh

15 directories, 17 files
content of /tmp/opencode-pty-bug/opencode_workspace/opencode.log
opencode-pty plugin loaded
```