### PR TITLE
docs: add OpenWork Enterprise to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -63,6 +63,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embedds OpenCode in Obsidian's UI           |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
+| [OpenWork Enterprise](https://github.com/different-ai/openwork-enterprise)                 | Automation-first workflows, skills, and runbooks for OpenWork    |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
 


### PR DESCRIPTION
## Summary
- add OpenWork Enterprise to the ecosystem projects list