### PR TITLE
fix: move changelog footer outside content div to fix padding

### DIFF
--- a/packages/console/app/src/routes/changelog/index.tsx
+++ b/packages/console/app/src/routes/changelog/index.tsx
@@ -187,9 +187,9 @@ export default function Changelog() {
               }}
             </For>
           </section>
-
-          <Footer />
         </div>
+
+        <Footer />
       </div>
 
       <Legal />


### PR DESCRIPTION
## Summary
- Moves `<Footer />` outside the `data-component="content"` div on the changelog page
- Fixes extra padding/margin appearing above the footer

The footer was inside the content div which has its own padding, causing the `margin-top: 4rem` on the footer to stack with the content padding.