### PR TITLE
fix(codex): remove non-existent gpt-5.2-codex from allowed models

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -359,7 +359,6 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.1-codex-max",
           "gpt-5.1-codex-mini",
           "gpt-5.2",
-          "gpt-5.2-codex",
           "gpt-5.1-codex",
         ])
         for (const modelId of Object.keys(provider.models)) {


### PR DESCRIPTION
## Summary

Fixes #10500

The `gpt-5.2-codex` model was included in the `allowedModels` set in the Codex plugin, but this model does not exist in OpenAI's API. This causes a 404 "Not Found" error for fresh installations when the plugin tries to use this model.

## Changes

- Removed `gpt-5.2-codex` from the allowed models list in `packages/opencode/src/plugin/codex.ts`

## Root Cause

The model `gpt-5.2-codex` was likely anticipated but never released by OpenAI. The available Codex models are:
- `gpt-5.1-codex`
- `gpt-5.1-codex-max`
- `gpt-5.1-codex-mini`
- `gpt-5.2` (non-codex variant)

## Testing

Verified that the removed model does not exist in OpenAI's API and that the remaining models are valid.