### PR TITLE
fix(ci): portable hash parsing in nix-hashes workflow

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -58,10 +58,8 @@ jobs:
           # Build with fakeHash to trigger hash mismatch and reveal correct hash
           nix build ".#packages.${SYSTEM}.node_modules_updater" --no-link 2>&1 | tee "$BUILD_LOG" || true
 
-          HASH="$(grep -E 'got:\s+sha256-' "$BUILD_LOG" | sed -E 's/.*got:\s+(sha256-[A-Za-z0-9+/=]+).*/\1/' | head -n1 || true)"
-          if [ -z "$HASH" ]; then
-            HASH="$(grep -A2 'hash mismatch' "$BUILD_LOG" | grep 'got:' | sed -E 's/.*got:\s+(sha256-[A-Za-z0-9+/=]+).*/\1/' | head -n1 || true)"
-          fi
+          # Extract hash from build log with portability
+          HASH="$(grep -oE 'sha256-[A-Za-z0-9+/=]+' "$BUILD_LOG" | tail -n1 || true)"
 
           if [ -z "$HASH" ]; then
             echo "::error::Failed to compute hash for ${SYSTEM}"


### PR DESCRIPTION
## Summary
- Fix hash parsing to work on both GNU (Linux) and BSD (macOS) systems

## Problem
PR #11495 introduced a regression where darwin hashes in `nix/hashes.json` include `got:` prefix (e.g., `got:sha256-...` instead of `sha256-...`).

The `sed -E` regex using `\s+` behaves differently on BSD sed (macOS) vs GNU sed (Linux), causing the substitution to fail on darwin runners.

Ref: https://github.com/anomalyco/opencode/pull/11530#issuecomment-3829329185

## Solution
Replace complex sed parsing with portable `grep -oE` to extract sha256 hashes directly. Use `tail -n1` to get the `got:` hash (second match) since nix outputs `specified:` hash first.

Ref: #11530