### PR TITLE
docs: Add opencode-architect to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-architect](https://github.com/qforge-dev/opencode-architect)                             | Architect for crafting OpenCode agents, plugins, commands, skills, tools, and MCP integrations.   |
 
 ---
 


### PR DESCRIPTION
What does this PR do?
Adds opencode-architect plugin to docs. What it is, when to use it, features.

I wanted an agent that truly knows the ins and outs of OpenCode, but the existing tooling kept producing subpar results. So I built OpenCode Architect: a plugin that bundles focused expert agents and stays synced with the freshest docs and guidelines, so developers can build better plugins, commands, skills, tools, and MCP integrations with confidence.

How did you verify your code works?
Not run (docs-only change).