### PR TITLE
feat: add mistral session affinity header

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -64,6 +64,13 @@ export namespace ProviderTransform {
     affinity.set(sessionID, count + 1)
   }
 
+  export function clearMistralAffinity(sessionID: string) {
+    // Only clean up if this session actually has mistral affinity tracking
+    if (affinity.has(sessionID)) {
+      affinity.delete(sessionID)
+    }
+  }
+
   export function isMistral(model: Provider.Model): boolean {
     const id = model.api.id.toLowerCase()
     return (

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -4,6 +4,7 @@ import type { JSONSchema } from "zod/v4/core"
 import type { Provider } from "./provider"
 import type { ModelsDev } from "./models"
 import { iife } from "@/util/iife"
+import { createHash } from "crypto"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -16,6 +17,8 @@ function mimeToModality(mime: string): Modality | undefined {
 }
 
 export namespace ProviderTransform {
+  const affinity = new Map<string, number>()
+
   // Maps npm package to the key the AI SDK expects for providerOptions
   function sdkKey(npm: string): string | undefined {
     switch (npm) {
@@ -38,6 +41,37 @@ export namespace ProviderTransform {
         return "openrouter"
     }
     return undefined
+  }
+
+  function affinityID(sessionID: string, count: number): string {
+    const seed = `${sessionID}:${count}`
+    const hash = createHash("sha256").update(seed).digest()
+    const bytes = Uint8Array.from(hash.subarray(0, 16))
+    bytes[6] = (bytes[6] & 0x0f) | 0x40
+    bytes[8] = (bytes[8] & 0x3f) | 0x80
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")
+    const parts = [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16), hex.slice(16, 20), hex.slice(20, 32)]
+    return parts.join("-")
+  }
+
+  export function mistralAffinity(sessionID: string): string {
+    const count = affinity.get(sessionID) ?? 0
+    return affinityID(sessionID, count)
+  }
+
+  export function bumpMistralAffinity(sessionID: string) {
+    const count = affinity.get(sessionID) ?? 0
+    affinity.set(sessionID, count + 1)
+  }
+
+  export function isMistral(model: Provider.Model): boolean {
+    const id = model.api.id.toLowerCase()
+    return (
+      model.providerID === "mistral" ||
+      model.api.npm === "@ai-sdk/mistral" ||
+      id.includes("mistral") ||
+      id.includes("devstral")
+    )
   }
 
   function normalizeMessages(
@@ -83,11 +117,7 @@ export namespace ProviderTransform {
         return msg
       })
     }
-    if (
-      model.providerID === "mistral" ||
-      model.api.id.toLowerCase().includes("mistral") ||
-      model.api.id.toLocaleLowerCase().includes("devstral")
-    ) {
+    if (isMistral(model)) {
       const result: ModelMessage[] = []
       for (let i = 0; i < msgs.length; i++) {
         const msg = msgs[i]

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -189,7 +189,7 @@ export namespace SessionCompaction {
       })
     }
     if (processor.message.error) return "stop"
-    ProviderTransform.bumpMistralAffinity(input.sessionID)
+    if (ProviderTransform.isMistral(model)) ProviderTransform.bumpMistralAffinity(input.sessionID)
     Bus.publish(Event.Compacted, { sessionID: input.sessionID })
     return "continue"
   }

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -14,6 +14,7 @@ import { fn } from "@/util/fn"
 import { Agent } from "@/agent/agent"
 import { Plugin } from "@/plugin"
 import { Config } from "@/config/config"
+import { ProviderTransform } from "@/provider/transform"
 
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
@@ -188,6 +189,7 @@ export namespace SessionCompaction {
       })
     }
     if (processor.message.error) return "stop"
+    ProviderTransform.bumpMistralAffinity(input.sessionID)
     Bus.publish(Event.Compacted, { sessionID: input.sessionID })
     return "continue"
   }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -20,6 +20,7 @@ import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
 
 import type { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
 import { PermissionNext } from "@/permission/next"
 import { Global } from "@/global"
 
@@ -365,6 +366,7 @@ export namespace Session {
       Bus.publish(Event.Deleted, {
         info: session,
       })
+      ProviderTransform.clearMistralAffinity(sessionID)
     } catch (e) {
       log.error(e)
     }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -228,6 +228,11 @@ export namespace LLM {
                 "User-Agent": `opencode/${Installation.VERSION}`,
               }
             : undefined),
