### PR TITLE
feat(opencode): gzip compress json responses for up to 97% smaller payload

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -3,6 +3,7 @@ import { Bus } from "@/bus"
 import { Log } from "../util/log"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
 import { Hono } from "hono"
+import type { MiddlewareHandler } from "hono"
 import { cors } from "hono/cors"
 import { streamSSE } from "hono/streaming"
 import { proxy } from "hono/proxy"
@@ -43,6 +44,39 @@ import { MDNS } from "./mdns"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
+
+const COMPRESSION_THRESHOLD = 1024 // Only compress responses > 1KB
+
+function gzipMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const acceptEncoding = c.req.header("Accept-Encoding") ?? c.req.header("accept-encoding") ?? ""
+    if (!acceptEncoding.includes("gzip")) return next()
+
+    await next()
+
+    const response = c.res
+    const contentType = response.headers.get("Content-Type") ?? ""
+    if (!contentType.includes("application/json")) return
+    if (response.headers.get("Content-Encoding")) return // Already encoded
+    if (!response.body) return
+
+    const body = await response.text()
+    if (body.length < COMPRESSION_THRESHOLD) {
+      c.res = new Response(body, response)
+      return
+    }
+
+    const compressed = Bun.gzipSync(body)
+    c.res = new Response(compressed, {
+      status: response.status,
+      headers: {
+        ...Object.fromEntries(response.headers.entries()),
+        "Content-Encoding": "gzip",
+        "Content-Length": String(compressed.byteLength),
+      },
+    })
+  }
+}
 
 export namespace Server {
   const log = Log.create({ service: "server" })
@@ -121,6 +155,7 @@ export namespace Server {
             },
           }),
         )
+        .use(gzipMiddleware())
         .route("/global", GlobalRoutes())
         .put(
           "/auth/:providerID",


### PR DESCRIPTION
### What does this PR do?

fixes #10475

Large sessions can have 20MB+ JSON payloads which can take 20-30s to transfer over mobile networks. Gzip compression reduces this dramatically, improving mobile load times perceptibly. In one case a 400-message session went from 20-30s (23.9MB) to ~5s (580KB).

I attempted to use hono’s own compression middleware but that seemed to break the client, so I opted to implement a middleware with bun’s gzip compression directly.

### How did you verify your code works?

ran the server locally (`bun run dev web`) and tested a session w 400 messages on my phone against v1.1.47:

### before (v1.1.47)

custom client logging:
```
[sync] fetch complete: 19071ms, size=22.73MB
[sync] processing (filter/sort/clone messages): 29ms, count=400
[sync] batch/reconcile complete: 612ms
[sync] TOTAL: 19712ms
```

23.9MB for that one session:

<img width="660" height="1434" alt="IMG_7137" src="https://github.com/user-attachments/assets/4311fc51-b6c1-4b33-8625-078c4d90ceb3" />


### after (this PR)

custom client logging:
```

[sync] fetch complete: 5096ms, size=22.73MB
[sync] processing (filter/sort/clone messages): 35ms, count=400
[sync] batch/reconcile complete: 402ms
[sync] TOTAL: 5533ms
```

23.9MB -> 580KB for that one session

<img width="660" height="1434" alt="IMG_7138" src="https://github.com/user-attachments/assets/deff1ae1-09f4-4308-a72a-879c20a42aa3" />
