### PR TITLE
fix(app) internal/external link handling (via markdown parser)

### DIFF
--- a/packages/desktop/src-tauri/src/markdown.rs
+++ b/packages/desktop/src-tauri/src/markdown.rs
@@ -9,6 +9,7 @@ pub fn parse_markdown(input: &str) -> String {
     options.render.r#unsafe = true;
 
     markdown_to_html(input, &options)
+        .replace("<a ", "<a class=\"external-link\" ")
 }
 
 #[tauri::command]


### PR DESCRIPTION
### What does this PR do?
fixes external link handling in the desktop app by adding the external-link class to markdown-generated <a> tags.

### How did you verify your code works?
local dev build and prod build testing

### Note
web app would open external links in the current window, probably not the best UX but is out of scope for this PR