### PR TITLE
feat: support delegate_task tool in subagent UI view (#11575)

### DIFF
--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -360,7 +360,7 @@ export function SessionTurn(
 
         if (
           part.type === "tool" &&
-          part.tool === "task" &&
+          (part.tool === "task" || part.tool === "delegate_task") &&
           part.state &&
           "metadata" in part.state &&
           part.state.metadata?.sessionId &&


### PR DESCRIPTION
## Summary

Extended the subagent UI view support to recognize `delegate_task` tool from plugins, enabling the same subagent UI experience for plugin tools.

## Changes Made

Modified `packages/ui/src/components/session-turn.tsx`:
- **Line 363**: Extended the tool name check from:
  ```typescript
  part.tool === "task"
  ```
  to:
  ```typescript
  (part.tool === "task" || part.tool === "delegate_task")
  ```

## Issue

This fix resolves #11575 - Plugin tools like `delegate_task` (from oh-my-opencode) correctly pass `sessionId` in metadata, but the UI didn't recognize them because of a hardcoded tool name check.

## Benefits

- ✅ Enables plugins to leverage the same subagent UI experience
- ✅ No breaking changes to existing `task` tool behavior
- ✅ Better plugin ecosystem support
- ✅ Minimal code change (1 line modification)

## Testing

- Code compiles successfully
- No breaking changes to existing functionality
- Follows existing code patterns