### PR TITLE
fix(pty): Add UTF-8 encoding defaults for Windows PTY

### DIFF
--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -108,6 +108,12 @@ export namespace Pty {
       TERM: "xterm-256color",
       OPENCODE_TERMINAL: "1",
     } as Record<string, string>
+
+    if (process.platform === "win32") {
+      env.LC_ALL = "C.UTF-8"
+      env.LC_CTYPE = "C.UTF-8"
+      env.LANG = "C.UTF-8"
+    }
     log.info("creating session", { id, cmd: command, args, cwd })
 
     const spawn = await pty()


### PR DESCRIPTION
## Fix Chinese Character Display Issues in Windows PTY

### Problem Description
This PR fixes issue #9793 where Chinese characters are displayed as garbled text in CLI mode on Windows terminals.
Fixes #9793

### Root Cause
The Windows PTY process was missing UTF-8 encoding environment variables, causing CJK characters to render incorrectly.

### Solution
Set UTF-8 encoding environment variables for Windows platform:
- LC_ALL=C.UTF-8
- LC_CTYPE=C.UTF-8
- LANG=C.UTF-8

### Related Issues
- #9793: Chinese characters displayed as garbled text in CLI mode
- #9790: Process killed with garbled output when dragging terminal window
- #9787: Occasional process killed with garbled output
- #8410: TUI icons show as garbage characters on Windows 10
- #7891: OpenCode TUI Chinese Text Display Issue

### Related PR
- #10489: fix(pty): Add UTF-8 defaults for Windows PTY

### Changes
- Modified packages/opencode/src/pty/index.ts to add UTF-8 locale settings for Windows

### Testing
Test Chinese character display in Windows PowerShell terminal to verify the fix works correctly.