### PR TITLE
feat(provider): add google-vertex-openai for Vertex AI partner models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -374,6 +374,44 @@ export namespace Provider {
         },
       }
     },
+    "google-vertex-openai": async () => {
+      const project = Env.get("GOOGLE_CLOUD_PROJECT") ?? Env.get("GCP_PROJECT") ?? Env.get("GCLOUD_PROJECT")
+      const location = Env.get("GOOGLE_CLOUD_LOCATION") ?? Env.get("VERTEX_LOCATION") ?? "global"
+
+      if (!project) return { autoload: false }
+
+      const { GoogleAuth } = await import(await BunProc.install("google-auth-library"))
+      const auth = new GoogleAuth({
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      })
+
+      // Verify credentials are available
+      try {
+        await auth.getClient()
+      } catch {
+        return { autoload: false }
+      }
+
+      // Host differs for global vs regional
+      const host = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
+
+      return {
+        autoload: true,
+        options: {
+          baseURL: `https://${host}/v1/projects/${project}/locations/${location}/endpoints/openapi`,
+          fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+            const client = await auth.getClient()
+            const tokenResponse = await client.getAccessToken()
+            const token = tokenResponse.token
+
+            const headers = new Headers(init?.headers)
+            headers.set("Authorization", `Bearer ${token}`)
+
+            return fetch(input, { ...init, headers })
+          },
+        },
+      }
+    },
     "sap-ai-core": async () => {
       const auth = await Auth.get("sap-ai-core")
       const envServiceKey = iife(() => {


### PR DESCRIPTION
## Summary

Adds custom loader for `google-vertex-openai` provider to enable Vertex AI partner models (GLM, Llama, Qwen, DeepSeek) via the OpenAI-compatible Chat Completions API endpoint.

## Problem

The `@ai-sdk/google-vertex` SDK only supports Google's Gemini models because it:
- Hardcodes `publishers/google` in URL construction
- Uses `v1beta1` API version
- Expects Gemini-specific API format

Partner models like GLM-4.7, Llama 4, Qwen3, and DeepSeek use a different endpoint:
```
https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi/chat/completions
```

## Solution

Created custom loader for `google-vertex-openai` provider that:
- Uses `@ai-sdk/openai-compatible` (already bundled in OpenCode)
- Injects Google OAuth tokens via custom fetch wrapper
- Uses `google-auth-library` for auto-refreshing tokens (transitive dep of `@ai-sdk/google-vertex`)
- Supports both global and regional endpoints
- Auto-loads when `GOOGLE_CLOUD_PROJECT` env var is set and credentials are available

## Technical Details

**Auth Method**: Google Application Default Credentials (ADC)
- Uses `GoogleAuth` from `google-auth-library`
- Scope: `https://www.googleapis.com/auth/cloud-platform`
- Tokens auto-refresh 5 minutes before expiry

**Endpoint Construction**:
- Global: `https://aiplatform.googleapis.com/v1/projects/{project}/locations/global/endpoints/openapi`
- Regional: `https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/endpoints/openapi`

**Implementation Pattern**:
Follows the same pattern as `google-vertex-anthropic` loader - custom SDK with OAuth injection.

## Models Supported

Models are defined in companion PR: anomalyco/models.dev#716

- GLM-4.7 (zai-org)
- Llama 4 Maverick 17B-128E (meta)
- Llama 3.3 70B (meta)
- Qwen3 235B Instruct (qwen)
- DeepSeek V3.1 (deepseek-ai)

## Testing

Requires:
- `GOOGLE_CLOUD_PROJECT` environment variable
- Google Application Default Credentials: `gcloud auth application-default login`
- Models enabled in Google Cloud Console (Model Garden)

Test command:
```bash
export GOOGLE_CLOUD_PROJECT=your-project-id
export GOOGLE_CLOUD_LOCATION=global  # or regional like us-central1
opencode
# Select: google-vertex-openai/glm-4.7-maas
```

## Related PRs

- anomalyco/models.dev#716 - Model definitions for google-vertex-openai provider

## References

- [Google Cloud: Call MaaS APIs for open models](https://cloud.google.com/vertex-ai/generative-ai/docs/maas/call-open-model-apis)
- [Google Cloud: OpenAI compatibility](https://cloud.google.com/vertex-ai/generative-ai/docs/start/openai)