### PR TITLE
docs: add Bun install on Windows

### DIFF
--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -107,6 +107,12 @@ You can also install it with the following commands:
   npm install -g opencode-ai
   ```
 
+- **Using Bun**
+
+  ```bash
+  bun add -g opencode-ai
+  ```
+
 - **Using Mise**
 
   ```bash
@@ -118,8 +124,6 @@ You can also install it with the following commands:
   ```bash
   docker run -it --rm ghcr.io/anomalyco/opencode
   ```
-
-Support for installing OpenCode on Windows using Bun is currently in progress.
 
 You can also grab the binary from the [Releases](https://github.com/anomalyco/opencode/releases).
 


### PR DESCRIPTION
## Why
The download page lists Bun installation (bun add -g opencode-ai) on Windows, but the docs still state Windows Bun support is in progress. This brings the docs in line with the current download guidance.

## What
- Add Bun install command under Windows instructions
- Remove the outdated Windows/Bun in-progress note

## Test
- Not required (docs-only change)