### PR TITLE
feat(tui): add /edit-last command to open last assistant message in editor

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -741,6 +741,64 @@ export function Session() {
       },
     },
     {
+      title: "Open last assistant message in editor",
+      value: "messages.open_in_editor",
+      category: "Session",
+      enabled: !!(process.env["VISUAL"] || process.env["EDITOR"]),
+      slash: {
+        name: "edit-last",
+      },
+      onSelect: async (dialog) => {
+        const revertID = session()?.revert?.messageID
+        const lastAssistantMessage = messages().findLast(
+          (msg) => msg.role === "assistant" && (!revertID || msg.id < revertID),
+        )
+        if (!lastAssistantMessage) {
+          toast.show({ message: "No assistant messages found", variant: "error" })
+          dialog.clear()
+          return
+        }
+        const parts = sync.data.part[lastAssistantMessage.id] ?? []
+        const textParts = parts.filter((part) => part.type === "text")
+        if (textParts.length === 0) {
+          toast.show({ message: "No text parts found in last assistant message", variant: "error" })
+          dialog.clear()
+          return
+        }
+        const text = textParts
+          .map((part) => part.text)
+          .join("\n")
+          .trim()
+        if (!text) {
+          toast.show({
+            message: "No text content found in last assistant message",
+            variant: "error",
+          })
+          dialog.clear()
+          return
+        }
+        dialog.clear()
+        const editedContent = await Editor.open({ value: text, renderer })
+
+        if (editedContent === undefined) {
+          return
+        }
+
+        if (editedContent.trim() === text.trim()) {
+          toast.show({ message: "No changes made", variant: "info" })
+          return
+        }
+
+        if (editedContent.trim() === "") {
+          toast.show({ message: "Empty message", variant: "warning" })
+          return
+        }
+
+        prompt.set({ input: editedContent, parts: [] })
+        toast.show({ message: "Edited message loaded. Press Enter to send.", variant: "success" })
+      },
+    },
+    {
       title: "Copy session transcript",
       value: "session.copy",
       category: "Session",


### PR DESCRIPTION
Fixes #11598

## Summary

Adds a new slash command "/edit-last" that opens the last assistant message in an external editor (vim/nvim/code etc.) for editing.

## What does this PR do?

When users type "/edit-last" or select it from the command dialog, the last assistant message will be opened in the external editor configured via VISUAL or EDITOR environment variable.

## Changes

- Added new command "Open last assistant message in editor" in session/index.tsx
- Command is only visible when VISUAL or EDITOR environment variable is set
- After editing and saving (`:wq` in vim), the edited content is loaded into the prompt input
- If no changes are made (`:q!`), the original message remains unchanged
- Users must press Enter to send the edited message

## How did you verify your code works?

- Typechecked with `bun run typecheck` - all 12 packages passed
- Manual testing scenarios:
  1. Without EDITOR set: command does not appear in command palette
  2. With EDITOR=vim: `/edit-last` opens vim with last assistant message
  3. After `:wq` in vim: edited content appears in input prompt
  4. After `:q!` in vim: "No changes made" toast shown, input unchanged

## Requirements

Users need to set the EDITOR or VISUAL environment variable:
```bash
export EDITOR=vim    # or nvim, nano, code, etc.
export VISUAL=nvim   # takes precedence over EDITOR
```