### PR TITLE
feat: add configurable plan path for plan mode

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -49,6 +49,22 @@ export namespace Agent {
   const state = Instance.state(async () => {
     const cfg = await Config.get()
 
+    // Compute the configured plan path for permission rules
+    const configuredPlanPath = cfg.plan?.path
+    const planEditPaths: Record<string, string> = {}
+    const planExternalDirs: Record<string, string> = {}
+
+    if (configuredPlanPath) {
+      // If path is absolute, use it directly; otherwise resolve relative to worktree
+      const resolvedPlanPath = path.isAbsolute(configuredPlanPath)
+        ? configuredPlanPath
+        : path.join(Instance.worktree, configuredPlanPath)
+      // Allow editing .md files in the configured plan directory
+      planEditPaths[path.join(path.dirname(resolvedPlanPath), "*.md")] = "allow"
+      // Allow external directory access to the configured plan directory
+      planExternalDirs[path.join(path.dirname(resolvedPlanPath), "*")] = "allow"
+    }
+
     const defaults = PermissionNext.fromConfig({
       "*": "allow",
       doom_loop: "ask",
@@ -97,11 +113,13 @@ export namespace Agent {
             plan_exit: "allow",
             external_directory: {
               [path.join(Global.Path.data, "plans", "*")]: "allow",
+              ...planExternalDirs,
             },
             edit: {
               "*": "deny",
               [path.join(".opencode", "plans", "*.md")]: "allow",
               [path.relative(Instance.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+              ...planEditPaths,
             },
           }),
           user,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1044,6 +1044,16 @@ export namespace Config {
           prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
         })
         .optional(),
+      plan: z
+        .object({
+          path: z
+            .string()
+            .optional()
+            .describe(
+              "Path where plan files are saved. Can be relative to project root or absolute. Defaults to '.opencode/plans/' in VCS projects or '~/.local/share/opencode/plans/' otherwise.",
+            ),
+        })
+        .optional(),
       experimental: z
         .object({
           hook: z

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -232,10 +232,22 @@ export namespace Session {
     return result
   }
 
-  export function plan(input: { slug: string; time: { created: number } }) {
-    const base = Instance.project.vcs
-      ? path.join(Instance.worktree, ".opencode", "plans")
-      : path.join(Global.Path.data, "plans")
+  export async function plan(input: { slug: string; time: { created: number } }) {
+    const cfg = await Config.get()
+    const configuredPath = cfg.plan?.path
+
+    let base: string
+    if (configuredPath) {
+      // If path is absolute, use it directly; otherwise resolve relative to worktree
+      base = path.isAbsolute(configuredPath)
+        ? configuredPath
+        : path.join(Instance.worktree, configuredPath)
+    } else {
+      // Default behavior: use .opencode/plans in VCS projects, or global data directory
+      base = Instance.project.vcs
+        ? path.join(Instance.worktree, ".opencode", "plans")
+        : path.join(Global.Path.data, "plans")
+    }
     return path.join(base, [input.time.created, input.slug].join("-") + ".md")
   }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1232,7 +1232,7 @@ export namespace SessionPrompt {
 
     // Switching from plan mode to build mode
     if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
-      const plan = Session.plan(input.session)
+      const plan = await Session.plan(input.session)
       const exists = await Bun.file(plan).exists()
       if (exists) {
         const part = await Session.updatePart({
@@ -1251,7 +1251,7 @@ export namespace SessionPrompt {
 
     // Entering plan mode
     if (input.agent.name === "plan" && assistantMessage?.info.agent !== "plan") {
-      const plan = Session.plan(input.session)
+      const plan = await Session.plan(input.session)
       const exists = await Bun.file(plan).exists()
       if (!exists) await fs.mkdir(path.dirname(plan), { recursive: true })
       const part = await Session.updatePart({

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -22,7 +22,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
   parameters: z.object({}),
   async execute(_params, ctx) {
     const session = await Session.get(ctx.sessionID)
-    const plan = path.relative(Instance.worktree, Session.plan(session))
+    const plan = path.relative(Instance.worktree, await Session.plan(session))
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
       questions: [
@@ -77,7 +77,7 @@ export const PlanEnterTool = Tool.define("plan_enter", {
   parameters: z.object({}),
   async execute(_params, ctx) {
     const session = await Session.get(ctx.sessionID)
-    const plan = path.relative(Instance.worktree, Session.plan(session))
+    const plan = path.relative(Instance.worktree, await Session.plan(session))
 
     const answers = await Question.ask({
       sessionID: ctx.sessionID,

--- a/packages/web/src/content/docs/modes.mdx
+++ b/packages/web/src/content/docs/modes.mdx
@@ -34,11 +34,19 @@ Build is the **default** mode with all tools enabled. This is the standard mode 
 A restricted mode designed for planning and analysis. In plan mode, the following tools are disabled by default:
 
 - `write` - Cannot create new files
-- `edit` - Cannot modify existing files, except for files located at `.opencode/plans/*.md` to detail the plan itself
+- `edit` - Cannot modify existing files, except for files located at the plan directory (default: `.opencode/plans/*.md`) to detail the plan itself
 - `patch` - Cannot apply patches
 - `bash` - Cannot execute shell commands
 
 This mode is useful when you want the AI to analyze code, suggest changes, or create plans without making any actual modifications to your codebase.
+
+#### Plan File Location
+
+By default, plan files are saved to:
+- **With VCS (git)**: `.opencode/plans/{timestamp}-{slug}.md` (relative to project root)
+- **Without VCS**: `~/.local/share/opencode/plans/{timestamp}-{slug}.md` (global data directory)
+
+You can customize the plan file location using the `plan.path` configuration option (see [Plan Path Configuration](#plan-path-configuration) below).
 
 ---
 
@@ -174,6 +182,36 @@ Temperature values typically range from 0.0 to 1.0:
 ```
 
 If no temperature is specified, opencode uses model-specific defaults (typically 0 for most models, 0.55 for Qwen models).
+
+---
+
+### Plan Path Configuration
+
+You can customize where plan files are saved using the `plan.path` configuration option. This is useful when working with multiple LLMs where one makes the plan, another iterates on it, and another executes it.
+
+```json title="opencode.json"
+{
+  "plan": {
+    "path": "plans"  // Relative to project root
+  }
+}
+```
+
+For an absolute path:
+
+```json title="opencode.json"
+{
+  "plan": {
+    "path": "/path/to/shared/plans"
+  }
+}
+```
+
+**Default locations:**
+- **With VCS (git)**: `.opencode/plans/`
+- **Without VCS**: `~/.local/share/opencode/plans/`
+
+The plan file is named with the format `{timestamp}-{slug}.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a `plan.path` configuration option to customize where PLAN.md files are saved when in plan mode. This enables workflows where different LLMs can collaborate on planning, with one making the plan, another iterating on it, and another executing it.

## Changes

- Add `plan.path` config option to `Config.Info` schema
- Modify `Session.plan()` to use configured path (now async)
- Update agent permissions to allow editing at configured plan path
- Update documentation with new configuration option

## Usage

Configure in `opencode.json`:

```json
{
  "plan": {
    "path": "plans"  // Relative to project root
  }
}
```

Or with an absolute path:

```json
{
  "plan": {
    "path": "/path/to/shared/plans"
  }
}
```

## Default Behavior (unchanged)

- **With VCS (git)**: `.opencode/plans/{timestamp}-{slug}.md`
- **Without VCS**: `~/.local/share/opencode/plans/{timestamp}-{slug}.md`

## Related Issue

Fixes #10870

🤖 Generated with [Claude Code](https://claude.com/claude-code)