### PR TITLE
feat: Add native Jupyter notebook (.ipynb) support

### DIFF
--- a/JUPYTER_SUPPORT.md
+++ b/JUPYTER_SUPPORT.md
@@ -1,0 +1,154 @@
+# Jupyter Notebook Support in OpenCode
+
+This feature adds native support for editing Jupyter notebook (`.ipynb`) files in OpenCode, making it a powerful tool for data scientists and researchers who use notebooks.
+
+## Features
+
+### 📓 Five New Tools
+
+1. **read_notebook** - Parse and display notebook structure
+   - Shows metadata (format version, language, kernel info)
+   - Lists all cells with types and content previews
+   - Displays execution counts and outputs for code cells
+
+2. **edit_notebook_cell** - Edit specific cells
+   - Modify cell content while preserving metadata
+   - Maintains execution counts and outputs
+   - Supports code, markdown, and raw cells
+
+3. **add_notebook_cell** - Insert new cells
+   - Add cells at any position (or at the end)
+   - Choose cell type (code, markdown, raw)
+   - Automatically initializes code cells with null execution count
+
+4. **delete_notebook_cell** - Remove cells
+   - Delete cells by index
+   - Preserves all other cells
+   - Provides confirmation before deletion
+
+5. **list_notebook_cells** - Quick cell overview
+   - List all cells with indices
+   - Filter by cell type
+   - Show content previews
+
+## Usage Examples
+
+### Read a Notebook
+```
+read_notebook("path/to/notebook.ipynb")
+```
+
+### Edit a Code Cell
+```
+edit_notebook_cell(
+  filePath="path/to/notebook.ipynb",
+  cellIndex=2,
+  newSource="print('Hello, World!')"
+)
+```
+
+### Add a New Markdown Cell
+```
+add_notebook_cell(
+  filePath="path/to/notebook.ipynb",
+  cellType="markdown",
+  source="# Analysis Results\n\nThis notebook shows...",
+  position=0
+)
+```
+
+### Delete a Cell
+```
+delete_notebook_cell(
+  filePath="path/to/notebook.ipynb",
+  cellIndex=5
+)
+```
+
+### List All Code Cells
+```
+list_notebook_cells(
+  filePath="path/to/notebook.ipynb",
+  cellType="code",
+  maxPreviewLength=100
+)
+```
+
+## Technical Details
+
+### Notebook Format Support
+- Jupyter notebook format 4.x
+- JSON structure validation
+- Preserves all metadata fields
+- Handles both string and string[] source formats
+
+### Cell Types
+- **Code cells**: Execution state, outputs preserved
+- **Markdown cells**: GitHub-flavored markdown
+- **Raw cells**: Unformatted text
+
+### Implementation
+The implementation uses TypeScript with Zod for parameter validation and follows OpenCode's tool architecture patterns. All tools:
+- Request user permission before modifications
+- Track file changes with FileTime
+- Support external directory access
+- Provide detailed error messages
+- Include diff tracking
+
+## Files Added
+
+- `packages/opencode/src/notebook/index.ts` - Core notebook utilities
+- `packages/opencode/src/tool/read-notebook.ts` - Read notebook tool
+- `packages/opencode/src/tool/edit-notebook-cell.ts` - Edit cell tool
+- `packages/opencode/src/tool/add-notebook-cell.ts` - Add cell tool
+- `packages/opencode/src/tool/delete-notebook-cell.ts` - Delete cell tool
+- `packages/opencode/src/tool/list-notebook-cells.ts` - List cells tool
+
+## Testing
+
+To test the notebook support:
+
+1. Create a sample notebook:
+```python
+# In Jupyter or with nbformat
+import nbformat
+nb = nbformat.v4.new_notebook()
+nb.cells.append(nbformat.v4.new_code_cell("print('Hello')"))
+nbformat.write(nb, 'test.ipynb')
+```
+
+2. Use OpenCode to interact with it:
+```bash
+opencode
+> read_notebook("test.ipynb")
+> edit_notebook_cell("test.ipynb", 0, "print('Updated')")
+> add_notebook_cell("test.ipynb", "markdown", "# Title")
+```
+
+## Benefits
+
+- **No notebook conversion needed** - Work directly with .ipynb files
+- **Preserves execution state** - Outputs and counts maintained
+- **Collaboration friendly** - Version control compatible
+- **Terminal-based workflow** - Edit notebooks without leaving the terminal
+- **AI-assisted** - Use OpenCode's AI to refactor and improve notebooks
+
+## Future Enhancements
+
+Possible future improvements:
+- Cell execution support
+- Image output handling
+- Notebook conversion tools
+- Cell reordering operations
+- Bulk cell operations
+
+## Contributing
+
+This is an open-source contribution to OpenCode. For issues, suggestions, or improvements, please:
+1. Check the existing GitHub issues
+2. Create a new issue with the "notebook" label
+3. Submit PRs with clear descriptions
+
+## License
+
+This feature follows the same license as OpenCode (MIT License).

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,0 +1,372 @@
+# Testing Guide for Jupyter Notebook Support
+
+This guide provides step-by-step instructions for testing the new Jupyter notebook support in OpenCode.
+
+## Prerequisites
+
+### 1. Install Dependencies
+
+```bash
+# Install nbformat to create test notebooks
+pip install nbformat
+
+# Or install Jupyter (includes nbformat)
+pip install jupyter
+```
+
+### 2. Create Test Notebooks
+
+```bash
+# Create test directory
+mkdir D:/test_notebooks
+cd D:/test_notebooks
+
+# Create test notebooks
+python ../test_notebooks/create_test_notebooks.py
+
+# Or create manually using Jupyter
+# jupyter notebook simple_test.ipynb
+```
+
+## Testing Methods
+
+### Method 1: Manual Tool Testing
+
+Start OpenCode and test each tool:
+
+```bash
+cd D:/opencode
+opencode
+```
+
+#### Test 1: Read Notebook
+```
+read_notebook("D:/test_notebooks/simple_test.ipynb")
+```
+**Expected Output**: 
+- Notebook summary with metadata
+- List of all cells with indices
+- Cell content previews
+- Execution counts for code cells
+
+#### Test 2: List Cells
+```
+list_notebook_cells("D:/test_notebooks/complex_test.ipynb")
+```
+**Expected Output**:
+- Quick overview of all cells
+- Cell indices and types
+- Content previews
+
+#### Test 3: List Only Code Cells
+```
+list_notebook_cells(
+  "D:/test_notebooks/complex_test.ipynb",
+  cellType="code",
+  maxPreviewLength=100
+)
+```
+**Expected Output**: Only code cells listed
+
+#### Test 4: Edit a Cell
+```
+edit_notebook_cell(
+  "D:/test_notebooks/simple_test.ipynb",
+  cellIndex=1,
+  newSource="print('Hello from OpenCode!')"
+)
+```
+**Expected Output**:
+- Confirmation of edit
+- Diff summary
+- Updated notebook info
+
+#### Test 5: Add a Cell
+```
+add_notebook_cell(
+  "D:/test_notebooks/simple_test.ipynb",
+  cellType="markdown",
+  source="## New Section\n\nAdded by OpenCode",
+  position=2
+)
+```
+**Expected Output**:
+- Cell added confirmation
+- Position info
+- Updated cell count
+
+#### Test 6: Delete a Cell
+```
+delete_notebook_cell(
+  "D:/test_notebooks/simple_test.ipynb",
+  cellIndex=0
+)
+```
+**Expected Output**:
+- Deletion confirmation
+- Cell info that was deleted
+- Updated notebook summary
+
+### Method 2: Automated Testing Script
+
+Create a test script:
+
+```bash
+# D:/test_notebooks/test_opencode.sh
+#!/bin/bash
+
+echo "Testing OpenCode Jupyter Support..."
+
+# Test 1: Read notebook
+echo "Test 1: Reading notebook..."
+opencode eval "read_notebook('D:/test_notebooks/simple_test.ipynb')"
+
+# Test 2: Edit cell
+echo "Test 2: Editing cell..."
+opencode eval "edit_notebook_cell('D:/test_notebooks/simple_test.ipynb', 1, 'print(\"Edited by OpenCode\")')"
+
+# Test 3: Add cell
+echo "Test 3: Adding cell..."
+opencode eval "add_notebook_cell('D:/test_notebooks/simple_test.ipynb', 'code', 'x = 100')"
+
+# Test 4: List cells
+echo "Test 4: Listing cells..."
+opencode eval "list_notebook_cells('D:/test_notebooks/simple_test.ipynb')"
+
+echo "Tests completed!"
+```
+
+### Method 3: Unit Testing
+
+Create unit tests in the repository:
+
+```typescript
+// D:/opencode/packages/opencode/src/notebook/test.ts
+import { 
+  parseNotebook, 
+  addCell, 
+  editCell, 
+  deleteCell,
+  normalizeSource 
+} from "../notebook"
+
+describe("Notebook Utilities", () => {
+  test("parse valid notebook", () => {
+    const content = JSON.stringify({
+      cells: [{ cell_type: "code", metadata: {}, source: "print('test')" }],
+      metadata: { language_info: { name: "python" } },
+      nbformat: 4,
+      nbformat_minor: 2
+    })
+    
+    const result = parseNotebook(content)
+    expect(result.success).toBe(true)
+    expect(result.notebook?.cells.length).toBe(1)
+  })
+
+  test("normalize source handles both formats", () => {
+    expect(normalizeSource("single line")).toBe("single line")
+    expect(normalizeSource(["line1", "line2"])).toBe("line1line2")
+  })
+
+  test("add cell inserts at correct position", () => {
+    const notebook = {
+      cells: [{ cell_type: "code", metadata: {}, source: "cell 1" }],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 2
+    }
+    
+    const updated = addCell(notebook, "code", "new cell", 0)
+    expect(updated.cells.length).toBe(2)
+    expect(updated.cells[0].source).toContain("new cell")
+  })
+
+  test("edit cell modifies correct cell", () => {
+    const notebook = {
+      cells: [
+        { cell_type: "code", metadata: {}, source: "original" }
+      ],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 2
+    }
+    
+    const updated = editCell(notebook, 0, "modified")
+    expect(updated.cells[0].source).toContain("modified")
+  })
+
+  test("delete cell removes correct cell", () => {
+    const notebook = {
+      cells: [
+        { cell_type: "code", metadata: {}, source: "cell 1" },
+        { cell_type: "markdown", metadata: {}, source: "cell 2" }
+      ],
+      metadata: {},
+      nbformat: 4,
+      nbformat_minor: 2
+    }
+    
+    const updated = deleteCell(notebook, 0)
+    expect(updated.cells.length).toBe(1)
+    expect(updated.cells[0].source).toContain("cell 2")
+  })
+})
+```
+
+Run tests:
+```bash
+cd D:/opencode
+bun test packages/opencode/src/notebook/test.ts
+```
+
+### Method 4: Integration Testing
+
+Test with real notebooks:
+
+```bash
+# Test with a real Jupyter notebook
+cd D:/test_notebooks
+
+# Create a notebook from Jupyter first
+jupyter notebook test.ipynb
+# Add some cells manually, save, and close
+
+# Then use OpenCode to read it
+opencode
+> read_notebook("D:/test_notebooks/test.ipynb")
+```
+
+## Validation Checklist
+
+Test each feature and verify:
+
+### Read Notebook ✅
+- [ ] Displays notebook metadata
+- [ ] Shows correct cell count
+- [ ] Lists all cell types (code, markdown, raw)
+- [ ] Displays execution counts
+- [ ] Shows outputs for code cells
+- [ ] Handles empty notebooks
+- [ ] Handles invalid JSON gracefully
+
+### Edit Notebook Cell ✅
+- [ ] Edits code cells correctly
+- [ ] Edits markdown cells correctly
+- [ ] Preserves cell metadata
+- [ ] Preserves execution counts
+- [ ] Preserves outputs
+- [ ] Handles out-of-bounds indices
+- [ ] Shows confirmation before edit
+
+### Add Notebook Cell ✅
+- [ ] Adds code cells
+- [ ] Adds markdown cells
+- [ ] Adds raw cells
+- [ ] Inserts at correct position
+- [ ] Appends when no position specified
+- [ ] Initializes code cells with null execution_count
+
+### Delete Notebook Cell ✅
+- [ ] Deletes cells correctly
+- [ ] Preserves other cells
+- [ ] Updates indices correctly
+- [ ] Handles last cell deletion
+- [ ] Shows confirmation before delete
+
+### List Notebook Cells ✅
+- [ ] Lists all cells
+- [ ] Filters by cell type
+- [ ] Shows correct indices
+- [ ] Displays content preview
+- [ ] Shows execution counts
+- [ ] Handles empty notebooks
+
+## Common Issues & Solutions
+
+### Issue: "File not found"
+**Solution**: Use absolute paths or check current working directory
+```
+read_notebook("D:/absolute/path/to/notebook.ipynb")
+```
+
+### Issue: "Invalid notebook format"
+**Solution**: Ensure the file is valid JSON and has required fields
+```bash
+# Validate with Python
+python -c "import json; json.load(open('test.ipynb'))"
+```
+
+### Issue: "Cell index out of bounds"
+**Solution**: Use `list_notebook_cells` to see valid indices first
+
+### Issue: Changes not saved
+**Solution**: Ensure you confirm the permission prompt when asked
+
+## Performance Testing
+
+Test with large notebooks:
+
+```python
+# Create a large notebook (1000 cells)
+import nbformat
+from nbformat.v4 import new_notebook, new_code_cell
+
+nb = new_notebook()
+for i in range(1000):
+    nb.cells.append(new_code_cell(f"# Cell {i}\nprint({i})"))
+
+with open('large_test.ipynb', 'w') as f:
+    nbformat.write(nb, f)
+
+# Test reading performance
+# opencode
+# > read_notebook("large_test.ipynb")
+```
+
+## Debugging
+
+Enable debug mode:
+
+```bash
+cd D:/opencode
+opencode --log-level DEBUG
+```
+
+Check file timestamps:
+```bash
+ls -la D:/test_notebooks/
+```
+
+Verify notebook format:
+```python
+import nbformat
+nb = nbformat.read('test.ipynb', as_version=4)
+print(f"Cells: {len(nb.cells)}")
+print(f"Format: {nb.nbformat}.{nb.nbformat_minor}")
+```
+
+## Next Steps After Testing
+
+1. **Report Issues**: Create GitHub issues for any bugs found
+2. **Submit PR**: If tests pass, prepare for pull request
+3. **Add Tests**: Contribute unit tests to the repository
+4. **Documentation**: Update main README with notebook support info
+
+## Test Results Template
+
+```
+Testing Date: [DATE]
+OpenCode Version: [VERSION]
+Test Environment: [OS/Shell]
+
+Results:
+✅ read_notebook - PASSED/FAILED
+✅ edit_notebook_cell - PASSED/FAILED
+✅ add_notebook_cell - PASSED/FAILED
+✅ delete_notebook_cell - PASSED/FAILED
+✅ list_notebook_cells - PASSED/FAILED
+
+Notes:
+[Any issues or observations]
+```

