### PR TITLE
fix: add directory parameter to plugin client for multi-project support

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -23,6 +23,7 @@ export namespace Plugin {
   const state = Instance.state(async () => {
     const client = createOpencodeClient({
       baseUrl: "http://localhost:4096",
+      directory: Instance.directory,
       // @ts-ignore - fetch type incompatibility
       fetch: async (...args) => Server.App().fetch(...args),
     })


### PR DESCRIPTION
Fixes #11342

## Problem

When OpenCode Desktop App connects to an external OpenCode Server, calling `delegate_task` fails with `NotFoundError`. The error occurs because the plugin system's internal client doesn't pass the `directory` parameter when making API calls.

Without the `directory` parameter, the server middleware falls back to `process.cwd()` (the server's startup directory) instead of using the actual project directory where the session was created. This causes session files to be searched in the wrong location.

## Solution

Add the `directory` parameter when creating the plugin client in `packages/opencode/src/plugin/index.ts`:

```typescript
const client = createOpencodeClient({
  baseUrl: "http://localhost:4096",
  directory: Instance.directory, // Add this line
  fetch: async (...args) => Server.App().fetch(...args),
})
```

This ensures the client includes the `x-opencode-directory` header in all API requests, allowing the server to correctly resolve the project context.

## How to Verify

### Setup

1. Start OpenCode Server from project A:

   ```bash
   cd /path/to/projectA
   opencode serve
   ```

2. Open OpenCode Desktop App and connect to http://localhost:4096

3. In the Desktop App, open project B (different from project A)

### Test

4. Create a session in project B

5. Execute an action that calls `delegate_task` (e.g., ask AI to perform a complex task that requires delegation)

### Expected Result

- Before fix: `NotFoundError: Resource not found: .../session/{projectA-hash}/ses_xxx.json`
- After fix: `delegate_task` executes successfully, session files are found in the correct project directory

## Changes

- Modified: `packages/opencode/src/plugin/index.ts` (1 line added)
