### PR TITLE
fix: allow user plugins to override built-in auth plugins

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -307,7 +307,7 @@ export const AuthLoginCommand = cmd({
 
         if (prompts.isCancel(provider)) throw new UI.CancelledError()
 
-        const plugin = await Plugin.list().then((x) => x.find((x) => x.auth?.provider === provider))
+        const plugin = await Plugin.list().then((x) => x.findLast((x) => x.auth?.provider === provider))
         if (plugin && plugin.auth) {
           const handled = await handlePluginAuth({ auth: plugin.auth }, provider)
           if (handled) return
@@ -323,7 +323,7 @@ export const AuthLoginCommand = cmd({
           if (prompts.isCancel(provider)) throw new UI.CancelledError()
 
           // Check if a plugin provides auth for this custom provider
-          const customPlugin = await Plugin.list().then((x) => x.find((x) => x.auth?.provider === provider))
+          const customPlugin = await Plugin.list().then((x) => x.findLast((x) => x.auth?.provider === provider))
           if (customPlugin && customPlugin.auth) {
             const handled = await handlePluginAuth({ auth: customPlugin.auth }, provider)
             if (handled) return

--- a/packages/opencode/test/plugin/auth-override.test.ts
+++ b/packages/opencode/test/plugin/auth-override.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { tmpdir } from "../fixture/fixture"
+import { Instance } from "../../src/project/instance"
+import { ProviderAuth } from "../../src/provider/auth"
+
+describe("plugin.auth-override", () => {
+  test("user plugin overrides built-in github-copilot auth", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const pluginDir = path.join(dir, ".opencode", "plugin")
+        await fs.mkdir(pluginDir, { recursive: true })
+
+        await Bun.write(
+          path.join(pluginDir, "custom-copilot-auth.ts"),
+          [
+            "export default async () => ({",
+            "  auth: {",
+            '    provider: "github-copilot",',
+            "    methods: [",
+            '      { type: "api", label: "Test Override Auth" },',
+            "    ],",
+            "    loader: async () => ({ access: 'test-token' }),",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const methods = await ProviderAuth.methods()
+        const copilot = methods["github-copilot"]
+        expect(copilot).toBeDefined()
+        expect(copilot.length).toBe(1)
+        expect(copilot[0].label).toBe("Test Override Auth")
+      },
+    })
+  }, 30000) // Increased timeout for plugin installation
+})


### PR DESCRIPTION
Fixes #11475

Change `.find()` to `.findLast()` in CLI auth flow so user plugins take precedence over internal plugins (e.g., github-copilot). This aligns CLI behavior with `ProviderAuth.methods()` which already uses last-wins semantics via `fromEntries()`.

### What does this PR do?

Fixes a bug where user/external plugins cannot override built-in auth plugins. The root cause is that `Plugin.list()` returns internal plugins first, then user plugins. The CLI auth command used `.find()` (first match wins), meaning the built-in plugin always took precedence. Meanwhile, `ProviderAuth.methods()` (used by TUI) already used `fromEntries()` which is last-wins.

This PR changes two `.find()` calls to `.findLast()` in `packages/opencode/src/cli/cmd/auth.ts` so user plugins can fully override built-in auth behavior (e.g., a company plugin replacing the default GitHub Copilot OAuth flow with a custom enterprise auth).

### How did you verify your code works?

Added `packages/opencode/test/plugin/auth-override.test.ts` which:
1. Creates a temp directory with a user plugin that registers `auth.provider: "github-copilot"` with a custom method
2. Calls `ProviderAuth.methods()` and asserts the user plugin's method takes precedence over the built-in