### PR TITLE
fix: address tool/plugin issues #11413, #11130, #11436

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -18,6 +18,7 @@ import {
   modify,
   parse as parseJsonc,
   printParseErrorCode,
+  visit as visitJsonc,
 } from "jsonc-parser"
 import { Instance } from "../project/instance"
 import { LSPServer } from "../lsp/server"
@@ -1190,8 +1191,27 @@ export namespace Config {
     }
 
     const errors: JsoncParseError[] = []
+    const duplicateKeys: { key: string; offset: number }[] = []
+    const keyStack: string[][] = [[]]
+    visitJsonc(text, {
+      onObjectBegin() {
+        keyStack.push([])
+      },
+      onObjectEnd() {
+        keyStack.pop()
+      },
+      onObjectProperty(property, offset) {
+        const currentLevel = keyStack[keyStack.length - 1]
+        if (currentLevel.includes(property)) {
+          duplicateKeys.push({ key: property, offset })
+        } else {
+          currentLevel.push(property)
+        }
+      },
+    })
+
     const data = parseJsonc(text, errors, { allowTrailingComma: true })
-    if (errors.length) {
+    if (errors.length || duplicateKeys.length) {
       const lines = text.split("\n")
       const errorDetails = errors
         .map((e) => {
@@ -1207,9 +1227,25 @@ export namespace Config {
         })
         .join("\n")
 
+      const duplicateDetails = duplicateKeys
+        .map((d) => {
+          const beforeOffset = text.substring(0, d.offset).split("\n")
+          const line = beforeOffset.length
+          const column = beforeOffset[beforeOffset.length - 1].length + 1
+          const problemLine = lines[line - 1]
+
+          const error = `Duplicate key "${d.key}" at line ${line}, column ${column}. Use an array for multiple values, e.g. "plugin": ["value1", "value2"]`
+          if (!problemLine) return error
+
+          return `${error}\n   Line ${line}: ${problemLine}\n${"".padStart(column + 9)}^`
+        })
+        .join("\n")
+
+      const allErrors = [errorDetails, duplicateDetails].filter(Boolean).join("\n")
+
       throw new JsonError({
         path: configFilepath,
-        message: `\n--- JSONC Input ---\n${text}\n--- Errors ---\n${errorDetails}\n--- End ---`,
+        message: `\n--- JSONC Input ---\n${text}\n--- Errors ---\n${allErrors}\n--- End ---`,
       })
     }
 

--- a/packages/opencode/src/file/time.ts
+++ b/packages/opencode/src/file/time.ts
@@ -60,7 +60,11 @@ export namespace FileTime {
     const time = get(sessionID, filepath)
     if (!time) throw new Error(`You must read file ${filepath} before overwriting it. Use the Read tool first`)
     const stats = await Bun.file(filepath).stat()
-    if (stats.mtime.getTime() > time.getTime()) {
+    const mtime = stats.mtime.getTime()
+    const readTime = time.getTime()
+    // Allow 100ms tolerance to account for filesystem timestamp precision differences
+    // Some filesystems may update mtime slightly after the read operation completes
+    if (mtime > readTime + 100) {
       throw new Error(
         `File ${filepath} has been modified since it was last read.\nLast modification: ${stats.mtime.toISOString()}\nLast read: ${time.toISOString()}\n\nPlease read the file again before modifying it.`,
       )

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -758,6 +758,10 @@ export namespace ProviderTransform {
 
         const result: any = {}
         for (const [key, value] of Object.entries(obj)) {
+          // Skip non-standard JSON Schema fields that Gemini doesn't support
+          if (key === "ref" || key === "$schema") {
+            continue
+          }
           if (key === "enum" && Array.isArray(value)) {
             // Convert all enum values to strings
             result[key] = value.map((v) => String(v))

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -225,6 +225,61 @@ test("throws error for invalid JSON", async () => {
   })
 })
 
+test("throws error for duplicate keys in config (#11130)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        `{
+  "plugin": "opencode-gemini-auth@latest",
+  "plugin": "@franlol/opencode-md-table-formatter@0.0.3"
+}`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        await Config.get()
+        expect(true).toBe(false)
+      } catch (e: any) {
+        expect(e.data?.message || e.message).toMatch(/Duplicate key/)
+      }
+    },
+  })
+})
+
+test("throws error for nested duplicate keys (#11130)", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        `{
+  "$schema": "https://opencode.ai/config.json",
+  "agent": {
+    "test": {
+      "model": "model1",
+      "model": "model2"
+    }
+  }
+}`,
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      try {
+        await Config.get()
+        expect(true).toBe(false)
+      } catch (e: any) {
+        expect(e.data?.message || e.message).toMatch(/Duplicate key.*model/)
+      }
+    },
+  })
+})
+
 test("handles agent configuration", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/file/time.test.ts
+++ b/packages/opencode/test/file/time.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach } from "bun:test"
+import { FileTime } from "../../src/file/time"
+import { Instance } from "../../src/project/instance"
+import { tmpdir } from "../fixture/fixture"
+import path from "path"
+
+describe("FileTime.assert - tolerance (#11436)", () => {
+  test("allows file with mtime within 100ms tolerance", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const file = path.join(tmp.path, "test.txt")
+        await Bun.write(file, "content")
+
+        FileTime.read("test-session", file)
+
+        // Should not throw - mtime is within tolerance
+        await expect(FileTime.assert("test-session", file)).resolves.toBeUndefined()
+      },
+    })
+  })
+
+  test("throws when file is modified after read", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const file = path.join(tmp.path, "test.txt")
+        await Bun.write(file, "content")
+
+        FileTime.read("test-session", file)
+
+        // Wait and modify file
+        await new Promise((r) => setTimeout(r, 150))
+        await Bun.write(file, "modified content")
+
+        await expect(FileTime.assert("test-session", file)).rejects.toThrow(/has been modified/)
+      },
+    })
+  })
+
+  test("throws when file was never read", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const file = path.join(tmp.path, "test.txt")
+        await Bun.write(file, "content")
+
+        await expect(FileTime.assert("test-session", file)).rejects.toThrow(/must read file/)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -363,6 +363,85 @@ describe("ProviderTransform.schema - gemini array items", () => {
   })
 })
 
+describe("ProviderTransform.schema - gemini removes non-standard fields (#11413)", () => {
+  const geminiModel = {
+    providerID: "google",
+    api: { id: "gemini-3-pro" },
+  } as any
+
+  test("removes ref field from schema", () => {
+    const schema = {
+      ref: "QuestionInfo",
+      type: "object",
+      properties: {
+        question: { type: "string" },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.ref).toBeUndefined()
+    expect(result.type).toBe("object")
+    expect(result.properties.question.type).toBe("string")
+  })
+
+  test("removes $schema field from schema", () => {
+    const schema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.$schema).toBeUndefined()
+    expect(result.type).toBe("object")
+  })
+
+  test("removes ref from nested objects", () => {
+    const schema = {
+      ref: "QuestionInfo",
+      type: "object",
+      properties: {
+        options: {
+          type: "array",
+          items: {
+            ref: "QuestionOption",
+            type: "object",
+            properties: {
+              label: { type: "string" },
+            },
+          },
+        },
+      },
+    } as any
+
+    const result = ProviderTransform.schema(geminiModel, schema) as any
+
+    expect(result.ref).toBeUndefined()
+    expect(result.properties.options.items.ref).toBeUndefined()
+    expect(result.properties.options.items.type).toBe("object")
+  })
+
+  test("does not remove ref for non-gemini providers", () => {
+    const openaiModel = {
+      providerID: "openai",
+      api: { id: "gpt-4" },
+    } as any
+
+    const schema = {
+      ref: "QuestionInfo",
+      type: "object",
+    } as any
+
+    const result = ProviderTransform.schema(openaiModel, schema) as any
+
+    expect(result.ref).toBe("QuestionInfo")
+  })
+})
+
 describe("ProviderTransform.message - DeepSeek reasoning content", () => {
   test("DeepSeek with tool calls includes reasoning_content in providerOptions", () => {
     const msgs = [


### PR DESCRIPTION
## Summary

This PR fixes three tool/plugin related issues:

### #11413 - question tool schema causes 400 with Gemini

**Problem**: The `question` tool's JSON Schema contains non-standard fields (`ref`, `$schema`) from Zod's `.meta()` that Gemini API rejects.

**Fix**: Updated `sanitizeGemini` function in `transform.ts` to skip these non-standard fields when preparing schemas for Gemini.

### #11130 - plugins silently fail with bad syntax

**Problem**: Duplicate keys in `opencode.json` (e.g., two `"plugin"` entries) are silently ignored, with the second value overwriting the first.

**Fix**: Added duplicate key detection using `jsonc-parser`'s `visit` function. Now throws a helpful error message suggesting array syntax:
```
Duplicate key "plugin" at line 3, column 3. Use an array for multiple values, e.g. "plugin": ["value1", "value2"]
```

### #11436 - file has been modified since it was last read

**Problem**: False positive errors when file mtime differs from read time by only a few milliseconds (e.g., 14ms difference) due to filesystem timestamp precision.

**Fix**: Added 100ms tolerance to the file modification time check in `time.ts`.

## Testing

- `bun run typecheck` passes

## Files Changed

- `packages/opencode/src/provider/transform.ts` - Gemini schema sanitization
- `packages/opencode/src/config/config.ts` - Duplicate key detection
- `packages/opencode/src/file/time.ts` - File time tolerance