### PR TITLE
chore(tui): remove unused experimental keys

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1078,29 +1078,6 @@ export namespace Config {
         .optional(),
       experimental: z
         .object({
-          hook: z
-            .object({
-              file_edited: z
-                .record(
-                  z.string(),
-                  z
-                    .object({
-                      command: z.string().array(),
-                      environment: z.record(z.string(), z.string()).optional(),
-                    })
-                    .array(),
-                )
-                .optional(),
-              session_completed: z
-                .object({
-                  command: z.string().array(),
-                  environment: z.record(z.string(), z.string()).optional(),
-                })
-                .array()
-                .optional(),
-            })
-            .optional(),
-          chatMaxRetries: z.number().optional().describe("Number of retries for chat completions on failure"),
           disable_paste_summary: z.boolean().optional(),
           batch_tool: z.boolean().optional().describe("Enable the batch tool"),
           openTelemetry: z


### PR DESCRIPTION
### What does this PR do?
cleanup a couple of experimental keys (`hook` and `chatMaxRetries`) from the config that are not used anywhere.


### How did you verify your code works?
1. grepped through the codebase to find if these keys are used anywhere
2. the typecheck would have failed after generating new type gen, if they were used anywhere in the codebase but it didn't fail (screen record below).

https://github.com/user-attachments/assets/9e5d6375-982d-4785-af90-d0229f1606b1


