### PR TITLE
feat: make skills invokable as slash commands in the TUI

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -142,7 +142,6 @@ for (const item of targets) {
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
     sourcemap: "external",
-    bytecode: true,
     compile: {
       autoloadBunfig: false,
       autoloadDotenv: false,

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -142,6 +142,7 @@ for (const item of targets) {
     tsconfig: "./tsconfig.json",
     plugins: [solidPlugin],
     sourcemap: "external",
+    bytecode: true,
     compile: {
       autoloadBunfig: false,
       autoloadDotenv: false,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -345,8 +345,9 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = [...command.slashes()]
 
     for (const serverCommand of sync.data.command) {
+      const label = serverCommand.mcp ? " (MCP)" : serverCommand.skill ? " (Skill)" : ""
       results.push({
-        display: "/" + serverCommand.name + (serverCommand.mcp ? " (MCP)" : ""),
+        display: "/" + serverCommand.name + label,
         description: serverCommand.description,
         onSelect: () => {
           const newText = "/" + serverCommand.name + " "

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -345,7 +345,7 @@ export function Autocomplete(props: {
     const results: AutocompleteOption[] = [...command.slashes()]
 
     for (const serverCommand of sync.data.command) {
-      const label = serverCommand.mcp ? " (MCP)" : serverCommand.skill ? " (Skill)" : ""
+      const label = serverCommand.source === "mcp" ? ":mcp" : serverCommand.source === "skill" ? ":skill" : ""
       results.push({
         display: "/" + serverCommand.name + label,
         description: serverCommand.description,

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -27,8 +27,7 @@ export namespace Command {
       description: z.string().optional(),
       agent: z.string().optional(),
       model: z.string().optional(),
-      mcp: z.boolean().optional(),
-      skill: z.boolean().optional(),
+      source: z.enum(["command", "mcp", "skill"]).optional(),
       // workaround for zod not supporting async functions natively so we use getters
       // https://zod.dev/v4/changelog?id=zfunction
       template: z.promise(z.string()).or(z.string()),
@@ -96,7 +95,7 @@ export namespace Command {
     for (const [name, prompt] of Object.entries(await MCP.prompts())) {
       result[name] = {
         name,
-        mcp: true,
+        source: "mcp",
         description: prompt.description,
         get template() {
           // since a getter can't be async we need to manually return a promise here
@@ -127,9 +126,9 @@ export namespace Command {
       result[skill.name] = {
         name: skill.name,
         description: skill.description,
-        skill: true,
+        source: "skill",
         get template() {
-          return Skill.content(skill.name).then((content) => content ?? "")
+          return skill.content
         },
         hints: [],
       }

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -153,4 +153,11 @@ export namespace Skill {
   export async function all() {
     return state().then((x) => Object.values(x))
   }
+
+  export async function content(name: string) {
+    const info = await get(name)
+    if (!info) return undefined
+    const md = await ConfigMarkdown.parse(info.location)
+    return md.content
+  }
 }

--- a/packages/opencode/src/skill/skill.ts
+++ b/packages/opencode/src/skill/skill.ts
@@ -18,6 +18,7 @@ export namespace Skill {
     name: z.string(),
     description: z.string(),
     location: z.string(),
+    content: z.string(),
   })
   export type Info = z.infer<typeof Info>
 
@@ -74,6 +75,7 @@ export namespace Skill {
         name: parsed.data.name,
         description: parsed.data.description,
         location: match,
+        content: md.content,
       }
     }
 
@@ -152,12 +154,5 @@ export namespace Skill {
 
   export async function all() {
     return state().then((x) => Object.values(x))
-  }
-
-  export async function content(name: string) {
-    const info = await get(name)
-    if (!info) return undefined
-    const md = await ConfigMarkdown.parse(info.location)
-    return md.content
   }
 }

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -2,7 +2,6 @@ import path from "path"
 import z from "zod"
 import { Tool } from "./tool"
 import { Skill } from "../skill"
-import { ConfigMarkdown } from "../config/markdown"
 import { PermissionNext } from "../permission/next"
 
 export const SkillTool = Tool.define("skill", async (ctx) => {
@@ -62,7 +61,7 @@ export const SkillTool = Tool.define("skill", async (ctx) => {
         always: [params.name],
         metadata: {},
       })
-      const content = (await ConfigMarkdown.parse(skill.location)).content
+      const content = skill.content
       const dir = path.dirname(skill.location)
 
       // Format output similar to plugin pattern

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2117,6 +2117,7 @@ export type Command = {
   agent?: string
   model?: string
   mcp?: boolean
+  skill?: boolean
   template: string
   subtask?: boolean
   hints: Array<string>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2116,8 +2116,7 @@ export type Command = {
   description?: string
   agent?: string
   model?: string
-  mcp?: boolean
-  skill?: boolean
+  source?: "command" | "mcp" | "skill"
   template: string
   subtask?: boolean
   hints: Array<string>
@@ -4914,6 +4913,7 @@ export type AppSkillsResponses = {
     name: string
     description: string
     location: string
+    content: string
   }>
 }
 


### PR DESCRIPTION
## Summary

This PR makes skills invokable as slash commands in the TUI, similar to how custom commands work.

## Changes

- Added `Skill.content()` method to load skill template content from SKILL.md files
- Modified `Command.list()` to include skills as invokable commands
- Added `skill` boolean property to `Command.Info` schema
- Updated autocomplete to show skills with "(Skill)" label in slash commands
- Regenerated SDK to include skill property in Command type

## How it works

Users can now invoke any skill defined in SKILL.md files by typing `/skillname` in the TUI. The skill's body content (markdown after the frontmatter) is used as the command template, and arguments are substituted just like with regular commands.

Skills appear in the slash command autocomplete alongside regular commands, marked with "(Skill)" label for clarity.
