### PR TITLE
fix(app): stop fetching all MCP prompts on initialization

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -126,6 +126,14 @@ export namespace Command {
   }
 
   export async function list() {
-    return state().then((x) => Object.values(x))
+    return state().then((x) =>
+      Object.values(x).map((cmd) =>
+        Object.fromEntries(
+          Object.keys(cmd)
+            .filter((key) => key !== "template")
+            .map((key) => [key, cmd[key as keyof typeof cmd]]),
+        ),
+      ),
+    )
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR removes the duplicative and useless `get_prompt` API calls that OpenCode makes to MCP servers when it initializes. These spam MCP servers with GET requests whenever OpenCode initializes

### How did you verify your code works?
I pointed it at my own MCP server before and after the fix.

#### Before

You can see in the MCP server logs that after OpenCode initializes, it fetches every single prompt on the server

<img width="2560" height="99" alt="image" src="https://github.com/user-attachments/assets/bc52ce3d-ab2a-4b40-ac10-00686e140bf1" />

#### After

After, it just initializes

<img width="2549" height="47" alt="image" src="https://github.com/user-attachments/assets/e638ef0b-0a04-4211-b8f9-99edf85374ee" />

fixes #10894