### PR TITLE
fix(app): restore external link opening in system browser

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -328,18 +328,23 @@ render(() => {
   const [serverPassword, setServerPassword] = createSignal<string | null>(null)
   const platform = createPlatform(() => serverPassword())
 
-  function handleClick(e: MouseEvent) {
-    const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
-    if (link?.href) {
-      e.preventDefault()
-      platform.openLink(link.href)
-    }
-  }
-
   onMount(() => {
-    document.addEventListener("click", handleClick)
+    // Handle external links - open in system browser instead of webview
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      const link = target.closest("a") as HTMLAnchorElement | null
+
+      if (link?.href && !link.href.startsWith("javascript:") && !link.href.startsWith("#")) {
+        e.preventDefault()
+        e.stopPropagation()
+        e.stopImmediatePropagation()
+        void shellOpen(link.href).catch(() => undefined)
+      }
+    }
+
+    document.addEventListener("click", handleClick, true)
     onCleanup(() => {
-      document.removeEventListener("click", handleClick)
+      document.removeEventListener("click", handleClick, true)
     })
   })
 


### PR DESCRIPTION
closes #10613
closes #8361

### What does this PR do?
Restores the ability to open markdown links in the system browser instead of within the webview.

## Problem
  After the markdown parser was migrated from JavaScript to Rust, clicking links in markdown would navigate within the desktop app's webview instead of opening in the system browser.

The old implementation relied on:
1. A module-level click event listener
 2. Filtering for links with the `external-link` class
 3. Using `platform.openLink()` to open them externally

## Solution
  Moved the external link handling into the component's `onMount()` hook to access  
  the platform
  after the DOM is ready. Key improvements:

  - **Catches ALL anchor clicks** instead of filtering by class (more robust as     
  markdown parser changed)
  - **Uses `stopPropagation()` and `stopImmediatePropagation()`** to prevent the    
  webview's default link handling
  - **Opens with `shellOpen()`** from @tauri-apps/plugin-shell to open in system    
  browser
  - **Skips internal links** (javascript: and # anchors) - but i don't think these are being used in the app as of now

### How did you verify your code works?
Ran the app locally and clicked on links to verify they open in your system browser instead of inside the app window


## Before
https://github.com/user-attachments/assets/eaae40ab-3ee0-40a6-be0a-e217b44d215c


## After
https://github.com/user-attachments/assets/d89b166b-8c61-4715-a744-70b7dc75595b


