### PR TITLE
feat(release): add highlights template to draft releases

### DIFF
--- a/script/publish-start.ts
+++ b/script/publish-start.ts
@@ -4,6 +4,35 @@ import { $ } from "bun"
 import { Script } from "@opencode-ai/script"
 import { buildNotes, getLatestRelease } from "./changelog"
 
+const highlightsTemplate = `## Highlights
+
+<!-- 
+Add highlights before publishing. Delete this section if no highlights.
+
+- For multiple highlights, use multiple <highlight> tags
+- Highlights with the same source attribute get grouped together
+-->
+
+<!--
+<highlight source="SourceName (TUI/Desktop/Web/Core)">
+  <h2>Feature title goes here</h2>
+  <p short="Short description used for Desktop Recap">
+    Full description of the feature or change
+  </p>
+
+  https://github.com/user-attachments/assets/uuid-for-video (you will want to drag & drop the video or picture)
+
+  <img
+    width="1912"
+    height="1164"
+    alt="image"
+    src="https://github.com/user-attachments/assets/uuid-for-image"
+  />
+</highlight>
+-->
+
+`
+
 let notes: string[] = []
 
 console.log("=== publishing ===\n")
@@ -11,6 +40,7 @@ console.log("=== publishing ===\n")
 if (!Script.preview) {
   const previous = await getLatestRelease()
   notes = await buildNotes(previous, "HEAD")
+  notes.unshift(highlightsTemplate)
 }
 
 const pkgjsons = await Array.fromAsync(


### PR DESCRIPTION
## Summary
- Adds a highlights template section at the top of draft release notes
- Template includes the `<highlight>` format with placeholders for title, description, video, and image
- Allows release publishers to fill in notable features before publishing, or delete the section if no highlights

This keeps releases as drafts with editable highlights until someone manually publishes.