### PR TITLE
docs: add opencode-copilot-multi to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -22,6 +22,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                  |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                           |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                           |
+| [opencode-copilot-multi](https://github.com/iamvaleriofantozzi/opencode-copilot-multi)             | Use multiple GitHub Copilot accounts simultaneously with per-model labeling                    |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling  |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                          |


### PR DESCRIPTION
Adds opencode-copilot-multi plugin to the ecosystem page.

Plugin enables using multiple GitHub Copilot accounts simultaneously with per-model labeling (e.g., `username:claude-sonnet-4`).

**Links:**
- npm: https://www.npmjs.com/package/opencode-copilot-multi
- Repo: https://github.com/iamvaleriofantozzi/opencode-copilot-multi

**Features:**
- 🔄 Multi-account support - Use 2+ GitHub Copilot accounts simultaneously
- 🎯 Per-model labeling - Models appear as `username:model-name`
- 🔒 Secure - OAuth tokens stored locally
- ⚡ Non-blocking - Zero impact on OpenCode startup