### PR TITLE
docs: add opencode-snippets to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -30,6 +30,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                 | Add native websearch support for supported providers with Google grounded style                   |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                       | Enables AI agents to run background processes in a PTY, send interactive input to them.           |
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
+| [opencode-snippets](https://github.com/JosXa/opencode-snippets)                                    | Instant inline text expansion - type `#snippet` anywhere for composable, DRY prompt engineering  |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                         |
 | [opencode-morph-plugin](https://github.com/morphllm/opencode-morph-plugin)                         | Fast Apply editing, WarpGrep codebase search, and context compaction via Morph                    |


### PR DESCRIPTION
Adds [opencode-snippets](https://github.com/JosXa/opencode-snippets) to the Plugins section of the ecosystem page.

opencode-snippets provides instant inline text expansion - users can type `#snippet` anywhere in their messages for composable, DRY prompt engineering.

The entry is placed alphabetically between opencode-skills and opencode-type-inject.