### PR TITLE
fix: prioritize OPENCODE_CONFIG_DIR for AGENTS.md

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -17,12 +17,13 @@ const FILES = [
 ]
 
 function globalFiles() {
-  const files = [path.join(Global.Path.config, "AGENTS.md")]
-  if (!Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
-    files.push(path.join(os.homedir(), ".claude", "CLAUDE.md"))
-  }
+  const files = []
   if (Flag.OPENCODE_CONFIG_DIR) {
     files.push(path.join(Flag.OPENCODE_CONFIG_DIR, "AGENTS.md"))
+  }
+  files.push(path.join(Global.Path.config, "AGENTS.md"))
+  if (!Flag.OPENCODE_DISABLE_CLAUDE_CODE_PROMPT) {
+    files.push(path.join(os.homedir(), ".claude", "CLAUDE.md"))
   }
   return files
 }


### PR DESCRIPTION
## Summary
When `OPENCODE_CONFIG_DIR` is set, the AGENTS.md from that directory should be loaded instead of the global one. Currently, global `~/.config/opencode/AGENTS.md` is always checked first and the loop breaks, so profile-specific AGENTS.md is never reached.

## Changes
- Check `OPENCODE_CONFIG_DIR` first in `globalFiles()` and return early if set
- This makes profiles isolated environments with their own configuration

## Test Plan
1. Create global AGENTS.md: `echo "# Global" > ~/.config/opencode/AGENTS.md`
2. Create profile AGENTS.md: `mkdir -p ~/.config/opencode/profiles/work && echo "# Work" > ~/.config/opencode/profiles/work/AGENTS.md`
3. Set `OPENCODE_CONFIG_DIR=~/.config/opencode/profiles/work`
4. Verify only the profile AGENTS.md is loaded

## How I verified it is working:
1. I prepared the AGENTS.md structure (global and profile).
2. Ran `OPENCODE_CONFIG_DIR=~/.config/opencode/profiles/work bun dev`.
3. Written `hi` in opencode.
4. Result as below:
<img width="1260" height="1401" alt="image" src="https://github.com/user-attachments/assets/126c23b6-8b55-4cc5-beb9-06b3efc6136c" />


Fixes #11534