### PR TITLE
fix: convert JSON string tool outputs to objects for Bedrock compatibility

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -441,6 +441,16 @@ export namespace MessageV2 {
 
     const toModelOutput = (output: unknown) => {
       if (typeof output === "string") {
+        // Try to parse as JSON - if successful and it's an object/array,
+        // return as json type to satisfy Bedrock's requirement for JSON objects
+        try {
+          const parsed = JSON.parse(output)
+          if (typeof parsed === "object" && parsed !== null) {
+            return { type: "json", value: parsed }
+          }
+        } catch {
+          // Not valid JSON, fall through to text
+        }
         return { type: "text", value: output }
       }
 

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -783,4 +783,141 @@ describe("session.message-v2.toModelMessage", () => {
       },
     ])
   })
+
+  test("converts JSON string tool output to json type for Bedrock compatibility", () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "todowrite",
+            state: {
+              status: "completed",
+              input: { todos: [{ id: "1", content: "test", status: "pending" }] },
+              output: JSON.stringify([{ id: "1", content: "test", status: "pending" }], null, 2),
+              title: "Todo",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "todowrite",
+            input: { todos: [{ id: "1", content: "test", status: "pending" }] },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "todowrite",
+            output: {
+              type: "json",
+              value: [{ id: "1", content: "test", status: "pending" }],
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("converts plain text tool output to text type", () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { cmd: "ls" },
+              output: "file1.txt\nfile2.txt",
+              title: "Bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            output: { type: "text", value: "file1.txt\nfile2.txt" },
+          },
+        ],
+      },
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

AWS Bedrock rejects tool results with string content, requiring JSON objects instead. This fix detects when a tool output is a valid JSON string (like the output from `todowrite` tool) and parses it into an object before sending to the model provider.

## Problem

When tool results contain JSON strings (e.g., `JSON.stringify(todos, null, 2)`), AWS Bedrock returns the error:
```
"The format of the value at messages.X.content.0.toolResult.content.0.json is invalid. Provide a json object for the field and try again."
```

This is because Bedrock requires tool result content to be a JSON object, not a string containing JSON.

## Solution

Modified the `toModelOutput` function in `packages/opencode/src/session/message-v2.ts` to:
1. Attempt to parse string outputs as JSON
2. If successful and the result is an object/array, return as `{ type: "json", value: parsed }`
3. Otherwise, fall back to `{ type: "text", value: output }` for plain text

## Changes

- `packages/opencode/src/session/message-v2.ts`: Added JSON parsing logic to `toModelOutput`
- `packages/opencode/test/session/message-v2.test.ts`: Added tests for JSON string and plain text tool outputs

## Test Results

All 15 tests pass:
- 13 existing tests continue to pass
- 2 new tests verify JSON string → object conversion and plain text handling

## Related

- Fixes #11035
- Related to AWS SDK issue: https://github.com/aws/aws-sdk-js-v3/issues/7330

🤖 Generated with [Claude Code](https://claude.com/claude-code)