### PR TITLE
feat: support headless authentication for chatgpt/codex

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -10,6 +10,11 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
+const DEVICE_CODE_URL = `${ISSUER}/api/accounts/deviceauth/usercode`
+const DEVICE_TOKEN_URL = `${ISSUER}/api/accounts/deviceauth/token`
+const DEVICE_REDIRECT_URI = `${ISSUER}/deviceauth/callback`
+const DEVICE_VERIFICATION_URL = `${ISSUER}/codex/device`
+const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
 interface PkceCodes {
   verifier: string
@@ -461,7 +466,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
       },
       methods: [
         {
-          label: "ChatGPT Pro/Plus",
+          label: "ChatGPT Pro/Plus (browser)",
           type: "oauth",
           authorize: async () => {
             const { redirectUri } = await startOAuthServer()
@@ -485,6 +490,83 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                   access: tokens.access_token,
                   expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
                   accountId,
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "ChatGPT Pro/Plus (headless)",
+          type: "oauth",
+          authorize: async () => {
+            const deviceResponse = await fetch(DEVICE_CODE_URL, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "User-Agent": `opencode/${Installation.VERSION}`,
+              },
+              body: JSON.stringify({ client_id: CLIENT_ID }),
+            })
+
+            if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
+
+            const deviceData = (await deviceResponse.json()) as {
+              device_auth_id: string
+              user_code: string
+              interval: string
+            }
+            const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
+
+            return {
+              url: DEVICE_VERIFICATION_URL,
+              instructions: `Enter code: ${deviceData.user_code}`,
+              method: "auto" as const,
+              async callback() {
+                while (true) {
+                  const response = await fetch(DEVICE_TOKEN_URL, {
+                    method: "POST",
+                    headers: {
+                      "Content-Type": "application/json",
+                      "User-Agent": `opencode/${Installation.VERSION}`,
+                    },
+                    body: JSON.stringify({
+                      device_auth_id: deviceData.device_auth_id,
+                      user_code: deviceData.user_code,
+                    }),
+                  })
+
+                  if (response.ok) {
+                    const data = (await response.json()) as {
+                      authorization_code: string
+                      code_verifier: string
+                    }
+
+                    const tokens: TokenResponse = await fetch(`${ISSUER}/oauth/token`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                      body: new URLSearchParams({
+                        grant_type: "authorization_code",
+                        code: data.authorization_code,
+                        redirect_uri: DEVICE_REDIRECT_URI,
+                        client_id: CLIENT_ID,
+                        code_verifier: data.code_verifier,
+                      }).toString(),
+                    }).then((r) => r.json())
+
+                    return {
+                      type: "success" as const,
+                      refresh: tokens.refresh_token,
+                      access: tokens.access_token,
+                      expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                      accountId: extractAccountId(tokens),
+                    }
+                  }
+
+                  if (response.status !== 403 && response.status !== 404) {
+                    return { type: "failed" as const }
+                  }
+
+                  await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
                 }
               },
             }

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -3,7 +3,6 @@ import { Log } from "../util/log"
 import { Installation } from "../installation"
 import { Auth, OAUTH_DUMMY_KEY } from "../auth"
 import os from "os"
-import { iife } from "@/util/iife"
 
 const log = Log.create({ service: "plugin.codex" })
 
@@ -349,27 +348,6 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
 }
 
 export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
