### PR TITLE
fix(opencode): use cached well-known config on fetch failure

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -2,6 +2,7 @@ import { Log } from "../util/log"
 import path from "path"
 import { pathToFileURL } from "url"
 import os from "os"
+import { createHash } from "crypto"
 import z from "zod"
 import { Filesystem } from "../util/filesystem"
 import { ModelsDev } from "../provider/models"
@@ -32,6 +33,19 @@ import { Event } from "../server/event"
 export namespace Config {
   const log = Log.create({ service: "config" })
 
+  const WELLKNOWN_TIMEOUT_MS = Flag.OPENCODE_WELLKNOWN_TIMEOUT_MS ?? 15_000
+
+  function wellknownCacheFile(url: string) {
+    const hash = createHash("sha256").update(url).digest("hex")
+    return path.join(Global.Path.cache, "wellknown", `${hash}.json`)
+  }
+
+  async function fetchWellKnown(url: string) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), WELLKNOWN_TIMEOUT_MS)
+    return fetch(url, { signal: controller.signal }).finally(() => clearTimeout(timer))
+  }
+
   // Custom merge function that concatenates array fields instead of replacing them
   function mergeConfigConcatArrays(target: Info, source: Info): Info {
     const merged = mergeDeep(target, source)
@@ -53,20 +67,39 @@ export namespace Config {
     for (const [key, value] of Object.entries(auth)) {
       if (value.type === "wellknown") {
         process.env[value.key] = value.token
-        log.debug("fetching remote config", { url: `${key}/.well-known/opencode` })
-        const response = await fetch(`${key}/.well-known/opencode`)
-        if (!response.ok) {
-          throw new Error(`failed to fetch remote config from ${key}: ${response.status}`)
+
+        const url = `${key}/.well-known/opencode`
+        const cacheFile = wellknownCacheFile(key)
+
+        log.debug("fetching remote config", { url })
+
+        const response = await fetchWellKnown(url).catch(() => undefined)
+        const fetched = await response
+          ?.json()
+          .then((x) => (x as any).config ?? {})
+          .catch(() => undefined)
+
+        if (response?.ok && fetched) {
+          if (!fetched.$schema) fetched.$schema = "https://opencode.ai/config.json"
+          await fs.mkdir(path.dirname(cacheFile), { recursive: true }).catch(() => {})
+          await Bun.write(cacheFile, JSON.stringify(fetched)).catch(() => {})
+          result = mergeConfigConcatArrays(result, await loadFile(cacheFile))
+          log.debug("loaded remote config from well-known", { url: key })
+          continue
         }
-        const wellknown = (await response.json()) as any
-        const remoteConfig = wellknown.config ?? {}
-        // Add $schema to prevent load() from trying to write back to a non-existent file
-        if (!remoteConfig.$schema) remoteConfig.$schema = "https://opencode.ai/config.json"
-        result = mergeConfigConcatArrays(
-          result,
-          await load(JSON.stringify(remoteConfig), `${key}/.well-known/opencode`),
-        )
-        log.debug("loaded remote config from well-known", { url: key })
+
+        const cached = await loadFile(cacheFile).catch(() => undefined)
+        if (cached) {
+          log.warn("failed to fetch remote config, using cached well-known config", {
+            url,
+            cacheFile,
+            status: response?.status,
+          })
+          result = mergeConfigConcatArrays(result, cached)
+          continue
+        }
+
+        throw new Error(`failed to fetch remote config from ${key}: ${response?.status ?? "unknown"}`)
       }
     }
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -28,6 +28,7 @@ export namespace Flag {
   export const OPENCODE_CLIENT = process.env["OPENCODE_CLIENT"] ?? "cli"
   export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
+  export const OPENCODE_WELLKNOWN_TIMEOUT_MS = number("OPENCODE_WELLKNOWN_TIMEOUT_MS")
 
   // Experimental
   export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL")

--- a/packages/opencode/test/config/wellknown-cache.test.ts
+++ b/packages/opencode/test/config/wellknown-cache.test.ts
@@ -1,0 +1,65 @@
+import { test, expect, mock } from "bun:test"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { Auth } from "../../src/auth"
+import { tmpdir } from "../fixture/fixture"
+
+test("uses cached well-known config when fetch fails", async () => {
+  const originalFetch = globalThis.fetch
+  let phase: "ok" | "fail" = "ok"
+
+  globalThis.fetch = mock((url: string | URL | Request) => {
+    const urlStr = url.toString()
+    if (!urlStr.includes(".well-known/opencode")) {
+      return originalFetch(url)
+    }
+
+    if (phase === "ok") {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            config: {
+              theme: "remote-theme",
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+    }
+
+    return Promise.resolve(new Response("nope", { status: 500 }))
+  }) as unknown as typeof fetch
+
+  const originalAuthAll = Auth.all
+  Auth.all = mock(() =>
+    Promise.resolve({
+      "https://example.com": {
+        type: "wellknown" as const,
+        key: "TEST_TOKEN",
+        token: "test-token",
+      },
+    }),
+  )
+
+  try {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        phase = "ok"
+        const first = await Config.get()
+        expect(first.theme).toBe("remote-theme")
+
+        await Instance.dispose()
+
+        phase = "fail"
+        const second = await Config.get()
+        expect(second.theme).toBe("remote-theme")
+      },
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+    Auth.all = originalAuthAll
+  }
+})
+

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -9,7 +9,9 @@ import { afterAll } from "bun:test"
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })
 afterAll(() => {
-  fsSync.rmSync(dir, { recursive: true, force: true })
+  try {
+    fsSync.rmSync(dir, { recursive: true, force: true })
+  } catch {}
 })
 // Set test home directory to isolate tests from user's actual home directory
 // This prevents tests from picking up real user configs/skills from ~/.claude/skills


### PR DESCRIPTION
Fixes #10930.

### What does this PR do?
- Caches the last successful `.well-known/opencode` config payload and falls back to it if the endpoint is temporarily unavailable.
- Adds a configurable timeout via `OPENCODE_WELLKNOWN_TIMEOUT_MS`.
- Makes test temp cleanup best-effort on Windows (avoids occasional `EBUSY` failures).

### How did you verify your code works?
- `bun test test/config/wellknown-cache.test.ts`
- `bun run typecheck`