### PR TITLE
fix(opencode): support multiple separators for provider/model parsing to avoid getting errors

### DIFF
--- a/packages/opencode/src/config/markdown.ts
+++ b/packages/opencode/src/config/markdown.ts
@@ -51,9 +51,9 @@ export namespace ConfigMarkdown {
         continue
       }
 
-      // if value contains a colon, convert to block scalar
+      // if value contains a colon, convert to block scalar (strip trailing newline)
       if (value.includes(":")) {
-        result.push(`${key}: |`)
+        result.push(`${key}: |-`)
         result.push(`  ${value}`)
         continue
       }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1194,9 +1194,28 @@ export namespace Provider {
   }
 
   export function parseModel(model: string) {
+    // Supported separators (in order of priority):
+    // 1. Pipe "|" - unambiguous, no model IDs use it (e.g. "openrouter|anthropic/claude-3-opus")
+    // 2. Colon ":" - if it appears before any slash (e.g. "openrouter:anthropic/claude-3-opus")
+    // 3. Slash "/" - default fallback (e.g. "openrouter/anthropic/claude-3-opus")
+    const pipeIdx = model.indexOf("|")
+    if (pipeIdx !== -1) {
+      return {
+        providerID: model.slice(0, pipeIdx),
+        modelID: model.slice(pipeIdx + 1),
+      }
+    }
+    const colonIdx = model.indexOf(":")
+    const slashIdx = model.indexOf("/")
+    if (colonIdx !== -1 && (slashIdx === -1 || colonIdx < slashIdx)) {
+      return {
+        providerID: model.slice(0, colonIdx),
+        modelID: model.slice(colonIdx + 1),
+      }
+    }
     const [providerID, ...rest] = model.split("/")
     return {
-      providerID: providerID,
+      providerID,
       modelID: rest.join("/"),
     }
   }

--- a/packages/opencode/test/config/markdown.test.ts
+++ b/packages/opencode/test/config/markdown.test.ts
@@ -104,7 +104,7 @@ describe("ConfigMarkdown: frontmatter parsing", async () => {
   })
 
   test("should extract occupation field with colon in value", () => {
-    expect(parsed.data.occupation).toBe("This man has the following occupation: Software Engineer\n")
+    expect(parsed.data.occupation).toBe("This man has the following occupation: Software Engineer")
   })
 
   test("should extract title field with single quotes", () => {
@@ -128,15 +128,15 @@ describe("ConfigMarkdown: frontmatter parsing", async () => {
   })
 
   test("should extract URL with port", () => {
-    expect(parsed.data.url).toBe("https://example.com:8080/path?query=value\n")
+    expect(parsed.data.url).toBe("https://example.com:8080/path?query=value")
   })
 
   test("should extract time with colons", () => {
-    expect(parsed.data.time).toBe("The time is 12:30:00 PM\n")
+    expect(parsed.data.time).toBe("The time is 12:30:00 PM")
   })
 
   test("should extract value with multiple colons", () => {
-    expect(parsed.data.nested).toBe("First: Second: Third: Fourth\n")
+    expect(parsed.data.nested).toBe("First: Second: Third: Fourth")
   })
 
   test("should preserve already double-quoted values with colons", () => {
@@ -148,7 +148,7 @@ describe("ConfigMarkdown: frontmatter parsing", async () => {
   })
 
   test("should extract value with quotes and colons mixed", () => {
-    expect(parsed.data.mixed).toBe('He said "hello: world" and then left\n')
+    expect(parsed.data.mixed).toBe('He said "hello: world" and then left')
   })
 
   test("should handle empty values", () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -382,6 +382,57 @@ test("parseModel handles model IDs with slashes", () => {
   expect(result.modelID).toBe("anthropic/claude-3-opus")
 })
 
+test("parseModel handles colon before slash as provider separator", () => {
+  // colon comes before any slash, so colon is the separator
+  const result = Provider.parseModel("openrouter:anthropic/claude-3-opus")
+  expect(result.providerID).toBe("openrouter")
+  expect(result.modelID).toBe("anthropic/claude-3-opus")
+})
+
+test("parseModel handles colon in model ID when it comes after slash", () => {
+  // colon comes after slash, so it's part of the model ID
+  const result = Provider.parseModel("synthetic/hf:zai-org/GLM-4.7")
+  expect(result.providerID).toBe("synthetic")
+  expect(result.modelID).toBe("hf:zai-org/GLM-4.7")
+})
+
+test("parseModel handles colon suffix in model ID", () => {
+  // colon at end of model ID (e.g. :free, :exacto variants)
+  const result = Provider.parseModel("openrouter/z-ai/glm-4.6:exacto")
+  expect(result.providerID).toBe("openrouter")
+  expect(result.modelID).toBe("z-ai/glm-4.6:exacto")
+})
+
+test("parseModel handles multiple slashes in model ID", () => {
+  const result = Provider.parseModel("siliconflow-cn/Pro/deepseek-ai/DeepSeek-R1")
+  expect(result.providerID).toBe("siliconflow-cn")
+  expect(result.modelID).toBe("Pro/deepseek-ai/DeepSeek-R1")
+})
+
+test("parseModel handles multiple colons in model ID", () => {
+  const result = Provider.parseModel("amazon-bedrock/amazon.titan-text-express-v1:0:8k")
+  expect(result.providerID).toBe("amazon-bedrock")
+  expect(result.modelID).toBe("amazon.titan-text-express-v1:0:8k")
+})
+
+test("parseModel handles cloudflare @ prefix in model ID", () => {
+  const result = Provider.parseModel("cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+  expect(result.providerID).toBe("cloudflare-ai-gateway")
+  expect(result.modelID).toBe("workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+})
+
+test("parseModel handles pipe separator", () => {
+  const result = Provider.parseModel("openrouter|anthropic/claude-3-opus")
+  expect(result.providerID).toBe("openrouter")
+  expect(result.modelID).toBe("anthropic/claude-3-opus")
+})
+
+test("parseModel handles pipe separator with colons in model ID", () => {
+  const result = Provider.parseModel("synthetic|hf:zai-org/GLM-4.7")
+  expect(result.providerID).toBe("synthetic")
+  expect(result.modelID).toBe("hf:zai-org/GLM-4.7")
+})
+
 test("defaultModel returns first available model when no config set", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
 Summary
- Add pipe (`|`) and colon (`:`) as provider/model separators in `parseModel` , as | is not been used on any model id from any provider 
- Fix YAML frontmatter to strip trailing newlines for values with colons

 Details
Fixes https://github.com/anomalyco/opencode/issues/8896

The `parseModel` function now supports three separator formats (in priority
order):
1. Pipe `|` - unambiguous, no model IDs use it (e.g. `openrouter|anthropic/
claude-3-opus`)
2. Colon `:` - if it appears before any slash (e.g. `openrouter:anthropic/
claude-3-opus`)
3. Slash `/` - default fallback (e.g. `openrouter/anthropic/claude-3-opus`)

Also fixed YAML frontmatter parsing in `.opencode/agent/*.md` files where
model values containing colons were getting a trailing newline (using `|-`
instead of `|` for block scalars).

 Testing
- Added tests for all separator formats
- Tested with complex model IDs like `synthetic/hf:zai-org/GLM-4.7` and
`amazon-bedrock/amazon.titan-text-express-v1:0:8k`