-  const useDeviceAuth = iife(() => {
-    // Returns true when likely running in an environment without a usable GUI.
-    // Intentionally conservative: frontends can use this to avoid flows that try to open a browser.
-    const isSet = (name: string): boolean => {
-      const v = process.env[name]
-      return v !== undefined && v !== ""
-    }
-
-    if (isSet("CI") || isSet("SSH_CONNECTION") || isSet("SSH_CLIENT") || isSet("SSH_TTY")) {
-      return true
-    }
-
-    if (process.platform === "linux") {
-      if (!isSet("DISPLAY") && !isSet("WAYLAND_DISPLAY")) {
-        return true
-      }
-    }
-
-    return false
-  })
-
   return {
     auth: {
       provider: "openai",
@@ -483,120 +461,113 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         }
       },
       methods: [
-        useDeviceAuth
-          ? {
-              label: "ChatGPT Pro/Plus",
-              type: "oauth",
-              authorize: async () => {
-                const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                    "User-Agent": `opencode/${Installation.VERSION}`,
-                  },
-                  body: JSON.stringify({ client_id: CLIENT_ID }),
-                })
+        {
+          label: "ChatGPT Pro/Plus (browser)",
+          type: "oauth",
+          authorize: async () => {
+            const { redirectUri } = await startOAuthServer()
+            const pkce = await generatePKCE()
+            const state = generateState()
+            const authUrl = buildAuthorizeUrl(redirectUri, pkce, state)
 
-                if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
+            const callbackPromise = waitForOAuthCallback(pkce, state)
 
-                const deviceData = (await deviceResponse.json()) as {
-                  device_auth_id: string
-                  user_code: string
-                  interval: string
-                }
-                const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
-
+            return {
+              url: authUrl,
+              instructions: "Complete authorization in your browser. This window will close automatically.",
+              method: "auto" as const,
+              callback: async () => {
+                const tokens = await callbackPromise
+                stopOAuthServer()
+                const accountId = extractAccountId(tokens)
                 return {
-                  url: `${ISSUER}/codex/device`,
-                  instructions: `Enter code: ${deviceData.user_code}`,
-                  method: "auto" as const,
-                  async callback() {
-                    while (true) {
-                      const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
-                        method: "POST",
-                        headers: {
-                          "Content-Type": "application/json",
-                          "User-Agent": `opencode/${Installation.VERSION}`,
-                        },
-                        body: JSON.stringify({
-                          device_auth_id: deviceData.device_auth_id,
-                          user_code: deviceData.user_code,
-                        }),
-                      })
-
-                      if (response.ok) {
-                        const data = (await response.json()) as {
-                          authorization_code: string
-                          code_verifier: string
-                        }
-
-                        const tokenResponse = await fetch(`${ISSUER}/oauth/token`, {
-                          method: "POST",
-                          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-                          body: new URLSearchParams({
-                            grant_type: "authorization_code",
-                            code: data.authorization_code,
-                            redirect_uri: `${ISSUER}/deviceauth/callback`,
-                            client_id: CLIENT_ID,
-                            code_verifier: data.code_verifier,
-                          }).toString(),
-                        })
-
-                        if (!tokenResponse.ok) {
-                          throw new Error(`Token exchange failed: ${tokenResponse.status}`)
-                        }
-
-                        const tokens = (await tokenResponse.json()) as TokenResponse
-
-                        return {
-                          type: "success" as const,
-                          refresh: tokens.refresh_token,
-                          access: tokens.access_token,
-                          expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                          accountId: extractAccountId(tokens),
-                        }
-                      }
-
-                      if (response.status !== 403 && response.status !== 404) {
-                        return { type: "failed" as const }
-                      }
-
-                      await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
-                    }
-                  },
+                  type: "success" as const,
+                  refresh: tokens.refresh_token,
+                  access: tokens.access_token,
+                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                  accountId,
                 }
               },
             }
-          : {
-              label: "ChatGPT Pro/Plus",
-              type: "oauth",
-              authorize: async () => {
-                const { redirectUri } = await startOAuthServer()
-                const pkce = await generatePKCE()
-                const state = generateState()
-                const authUrl = buildAuthorizeUrl(redirectUri, pkce, state)
+          },
+        },
+        {
+          label: "ChatGPT Pro/Plus (headless)",
+          type: "oauth",
+          authorize: async () => {
+            const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "User-Agent": `opencode/${Installation.VERSION}`,
+              },
+              body: JSON.stringify({ client_id: CLIENT_ID }),
+            })
 
-                const callbackPromise = waitForOAuthCallback(pkce, state)
+            if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
 
