### PR TITLE
feat(opencode): agent-specific `instructions` array

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -38,6 +38,7 @@ export namespace Agent {
         })
         .optional(),
       prompt: z.string().optional(),
+      instructions: z.array(z.string()).optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
     })
@@ -213,6 +214,7 @@ export namespace Agent {
         }
       if (value.model) item.model = Provider.parseModel(value.model)
       item.prompt = value.prompt ?? item.prompt
+      item.instructions = value.instructions ?? item.instructions
       item.description = value.description ?? item.description
       item.temperature = value.temperature ?? item.temperature
       item.topP = value.top_p ?? item.topP

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -565,6 +565,10 @@ export namespace Config {
       temperature: z.number().optional(),
       top_p: z.number().optional(),
       prompt: z.string().optional(),
+      instructions: z
+        .array(z.string())
+        .optional()
+        .describe("Additional per-agents instruction files or patterns to include"),
       tools: z.record(z.string(), z.boolean()).optional().describe("@deprecated Use 'permission' field instead"),
       disable: z.boolean().optional(),
       description: z.string().optional().describe("Description of when to use the agent"),
@@ -594,6 +598,7 @@ export namespace Config {
         "name",
         "model",
         "prompt",
+        "instructions",
         "description",
         "temperature",
         "top_p",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -598,7 +598,11 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
-        system: [...(await SystemPrompt.environment(model)), ...(await SystemPrompt.custom())],
+        system: [
+          ...(await SystemPrompt.environment(model)),
+          ...(await SystemPrompt.custom()),
+          ...(await SystemPrompt.agent(agent)),
+        ],
         messages: [
           ...MessageV2.toModelMessages(sessionMessages, model),
           ...(isLastStep

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -17,6 +17,7 @@ import PROMPT_ANTHROPIC_SPOOF from "./prompt/anthropic_spoof.txt"
 import PROMPT_CODEX from "./prompt/codex_header.txt"
 import type { Provider } from "@/provider/provider"
 import { Flag } from "@/flag/flag"
+import type { Agent } from "@/agent/agent"
 
 const log = Log.create({ service: "system-prompt" })
 
@@ -31,6 +32,48 @@ async function resolveRelativeInstruction(instruction: string): Promise<string[]
     return []
   }
   return Filesystem.globUp(instruction, Flag.OPENCODE_CONFIG_DIR, Flag.OPENCODE_CONFIG_DIR).catch(() => [])
+}
+
+async function loadInstructions(instructions: string[]): Promise<string[]> {
+  const paths = new Set<string>()
+  const urls: string[] = []
+
+  for (let instruction of instructions) {
+    if (instruction.startsWith("https://") || instruction.startsWith("http://")) {
+      urls.push(instruction)
+      continue
+    }
+    if (instruction.startsWith("~/")) {
+      instruction = path.join(os.homedir(), instruction.slice(2))
+    }
+    let matches: string[] = []
+    if (path.isAbsolute(instruction)) {
+      matches = await Array.fromAsync(
+        new Bun.Glob(path.basename(instruction)).scan({
+          cwd: path.dirname(instruction),
+          absolute: true,
+          onlyFiles: true,
+        }),
+      ).catch(() => [])
+    } else {
+      matches = await resolveRelativeInstruction(instruction)
+    }
+    matches.forEach((p) => paths.add(p))
+  }
+
+  const foundFiles = Array.from(paths).map((p) =>
+    Bun.file(p)
+      .text()
+      .catch(() => "")
+      .then((x) => "Instructions from: " + p + "\n" + x),
+  )
+  const foundUrls = urls.map((url) =>
+    fetch(url, { signal: AbortSignal.timeout(5000) })
+      .then((res) => (res.ok ? res.text() : ""))
+      .catch(() => "")
+      .then((x) => (x ? "Instructions from: " + url + "\n" + x : "")),
+  )
+  return Promise.all([...foundFiles, ...foundUrls]).then((result) => result.filter(Boolean))
 }
 
 export namespace SystemPrompt {
@@ -109,44 +152,22 @@ export namespace SystemPrompt {
       }
     }
 
-    const urls: string[] = []
-    if (config.instructions) {
-      for (let instruction of config.instructions) {
-        if (instruction.startsWith("https://") || instruction.startsWith("http://")) {
-          urls.push(instruction)
-          continue
-        }
-        if (instruction.startsWith("~/")) {
-          instruction = path.join(os.homedir(), instruction.slice(2))
-        }
-        let matches: string[] = []
-        if (path.isAbsolute(instruction)) {
-          matches = await Array.fromAsync(
-            new Bun.Glob(path.basename(instruction)).scan({
-              cwd: path.dirname(instruction),
-              absolute: true,
-              onlyFiles: true,
-            }),
-          ).catch(() => [])
-        } else {
-          matches = await resolveRelativeInstruction(instruction)
-        }
-        matches.forEach((path) => paths.add(path))
-      }
-    }
-
-    const foundFiles = Array.from(paths).map((p) =>
+    // Load AGENTS.md and global rule files
+    const ruleFiles = Array.from(paths).map((p) =>
       Bun.file(p)
         .text()
         .catch(() => "")
         .then((x) => "Instructions from: " + p + "\n" + x),
     )
-    const foundUrls = urls.map((url) =>
-      fetch(url, { signal: AbortSignal.timeout(5000) })
-        .then((res) => (res.ok ? res.text() : ""))
-        .catch(() => "")
-        .then((x) => (x ? "Instructions from: " + url + "\n" + x : "")),
-    )
-    return Promise.all([...foundFiles, ...foundUrls]).then((result) => result.filter(Boolean))
+
+    // Load config.instructions
+    const configInstructions = config.instructions ? await loadInstructions(config.instructions) : []
+
+    return Promise.all(ruleFiles).then((result) => [...result.filter(Boolean), ...configInstructions])
+  }
+
+  export async function agent(agent: Agent.Info): Promise<string[]> {
+    if (!agent.instructions?.length) return []
+    return loadInstructions(agent.instructions)
   }
 }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -297,6 +297,25 @@ test("agent prompt can be set from config", async () => {
   })
 })
 
