### PR TITLE
fix(enterprise): clean up share_event and share_compaction on unshare

### DIFF
--- a/packages/enterprise/src/core/share.ts
+++ b/packages/enterprise/src/core/share.ts
@@ -60,8 +60,13 @@ export namespace Share {
     if (!share) throw new Errors.NotFound(body.id)
     if (share.secret !== body.secret) throw new Errors.InvalidSecret(body.id)
     await Storage.remove(["share", body.id])
+    await Storage.remove(["share_compaction", body.id])
     const list = await Storage.list({ prefix: ["share_data", body.id] })
     for (const item of list) {
+      await Storage.remove(item)
+    }
+    const events = await Storage.list({ prefix: ["share_event", body.id] })
+    for (const item of events) {
       await Storage.remove(item)
     }
   })

--- a/packages/enterprise/src/core/storage.ts
+++ b/packages/enterprise/src/core/storage.ts
@@ -83,10 +83,40 @@ export namespace Storage {
     return createAdapter(client, `https://${accountId}.r2.cloudflarestorage.com`, process.env.OPENCODE_STORAGE_BUCKET!)
   }
 
+  function memory(): Adapter {
+    const store = new Map<string, string>()
+    return {
+      async read(path: string) {
+        return store.get(path)
+      },
+      async write(path: string, value: string) {
+        store.set(path, value)
+      },
+      async remove(path: string) {
+        store.delete(path)
+      },
+      async list(options?: { prefix?: string; limit?: number; after?: string; before?: string }) {
+        const prefix = options?.prefix || ""
+        let keys = Array.from(store.keys()).filter((k) => k.startsWith(prefix)).sort()
+        if (options?.after) {
+          const afterPath = prefix + options.after + ".json"
+          keys = keys.filter((k) => k > afterPath)
+        }
+        if (options?.before) {
+          const beforePath = prefix + options.before + ".json"
+          keys = keys.filter((k) => k < beforePath)
+        }
+        if (options?.limit) keys = keys.slice(0, options.limit)
+        return keys
+      },
+    }
+  }
+
   const adapter = lazy(() => {
     const type = process.env.OPENCODE_STORAGE_ADAPTER
     if (type === "r2") return r2()
     if (type === "s3") return s3()
+    if (type === "memory") return memory()
     throw new Error("No storage adapter configured")
   })
 

--- a/packages/enterprise/test/core/share.test.ts
+++ b/packages/enterprise/test/core/share.test.ts
@@ -259,4 +259,53 @@ describe.concurrent("core.share", () => {
 
     await Share.remove({ id: share.id, secret: share.secret })
   })
+
+  test("should allow resharing after unsharing with fresh data", async () => {
+    const sessionID = "test_" + Identifier.descending()
+    const share1 = await Share.create({ sessionID })
+
+    const data1: Share.Data[] = [
+      { type: "session", data: { id: sessionID, title: "Original" } as any },
+      {
+        type: "part",
+        data: { id: "part1", sessionID, messageID: "msg1", type: "text", text: "Original content" },
+      },
+    ]
+
+    await Share.sync({
+      share: { id: share1.id, secret: share1.secret },
+      data: data1,
+    })
+
+    const result1 = await Share.data(share1.id)
+    expect(result1.length).toBe(2)
+
+    await Share.remove({ id: share1.id, secret: share1.secret })
+
+    const share2 = await Share.create({ sessionID })
+    expect(share2.id).toBe(share1.id)
+
+    const data2: Share.Data[] = [
+      { type: "session", data: { id: sessionID, title: "Reshared" } as any },
+      {
+        type: "part",
+        data: { id: "part2", sessionID, messageID: "msg2", type: "text", text: "New content" },
+      },
+    ]
+
+    await Share.sync({
+      share: { id: share2.id, secret: share2.secret },
+      data: data2,
+    })
+
+    const result2 = await Share.data(share2.id)
+
+    expect(result2.length).toBe(2)
+    const session = result2.find((d) => d.type === "session")
+    expect(session?.type === "session" && (session.data as any).title).toBe("Reshared")
+    const part = result2.find((d) => d.type === "part")
+    expect(part?.type === "part" && part.data.type === "text" && part.data.text).toBe("New content")
+
+    await Share.remove({ id: share2.id, secret: share2.secret })
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Fixes #11372

When a session is unshared and then reshared, stale data from the previous share appeared mixed with the new data.
This happened because `share_event` and `share_compaction` storage entries were not being cleaned up during unshare,
causing old sync events to be replayed when the session was reshared.

#### Changes:
- Clean up `share_compaction` entries in `Share.remove()`
- Clean up `share_event` entries in `Share.remove()`
- Add test for the reshare scenario

#### Memory storage adapter:

A simple in-memory storage adapter was added to enable local development and testing of the enterprise package
without requiring R2/S3 credentials. It is only activated when explicitly setting `OPENCODE_STORAGE_ADAPTER=memory` - production deployments are unaffected and will continue using r2 or s3 adapters.
If this is not okay then tell me to remove it.

### How did you verify your code works?

You can take a look at the attached video.

https://github.com/user-attachments/assets/f0f135ad-8451-4a0a-94d4-6ba2f7258c32

1. Create a session and send a message ("hi 1" in the shared video)
2. Share the session with `/share`
3. Open the share URL in a browser (this triggers compaction cache)
4. Unshare with `/unshare`
5. `/undo` and edit the previous message  ("hi 2" in the shared video)
6. Share again with `/share`
7. Open/refresh the share URL in browser
8. Only the new message ("hi 2") is visible, which is the expected behaviour.

