### PR TITLE
docs: fix documentation issues

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -100,7 +100,7 @@ const TIPS = [
   'Set {highlight}"formatter": false{/highlight} in config to disable all auto-formatting',
   "Define custom formatter commands with file extensions in config",
   "OpenCode uses LSP servers for intelligent code analysis",
-  "Create {highlight}.ts{/highlight} files in {highlight}.opencode/tool/{/highlight} to define new LLM tools",
+  "Create {highlight}.ts{/highlight} files in {highlight}.opencode/tools/{/highlight} to define new LLM tools",
   "Tool definitions can invoke scripts written in Python, Go, etc",
   "Add {highlight}.ts{/highlight} files to {highlight}.opencode/plugin/{/highlight} for event hooks",
   "Use plugins to send OS notifications when sessions complete",

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -87,6 +87,50 @@ Let's look at some examples.
 
 ---
 
+### Environment variables
+
+Use the `env` property to set environment variables when starting the LSP server:
+
+```json title="opencode.json" {5-7}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "rust": {
+      "env": {
+        "RUST_LOG": "debug"
+      }
+    }
+  }
+}
+```
+
+---
+
+### Initialization options
+
+Use the `initialization` property to pass initialization options to the LSP server. These are server-specific settings sent during the LSP `initialize` request:
+
+```json title="opencode.json" {5-9}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "lsp": {
+    "typescript": {
+      "initialization": {
+        "preferences": {
+          "importModuleSpecifierPreference": "relative"
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+Initialization options vary by LSP server. Check your LSP server's documentation for available options.
+:::
+
+---
+
 ### Disabling LSP servers
 
 To disable **all** LSP servers globally, set `lsp` to `false`:

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1222,6 +1222,10 @@ To use Kimi K2 from Moonshot AI:
 
 You can configure opencode to use local models through Ollama.
 
+:::tip
+Ollama can automatically configure itself for OpenCode. See the [Ollama integration docs](https://docs.ollama.com/integrations/opencode) for details.
+:::
+
 ```json title="opencode.json" "ollama" {5, 6, 8, 10-14}
 {
   "$schema": "https://opencode.ai/config.json",


### PR DESCRIPTION
## Summary

This PR fixes three documentation-related issues:

### Changes

1. **Fix #10343**: Change `.opencode/tool/` to `.opencode/tools/` in TUI tips
   - The tip was showing the wrong path for custom tools directory
   - Updated to match the official documentation

2. **Fix #10768**: Add Ollama auto config documentation link
   - Added a tip pointing to Ollama's integration docs for automatic configuration

3. **Fix #10978**: Add `env` and `initialization` examples for LSP config
   - The LSP documentation mentioned these options but had no examples
   - Added clear examples showing how to use both properties

### Testing

- `bun run typecheck` passes locally

Closes #10343
Closes #10768
Closes #10978