### PR TITLE
fix(opencode): prefer session-selected model over agent default

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -647,6 +647,16 @@ export namespace SessionPrompt {
     return Provider.defaultModel()
   }
 
+  async function lastModelForAgent(sessionID: string, agent: string) {
+    for await (const item of MessageV2.stream(sessionID)) {
+      if (item.info.role !== "user") continue
+      if (item.info.agent !== agent) continue
+      if (!item.info.model) continue
+      return item.info.model
+    }
+    return lastModel(sessionID)
+  }
+
   async function resolveTools(input: {
     agent: Agent.Info
     model: Provider.Model
@@ -827,6 +837,7 @@ export namespace SessionPrompt {
 
   async function createUserMessage(input: PromptInput) {
     const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
+    const history = await lastModelForAgent(input.sessionID, agent.name)
     const info: MessageV2.Info = {
       id: input.messageID ?? Identifier.ascending("message"),
       role: "user",
@@ -836,7 +847,7 @@ export namespace SessionPrompt {
       },
       tools: input.tools,
       agent: agent.name,
-      model: input.model ?? agent.model ?? (await lastModel(input.sessionID)),
+      model: input.model ?? history ?? agent.model ?? (await lastModel(input.sessionID)),
       system: input.system,
       variant: input.variant,
     }
@@ -1361,7 +1372,8 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       await SessionRevert.cleanup(session)
     }
     const agent = await Agent.get(input.agent)
-    const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
+    const history = await lastModelForAgent(input.sessionID, agent.name)
+    const model = input.model ?? history ?? agent.model ?? (await lastModel(input.sessionID))
     const userMsg: MessageV2.User = {
       id: Identifier.ascending("message"),
       sessionID: input.sessionID,


### PR DESCRIPTION
Fixes #11334

OpenCode currently resolves the model for a prompt as:

`input.model ?? agent.model ?? lastModel(sessionID)`

If an agent is launched with `-m` (or has a default model configured), that default can override the session-selected model for callers that don't pass `model` explicitly (e.g. chat integrations).

This change prefers the session's last-used model (scoped to the current agent) before falling back to the agent default.

Related: #4243, #4901
