### PR TITLE
fix: prioritize explicit provider config over stored auth

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -823,6 +823,23 @@ export namespace Provider {
     // load apikeys
     for (const [providerID, provider] of Object.entries(await Auth.all())) {
       if (disabled.has(providerID)) continue
+
+      // Skip stored auth if provider already has explicit config with custom baseURL or apiKey
+      const existingProvider = providers[providerID]
+      if (existingProvider) {
+        const hasExplicitBaseURL = existingProvider.options?.baseURL !== undefined
+        const hasExplicitApiKey = existingProvider.options?.apiKey !== undefined
+
+        if (hasExplicitBaseURL || hasExplicitApiKey) {
+          log.info("skipping stored auth for provider with explicit config", {
+            providerID,
+            hasExplicitBaseURL,
+            hasExplicitApiKey
+          })
+          continue
+        }
+      }
+
       if (provider.type === "api") {
         mergeProvider(providerID, {
           source: "api",
@@ -852,10 +869,19 @@ export namespace Provider {
 
       // Load for the main provider if auth exists
       if (auth) {
-        const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
-        const opts = options ?? {}
-        const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
-        mergeProvider(providerID, patch)
+        // Skip plugin auth if provider already has explicit config with custom baseURL or apiKey
+        const existingProvider = providers[providerID]
+        const hasExplicitConfig = existingProvider &&
+          (existingProvider.options?.baseURL !== undefined || existingProvider.options?.apiKey !== undefined)
+
+        if (!hasExplicitConfig) {
+          const options = await plugin.auth.loader(() => Auth.get(providerID) as any, database[plugin.auth.provider])
+          const opts = options ?? {}
+          const patch: Partial<Info> = providers[providerID] ? { options: opts } : { source: "custom", options: opts }
+          mergeProvider(providerID, patch)
+        } else {
+          log.info("skipping plugin auth for provider with explicit config", { providerID })
+        }
       }
 
       // If this is github-copilot plugin, also register for github-copilot-enterprise if auth exists
@@ -864,15 +890,24 @@ export namespace Provider {
         if (!disabled.has(enterpriseProviderID)) {
           const enterpriseAuth = await Auth.get(enterpriseProviderID)
           if (enterpriseAuth) {
-            const enterpriseOptions = await plugin.auth.loader(
-              () => Auth.get(enterpriseProviderID) as any,
-              database[enterpriseProviderID],
-            )
-            const opts = enterpriseOptions ?? {}
-            const patch: Partial<Info> = providers[enterpriseProviderID]
-              ? { options: opts }
-              : { source: "custom", options: opts }
-            mergeProvider(enterpriseProviderID, patch)
+            // Skip plugin auth if provider already has explicit config with custom baseURL or apiKey
+            const existingEnterprise = providers[enterpriseProviderID]
+            const hasExplicitConfig = existingEnterprise &&
+              (existingEnterprise.options?.baseURL !== undefined || existingEnterprise.options?.apiKey !== undefined)
+
+            if (!hasExplicitConfig) {
+              const enterpriseOptions = await plugin.auth.loader(
+                () => Auth.get(enterpriseProviderID) as any,
+                database[enterpriseProviderID],
+              )
+              const opts = enterpriseOptions ?? {}
+              const patch: Partial<Info> = providers[enterpriseProviderID]
+                ? { options: opts }
+                : { source: "custom", options: opts }
+              mergeProvider(enterpriseProviderID, patch)
+            } else {
+              log.info("skipping plugin auth for provider with explicit config", { providerID: enterpriseProviderID })
+            }
           }
         }
       }


### PR DESCRIPTION
## Problem

Stored OAuth credentials in `~/.local/share/opencode/auth.json` silently override explicit provider configuration in `opencode.json`, making it impossible to use custom provider endpoints (e.g., Azure Foundry) once credentials are stored.

Fixes #10950

## Solution

This PR ensures that explicit provider configuration in `opencode.json` always takes precedence over stored credentials from `auth.json`.

### Changes

- Check if provider has explicit `baseURL` or `apiKey` before loading stored auth
- Skip stored auth (API keys and OAuth) when explicit config exists  
- Add log messages for transparency when skipping stored auth
- Apply fix to both regular auth and plugin auth loading (including GitHub Copilot Enterprise)

### Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Explicit config + stored auth | Uses stored auth ❌ | Uses explicit config ✅ |
| No explicit config + stored auth | Uses stored auth ✅ | Uses stored auth ✅ |
| Explicit config only | Uses explicit config ✅ | Uses explicit config ✅ |

### Example Log Output

When skipping stored auth, users will see:
```
INFO skipping stored auth for provider with explicit config {providerID: "anthropic", hasExplicitBaseURL: true, hasExplicitApiKey: true}
```

## Testing

Tested with Azure Foundry configuration:
- Explicit Azure config correctly overrides stored Anthropic OAuth
- Stored auth still used when no explicit config present
- Log messages provide transparency

## Impact

This allows users to:
- Use Azure Foundry endpoints for Anthropic models
- Configure custom provider proxies
- Override stored credentials without manual `auth.json` editing