### PR TITLE
fix(desktop): user prompt message animation lags on close

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -335,6 +335,16 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
     updateCanExpand()
   })
 
+  createEffect(() => {
+    const el = textRef
+    if (!el) return
+    if (expanded()) {
+      el.style.maxHeight = el.scrollHeight + "px"
+    } else {
+      el.style.maxHeight = ""
+    }
+  })
+
   const files = createMemo(() => (props.parts?.filter((p) => p.type === "file") as FilePart[]) ?? [])
 
   const attachments = createMemo(() =>

--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -105,10 +105,6 @@
     transition: max-height 200ms cubic-bezier(0.25, 0, 0.5, 1);
   }
 
-  [data-component="user-message"][data-expanded="true"] [data-slot="user-message-text"] {
-    max-height: 2000px;
-  }
-
   [data-component="user-message"][data-can-expand="true"] [data-slot="user-message-text"] {
     padding-right: 36px;
     padding-bottom: 28px;


### PR DESCRIPTION
### What does this PR do?

This PR fixes the animation when closing expanded messages. On dev, the expanded user messages used max-height: 2000px in CSS. When collapsing, the browser animated from 2000px → 64px (collaped height). If the expanded height was a lot smaller than 2000px, there was quite a bit of "dead" space where nothing visibly moved, making it feel laggy.

The fix sets maxHeight to the element's actual scrollHeight via JS. Now the animation starts immediately from the real content height, eliminating the perceived delay.

Fixes #11419.

### How did you verify your code works?

Testing on the desktop.

#### Before

https://github.com/user-attachments/assets/bd1f47db-967d-4fa8-9eab-34d58463a97f

#### After

https://github.com/user-attachments/assets/6f06a9a4-b261-4686-9129-6815ae189af0


