### PR TITLE
fix: handle nested tool format and include strict field in oa-compat provider

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -187,14 +187,18 @@ export function toOaCompatibleRequest(body: CommonRequest) {
   }
 
   const tools = Array.isArray(body.tools)
-    ? body.tools.map((tool: any) => ({
-        type: "function",
-        function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
-        },
-      }))
+    ? body.tools.map((tool: any) => {
+        const t = tool.function ? tool.function : tool
+        return {
+          type: "function",
+          function: {
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+            strict: t.strict,
+          },
+        }
+      })
     : undefined
 
   return {


### PR DESCRIPTION
## Summary

Fixes tool calling for Qwen2.5 and other models when using the `oa-compat` provider.

## Root Cause

The `toOaCompatibleRequest` function in `openai-compatible.ts` had two issues:

1. **Assumes flat tool format only** — The function was accessing `tool.name`, `tool.description`, `tool.parameters` directly, but `CommonTool` objects are already in the nested OpenAI format `{ type: "function", function: { name, description, parameters } }`. When tools arrived in the nested format, `tool.name` was `undefined` and the tool definition sent to the model was empty.

2. **Missing `strict` field** — The `CommonTool` interface defines `strict?: boolean`, but `toOaCompatibleRequest` was dropping it during tool mapping. Some models (including Qwen2.5) rely on this field.

## Changes

- Handle both flat and nested tool formats by checking for `tool.function` first
- Include the `strict` field in the tool mapping

## Test Plan

- Verify Qwen2.5 models can now properly call tools when using the `oa-compat` provider
- Confirm the fix doesn't break other provider formats

Fixes #11171