### PR TITLE
feat(permission): persist 'always' approvals to disk

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -147,11 +147,11 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
           body={
             <Switch>
               <Match when={props.request.always.length === 1 && props.request.always[0] === "*"}>
-                <TextBody title={"This will allow " + props.request.permission + " until OpenCode is restarted."} />
+                <TextBody title={"This will allow " + props.request.permission + " for this project."} />
               </Match>
               <Match when={true}>
                 <box paddingLeft={1} gap={1}>
-                  <text fg={theme.textMuted}>This will allow the following patterns until OpenCode is restarted</text>
+                  <text fg={theme.textMuted}>This will allow the following patterns for this project</text>
                   <box>
                     <For each={props.request.always}>
                       {(pattern) => (

--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -220,9 +220,7 @@ export namespace PermissionNext {
           pending.resolve()
         }
 
-        // TODO: we don't save the permission ruleset to disk yet until there's
-        // UI to manage it
-        // await Storage.write(["permission", Instance.project.id], s.approved)
+        await Storage.write(["permission", Instance.project.id], s.approved)
         return
       }
     },

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -137,10 +137,14 @@ If you don’t specify anything, OpenCode starts from permissive defaults:
 When OpenCode prompts for approval, the UI offers three outcomes:
 
 - `once` — approve just this request
-- `always` — approve future requests matching the suggested patterns (for the rest of the current OpenCode session)
+- `always` — approve future requests matching the suggested patterns
 - `reject` — deny the request
 
 The set of patterns that `always` would approve is provided by the tool (for example, bash approvals typically whitelist a safe command prefix like `git status*`).
+
+#### Persistent approvals
+
+When you select `always`, the approval is saved to disk and persists across sessions. Approvals are stored per-project based on the repository's root commit hash, so different projects maintain separate approval lists.
 
 ---
 


### PR DESCRIPTION
Fixes #10753

Uncomments the Storage.write call to persist "always" permission approvals.

The loading code already existed - approvals are stored per-project based on git root commit hash.

Tested by verifying typecheck passes and tracing the code flow.