### PR TITLE
fix(opencode): keep session loop running after tool parts

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -293,11 +293,25 @@ export namespace SessionPrompt {
       }
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
-      if (
-        lastAssistant?.finish &&
-        !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
-        lastUser.id < lastAssistant.id
-      ) {
+      const complete = iife(() => {
+        if (!lastAssistant?.finish) return false
+        if (lastUser.id >= lastAssistant.id) return false
+        if (lastAssistant.finish === "tool-calls") return false
+        const msg = msgs.findLast((m) => m.info.role === "assistant")
+        const hasText = msg?.parts.some((p) => p.type === "text") ?? false
+        const hasTool = msg?.parts.some((p) => p.type === "tool") ?? false
+
+        // Some providers may return `stop` (or other finish reasons) while still emitting tool calls.
+        // If the last assistant message contains any tool parts, keep looping so the model can consume
+        // tool results and produce a final response.
+        if (hasTool) return false
+
+        if (lastAssistant.finish !== "unknown") return true
+        if (!msg) return true
+        return hasText || !hasTool
+      })
+
+      if (complete) {
         log.info("exiting loop", { sessionID })
         break
       }

--- a/packages/opencode/test/session/prompt-loop.test.ts
+++ b/packages/opencode/test/session/prompt-loop.test.ts
@@ -12,7 +12,9 @@ const { Session } = await import("../../src/session")
 const { SessionPrompt } = await import("../../src/session/prompt")
 
 describe("SessionPrompt.loop", () => {
-  test("exits when assistant finish is unknown but text exists", async () => {
+  test(
+    "exits when assistant finish is unknown but text exists",
+    async () => {
     await Instance.provide({
       directory: projectRoot,
       fn: async () => {
@@ -62,10 +64,7 @@ describe("SessionPrompt.loop", () => {
             time: { start: Date.now(), end: Date.now() },
           })
 
-          const result = (await Promise.race([
-            SessionPrompt.loop(session.id),
-            new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 1_000)),
-          ])) as Awaited<ReturnType<typeof SessionPrompt.loop>>
+          const result = (await SessionPrompt.loop(session.id)) as Awaited<ReturnType<typeof SessionPrompt.loop>>
 
           expect(result.info.id).toBe(assistantId)
         } finally {
@@ -73,5 +72,7 @@ describe("SessionPrompt.loop", () => {
         }
       },
     })
-  })
+    },
+    20_000,
+  )
 })

--- a/packages/opencode/test/session/prompt-loop.test.ts
+++ b/packages/opencode/test/session/prompt-loop.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const projectRoot = path.join(__dirname, "../..")
+
+// Ensure isolated XDG dirs even when running this test file directly.
+await import("../preload")
+
+const { Identifier } = await import("../../src/id/id")
+const { Instance } = await import("../../src/project/instance")
+const { Session } = await import("../../src/session")
+const { SessionPrompt } = await import("../../src/session/prompt")
+
+describe("SessionPrompt.loop", () => {
+  test("exits when assistant finish is unknown but text exists", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const session = await Session.create({})
+
+        try {
+          const userId = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: userId,
+            sessionID: session.id,
+            role: "user",
+            time: { created: Date.now() },
+            agent: "sisyphus",
+            model: { providerID: "anthropic", modelID: "claude-sonnet-4-5" },
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: userId,
+            sessionID: session.id,
+            type: "text",
+            text: "ping",
+            time: { start: Date.now(), end: Date.now() },
+          })
+
+          const assistantId = Identifier.ascending("message")
+          await Session.updateMessage({
+            id: assistantId,
+            parentID: userId,
+            role: "assistant",
+            mode: "sisyphus",
+            agent: "sisyphus",
+            path: { cwd: Instance.directory, root: Instance.worktree },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            finish: "unknown",
+            modelID: "claude-sonnet-4-5",
+            providerID: "anthropic",
+            time: { created: Date.now(), completed: Date.now() },
+            sessionID: session.id,
+          })
+          await Session.updatePart({
+            id: Identifier.ascending("part"),
+            messageID: assistantId,
+            sessionID: session.id,
+            type: "text",
+            text: "pong",
+            time: { start: Date.now(), end: Date.now() },
+          })
+
+          const result = (await Promise.race([
+            SessionPrompt.loop(session.id),
+            new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 1_000)),
+          ])) as Awaited<ReturnType<typeof SessionPrompt.loop>>
+
+          expect(result.info.id).toBe(assistantId)
+        } finally {
+          await Session.remove(session.id)
+        }
+      },
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
When using the Anthropic provider behind an Anthropic-compatible gateway/proxy, the model may return `finish_reason=stop` while the assistant message still contains tool parts. In that case OpenCode could exit the session loop right after tool execution, so the model never gets a follow-up turn to consume tool results and produce the final text reply.

This change keeps the session loop running whenever the latest assistant message contains tool parts, allowing the model to produce the final response.

Fixes #11417

### How did you verify your code works?
- `bun test test/session/prompt-loop.test.ts`
- Manually reproduced with prompts that trigger multiple MCP tool calls (serial and parallel) and verified a final one-line response is produced after tools complete.