### PR TITLE
feat(app): Align desktop model picker visibility with TUI

### DIFF
--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -1,7 +1,6 @@
 import { createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
-import { DateTime } from "luxon"
-import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
+import { uniqueBy } from "remeda"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
@@ -39,30 +38,6 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       ),
     )
 
-    const latest = createMemo(() =>
-      pipe(
-        available(),
-        filter((x) => Math.abs(DateTime.fromISO(x.release_date).diffNow().as("months")) < 6),
-        groupBy((x) => x.provider.id),
-        mapValues((models) =>
-          pipe(
-            models,
-            groupBy((x) => x.family),
-            values(),
-            (groups) =>
-              groups.flatMap((g) => {
-                const first = firstBy(g, [(x) => x.release_date, "desc"])
-                return first ? [{ modelID: first.id, providerID: first.provider.id }] : []
-              }),
-          ),
-        ),
-        values(),
-        flat(),
-      ),
-    )
-
-    const latestSet = createMemo(() => new Set(latest().map((x) => `${x.providerID}:${x.modelID}`)))
-
     const visibility = createMemo(() => {
       const map = new Map<string, Visibility>()
       for (const item of store.user) map.set(`${item.providerID}:${item.modelID}`, item.visibility)
@@ -93,10 +68,9 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       const state = visibility().get(key)
       if (state === "hide") return false
       if (state === "show") return true
-      if (latestSet().has(key)) return true
       const m = find(model)
-      if (!m?.release_date || !DateTime.fromISO(m.release_date).isValid) return true
-      return false
+      if (m?.status === "deprecated") return false
+      return true
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -1,6 +1,7 @@
 import { createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
-import { uniqueBy } from "remeda"
+import { DateTime } from "luxon"
+import { filter, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
@@ -52,6 +53,24 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       })),
     )
 
+    const latest = createMemo(() =>
+      pipe(
+        available(),
+        filter((x) => Math.abs(DateTime.fromISO(x.release_date).diffNow().as("months")) < 6),
+        groupBy((x) => x.provider.id),
+        mapValues((models) =>
+          models.map((model) => ({
+            modelID: model.id,
+            providerID: model.provider.id,
+          })),
+        ),
+        values(),
+        flat(),
+      ),
+    )
+
+    const latestSet = createMemo(() => new Set(latest().map((x) => `${x.providerID}:${x.modelID}`)))
+
     const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)
 
     function update(model: ModelKey, state: Visibility) {
@@ -70,7 +89,8 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       if (state === "show") return true
       const m = find(model)
       if (m?.status === "deprecated") return false
-      return true
+      if (!m?.release_date || !DateTime.fromISO(m.release_date).isValid) return true
+      return latestSet().has(key)
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {


### PR DESCRIPTION
### What does this PR do?

This PR aligns Desktop behavior with TUI:
- Default visibility: show all non-deprecated models based on the provider.
Fixes: #10560 

### How did you verify your code works?
Comparing desktop model list with that of TUI
<img width="286" height="360" alt="image" src="https://github.com/user-attachments/assets/25509536-f32b-4abf-b773-4bbc82146fcd" />


<img width="423" height="284" alt="image" src="https://github.com/user-attachments/assets/d640feef-1cdb-41c8-8e97-ff104afa6975" />


