### PR TITLE
feat(opencode): cost calculation according to service_tier (OpenAI)

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -39,6 +39,34 @@ export namespace ModelsDev {
         output: z.number(),
         cache_read: z.number().optional(),
         cache_write: z.number().optional(),
+        service_tier: z
+          .object({
+            default: z
+              .object({
+                input: z.number(),
+                output: z.number(),
+                cache_read: z.number().optional(),
+                cache_write: z.number().optional(),
+              })
+              .optional(),
+            flex: z
+              .object({
+                input: z.number(),
+                output: z.number(),
+                cache_read: z.number().optional(),
+                cache_write: z.number().optional(),
+              })
+              .optional(),
+            priority: z
+              .object({
+                input: z.number(),
+                output: z.number(),
+                cache_read: z.number().optional(),
+                cache_write: z.number().optional(),
+              })
+              .optional(),
+          })
+          .optional(),
         context_over_200k: z
           .object({
             input: z.number(),

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -556,6 +556,40 @@ export namespace Provider {
           read: z.number(),
           write: z.number(),
         }),
+        serviceTier: z
+          .object({
+            default: z
+              .object({
+                input: z.number(),
+                output: z.number(),
+                cache: z.object({
+                  read: z.number(),
+                  write: z.number(),
+                }),
+              })
+              .optional(),
+            flex: z
+              .object({
+                input: z.number(),
+                output: z.number(),
+                cache: z.object({
+                  read: z.number(),
+                  write: z.number(),
+                }),
+              })
+              .optional(),
+            priority: z
+              .object({
+                input: z.number(),
+                output: z.number(),
+                cache: z.object({
+                  read: z.number(),
+                  write: z.number(),
+                }),
+              })
+              .optional(),
+          })
+          .optional(),
         experimentalOver200K: z
           .object({
             input: z.number(),
@@ -619,6 +653,40 @@ export namespace Provider {
           read: model.cost?.cache_read ?? 0,
           write: model.cost?.cache_write ?? 0,
         },
+        serviceTier: model.cost?.service_tier
+          ? {
+              default: model.cost.service_tier.default
+                ? {
+                    input: model.cost.service_tier.default.input,
+                    output: model.cost.service_tier.default.output,
+                    cache: {
+                      read: model.cost.service_tier.default.cache_read ?? 0,
+                      write: model.cost.service_tier.default.cache_write ?? 0,
+                    },
+                  }
+                : undefined,
+              flex: model.cost.service_tier.flex
+                ? {
+                    input: model.cost.service_tier.flex.input,
+                    output: model.cost.service_tier.flex.output,
+                    cache: {
+                      read: model.cost.service_tier.flex.cache_read ?? 0,
+                      write: model.cost.service_tier.flex.cache_write ?? 0,
+                    },
+                  }
+                : undefined,
+              priority: model.cost.service_tier.priority
+                ? {
+                    input: model.cost.service_tier.priority.input,
+                    output: model.cost.service_tier.priority.output,
+                    cache: {
+                      read: model.cost.service_tier.priority.cache_read ?? 0,
+                      write: model.cost.service_tier.priority.cache_write ?? 0,
+                    },
+                  }
+                : undefined,
+            }
+          : undefined,
         experimentalOver200K: model.cost?.context_over_200k
           ? {
               cache: {
@@ -791,6 +859,42 @@ export namespace Provider {
               read: model?.cost?.cache_read ?? existingModel?.cost?.cache.read ?? 0,
               write: model?.cost?.cache_write ?? existingModel?.cost?.cache.write ?? 0,
             },
+            serviceTier: iife(() => {
+              const current = existingModel?.cost?.serviceTier
+              if (!model?.cost?.service_tier) return current
+              return {
+                default: model.cost.service_tier.default
+                  ? {
+                      input: model.cost.service_tier.default.input,
+                      output: model.cost.service_tier.default.output,
+                      cache: {
+                        read: model.cost.service_tier.default.cache_read ?? 0,
+                        write: model.cost.service_tier.default.cache_write ?? 0,
+                      },
+                    }
+                  : current?.default,
+                flex: model.cost.service_tier.flex
+                  ? {
+                      input: model.cost.service_tier.flex.input,
+                      output: model.cost.service_tier.flex.output,
+                      cache: {
+                        read: model.cost.service_tier.flex.cache_read ?? 0,
+                        write: model.cost.service_tier.flex.cache_write ?? 0,
+                      },
+                    }
+                  : current?.flex,
+                priority: model.cost.service_tier.priority
+                  ? {
+                      input: model.cost.service_tier.priority.input,
+                      output: model.cost.service_tier.priority.output,
+                      cache: {
+                        read: model.cost.service_tier.priority.cache_read ?? 0,
+                        write: model.cost.service_tier.priority.cache_write ?? 0,
+                      },
+                    }
+                  : current?.priority,
+              }
+            }),
           },
           options: mergeDeep(existingModel?.options ?? {}, model.options ?? {}),
           limit: {

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -478,18 +478,24 @@ export namespace Session {
           ? input.model.cost.experimentalOver200K
           : input.model.cost
       const base = rate ?? costInfo
+      const cost = safe(
+        new Decimal(0)
+          .add(new Decimal(tokens.input).mul(base?.input ?? 0).div(1_000_000))
+          .add(new Decimal(tokens.output).mul(base?.output ?? 0).div(1_000_000))
+          .add(new Decimal(tokens.cache.read).mul(base?.cache?.read ?? 0).div(1_000_000))
+          .add(new Decimal(tokens.cache.write).mul(base?.cache?.write ?? 0).div(1_000_000))
+          // TODO: update models.dev to have better pricing model, for now:
+          // charge reasoning tokens at the same rate as output tokens
+          .add(new Decimal(tokens.reasoning).mul(base?.output ?? 0).div(1_000_000))
+          .toNumber(),
+      )
+      log.debug("usage", {
+        tier: rate ? tier : "base",
+        rate: base,
+        price: cost,
+      })
       return {
-        cost: safe(
-          new Decimal(0)
-            .add(new Decimal(tokens.input).mul(base?.input ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.output).mul(base?.output ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.read).mul(base?.cache?.read ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.write).mul(base?.cache?.write ?? 0).div(1_000_000))
-            // TODO: update models.dev to have better pricing model, for now:
-            // charge reasoning tokens at the same rate as output tokens
-            .add(new Decimal(tokens.reasoning).mul(base?.output ?? 0).div(1_000_000))
-            .toNumber(),
-        ),
+        cost,
         tokens,
       }
     },

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -16,6 +16,7 @@ import { MessageV2 } from "./message-v2"
 import { Instance } from "../project/instance"
 import { SessionPrompt } from "./prompt"
 import { fn } from "@/util/fn"
+import { iife } from "@/util/iife"
 import { Command } from "../command"
 import { Snapshot } from "@/snapshot"
 
@@ -467,20 +468,26 @@ export namespace Session {
         },
       }
 
+      const tier = input.metadata?.openai?.serviceTier
+      const rate = iife(() => {
+        if (tier !== "default" && tier !== "flex" && tier !== "priority") return undefined
+        return input.model.cost?.serviceTier?.[tier]
+      })
       const costInfo =
         input.model.cost?.experimentalOver200K && tokens.input + tokens.cache.read > 200_000
           ? input.model.cost.experimentalOver200K
           : input.model.cost
+      const base = rate ?? costInfo
       return {
         cost: safe(
           new Decimal(0)
-            .add(new Decimal(tokens.input).mul(costInfo?.input ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.output).mul(costInfo?.output ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.read).mul(costInfo?.cache?.read ?? 0).div(1_000_000))
-            .add(new Decimal(tokens.cache.write).mul(costInfo?.cache?.write ?? 0).div(1_000_000))
+            .add(new Decimal(tokens.input).mul(base?.input ?? 0).div(1_000_000))
+            .add(new Decimal(tokens.output).mul(base?.output ?? 0).div(1_000_000))
+            .add(new Decimal(tokens.cache.read).mul(base?.cache?.read ?? 0).div(1_000_000))
+            .add(new Decimal(tokens.cache.write).mul(base?.cache?.write ?? 0).div(1_000_000))
             // TODO: update models.dev to have better pricing model, for now:
             // charge reasoning tokens at the same rate as output tokens
-            .add(new Decimal(tokens.reasoning).mul(costInfo?.output ?? 0).div(1_000_000))
+            .add(new Decimal(tokens.reasoning).mul(base?.output ?? 0).div(1_000_000))
             .toNumber(),
         ),
         tokens,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -239,6 +239,12 @@ export namespace SessionProcessor {
                     usage: value.usage,
                     metadata: value.providerMetadata,
                   })
+                  log.debug("response", {
+                    messageID: input.assistantMessage.id,
+                    sessionID: input.assistantMessage.sessionID,
+                    model: input.model.id,
+                    serviceTier: value.providerMetadata?.openai?.serviceTier,
+                  })
                   input.assistantMessage.finish = value.finishReason
                   input.assistantMessage.cost += usage.cost
                   input.assistantMessage.tokens = usage.tokens

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -290,4 +290,67 @@ describe("session.getUsage", () => {
 
     expect(result.cost).toBe(3 + 1.5)
   })
+
+  test("uses service tier pricing when provided", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0.3, write: 0 },
+        serviceTier: {
+          flex: {
+            input: 0.875,
+            output: 7,
+            cache: { read: 0.0875, write: 0 },
+          },
+        },
+      },
+    })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 1_000_000,
+        outputTokens: 100_000,
+        totalTokens: 1_100_000,
+        cachedInputTokens: 100_000,
+      },
+      metadata: {
+        openai: {
+          serviceTier: "flex",
+        },
+      },
+    })
+
+    expect(result.cost).toBe(1.49625)
+  })
+
+  test("falls back to base pricing when service tier missing", () => {
+    const model = createModel({
+      context: 100_000,
+      output: 32_000,
+      cost: {
+        input: 3,
+        output: 15,
+        cache: { read: 0.3, write: 0 },
+      },
+    })
+    const result = Session.getUsage({
+      model,
+      usage: {
+        inputTokens: 1_000_000,
+        outputTokens: 100_000,
+        totalTokens: 1_100_000,
+        cachedInputTokens: 100_000,
+      },
+      metadata: {
+        openai: {
+          serviceTier: "priority",
+        },
+      },
+    })
+
+    expect(result.cost).toBe(4.23)
+  })
 })

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -135,6 +135,51 @@ You can also define custom variants that extend built-in ones. Variants let you 
 
 ---
 
