### PR TITLE
feat(app): add 'connect provider' button to the manage models dialog

### DIFF
--- a/packages/app/src/components/dialog-manage-models.tsx
+++ b/packages/app/src/components/dialog-manage-models.tsx
@@ -1,16 +1,33 @@
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
 import { Switch } from "@opencode-ai/ui/switch"
+import { Button } from "@opencode-ai/ui/button"
 import type { Component } from "solid-js"
 import { useLocal } from "@/context/local"
 import { popularProviders } from "@/hooks/use-providers"
 import { useLanguage } from "@/context/language"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { DialogSelectProvider } from "./dialog-select-provider"
 
 export const DialogManageModels: Component = () => {
   const local = useLocal()
   const language = useLanguage()
+  const dialog = useDialog()
+
+  const handleConnectProvider = () => {
+    dialog.show(() => <DialogSelectProvider />)
+  }
+
   return (
-    <Dialog title={language.t("dialog.model.manage")} description={language.t("dialog.model.manage.description")}>
+    <Dialog
+      title={language.t("dialog.model.manage")}
+      description={language.t("dialog.model.manage.description")}
+      action={
+        <Button class="h-7 -my-1 text-14-medium" icon="plus-small" tabIndex={-1} onClick={handleConnectProvider}>
+          {language.t("command.provider.connect")}
+        </Button>
+      }
+    >
       <List
         search={{ placeholder: language.t("dialog.model.search.placeholder"), autofocus: true }}
         emptyMessage={language.t("dialog.model.empty")}


### PR DESCRIPTION
### What does this PR do?
adds button to connect provider to manage models dialog, similar to select model dialog

### How did you verify your code works?
ran in dev, ensured button is rendered and is functional

## before
<img width="660" height="537" alt="connect_button_in_manage_models_before_1" src="https://github.com/user-attachments/assets/dd295257-1fd0-4191-931f-4cb01832d3e0" />

## after
<img width="660" height="537" alt="connect_button_in_manage_models_after_1" src="https://github.com/user-attachments/assets/35211006-5236-4e98-9fa2-4eeb088f2e66" />
