### PR TITLE
Showcase DeepWiki and DuckDuckGo search MCP servers

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -482,6 +482,54 @@ When you need to search docs, use `context7` tools.
 
 ---
 
+### DeepWiki by Devin
+
+Add the [DeepWiki MCP server](https://mcp.deepwiki.com/) to search through docs and enable the ability to **ask questions about them efficiently** (Ask Devin).
+
+```json title="opencode.json" {4-7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "deepwiki": {
+      "type": "remote",
+      "url": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}
+```
+
+Add `use deepwiki` to your prompts to force usage of DeepWiki MCP server.
+
+```txt "use deepwiki"
+Migrate a project to use the latest Tailwind. use deepwiki
+```
+
+---
+
+### DuckDuckGo
+
+Add the [DuckDuckGo MCP server](https://github.com/nickclyde/duckduckgo-mcp-server) that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing.
+
+```json title="opencode.json" {4-7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "duckduckgo": {
+      "type": "local",
+      "command": ["uvx", "duckduckgo-mcp-server"]
+    }
+  }
+}
+```
+
+Add `use duckduckgo` to your prompts to force usage of DuckDuckGo MCP server.
+
+```txt "use duckduckgo"
+Use duckduckgo to research information about alpacas.
+```
+
+---
+
 ### Grep by Vercel
 
 Add the [Grep by Vercel](https://grep.app) MCP server to search through code snippets on GitHub.


### PR DESCRIPTION
This pull request adds documentation for integrating two new MCP servers — DeepWiki by Devin and DuckDuckGo — into the system, providing enhanced capabilities for searching documentation and performing web searches directly from prompts.

**New MCP server integrations:**

* Added instructions for configuring the DeepWiki MCP server in `opencode.json`, enabling efficient documentation search and question-answering via prompts.
  * `read_wiki_structure` - Get a list of documentation topics for a GitHub repository
  * `read_wiki_contents` - View documentation about a GitHub repository
  * `ask_question` - Ask any question about a GitHub repository and get an AI-powered, context-grounded response
* Added instructions for configuring the [DuckDuckGo MCP](https://github.com/nickclyde/duckduckgo-mcp-server) server in `opencode.json`, allowing web search and content fetching/parsing through prompts.
  * Web Search: Search DuckDuckGo with advanced rate limiting and result formatting
  * Content Fetching: Retrieve and parse webpage content with intelligent text extraction
  * Rate Limiting: Built-in protection against rate limits for both search and content fetching
  * Error Handling: Comprehensive error handling and logging
  * LLM-Friendly Output: Results formatted specifically for large language model consumption

**Prompt usage examples:**

* Provided examples showing how to force the use of DeepWiki or DuckDuckGo MCP servers within prompts.

For @skwde based on https://github.com/anomalyco/opencode/issues/309#issuecomment-3822132684