### PR TITLE
feat(plugin): add dynamic skill discovery via plugin hooks

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -11,6 +11,7 @@ import { CodexAuthPlugin } from "./codex"
 import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
+import { Skill } from "../skill"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -119,6 +120,16 @@ export namespace Plugin {
   export async function init() {
     const hooks = await state().then((x) => x.hooks)
     const config = await Config.get()
+
+    for (const hook of hooks) {
+      if (hook["skill.list"] || hook["skill.load"]) {
+        Skill.registerProvider({
+          list: hook["skill.list"] ?? (async () => []),
+          load: hook["skill.load"] ?? (async () => undefined),
+        })
+      }
+    }
+
     for (const hook of hooks) {
       // @ts-expect-error this is because we haven't moved plugin to sdk v2
       await hook.config?.(config)

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -20,6 +20,22 @@ export namespace Skill {
   })
   export type Info = z.infer<typeof Info>
 
+  export type SkillProvider = {
+    list: () => Promise<Info[]>
+    load: (location: string) => Promise<string | undefined>
+  }
+
+  const providers: SkillProvider[] = []
+
+  export function registerProvider(provider: SkillProvider) {
+    providers.push(provider)
+  }
+
+  export function unregisterProvider(provider: SkillProvider) {
+    const idx = providers.indexOf(provider)
+    if (idx >= 0) providers.splice(idx, 1)
+  }
+
   export const InvalidError = NamedError.create(
     "SkillInvalidError",
     z.object({
@@ -126,10 +142,50 @@ export namespace Skill {
   })
 
   export async function get(name: string) {
+    for (const provider of providers) {
+      try {
+        const skills = await provider.list()
+        const match = skills.find((s) => s.name === name)
+        if (match) return match
+      } catch (e) {
+        log.error("skill provider get failed", { error: e })
+      }
+    }
+
     return state().then((x) => x[name])
   }
 
   export async function all() {
-    return state().then((x) => Object.values(x))
+    const staticSkills = await state()
+    const dynamicSkills: Info[] = []
+
+    for (const provider of providers) {
+      try {
+        const skills = await provider.list()
+        dynamicSkills.push(...skills)
+      } catch (e) {
+        log.error("skill provider list failed", { error: e })
+      }
+    }
+
+    const merged = { ...staticSkills }
+    for (const skill of dynamicSkills) {
+      merged[skill.name] = skill
+    }
+    return Object.values(merged)
+  }
+
+  export async function loadContent(info: Info): Promise<string> {
+    for (const provider of providers) {
+      try {
+        const content = await provider.load(info.location)
+        if (content) return content
+      } catch (e) {
+        log.error("skill provider load failed", { error: e })
+      }
+    }
+
+    const parsed = await ConfigMarkdown.parse(info.location)
+    return parsed.content.trim()
   }
 }

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -2,8 +2,8 @@ import path from "path"
 import z from "zod"
 import { Tool } from "./tool"
 import { Skill } from "../skill"
-import { ConfigMarkdown } from "../config/markdown"
 import { PermissionNext } from "../permission/next"
+import { Instance } from "../project/instance"
 
 export const SkillTool = Tool.define("skill", async (ctx) => {
   const skills = await Skill.all()
@@ -62,12 +62,11 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
         always: [params.name],
         metadata: {},
       })
-      // Load and parse skill content
-      const parsed = await ConfigMarkdown.parse(skill.location)
-      const dir = path.dirname(skill.location)
 
-      // Format output similar to plugin pattern
-      const output = [`## Skill: ${skill.name}`, "", `**Base directory**: ${dir}`, "", parsed.content.trim()].join("\n")
+      const content = await Skill.loadContent(skill)
+      const dir = path.isAbsolute(skill.location) ? path.dirname(skill.location) : Instance.directory
+
+      const output = [`## Skill: ${skill.name}`, "", `**Base directory**: ${dir}`, "", content].join("\n")
 
       return {
         title: `Loaded skill: ${skill.name}`,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -223,4 +223,22 @@ export interface Hooks {
     input: { sessionID: string; messageID: string; partID: string },
     output: { text: string },
   ) => Promise<void>
+
+  /**
+   * Provide additional skills dynamically.
+   * Called when the skill list is requested.
+   */
+  "skill.list"?: () => Promise<
+    Array<{
+      name: string
+      description: string
+      location: string
+    }>
+  >
+
+  /**
+   * Load skill content by location.
+   * Called when a plugin-provided skill is invoked.
+   */
+  "skill.load"?: (location: string) => Promise<string | undefined>
 }


### PR DESCRIPTION
# Add Dynamic Skill Discovery via Plugin Hooks

Fixes #8304 #10148

## What does this PR do?

This PR adds support for plugins to dynamically provide skills through two new hooks: `skill.list` and `skill.load`. Plugins can now register skills at runtime that will be discovered and made available to the LLM alongside static skills from `.opencode/skill/` directories.

## Problem Solved

Previously, skills were only loaded from static filesystem locations. Plugins had no way to dynamically provide skills based on runtime conditions. This limitation prevented use cases like:

- Loading skills specific to the current workspace/project context
- Providing skills that depend on external configuration or APIs
- Dynamic skill discovery based on environment or runtime state
- Context-aware skills that change based on user preferences or project type

## Implementation

The implementation adds a skill provider registry system:

1. **Provider Registration** (`packages/opencode/src/plugin/index.ts`):
   - During plugin initialization, plugins implementing `skill.list` or `skill.load` hooks are registered as skill providers
   - Each provider is stored in a module-level registry

2. **Dynamic Skill Discovery** (`packages/opencode/src/skill/skill.ts`):
   - `Skill.all()` now queries all registered providers in addition to static skills
   - `Skill.get()` checks providers when looking up skills by name
   - `Skill.loadContent()` uses provider's `skill.load` hook to retrieve skill content
   - Provider errors are caught and logged without crashing the system

3. **Hook Definitions** (`packages/plugin/src/index.ts`):
   - `skill.list`: Returns array of skill metadata (name, description, location)
   - `skill.load`: Returns skill content for a given location string

## How did you verify your code works?

1. **Type Safety**: `bun typecheck` passes without errors

2. **Test Suite**: `bun turbo test` executes successfully

3. **Manual Testing**:
   - Created a plugin implementing `skill.list` and `skill.load` hooks
   - Verified dynamic skills from plugin appear in the Skill tool description
   - Executed plugin-provided skills successfully
   - Confirmed static skills continue to work alongside dynamic skills
   - Tested error handling by triggering provider failures
   - Verified skills are re-discovered on each session turn

4. **Code Review**:
   - Follows OpenCode style guide (no `any` types, uses `const`, error handling with `.catch()`)
   - Maintains backward compatibility with existing static skill loading
   - Properly handles multiple providers and merges results

## Edge Cases Handled

- Multiple plugins can each provide skills independently
- Provider failures are logged but don't crash the system
- Static and dynamic skills are properly merged (dynamic skills can override static ones)
- Skill loading falls back to filesystem if no provider handles the location
