### PR TITLE
fix(opencode): keep --version output clean

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -26,6 +26,7 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { ModelsDev } from "./provider/models"
 
 process.on("unhandledRejection", (e) => {
   Log.Default.error("rejection", {
@@ -39,7 +40,12 @@ process.on("uncaughtException", (e) => {
   })
 })
 
-const cli = yargs(hideBin(process.argv))
+const argv = hideBin(process.argv)
+const passthroughIndex = argv.indexOf("--")
+const visibleArgs = passthroughIndex === -1 ? argv : argv.slice(0, passthroughIndex)
+const version = visibleArgs.includes("--version") || visibleArgs.includes("-v")
+
+const cli = yargs(argv)
   .parserConfiguration({ "populate--": true })
   .scriptName("opencode")
   .wrap(100)
@@ -69,6 +75,7 @@ const cli = yargs(hideBin(process.argv))
 
     process.env.AGENT = "1"
     process.env.OPENCODE = "1"
+    if (!version) ModelsDev.start()
 
     Log.Default.info("opencode", {
       version: Installation.VERSION,

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -13,6 +13,7 @@ import { lazy } from "@/util/lazy"
 export namespace ModelsDev {
   const log = Log.create({ service: "models.dev" })
   const filepath = path.join(Global.Path.cache, "models.json")
+  const state = { started: false }
 
   export const Model = z.object({
     id: z.string(),
@@ -120,14 +121,17 @@ export namespace ModelsDev {
       ModelsDev.Data.reset()
     }
   }
-}
 
-if (!Flag.OPENCODE_DISABLE_MODELS_FETCH) {
-  ModelsDev.refresh()
-  setInterval(
-    async () => {
-      await ModelsDev.refresh()
-    },
-    60 * 1000 * 60,
-  ).unref()
+  export function start() {
+    if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return
+    if (state.started) return
+    state.started = true
+    ModelsDev.refresh()
+    setInterval(
+      async () => {
+        await ModelsDev.refresh()
+      },
+      60 * 1000 * 60,
+    ).unref()
+  }
 }


### PR DESCRIPTION
Fixes #10889.

I moved the models.dev refresh out of import side effects into an explicit start call and invoke it after logger setup only when `--version` is a real CLI flag (args before `--`). That keeps `opencode --version` deterministic and silent on stderr while preserving refresh for normal commands.

I verified this by building the CLI and running `dist/.../opencode --version`, which now outputs a single version line with no stderr.
