### PR TITLE
feat(tui): tab through permissions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -393,14 +393,14 @@ function Prompt<const T extends Record<string, string>>(props: {
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
 
-    if (evt.name === "left" || evt.name == "h") {
+    if (evt.name === "left" || evt.name == "h" || (evt.name === "tab" && evt.shift)) {
       evt.preventDefault()
       const idx = keys.indexOf(store.selected)
       const next = keys[(idx - 1 + keys.length) % keys.length]
       setStore("selected", next)
     }
 
-    if (evt.name === "right" || evt.name == "l") {
+    if (evt.name === "right" || evt.name == "l" || (evt.name === "tab" && !evt.shift)) {
       evt.preventDefault()
       const idx = keys.indexOf(store.selected)
       const next = keys[(idx + 1) % keys.length]


### PR DESCRIPTION
### What does this PR do?
adds tab and shift+tab as an option to cycle through permission options

### How did you verify your code works?
ran the app with `npm run dev`, asked opencode to read a file outside the working directory, prompted for a permission, tabbed through the options and selected

Closes #11515 