### PR TITLE
fix(tui): Ensure version check is skipped when autoupdate is disabled

### DIFF
--- a/packages/opencode/src/cli/upgrade.ts
+++ b/packages/opencode/src/cli/upgrade.ts
@@ -5,14 +5,15 @@ import { Installation } from "@/installation"
 
 export async function upgrade() {
   const config = await Config.global()
-  const method = await Installation.method()
-  const latest = await Installation.latest(method).catch(() => {})
-  if (!latest) return
-  if (Installation.VERSION === latest) return
 
   if (config.autoupdate === false || Flag.OPENCODE_DISABLE_AUTOUPDATE) {
     return
   }
+
+  const method = await Installation.method()
+  const latest = await Installation.latest(method).catch(() => {})
+  if (!latest) return
+  if (Installation.VERSION === latest) return
   if (config.autoupdate === "notify") {
     await Bus.publish(Installation.Event.UpdateAvailable, { version: latest })
     return


### PR DESCRIPTION
### What does this PR do?

It reorders upgrade() to prevent launching the code path to determine version information in case the user configured `autoupdate: false`. The information is not used anyway.

Main reason is, that launching the version check code causes issues with Ctrl-C not clearing the input on Windows afterwards, but instead crashing the whole app. The user is left on terminal, mouse movements produce strange ansi characters, until the user closes the terminal session and opens a new one. This PR allows users to set `autoupdate: false` as a workaround on Windows, to prevent the crashes.

### How did you verify your code works?
- `bun run dev` and use it with `autoupdate: false` on Windows, check that ctrl-c now indeed clears the input

Fixes #10538 for `autoupdate: false` (`autoupdate: true` still has the issue)