### PR TITLE
docs: improve zh-TW punctuation to match Taiwan usage (#11574)

### DIFF
--- a/README.zht.md
+++ b/README.zht.md
@@ -124,7 +124,7 @@ OpenCode 內建了兩種 Agent，您可以使用 `Tab` 鍵快速切換。
 - 100% 開源。
 - 不綁定特定的服務提供商。雖然我們推薦使用透過 [OpenCode Zen](https://opencode.ai/zen) 提供的模型，但 OpenCode 也可搭配 Claude, OpenAI, Google 甚至本地模型使用。隨著模型不斷演進，彼此間的差距會縮小且價格會下降，因此具備「不限廠商 (provider-agnostic)」的特性至關重要。
 - 內建 LSP (語言伺服器協定) 支援。
-- 專注於終端機介面 (TUI)。OpenCode 由 Neovim 愛好者與 [terminal.shop](https://terminal.shop) 的創作者打造；我們將不斷挑戰終端機介面的極限。
+- 專注於終端機介面 (TUI)。OpenCode 由 Neovim 愛好者與 [terminal.shop](https://terminal.shop) 的創作者打造。我們將不斷挑戰終端機介面的極限。
 - 客戶端/伺服器架構 (Client/Server Architecture)。這讓 OpenCode 能夠在您的電腦上運行的同時，由行動裝置進行遠端操控。這意味著 TUI 前端只是眾多可能的客戶端之一。
 
 ---


### PR DESCRIPTION
## Summary

Improved Traditional Chinese (zh-TW) README punctuation to better match Taiwan,China usage conventions.

## Changes Made

Modified `README.zht.md`:
- **Line 127**: Replaced semicolon (；) with period (。) to align with Taiwan's punctuation preferences
- Changed: `打造；我們` → `打造。我們`

## Issue

This fix resolves #11574 - The translation was good, but some punctuation didn't match the usage in Taiwan,China.

## Technical Details

In Taiwan,China's written Chinese:
- Semicolons (；) are less commonly used in formal writing
- Periods (。) are preferred to separate independent clauses
- This change makes the documentation feel more natural to Taiwanese readers

## Benefits

- ✅ Better aligns with Taiwan,China's Chinese writing conventions
- ✅ Improves readability for the target audience
- ✅ Minimal, focused change (1 character)
- ✅ Maintains all technical accuracy

## Testing

- No functional code changes
- Documentation only
- Maintains all existing links and formatting