### PR TITLE
fix(app): file tabs - auto scroll on open & scroll via mouse wheel

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2183,7 +2183,46 @@ export default function Page() {
                     <ConstrainDragYAxis />
                     <Tabs value={activeTab()} onChange={openTab}>
                       <div class="sticky top-0 shrink-0 flex">
-                        <Tabs.List>
+                        <Tabs.List
+                          ref={(el) => {
+                            let scrollTimeout: number | undefined
+
+                            const handler = () => {
+                              if (scrollTimeout !== undefined) clearTimeout(scrollTimeout)
+                              scrollTimeout = window.setTimeout(() => {
+                                const scrollWidth = el.scrollWidth
+                                const clientWidth = el.clientWidth
+
+                                // Only scroll if there's overflow
+                                if (scrollWidth > clientWidth) {
+                                  el.scrollTo({
+                                    left: scrollWidth - clientWidth,
+                                    behavior: "smooth",
+                                  })
+                                }
+                              }, 0)
+                            }
+
+                            const wheelHandler = (e: WheelEvent) => {
+                              // Enable horizontal scrolling with mouse wheel
+                              if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+                                el.scrollLeft += e.deltaY > 0 ? 50 : -50
+                                e.preventDefault()
+                              }
+                            }
+
+                            el.addEventListener("wheel", wheelHandler, { passive: false })
+
+                            const observer = new MutationObserver(handler)
+                            observer.observe(el, { childList: true })
+
+                            onCleanup(() => {
+                              el.removeEventListener("wheel", wheelHandler)
+                              observer.disconnect()
+                              if (scrollTimeout !== undefined) clearTimeout(scrollTimeout)
+                            })
+                          }}
+                        >
                           <Show when={contextOpen()}>
                             <Tabs.Trigger
                               value="context"

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2186,20 +2186,36 @@ export default function Page() {
                         <Tabs.List
                           ref={(el) => {
                             let scrollTimeout: number | undefined
+                            let prevScrollWidth = el.scrollWidth
+                            let prevContextOpen = contextOpen()
 
                             const handler = () => {
                               if (scrollTimeout !== undefined) clearTimeout(scrollTimeout)
                               scrollTimeout = window.setTimeout(() => {
                                 const scrollWidth = el.scrollWidth
                                 const clientWidth = el.clientWidth
+                                const currentContextOpen = contextOpen()
 
-                                // Only scroll if there's overflow
-                                if (scrollWidth > clientWidth) {
-                                  el.scrollTo({
-                                    left: scrollWidth - clientWidth,
-                                    behavior: "smooth",
-                                  })
+                                // Only scroll when a tab is added (width increased), not on removal
+                                if (scrollWidth > prevScrollWidth) {
+                                  if (!prevContextOpen && currentContextOpen) {
+                                    // Context tab was opened, scroll to first
+                                    el.scrollTo({
+                                      left: 0,
+                                      behavior: "smooth",
+                                    })
+                                  } else if (scrollWidth > clientWidth) {
+                                    // File tab was added, scroll to rightmost
+                                    el.scrollTo({
+                                      left: scrollWidth - clientWidth,
+                                      behavior: "smooth",
+                                    })
+                                  }
                                 }
+                                // When width decreases (tab removed), don't scroll - let browser handle it naturally
+
+                                prevScrollWidth = scrollWidth
+                                prevContextOpen = currentContextOpen
                               }, 0)
                             }
 


### PR DESCRIPTION
closes #11013 

### What does this PR do?
 Fixes two issues with the file tabs in the session view:

1. Auto-scroll to new tabs: When opening a new file tab, the tab list now automatically scrolls to show the rightmost tab, ensuring the tab name and close button are fully visible.
2. Mouse wheel scrolling: Users can now scroll through tabs horizontally via mouse wheel

### How did you verify your code works?
ran locally, ran e2e test suite (local, 1 failure vs 21 passes - same as before the change. The failure is preexisting issue: 
e2e\file-tree.spec.ts:3:1 › file tree can expand folders and open a file)

## Before

https://github.com/user-attachments/assets/f345f91c-0ccd-454d-874c-eb2be3cb0a28


## After

https://github.com/user-attachments/assets/956bb25f-d6e9-411f-b29e-c74011e85af0


