### PR TITLE
fix(tui): conditionally render bash tool output

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1636,7 +1636,9 @@ function Bash(props: ToolProps<typeof BashTool>) {
         >
           <box gap={1}>
             <text fg={theme.text}>$ {props.input.command}</text>
-            <text fg={theme.text}>{limited()}</text>
+            <Show when={output()}>
+              <text fg={theme.text}>{limited()}</text>
+            </Show>
             <Show when={overflow()}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
             </Show>


### PR DESCRIPTION
## Summary
Conditionally render the bash tool output using SolidJS `<Show>` component to prevent empty output display when there is no output.

## Changes
- Wrap `{limited()}` in `<Show when={output()}>` in the Bash tool component
- This prevents rendering empty output text when the bash command has no output