### PR TITLE
fix(app): rendering question tool when the step are collapsed

### DIFF
--- a/packages/ui/src/components/session-turn.css
+++ b/packages/ui/src/components/session-turn.css
@@ -569,4 +569,20 @@
     flex-direction: column;
     gap: 12px;
   }
+
+  [data-slot="session-turn-question-parts"] {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  [data-slot="session-turn-answered-question-parts"] {
+    width: 100%;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

When steps were collapsed the question tool was not rendering, so the user had no idea he needed to provide an anwser.
This PR fixes it and also shows the anwsered question in the session chat. 

Left OC is production, right is the fixed one

<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/6a6cd4b8-527f-457d-a95e-56826d3ea614" />

<img width="1919" height="1027" alt="image" src="https://github.com/user-attachments/assets/0e878586-3ef5-44a1-8582-a2fe7189e8e2" />


### How did you verify your code works?

Prompt "Ask me question using the question tool" collapsed and hide steps. 
Then provide an anwser. 

The provided questions should render even when steps are collapsed, same goes for the anwsered questions. 