### PR TITLE
fix: prevent duplicate AGENTS.md injection when reading instruction files

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -75,7 +75,9 @@ export namespace InstructionPrompt {
       for (const file of FILES) {
         const matches = await Filesystem.findUp(file, Instance.directory, Instance.worktree)
         if (matches.length > 0) {
-          matches.forEach((p) => paths.add(path.resolve(p)))
+          matches.forEach((p) => {
+            paths.add(path.resolve(p))
+          })
           break
         }
       }
@@ -103,7 +105,9 @@ export namespace InstructionPrompt {
               }),
             ).catch(() => [])
           : await resolveRelative(instruction)
-        matches.forEach((p) => paths.add(path.resolve(p)))
+        matches.forEach((p) => {
+          paths.add(path.resolve(p))
+        })
       }
     }
 
@@ -168,11 +172,17 @@ export namespace InstructionPrompt {
     const already = loaded(messages)
     const results: { filepath: string; content: string }[] = []
 
-    let current = path.dirname(path.resolve(filepath))
+    const target = path.resolve(filepath)
+    let current = path.dirname(target)
     const root = path.resolve(Instance.directory)
 
     while (current.startsWith(root)) {
       const found = await find(current)
+      if (found === target) {
+        if (current === root) break
+        current = path.dirname(current)
+        continue
+      }
       if (found && !system.has(found) && !already.has(found) && !isClaimed(messageID, found)) {
         claim(messageID, found)
         const content = await Bun.file(found)

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -176,14 +176,10 @@ export namespace InstructionPrompt {
     let current = path.dirname(target)
     const root = path.resolve(Instance.directory)
 
-    while (current.startsWith(root)) {
+    while (current.startsWith(root) && current !== root) {
       const found = await find(current)
-      if (found === target) {
-        if (current === root) break
-        current = path.dirname(current)
-        continue
-      }
-      if (found && !system.has(found) && !already.has(found) && !isClaimed(messageID, found)) {
+
+      if (found && found !== target && !system.has(found) && !already.has(found) && !isClaimed(messageID, found)) {
         claim(messageID, found)
         const content = await Bun.file(found)
           .text()
@@ -192,7 +188,6 @@ export namespace InstructionPrompt {
           results.push({ filepath: found, content: "Instructions from: " + found + "\n" + content })
         }
       }
-      if (current === root) break
       current = path.dirname(current)
     }
 

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -47,4 +47,24 @@ describe("InstructionPrompt.resolve", () => {
       },
     })
   })
+
+  test("doesn't reload AGENTS.md when reading it directly", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "subdir", "AGENTS.md"), "# Subdir Instructions")
+        await Bun.write(path.join(dir, "subdir", "nested", "file.ts"), "const x = 1")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const filepath = path.join(tmp.path, "subdir", "AGENTS.md")
+        const system = await InstructionPrompt.systemPaths()
+        expect(system.has(filepath)).toBe(false)
+
+        const results = await InstructionPrompt.resolve([], filepath, "test-message-2")
+        expect(results).toEqual([])
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- When reading an AGENTS.md file directly, the same file was being re-injected as a system-reminder, causing duplicate "Read/Loaded" log entries
- Skip instruction files that match the file being read to prevent this duplication

## Changes

- Modified `InstructionPrompt.resolve()` in `packages/opencode/src/session/instruction.ts`
- Added check to skip when found instruction file equals the target file being read