### PR TITLE
docs: update agents options section to include color and top_p options

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -269,13 +269,17 @@ If this is not set, the agent will continue to iterate until the model chooses t
     "quick-thinker": {
       "description": "Fast reasoning with limited iterations",
       "prompt": "You are a quick thinker. Solve problems with minimal steps.",
-      "maxSteps": 5
+      "steps": 5
     }
   }
 }
 ```
 
 When the limit is reached, the agent receives a special system prompt instructing it to respond with a summarization of its work and recommended remaining tasks.
+
+:::caution
+The legacy `maxSteps` field is deprecated. Use `steps` instead.
+:::
 
 ---
 

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -568,6 +568,42 @@ Users can always invoke any subagent directly via the `@` autocomplete menu, eve
 
 ---
 
+### Color
+
+Customize the agent's visual appearance in the UI with the `color` option. This affects how the agent appears in the interface.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "creative": {
+      "color": "#ff6b6b"
+    }
+  }
+}
+```
+
+Must be a valid hex color code like `#FF5733`.
+
+---
+
+### Top P
+
+Control response diversity with the `top_p` option. Alternative to temperature for controlling randomness.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "brainstorm": {
+      "top_p": 0.9
+    }
+  }
+}
+```
+
+Values range from 0.0 to 1.0. Lower values are more focused, higher values more diverse.
+
+---
+
 ### Additional
 
 Any other options you specify in your agent configuration will be **passed through directly** to the provider as model options. This allows you to use provider-specific features and parameters.


### PR DESCRIPTION
### What does this PR do?
- Added documentation for missing agent config options (**color**  and **top_p**).
- Updated **maxSteps** references to use current **steps** field with proper deprecation warning.

### How did you verify your code works?

Ran the docs server locally.

<img width="2121" height="1349" alt="image" src="https://github.com/user-attachments/assets/e506c571-1b95-42bc-81ad-dc817c384a21" />
