### PR TITLE
fix(ui): allow KaTeX inline math to be followed by punctuation

### DIFF
--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -475,6 +475,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
       },
       markedKatex({
         throwOnError: false,
+        nonStandard: true,
       }),
       markedShiki({
         async highlight(code, lang) {


### PR DESCRIPTION
## Summary
Fixes #10979

Enable `nonStandard: true` in marked-katex-extension to allow inline math expressions to be immediately followed by punctuation like `)`, `]`, `}`, `;`, etc.

## Problem
When inline math delimited with `$...$` is immediately followed by punctuation (e.g., `$\alpha$)`), the math fails to render. This is because the standard regex in marked-katex-extension only allows whitespace and limited punctuation after the closing `$`.

## Solution
The `marked-katex-extension` package already provides a `nonStandard` option that removes this restriction, allowing any character to follow the closing delimiter. This is the minimal change to fix the issue.

## Changes
- `packages/ui/src/context/marked.tsx` (+1 line): Add `nonStandard: true` to markedKatex config

## Test Plan
- In the web UI, enter `$\alpha$)` in a chat message
- Expected: The Greek letter alpha followed by a closing parenthesis
- Previously: KaTeX parsing error / math not rendered

---
🤖 Generated with Claude Code (issue-hunter-pro)