### PR TITLE
ci: added gh workflow that adds 'contributor' label to PRs/Issues

### DIFF
--- a/.github/workflows/contributors-label.yml
+++ b/.github/workflows/contributors-label.yml
@@ -1,8 +1,8 @@
 name: Add Contributors Label
 
 on:
-  issues:
-    types: [opened]
+  # issues:
+  #   types: [opened]
 
   pull_request_target:
     types: [opened]

--- a/.github/workflows/contributors-label.yml
+++ b/.github/workflows/contributors-label.yml
@@ -1,0 +1,33 @@
+name: Add Contributors Label
+
+on:
+  issues:
+    types: [opened]
+
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  add-contributor-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    
+    steps:
+      - name: Add Contributor Label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const issueNumber = isPR ? context.payload.pull_request.number : context.payload.issue.number;
+            const authorAssociation = isPR ? context.payload.pull_request.author_association : context.payload.issue.author_association;
+
+            if (authorAssociation === 'CONTRIBUTOR') {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['contributor']
+              });
+            }


### PR DESCRIPTION
### What does this PR do?
This PR  adds a new GH workflow that is triggered by new Issue / Pull request creation and sets a new label called "contributor" if the author of the event is marked as "Contributor" by Github (Previously committed to this repo).

The purpose is to help the maintainers easily sort between issues/PRs from returning contributors and first timers.

### How did you verify your code works?
Tested this in my own fork.

<img width="677" height="77" alt="image" src="https://github.com/user-attachments/assets/a2f9a643-d40c-45a8-b228-8f466f63bea4" />


### Notes
Snapshot of current issues/pr distribution:

```
opencode dev ? ❯︎ bun ./script/contributor-issues.ts --summary-only
contributor_issues      363
non_contributor_issues  2604
contributor_prs         490
non_contributor_prs     716
```