+## Set pricing
+
+Override per-service-tier rates for a specific model when you need custom cost tracking.
+
+```jsonc title="opencode.jsonc" {7-26}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-5.2": {
+          "options": {
+            "serviceTier": "flex"
+          },
+          "cost": {
+            "input": 1.75,
+            "output": 14.00,
+            "cache_read": 0.175,
+            "service_tier": {
+              "default": {
+                "input": 1.75,
+                "output": 14.00,
+                "cache_read": 0.175,
+              },
+              "flex": {
+                "input": 0.875,
+                "output": 7.00,
+                "cache_read": 0.0875,
+              },
+              "priority": {
+                "input": 3.50,
+                "output": 28.00,
+                "cache_read": 0.35,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+---
+
 ## Variants
 
 Many models support multiple variants with different configurations. OpenCode ships with built-in default variants for popular providers.


### PR DESCRIPTION
### What does this PR do?
Allows to set (override) detailed prices for models by service_tier. It helps to calculate price by reading service_tier from result.

### How to verify:
Example of config for get-5.2:
```
"provider": {
        "openai": {
            "models": {
                "gpt-5.2": {
                    "options": {
                        "serviceTier": "flex"
                    },
                    "cost": {
                        "input": 1.75,
                        "output": 14.00,
                        "cache_read": 0.175,
                        "service_tier": {
                            "default": {
                                "input": 1.75,
                                "output": 14.00,
                                "cache_read": 0.175,
                            },
                            "flex": {
                                "input": 0.875,
                                "output": 7.00,
                                "cache_read": 0.0875,
                            },
                            "priority": {
                                "input": 3.50,
                                "output": 28.00,
                                "cache_read": 0.35,
                            },
                        },
                    }
                }
            }
        },
        ...
```
* Try to run model via OpenAI and take a look at logs and actual price in OpenAI

### Notes
models.dev is not providing the prices for tiers now but if it will be added from theirs side it will be possible to start reading values in the future

Closes #11597 and maybe #Closes #7511