### PR TITLE
chore(app): remove extra modal for model selector

### DIFF
--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -18,7 +18,6 @@ import { useLanguage } from "@/context/language"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { usePlatform } from "@/context/platform"
-import { DialogSelectModel } from "./dialog-select-model"
 import { DialogSelectProvider } from "./dialog-select-provider"
 
 export function DialogConnectProvider(props: { provider: string }) {

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -1,13 +1,11 @@
 import { Popover as Kobalte } from "@kobalte/core/popover"
-import { Component, ComponentProps, createEffect, createMemo, JSX, onCleanup, Show, ValidComponent } from "solid-js"
+import { Accessor, Component, ComponentProps, createEffect, createMemo, JSX, onCleanup, Show, ValidComponent } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLocal } from "@/context/local"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { popularProviders } from "@/hooks/use-providers"
-import { Button } from "@opencode-ai/ui/button"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tag } from "@opencode-ai/ui/tag"
-import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { DialogSelectProvider } from "./dialog-select-provider"
@@ -93,6 +91,8 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
   children?: JSX.Element
   triggerAs?: T
   triggerProps?: ComponentProps<T>
+  externalOpen?: Accessor<boolean>
+  onExternalOpenHandled?: () => void
 }) {
   const [store, setStore] = createStore<{
     open: boolean
@@ -117,6 +117,13 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
     dialog.show(() => <DialogSelectProvider />)
   }
   const language = useLanguage()
+
+  createEffect(() => {
+    if (props.externalOpen?.()) {
+      setStore("open", true)
+      props.onExternalOpenHandled?.()
+    }
+  })
 
   createEffect(() => {
     if (!store.open) return
@@ -243,32 +250,3 @@ export function ModelSelectorPopover<T extends ValidComponent = "div">(props: {
   )
 }
 
-export const DialogSelectModel: Component<{ provider?: string }> = (props) => {
-  const dialog = useDialog()
-  const language = useLanguage()
-
-  return (
-    <Dialog
-      title={language.t("dialog.model.select.title")}
-      action={
-        <Button
-          class="h-7 -my-1 text-14-medium"
-          icon="plus-small"
-          tabIndex={-1}
-          onClick={() => dialog.show(() => <DialogSelectProvider />)}
-        >
-          {language.t("command.provider.connect")}
-        </Button>
-      }
-    >
-      <ModelList provider={props.provider} onSelect={() => dialog.close()} />
-      <Button
-        variant="ghost"
-        class="ml-3 mt-5 mb-6 text-text-base self-start"
-        onClick={() => dialog.show(() => <DialogManageModels />)}
-      >
-        {language.t("dialog.model.manage")}
-      </Button>
-    </Dialog>
-  )
-}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -59,6 +59,12 @@ import { Binary } from "@opencode-ai/util/binary"
 import { showToast } from "@opencode-ai/ui/toast"
 import { base64Encode } from "@opencode-ai/util/encode"
 
+const [modelSelectorOpen, setModelSelectorOpen] = createSignal(false)
+
+export function openModelSelector() {
+  setModelSelectorOpen(true)
+}
+
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
 const ACCEPTED_FILE_TYPES = [...ACCEPTED_IMAGE_TYPES, "application/pdf"]
 
@@ -1937,7 +1943,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     title={language.t("command.model.choose")}
                     keybind={command.keybind("model.choose")}
                   >
-                    <ModelSelectorPopover triggerAs={Button} triggerProps={{ variant: "ghost" }}>
+                    <ModelSelectorPopover
+                      triggerAs={Button}
+                      triggerProps={{ variant: "ghost" }}
+                      externalOpen={modelSelectorOpen}
+                      onExternalOpenHandled={() => setModelSelectorOpen(false)}
+                    >
                       <Show when={local.model.current()?.provider?.id}>
                         <ProviderIcon id={local.model.current()!.provider.id as IconName} class="size-4 shrink-0" />
                       </Show>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -44,7 +44,7 @@ import { findLast } from "@opencode-ai/util/array"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { DialogSelectFile } from "@/components/dialog-select-file"
 import FileTree from "@/components/file-tree"
-import { DialogSelectModel } from "@/components/dialog-select-model"
+import { openModelSelector } from "@/components/prompt-input"
 import { DialogSelectMcp } from "@/components/dialog-select-mcp"
 import { DialogFork } from "@/components/dialog-fork"
 import { useCommand } from "@/context/command"
@@ -787,7 +787,7 @@ export default function Page() {
       category: language.t("command.category.model"),
       keybind: "mod+'",
       slash: "model",
-      onSelect: () => dialog.show(() => <DialogSelectModel />),
+      onSelect: () => openModelSelector(),
     },
     {
       id: "mcp.toggle",


### PR DESCRIPTION
### What does this PR do?
we have many redudant ui component. for example on clicking on model selector it opens something like this menu. 
<img width="660" height="434" alt="image" src="https://github.com/user-attachments/assets/71c2c4b7-a945-40df-8c3d-8711e98b34f3" />


but when i press command + ' for open the model selector it opens in this ui. 
<img width="915" height="815" alt="image" src="https://github.com/user-attachments/assets/aaf62fc7-df46-48a2-b326-4e092c62be63" />


which doesnt make sense now we have connect provider and manage button in the small dropdown only. so we should have the similar fuctionality so this pr removed the extra component.  @adamdotdevin 
