### PR TITLE
docs: add instruction for ollama auto config cli

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1281,6 +1281,8 @@ In this example:
 If tool calls aren't working, try increasing `num_ctx` in Ollama. Start around 16k - 32k.
 :::
 
+For more information, see the [Ollama documentation for OpenCode](https://docs.ollama.com/integrations/opencode).
+
 ---
 
 ### Ollama Cloud

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1222,6 +1222,33 @@ To use Kimi K2 from Moonshot AI:
 
 You can configure opencode to use local models through Ollama.
 
+#### Automatic Setup
+
+The easiest way to configure Ollama with OpenCode is using the built-in launch command:
+
+```bash
+ollama launch opencode
+```
+
+This opens an interactive TUI where you can select Ollama models to be added to opencode. 
+
+```bash
+$ ollama launch opencode
+
+Select models for OpenCode:
+  >  [x] glm-4.7-flash:latest (default)
+     [ ] glm-4.7:cloud
+     [ ] gpt-oss:latest
+
+    [ Continue ] (1 selected) - press Tab
+```
+
+Once you confirm, the command automatically overwrites your `opencode.json` config with the selected models.
+
+#### Manual Configuration
+
+Alternatively, you can manually configure Ollama in your `opencode.json`:
+
 ```json title="opencode.json" "ollama" {5, 6, 8, 10-14}
 {
   "$schema": "https://opencode.ai/config.json",


### PR DESCRIPTION
### What does this PR do?
Adds instructions about `ollama launch opencode` to the docs. 
### How did you verify your code works?
Ran the docs to make sure the changes look proper. 

Fixes #10768

<img width="804" height="768" alt="image" src="https://github.com/user-attachments/assets/a31b4a26-5755-4892-b563-fc6a0d0749dd" />
