### PR TITLE
fix(keybinds): remove ctrl+c from default app_exit to prevent accidental exits

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -20,7 +20,7 @@ import { DialogHelp } from "./ui/dialog-help"
 import { CommandProvider, useCommandDialog } from "@tui/component/dialog-command"
 import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
-import { KeybindProvider } from "@tui/context/keybind"
+import { KeybindProvider, useKeybind } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
@@ -777,8 +777,9 @@ function ErrorComponent(props: {
     await props.onExit()
   }
 
+  const keybind = useKeybind()
   useKeyboard((evt) => {
-    if (evt.ctrl && evt.name === "c") {
+    if (keybind.match("app_exit", evt)) {
       handleExit()
     }
   })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -754,7 +754,7 @@ export namespace Config {
   export const Keybinds = z
     .object({
       leader: z.string().optional().default("ctrl+x").describe("Leader key for keybind combinations"),
-      app_exit: z.string().optional().default("ctrl+c,ctrl+d,<leader>q").describe("Exit the application"),
+      app_exit: z.string().optional().default("ctrl+d,<leader>q").describe("Exit the application"),
       editor_open: z.string().optional().default("<leader>e").describe("Open external editor"),
       theme_list: z.string().optional().default("<leader>t").describe("List available themes"),
       sidebar_toggle: z.string().optional().default("<leader>b").describe("Toggle sidebar"),


### PR DESCRIPTION
## Summary
Removes `Ctrl+C` from the default `app_exit` keybind to prevent users from accidentally exiting OpenCode when trying to copy text.

## Problem
`Ctrl+C` is the universal copy shortcut on Windows and commonly used on Linux. Users frequently press it out of habit, accidentally terminating their session and losing context/conversation history.

## Changes
- **Config**: Changed default `app_exit` from `"ctrl+c,ctrl+d,<leader>q"` to `"ctrl+d,<leader>q"`
- **Error Screen**: Fixed hardcoded `ctrl+c` check in ErrorComponent to respect configurable keybinds

## Testing
- ✅ All 12 packages pass typecheck
- ✅ 101 tests pass (keybind + config suites)
- ✅ Manual testing confirms:
  - `Ctrl+C` no longer exits (clears input or does nothing)
  - `Ctrl+D` exits as expected
  - User config overrides still work (backward compatible)

## Migration
Users who prefer the old behavior can restore it via config:
```json
{
  "keybinds": {
    "app_exit": "ctrl+c,ctrl+d,<leader>q"
  }
}
```

Closes #7957