### PR TITLE
fix(config): only install dependencies in project worktree

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -138,9 +138,15 @@ export namespace Config {
         }
       }
 
-      const exists = existsSync(path.join(dir, "node_modules"))
-      const installing = installDependencies(dir)
-      if (!exists) await installing
+      // Only install dependencies for directories within the project worktree
+      // This prevents creating unwanted .opencode/node_modules in arbitrary directories
+      const isWithinWorktree =
+        Instance.worktree === "/" || Filesystem.contains(Instance.worktree, dir)
+      if (isWithinWorktree) {
+        const exists = existsSync(path.join(dir, "node_modules"))
+        const installing = installDependencies(dir)
+        if (!exists) await installing
+      }
 
       result.command = mergeDeep(result.command ?? {}, await loadCommand(dir))
       result.agent = mergeDeep(result.agent, await loadAgent(dir))


### PR DESCRIPTION
## Summary

Prevents creating unwanted `.opencode/node_modules` directories in arbitrary directories that happen to contain a `.opencode` folder.

## Problem

Previously, when scanning for `.opencode` directories, OpenCode would install dependencies (`package.json`, `node_modules`, `bun.lock`) in ANY directory that had a `.opencode` folder, including directories outside the project worktree (e.g., parent directories or unrelated projects).

## Solution

Now, dependencies are only installed for `.opencode` directories that are within the project's worktree boundary. This is done by checking if the directory is within `Instance.worktree` before calling `installDependencies()`.

## Changes

- Added a check using `Filesystem.contains(Instance.worktree, dir)` before installing dependencies
- The check also handles the case where `Instance.worktree === "/"` (non-git projects)

## Testing

The fix ensures that:
1. Dependencies are still installed for project `.opencode` directories
2. Dependencies are NOT installed for arbitrary `.opencode` directories found in parent paths
3. Global `~/.opencode` directory behavior is preserved (when worktree is `/`)

Fixes #11147