### PR TITLE
fix: prevent infinite retry loop for Kimi K2.5 reasoning field errors

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -665,6 +665,29 @@ export namespace MessageV2 {
     return status === 404 || e.isRetryable
   }
 
+  /**
+   * Detects validation errors from providers that don't support certain fields.
+   * These errors should not be retried as they will always fail.
+   *
+   * For example, when using Kimi K2.5 through OpenRouter with Together/Fireworks
+   * as backend providers, the reasoning_content field causes 400 errors that
+   * would otherwise be retried indefinitely.
+   */
+  const isNonRetryableValidationError = (e: APICallError): boolean => {
+    if (e.statusCode !== 400) return false
+
+    const errorText = (e.responseBody || e.message || "").toLowerCase()
+
+    const nonRetryablePatterns = ["extra inputs are not permitted", "unknown parameter", "unexpected field"]
+
+    const reasoningFields = ["reasoning_content", "reasoning_details", "reasoning"]
+
+    const hasNonRetryablePattern = nonRetryablePatterns.some((p) => errorText.includes(p))
+    const involvesReasoningField = reasoningFields.some((f) => errorText.includes(f))
+
+    return hasNonRetryablePattern && involvesReasoningField
+  }
+
   export function fromError(e: unknown, ctx: { providerID: string }) {
     switch (true) {
       case e instanceof DOMException && e.name === "AbortError":
@@ -733,7 +756,11 @@ export namespace MessageV2 {
           {
             message,
             statusCode: e.statusCode,
-            isRetryable: ctx.providerID.startsWith("openai") ? isOpenAiErrorRetryable(e) : e.isRetryable,
+            isRetryable: isNonRetryableValidationError(e)
+              ? false
+              : ctx.providerID.startsWith("openai")
+                ? isOpenAiErrorRetryable(e)
+                : e.isRetryable,
             responseHeaders: e.responseHeaders,
             responseBody: e.responseBody,
             metadata,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -176,4 +176,60 @@ describe("session.message-v2.fromError", () => {
     const result = MessageV2.fromError(error, { providerID: "openai" }) as MessageV2.APIError
     expect(result.data.isRetryable).toBe(true)
   })
+
+  test("marks reasoning field validation errors as non-retryable", () => {
+    const error = new APICallError({
+      message: "Bad Request",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"error":"Extra inputs are not permitted, field: \'reasoning_content\'"}',
+      isRetryable: true, // AI SDK marks 400 as retryable by default
+    })
+    const result = MessageV2.fromError(error, { providerID: "openrouter" }) as MessageV2.APIError
+    expect(result.data.isRetryable).toBe(false)
+  })
+
+  test("marks reasoning_details validation errors as non-retryable", () => {
+    const error = new APICallError({
+      message: "Bad Request",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"error":"unknown parameter: reasoning_details"}',
+      isRetryable: true,
+    })
+    const result = MessageV2.fromError(error, { providerID: "openrouter" }) as MessageV2.APIError
+    expect(result.data.isRetryable).toBe(false)
+  })
+
+  test("preserves retryability for non-reasoning validation errors", () => {
+    const error = new APICallError({
+      message: "Bad Request",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 400,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"error":"Extra inputs are not permitted, field: \'some_other_field\'"}',
+      isRetryable: true,
+    })
+    const result = MessageV2.fromError(error, { providerID: "openrouter" }) as MessageV2.APIError
+    expect(result.data.isRetryable).toBe(true)
+  })
+
+  test("preserves retryability for rate limit errors (429)", () => {
+    const error = new APICallError({
+      message: "Rate limit exceeded",
+      url: "https://openrouter.ai/api/v1/chat/completions",
+      requestBodyValues: {},
+      statusCode: 429,
+      responseHeaders: { "content-type": "application/json" },
+      responseBody: '{"error":"Rate limit exceeded"}',
+      isRetryable: true,
+    })
+    const result = MessageV2.fromError(error, { providerID: "openrouter" }) as MessageV2.APIError
+    expect(result.data.isRetryable).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- Detect validation errors about unsupported reasoning fields (reasoning_content, reasoning_details)
- Mark these 400 errors as non-retryable to prevent infinite retry loops
- Affects Kimi K2.5 models when routed through Together/Fireworks via OpenRouter

## Test Plan
- Added 4 test cases in retry.test.ts
- Verified reasoning field errors → non-retryable
- Verified non-reasoning 400 errors → still retryable
- Verified 429 rate limit errors → still retryable

Fixes #11541

🤖 Generated with [Claude Code](https://claude.com/claude-code)