### PR TITLE
fix(tui): remove extra padding between search and results in dialog-select

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -228,7 +228,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           </text>
           <text fg={theme.textMuted}>esc</text>
         </box>
-        <box paddingTop={1} paddingBottom={1}>
+        <box paddingTop={1}>
           <input
             onInput={(e) => {
               batch(() => {


### PR DESCRIPTION
## Summary

Removed extra padding between the search input and results in the dialog-select component.

### Problem
The input wrapper had both `paddingTop={1}` and `paddingBottom={1}`, and the outer container also had `gap={1}`, creating 2 spaces total between search and results instead of the intended 1 space.

### Solution
Removed `paddingBottom={1}` from the input wrapper box, leaving only the `gap={1}` from the outer container.

### Files Changed
- `packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx` - Removed `paddingBottom={1}` from line 231