### PR TITLE
feat(tui): space to toggle answers in multi-select and enter for submit in questions tool

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -237,9 +237,20 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         moveTo((store.selected + 1) % total)
       }
 
-      if (evt.name === "return") {
+      if (evt.name === "space" && multi()) {
         evt.preventDefault()
         selectOption()
+      }
+
+      if (evt.name === "return") {
+        evt.preventDefault()
+        if (multi()) {
+          setStore("tab", store.tab + 1)
+          setStore("selected", 0)
+          return
+        }
+        selectOption()
+        return
       }
 
       if (evt.name === "escape" || keybind.match("app_exit", evt)) {
@@ -436,10 +447,15 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               {"↑↓"} <span style={{ fg: theme.textMuted }}>select</span>
             </text>
           </Show>
+          <Show when={multi() && !confirm()}>
+            <text fg={theme.text}>
+              space <span style={{ fg: theme.textMuted }}>toggle</span>
+            </text>
+          </Show>
           <text fg={theme.text}>
             enter{" "}
             <span style={{ fg: theme.textMuted }}>
-              {confirm() ? "submit" : multi() ? "toggle" : single() ? "submit" : "confirm"}
+              {confirm() || single() ? "submit" : "confirm"}
             </span>
           </text>
 


### PR DESCRIPTION
### What does this PR do?
Updates multi-select in questions tool to use "space" to toggle answers while keeping "enter" as the submit action, for a more natural and consistent keyboard flow.

### How did you verify your code works?
Tested locally while by invoking the questions tool and verified that "space" toggles answers and "enter" submits as expected. (I have attached a screen recording)

### UX note
I am aware that this changes the existing behavior where users may expect "enter" to toggle answers but this will submit it, however this should not be a major issue as answers are not just sent immediately and there is a confirmation step at the end (which shows warning of empty answer).

Since using "space" to toggle options is a common pattern in TUIs and CLIs, this should be fairly easy for users to adapt and fits better with people who already enjoy terminal apps.

*screen recording of the fix applied in this PR*

https://github.com/user-attachments/assets/6d697e86-8bd9-4b6a-b4a1-2d96d1618f63


closes #11471 
