### PR TITLE
fix: remove redundant Highlights heading from publish template

### DIFF
--- a/script/publish-start.ts
+++ b/script/publish-start.ts
@@ -4,8 +4,7 @@ import { $ } from "bun"
 import { Script } from "@opencode-ai/script"
 import { buildNotes, getLatestRelease } from "./changelog"
 
-const highlightsTemplate = `## Highlights
-
+const highlightsTemplate = `
 <!--
 Add highlights before publishing. Delete this section if no highlights.
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded `## Highlights` heading from the publish release notes template
- The heading was redundant since highlights are manually added when publishing

## Testing
Verified the template change is correct by reviewing the publish script.