### PR TITLE
feat: stream partial tool arguments

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -406,6 +406,10 @@ export namespace Session {
       part: MessageV2.ReasoningPart,
       delta: z.string(),
     }),
+    z.object({
+      part: MessageV2.ToolPart,
+      delta: z.string(),
+    }),
   ])
 
   export const updatePart = fn(UpdatePartInput, async (input) => {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -117,8 +117,14 @@ export namespace SessionProcessor {
                   toolcalls[value.id] = part as MessageV2.ToolPart
                   break
 
-                case "tool-input-delta":
+                case "tool-input-delta": {
+                  const match = toolcalls[value.id]
+                  if (match && match.state.status === "pending") {
+                    match.state.raw += value.delta
+                    await Session.updatePart({ part: match, delta: value.delta })
+                  }
                   break
+                }
 
                 case "tool-input-end":
                   break


### PR DESCRIPTION
### What does this PR do?

Exposes partial tool arguments during streaming by populating `state.raw` with accumulated deltas. Previously, `tool-input-delta` events were ignored and consumers had to wait for the full tool call to complete before seeing any arguments.

Fixes #9737

### How did you verify your code works?

- Tests pass
- Follows the same pattern as existing `text-delta` handling
- TypeScript compiles
- Tested in app