### PR TITLE
fix(tui): increase max width to prevent tip text cut off

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -105,7 +105,7 @@ export function Home() {
             hint={Hint}
           />
         </box>
-        <box height={3} width="100%" maxWidth={75} alignItems="center" paddingTop={2}>
+        <box height={3} width="100%" maxWidth={100} alignItems="center" paddingTop={2}>
           <Show when={showTips()}>
             <Tips />
           </Show>


### PR DESCRIPTION
### What does this PR do?
Fixes #11154


### How did you verify your code works?

**Before**
<img width="1357" height="680" alt="screenshot-2026-01-29_10-13-01" src="https://github.com/user-attachments/assets/b634e4ba-d3dc-48f4-8012-8ae54d7a6643" />


**After**
<img width="1356" height="689" alt="screenshot-2026-01-29_11-01-02" src="https://github.com/user-attachments/assets/11dda26c-0213-4d8c-8413-bf867ec760b3" />

I also read the 101 tips and they all display correctly on screen.