### PR TITLE
fix(opencode): fix issues with glob behaviour for config instructions…

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1164,7 +1164,7 @@ export namespace Config {
         }
         let filePath = match.replace(/^\{file:/, "").replace(/\}$/, "")
         if (filePath.startsWith("~/")) {
-          filePath = path.join(os.homedir(), filePath.slice(2))
+          filePath = path.join(Global.Path.home, filePath.slice(2))
         }
         const resolvedPath = path.isAbsolute(filePath) ? filePath : path.resolve(configDir, filePath)
         const fileContent = (

--- a/packages/opencode/src/global/index.ts
+++ b/packages/opencode/src/global/index.ts
@@ -20,7 +20,10 @@ export namespace Global {
     bin: path.join(data, "bin"),
     log: path.join(data, "log"),
     cache,
-    config,
+    // Allow override via OPENCODE_TEST_HOME for test isolation
+    get config() {
+       return process.env.OPENCODE_TEST_HOME ? path.join(process.env.OPENCODE_TEST_HOME, ".config", app) : config
+     },
     state,
   }
 }

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -1,5 +1,4 @@
 import path from "path"
-import os from "os"
 import { Global } from "../global"
 import { Filesystem } from "../util/filesystem"
 import { Config } from "../config/config"
@@ -19,7 +18,7 @@ const FILES = [
 function globalFiles() {
   const files = [path.join(Global.Path.config, "AGENTS.md")]
   if (!Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
-    files.push(path.join(os.homedir(), ".claude", "CLAUDE.md"))
+    files.push(path.join(Global.Path.home, ".claude", "CLAUDE.md"))
   }
   if (Flag.OPENCODE_CONFIG_DIR) {
     files.push(path.join(Flag.OPENCODE_CONFIG_DIR, "AGENTS.md"))
@@ -92,12 +91,12 @@ export namespace InstructionPrompt {
       for (let instruction of config.instructions) {
         if (instruction.startsWith("https://") || instruction.startsWith("http://")) continue
         if (instruction.startsWith("~/")) {
-          instruction = path.join(os.homedir(), instruction.slice(2))
+          instruction = path.join(Global.Path.home, instruction.slice(2))
         }
         const matches = path.isAbsolute(instruction)
           ? await Array.fromAsync(
-              new Bun.Glob(path.basename(instruction)).scan({
-                cwd: path.dirname(instruction),
+              new Bun.Glob(instruction).scan({
+                cwd: instruction.includes("**/") ? path.resolve(path.dirname(instruction),"..") : path.dirname(instruction),
                 absolute: true,
                 onlyFiles: true,
               }),

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import path from "path"
+import fs from "fs/promises"
 import { InstructionPrompt } from "../../src/session/instruction"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
@@ -48,3 +49,98 @@ describe("InstructionPrompt.resolve", () => {
     })
   })
 })
+
+describe("InstructionPrompt.system", () => {
+
+  test("globbed instructions included in config are read", async () => {
+    
+    await using tmp = await tmpdir({ })
+
+    // because of the way this loads, we need to override env:HOME and env:XDG_CONFIG_HOME
+    const originalHome = process.env.OPENCODE_TEST_HOME
+    const originalXdgConfigHome = process.env.XDG_CONFIG_HOME 
+    console.debug(tmp.path)
+
+    const projectDir = path.join(tmp.path, "project")
+    const homeDir = path.join(tmp.path, "home")
+    const opencodeDir = path.join(homeDir, ".config/opencode")
+
+    process.env.OPENCODE_TEST_HOME = homeDir
+    process.env.XDG_CONFIG_HOME = opencodeDir
+
+    await fs.mkdir(opencodeDir, { recursive: true })
+
+    // create a bunch of global instructions files and globs
+    const instruction_paths = [
+      "shared-rules.md",
+      "instructions-flat/*.md",
+      "instructions-nested/**/*.md",
+      "instructions-match-1/{a,b,c}.md",
+      "instructions-match-2/[fb]oo.md",
+      "instructions-match-3/?oo.md",
+      "instructions-match-4/!*.txt",
+    ]
+    const instruction_files = [
+      "shared-rules.md",                              // no glob
+      "instructions-flat/test-1.md",                  // ../*.md glob pattern
+      "instructions-flat/test-2.md",                  // ../*.md glob pattern
+      "instructions-nested/test-1/test.md",           // **/* glob pattern
+      "instructions-nested/test-2/test/test.md",      // **/* glob pattern
+      "instructions-match-1/a.md",                    // {a,b,c} glob pattern
+      "instructions-match-1/b.md",                    // {a,b,c} glob pattern
+      "instructions-match-1/c.md",                    // {a,b,c} glob pattern
+      "instructions-match-1/d.md",                    // {a,b,c} glob pattern - should be false
+      "instructions-match-2/foo.md",                  // [ab] glob pattern
+      "instructions-match-2/boo.md",                  // [ab] glob pattern
+      "instructions-match-2/bar.md",                  // [ab] glob pattern - should be false
+      "instructions-match-3/foo.md",                  // ? glob pattern
+      "instructions-match-3/boo.md",                  // ? glob pattern
+      "instructions-match-3/bar.md",                  // ? glob pattern - should be false
+      "instructions-match-4/test.md",                 // ! glob pattern
+      "instructions-match-4/test.txt",                // ! glob pattern - should be false
+    ]
+
+    await Bun.write(
+      path.join(opencodeDir, "opencode.json"),
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        instructions: instruction_paths.map(p => path.join(opencodeDir, p)),
+      }),
+    )
+    for (const item of instruction_files) { 
+      await Bun.write(path.resolve(opencodeDir, item), item, {createPath: true})
+    }
+
+    try {
+      await Instance.provide({
+        directory: projectDir,
+        fn: async () => {
+          const system = await InstructionPrompt.systemPaths()
+          expect(system.has(path.resolve(projectDir, "shared-rules.md"))).toBe(false)
+          expect(system.has(path.resolve(opencodeDir, "instructions-flat", "test-1.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-flat", "test-2.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-nested", "test-1", "test.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-nested", "test-2", "test", "test.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-1", "a.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-1", "b.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-1", "c.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-1", "d.md"))).toBe(false)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-2", "foo.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-2", "boo.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-2", "bar.md"))).toBe(false)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-3", "foo.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-3", "boo.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-3", "bar.md"))).toBe(false)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-4", "test.md"))).toBe(true)
+          expect(system.has(path.resolve(opencodeDir, "instructions-match-4", "test.txt"))).toBe(false)
+        },
+      })
+    } finally {
+      process.env.OPENCODE_TEST_HOME = originalHome
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+      await fs.rm(tmp.path, {recursive: true, force: true})
+    }
+   
+  })
+})
+


### PR DESCRIPTION
… and changes to support testing global instructions

### What does this PR do?

Changes to `instuctions.ts` to correct path loading behviour so the full range of glob patterns work.

Previously `**` globs would get parse out by `path.dirname` (actually resulting in a file not found error which was silent).

I suspect this was probably related to #8892, and maybe some other issues around instructions being ignored. 

Fixes #11317

### How did you verify your code works?

Added tests to `instructions.test.ts` to cover cases for globs and global config instructions which seemed to not previously covered. 

It's worth noting, whilst digging around the tests and code, getting the tests to ignore my actual homedir was very challenging do to the inconsistent use of `Global.path.home`, `Global.path.config` and `os.homedir()`. 