### PR TITLE
fix(provider): include providerID in SDK cache key

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -977,7 +977,7 @@ export namespace Provider {
           ...model.headers,
         }
 
-      const key = Bun.hash.xxHash32(JSON.stringify({ npm: model.api.npm, options }))
+      const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
       const existing = s.sdk.get(key)
       if (existing) return existing
 


### PR DESCRIPTION
Fixes #7514

## Problem

When switching between different providers on Vertex AI (e.g., from an Anthropic model to a Gemini model), the SDK cache would return the wrong cached instance. This caused incorrect API URLs like:

```
https://aiplatform.googleapis.com/v1/projects/.../publishers/anthropic/models/gemini-3-flash-preview:streamRawPredict
```

## Root Cause

The SDK cache key was computed using only `{ npm, options }`, but both `google-vertex` and `google-vertex-anthropic` providers share the same npm package (`@ai-sdk/google-vertex`) with similar options (project, location).

## Solution

Include `providerID` in the SDK cache key:

```typescript
// Before
const key = Bun.hash.xxHash32(JSON.stringify({ npm: model.api.npm, options }))

// After
const key = Bun.hash.xxHash32(JSON.stringify({ providerID: model.providerID, npm: model.api.npm, options }))
```

## Verification

Tested by switching between Anthropic and Gemini models on Vertex AI - each now correctly uses its own SDK instance with proper publisher URLs.