### PR TITLE
docs: update outdated storage directory structure (#11560)

### DIFF
--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -30,10 +30,18 @@ opencode stores session data and other application data on disk at:
 This directory contains:
 
 - `auth.json` - Authentication data like API keys, OAuth tokens
+- `bin/` - Binary executables
 - `log/` - Application logs
-- `project/` - Project-specific data like session and message data
-  - If the project is within a Git repo, it is stored in `./<project-slug>/storage/`
-  - If it is not a Git repo, it is stored in `./global/storage/`
+- `snapshot/` - Project snapshots
+  - If the project is within a Git repo, it is stored in `./<git-commit-hash>/` (identified by git commit hash, not slug)
+  - If it is not a Git repo, it is stored in `./global/`
+- `storage/` - Session and message data
+  - `message/` - Message history
+  - `part/` - Part data
+  - `project/` - Project-specific data
+  - `session/` - Session data
+  - `session_diff/` - Session differences
+- `tool-output/` - Tool execution outputs
 
 ---
 


### PR DESCRIPTION
## Summary

Fixed outdated storage directory structure documentation in the troubleshooting guide.

## Changes Made

Updated `packages/web/src/content/docs/troubleshooting.mdx` to reflect the current data directory structure:

- **Removed outdated structure**:
  - `project/` directory at root level
  - Projects identified by slug
  - `project//storage/` path

- **Added current structure**:
  - `bin/` - Binary executables
  - `snapshot/` - Project snapshots (identified by git commit hash, not slug)
  - `storage/` - Session and message data with subdirectories:
    - `message/` - Message history
    - `part/` - Part data
    - `project/` - Project-specific data
    - `session/` - Session data
    - `session_diff/` - Session differences
  - `tool-output/` - Tool execution outputs

## Issue

Resolves #11560 - Documentation was outdated and didn't match the actual implementation.

## Testing

- Documentation builds successfully
- Changes are consistent with actual file structure
- No breaking changes to existing functionality