### PR TITLE
fix: add fallback for when crypto.randomUUID is unavailable

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -336,7 +336,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       const dataUrl = reader.result as string
       const attachment: ImageAttachmentPart = {
         type: "image",
-        id: crypto.randomUUID(),
+        id: crypto.randomUUID?.() ?? Math.random().toString(16).slice(2),
         filename: file.name,
         mime: file.type,
         dataUrl,


### PR DESCRIPTION
The web app uses crypto.randomUUID for generating an ID of every file attachment. Unfortunately, crypto.randomUUID is only available in "secure contexts" (https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID). This prevents users from uploading files in opencode when running inside internal networks, over HTTP. The security concern here is very weak: this is simply an identifier for the file, and setting up SSL certificates inside the internal network is a pain.

The solution here is identical to what is already implemented elsewhere in the app: https://github.com/anomalyco/opencode/blob/f834915d3fbcf05137fc61fc51b9fa07b815e82c/packages/app/src/utils/perf.ts#L19 , and is simple: if randomUUID isn't available, we're using Math.random to generate the file ID.

Fixes #11452 