### PR TITLE
fix(opencode): confirm insecure serve

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,16 +2,76 @@ import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import * as prompts from "@clack/prompts"
+
+type Decision = "allow" | "confirm" | "deny"
+
+function normalizeHost(input: string) {
+  const trimmed = input.trim()
+  if (!trimmed) return ""
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) return trimmed.slice(1, -1).toLowerCase()
+  return trimmed.toLowerCase()
+}
+
+function isLoopbackHost(hostname: string) {
+  const host = normalizeHost(hostname)
+  if (!host) return true
+  return host === "127.0.0.1" || host === "localhost" || host === "::1"
+}
+
+export function serveSecurityDecision(input: { hostname: string; passwordSet: boolean; yes?: boolean; isTTY: boolean }) {
+  if (input.passwordSet) return "allow" as const
+  if (isLoopbackHost(input.hostname)) return "allow" as const
+  if (input.yes) return "allow" as const
+  return input.isTTY ? ("confirm" as const) : ("deny" as const)
+}
 
 export const ServeCommand = cmd({
   command: "serve",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("yes", {
+      alias: "y",
+      type: "boolean",
+      describe: "skip confirmation prompts",
+      default: false,
+    }),
   describe: "starts a headless opencode server",
   handler: async (args) => {
-    if (!Flag.OPENCODE_SERVER_PASSWORD) {
+    const opts = await resolveNetworkOptions(args as any)
+    const passwordSet = !!Flag.OPENCODE_SERVER_PASSWORD
+    const decision = serveSecurityDecision({
+      hostname: opts.hostname,
+      passwordSet,
+      yes: (args as any).yes,
+      isTTY: !!process.stdin.isTTY,
+    })
+
+    if (!passwordSet) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
-    const opts = await resolveNetworkOptions(args)
+
+    if (decision === "deny") {
+      console.error("Refusing to start an unsecured server on a non-loopback hostname.")
+      console.error("Set OPENCODE_SERVER_PASSWORD, or pass --yes to explicitly accept this risk.")
+      process.exitCode = 1
+      return
+    }
+
+    if (decision === "confirm") {
+      prompts.intro("Start unsecured server?")
+      prompts.log.warn(`Hostname: ${opts.hostname}`)
+      prompts.log.warn("OPENCODE_SERVER_PASSWORD is not set; anyone who can reach this host can access the server.")
+      const confirm = await prompts.confirm({
+        message: "Start anyway?",
+        initialValue: false,
+      })
+      if (!confirm || prompts.isCancel(confirm)) {
+        prompts.outro("Cancelled")
+        return
+      }
+      prompts.outro("Starting server")
+    }
+
     const server = Server.listen(opts)
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
     await new Promise(() => {})

--- a/packages/opencode/test/cli/serve-security.test.ts
+++ b/packages/opencode/test/cli/serve-security.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { serveSecurityDecision } from "../../src/cli/cmd/serve"
+
+test("serveSecurityDecision allows loopback without password", () => {
+  expect(
+    serveSecurityDecision({
+      hostname: "127.0.0.1",
+      passwordSet: false,
+      yes: false,
+      isTTY: true,
+    }),
+  ).toBe("allow")
+})
+
+test("serveSecurityDecision requires confirmation for 0.0.0.0 without password in TTY", () => {
+  expect(
+    serveSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: false,
+      isTTY: true,
+    }),
+  ).toBe("confirm")
+})
+
+test("serveSecurityDecision denies 0.0.0.0 without password when not TTY", () => {
+  expect(
+    serveSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: false,
+      isTTY: false,
+    }),
+  ).toBe("deny")
+})
+
+test("serveSecurityDecision allows 0.0.0.0 without password when --yes is set", () => {
+  expect(
+    serveSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: true,
+      isTTY: false,
+    }),
+  ).toBe("allow")
+})
+
+test("serveSecurityDecision allows non-loopback when password is set", () => {
+  expect(
+    serveSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: true,
+      yes: false,
+      isTTY: false,
+    }),
+  ).toBe("allow")
+})
+


### PR DESCRIPTION
Fixes #10948.

### What does this PR do?
- When binding `opencode serve` to a non-loopback hostname without `OPENCODE_SERVER_PASSWORD`, require explicit confirmation before starting.
- Avoids hanging in non-interactive environments by refusing to start unless `--yes` is provided.

### How did you verify your code works?
- `bun test test/cli/serve-security.test.ts`
- `bun run typecheck`