-                return {
-                  url: authUrl,
-                  instructions: "Complete authorization in your browser. This window will close automatically.",
-                  method: "auto" as const,
-                  callback: async () => {
-                    const tokens = await callbackPromise
-                    stopOAuthServer()
-                    const accountId = extractAccountId(tokens)
+            const deviceData = (await deviceResponse.json()) as {
+              device_auth_id: string
+              user_code: string
+              interval: string
+            }
+            const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
+
+            return {
+              url: `${ISSUER}/codex/device`,
+              instructions: `Enter code: ${deviceData.user_code}`,
+              method: "auto" as const,
+              async callback() {
+                while (true) {
+                  const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
+                    method: "POST",
+                    headers: {
+                      "Content-Type": "application/json",
+                      "User-Agent": `opencode/${Installation.VERSION}`,
+                    },
+                    body: JSON.stringify({
+                      device_auth_id: deviceData.device_auth_id,
+                      user_code: deviceData.user_code,
+                    }),
+                  })
+
+                  if (response.ok) {
+                    const data = (await response.json()) as {
+                      authorization_code: string
+                      code_verifier: string
+                    }
+
+                    const tokens: TokenResponse = await fetch(`${ISSUER}/oauth/token`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                      body: new URLSearchParams({
+                        grant_type: "authorization_code",
+                        code: data.authorization_code,
+                        redirect_uri: `${ISSUER}/deviceauth/callback`,
+                        client_id: CLIENT_ID,
+                        code_verifier: data.code_verifier,
+                      }).toString(),
+                    }).then((r) => r.json())
+
                     return {
                       type: "success" as const,
                       refresh: tokens.refresh_token,
                       access: tokens.access_token,
                       expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                      accountId,
+                      accountId: extractAccountId(tokens),
                     }
-                  },
+                  }
+
+                  if (response.status !== 403 && response.status !== 404) {
+                    return { type: "failed" as const }
+                  }
+
+                  await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
                 }
               },
-            },
+            }
+          },
+        },
         {
           label: "Manually enter API Key",
           type: "api",

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -537,7 +537,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                       code_verifier: string
                     }
 
-                    const tokens: TokenResponse = await fetch(`${ISSUER}/oauth/token`, {
+                    const tokenResponse = await fetch(`${ISSUER}/oauth/token`, {
                       method: "POST",
                       headers: { "Content-Type": "application/x-www-form-urlencoded" },
                       body: new URLSearchParams({
@@ -547,7 +547,13 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                         client_id: CLIENT_ID,
                         code_verifier: data.code_verifier,
                       }).toString(),
-                    }).then((r) => r.json())
+                    })
+
+                    if (!tokenResponse.ok) {
+                      throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+                    }
+
+                    const tokens: TokenResponse = await tokenResponse.json()
 
                     return {
                       type: "success" as const,

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -3,6 +3,7 @@ import { Log } from "../util/log"
 import { Installation } from "../installation"
 import { Auth, OAUTH_DUMMY_KEY } from "../auth"
 import os from "os"
+import { iife } from "@/util/iife"
 
 const log = Log.create({ service: "plugin.codex" })
 
@@ -348,6 +349,27 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
 }
 
 export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
