### PR TITLE
fix(tui): disable mouse tracking on exit to prevent terminal corruption

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -27,7 +27,7 @@ import { FrecencyProvider } from "./component/prompt/frecency"
 import { PromptStashProvider } from "./component/prompt/stash"
 import { DialogAlert } from "./ui/dialog-alert"
 import { ToastProvider, useToast } from "./ui/toast"
-import { ExitProvider, useExit } from "./context/exit"
+import { ExitProvider, useExit, destroyRenderer } from "./context/exit"
 import { Session as SessionApi } from "@/session"
 import { TuiEvent } from "./event"
 import { KVProvider, useKV } from "./context/kv"
@@ -110,7 +110,18 @@ export function tui(input: {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
     const mode = await getTerminalBackgroundColor()
+
+    // Handle SIGINT (Ctrl+C) to ensure proper terminal cleanup on Windows
+    // This is critical because the default SIGINT behavior may not give
+    // the renderer enough time to send mouse tracking disable sequences
+    const sigintHandler = () => {
+      destroyRenderer()
+      process.exit(0)
+    }
+    process.on("SIGINT", sigintHandler)
+
     const onExit = async () => {
+      process.off("SIGINT", sigintHandler)
       await input.onExit?.()
       resolve()
     }
@@ -695,11 +706,9 @@ function ErrorComponent(props: {
   mode?: "dark" | "light"
 }) {
   const term = useTerminalDimensions()
-  const renderer = useRenderer()
 
   const handleExit = async () => {
-    renderer.setTerminalTitle("")
-    renderer.destroy()
+    destroyRenderer()
     props.onExit()
   }
 

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -1,22 +1,76 @@
 import { useRenderer } from "@opentui/solid"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import * as fs from "fs"
+
+type Renderer = ReturnType<typeof useRenderer>
+
+// Module-level state to track renderer for SIGINT handler
+const state: { renderer: Renderer | null } = { renderer: null }
+
+// ANSI escape sequences to disable all mouse tracking modes
+// This covers: basic tracking, button events, any-event, SGR extended, URXVT modes
+const DISABLE_MOUSE_SEQUENCES = [
+  "\x1b[?1000l", // Disable X11 mouse tracking (button press/release)
+  "\x1b[?1002l", // Disable button-event tracking (press/release/motion with button)
+  "\x1b[?1003l", // Disable any-event tracking (all motion)
+  "\x1b[?1006l", // Disable SGR extended mouse mode
+  "\x1b[?1015l", // Disable URXVT extended mouse mode
+  "\x1b[?25h",   // Show cursor (ensure cursor is visible after exit)
+].join("")
+
+/**
+ * Synchronously write terminal cleanup sequences directly to stdout.
+ * Using fs.writeSync ensures the sequences are sent immediately before process exit,
+ * bypassing any buffering that could cause sequences to be lost.
+ */
+function cleanupTerminal(): void {
+  try {
+    fs.writeSync(1, DISABLE_MOUSE_SEQUENCES)
+  } catch {
+    // Ignore errors - stdout may already be closed
+  }
+}
+
+/**
+ * Cleanup and destroy the renderer.
+ * Called from SIGINT handler to ensure proper terminal restoration on Ctrl+C.
+ */
+export function destroyRenderer(): void {
+  cleanupTerminal()
+
+  if (!state.renderer) return
+
+  try {
+    state.renderer.setTerminalTitle("")
+    state.renderer.destroy()
+  } catch {
+    // Ignore errors during cleanup
+  }
+  state.renderer = null
+}
 
 export const { use: useExit, provider: ExitProvider } = createSimpleContext({
   name: "Exit",
   init: (input: { onExit?: () => Promise<void> }) => {
     const renderer = useRenderer()
-    return async (reason?: any) => {
-      // Reset window title before destroying renderer
+    state.renderer = renderer
+
+    return async (reason?: unknown) => {
+      // Send cleanup sequences BEFORE destroying renderer to ensure they're flushed
+      cleanupTerminal()
+
+      // Reset window title and destroy renderer
       renderer.setTerminalTitle("")
       renderer.destroy()
+
       await input.onExit?.()
+
       if (reason) {
         const formatted = FormatError(reason) ?? FormatUnknownError(reason)
-        if (formatted) {
-          process.stderr.write(formatted + "\n")
-        }
+        if (formatted) process.stderr.write(formatted + "\n")
       }
+
       process.exit(0)
     }
   },


### PR DESCRIPTION
Fixes #6912

## Problem

When pressing Ctrl+C to exit OpenCode on Windows, the terminal is left in mouse tracking mode. This causes raw SGR mouse tracking escape sequences to flood the terminal on every mouse movement, rendering the terminal unusable:

```
[555;58;25M[555;58;26M[555;57;25M[555;57;24M...
```

The issue occurs because:
1. SIGINT handler wasn't properly cleaning up terminal state
2. `process.exit(0)` was called before cleanup sequences could be flushed
3. The async nature of `renderer.destroy()` meant sequences might not reach the terminal

## Solution

Added synchronous terminal cleanup using `fs.writeSync()` to ensure ANSI disable sequences are written immediately before process exit:

- **`cleanupTerminal()`** - Synchronously writes disable sequences directly to stdout (fd 1)
- **`destroyRenderer()`** - Exported function for SIGINT handler to properly cleanup
- **SIGINT handler** - Registered in `tui()` to catch Ctrl+C and call cleanup

## ANSI Sequences Covered

The fix disables all common mouse tracking modes:

| Sequence | Mode |
|----------|------|
| `\x1b[?1000l` | X11 mouse tracking (button press/release) |
| `\x1b[?1002l` | Button-event tracking (press/release/motion with button) |
| `\x1b[?1003l` | Any-event tracking (all motion) |
| `\x1b[?1006l` | SGR extended mouse mode |
| `\x1b[?1015l` | URXVT extended mouse mode |
| `\x1b[?25h` | Show cursor |

## Changes

- `packages/opencode/src/cli/cmd/tui/context/exit.tsx`:
  - Added `cleanupTerminal()` for synchronous cleanup
  - Added `destroyRenderer()` export for external use
  - Call cleanup before `renderer.destroy()`
  
- `packages/opencode/src/cli/cmd/tui/app.tsx`:
  - Import `destroyRenderer` from exit context
  - Register SIGINT handler in `tui()` function
  - Update `ErrorComponent` to use `destroyRenderer()`

## Testing

1. Run `bun dev` or `opencode`
2. Press `Ctrl+C` to exit
3. Mouse movements should NOT produce escape sequence output
4. Terminal should be in normal state

## Related Issues

- Fixes #6912 - Ctrl+C does not disable mouse tracking (Windows)
- Related to #8908 - Mouse wheel triggering abnormal ASCII codes after exit
- Related to #7861 - Terminal becomes unusable after opencode exits (macOS)

## Note

This PR provides a similar fix to #8355 but with improvements:
- More comprehensive ANSI sequences coverage
- Better code organization with JSDoc comments
- Consistent cleanup across all exit paths (normal exit, Ctrl+C, error component)