### PR TITLE
fix(shell): derive Git Bash path from git.exe directory on Windows

### DIFF
--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -42,7 +42,7 @@ export namespace Shell {
       if (git) {
         // git.exe is typically at: C:\Program Files\Git\cmd\git.exe
         // bash.exe is at: C:\Program Files\Git\bin\bash.exe
-        const bash = path.join(git, "..", "..", "bin", "bash.exe")
+        const bash = path.join(path.dirname(git), "..", "..", "bin", "bash.exe")
         if (Bun.file(bash).size) return bash
       }
       return process.env.COMSPEC || "cmd.exe"


### PR DESCRIPTION
Fixes #10871

### What does this PR do?
Fixes Windows Git Bash auto-detection by deriving `bash.exe` from `path.dirname(git)` instead of treating `git.exe` as a directory.

### How did you verify your code works?
- `bun run --cwd packages/opencode typecheck`