### PR TITLE
fix(tui): resolve EditBuffer destroyed error in dialog-select

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -241,7 +241,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
             focusedTextColor={theme.textMuted}
             ref={(r) => {
               input = r
-              setTimeout(() => input.focus(), 1)
+              queueMicrotask(() => r.focus())
             }}
             placeholder={props.placeholder ?? "Search"}
           />


### PR DESCRIPTION
Fixes #10926 

Fixes race condition where input focus was called on a potentially stale reference before the EditBuffer was fully initialized.

### What does this PR do?
The problem stems from a race condition where `input.focus()` was being called on a potationally stale closure variable before EditBuffer was fully initialized. Changing to `queueMicrotask` instead of `setTimeout` for more immediate execution and `r.focus()` instead of `input.focus()` to ensure we're focusing the instance that was just created. 

### How did you verify your code works?
Verified by testing provider connection flow (Moonshot AI) which previously crashed with "EditBuffer is destroyed" error.
