### PR TITLE
docs: add Daytona OpenCode plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -17,6 +17,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 | Name                                                                                               | Description                                                                                    |
 | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [opencode-daytona](https://github.com/jamesmurdza/daytona/tree/main/libs/opencode-plugin) | Automatically run OpenCode sessions in isolated Daytona sandboxes with git sync and live previews |
 | [opencode-helicone-session](https://github.com/H2Shami/opencode-helicone-session)                  | Automatically inject Helicone session headers for request grouping                             |
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                          |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                  |


### PR DESCRIPTION
### What does this PR do?

This PR adds the [opencode-daytona](https://www.npmjs.com/package/opencode-daytona) plugin which runs OpenCode sessions in cloud sandboxes.

### How did you verify your code works?

I've tested thoroughly as per the instructions here: https://github.com/jamesmurdza/daytona/tree/feat/opencode-plugin/libs/opencode-plugin

### Demo

https://github.com/user-attachments/assets/61ff098d-b21b-43df-bf84-a5ac67fd0573