--- a/packages/opencode/src/notebook/index.ts
+++ b/packages/opencode/src/notebook/index.ts
@@ -1,0 +1,237 @@
+/**
+ * Jupyter Notebook (.ipynb) utility functions for OpenCode
+ * Handles parsing, validating, and manipulating Jupyter notebook JSON structure
+ */
+
+export type CellType = "code" | "markdown" | "raw"
+
+export interface NotebookCell {
+  cell_type: CellType
+  metadata: Record<string, any>
+  source: string | string[]
+  execution_count?: number | null
+  outputs?: Array<{
+    output_type: string
+    [key: string]: any
+  }>
+}
+
+export interface NotebookMetadata {
+  language_info?: {
+    name: string
+    [key: string]: any
+  }
+  kernelspec?: {
+    name: string
+    display_name: string
+    [key: string]: any
+  }
+  [key: string]: any
+}
+
+export interface Notebook {
+  cells: NotebookCell[]
+  metadata: NotebookMetadata
+  nbformat: number
+  nbformat_minor: number
+}
+
+export interface NotebookParseResult {
+  success: boolean
+  notebook?: Notebook
+  error?: string
+}
+
+/**
+ * Validates if a file is a valid Jupyter notebook
+ */
+export function isValidNotebook(content: string): boolean {
+  try {
+    const data = JSON.parse(content)
+    return (
+      typeof data === "object" &&
+      data !== null &&
+      "cells" in data &&
+      Array.isArray(data.cells) &&
+      "nbformat" in data &&
+      "metadata" in data
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse notebook JSON content
+ */
+export function parseNotebook(content: string): NotebookParseResult {
+  try {
+    const data = JSON.parse(content)
+    
+    if (!isValidNotebook(content)) {
+      return {
+        success: false,
+        error: "Invalid notebook format: missing required fields (cells, nbformat, metadata)"
+      }
+    }
+
+    return {
+      success: true,
+      notebook: data as Notebook
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to parse notebook JSON: ${error instanceof Error ? error.message : String(error)}`
+    }
+  }
+}
+
+/**
+ * Convert notebook back to JSON string
+ */
+export function stringifyNotebook(notebook: Notebook): string {
+  return JSON.stringify(notebook, null, 2)
+}
+
+/**
+ * Normalize cell source to string (handles both string and string[] formats)
+ */
+export function normalizeSource(source: string | string[]): string {
+  if (Array.isArray(source)) {
+    return source.join("")
+  }
+  return source
+}
+
+/**
+ * Convert source to array format (preferred format)
+ */
+export function sourceToArray(source: string | string[]): string[] {
+  if (Array.isArray(source)) {
+    return source
+  }
+  return source.split(/(?<=\n)/)
+}
+
+/**
+ * Get cell by index
+ */
+export function getCell(notebook: Notebook, index: number): NotebookCell | null {
+  if (index < 0 || index >= notebook.cells.length) {
+    return null
+  }
+  return notebook.cells[index]
+}
+
+/**
+ * Add a new cell at the specified position
+ */
+export function addCell(
+  notebook: Notebook,
+  cellType: CellType,
+  source: string,
+  position?: number
+): Notebook {
+  const newCell: NotebookCell = {
+    cell_type: cellType,
+    metadata: {},
+    source: sourceToArray(source)
+  }
+
+  if (cellType === "code") {
+    newCell.execution_count = null
+    newCell.outputs = []
+  }
+
+  const cells = [...notebook.cells]
+  if (position === undefined || position === cells.length) {
+    cells.push(newCell)
+  } else {
+    cells.splice(position, 0, newCell)
+  }
+
+  return {
+    ...notebook,
+    cells
+  }
+}
+
+/**
+ * Edit cell at specified index
+ */
+export function editCell(
+  notebook: Notebook,
+  index: number,
+  source: string
+): Notebook {
+  if (index < 0 || index >= notebook.cells.length) {
+    throw new Error(`Cell index ${index} out of bounds`)
+  }
+
+  const cells = [...notebook.cells]
+  cells[index] = {
+    ...cells[index],
+    source: sourceToArray(source)
+  }
+
+  return {
+    ...notebook,
+    cells
+  }
+}
+
+/**
+ * Delete cell at specified index
+ */
+export function deleteCell(notebook: Notebook, index: number): Notebook {
+  if (index < 0 || index >= notebook.cells.length) {
+    throw new Error(`Cell index ${index} out of bounds`)
+  }
+
+  const cells = notebook.cells.filter((_, i) => i !== index)
+
+  return {
+    ...notebook,
+    cells
+  }
+}
+
+/**
+ * Format cell information for display
+ */
+export function formatCellInfo(cell: NotebookCell, index: number): string {
+  const source = normalizeSource(cell.source)
+  const preview = source.split("\n")[0].trim().slice(0, 50)
+  const cellType = cell.cell_type.toUpperCase()
+  
+  let info = `[${index}] ${cellType}`
+  
+  if (cell.cell_type === "code") {
+    info += ` [exec: ${cell.execution_count ?? "not run"}]`
+  }
+  
+  if (preview) {
+    info += `: ${preview}${source.length > 50 ? "..." : ""}`
+  }
+  
+  return info
+}
+
+/**
+ * Get notebook summary
+ */
+export function getNotebookSummary(notebook: Notebook): string {
+  const codeCells = notebook.cells.filter(c => c.cell_type === "code").length
+  const markdownCells = notebook.cells.filter(c => c.cell_type === "markdown").length
+  const rawCells = notebook.cells.filter(c => c.cell_type === "raw").length
+  
+  const language = notebook.metadata.language_info?.name || "unknown"
+  
+  return `Notebook (${notebook.nbformat}.${notebook.nbformat_minor})` +
+         `\nLanguage: ${language}` +
+         `\nTotal cells: ${notebook.cells.length}` +
+         `  • Code: ${codeCells}` +
+         `  • Markdown: ${markdownCells}` +
+         `  • Raw: ${rawCells}`
+}

--- a/packages/opencode/src/tool/add-notebook-cell.ts
+++ b/packages/opencode/src/tool/add-notebook-cell.ts
@@ -1,0 +1,157 @@
+import z from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { FileTime } from "../file/time"
+import { Instance } from "../project/instance"
+import { Bus } from "../bus"
+import { File } from "../file"
+import { FileWatcher } from "../file/watcher"
+import { Snapshot } from "@/snapshot"
+import { assertExternalDirectory } from "./external-directory"
+import {
+  parseNotebook,
+  stringifyNotebook,
+  addCell,
+  getNotebookSummary,
+  type Notebook,
+  type CellType
+} from "../notebook"
+
+const DESCRIPTION = `
+Add a new cell to a Jupyter notebook (.ipynb) file.
+
+This tool creates a new cell and inserts it at the specified position.
+If no position is specified, the cell is added at the end of the notebook.
+
+Parameters:
+- filePath: Path to the .ipynb file
+- cellType: Type of cell to create (code, markdown, or raw)
+- source: Content for the new cell
+- position: (optional) Zero-based index where to insert the cell
+
+Examples:
+- Add code cell at end: cellType="code", source="print('hello')"
+- Add markdown at position 0: cellType="markdown", source="# Title", position=0
+`.trim()
+
+export const AddNotebookCellTool = Tool.define("add_notebook_cell", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    filePath: z.string().describe("The absolute path to the .ipynb file"),
+    cellType: z.enum(["code", "markdown", "raw"])
+      .describe("Type of cell to create"),
+    source: z.string().describe("Content for the new cell"),
+    position: z.number().int().min(0).optional()
+      .describe("Zero-based index where to insert (default: at end)"),
+  }),
+  async execute(params, ctx) {
+    if (!params.filePath) {
+      throw new Error("filePath is required")
+    }
+
+    const filePath = path.isAbsolute(params.filePath) 
+      ? params.filePath 
+      : path.join(Instance.directory, params.filePath)
+    
+    await assertExternalDirectory(ctx, filePath)
+    
+    const file = Bun.file(filePath)
+    const stats = await file.stat().catch(() => {})
+    
+    if (!stats) {
+      throw new Error(`File not found: ${filePath}`)
+    }
+    
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory, not a file: ${filePath}`)
+    }
+
+    await FileTime.assert(ctx.sessionID, filePath)
+    const contentOld = await file.text()
+    
+    // Parse the notebook
+    const result = parseNotebook(contentOld)
+    
+    if (!result.success) {
+      throw new Error(`Failed to parse notebook: ${result.error}`)
+    }
+    
+    const notebook = result.notebook!
+    
+    // Validate position
+    if (params.position !== undefined && params.position > notebook.cells.length) {
+      throw new Error(
+        `Position ${params.position} out of bounds. ` +
+        `Notebook has ${notebook.cells.length} cells (valid range: 0-${notebook.cells.length})`
+      )
+    }
+    
+    // Add the new cell
+    const updatedNotebook = addCell(
+      notebook, 
+      params.cellType as CellType, 
+      params.source, 
+      params.position
+    )
+    const contentNew = stringifyNotebook(updatedNotebook)
+    
+    // Determine the actual position where the cell was inserted
+    const insertPosition = params.position ?? notebook.cells.length
+    
+    // Ask for permission
+    await ctx.ask({
+      permission: "edit",
+      patterns: [path.relative(Instance.worktree, filePath)],
+      always: ["*"],
+      metadata: {
+        filepath: filePath,
+        cellType: params.cellType,
+        position: insertPosition,
+        preview: params.source.slice(0, 100)
+      },
+    })
+    
+    // Write the updated notebook
+    await FileTime.withLock(filePath, async () => {
+      await file.write(contentNew)
+      await Bus.publish(File.Event.Edited, { file: filePath })
+      await Bus.publish(FileWatcher.Event.Updated, {
+        file: filePath,
+        event: "change"
+      })
+      FileTime.read(ctx.sessionID, filePath)
+    })
+    
+    // Calculate diff
+    const filediff: Snapshot.FileDiff = {
+      file: filePath,
+      before: contentOld,
+      after: contentNew,
+      additions: contentNew.split("\n").length - contentOld.split("\n").length,
+      deletions: 0,
+    }
+    
+    // Format output
+    const preview = params.source.slice(0, 100)
+    let output = `✓ Added ${params.cellType.toUpperCase()} cell at position ${insertPosition}\n`
+    output += `File: ${path.relative(Instance.worktree, filePath)}\n\n`
+    output += `Content:\n  ${preview}${params.source.length > 100 ? "..." : ""}\n`
+    output += `\n${getNotebookSummary(updatedNotebook)}`
+    
+    ctx.metadata({
+      metadata: {
+        filediff,
+        cellType: params.cellType,
+        position: insertPosition
+      }
+    })
+    
+    return {
+      metadata: {
+        filediff
+      },
+      title: path.relative(Instance.worktree, filePath),
+      output
+    }
+  }
+})

--- a/packages/opencode/src/tool/delete-notebook-cell.ts
+++ b/packages/opencode/src/tool/delete-notebook-cell.ts
@@ -1,0 +1,145 @@
+import z from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { FileTime } from "../file/time"
+import { Instance } from "../project/instance"
+import { Bus } from "../bus"
+import { File } from "../file"
+import { FileWatcher } from "../file/watcher"
+import { Snapshot } from "@/snapshot"
+import { assertExternalDirectory } from "./external-directory"
+import {
+  parseNotebook,
+  stringifyNotebook,
+  deleteCell,
+  getNotebookSummary,
+  normalizeSource,
+  type Notebook
+} from "../notebook"
+
+const DESCRIPTION = `
+Delete a cell from a Jupyter notebook (.ipynb) file.
+
+This tool removes a cell at the specified index permanently.
+Be careful - this action cannot be undone unless you have version control.
+
+Parameters:
+- filePath: Path to the .ipynb file
+- cellIndex: Zero-based index of the cell to delete
+
+Use read_notebook first to see the cell indices and their content before deleting.
+`.trim()
+
+export const DeleteNotebookCellTool = Tool.define("delete_notebook_cell", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    filePath: z.string().describe("The absolute path to the .ipynb file"),
+    cellIndex: z.number().int().min(0)
+      .describe("Zero-based index of the cell to delete"),
+  }),
+  async execute(params, ctx) {
+    if (!params.filePath) {
+      throw new Error("filePath is required")
+    }
+
+    const filePath = path.isAbsolute(params.filePath) 
+      ? params.filePath 
+      : path.join(Instance.directory, params.filePath)
+    
+    await assertExternalDirectory(ctx, filePath)
+    
+    const file = Bun.file(filePath)
+    const stats = await file.stat().catch(() => {})
+    
+    if (!stats) {
+      throw new Error(`File not found: ${filePath}`)
+    }
+    
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory, not a file: ${filePath}`)
+    }
+
+    await FileTime.assert(ctx.sessionID, filePath)
+    const contentOld = await file.text()
+    
+    // Parse the notebook
+    const result = parseNotebook(contentOld)
+    
+    if (!result.success) {
+      throw new Error(`Failed to parse notebook: ${result.error}`)
+    }
+    
+    const notebook = result.notebook!
+    
+    // Validate cell index
+    if (params.cellIndex >= notebook.cells.length) {
+      throw new Error(
+        `Cell index ${params.cellIndex} out of bounds. ` +
+        `Notebook has ${notebook.cells.length} cells (indices 0-${notebook.cells.length - 1})`
+      )
+    }
+    
+    // Get the cell info before deletion
+    const cellToDelete = notebook.cells[params.cellIndex]
+    const source = normalizeSource(cellToDelete.source)
+    
+    // Delete the cell
+    const updatedNotebook = deleteCell(notebook, params.cellIndex)
+    const contentNew = stringifyNotebook(updatedNotebook)
+    
+    // Ask for permission
+    await ctx.ask({
+      permission: "edit",
+      patterns: [path.relative(Instance.worktree, filePath)],
+      always: ["*"],
+      metadata: {
+        filepath: filePath,
+        cellIndex: params.cellIndex,
+        cellType: cellToDelete.cell_type,
+        deletedContent: source.slice(0, 100)
+      },
+    })
+    
+    // Write the updated notebook
+    await FileTime.withLock(filePath, async () => {
+      await file.write(contentNew)
+      await Bus.publish(File.Event.Edited, { file: filePath })
+      await Bus.publish(FileWatcher.Event.Updated, {
+        file: filePath,
+        event: "change"
+      })
+      FileTime.read(ctx.sessionID, filePath)
+    })
+    
+    // Calculate diff
+    const filediff: Snapshot.FileDiff = {
+      file: filePath,
+      before: contentOld,
+      after: contentNew,
+      additions: 0,
+      deletions: contentOld.split("\n").length - contentNew.split("\n").length,
+    }
+    
+    // Format output
+    let output = `✓ Deleted cell ${params.cellIndex} from ${path.relative(Instance.worktree, filePath)}\n\n`
+    output += `Deleted ${cellToDelete.cell_type.toUpperCase()} cell:\n`
+    output += `  ${source.slice(0, 100)}${source.length > 100 ? "..." : ""}\n`
+    output += `\n${getNotebookSummary(updatedNotebook)}`
+    
+    ctx.metadata({
+      metadata: {
+        filediff,
+        cellIndex: params.cellIndex,
+        cellType: cellToDelete.cell_type
+      }
+    })
+    
+    return {
+      metadata: {
+        filediff
+      },
+      title: path.relative(Instance.worktree, filePath),
+      output
+    }
+  }
+})

--- a/packages/opencode/src/tool/edit-notebook-cell.ts
+++ b/packages/opencode/src/tool/edit-notebook-cell.ts
@@ -1,0 +1,169 @@
+import z from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { FileTime } from "../file/time"
+import { Instance } from "../project/instance"
+import { Bus } from "../bus"
+import { File } from "../file"
+import { FileWatcher } from "../file/watcher"
+import { Snapshot } from "@/snapshot"
+import { assertExternalDirectory } from "./external-directory"
+import {
+  parseNotebook,
+  stringifyNotebook,
+  editCell,
+  getNotebookSummary,
+  normalizeSource,
+  type Notebook
+} from "../notebook"
+
+const DESCRIPTION = `
+Edit a specific cell in a Jupyter notebook (.ipynb) file.
+
+This tool allows you to modify the content of a specific cell while preserving:
+- Cell metadata
+- Cell type (code, markdown, raw)
+- Execution counts
+- Cell outputs (for code cells)
+- All other cells in the notebook
+
+Parameters:
+- filePath: Path to the .ipynb file
+- cellIndex: Zero-based index of the cell to edit (0 = first cell)
+- newSource: New content for the cell
+
+Use read_notebook first to see the cell indices and their content.
+`.trim()
+
+export const EditNotebookCellTool = Tool.define("edit_notebook_cell", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    filePath: z.string().describe("The absolute path to the .ipynb file"),
+    cellIndex: z.number().int().min(0)
+      .describe("Zero-based index of the cell to edit"),
+    newSource: z.string().describe("New content for the cell"),
+  }),
+  async execute(params, ctx) {
+    if (!params.filePath) {
+      throw new Error("filePath is required")
+    }
+
+    const filePath = path.isAbsolute(params.filePath) 
+      ? params.filePath 
+      : path.join(Instance.directory, params.filePath)
+    
+    await assertExternalDirectory(ctx, filePath)
+    
+    const file = Bun.file(filePath)
+    const stats = await file.stat().catch(() => {})
+    
+    if (!stats) {
+      throw new Error(`File not found: ${filePath}`)
+    }
+    
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory, not a file: ${filePath}`)
+    }
+
+    await FileTime.assert(ctx.sessionID, filePath)
+    const contentOld = await file.text()
+    
+    // Parse the notebook
+    const result = parseNotebook(contentOld)
+    
+    if (!result.success) {
+      throw new Error(`Failed to parse notebook: ${result.error}`)
+    }
+    
+    const notebook = result.notebook!
+    
+    // Validate cell index
+    if (params.cellIndex >= notebook.cells.length) {
+      throw new Error(
+        `Cell index ${params.cellIndex} out of bounds. ` +
+        `Notebook has ${notebook.cells.length} cells (indices 0-${notebook.cells.length - 1})`
+      )
+    }
+    
+    // Get the old cell info for the diff
+    const oldCell = notebook.cells[params.cellIndex]
+    const oldSource = normalizeSource(oldCell.source)
+    
+    // Edit the cell
+    const updatedNotebook = editCell(notebook, params.cellIndex, params.newSource)
+    const contentNew = stringifyNotebook(updatedNotebook)
+    
+    // Ask for permission
+    await ctx.ask({
+      permission: "edit",
+      patterns: [path.relative(Instance.worktree, filePath)],
+      always: ["*"],
+      metadata: {
+        filepath: filePath,
+        cellIndex: params.cellIndex,
+        cellType: oldCell.cell_type,
+        oldPreview: oldSource.slice(0, 100),
+        newPreview: params.newSource.slice(0, 100)
+      },
+    })
+    
+    // Write the updated notebook
+    await FileTime.withLock(filePath, async () => {
+      await file.write(contentNew)
+      await Bus.publish(File.Event.Edited, { file: filePath })
+      await Bus.publish(FileWatcher.Event.Updated, {
+        file: filePath,
+        event: "change"
+      })
+      FileTime.read(ctx.sessionID, filePath)
+    })
+    
+    // Calculate diff
+    const filediff: Snapshot.FileDiff = {
+      file: filePath,
+      before: contentOld,
+      after: contentNew,
+      additions: 0,
+      deletions: 0,
+    }
+    
+    // Simple line-based diff for summary
+    const oldLines = contentOld.split("\n")
+    const newLines = contentNew.split("\n")
+    
+    for (let i = 0; i < Math.max(oldLines.length, newLines.length); i++) {
+      if (oldLines[i] !== newLines[i]) {
+        if (i < newLines.length && oldLines[i] !== newLines[i]) {
+          filediff.additions++
+        }
+        if (i < oldLines.length && oldLines[i] !== newLines[i]) {
+          filediff.deletions++
+        }
+      }
+    }
+    
+    // Format output
+    const updatedCell = updatedNotebook.cells[params.cellIndex]
+    let output = `✓ Edited cell ${params.cellIndex} in ${path.relative(Instance.worktree, filePath)}\n\n`
+    output += `Cell type: ${updatedCell.cell_type.toUpperCase()}\n`
+    output += `Old content:\n  ${oldSource.slice(0, 100)}${oldSource.length > 100 ? "..." : ""}\n`
+    output += `New content:\n  ${params.newSource.slice(0, 100)}${params.newSource.length > 100 ? "..." : ""}\n`
+    output += `\n${getNotebookSummary(updatedNotebook)}`
+    
+    ctx.metadata({
+      metadata: {
+        filediff,
+        cellIndex: params.cellIndex,
+        cellType: updatedCell.cell_type
+      }
+    })
+    
+    return {
+      metadata: {
+        filediff
+      },
+      title: path.relative(Instance.worktree, filePath),
+      output
+    }
+  }
+})

