### PR TITLE
fix(app): session header 'share' button to hug content

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -167,7 +167,7 @@ export function SessionHeader() {
                     triggerAs={Button}
                     triggerProps={{
                       variant: "secondary",
-                      class: "rounded-sm w-[60px] h-[24px]",
+                      class: "rounded-sm h-[24px] px-3",
                       classList: { "rounded-r-none": shareUrl() !== undefined },
                       style: { scale: 1 },
                     }}


### PR DESCRIPTION
### What does this PR do?

Issue: The share button in session-header.tsx had a fixed width of w-[60px], causing it to not properly resize when the button text is longer (e.g., in different languages, such as Portuguese like in the before/after).

Changes Made:

Changed the share button's class prop from rounded-sm w-[60px] h-[24px] to rounded-sm h-[24px] px-3
This replaces the fixed width with horizontal padding, allowing the button to hug its content, while maintaining the original style.

## Before
<img width="248" height="79" alt="share-btn_BEFORE" src="https://github.com/user-attachments/assets/11f7dd9f-db40-4242-9dfc-e4e7cb34dcfe" />

## After
<img width="299" height="80" alt="share-btn_AFTER" src="https://github.com/user-attachments/assets/f39a34fa-4f5c-4a83-b257-6eb3e8a143cf" />


Why it works: 
Using px-3 instead of a fixed width allows the button to size itself based on the content (the localized text), making it responsive to different language lengths while maintaining consistent padding.


Files Changed:

packages/app/src/components/session/session-header.tsx:170 - Share button trigger props

### How did you verify your code works?

Manual testing: 
1. made sure style is consistent with original style (px-3 achieves the same look)
2. checked different screen widths
