### PR TITLE
fix(app): show retry status only on active turn

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -350,6 +350,8 @@ export function SessionTurn(
   const status = createMemo(() => data.store.session_status[props.sessionID] ?? idle)
   const working = createMemo(() => status().type !== "idle" && isLastUserMessage())
   const retry = createMemo(() => {
+    // session_status is session-scoped; only show retry on the active (last) turn
+    if (!isLastUserMessage()) return
     const s = status()
     if (s.type !== "retry") return
     return s


### PR DESCRIPTION
### What does this PR do?

Retry error was rendered on every session turn instead of the current one 

### How did you verify your code works?

In `session-turn.tsx` replace line 350 
`const status = createMemo(() => data.store.session_status[props.sessionID] ?? idle)`

with this: 

```
const mock = createMemo(() => {
    if (typeof window === "undefined") return false
    if (new URLSearchParams(window.location.search).has("mockRetry")) return true

    // Some shells/apps use hash routing where query params live after `#`.
    const hash = window.location.hash
    const index = hash.indexOf("?")
    if (index < 0) return false
    return new URLSearchParams(hash.slice(index + 1)).has("mockRetry")
  })

  const status = createMemo(() => {
    if (!mock()) return data.store.session_status[props.sessionID] ?? idle
    return {
      type: "retry" as const,
      attempt: 1,
      message: "Time to first token is taking longer than expected...",
      next: Date.now() + 30_000,
    }
  })  
```

and enter a session link with link param `?mockRetry=1`  for example `http://localhost:4445/L2hvbWUvbmVyaW91c3kvcHJvZ3JhbW1pbmcvb3BlbmNvZGU/session/ses_3e9583af8ffeCPJn6IX9bUCVRV?mockRetry=1`



Left screen is fixed, right screen is old one


<img width="807" height="623" alt="image" src="https://github.com/user-attachments/assets/435ebfb4-fca0-4f04-a30b-13ef4afe7e81" />

