### PR TITLE
fix(script): remove highlights template from release notes

### DIFF
--- a/script/publish-start.ts
+++ b/script/publish-start.ts
@@ -6,7 +6,7 @@ import { buildNotes, getLatestRelease } from "./changelog"
 
 const highlightsTemplate = `## Highlights
 
-<!-- 
+<!--
 Add highlights before publishing. Delete this section if no highlights.
 
 - For multiple highlights, use multiple <highlight> tags
@@ -40,7 +40,7 @@ console.log("=== publishing ===\n")
 if (!Script.preview) {
   const previous = await getLatestRelease()
   notes = await buildNotes(previous, "HEAD")
-  notes.unshift(highlightsTemplate)
+  // notes.unshift(highlightsTemplate)
 }
 
 const pkgjsons = await Array.fromAsync(


### PR DESCRIPTION
## Summary
- Removes the highlights template that was automatically prepended to release notes
- Minor whitespace cleanup in the template comment