### PR TITLE
fix(tui): add scroll keybindings to permission prompt, error screen, and sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,6 +1,6 @@
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
-import { TextAttributes } from "@opentui/core"
+import { type ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
 import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
 import { Installation } from "@/installation"
@@ -703,11 +703,7 @@ function ErrorComponent(props: {
     props.onExit()
   }
 
-  useKeyboard((evt) => {
-    if (evt.ctrl && evt.name === "c") {
-      handleExit()
-    }
-  })
+  let scroll: ScrollBoxRenderable | undefined
   const [copied, setCopied] = createSignal(false)
 
   const issueURL = new URL("https://github.com/anomalyco/opencode/issues/new?template=bug-report.yml")
@@ -740,6 +736,57 @@ function ErrorComponent(props: {
     })
   }
 
+  useKeyboard((evt) => {
+    if (evt.ctrl && evt.name === "c") {
+      handleExit()
+    }
+
+    if (evt.name === "x" || evt.name === "escape") {
+      evt.preventDefault()
+      handleExit()
+    }
+
+    if (evt.name === "r") {
+      evt.preventDefault()
+      props.reset()
+    }
+
+    if (evt.name === "c") {
+      evt.preventDefault()
+      copyIssueURL()
+    }
+
+    if (evt.name === "up" || evt.name === "k") {
+      evt.preventDefault()
+      scroll?.scrollBy(-1)
+    }
+
+    if (evt.name === "down" || evt.name === "j") {
+      evt.preventDefault()
+      scroll?.scrollBy(1)
+    }
+
+    if (evt.name === "pageup") {
+      evt.preventDefault()
+      if (scroll) scroll.scrollBy(-scroll.height / 2)
+    }
+
+    if (evt.name === "pagedown") {
+      evt.preventDefault()
+      if (scroll) scroll.scrollBy(scroll.height / 2)
+    }
+
+    if (evt.name === "home") {
+      evt.preventDefault()
+      scroll?.scrollTo(0)
+    }
+
+    if (evt.name === "end") {
+      evt.preventDefault()
+      if (scroll) scroll.scrollTo(scroll.scrollHeight)
+    }
+  })
+
   return (
     <box flexDirection="column" gap={1} backgroundColor={colors.bg}>
       <box flexDirection="row" gap={1} alignItems="center">
@@ -748,7 +795,7 @@ function ErrorComponent(props: {
         </text>
         <box onMouseUp={copyIssueURL} backgroundColor={colors.primary} padding={1}>
           <text attributes={TextAttributes.BOLD} fg={colors.bg}>
-            Copy issue URL (exception info pre-filled)
+            C̲opy issue URL (exception info pre-filled)
           </text>
         </box>
         {copied() && <text fg={colors.muted}>Successfully copied</text>}
@@ -756,13 +803,13 @@ function ErrorComponent(props: {
       <box flexDirection="row" gap={2} alignItems="center">
         <text fg={colors.text}>A fatal error occurred!</text>
         <box onMouseUp={props.reset} backgroundColor={colors.primary} padding={1}>
-          <text fg={colors.bg}>Reset TUI</text>
+          <text fg={colors.bg}>R̲eset TUI</text>
         </box>
         <box onMouseUp={handleExit} backgroundColor={colors.primary} padding={1}>
-          <text fg={colors.bg}>Exit</text>
+          <text fg={colors.bg}>Ex̲it</text>
         </box>
       </box>
-      <scrollbox height={Math.floor(term().height * 0.7)}>
+      <scrollbox height={Math.floor(term().height * 0.7)} ref={(r: ScrollBoxRenderable) => (scroll = r)}>
         <text fg={colors.muted}>{props.error.stack}</text>
       </scrollbox>
       <text fg={colors.text}>{props.error.message}</text>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -1,7 +1,7 @@
 import { createStore } from "solid-js/store"
 import { createMemo, For, Match, Show, Switch } from "solid-js"
 import { Portal, useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
-import type { TextareaRenderable } from "@opentui/core"
+import type { ScrollBoxRenderable, TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
 import { useTheme, selectedForeground } from "../../context/theme"
 import type { PermissionRequest } from "@opencode-ai/sdk/v2"
@@ -69,7 +69,7 @@ function EditBody(props: { request: PermissionRequest }) {
         <text fg={theme.textMuted}>Edit {normalizePath(filepath())}</text>
       </box>
       <Show when={diff()}>
-        <scrollbox height="100%">
+        <scrollbox height="100%" ref={(r: ScrollBoxRenderable) => (sharedScrollRef = r)}>
           <diff
             diff={diff()}
             view={view()}
@@ -370,6 +370,9 @@ function RejectPrompt(props: { onConfirm: (message: string) => void; onCancel: (
   )
 }
 
+// Shared scroll ref that EditBody can set and Prompt can use
+let sharedScrollRef: ScrollBoxRenderable | undefined
+
 function Prompt<const T extends Record<string, string>>(props: {
   title: string
   body: JSX.Element
@@ -405,6 +408,36 @@ function Prompt<const T extends Record<string, string>>(props: {
       const idx = keys.indexOf(store.selected)
       const next = keys[(idx + 1) % keys.length]
       setStore("selected", next)
+    }
+
+    if (evt.name === "up" || evt.name === "k") {
+      evt.preventDefault()
+      sharedScrollRef?.scrollBy(-1)
+    }
+
+    if (evt.name === "down" || evt.name === "j") {
+      evt.preventDefault()
+      sharedScrollRef?.scrollBy(1)
+    }
+
+    if (evt.name === "pageup") {
+      evt.preventDefault()
+      if (sharedScrollRef) sharedScrollRef.scrollBy(-sharedScrollRef.height / 2)
+    }
+
+    if (evt.name === "pagedown") {
+      evt.preventDefault()
+      if (sharedScrollRef) sharedScrollRef.scrollBy(sharedScrollRef.height / 2)
+    }
+
+    if (evt.name === "home") {
+      evt.preventDefault()
+      sharedScrollRef?.scrollTo(0)
+    }
+
+    if (evt.name === "end") {
+      evt.preventDefault()
+      if (sharedScrollRef) sharedScrollRef.scrollTo(sharedScrollRef.scrollHeight)
     }
 
     if (evt.name === "return") {
@@ -487,6 +520,11 @@ function Prompt<const T extends Record<string, string>>(props: {
           <Show when={props.fullscreen}>
             <text fg={theme.text}>
               {"ctrl+f"} <span style={{ fg: theme.textMuted }}>{hint()}</span>
+            </text>
+          </Show>
+          <Show when={sharedScrollRef}>
+            <text fg={theme.text}>
+              {"↑↓"} <span style={{ fg: theme.textMuted }}>scroll</span>
             </text>
           </Show>
           <text fg={theme.text}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,6 +1,8 @@
 import { useSync } from "@tui/context/sync"
 import { createMemo, For, Show, Switch, Match } from "solid-js"
 import { createStore } from "solid-js/store"
+import { useKeyboard } from "@opentui/solid"
+import type { ScrollBoxRenderable } from "@opentui/core"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
 import path from "path"
@@ -19,6 +21,18 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const diff = createMemo(() => sync.data.session_diff[props.sessionID] ?? [])
   const todo = createMemo(() => sync.data.todo[props.sessionID] ?? [])
   const messages = createMemo(() => sync.data.message[props.sessionID] ?? [])
+  let scroll: ScrollBoxRenderable | undefined
+
+  useKeyboard((evt) => {
+    if (evt.ctrl && evt.shift && evt.name === "up") {
+      evt.preventDefault()
+      scroll?.scrollBy(-1)
+    }
+    if (evt.ctrl && evt.shift && evt.name === "down") {
+      evt.preventDefault()
+      scroll?.scrollBy(1)
+    }
+  })
 
   const [expanded, setExpanded] = createStore({
     mcp: true,
@@ -80,7 +94,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         paddingRight={2}
         position={props.overlay ? "absolute" : "relative"}
       >
-        <scrollbox flexGrow={1}>
+        <scrollbox flexGrow={1} ref={(r: ScrollBoxRenderable) => (scroll = r)}>
           <box flexShrink={0} gap={1} paddingRight={1}>
             <box paddingRight={1}>
               <text fg={theme.text}>

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -151,6 +151,17 @@ The OpenCode desktop app prompt input supports common Readline/Emacs-style short
 
 ---
 
+## Sidebar scroll
+
+The sidebar can be scrolled using keyboard shortcuts.
+
+| Shortcut          | Action               |
+| ----------------- | -------------------- |
+| `ctrl+shift+up`   | Scroll up one line   |
+| `ctrl+shift+down` | Scroll down one line |
+
+---
+
 ## Shift+Enter
 
 Some terminals don't send modifier keys with Enter by default. You may need to configure your terminal to send `Shift+Enter` as an escape sequence.


### PR DESCRIPTION
## Summary

- Add keyboard scroll support to permission prompt diff view
- Add keyboard scroll support and button shortcuts to error screen
- Add keyboard scroll support to sidebar
- Document sidebar scroll keybindings

Fixes #10923

## Changes

### Permission prompt
- `up`/`down`/`j`/`k` - scroll one line
- `pageup`/`pagedown` - scroll half page
- `home`/`end` - scroll to top/bottom
- Shows "↑↓ scroll" hint when scrollbox is present

### Error screen
Same scroll keybindings plus button shortcuts:
- `c` - Copy issue URL (C̲opy)
- `r` - Reset TUI (R̲eset)
- `x`/`escape` - Exit (Ex̲it)

### Sidebar
- `ctrl+shift+up`/`ctrl+shift+down` - scroll one line