### PR TITLE
feat(ui): support delegate_task tool for subagent view

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -43,6 +43,7 @@ function computeStatusFromPart(part: PartType | undefined, t: Translator): strin
   if (part.type === "tool") {
     switch (part.tool) {
       case "task":
+      case "delegate_task":
         return t("ui.sessionTurn.status.delegating")
       case "todowrite":
       case "todoread":
@@ -360,7 +361,7 @@ export function SessionTurn(
 
         if (
           part.type === "tool" &&
-          part.tool === "task" &&
+          (part.tool === "task" || part.tool === "delegate_task") &&
           part.state &&
           "metadata" in part.state &&
           part.state.metadata?.sessionId &&


### PR DESCRIPTION
## Summary

Fixes #11575

This PR enables plugins (like oh-my-opencode) to display the "View Sub Agents" UI for their custom delegation tools.

## Changes

- Modified `packages/ui/src/components/session-turn.tsx` to check for both `task` and `delegate_task` tool names when detecting running subagent sessions
- No breaking changes to existing `task` tool behavior

## Motivation

Currently, the UI only shows the subagent view for the built-in `task` tool. Plugin tools like `delegate_task` (from oh-my-opencode) pass the correct `sessionId` in metadata but the UI doesn't recognize them because of the hardcoded tool name check.

This small change allows plugins to leverage the same subagent UI experience.

## Testing

- Existing `task` tool behavior unchanged
- `delegate_task` tool with `metadata.sessionId` now triggers subagent view