### PR TITLE
fix(opencode): guard tui server exposure

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -9,6 +9,9 @@ import { Log } from "@/util/log"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
+import { Flag } from "@/flag/flag"
+import * as prompts from "@clack/prompts"
+import { exposureGuardDecision } from "@/cli/exposure"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -71,6 +74,12 @@ export const TuiThreadCommand = cmd({
       .option("agent", {
         type: "string",
         describe: "agent to use",
+      })
+      .option("yes", {
+        alias: "y",
+        type: "boolean",
+        describe: "skip confirmation prompts",
+        default: false,
       }),
   handler: async (args) => {
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
@@ -130,6 +139,40 @@ export const TuiThreadCommand = cmd({
     let events: EventSource | undefined
 
     if (shouldStartServer) {
+      const passwordSet = !!Flag.OPENCODE_SERVER_PASSWORD
+      const decision = exposureGuardDecision({
+        hostname: networkOpts.hostname,
+        passwordSet,
+        yes: (args as any).yes,
+        isTTY: !!process.stdin.isTTY,
+      })
+
+      if (!passwordSet) {
+        UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
+      }
+
+      if (decision === "deny") {
+        UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "Refusing to start unsecured server on non-loopback hostname.")
+        UI.println(UI.Style.TEXT_DIM + "Set OPENCODE_SERVER_PASSWORD, or pass --yes to explicitly accept this risk.")
+        process.exitCode = 1
+        return
+      }
+
+      if (decision === "confirm") {
+        prompts.intro("Start unsecured server?")
+        prompts.log.warn(`Hostname: ${networkOpts.hostname}`)
+        prompts.log.warn("OPENCODE_SERVER_PASSWORD is not set; anyone who can reach this host can access the server.")
+        const confirm = await prompts.confirm({
+          message: "Start anyway?",
+          initialValue: false,
+        })
+        if (!confirm || prompts.isCancel(confirm)) {
+          prompts.outro("Cancelled")
+          return
+        }
+        prompts.outro("Starting server")
+      }
+
       // Start HTTP server for external access
       const server = await client.call("server", networkOpts)
       url = server.url

--- a/packages/opencode/src/cli/exposure.ts
+++ b/packages/opencode/src/cli/exposure.ts
@@ -1,0 +1,27 @@
+type Decision = "allow" | "confirm" | "deny"
+
+function normalizeHost(input: string) {
+  const trimmed = input.trim()
+  if (!trimmed) return ""
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) return trimmed.slice(1, -1).toLowerCase()
+  return trimmed.toLowerCase()
+}
+
+function isLoopbackHost(hostname: string) {
+  const host = normalizeHost(hostname)
+  if (!host) return true
+  return host === "127.0.0.1" || host === "localhost" || host === "::1"
+}
+
+export function exposureGuardDecision(input: {
+  hostname: string
+  passwordSet: boolean
+  yes?: boolean
+  isTTY: boolean
+}): Decision {
+  if (input.passwordSet) return "allow"
+  if (isLoopbackHost(input.hostname)) return "allow"
+  if (input.yes) return "allow"
+  return input.isTTY ? "confirm" : "deny"
+}
+

--- a/packages/opencode/test/cli/exposure-guard.test.ts
+++ b/packages/opencode/test/cli/exposure-guard.test.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "bun:test"
+import { exposureGuardDecision } from "../../src/cli/exposure"
+
+test("exposureGuardDecision allows loopback without password", () => {
+  expect(
+    exposureGuardDecision({
+      hostname: "127.0.0.1",
+      passwordSet: false,
+      yes: false,
+      isTTY: true,
+    }),
+  ).toBe("allow")
+})
+
+test("exposureGuardDecision requires confirmation for 0.0.0.0 without password in TTY", () => {
+  expect(
+    exposureGuardDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: false,
+      isTTY: true,
+    }),
+  ).toBe("confirm")
+})
+
+test("exposureGuardDecision denies 0.0.0.0 without password when not TTY", () => {
+  expect(
+    exposureGuardDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: false,
+      isTTY: false,
+    }),
+  ).toBe("deny")
+})
+
+test("exposureGuardDecision allows 0.0.0.0 without password when --yes is set", () => {
+  expect(
+    exposureGuardDecision({
+      hostname: "0.0.0.0",
+      passwordSet: false,
+      yes: true,
+      isTTY: false,
+    }),
+  ).toBe("allow")
+})
+
+test("exposureGuardDecision allows non-loopback when password is set", () => {
+  expect(
+    exposureGuardDecision({
+      hostname: "0.0.0.0",
+      passwordSet: true,
+      yes: false,
+      isTTY: false,
+    }),
+  ).toBe("allow")
+})
+


### PR DESCRIPTION
Fixes #10973.

### What does this PR do?
- Applies the same insecure-non-loopback guardrail to the TUI external-server path as `serve`/`web`.
- Adds `--yes` to skip confirmation prompts.

### How did you verify your code works?
- `bun test test/cli/exposure-guard.test.ts`
- `bun run typecheck`