### PR TITLE
fix: remove invalid meta ref from question schema to prevent validati…

### DIFF
--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -13,9 +13,7 @@ export namespace Question {
       label: z.string().describe("Display text (1-5 words, concise)"),
       description: z.string().describe("Explanation of choice"),
     })
-    .meta({
-      ref: "QuestionOption",
-    })
+
   export type Option = z.infer<typeof Option>
 
   export const Info = z
@@ -26,9 +24,7 @@ export namespace Question {
       multiple: z.boolean().optional().describe("Allow selecting multiple choices"),
       custom: z.boolean().optional().describe("Allow typing a custom answer (default: true)"),
     })
-    .meta({
-      ref: "QuestionInfo",
-    })
+
   export type Info = z.infer<typeof Info>
 
   export const Request = z


### PR DESCRIPTION
# Fix: Remove invalid `Schema.ref` usage in Question schema

## Description
This PR fixes a validation error that occurs when using certain providers (like `openai_compatible`) in `opencode` v1.1.x.

### The Issue
The application was crashing with the following error:
> "Schema.ref 'QuestionOption' was set alongside unsupported fields. If a schema node has Schema.ref set, then only description and default can be set alongside it..."

This was caused by the usage of `.meta({ ref: "..." })` on Zod schemas for `QuestionOption` and `QuestionInfo`. When converted to JSON Schema, this resulted in objects containing both a `$ref` and other properties (like `type`, `properties`, etc.), which is strictly forbidden in standard JSON Schema (pre-2019 drafts) and causes strict validators to fail.

### The Fix
I removed the `.meta({ ref: ... })` calls from `packages/opencode/src/question/index.ts`.
This ensures that `zod-to-json-schema` (or the internal schema generator) inlines the schema definitions correctly instead of creating invalid reference nodes that conflict with their sibling properties.

## Verification
- Checked out the code locally.
- Reproduced the issue with the original code.
- Applied the fix.
- Ran `bun run dev -- run "hi"` and confirmed that the application now starts and runs successfully without the schema validation error.

## Related Issue
Fixes #7791
