### PR TITLE
fix(desktop): open external links in default browser

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -3,7 +3,7 @@ import "./webview-zoom"
 import { render } from "solid-js/web"
 import { AppBaseProviders, AppInterface, PlatformProvider, Platform } from "@opencode-ai/app"
 import { open, save } from "@tauri-apps/plugin-dialog"
-import { open as shellOpen } from "@tauri-apps/plugin-shell"
+import { openUrl } from "@tauri-apps/plugin-opener"
 import { type as ostype } from "@tauri-apps/plugin-os"
 import { check, Update } from "@tauri-apps/plugin-updater"
 import { invoke } from "@tauri-apps/api/core"
@@ -77,7 +77,7 @@ const createPlatform = (password: Accessor<string | null>): Platform => ({
   },
 
   openLink(url: string) {
-    void shellOpen(url).catch(() => undefined)
+    void openUrl(url).catch(() => undefined)
   },
 
   back() {
@@ -337,11 +337,31 @@ render(() => {
   const platform = createPlatform(() => serverPassword())
 
   function handleClick(e: MouseEvent) {
-    const link = (e.target as HTMLElement).closest("a.external-link") as HTMLAnchorElement | null
-    if (link?.href) {
-      e.preventDefault()
-      platform.openLink(link.href)
-    }
+    if (e.defaultPrevented) return
+    if (e.button !== 0) return
+    if (!(e.target instanceof Element)) return
+
+    const link = e.target.closest("a[href]")
+    if (!(link instanceof HTMLAnchorElement)) return
+
+    const href = link.getAttribute("href")
+    if (!href) return
+
+    const url = (() => {
+      try {
+        return new URL(href, window.location.href)
+      } catch {
+        return
+      }
+    })()
+    if (!url) return
+
+    const http = url.protocol === "http:" || url.protocol === "https:"
+    if (!http) return
+    if (url.origin === window.location.origin) return
+
+    e.preventDefault()
+    platform.openLink(url.toString())
   }
 
   onMount(() => {


### PR DESCRIPTION
Fixes #10901
### What does this PR do?
Prevents external http(s) links in AI responses from navigating the app webview. External links now open in the OS default browser so OpenCode’s main UI is never replaced.
### How did you verify your code works?
- Ran the desktop app locally (`bun run --cwd packages/desktop tauri dev`)
- Clicked external https links in an assistant message and confirmed they open in the system browser while OpenCode stays on the current view
- Confirmed same-origin links are not intercepted