### PR TITLE
refactor(provider): remove google-vertex-anthropic special case in ge…

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1023,12 +1023,9 @@ export namespace Provider {
         })
       }
 
-      // Special case: google-vertex-anthropic uses a subpath import
-      const bundledKey =
-        model.providerID === "google-vertex-anthropic" ? "@ai-sdk/google-vertex/anthropic" : model.api.npm
-      const bundledFn = BUNDLED_PROVIDERS[bundledKey]
+      const bundledFn = BUNDLED_PROVIDERS[model.api.npm]
       if (bundledFn) {
-        log.info("using bundled provider", { providerID: model.providerID, pkg: bundledKey })
+        log.info("using bundled provider", { providerID: model.providerID, pkg: model.api.npm })
         const loaded = bundledFn({
           name: model.providerID,
           ...options,


### PR DESCRIPTION
Remove redundant `google-vertex-anthropic` special case in `getSDK()`

## Context
The getSDK() function had a workaround that manually mapped `google-vertex-anthropic` to `@ai-sdk/google-vertex/anthropic` because models.dev was returning the incorrect NPM package (`@ai-sdk/google-vertex`).

This special case will no longer be needed once fix will be merged on https://github.com/anomalyco/models.dev/pull/717

Related to https://github.com/anomalyco/opencode/issues/9894

> [!CAUTION]
> Merge only after https://github.com/anomalyco/models.dev/pull/717 is merged and the fix is applied on models.dev.