### PR TITLE
fix(opencode): handle http/https URLs in file parts and prevent ENOENT crash

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -917,6 +917,16 @@ export namespace SessionPrompt {
           }
           const url = new URL(part.url)
           switch (url.protocol) {
+            case "http:":
+            case "https:":
+              return [
+                {
+                  ...part,
+                  id: part.id ?? Identifier.ascending("part"),
+                  messageID: info.id,
+                  sessionID: input.sessionID,
+                },
+              ]
             case "data:":
               if (part.mime === "text/plain") {
                 return [
@@ -950,7 +960,32 @@ export namespace SessionPrompt {
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
               const filepath = fileURLToPath(part.url)
-              const stat = await Bun.file(filepath).stat()
+              const stat = await Bun.file(filepath).stat().catch(() => undefined)
+
+              if (!stat) {
+                const message = `File not found: ${filepath}`
+                log.error("file not found", { filepath })
+                Bus.publish(Session.Event.Error, {
+                  sessionID: input.sessionID,
+                  error: new NamedError.Unknown({ message }).toObject(),
+                })
+                return [
+                  {
+                    id: Identifier.ascending("part"),
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: message,
+                  },
+                  {
+                    ...part,
+                    id: part.id ?? Identifier.ascending("part"),
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                  },
+                ]
+              }
 
               if (stat.isDirectory()) {
                 part.mime = "application/x-directory"


### PR DESCRIPTION
### What does this PR do?

Fixes #10730

When a file part has an `http:` or `https:` URL (e.g., a GitHub image URL), the switch statement in `createUserMessage` had no matching case. If such a URL was ever wrapped in a `file://` scheme, the unhandled `Bun.file(filepath).stat()` call would throw ENOENT and crash the TUI.

Two changes:

1. Added `case "http:"` / `case "https:"` to the protocol switch — returns the part as-is instead of falling through silently
2. Added `.catch(() => undefined)` to `Bun.file(filepath).stat()` in the `file:` case — if the file doesn't exist, returns a "File not found" text part instead of crashing

### How did you verify your code works?

Traced the code path in `packages/opencode/src/session/prompt.ts` `createUserMessage`. The `stat()` call on line 953 (now 963) had no error handling — any ENOENT would propagate through `Promise.all` and crash. Verified the fix handles both cases: unknown protocols return gracefully, and missing files produce a user-visible message instead of a raw error dump.