+  const useDeviceAuth = iife(() => {
+    // Returns true when likely running in an environment without a usable GUI.
+    // Intentionally conservative: frontends can use this to avoid flows that try to open a browser.
+    const isSet = (name: string): boolean => {
+      const v = process.env[name]
+      return v !== undefined && v !== ""
+    }
+
+    if (isSet("CI") || isSet("SSH_CONNECTION") || isSet("SSH_CLIENT") || isSet("SSH_TTY")) {
+      return true
+    }
+
+    if (process.platform === "linux") {
+      if (!isSet("DISPLAY") && !isSet("WAYLAND_DISPLAY")) {
+        return true
+      }
+    }
+
+    return false
+  })
+
   return {
     auth: {
       provider: "openai",
@@ -461,113 +483,120 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         }
       },
       methods: [
-        {
-          label: "ChatGPT Pro/Plus (browser)",
-          type: "oauth",
-          authorize: async () => {
-            const { redirectUri } = await startOAuthServer()
-            const pkce = await generatePKCE()
-            const state = generateState()
-            const authUrl = buildAuthorizeUrl(redirectUri, pkce, state)
+        useDeviceAuth
+          ? {
+              label: "ChatGPT Pro/Plus",
+              type: "oauth",
+              authorize: async () => {
+                const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                    "User-Agent": `opencode/${Installation.VERSION}`,
+                  },
+                  body: JSON.stringify({ client_id: CLIENT_ID }),
+                })
 
-            const callbackPromise = waitForOAuthCallback(pkce, state)
+                if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
 
-            return {
-              url: authUrl,
-              instructions: "Complete authorization in your browser. This window will close automatically.",
-              method: "auto" as const,
-              callback: async () => {
-                const tokens = await callbackPromise
-                stopOAuthServer()
-                const accountId = extractAccountId(tokens)
+                const deviceData = (await deviceResponse.json()) as {
+                  device_auth_id: string
+                  user_code: string
+                  interval: string
+                }
+                const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
+
                 return {
-                  type: "success" as const,
-                  refresh: tokens.refresh_token,
-                  access: tokens.access_token,
-                  expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                  accountId,
+                  url: `${ISSUER}/codex/device`,
+                  instructions: `Enter code: ${deviceData.user_code}`,
+                  method: "auto" as const,
+                  async callback() {
+                    while (true) {
+                      const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
+                        method: "POST",
+                        headers: {
+                          "Content-Type": "application/json",
+                          "User-Agent": `opencode/${Installation.VERSION}`,
+                        },
+                        body: JSON.stringify({
+                          device_auth_id: deviceData.device_auth_id,
+                          user_code: deviceData.user_code,
+                        }),
+                      })
+
+                      if (response.ok) {
+                        const data = (await response.json()) as {
+                          authorization_code: string
+                          code_verifier: string
+                        }
+
+                        const tokenResponse = await fetch(`${ISSUER}/oauth/token`, {
+                          method: "POST",
+                          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                          body: new URLSearchParams({
+                            grant_type: "authorization_code",
+                            code: data.authorization_code,
+                            redirect_uri: `${ISSUER}/deviceauth/callback`,
+                            client_id: CLIENT_ID,
+                            code_verifier: data.code_verifier,
+                          }).toString(),
+                        })
+
+                        if (!tokenResponse.ok) {
+                          throw new Error(`Token exchange failed: ${tokenResponse.status}`)
+                        }
+
+                        const tokens = (await tokenResponse.json()) as TokenResponse
+
+                        return {
+                          type: "success" as const,
+                          refresh: tokens.refresh_token,
+                          access: tokens.access_token,
+                          expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                          accountId: extractAccountId(tokens),
+                        }
+                      }
+
+                      if (response.status !== 403 && response.status !== 404) {
+                        return { type: "failed" as const }
+                      }
+
+                      await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
+                    }
+                  },
                 }
               },
             }
