### PR TITLE
feat(tui): Add clickable version number to see release notes + register /changelog slash command.

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -26,6 +26,8 @@ import { PromptHistoryProvider } from "./component/prompt/history"
 import { FrecencyProvider } from "./component/prompt/frecency"
 import { PromptStashProvider } from "./component/prompt/stash"
 import { DialogAlert } from "./ui/dialog-alert"
+import { DialogChangelog } from "@tui/component/dialog-changelog"
+import { getReleaseNotes } from "@tui/util/changelog"
 import { ToastProvider, useToast } from "./ui/toast"
 import { ExitProvider, useExit } from "./context/exit"
 import { Session as SessionApi } from "@/session"
@@ -281,6 +283,14 @@ function App() {
   )
 
   const connected = useConnected()
+
+  async function showChangelog() {
+    const notes = await getReleaseNotes()
+    if (notes && notes.trim().length > 0) {
+      dialog.replace(() => <DialogChangelog version={Installation.VERSION} notes={notes} />)
+    }
+  }
+
   command.register(() => [
     {
       title: "Switch session",
@@ -579,6 +589,15 @@ function App() {
         kv.set("diff_wrap_mode", current === "word" ? "none" : "word")
         dialog.clear()
       },
+    },
+    {
+      title: "View changelog",
+      value: "changelog.show",
+      slash: {
+        name: "changelog",
+      },
+      category: "System",
+      onSelect: () => showChangelog(),
     },
   ])
 

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-changelog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-changelog.tsx
@@ -1,0 +1,45 @@
+import { useDialog } from "@tui/ui/dialog"
+import { useTheme } from "@tui/context/theme"
+import { useKeyboard } from "@opentui/solid"
+import { TextAttributes } from "@opentui/core"
+
+export type DialogChangelogProps = {
+  version: string
+  notes: string
+}
+
+export function DialogChangelog(props: DialogChangelogProps) {
+  const dialog = useDialog()
+  const { theme, syntax } = useTheme()
+
+  useKeyboard((evt) => {
+    if (evt.name === "return" || evt.name === "escape") {
+      dialog.clear()
+    }
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          Changelog {props.version !== "local" ? `v${props.version}` : "(local)"}
+        </text>
+        <text fg={theme.textMuted}>esc/enter</text>
+      </box>
+      <scrollbox height={20} paddingBottom={1}>
+        <code
+          filetype="markdown"
+          drawUnstyledText={false}
+          syntaxStyle={syntax()}
+          content={props.notes}
+          fg={theme.text}
+        />
+      </scrollbox>
+      <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
+        <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={() => dialog.clear()}>
+          <text fg={theme.selectedListItemText}>close</text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/version-tag.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/version-tag.tsx
@@ -1,0 +1,42 @@
+import { createMemo, createSignal, onMount, Show } from "solid-js"
+import { Installation } from "@/installation"
+import { useTheme } from "@tui/context/theme"
+import { useCommandDialog } from "@tui/component/dialog-command"
+import { getReleaseNotes } from "@tui/util/changelog"
+
+export type VersionTagProps = {
+  version?: string
+}
+
+export function VersionTag(props: VersionTagProps) {
+  const { theme } = useTheme()
+  const command = useCommandDialog()
+  const version = () => props.version ?? Installation.VERSION
+
+  const [hasChangelog, setHasChangelog] = createSignal(false)
+
+  onMount(async () => {
+    const notes = await getReleaseNotes(version())
+    setHasChangelog(notes !== null && notes.trim().length > 0)
+  })
+
+  const [hover, setHover] = createSignal(false)
+  const textStyle = createMemo(() => ({
+    fg: hover() && hasChangelog() ? theme.text : theme.textMuted,
+    underline: hover() && hasChangelog(),
+  }))
+
+  return (
+    <Show when={hasChangelog()} fallback={<text fg={theme.textMuted}>{version()}</text>}>
+      <text
+        fg={textStyle().fg}
+        style={textStyle()}
+        onMouseOver={() => setHover(true)}
+        onMouseOut={() => setHover(false)}
+        onMouseUp={() => command.trigger("changelog.show")}
+      >
+        {version()}
+      </text>
+    </Show>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -11,7 +11,7 @@ import { useArgs } from "../context/args"
 import { useDirectory } from "../context/directory"
 import { useRouteData } from "@tui/context/route"
 import { usePromptRef } from "../context/prompt"
-import { Installation } from "@/installation"
+import { VersionTag } from "@tui/component/version-tag"
 import { useKV } from "../context/kv"
 import { useCommandDialog } from "../component/dialog-command"
 
@@ -132,7 +132,7 @@ export function Home() {
         </box>
         <box flexGrow={1} />
         <box flexShrink={0}>
-          <text fg={theme.textMuted}>{Installation.VERSION}</text>
+          <VersionTag />
         </box>
       </box>
     </>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -7,7 +7,7 @@ import { SplitBorder } from "@tui/component/border"
 import type { AssistantMessage, Session } from "@opencode-ai/sdk/v2"
 import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
-import { Installation } from "@/installation"
+import { VersionTag } from "@tui/component/version-tag"
 import { useTerminalDimensions } from "@opentui/solid"
 
 const Title = (props: { session: Accessor<Session> }) => {
@@ -89,7 +89,7 @@ export function Header() {
                 </text>
                 <box flexDirection="row" gap={1} flexShrink={0}>
                   <ContextInfo context={context} cost={cost} />
-                  <text fg={theme.textMuted}>v{Installation.VERSION}</text>
+                  <VersionTag />
                 </box>
               </box>
               <box flexDirection="row" gap={2}>
@@ -131,7 +131,7 @@ export function Header() {
               <Title session={session} />
               <box flexDirection="row" gap={1} flexShrink={0}>
                 <ContextInfo context={context} cost={cost} />
-                <text fg={theme.textMuted}>v{Installation.VERSION}</text>
+                <VersionTag />
               </box>
             </box>
           </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -6,7 +6,7 @@ import { Locale } from "@/util/locale"
 import path from "path"
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Global } from "@/global"
-import { Installation } from "@/installation"
+import { VersionTag } from "@tui/component/version-tag"
 import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
@@ -304,8 +304,8 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
             <span style={{ fg: theme.text }}>
               <b>Code</b>
             </span>{" "}
-            <span>{Installation.VERSION}</span>
           </text>
+          <VersionTag />
         </box>
       </box>
     </Show>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -6,7 +6,7 @@ import { Locale } from "@/util/locale"
 import path from "path"
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Global } from "@/global"
-import { Installation } from "@/installation"
+import { VersionTag } from "@tui/component/version-tag"
 import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
@@ -304,7 +304,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
             <span style={{ fg: theme.text }}>
               <b>Code</b>
             </span>{" "}
-            <span>{Installation.VERSION}</span>
+            <VersionTag />
           </text>
         </box>
       </box>

--- a/packages/opencode/src/cli/cmd/tui/util/changelog.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/changelog.ts
@@ -1,0 +1,52 @@
+import { Installation } from "@/installation"
+import { Storage } from "@/storage/storage"
+import { config } from "@/../../console/app/src/config"
+
+const REPO = config.github.repoUrl.replace("https://github.com/", "")
+const CACHE_DURATION = 60 * 60 * 1000 // 1 hour
+
+async function getFromCache(version: string): Promise<string | null> {
+  try {
+    const cached = await Storage.read<{ notes: string; fetchedAt: number }>(["release_notes", version])
+    if (cached && Date.now() - cached.fetchedAt < CACHE_DURATION) {
+      return cached.notes
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+async function saveToCache(version: string, notes: string) {
+  await Storage.write(["release_notes", version], { notes, fetchedAt: Date.now() })
+}
+
+export async function getReleaseNotes(version?: string): Promise<string | null> {
+  const targetVersion = version ?? Installation.VERSION
+
+  const cached = await getFromCache(targetVersion)
+  if (cached) return cached
+
+  try {
+    const tag =
+      targetVersion === "local" ? "latest" : targetVersion.startsWith("v") ? targetVersion : `v${targetVersion}`
+    const url =
+      tag === "latest"
+        ? `https://api.github.com/repos/${REPO}/releases/latest`
+        : `https://api.github.com/repos/${REPO}/releases/tags/${tag}`
+
+    const response = await fetch(url)
+    if (!response.ok) return null
+
+    const data = await response.json()
+    const notes = data.body
+
+    if (!notes || typeof notes !== "string") return null
+
+    await saveToCache(targetVersion, notes)
+
+    return notes
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds a clickable version tag in the TUI footer that opens a scrollable dialog displaying the current version's release notes fetched from GitHub. Closes #9826 

Users previously had no way to see what changed in their current OpenCode version without leaving the CLI. This provides immediate access to release information right where users work.
- Added new utility file: `changelog.ts` with  `getReleaseNotes()` function that fetches release notes from GitHub API
- Persistent caching via Storage namespace (1-hour TTL) to avoid repeated API calls
- Added `VersionTag` component that shows version with hover (white) when release changelog available
- `DialogChangelog` component displaying formatted release notes using `<code>` component
- Registered `/changelog` slash command for keyboard access
- Updated version displays in `sidebar`, `header`, and home screen to use clickable VersionTag

### How did you verify your code works?
- Click version tag in footer → scrollable dialog opens with release notes
- Type `/changelog` → same dialog opens

<img width="2248" height="910" alt="screenshot-01" src="https://github.com/user-attachments/assets/901800be-63a0-455c-9371-2e96a607541a" />


