### PR TITLE
fix: show all provider models when no providers connected

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -158,7 +158,7 @@ export function DialogModel(props: { providerID?: string }) {
               (item) => item.providerID === value.providerID && item.modelID === value.modelID,
             )
             if (inFavorites) return false
-            const inRecents = recentList.some(
+            const inRecents = recents.some(
               (item) => item.providerID === value.providerID && item.modelID === value.modelID,
             )
             if (inRecents) return false


### PR DESCRIPTION
When no providers were connected, the model dialog would hide models that were in the recent list, but the recent section wasn't being displayed. This caused models to completely disappear from the dialog.

The filter was checking \"recentList\" (which only contained non-favorite recent items) instead of \"recents\" (all recent items), causing models to be incorrectly filtered out of the main provider list when the recent section wasn't shown.

## Changes
- Changed \"recentList\" to \"recents\" in the filter function so all recent items are properly checked when filtering duplicates in sectioned view

Fixes: model dialog showing empty when no providers connected