### PR TITLE
fix: ensure Codex OAuth sessions use agent prompt correctly

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -73,8 +73,7 @@ export namespace LLM {
         // For Codex sessions, skip SystemPrompt.provider() and agent.prompt since they're sent via options.instructions
         ...(!isCodex && input.agent.prompt ? [input.agent.prompt] : isCodex ? [] : SystemPrompt.provider(input.model)),
         // any custom prompt passed into this call
-        // For Codex sessions, skip input.system since it's sent via options.instructions
-        ...(!isCodex ? input.system : []),
+        ...input.system,
         // any custom prompt from last user message
         ...(input.user.system ? [input.user.system] : []),
       ]

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -70,10 +70,11 @@ export namespace LLM {
     system.push(
       [
         // use agent prompt otherwise provider prompt
-        // For Codex sessions, skip SystemPrompt.provider() since it's sent via options.instructions
-        ...(input.agent.prompt ? [input.agent.prompt] : isCodex ? [] : SystemPrompt.provider(input.model)),
+        // For Codex sessions, skip SystemPrompt.provider() and agent.prompt since they're sent via options.instructions
+        ...(!isCodex && input.agent.prompt ? [input.agent.prompt] : isCodex ? [] : SystemPrompt.provider(input.model)),
         // any custom prompt passed into this call
-        ...input.system,
+        // For Codex sessions, skip input.system since it's sent via options.instructions
+        ...(!isCodex ? input.system : []),
         // any custom prompt from last user message
         ...(input.user.system ? [input.user.system] : []),
       ]
@@ -114,7 +115,9 @@ export namespace LLM {
       mergeDeep(variant),
     )
     if (isCodex) {
-      options.instructions = SystemPrompt.instructions()
+      const base = input.agent.prompt ? input.agent.prompt : SystemPrompt.instructions()
+      const env = input.system.join("\n\n")
+      options.instructions = [base, env].filter(Boolean).join("\n\n")
     }
 
     const params = await Plugin.trigger(

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -73,7 +73,8 @@ export namespace LLM {
         // For Codex sessions, skip SystemPrompt.provider() and agent.prompt since they're sent via options.instructions
         ...(!isCodex && input.agent.prompt ? [input.agent.prompt] : isCodex ? [] : SystemPrompt.provider(input.model)),
         // any custom prompt passed into this call
-        ...input.system,
+        // For Codex sessions, skip input.system since it's sent via options.instructions
+        ...(!isCodex ? input.system : []),
         // any custom prompt from last user message
         ...(input.user.system ? [input.user.system] : []),
       ]


### PR DESCRIPTION
## Summary

Fixes #11163: OpenAI OAuth 5.2 Codex was not applying the agent persona as a system-level instruction.

## Changes

Modified `packages/opencode/src/session/llm.ts` to ensure Codex OAuth sessions mirror other providers:

- **Exclude agent prompt from message stream**: For Codex OAuth sessions, `agent.prompt` is excluded from the message stream since it's sent via `options.instructions`
- **Construct proper instructions**: When `isCodex` is true, `options.instructions` now includes:
  - `agent.prompt` (if present) or base `SystemPrompt.instructions()`
  - Environment + instruction context from `input.system` (`SystemPrompt.environment()` + `InstructionPrompt.system()`)
  - Joined with double newlines and filtered for truthiness
- **Maintain user.system**: `input.user.system` is still kept in the message stream for per-request context

## Rationale

The OpenAI Codex OAuth provider sends prompts differently than other providers via the `options.instructions` field. Previously only the base `SystemPrompt.instructions()` was sent there; agent/environment instructions were relegated to user content. This caused:

- Agent persona to not be injected (issue #11163)
- Agent/env instructions to be sent as user content instead of system-level instructions

This fix ensures parity with other providers by:
1. Sending `agent.prompt` through `options.instructions` (excluded from message stream)
2. Appending `input.system` to `options.instructions`

## Testing

Verified that:
- Agent persona is now correctly injected for Codex OAuth sessions

Fixes #11163