### PR TITLE
fix(app): terminal tabs - auto scroll on addition & scroll via mouse …

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2963,7 +2963,54 @@ export default function Page() {
                   }}
                   class="!h-auto !flex-none"
                 >
-                  <Tabs.List class="h-10">
+                  <Tabs.List 
+                    class="h-10"
+                    ref={(el: HTMLDivElement) => {
+                      let scrollTimeout: number | undefined
+                      let prevScrollWidth = el.scrollWidth
+
+                      const handler = () => {
+                        if (scrollTimeout !== undefined) clearTimeout(scrollTimeout)
+                        scrollTimeout = window.setTimeout(() => {
+                          const scrollWidth = el.scrollWidth
+                          const clientWidth = el.clientWidth
+
+                          // Only scroll when a tab is added (width increased), not on removal
+                          if (scrollWidth > prevScrollWidth) {
+                            if (scrollWidth > clientWidth) {
+                              // Terminal tab was added, scroll to rightmost
+                              el.scrollTo({
+                                left: scrollWidth - clientWidth,
+                                behavior: "smooth",
+                              })
+                            }
+                          }
+                          // When width decreases (tab removed), don't scroll - let browser handle it naturally
+
+                          prevScrollWidth = scrollWidth
+                        }, 0)
+                      }
+
+                      const wheelHandler = (e: WheelEvent) => {
+                        // Enable horizontal scrolling with mouse wheel
+                        if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+                          el.scrollLeft += e.deltaY > 0 ? 50 : -50
+                          e.preventDefault()
+                        }
+                      }
+
+                      el.addEventListener("wheel", wheelHandler, { passive: false })
+
+                      const observer = new MutationObserver(handler)
+                      observer.observe(el, { childList: true })
+
+                      onCleanup(() => {
+                        el.removeEventListener("wheel", wheelHandler)
+                        observer.disconnect()
+                        if (scrollTimeout !== undefined) clearTimeout(scrollTimeout)
+                      })
+                    }}
+                  >
                     <SortableProvider ids={terminal.all().map((t: LocalPTY) => t.id)}>
                       <For each={terminal.all()}>
                         {(pty) => (


### PR DESCRIPTION
Closes #11174 

### What does this PR do?

Fixes two issues with the terminal tabs in the session view:

- Auto-scroll to new tabs: When opening a new terminal tab, the tab list now automatically scrolls to show the rightmost tab, ensuring the tab name and close button are fully visible.
- Mouse wheel scrolling: Users can now scroll through tabs horizontally via mouse wheel

### How did you verify your code works?

ran locally, ran e2e test suite (local, 1 failure vs 21 passes - same as before the change. The failure is preexisting issue:
e2e\file-tree.spec.ts:3:1 › file tree can expand folders and open a file)

### Before

https://github.com/user-attachments/assets/f579633e-626b-40bc-b261-a676aeff7d5d

### After

https://github.com/user-attachments/assets/a5f7893b-425d-4f00-9674-a2a4f54b9122

