### PR TITLE
fix: don't --follow by default for grep and other things using ripgrep

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -214,8 +214,8 @@ export namespace Ripgrep {
     input.signal?.throwIfAborted()
 
     const args = [await filepath(), "--files", "--glob=!.git/*"]
-    if (input.follow !== false) args.push("--follow")
-    if (input.hidden !== false) args.push("--hidden")
+    if (input.follow) args.push("--follow")
+    if (input.hidden) args.push("--hidden")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
     if (input.glob) {
       for (const g of input.glob) {
@@ -381,7 +381,7 @@ export namespace Ripgrep {
     follow?: boolean
   }) {
     const args = [`${await filepath()}`, "--json", "--hidden", "--glob='!.git/*'"]
-    if (input.follow !== false) args.push("--follow")
+    if (input.follow) args.push("--follow")
 
     if (input.glob) {
       for (const g of input.glob) {

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -37,15 +37,7 @@ export const GrepTool = Tool.define("grep", {
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()
-    const args = [
-      "-nH",
-      "--hidden",
-      "--follow",
-      "--no-messages",
-      "--field-match-separator=|",
-      "--regexp",
-      params.pattern,
-    ]
+    const args = ["-nH", "--hidden", "--no-messages", "--field-match-separator=|", "--regexp", params.pattern]
     if (params.include) {
       args.push("--glob", params.include)
     }


### PR DESCRIPTION
fixes: #9676

(Not following symlinks is the default behaviour of almost all traditional UNIX CLI tools)


