### PR TITLE
fix: add 44px top padding to sticky version header on changelog

### DIFF
--- a/packages/console/app/src/routes/changelog/index.css
+++ b/packages/console/app/src/routes/changelog/index.css
@@ -371,7 +371,7 @@
       top: 80px;
       align-self: start;
       background: var(--color-background);
-      padding: 8px 0;
+      padding: 44px 0 8px;
 
       @media (max-width: 50rem) {
         position: static;


### PR DESCRIPTION
## Summary
- Adds 44px top padding to the sticky version header on the changelog page
- Ensures proper spacing when the version tag sticks to the top of the viewport