### PR TITLE
fix(session): stop loop when model returns non-tool finish reason

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -397,6 +397,13 @@ export namespace SessionProcessor {
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"
+          // Stop when the model indicates it's done (finish_reason is not tool-calls/unknown)
+          if (
+            input.assistantMessage.finish &&
+            !["tool-calls", "unknown"].includes(input.assistantMessage.finish)
+          ) {
+            return "stop"
+          }
           return "continue"
         }
       },


### PR DESCRIPTION
Fixes #11153

When the model returns finish_reason=stop, the processor was returning "continue" causing repeated API calls with identical messages.

**Change:** Return "stop" from processor when finish reason is not "tool-calls" or "unknown".

**Verification:** Traced through logs from a stuck session - model returned finish_reason=stop but processor returned "continue", loop kept running. With this fix, processor returns "stop" and loop breaks.