### PR TITLE
feat(opencode): add agent description

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -73,6 +73,7 @@ export namespace Agent {
     const result: Record<string, Info> = {
       build: {
         name: "build",
+        description: "The default agent. Executes tools based on configured permissions.",
         options: {},
         permission: PermissionNext.merge(
           defaults,
@@ -87,6 +88,7 @@ export namespace Agent {
       },
       plan: {
         name: "plan",
+        description: "Plan mode. Disallows all edit tools.",
         options: {},
         permission: PermissionNext.merge(
           defaults,


### PR DESCRIPTION
Closes https://github.com/anomalyco/opencode/issues/10679.

### What does this PR do?

Adds a description to the `build` and `plan` agents, as those are shown in ACP clients.

### How did you verify your code works?

Screenshot from [Tidewave](https://tidewave.ai):

<img width="499" height="188" alt="image" src="https://github.com/user-attachments/assets/56acaf3f-f667-4738-86d3-b49f64a9c50c" />

Feel free to adjust the text as necessary!