### PR TITLE
fix: convert system message content to string for Copilot provider

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages.ts
@@ -18,12 +18,7 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV2Pro
       case "system": {
         messages.push({
           role: "system",
-          content: [
-            {
-              type: "text",
-              text: content,
-            },
-          ],
+          content: content,
           ...metadata,
         })
         break

--- a/packages/opencode/test/provider/copilot/convert-to-copilot-messages.test.ts
+++ b/packages/opencode/test/provider/copilot/convert-to-copilot-messages.test.ts
@@ -1,6 +1,24 @@
 import { convertToOpenAICompatibleChatMessages as convertToCopilotMessages } from "@/provider/sdk/copilot/chat/convert-to-openai-compatible-chat-messages"
 import { describe, test, expect } from "bun:test"
 
+describe("system messages", () => {
+  test("should convert system message content to string", () => {
+    const result = convertToCopilotMessages([
+      {
+        role: "system",
+        content: "You are a helpful assistant with AGENTS.md instructions.",
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "system",
+        content: "You are a helpful assistant with AGENTS.md instructions.",
+      },
+    ])
+  })
+})
+
 describe("user messages", () => {
   test("should convert messages with only a text part to a string content", () => {
     const result = convertToCopilotMessages([


### PR DESCRIPTION
## Summary
- Fixed system message content being wrapped in array format instead of plain string
- The GitHub Copilot API for Claude/Anthropic models expects system message content as a string, causing AGENTS.md instructions to be silently ignored
- Added explicit test for system message format

Fixes #11540
Fixes #11732

## Test plan
- [x] Unit tests pass: `bun test test/provider/copilot/convert-to-copilot-messages.test.ts`
- [x] Manual test: Create AGENTS.md with custom instruction and verify Opus via Copilot follows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)