+test("agent instructions can be set from config", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        build: {
+          instructions: ["~/.config/opencode/build-only.md", "custom-rules.md"],
+        },
+      },
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const build = await Agent.get("build")
+      expect(build?.instructions).toEqual(["~/.config/opencode/build-only.md", "custom-rules.md"])
+    },
+  })
+})
+
 test("unknown agent properties are placed into options", async () => {
   await using tmp = await tmpdir({
     config: {

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -1,0 +1,133 @@
+import { test, expect } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { SystemPrompt } from "../../src/session/system"
+import type { Agent } from "../../src/agent/agent"
+import path from "path"
+
+test("SystemPrompt.agent returns empty array when no instructions", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent: Agent.Info = {
+        name: "test",
+        mode: "primary",
+        permission: [],
+        options: {},
+      }
+      const result = await SystemPrompt.agent(agent)
+      expect(result).toEqual([])
+    },
+  })
+})
+
+test("SystemPrompt.agent returns empty array when instructions is empty array", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent: Agent.Info = {
+        name: "test",
+        mode: "primary",
+        permission: [],
+        options: {},
+        instructions: [],
+      }
+      const result = await SystemPrompt.agent(agent)
+      expect(result).toEqual([])
+    },
+  })
+})
+
+test("SystemPrompt.agent loads instructions from absolute path", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "custom-instructions.md"), "# Custom Instructions\nAlways use Researcher agent")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent: Agent.Info = {
+        name: "test",
+        mode: "primary",
+        permission: [],
+        options: {},
+        instructions: [path.join(tmp.path, "custom-instructions.md")],
+      }
+      const result = await SystemPrompt.agent(agent)
+      expect(result.length).toBe(1)
+      expect(result[0]).toContain("Instructions from:")
+      expect(result[0]).toContain("custom-instructions.md")
+      expect(result[0]).toContain("Always use Researcher agent")
+    },
+  })
+})
+
+test("SystemPrompt.agent loads instructions from relative path", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "agent-rules.md"), "# Agent Rules\nBe thorough")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent: Agent.Info = {
+        name: "test",
+        mode: "primary",
+        permission: [],
+        options: {},
+        instructions: ["agent-rules.md"],
+      }
+      const result = await SystemPrompt.agent(agent)
+      expect(result.length).toBe(1)
+      expect(result[0]).toContain("Be thorough")
+    },
+  })
+})
+
+test("SystemPrompt.agent loads multiple instruction files", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "rules1.md"), "Rule 1: Be concise")
+      await Bun.write(path.join(dir, "rules2.md"), "Rule 2: Be helpful")
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent: Agent.Info = {
+        name: "test",
+        mode: "primary",
+        permission: [],
+        options: {},
+        instructions: ["rules1.md", "rules2.md"],
+      }
+      const result = await SystemPrompt.agent(agent)
+      expect(result.length).toBe(2)
+      expect(result.some((r) => r.includes("Be concise"))).toBe(true)
+      expect(result.some((r) => r.includes("Be helpful"))).toBe(true)
+    },
+  })
+})
+
+test("SystemPrompt.agent ignores non-existent files", async () => {
+  await using tmp = await tmpdir()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const agent: Agent.Info = {
+        name: "test",
+        mode: "primary",
+        permission: [],
+        options: {},
+        instructions: ["nonexistent.md"],
+      }
+      const result = await SystemPrompt.agent(agent)
+      // Should return empty array since file doesn't exist (empty content is filtered)
+      expect(result.length).toBe(0)
+    },
+  })
+})

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -311,6 +311,32 @@ Specify a custom system prompt file for this agent with the `prompt` config. The
 
 This path is relative to where the config file is located. So this works for both the global OpenCode config and the project specific config.
 
