### PR TITLE
fix(opencode): allow media-src data: URL for small audio files

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -539,7 +539,7 @@ export namespace Server {
           })
           response.headers.set(
             "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' data:",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
           )
           return response
         }) as unknown as Hono,


### PR DESCRIPTION
Small audio files (<4KB) are inlined by Vite as base64 data URLs, but Content-Security-Policy didn't allow data: for media resources. This caused sound preview to fail for several sounds.

Added 'media-src "self" data:' to CSP to allow both regular file URLs and data URLs for audio playback.

Fixes #11081 

### What does this PR do?

18 out of 48 sound options don't play on hover in the sound settings page. Small audio files (<4KB) are inlined by Vite as base64 data URLs, but the Content-Security-Policy blocks `data:` URLs for media resources.

#### Root Cause
- Vite automatically inlines assets <4KB as data URLs for performance
- CSP didn't have a `media-src` directive, falling back to `default-src 'self'` which blocks `data:` URLs
- Large audio files (>4KB) were not inlined, so they loaded normally

#### Solution
Added `media-src 'self' data:` to Content-Security-Policy to allow both:
- Regular file URLs for large audio files
- Base64 data URLs for small audio files

#### Verification
- Tested all 48 audio options in Firefox and Chrome
- All sounds now play correctly on hover
- Confirmed no CSP errors in browser console

### How did you verify your code works?

1. Start OpenCode web app

2. Navigate to Settings → Sound effects

3. Open any sound dropdown (e.g., Agent sound)

4. Hover over each sound option
   - Alert 01-10: All should play
   - Bip-bop 01-10: All should play
   - Staplebops 01-07: All should play
   - Nope 01-12: All should play
   - Yup 01-06: All should play

5. Check browser console for CSP errors
   - Should see no CSP violations
```
