### PR TITLE
docs: add opencode-qwencode-auth to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -22,7 +22,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
-| [opencode-qwencode-auth](https://github.com/gustavodiasdev/opencode-qwencode-auth)                 | Use your Qwen.ai account with 2K free requests/day and 1M context window                          |
+| [opencode-qwencode-auth](https://github.com/gustavodiasdev/opencode-qwencode-auth)                 | Use your Qwen.ai account with 2,000 free requests per day and a 1 million-token context window    |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -22,6 +22,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-type-inject](https://github.com/nick-vi/opencode-type-inject)                            | Auto-inject TypeScript/Svelte types into file reads with lookup tools                             |
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)             | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                            | Use your existing Gemini plan instead of API billing                                              |
+| [opencode-qwencode-auth](https://github.com/gustavodiasdev/opencode-qwencode-auth)                 | Use your Qwen.ai account with 2K free requests/day and 1M context window                          |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                | Use Antigravity's free models instead of API billing                                              |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |


### PR DESCRIPTION
### What does this PR do?

Adds [opencode-qwencode-auth](https://github.com/gustavodiasdev/opencode-qwencode-auth) to the ecosystem page.

**opencode-qwencode-auth** is an OAuth authentication plugin for Qwen.ai (Alibaba's Qwen3-Coder models):

- **npm**: https://www.npmjs.com/package/opencode-qwencode-auth
- 🔐 OAuth Device Flow (RFC 8628)
- 🆓 2,000 free requests/day
- 🧠 1M token context window
- 🔗 Compatible with qwen-code credentials

### How did you verify your code works?

Verified markdown table structure matches existing entries.

Closes #11557