### PR TITLE
feat(opencode): add elapsed time display next to TUI throbber

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -69,6 +69,18 @@ export function Prompt(props: PromptProps) {
   const dialog = useDialog()
   const toast = useToast()
   const status = createMemo(() => sync.data.session_status?.[props.sessionID ?? ""] ?? { type: "idle" })
+  const [elapsed, setElapsed] = createSignal(0)
+  createEffect(() => {
+    const s = status()
+    if (s.type === "busy") {
+      const now = Date.now()
+      setElapsed(0)
+      const timer = setInterval(() => {
+        setElapsed(Math.floor((Date.now() - now) / 1000))
+      }, 1000)
+      onCleanup(() => clearInterval(timer))
+    }
+  })
   const history = usePromptHistory()
   const stash = usePromptStash()
   const command = useCommandDialog()
@@ -1055,6 +1067,9 @@ export function Prompt(props: PromptProps) {
                     <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
                   </Show>
                 </box>
+                <Show when={elapsed() > 0}>
+                  <text fg={theme.textMuted}>{formatDuration(elapsed())}</text>
+                </Show>
                 <box flexDirection="row" gap={1} flexShrink={0}>
                   {(() => {
                     const retry = createMemo(() => {


### PR DESCRIPTION
Closes #10739

### What does this PR do?

Adds a live elapsed time counter next to the throbber/spinner in the bottom-left of the TUI prompt bar. While a prompt is running, the timer ticks every second (e.g. `1s`, `2s`, `1m 30s`). When the prompt completes, the timer freezes at its final value. Starting a new prompt resets it.

Single file change in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`:
- Added a `createEffect` that watches `status()` and starts a 1-second interval when busy, using SolidJS `onCleanup` to stop the interval when status changes
- Renders the elapsed time in muted text next to the spinner using the existing `formatDuration` utility

### How did you verify your code works?

Ran `bun dev`, submitted prompts, and confirmed the timer appears next to the spinner, ticks while running, freezes on completion, and resets on new prompts.

### Demo
![demo](https://github.com/user-attachments/assets/1013ddf4-862c-4fb7-8e9c-738ad221257c)
