### PR TITLE
feat: add model aliases

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -1113,7 +1113,9 @@ export namespace ACP {
         .providers({ directory: session.cwd }, { throwOnError: true })
         .then((x) => x.data!.providers)
 
-      const selection = parseModelSelection(params.modelId, providers)
+      const resolved = await Provider.resolveModel(params.modelId)
+      const resolvedModelId = `${resolved.providerID}/${resolved.modelID}`
+      const selection = parseModelSelection(resolvedModelId, providers)
       this.sessionManager.setModel(session.id, selection.model)
       this.sessionManager.setVariant(session.id, selection.variant)
 
@@ -1359,10 +1361,10 @@ export namespace ACP {
 
     const specified = await sdk.config
       .get({ directory }, { throwOnError: true })
-      .then((resp) => {
+      .then(async (resp) => {
         const cfg = resp.data
         if (!cfg || !cfg.model) return undefined
-        const parsed = Provider.parseModel(cfg.model)
+        const parsed = await Provider.resolveModel(cfg.model)
         return {
           providerID: parsed.providerID,
           modelID: parsed.modelID,

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -213,7 +213,7 @@ export namespace Agent {
           options: {},
           native: false,
         }
-      if (value.model) item.model = Provider.parseModel(value.model)
+      if (value.model) item.model = Provider.parseModel(Provider.resolveAlias(value.model, cfg.model_aliases))
       item.prompt = value.prompt ?? item.prompt
       item.description = value.description ?? item.description
       item.temperature = value.temperature ?? item.temperature

--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -120,7 +120,7 @@ const AgentCreateCommand = cmd({
         // Generate agent
         const spinner = prompts.spinner()
         spinner.start("Generating agent configuration...")
-        const model = args.model ? Provider.parseModel(args.model) : undefined
+        const model = args.model ? await Provider.resolveModel(args.model) : undefined
         const generated = await Agent.generate({ description, model }).catch((error) => {
           spinner.stop(`LLM failed to generate agent: ${error.message}`, 1)
           if (isFullyNonInteractive) process.exit(1)

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -444,7 +444,7 @@ export const GithubRunCommand = cmd({
       const isScheduleEvent = context.eventName === "schedule"
       const isWorkflowDispatchEvent = context.eventName === "workflow_dispatch"
 
-      const { providerID, modelID } = normalizeModel()
+      const { providerID, modelID } = await normalizeModel()
       const runId = normalizeRunId()
       const share = normalizeShare()
       const oidcBaseUrl = normalizeOidcBaseUrl()
@@ -648,11 +648,11 @@ export const GithubRunCommand = cmd({
       }
       process.exit(exitCode)
 
-      function normalizeModel() {
+      async function normalizeModel() {
         const value = process.env["MODEL"]
         if (!value) throw new Error(`Environment variable "MODEL" is not set`)
 
-        const { providerID, modelID } = Provider.parseModel(value)
+        const { providerID, modelID } = await Provider.resolveModel(value)
 
         if (!providerID.length || !modelID.length)
           throw new Error(`Invalid model ${value}. Model must be in the format "provider/model".`)

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -261,7 +261,7 @@ export const RunCommand = cmd({
           variant: args.variant,
         })
       } else {
-        const modelParam = args.model ? Provider.parseModel(args.model) : undefined
+        const modelParam = args.model ? await Provider.resolveModel(args.model) : undefined
         await sdk.session.prompt({
           sessionID,
           agent: resolvedAgent,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -997,6 +997,12 @@ export namespace Config {
         .record(z.string(), Provider)
         .optional()
         .describe("Custom provider configurations and model overrides"),
+      model_aliases: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+          "Model aliases mapping short names to provider/model strings (e.g., 'cheap': 'anthropic/claude-3-haiku')",
+        ),
       mcp: z
         .record(
           z.string(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1201,6 +1201,17 @@ export namespace Provider {
     }
   }
 
+  export function resolveAlias(model: string, aliases: Record<string, string> | undefined): string {
+    if (!aliases) return model
+    return aliases[model] ?? model
+  }
+
+  export async function resolveModel(model: string) {
+    const cfg = await Config.get()
+    const resolved = resolveAlias(model, cfg.model_aliases)
+    return parseModel(resolved)
+  }
+
   export const ModelNotFoundError = NamedError.create(
     "ProviderModelNotFoundError",
     z.object({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1653,7 +1653,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
 
     const taskModel = await (async () => {
       if (command.model) {
-        return Provider.parseModel(command.model)
+        return Provider.resolveModel(command.model)
       }
       if (command.agent) {
         const cmdAgent = await Agent.get(command.agent)
@@ -1661,7 +1661,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           return cmdAgent.model
         }
       }
-      if (input.model) return Provider.parseModel(input.model)
+      if (input.model) return Provider.resolveModel(input.model)
       return await lastModel(input.sessionID)
     })()
 
@@ -1712,7 +1712,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const userAgent = isSubtask ? (input.agent ?? (await Agent.defaultAgent())) : agentName
     const userModel = isSubtask
       ? input.model
-        ? Provider.parseModel(input.model)
+        ? await Provider.resolveModel(input.model)
         : await lastModel(input.sessionID)
       : taskModel
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2148,3 +2148,146 @@ test("custom model with variants enabled and disabled", async () => {
     },
   })
 })
+
+// Global model alias tests
+
+test("resolveAlias returns original when no aliases provided", () => {
+  const result = Provider.resolveAlias("anthropic/claude-sonnet-4", undefined)
+  expect(result).toBe("anthropic/claude-sonnet-4")
+})
+
+test("resolveAlias returns original when aliases is empty", () => {
+  const result = Provider.resolveAlias("anthropic/claude-sonnet-4", {})
+  expect(result).toBe("anthropic/claude-sonnet-4")
+})
+
+test("resolveAlias returns original when no match found", () => {
+  const aliases = { cheap: "anthropic/claude-3-haiku" }
+  const result = Provider.resolveAlias("anthropic/claude-sonnet-4", aliases)
+  expect(result).toBe("anthropic/claude-sonnet-4")
+})
+
+test("resolveAlias resolves simple alias", () => {
+  const aliases = { cheap: "anthropic/claude-3-haiku" }
+  const result = Provider.resolveAlias("cheap", aliases)
+  expect(result).toBe("anthropic/claude-3-haiku")
+})
+
+test("resolveAlias resolves namespaced alias", () => {
+  const aliases = { "acme/fast": "openai/gpt-4o-mini" }
+  const result = Provider.resolveAlias("acme/fast", aliases)
+  expect(result).toBe("openai/gpt-4o-mini")
+})
+
+test("resolveAlias resolves complex namespaced alias", () => {
+  const aliases = { "team/reasoning/advanced": "anthropic/claude-opus-4" }
+  const result = Provider.resolveAlias("team/reasoning/advanced", aliases)
+  expect(result).toBe("anthropic/claude-opus-4")
+})
+
+test("resolveAlias does not chain aliases", () => {
+  const aliases = { cheap: "fast", fast: "openai/gpt-4" }
+  const result = Provider.resolveAlias("cheap", aliases)
+  expect(result).toBe("fast") // Only resolves one level
+})
+
+test("resolveAlias handles alias that looks like provider/model but matches exactly", () => {
+  const aliases = { "custom/model": "anthropic/claude-sonnet-4" }
+  const result = Provider.resolveAlias("custom/model", aliases)
+  expect(result).toBe("anthropic/claude-sonnet-4")
+})
+
+test("resolveModel resolves alias and parses model", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model_aliases: {
+            cheap: "anthropic/claude-3-haiku",
+            fast: "openai/gpt-4o-mini",
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const result = await Provider.resolveModel("cheap")
+      expect(result.providerID).toBe("anthropic")
+      expect(result.modelID).toBe("claude-3-haiku")
+    },
+  })
+})
+
+test("resolveModel passes through non-aliased model", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model_aliases: {
+            cheap: "anthropic/claude-3-haiku",
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const result = await Provider.resolveModel("openai/gpt-4-turbo")
+      expect(result.providerID).toBe("openai")
+      expect(result.modelID).toBe("gpt-4-turbo")
+    },
+  })
+})
+
+test("resolveModel works when no aliases configured", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const result = await Provider.resolveModel("anthropic/claude-sonnet-4")
+      expect(result.providerID).toBe("anthropic")
+      expect(result.modelID).toBe("claude-sonnet-4")
+    },
+  })
+})
+
+test("resolveModel handles namespaced aliases", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          model_aliases: {
+            "acme/reasoning": "anthropic/claude-opus-4",
+            "acme/fast": "openai/gpt-4o-mini",
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const result = await Provider.resolveModel("acme/reasoning")
+      expect(result.providerID).toBe("anthropic")
+      expect(result.modelID).toBe("claude-opus-4")
+    },
+  })
+})

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -239,6 +239,21 @@ You can configure the providers and models you want to use in your OpenCode conf
 
 The `small_model` option configures a separate model for lightweight tasks like title generation. By default, OpenCode tries to use a cheaper model if one is available from your provider, otherwise it falls back to your main model.
 
+You can also define model aliases to create short names for models:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model_aliases": {
+    "cheap": "anthropic/claude-3-haiku",
+    "fast": "openai/gpt-4o-mini"
+  },
+  "model": "cheap"
+}
+```
+
+[Learn more about model aliases](/docs/models#model-aliases).
+
 Provider options can include `timeout` and `setCacheKey`:
 
 ```json title="opencode.json"

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -64,6 +64,90 @@ If you've configured a [custom provider](/docs/providers#custom), the `provider_
 
 ---
 
+## Model aliases
+
+Model aliases let you define short names that map to full `provider/model` strings. This is useful for:
+
+- Creating memorable shortcuts like `cheap` or `fast`
+- Letting team members use different providers with shared agent configs
+- Abstracting away provider details from your workflow
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model_aliases": {
+    "cheap": "anthropic/claude-3-haiku-20240307",
+    "fast": "openai/gpt-4o-mini",
+    "reasoning": "anthropic/claude-opus-4"
+  }
+}
+```
+
+Once defined, use aliases anywhere you'd use a model ID.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model_aliases": {
+    "cheap": "anthropic/claude-3-haiku-20240307"
+  },
+  "model": "cheap",
+  "small_model": "cheap"
+}
+```
+
+Or in agent configurations:
+
+```markdown title=".opencode/agents/reviewer.md"
+---
+description: Code review agent
+model: cheap
+---
+
+Review the code for issues.
+```
+
+---
+
+### Team workflows
+
+Aliases are powerful for teams where members have different LLM subscriptions. Define alias names in your shared repo config, and let each developer resolve them in their personal global config.
+
+**Shared agent** in `.opencode/agents/dev.md`:
+
+```markdown
+---
+description: Development agent
+model: acme/reasoning
+---
+
+You are a development assistant.
+```
+
+**Developer A's global config** in `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "model_aliases": {
+    "acme/reasoning": "anthropic/claude-opus-4"
+  }
+}
+```
+
+**Developer B's global config** in `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "model_aliases": {
+    "acme/reasoning": "openai/gpt-5"
+  }
+}
+```
+
+Each developer uses their preferred provider while the team shares the same agent definitions.
+
+---
+
 ## Configure models
 
 You can globally configure a model's options through the config.


### PR DESCRIPTION
Closes #3439

This is my first PR to OpenCode. I've done my best to follow the contributing guidelines and code style, but I fully expect maintainers may want adjustments to the code, documentation, or both. Happy to iterate based on feedback.

#### Summary
Adds `model_aliases` config option to map short names to provider/model strings. Aliases work anywhere a model ID is accepted.
Example
```
{
  model_aliases: {
    cheap: anthropic/claude-3-haiku,
    acme/reasoning: openai/gpt-5
  },
  model: cheap
}
```

One concern: I introduced an async resolveModel() function (since it needs config access). Most call sites were already async, but I'd appreciate a sanity check that this doesn't cause issues I'm not aware of.

#### Verification
- Added 12 unit tests for resolveAlias() and resolveModel()
- Tested manually