--- a/packages/opencode/src/tool/list-notebook-cells.ts
+++ b/packages/opencode/src/tool/list-notebook-cells.ts
@@ -1,0 +1,131 @@
+import z from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { FileTime } from "../file/time"
+import { Instance } from "../project/instance"
+import { assertExternalDirectory } from "./external-directory"
+import {
+  parseNotebook,
+  formatCellInfo,
+  normalizeSource,
+  type Notebook
+} from "../notebook"
+
+const DESCRIPTION = `
+List all cells in a Jupyter notebook (.ipynb) file.
+
+This tool provides a quick overview of all cells with their indices,
+types, and content previews. Useful for navigating large notebooks.
+
+Parameters:
+- filePath: Path to the .ipynb file
+- cellType: (optional) Filter by cell type (code, markdown, raw)
+- maxPreviewLength: Maximum length of content preview (default 80)
+
+Output shows:
+- Cell index (for use with edit/delete operations)
+- Cell type
+- Content preview
+- Execution count (for code cells)
+`.trim()
+
+export const ListNotebookCellsTool = Tool.define("list_notebook_cells", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    filePath: z.string().describe("The absolute path to the .ipynb file"),
+    cellType: z.enum(["code", "markdown", "raw"]).optional()
+      .describe("Filter by cell type (optional)"),
+    maxPreviewLength: z.number().optional().default(80)
+      .describe("Maximum length of content preview"),
+  }),
+  async execute(params, ctx) {
+    if (!params.filePath) {
+      throw new Error("filePath is required")
+    }
+
+    const filePath = path.isAbsolute(params.filePath) 
+      ? params.filePath 
+      : path.join(Instance.directory, params.filePath)
+    
+    await assertExternalDirectory(ctx, filePath)
+    
+    const file = Bun.file(filePath)
+    const stats = await file.stat().catch(() => {})
+    
+    if (!stats) {
+      throw new Error(`File not found: ${filePath}`)
+    }
+    
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory, not a file: ${filePath}`)
+    }
+
+    await FileTime.assert(ctx.sessionID, filePath)
+    const content = await file.text()
+    
+    // Parse the notebook
+    const result = parseNotebook(content)
+    
+    if (!result.success) {
+      throw new Error(`Failed to parse notebook: ${result.error}`)
+    }
+    
+    const notebook = result.notebook!
+    
+    // Filter cells if requested
+    let cells = notebook.cells
+    if (params.cellType) {
+      cells = cells.filter(c => c.cell_type === params.cellType)
+    }
+    
+    // Build output
+    let output = `📓 ${path.relative(Instance.worktree, filePath)}\n`
+    output += `${"─".repeat(80)}\n\n`
+    
+    if (params.cellType) {
+      output += `Showing ${params.cellType.toUpperCase()} cells only\n`
+    }
+    
+    output += `Total cells: ${cells.length} / ${notebook.cells.length}\n\n`
+    
+    if (cells.length === 0) {
+      output += "No cells found"
+      if (params.cellType) {
+        output += ` (filtering by ${params.cellType})`
+      }
+      output += "\n"
+    } else {
+      cells.forEach((cell, notebookIndex) => {
+        // Find actual index in notebook
+        const actualIndex = notebook.cells.indexOf(cell)
+        output += formatCellInfo(cell, actualIndex) + "\n"
+        
+        // Add content preview
+        const source = normalizeSource(cell.source)
+        if (source.trim()) {
+          const lines = source.split("\n")
+          const preview = lines[0].trim().slice(0, params.maxPreviewLength)
+          output += `  ${preview}${lines[0].length > params.maxPreviewLength ? "..." : ""}\n`
+          
+          // Show line count if multiline
+          if (lines.length > 1) {
+            output += `  (${lines.length} lines total)\n`
+          }
+        }
+        
+        output += "\n"
+      })
+    }
+    
+    FileTime.read(ctx.sessionID, filePath)
+    
+    return {
+      metadata: {
+        cellCount: cells.length,
+        filteredBy: params.cellType
+      },
+      title: path.relative(Instance.worktree, filePath),
+      output
+    }
+  }
+})<arg_value>

--- a/packages/opencode/src/tool/read-notebook.ts
+++ b/packages/opencode/src/tool/read-notebook.ts
@@ -1,0 +1,150 @@
+import z from "zod"
+import * as path from "path"
+import { Tool } from "./tool"
+import { FileTime } from "../file/time"
+import { Instance } from "../project/instance"
+import { assertExternalDirectory } from "./external-directory"
+import { 
+  parseNotebook, 
+  getNotebookSummary, 
+  formatCellInfo,
+  normalizeSource,
+  type Notebook 
+} from "../notebook"
+
+const DESCRIPTION = `
+Read and parse a Jupyter notebook (.ipynb) file.
+
+This tool reads a Jupyter notebook file and displays:
+- Notebook metadata (format version, language, kernel info)
+- Cell summary (total cells, breakdown by type)
+- Detailed information for each cell including:
+  - Cell type (code, markdown, raw)
+  - Source content preview
+  - Execution count (for code cells)
+  - Outputs (for code cells)
+
+Use this tool to explore the structure and content of Jupyter notebooks before making edits.
+`.trim()
+
+export const ReadNotebookTool = Tool.define("read_notebook", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    filePath: z.string().describe("The absolute path to the .ipynb file to read"),
+    maxPreviewLength: z.number().optional().default(200)
+      .describe("Maximum length of cell source to display (default 200)"),
+  }),
+  async execute(params, ctx) {
+    if (!params.filePath) {
+      throw new Error("filePath is required")
+    }
+
+    const filePath = path.isAbsolute(params.filePath) 
+      ? params.filePath 
+      : path.join(Instance.directory, params.filePath)
+    
+    await assertExternalDirectory(ctx, filePath)
+    
+    const file = Bun.file(filePath)
+    const stats = await file.stat().catch(() => {})
+    
+    if (!stats) {
+      throw new Error(`File not found: ${filePath}`)
+    }
+    
+    if (stats.isDirectory()) {
+      throw new Error(`Path is a directory, not a file: ${filePath}`)
+    }
+
+    // Check if file extension is .ipynb
+    if (!filePath.toLowerCase().endsWith(".ipynb")) {
+      ctx.metadata({
+        metadata: {
+          warning: "File does not have .ipynb extension"
+        }
+      })
+    }
+
+    await FileTime.assert(ctx.sessionID, filePath)
+    const content = await file.text()
+    
+    // Parse the notebook
+    const result = parseNotebook(content)
+    
+    if (!result.success) {
+      throw new Error(`Failed to parse notebook: ${result.error}`)
+    }
+    
+    const notebook = result.notebook!
+    
+    // Build output
+    let output = ""
+    
+    // Add file info
+    output += `📓 ${path.relative(Instance.worktree, filePath)}\n`
+    output += `${"─".repeat(60)}\n\n`
+    
+    // Add summary
+    output += getNotebookSummary(notebook)
+    output += "\n\n"
+    
+    // Add metadata
+    if (notebook.metadata.kernelspec) {
+      output += `Kernel: ${notebook.metadata.kernelspec.display_name} ` +
+                `(${notebook.metadata.kernelspec.name})\n`
+    }
+    
+    // Add cell details
+    output += `\n${"═".repeat(60)}\n`
+    output += "CELLS\n"
+    output += `${"═".repeat(60)}\n\n`
+    
+    notebook.cells.forEach((cell, index) => {
+      output += formatCellInfo(cell, index)
+      output += "\n"
+      
+      // Add source preview
+      const source = normalizeSource(cell.source)
+      if (source.trim()) {
+        const preview = source.slice(0, params.maxPreviewLength)
+        output += "```"
+        if (cell.cell_type === "code" && notebook.metadata.language_info?.name) {
+          output += notebook.metadata.language_info.name
+        }
+        output += "\n"
+        output += preview
+        if (source.length > params.maxPreviewLength) {
+          output += "\n... (truncated)"
+        }
+        output += "\n```\n"
+      }
+      
+      // Add outputs for code cells
+      if (cell.cell_type === "code" && cell.outputs && cell.outputs.length > 0) {
+        output += "Outputs:\n"
+        cell.outputs.forEach((output, i) => {
+          output += `  [${i}] ${output.output_type}\n`
+          if ("text" in output) {
+            output += `    ${String(output.text).slice(0, 100)}\n`
+          }
+        })
+      }
+      
+      output += "\n"
+    })
+    
+    FileTime.read(ctx.sessionID, filePath)
+    
+    return {
+      metadata: {
+        notebook: {
+          cellCount: notebook.cells.length,
+          language: notebook.metadata.language_info?.name,
+          format: `${notebook.nbformat}.${notebook.nbformat_minor}`
+        }
+      },
+      title: path.relative(Instance.worktree, filePath),
+      output
+    }
+  }
+})


### PR DESCRIPTION
    ## Summary
     Add comprehensive support for editing Jupyter notebooks with 5 new tools:
     - `read_notebook`: Parse and display notebook structure and content
     - `edit_notebook_cell`: Edit specific cells while preserving metadata
     - `add_notebook_cell`: Insert new cells at any position
     - `delete_notebook_cell`: Remove cells from notebooks
     - `list_notebook_cells`: Quick overview of all cells

     ## Features
     - Full JSON structure validation and preservation
     - Supports code, markdown, and raw cell types
     - Maintains execution counts and outputs
     - Cell metadata and language info preserved
     - Compatible with Jupyter notebook format 4.x+
