### PR TITLE
fix(plugin): correct exports to point to dist instead of src

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -9,8 +9,14 @@
     "build": "tsc"
   },
   "exports": {
-    ".": "./src/index.ts",
-    "./tool": "./src/tool.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./tool": {
+      "types": "./dist/tool.d.ts",
+      "import": "./dist/tool.js"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Fixes the `Cannot find module '@opencode-ai/plugin'` error when using custom tools in `.opencode/tool/`.

## Problem

The `package.json` exports were pointing to source files:
```json
"exports": {
  ".": "./src/index.ts",
  "./tool": "./src/tool.ts"
}
```

But the published package only includes `dist/` (via `"files": ["dist"]`), so the source files don't exist in the installed package.

## Fix

Updated exports to point to the compiled dist files with proper types:
```json
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js"
  },
  "./tool": {
    "types": "./dist/tool.d.ts",
    "import": "./dist/tool.js"
  }
}
```

## Testing

- Built the package and installed from tarball locally
- Verified custom tools in `.opencode/tool/` can now import `@opencode-ai/plugin` without errors