### PR TITLE
fix(app): add connect provier in model selector

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -110,6 +110,11 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
     setStore("open", false)
     dialog.show(() => <DialogManageModels />)
   }
+
+  const handleConnectProvider = () => {
+    setStore("open", false)
+    dialog.show(() => <DialogSelectProvider />)
+  }
   const language = useLanguage()
 
   createEffect(() => {
@@ -207,15 +212,26 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
             onSelect={() => setStore("open", false)}
             class="p-1"
             action={
-              <IconButton
-                icon="sliders"
-                variant="ghost"
-                iconSize="normal"
-                class="size-6"
-                aria-label={language.t("dialog.model.manage")}
-                title={language.t("dialog.model.manage")}
-                onClick={handleManage}
-              />
+              <div class="flex items-center gap-1">
+                <IconButton
+                  icon="plus-small"
+                  variant="ghost"
+                  iconSize="normal"
+                  class="size-6"
+                  aria-label={language.t("command.provider.connect")}
+                  title={language.t("command.provider.connect")}
+                  onClick={handleConnectProvider}
+                />
+                <IconButton
+                  icon="sliders"
+                  variant="ghost"
+                  iconSize="normal"
+                  class="size-6"
+                  aria-label={language.t("dialog.model.manage")}
+                  title={language.t("dialog.model.manage")}
+                  onClick={handleManage}
+                />
+              </div>
             }
           />
         </Kobalte.Content>


### PR DESCRIPTION
### What does this PR do?

added + icon as you can see @adamdotdevin lots of people are not able to see the connect provider
<img width="415" height="405" alt="image" src="https://github.com/user-attachments/assets/17695fb2-a4d0-45a0-b2f1-40697b4899f3" />

### How did you verify your code works?
