### PR TITLE
fix(console): handle nested tools and preserve strict in oa-compat

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -187,14 +187,18 @@ export function toOaCompatibleRequest(body: CommonRequest) {
   }
 
   const tools = Array.isArray(body.tools)
-    ? body.tools.map((tool: any) => ({
-        type: "function",
-        function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
-        },
-      }))
+    ? body.tools.map((tool: any) => {
+        const t = tool.function ? tool.function : tool
+        return {
+          type: "function",
+          function: {
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+            strict: t.strict,
+          },
+        }
+      })
     : undefined
 
   return {
@@ -281,25 +285,25 @@ export function fromOaCompatibleResponse(resp: any): CommonResponse {
           role: "assistant" as const,
           ...(content.length > 0 && content.some((c) => c.type === "text")
             ? {
-                content: content
-                  .filter((c) => c.type === "text")
-                  .map((c: any) => c.text)
-                  .join(""),
-              }
+              content: content
+                .filter((c) => c.type === "text")
+                .map((c: any) => c.text)
+                .join(""),
+            }
             : {}),
           ...(content.length > 0 && content.some((c) => c.type === "tool_use")
             ? {
-                tool_calls: content
-                  .filter((c) => c.type === "tool_use")
-                  .map((c: any) => ({
-                    id: c.id,
-                    type: "function" as const,
-                    function: {
-                      name: c.name,
-                      arguments: typeof c.input === "string" ? c.input : JSON.stringify(c.input),
-                    },
-                  })),
-              }
+              tool_calls: content
+                .filter((c) => c.type === "tool_use")
+                .map((c: any) => ({
+                  id: c.id,
+                  type: "function" as const,
+                  function: {
+                    name: c.name,
+                    arguments: typeof c.input === "string" ? c.input : JSON.stringify(c.input),
+                  },
+                })),
+            }
             : {}),
         },
         finish_reason: stopReason,
@@ -534,10 +538,10 @@ export function toOaCompatibleChunk(chunk: CommonChunk): string {
       total_tokens: chunk.usage.total_tokens,
       ...(chunk.usage.prompt_tokens_details?.cached_tokens
         ? {
-            prompt_tokens_details: {
-              cached_tokens: chunk.usage.prompt_tokens_details.cached_tokens,
-            },
-          }
+          prompt_tokens_details: {
+            cached_tokens: chunk.usage.prompt_tokens_details.cached_tokens,
+          },
+        }
         : {}),
     }
   }

--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -188,17 +188,19 @@ export function toOaCompatibleRequest(body: CommonRequest) {
 
   const tools = Array.isArray(body.tools)
     ? body.tools.map((tool: any) => {
-        const t = tool.function ? tool.function : tool
-        return {
-          type: "function",
-          function: {
-            name: t.name,
-            description: t.description,
-            parameters: t.parameters,
-            strict: t.strict,
-          },
-        }
-      })
+      const t = tool.function ?? tool
+      const strict = tool.strict ?? t.strict
+
+      return {
+        type: "function",
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.parameters,
+          strict,
+        },
+      }
+    })
     : undefined
 
   return {


### PR DESCRIPTION
Fixes #11171

### What does this PR do?
- Ensures `toOaCompatibleRequest` supports tools arriving in either:
  - flat format: `{ name, description, parameters, strict? }`
  - nested OpenAI format: `{ type: "function", function: { name, description, parameters, strict? } }`
- Preserves `strict` when building the OpenAI-compatible tool schema.

### Why?
When tools arrive nested, the current mapping reads `tool.name` etc. as `undefined`, which results in empty tool definitions being sent to the model and breaks tool calling (observed with Qwen2.5).

### How did you verify?
- Confirmed the serialized request now includes correct tool fields (`name/description/parameters`) for nested tools.
- Verified `strict` is included in the outgoing tool definition.
