### PR TITLE
feat: BROWSER interrupt

### DIFF
--- a/packages/opencode/src/browser/index.ts
+++ b/packages/opencode/src/browser/index.ts
@@ -1,0 +1,13 @@
+import z from "zod"
+import { BusEvent } from "../bus/bus-event"
+
+export namespace Browser {
+  export const OpenRequested = BusEvent.define(
+    "browser.open.requested",
+    z.object({
+      url: z.string(),
+      sessionID: z.string(),
+      messageID: z.string(),
+    }),
+  )
+}

--- a/packages/opencode/src/cli/cmd/browser-callback.ts
+++ b/packages/opencode/src/cli/cmd/browser-callback.ts
@@ -1,0 +1,57 @@
+import { cmd } from "./cmd"
+
+export const BrowserCallbackCommand = cmd({
+  command: "browser-callback <server-url> <session-id> <message-id> <url>",
+  describe: false,
+  builder: (yargs) =>
+    yargs
+      .positional("server-url", {
+        describe: "OpenCode server URL (can include credentials)",
+        type: "string",
+        demandOption: true,
+      })
+      .positional("session-id", {
+        describe: "Session ID",
+        type: "string",
+        demandOption: true,
+      })
+      .positional("message-id", {
+        describe: "Message ID",
+        type: "string",
+        demandOption: true,
+      })
+      .positional("url", {
+        describe: "URL to open",
+        type: "string",
+        demandOption: true,
+      }),
+  handler: async (args) => {
+    const serverUrl = new URL(args["server-url"] as string)
+    const sessionID = args["session-id"] as string
+    const messageID = args["message-id"] as string
+    const url = args.url as string
+
+    const endpoint = new URL("/browser/open", serverUrl)
+    endpoint.username = ""
+    endpoint.password = ""
+
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    }
+
+    if (serverUrl.username && serverUrl.password) {
+      const credentials = btoa(`${serverUrl.username}:${serverUrl.password}`)
+      headers["Authorization"] = `Basic ${credentials}`
+    }
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ url, sessionID, messageID }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to notify server: ${response.status} ${response.statusText}`)
+    }
+  },
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -24,6 +24,7 @@ import { TuiThreadCommand } from "./cli/cmd/tui/thread"
 import { AcpCommand } from "./cli/cmd/acp"
 import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
+import { BrowserCallbackCommand } from "./cli/cmd/browser-callback"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
 
@@ -97,6 +98,7 @@ const cli = yargs(hideBin(process.argv))
   .command(GithubCommand)
   .command(PrCommand)
   .command(SessionCommand)
+  .command(BrowserCallbackCommand)
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||

--- a/packages/opencode/src/server/routes/browser.ts
+++ b/packages/opencode/src/server/routes/browser.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono"
+import { describeRoute, validator, resolver } from "hono-openapi"
+import z from "zod"
+import { Bus } from "../../bus"
+import { Browser } from "../../browser"
+import { lazy } from "../../util/lazy"
+
+export const BrowserRoutes = lazy(() =>
+  new Hono().post(
+    "/open",
+    describeRoute({
+      summary: "Browser open callback",
+      description: "Callback endpoint for terminal processes to request opening a URL in a browser.",
+      operationId: "browser.open",
+      responses: {
+        200: {
+          description: "Browser open request received",
+          content: {
+            "application/json": {
+              schema: resolver(z.boolean()),
+            },
+          },
+        },
+      },
+    }),
+    validator(
+      "json",
+      z.object({
+        url: z.string(),
+        sessionID: z.string(),
+        messageID: z.string(),
+      }),
+    ),
+    async (c) => {
+      const { url, sessionID, messageID } = c.req.valid("json")
+      await Bus.publish(Browser.OpenRequested, { url, sessionID, messageID })
+      return c.json(true)
+    },
+  ),
+)

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -40,6 +40,7 @@ import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
+import { BrowserRoutes } from "./routes/browser"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -52,6 +53,10 @@ export namespace Server {
 
   export function url(): URL {
     return _url ?? new URL("http://localhost:4096")
+  }
+
+  export function listening() {
+    return _url !== undefined
   }
 
   const app = new Hono()
@@ -162,6 +167,7 @@ export namespace Server {
         .route("/", FileRoutes())
         .route("/mcp", McpRoutes())
         .route("/tui", TuiRoutes())
+        .route("/browser", BrowserRoutes())
         .post(
           "/instance/dispose",
           describeRoute({

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -16,6 +16,9 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
+import { Server } from "@/server/server"
+import { Bus } from "@/bus"
+import { Browser } from "@/browser"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -154,12 +157,20 @@ export const BashTool = Tool.define("bash", async () => {
         })
       }
 
+      let env = { ...process.env };
+      if (Server.listening()) {
+        const serverUrl = new URL(Server.url())
+        if (Flag.OPENCODE_SERVER_PASSWORD) {
+          serverUrl.username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
+          serverUrl.password = Flag.OPENCODE_SERVER_PASSWORD
+        }
+        env.BROWSER = `${process.execPath} browser-callback ${JSON.stringify(serverUrl.toString())} ${ctx.sessionID} ${ctx.messageID}`
+      }
+
       const proc = spawn(params.command, {
         shell,
         cwd,
-        env: {
-          ...process.env,
-        },
+        env,
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",
       })
@@ -191,6 +202,7 @@ export const BashTool = Tool.define("bash", async () => {
       let timedOut = false
       let aborted = false
       let exited = false
+      let browserUrl: string | undefined
 
       const kill = () => Shell.killTree(proc, { exited: () => exited })
 
@@ -215,7 +227,15 @@ export const BashTool = Tool.define("bash", async () => {
         const cleanup = () => {
           clearTimeout(timeoutTimer)
           ctx.abort.removeEventListener("abort", abortHandler)
+          unsubscribeBrowser()
         }
+
+        const unsubscribeBrowser = Bus.subscribe(Browser.OpenRequested, (evt) => {
+          if (evt.properties.sessionID !== ctx.sessionID || evt.properties.messageID !== ctx.messageID) return
+          browserUrl = evt.properties.url
+          cleanup()
+          resolve()
+        })
 
         proc.once("exit", () => {
           exited = true
@@ -231,6 +251,12 @@ export const BashTool = Tool.define("bash", async () => {
       })
 
       const resultMetadata: string[] = []
+
+      if (browserUrl) {
+        resultMetadata.push(`Process requested to open browser at: ${browserUrl}. Take a look with agent-browser or playwright-cli.`)
+        resultMetadata.push(`Process is still running in background with PID: ${proc.pid}`)
+        resultMetadata.push(`To terminate the process, run: kill ${proc.pid}`)
+      }
 
       if (timedOut) {
         resultMetadata.push(`bash tool terminated command after exceeding timeout ${timeout} ms`)


### PR DESCRIPTION
### What does this PR do?

I'm mainly opening this PR to discuss the approach and spark debate, not with intent to merge it. So take it as a sketch!

Some CLI tools turn interactive, like Git opening a text editor, or Vite opening a browser.

Coding Agent implementations currently struggle with detecting this interactiveness.
- opencode [explitictly tells models to use `&`](https://github.com/anomalyco/opencode/blob/8798a77a72ddfc7c41563f63af39890245d4a4c6/packages/opencode/src/session/prompt/gemini.txt#L56), making it hard to prevent process leaks
- Claude SDK has an [`is_background`](https://github.com/microsoft/vscode-copilot-chat/blob/7af31e6f35a643803a8412b0c4e889e3cb5cd3e2/src/extension/agents/claude/common/toolPermissionHandlers/bashToolHandler.ts#L42) tool param that decides a priori whether a tool call is in the background or not, which means it only works through knowledge of popular tools or mentions in the context

I have a hunch that we should implement the convention of the `EDITOR` environment variable. When Git needs to open an interactive editor, it spawns the binary in `EDITOR` and waits until completion. Vite does the same with the `BROWSER` environment variable.
These env variables are hooks for interactiveness, and Coding Agents can inject themselves to perform the interaction like a user would.

This PR sketches how that could work for `BROWSER`. If a command calls `BROWSER`, opencode yields back control to the model and asks it to handle the interaction.

As mentioned, at this point I'd love to hear your thoughts on the approach. Thanks!

### How did you verify your code works?

Manual testing, not meant to be merged.
