### PR TITLE
fix(tui): preserve markdown headers in TUI output

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1320,14 +1320,11 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
         customBorderChars={SplitBorder.customBorderChars}
         borderColor={theme.backgroundElement}
       >
-        <code
-          filetype="markdown"
-          drawUnstyledText={false}
-          streaming={true}
+        <markdown
           syntaxStyle={subtleSyntax()}
+          streaming={true}
           content={"_Thinking:_ " + content()}
           conceal={ctx.conceal()}
-          fg={theme.textMuted}
         />
       </box>
     </Show>
@@ -1342,14 +1339,6 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-            />
-          </Match>
-          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code
               filetype="markdown"
               drawUnstyledText={false}
@@ -1358,6 +1347,14 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               content={props.part.text.trim()}
               conceal={ctx.conceal()}
               fg={theme.text}
+            />
+          </Match>
+          <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
+            <markdown
+              syntaxStyle={syntax()}
+              streaming={true}
+              content={props.part.text.trim()}
+              conceal={ctx.conceal()}
             />
           </Match>
         </Switch>

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -593,5 +593,5 @@ These environment variables enable experimental features that may change or be r
 | `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | Disable file watcher                    |
 | `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Enable experimental Exa features        |
 | `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable experimental LSP type checking   |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Enable experimental markdown features   |
+| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | Use legacy markdown renderer (strips headers) |
 | `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |


### PR DESCRIPTION
## Summary

The TUI was using the `@opentui/core` library's `<code filetype="markdown">` component which strips markdown header symbols (`#`, `##`, `###`) while preserving other markdown formatting like bold, italic, lists, and code blocks.

This fix makes the `<markdown>` component the default renderer, which properly preserves markdown headers.

## Changes

- **ReasoningPart**: Now uses `<markdown>` component instead of `<code filetype="markdown">`
- **TextPart**: Swapped default to `<markdown>`, legacy `<code filetype="markdown">` is now behind the `OPENCODE_EXPERIMENTAL_MARKDOWN` flag
- **Documentation**: Updated to reflect the new flag behavior - `OPENCODE_EXPERIMENTAL_MARKDOWN=true` now uses the legacy renderer (which strips headers)

## Root Cause

The `@opentui/core` library's markdown parser in the `<code filetype="markdown">` component was stripping header symbols while preserving other markdown formatting. This explains why:
- Headers worked when writing to files (different rendering path)
- Headers were stripped in terminal output (used `<code filetype="markdown">`)
- Other markdown formatting was preserved

## Backwards Compatibility

Users who need the old behavior can set `OPENCODE_EXPERIMENTAL_MARKDOWN=true` to use the legacy renderer.

## Related Issues

Fixes #11048

🤖 Generated with [Claude Code](https://claude.com/claude-code)