### PR TITLE
feat(bash): add env parameter for setting environment variables

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -73,6 +73,7 @@ export const BashTool = Tool.define("bash", async () => {
         .describe(
           "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
         ),
+      env: z.record(z.string(), z.string()).optional().describe("Environment variables to set for the command"),
     }),
     async execute(params, ctx) {
       const cwd = params.workdir || Instance.directory
@@ -159,6 +160,7 @@ export const BashTool = Tool.define("bash", async () => {
         cwd,
         env: {
           ...process.env,
+          ...params.env,
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -23,6 +23,7 @@ Before executing the command, please follow these steps:
 Usage notes:
   - The command argument is required.
   - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
+  - You can specify an optional env parameter to set environment variables for the command (e.g., `env: { "MY_VAR": "value" }`). These are merged with the existing environment.
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds ${maxLines} lines or ${maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Because of this, you do NOT need to use `head`, `tail`, or other truncation commands to limit output - just run the command directly.
 

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -319,3 +319,43 @@ describe("tool.bash truncation", () => {
     })
   })
 })
+
+describe("tool.bash env", () => {
+  test("sets environment variables", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: "echo $TEST_VAR",
+            description: "Echo environment variable",
+            env: { TEST_VAR: "hello_world" },
+          },
+          ctx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("hello_world")
+      },
+    })
+  })
+
+  test("sets multiple environment variables", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: "echo $VAR1 $VAR2",
+            description: "Echo multiple environment variables",
+            env: { VAR1: "foo", VAR2: "bar" },
+          },
+          ctx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("foo bar")
+      },
+    })
+  })
+})


### PR DESCRIPTION
Fixes #11065

Adds optional `env` parameter to the bash tool that allows plugins to inject environment variables into spawned processes.

**Changes:**
- Added `env: z.record(z.string(), z.string()).optional()` to bash tool schema
- Merged env vars with `process.env` in spawn call
- Added tests for single and multiple environment variables

**Verified:**
- All tests pass including new env tests
- Tested with a plugin using `tool.execute.before` hook to set env vars