### PR TITLE
fix: add SubtaskPart with metadata reference

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -176,6 +176,8 @@ export namespace MessageV2 {
       })
       .optional(),
     command: z.string().optional(),
+  }).meta({
+    ref: "SubtaskPart",
   })
   export type SubtaskPart = z.infer<typeof SubtaskPart>
 


### PR DESCRIPTION
Fixes #10991

### What does this PR do?

This PR adds the missing `.meta({ ref: "SubtaskPart" })` to the `SubtaskPart` Zod definition in `packages/opencode/src/session/message-v2.ts`. This change ensures that the `SubtaskPart` schema is correctly identified and generated in the `openapi.json` file.

### How did you verify your code works?

I verified the fix by regenerating the `openapi.json` file.

- Before this change, the `SubtaskPart` content in the generated `openapi.json` was incorrect.
- With this change, the `openapi.json` is now generated correctly with the proper `SubtaskPart` definition.