+:::note
+Using `prompt` on a built-in agent **replaces** that agent's default prompt entirely. If you want to add instructions without replacing the default prompt, use `instructions` instead.
+:::
+
+---
+
+### Instructions
+
+Add custom instructions that are **appended** to the agent's system prompt without replacing it. This is useful for adding agent-specific rules while keeping the default behavior.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "build": {
+      "instructions": ["~/.config/opencode/prompts/build-only.md", "./project-rules.md"]
+    }
+  }
+}
+```
+
+The `instructions` array accepts the same formats as the [global instructions](/docs/rules).
+
+:::tip
+Use `instructions` when you want to add rules to a specific agent without affecting other agents. For example, adding "Always use the Researcher agent for lookups" only to the Build agent.
+:::
+
 ---
 
 ### Model

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -122,6 +122,10 @@ Remote instructions are fetched with a 5 second timeout.
 
 All instruction files are combined with your `AGENTS.md` files.
 
+:::tip
+Need instructions that only apply to a specific agent? Use [agent-specific instructions](/docs/agents#instructions) instead of global instructions.
+:::
+
 ---
 
 ## Referencing External Files


### PR DESCRIPTION
### What does this PR do?

Adds ability to specify `agent.<name>.instructions` array that behaves like global `instructions` array, but only for that agent.

Example:
```json
{
  "agent": {
    "build": {
      "instructions": [
        "~/.config/opencode/prompts/build-only.md"
      ]
    }
  }
}
```

Closes #10688


### How did you verify your code works?

Added unit tests:
- `test/agent/agent.test.ts` - Test that instructions can be set from agent config
- `test/session/system.test.ts` (new file) - Tests for `SystemPrompt.agent()` function

All 41 tests pass.
