### PR TITLE
fix(plugin): pass server auth headers to plugin client

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -21,8 +21,14 @@ export namespace Plugin {
   const INTERNAL_PLUGINS: PluginInstance[] = [CodexAuthPlugin, CopilotAuthPlugin]
 
   const state = Instance.state(async () => {
+    const password = process.env.OPENCODE_SERVER_PASSWORD
     const client = createOpencodeClient({
       baseUrl: "http://localhost:4096",
+      headers: password
+        ? {
+            Authorization: `Basic ${btoa(`opencode:${password}`)}`,
+          }
+        : {},
       // @ts-ignore - fetch type incompatibility
       fetch: async (...args) => Server.App().fetch(...args),
     })


### PR DESCRIPTION
## Summary
When the OpenCode server is protected with a password (`OPENCODE_SERVER_PASSWORD`), plugins lose the ability to create sub-sessions or interact with the server because the injected SDK client lacks authentication headers.

This PR fixes this by:
1. Detecting the `OPENCODE_SERVER_PASSWORD` environment variable.
2. Injecting the corresponding `Authorization` (Basic Auth) header into the `createOpencodeClient` configuration during plugin initialization.

## Impact
- Fixes `Unauthorized` errors in tools like `look_at` and other sub-agent calls when server password is set.
- Aligns with the expected behavior where internal components automatically inherit server credentials.