+        ...(ProviderTransform.isMistral(input.model)
+          ? {
+              "x-affinity": ProviderTransform.mistralAffinity(input.sessionID),
+            }
+          : undefined),
         ...input.model.headers,
         ...headers,
       },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -103,6 +103,43 @@ describe("ProviderTransform.options - setCacheKey", () => {
   })
 })
 
+describe("ProviderTransform.mistralAffinity", () => {
+  test("returns deterministic uuid for same session", () => {
+    const sessionID = "ses_test_mistral_affinity"
+    const first = ProviderTransform.mistralAffinity(sessionID)
+    const second = ProviderTransform.mistralAffinity(sessionID)
+    expect(first).toBe(second)
+    expect(first).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  test("changes after compaction bump", () => {
+    const sessionID = "ses_test_mistral_affinity_bump"
+    const before = ProviderTransform.mistralAffinity(sessionID)
+    ProviderTransform.bumpMistralAffinity(sessionID)
+    const after = ProviderTransform.mistralAffinity(sessionID)
+    expect(before).not.toBe(after)
+  })
+
+  test("detects mistral models", () => {
+    const model = {
+      providerID: "mistral",
+      api: {
+        id: "mistral-large-latest",
+        npm: "@ai-sdk/mistral",
+      },
+    } as any
+    const nonMistral = {
+      providerID: "openai",
+      api: {
+        id: "gpt-4",
+        npm: "@ai-sdk/openai",
+      },
+    } as any
+    expect(ProviderTransform.isMistral(model)).toBe(true)
+    expect(ProviderTransform.isMistral(nonMistral)).toBe(false)
+  })
+})
+
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
   const sessionID = "test-session-123"
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -138,6 +138,28 @@ describe("ProviderTransform.mistralAffinity", () => {
     expect(ProviderTransform.isMistral(model)).toBe(true)
     expect(ProviderTransform.isMistral(nonMistral)).toBe(false)
   })
+
+  test("clears affinity on session cleanup", () => {
+    const sessionID = "ses_test_mistral_cleanup"
+    ProviderTransform.bumpMistralAffinity(sessionID)
+    ProviderTransform.bumpMistralAffinity(sessionID)
+    const before = ProviderTransform.mistralAffinity(sessionID)
+    
+    ProviderTransform.clearMistralAffinity(sessionID)
+    
+    const after = ProviderTransform.mistralAffinity(sessionID)
+    expect(before).not.toBe(after)
+    expect(after).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  test("clearMistralAffinity is safe for non-mistral sessions", () => {
+    const sessionID = "ses_test_non_mistral_cleanup"
+    
+    ProviderTransform.clearMistralAffinity(sessionID)
+    
+    const affinityID = ProviderTransform.mistralAffinity(sessionID)
+    expect(affinityID).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
 })
 
 describe("ProviderTransform.options - gpt-5 textVerbosity", () => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -688,4 +688,113 @@ describe("session.llm.stream", () => {
       },
     })
   })
+
+  test("sends stable mistral affinity header", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "mistral"
+    const modelID = "mistral-large-2512"
+    const fixture = await loadFixture(providerID, modelID)
+    const model = fixture.model
+
+    const requestOne = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    const requestTwo = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hi"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-mistral-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(providerID, model.id)
+        const sessionID = "session-test-mistral"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.4,
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-mistral",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const streamOne = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of streamOne.fullStream) {
+        }
+
+        const streamTwo = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello again" }],
+          tools: {},
+        })
+
+        for await (const _ of streamTwo.fullStream) {
+        }
+
+        const captureOne = await requestOne
+        const captureTwo = await requestTwo
+
+        const affinityOne = captureOne.headers.get("x-affinity")
+        const affinityTwo = captureTwo.headers.get("x-affinity")
+
+        expect(affinityOne).toBeTruthy()
+        expect(affinityOne).toBe(affinityTwo)
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- add deterministic Mistral `x-affinity` header based on session ID
- bump affinity after compaction to reset session affinity
- add tests for affinity generation and Mistral detection

## Testing
- I tested the development build server with the Mistral provider and it works as expected.
- Unit tests have been added for the x-affinity header and cleanup of Mistral affinity id.

Fixes #11466