### PR TITLE
fix(provider): retry responses API without include on 400 rejection

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1016,11 +1016,44 @@ export namespace Provider {
           }
         }
 
-        return fetchFn(input, {
+        const res = await fetchFn(input, {
           ...opts,
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682
           timeout: false,
         })
+
+        if (
+          res.status === 400 &&
+          typeof input === "string" &&
+          input.includes("/responses") &&
+          opts.method === "POST" &&
+          typeof opts.body === "string"
+        ) {
+          try {
+            const text = await res.clone().text()
+            if (text.includes("include") && (text.includes("not supported") || text.includes("is not"))) {
+              const body = JSON.parse(opts.body)
+              if (body && typeof body === "object" && "include" in body) {
+                delete body.include
+                log.info("retrying request without include", {
+                  url: input,
+                  providerID: model.providerID,
+                  modelID: model.id,
+                })
+                return fetchFn(input, {
+                  ...opts,
+                  body: JSON.stringify(body),
+                  // @ts-ignore
+                  timeout: false,
+                })
+              }
+            }
+          } catch {
+            return res
+          }
+        }
+
+        return res
       }
 
       // Special case: google-vertex-anthropic uses a subpath import

--- a/packages/opencode/test/provider/amazon-bedrock.test.ts
+++ b/packages/opencode/test/provider/amazon-bedrock.test.ts
@@ -31,9 +31,21 @@ mock.module("@aws-sdk/credential-providers", () => ({
 }))
 
 const mockPlugin = () => ({})
+mock.module("../../src/plugin", () => ({
+  Plugin: {
+    trigger: async (_name: string, _input: unknown, output: unknown) => output,
+    list: async () => [],
+    init: async () => {},
+  },
+}))
 mock.module("opencode-copilot-auth", () => ({ default: mockPlugin }))
 mock.module("opencode-anthropic-auth", () => ({ default: mockPlugin }))
 mock.module("@gitlab/opencode-gitlab-auth", () => ({ default: mockPlugin }))
+mock.module("opencode-antigravity-auth", () => ({ default: mockPlugin }))
+mock.module("opencode-pty", () => ({ default: mockPlugin }))
+mock.module("opencode-scheduler", () => ({ default: mockPlugin }))
+mock.module("opencode-wakatime", () => ({ default: mockPlugin }))
+mock.module("opencode-devcontainers", () => ({ default: mockPlugin }))
 
 // Import after mocks are set up
 const { tmpdir } = await import("../fixture/fixture")

--- a/packages/opencode/test/provider/responses-include-retry.test.ts
+++ b/packages/opencode/test/provider/responses-include-retry.test.ts
@@ -1,0 +1,293 @@
+import { expect, mock, test } from "bun:test"
+import path from "path"
+mock.module("../../src/bun/index", () => ({
+  BunProc: {
+    install: async (pkg: string, _version?: string) => {
+      const lastAtIndex = pkg.lastIndexOf("@")
+      return lastAtIndex > 0 ? pkg.substring(0, lastAtIndex) : pkg
+    },
+    run: async () => {
+      throw new Error("BunProc.run should not be called in tests")
+    },
+    which: () => process.execPath,
+    InstallFailedError: class extends Error {},
+  },
+}))
+
+const mockPlugin = () => ({})
+mock.module("../../src/plugin", () => ({
+  Plugin: {
+    trigger: async (_name: string, _input: unknown, output: unknown) => output,
+    list: async () => [],
+    init: async () => {},
+  },
+}))
+mock.module("opencode-copilot-auth", () => ({ default: mockPlugin }))
+mock.module("opencode-anthropic-auth", () => ({ default: mockPlugin }))
+mock.module("@gitlab/opencode-gitlab-auth", () => ({ default: mockPlugin }))
+mock.module("opencode-antigravity-auth", () => ({ default: mockPlugin }))
+mock.module("opencode-pty", () => ({ default: mockPlugin }))
+mock.module("opencode-scheduler", () => ({ default: mockPlugin }))
+
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+
+const schema = "https://opencode.ai/config.json"
+
+const responseBody = {
+  id: "res_1",
+  created_at: 0,
+  model: "retry-model",
+  output: [
+    {
+      type: "message",
+      role: "assistant",
+      id: "msg_1",
+      content: [
+        {
+          type: "output_text",
+          text: "ok",
+          annotations: [],
+        },
+      ],
+    },
+  ],
+  usage: {
+    input_tokens: 1,
+    output_tokens: 1,
+    total_tokens: 2,
+  },
+}
+
+const prompt = () => [
+  {
+    role: "user" as const,
+    content: [{ type: "text" as const, text: "hi" }],
+  },
+]
+
+const writeConfig = async (dir: string, config: Record<string, unknown>) => {
+  await Bun.write(path.join(dir, "opencode.json"), JSON.stringify({ $schema: schema, ...config }))
+}
+
+test("retries /responses when include is rejected", async () => {
+  const calls: { url: string; body: string }[] = []
+  const attempt = { count: 0 }
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text()
+      calls.push({ url: req.url, body })
+      if (attempt.count === 0) {
+        attempt.count += 1
+        return new Response(JSON.stringify({ error: { message: "include is not supported" } }), {
+          status: 400,
+        })
+      }
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    },
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        provider: {
+          openai: {
+            npm: "@ai-sdk/openai",
+            api: server.url.origin,
+            options: { apiKey: "test-key", baseURL: server.url.origin },
+            models: {
+              "retry-model": {
+                name: "Retry Model",
+                tool_call: true,
+                limit: { context: 8000, output: 2000 },
+              },
+            },
+          },
+        },
+      })
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await Provider.getModel("openai", "retry-model")
+      const language = await Provider.getLanguage(model)
+      await language.doGenerate({
+        prompt: prompt(),
+        providerOptions: { openai: { include: ["message.output_text.logprobs"] } },
+      })
+    },
+  })
+
+  expect(calls.length).toBe(2)
+  expect(new URL(calls[0].url).pathname).toBe("/responses")
+  expect(new URL(calls[1].url).pathname).toBe("/responses")
+  const first = JSON.parse(calls[0].body)
+  const second = JSON.parse(calls[1].body)
+  expect(first.include).toContain("message.output_text.logprobs")
+  expect("include" in second).toBe(false)
+})
+
+test("does not retry /responses when error text lacks include", async () => {
+  const calls: { url: string; body: string }[] = []
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text()
+      calls.push({ url: req.url, body })
+      return new Response(JSON.stringify({ error: { message: "bad request" } }), { status: 400 })
+    },
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        provider: {
+          openai: {
+            npm: "@ai-sdk/openai",
+            api: server.url.origin,
+            options: { apiKey: "test-key", baseURL: server.url.origin },
+            models: {
+              "retry-model": {
+                name: "Retry Model",
+                tool_call: true,
+                limit: { context: 8000, output: 2000 },
+              },
+            },
+          },
+        },
+      })
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await Provider.getModel("openai", "retry-model")
+      const language = await Provider.getLanguage(model)
+      await expect(
+        language.doGenerate({
+          prompt: prompt(),
+          providerOptions: { openai: { include: ["message.output_text.logprobs"] } },
+        }),
+      ).rejects.toThrow()
+    },
+  })
+
+  expect(calls.length).toBe(1)
+  expect(new URL(calls[0].url).pathname).toBe("/responses")
+})
+
+test("does not retry /responses when include was not sent", async () => {
+  const calls: { url: string; body: string }[] = []
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text()
+      calls.push({ url: req.url, body })
+      return new Response(JSON.stringify({ error: { message: "include is not supported" } }), {
+        status: 400,
+      })
+    },
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        provider: {
+          openai: {
+            npm: "@ai-sdk/openai",
+            api: server.url.origin,
+            options: { apiKey: "test-key", baseURL: server.url.origin },
+            models: {
+              "retry-model": {
+                name: "Retry Model",
+                tool_call: true,
+                limit: { context: 8000, output: 2000 },
+              },
+            },
+          },
+        },
+      })
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await Provider.getModel("openai", "retry-model")
+      const language = await Provider.getLanguage(model)
+      await expect(
+        language.doGenerate({
+          prompt: prompt(),
+        }),
+      ).rejects.toThrow()
+    },
+  })
+
+  expect(calls.length).toBe(1)
+  expect(new URL(calls[0].url).pathname).toBe("/responses")
+  const body = JSON.parse(calls[0].body)
+  expect("include" in body).toBe(false)
+})
+
+test("does not retry non-/responses endpoints", async () => {
+  const calls: { url: string; body: string }[] = []
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = await req.text()
+      calls.push({ url: req.url, body })
+      return new Response(JSON.stringify({ error: { message: "include is not supported" } }), {
+        status: 400,
+      })
+    },
+  })
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await writeConfig(dir, {
+        provider: {
+          "openai-compatible": {
+            npm: "@ai-sdk/openai-compatible",
+            api: server.url.origin,
+            options: { apiKey: "test-key", baseURL: server.url.origin },
+            models: {
+              "chat-model": {
+                name: "Chat Model",
+                tool_call: true,
+                limit: { context: 8000, output: 2000 },
+              },
+            },
+          },
+        },
+      })
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = await Provider.getModel("openai-compatible", "chat-model")
+      const language = await Provider.getLanguage(model)
+      await expect(
+        language.doGenerate({
+          prompt: prompt(),
+        }),
+      ).rejects.toThrow()
+    },
+  })
+
+  expect(calls.length).toBe(1)
+  expect(new URL(calls[0].url).pathname).toBe("/chat/completions")
+})


### PR DESCRIPTION
Fixes #7524

when using scaleway's gpt-oss-120b with the responses api, requests fail because scaleway doesn't support the `include` parameter that the ai sdk adds automatically.

this adds retry logic to the fetch wrapper - if a /responses request returns 400 with an error mentioning "include is not supported", it strips the include field and retries once.

changes:
- added retry-on-400 logic in provider.ts fetch wrapper
- logs when retry happens for debugging
- added tests with mock server covering retry and no-retry cases
- fixed missing plugin mocks in amazon-bedrock tests that were causing unrelated failures

tested with `bun test test/provider/` (165 pass) and `bun run typecheck` (all packages pass)