### PR TITLE
fix(opencode): confirm insecure web

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -5,6 +5,29 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
+import * as prompts from "@clack/prompts"
+
+type Decision = "allow" | "confirm" | "deny"
+
+function normalizeHost(input: string) {
+  const trimmed = input.trim()
+  if (!trimmed) return ""
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) return trimmed.slice(1, -1).toLowerCase()
+  return trimmed.toLowerCase()
+}
+
+function isLoopbackHost(hostname: string) {
+  const host = normalizeHost(hostname)
+  if (!host) return true
+  return host === "127.0.0.1" || host === "localhost" || host === "::1"
+}
+
+export function webSecurityDecision(input: { hostname: string; passwordSet: boolean; yes?: boolean; isTTY: boolean }): Decision {
+  if (input.passwordSet) return "allow"
+  if (isLoopbackHost(input.hostname)) return "allow"
+  if (input.yes) return "allow"
+  return input.isTTY ? "confirm" : "deny"
+}
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -30,13 +53,50 @@ function getNetworkIPs() {
 
 export const WebCommand = cmd({
   command: "web",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) =>
+    withNetworkOptions(yargs).option("yes", {
+      alias: "y",
+      type: "boolean",
+      describe: "skip confirmation prompts",
+      default: false,
+    }),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
-    if (!Flag.OPENCODE_SERVER_PASSWORD) {
+    const opts = await resolveNetworkOptions(args as any)
+    const passwordSet = !!Flag.OPENCODE_SERVER_PASSWORD
+    const decision = webSecurityDecision({
+      hostname: opts.hostname,
+      passwordSet,
+      yes: (args as any).yes,
+      isTTY: !!process.stdin.isTTY,
+    })
+
+    if (!passwordSet) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
-    const opts = await resolveNetworkOptions(args)
+
+    if (decision === "deny") {
+      UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "Refusing to start unsecured server on non-loopback hostname.")
+      UI.println(UI.Style.TEXT_DIM + "Set OPENCODE_SERVER_PASSWORD, or pass --yes to explicitly accept this risk.")
+      process.exitCode = 1
+      return
+    }
+
+    if (decision === "confirm") {
+      prompts.intro("Start unsecured server?")
+      prompts.log.warn(`Hostname: ${opts.hostname}`)
+      prompts.log.warn("OPENCODE_SERVER_PASSWORD is not set; anyone who can reach this host can access the server.")
+      const confirm = await prompts.confirm({
+        message: "Start anyway?",
+        initialValue: false,
+      })
+      if (!confirm || prompts.isCancel(confirm)) {
+        prompts.outro("Cancelled")
+        return
+      }
+      prompts.outro("Starting server")
+    }
+
     const server = Server.listen(opts)
     UI.empty()
     UI.println(UI.logo("  "))

--- a/packages/opencode/test/cli/web-security.test.ts
+++ b/packages/opencode/test/cli/web-security.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { webSecurityDecision } from "../../src/cli/cmd/web"
+
+test("webSecurityDecision allows loopback without password", () => {
+  expect(
+    webSecurityDecision({
+      hostname: "127.0.0.1",
+      passwordSet: false,
+      yes: false,
+      isTTY: true,
+    }),
+  ).toBe("allow")
+})
+
+test("webSecurityDecision requires confirmation for 0.0.0.0 without password in TTY", () => {
+  expect(
+    webSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: false,
+      isTTY: true,
+    }),
+  ).toBe("confirm")
+})
+
+test("webSecurityDecision denies 0.0.0.0 without password when not TTY", () => {
+  expect(
+    webSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: false,
+      isTTY: false,
+    }),
+  ).toBe("deny")
+})
+
+test("webSecurityDecision allows 0.0.0.0 without password when --yes is set", () => {
+  expect(
+    webSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: true,
+      isTTY: false,
+    }),
+  ).toBe("allow")
+})
+
+test("webSecurityDecision allows non-loopback when password is set", () => {
+  expect(
+    webSecurityDecision({
+      hostname: "0.0.0.0",
+      passwordSet: true,
+      yes: false,
+      isTTY: false,
+    }),
+  ).toBe("allow")
+})
+


### PR DESCRIPTION
Fixes #10958.

### What does this PR do?
- When binding `opencode web` to a non-loopback hostname without `OPENCODE_SERVER_PASSWORD`, require explicit confirmation before starting.
- Avoids hanging in non-interactive environments by refusing to start unless `--yes` is provided.

### How did you verify your code works?
- `bun test test/cli/web-security.test.ts`
- `bun run typecheck`