-          },
-        },
-        {
-          label: "ChatGPT Pro/Plus (headless)",
-          type: "oauth",
-          authorize: async () => {
-            const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                "User-Agent": `opencode/${Installation.VERSION}`,
-              },
-              body: JSON.stringify({ client_id: CLIENT_ID }),
-            })
+          : {
+              label: "ChatGPT Pro/Plus",
+              type: "oauth",
+              authorize: async () => {
+                const { redirectUri } = await startOAuthServer()
+                const pkce = await generatePKCE()
+                const state = generateState()
+                const authUrl = buildAuthorizeUrl(redirectUri, pkce, state)
 
-            if (!deviceResponse.ok) throw new Error("Failed to initiate device authorization")
+                const callbackPromise = waitForOAuthCallback(pkce, state)
 
-            const deviceData = (await deviceResponse.json()) as {
-              device_auth_id: string
-              user_code: string
-              interval: string
-            }
-            const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
-
-            return {
-              url: `${ISSUER}/codex/device`,
-              instructions: `Enter code: ${deviceData.user_code}`,
-              method: "auto" as const,
-              async callback() {
-                while (true) {
-                  const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                      "User-Agent": `opencode/${Installation.VERSION}`,
-                    },
-                    body: JSON.stringify({
-                      device_auth_id: deviceData.device_auth_id,
-                      user_code: deviceData.user_code,
-                    }),
-                  })
-
-                  if (response.ok) {
-                    const data = (await response.json()) as {
-                      authorization_code: string
-                      code_verifier: string
-                    }
-
-                    const tokens: TokenResponse = await fetch(`${ISSUER}/oauth/token`, {
-                      method: "POST",
-                      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-                      body: new URLSearchParams({
-                        grant_type: "authorization_code",
-                        code: data.authorization_code,
-                        redirect_uri: `${ISSUER}/deviceauth/callback`,
-                        client_id: CLIENT_ID,
-                        code_verifier: data.code_verifier,
-                      }).toString(),
-                    }).then((r) => r.json())
-
+                return {
+                  url: authUrl,
+                  instructions: "Complete authorization in your browser. This window will close automatically.",
+                  method: "auto" as const,
+                  callback: async () => {
+                    const tokens = await callbackPromise
+                    stopOAuthServer()
+                    const accountId = extractAccountId(tokens)
                     return {
                       type: "success" as const,
                       refresh: tokens.refresh_token,
                       access: tokens.access_token,
                       expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
-                      accountId: extractAccountId(tokens),
+                      accountId,
                     }
-                  }
-
-                  if (response.status !== 403 && response.status !== 404) {
-                    return { type: "failed" as const }
-                  }
-
-                  await Bun.sleep(interval + OAUTH_POLLING_SAFETY_MARGIN_MS)
+                  },
                 }
               },
-            }
-          },
-        },
+            },
         {
           label: "Manually enter API Key",
           type: "api",

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -10,10 +10,6 @@ const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
-const DEVICE_CODE_URL = `${ISSUER}/api/accounts/deviceauth/usercode`
-const DEVICE_TOKEN_URL = `${ISSUER}/api/accounts/deviceauth/token`
-const DEVICE_REDIRECT_URI = `${ISSUER}/deviceauth/callback`
-const DEVICE_VERIFICATION_URL = `${ISSUER}/codex/device`
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
 
 interface PkceCodes {
@@ -499,7 +495,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           label: "ChatGPT Pro/Plus (headless)",
           type: "oauth",
           authorize: async () => {
-            const deviceResponse = await fetch(DEVICE_CODE_URL, {
+            const deviceResponse = await fetch(`${ISSUER}/api/accounts/deviceauth/usercode`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -518,12 +514,12 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
             const interval = Math.max(parseInt(deviceData.interval) || 5, 1) * 1000
 
             return {
-              url: DEVICE_VERIFICATION_URL,
+              url: `${ISSUER}/codex/device`,
               instructions: `Enter code: ${deviceData.user_code}`,
               method: "auto" as const,
               async callback() {
                 while (true) {
-                  const response = await fetch(DEVICE_TOKEN_URL, {
+                  const response = await fetch(`${ISSUER}/api/accounts/deviceauth/token`, {
                     method: "POST",
                     headers: {
                       "Content-Type": "application/json",
@@ -547,7 +543,7 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
                       body: new URLSearchParams({
                         grant_type: "authorization_code",
                         code: data.authorization_code,
-                        redirect_uri: DEVICE_REDIRECT_URI,
+                        redirect_uri: `${ISSUER}/deviceauth/callback`,
                         client_id: CLIENT_ID,
                         code_verifier: data.code_verifier,
                       }).toString(),


### PR DESCRIPTION
### What does this PR do?


https://github.com/user-attachments/assets/8fab0bed-4dc5-4665-aedb-1b9389bead20

add the option to use the [device auth authorization method](https://developers.openai.com/codex/auth/#preferred-device-code-authentication-beta:~:text=Preferred%3A%20Device%20code%20authentication%20(beta)) to sign in with chatgpt/codex subscription

closes #10421, closes #8274, and approved by dax on twitter
<img width="1222" height="1632" alt="Screenshot 2026-01-27 at 2 33 54 PM" src="https://github.com/user-attachments/assets/47f2b81f-f24b-40aa-a3c3-dccb8aa6a47c" />




### How did you verify your code works?

manual testing (in the video)
copied mostly off of the copilot implementation of a similar (not exactly the same for some reason?) pattern
[opencode share url](https://opncd.ai/share/ORvrKnzf)
