### PR TITLE
feat(messages): add renderAsAssistant field for user messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1061,7 +1061,7 @@ export function Session() {
                     <Match when={revert()?.messageID && message.id >= revert()!.messageID}>
                       <></>
                     </Match>
-                    <Match when={message.role === "user"}>
+                    <Match when={message.role === "user" && !(message as UserMessage).renderAsAssistant}>
                       <UserMessage
                         index={index()}
                         onMouseUp={() => {
@@ -1079,7 +1079,12 @@ export function Session() {
                         pending={pending()}
                       />
                     </Match>
-                    <Match when={message.role === "assistant"}>
+                    <Match
+                      when={
+                        message.role === "assistant" ||
+                        (message.role === "user" && (message as UserMessage).renderAsAssistant)
+                      }
+                    >
                       <AssistantMessage
                         last={lastAssistant()?.id === message.id}
                         message={message as AssistantMessage}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1087,7 +1087,7 @@ export function Session() {
                     >
                       <AssistantMessage
                         last={lastAssistant()?.id === message.id}
-                        message={message as AssistantMessage}
+                        message={message}
                         parts={sync.data.part[message.id] ?? []}
                       />
                     </Match>
@@ -1254,22 +1254,29 @@ function UserMessage(props: {
   )
 }
 
-function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; last: boolean }) {
+function AssistantMessage(props: { message: AssistantMessage | UserMessage; parts: Part[]; last: boolean }) {
   const local = useLocal()
   const { theme } = useTheme()
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
 
+  // Check if this is an actual AssistantMessage (not UserMessage with renderAsAssistant)
+  const isActualAssistant = createMemo(() => props.message.role === "assistant")
+
   const final = createMemo(() => {
-    return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)
+    if (!isActualAssistant()) return false
+    const msg = props.message as AssistantMessage
+    return msg.finish && !["tool-calls", "unknown"].includes(msg.finish)
   })
 
   const duration = createMemo(() => {
+    if (!isActualAssistant()) return 0
     if (!final()) return 0
-    if (!props.message.time.completed) return 0
-    const user = messages().find((x) => x.role === "user" && x.id === props.message.parentID)
+    const msg = props.message as AssistantMessage
+    if (!msg.time.completed) return 0
+    const user = messages().find((x) => x.role === "user" && x.id === msg.parentID)
     if (!user || !user.time) return 0
-    return props.message.time.completed - user.time.created
+    return msg.time.completed - user.time.created
   })
 
   return (
@@ -1289,46 +1296,55 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
           )
         }}
       </For>
-      <Show when={props.message.error && props.message.error.name !== "MessageAbortedError"}>
-        <box
-          border={["left"]}
-          paddingTop={1}
-          paddingBottom={1}
-          paddingLeft={2}
-          marginTop={1}
-          backgroundColor={theme.backgroundPanel}
-          customBorderChars={SplitBorder.customBorderChars}
-          borderColor={theme.error}
+      <Show when={isActualAssistant()}>
+        <Show
+          when={
+            (props.message as AssistantMessage).error &&
+            (props.message as AssistantMessage).error?.name !== "MessageAbortedError"
+          }
         >
-          <text fg={theme.textMuted}>{props.message.error?.data.message}</text>
-        </box>
-      </Show>
-      <Switch>
-        <Match when={props.last || final() || props.message.error?.name === "MessageAbortedError"}>
-          <box paddingLeft={3}>
-            <text marginTop={1}>
-              <span
-                style={{
-                  fg:
-                    props.message.error?.name === "MessageAbortedError"
-                      ? theme.textMuted
-                      : local.agent.color(props.message.agent),
-                }}
-              >
-                ▣{" "}
-              </span>{" "}
-              <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
-              <span style={{ fg: theme.textMuted }}> · {props.message.modelID}</span>
-              <Show when={duration()}>
-                <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
-              </Show>
-              <Show when={props.message.error?.name === "MessageAbortedError"}>
-                <span style={{ fg: theme.textMuted }}> · interrupted</span>
-              </Show>
-            </text>
+          <box
+            border={["left"]}
+            paddingTop={1}
+            paddingBottom={1}
+            paddingLeft={2}
+            marginTop={1}
+            backgroundColor={theme.backgroundPanel}
+            customBorderChars={SplitBorder.customBorderChars}
+            borderColor={theme.error}
+          >
+            <text fg={theme.textMuted}>{(props.message as AssistantMessage).error?.data.message}</text>
           </box>
-        </Match>
-      </Switch>
+        </Show>
+        <Switch>
+          <Match
+            when={props.last || final() || (props.message as AssistantMessage).error?.name === "MessageAbortedError"}
+          >
+            <box paddingLeft={3}>
+              <text marginTop={1}>
+                <span
+                  style={{
+                    fg:
+                      (props.message as AssistantMessage).error?.name === "MessageAbortedError"
+                        ? theme.textMuted
+                        : local.agent.color(props.message.agent),
+                  }}
+                >
+                  ▣{" "}
+                </span>{" "}
+                <span style={{ fg: theme.text }}>{Locale.titlecase((props.message as AssistantMessage).mode)}</span>
+                <span style={{ fg: theme.textMuted }}>· {(props.message as AssistantMessage).modelID}</span>
+                <Show when={duration()}>
+                  <span style={{ fg: theme.textMuted }}>· {Locale.duration(duration())}</span>
+                </Show>
+                <Show when={(props.message as AssistantMessage).error?.name === "MessageAbortedError"}>
+                  <span style={{ fg: theme.textMuted }}>· interrupted</span>
+                </Show>
+              </text>
+            </box>
+          </Match>
+        </Switch>
+      </Show>
     </>
   )
 }
@@ -1339,7 +1355,7 @@ const PART_MAPPING = {
   reasoning: ReasoningPart,
 }
 
-function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage }) {
+function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: AssistantMessage | UserMessage }) {
   const { theme, subtleSyntax } = useTheme()
   const ctx = use()
   const content = createMemo(() => {
@@ -1372,7 +1388,7 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
   )
 }
 
-function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
+function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage | UserMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
   return (
@@ -1406,7 +1422,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
 
 // Pending messages moved to individual tool pending functions
 
-function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMessage }) {
+function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMessage | UserMessage }) {
   const ctx = use()
   const sync = useSync()
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -359,6 +359,7 @@ export namespace MessageV2 {
     system: z.string().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
     variant: z.string().optional(),
+    renderAsAssistant: z.boolean().optional().describe("Render this user message with assistant styling in the UI"),
   }).meta({
     ref: "UserMessage",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -152,6 +152,7 @@ export namespace SessionPrompt {
           }),
       ]),
     ),
+    renderAsAssistant: z.boolean().optional().describe("Render this user message with assistant styling in the UI"),
   })
   export type PromptInput = z.infer<typeof PromptInput>
 
@@ -963,7 +964,8 @@ export namespace SessionPrompt {
       model,
       system: input.system,
       format: input.format,
-      variant,
+      variant: input.variant,
+      renderAsAssistant: input.renderAsAssistant,
     }
     using _ = defer(() => InstructionPrompt.clear(info.id))
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -1478,6 +1478,7 @@ export class Session extends HeyApiClient {
       system?: string
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      renderAsAssistant?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1497,6 +1498,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
+            { in: "body", key: "renderAsAssistant" },
           ],
         },
       ],
@@ -1568,6 +1570,7 @@ export class Session extends HeyApiClient {
       system?: string
       variant?: string
       parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      renderAsAssistant?: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1587,6 +1590,7 @@ export class Session extends HeyApiClient {
             { in: "body", key: "system" },
             { in: "body", key: "variant" },
             { in: "body", key: "parts" },
+            { in: "body", key: "renderAsAssistant" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -138,6 +138,10 @@ export type UserMessage = {
     [key: string]: boolean
   }
   variant?: string
+  /**
+   * Render this user message with assistant styling in the UI
+   */
+  renderAsAssistant?: boolean
 }
 
 export type ProviderAuthError = {
@@ -3435,6 +3439,10 @@ export type SessionPromptData = {
     system?: string
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    /**
+     * Render this user message with assistant styling in the UI
+     */
+    renderAsAssistant?: boolean
   }
   path: {
     /**
@@ -3623,6 +3631,10 @@ export type SessionPromptAsyncData = {
     system?: string
     variant?: string
     parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    /**
+     * Render this user message with assistant styling in the UI
+     */
+    renderAsAssistant?: boolean
   }
   path: {
     /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2447,6 +2447,10 @@
                         }
                       ]
                     }
+                  },
+                  "renderAsAssistant": {
+                    "description": "Render this user message with assistant styling in the UI",
+                    "type": "boolean"
                   }
                 },
                 "required": ["parts"]
@@ -2826,6 +2830,10 @@
                         }
                       ]
                     }
+                  },
+                  "renderAsAssistant": {
+                    "description": "Render this user message with assistant styling in the UI",
+                    "type": "boolean"
                   }
                 },
                 "required": ["parts"]
@@ -6221,6 +6229,10 @@
           },
           "variant": {
             "type": "string"
+          },
+          "renderAsAssistant": {
+            "description": "Render this user message with assistant styling in the UI",
+            "type": "boolean"
           }
         },
         "required": ["id", "sessionID", "role", "time", "agent", "model"]

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -274,12 +274,16 @@ export function registerPartComponent(type: string, component: PartComponent) {
 }
 
 export function Message(props: MessageProps) {
+  const isUser = props.message.role === "user"
+  const isAssistant = props.message.role === "assistant"
+  const renderAsAssistant = isUser && (props.message as UserMessage).renderAsAssistant === true
+
   return (
     <Switch>
-      <Match when={props.message.role === "user" && props.message}>
+      <Match when={isUser && !renderAsAssistant && props.message}>
         {(userMessage) => <UserMessageDisplay message={userMessage() as UserMessage} parts={props.parts} />}
       </Match>
-      <Match when={props.message.role === "assistant" && props.message}>
+      <Match when={(isAssistant || renderAsAssistant) && props.message}>
         {(assistantMessage) => (
           <AssistantMessageDisplay message={assistantMessage() as AssistantMessage} parts={props.parts} />
         )}

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -292,7 +292,7 @@ export function Message(props: MessageProps) {
   )
 }
 
-export function AssistantMessageDisplay(props: { message: AssistantMessage; parts: PartType[] }) {
+export function AssistantMessageDisplay(props: { message: MessageType; parts: PartType[] }) {
   const emptyParts: PartType[] = []
   const filteredParts = createMemo(
     () =>


### PR DESCRIPTION
Closes #11611

## Summary

This PR adds a new `renderAsAssistant` field to user messages, allowing plugins to send user messages that render with assistant styling in the UI. This enables plugins to display content beautifully (like plans, summaries, or reports) before requesting user approval or action.

## Motivation

Plugins that generate structured content (like plans, documentation, or reports) need to present this content to users in a visually distinct way before requesting approval. The plan-mode plugin is a primary use case: it needs to display implementation plans with assistant styling before showing approval buttons via the built-in `plan_exit` tool.

Without this feature, plugins can only send regular user messages, which don't have the same visual presentation as assistant messages.

## Changes

### Backend (Core)

- **`packages/opencode/src/session/message-v2.ts`**
  - Added `renderAsAssistant: z.boolean().optional()` to `UserMessage` schema
  - Allows user messages to opt into assistant-style rendering

- **`packages/opencode/src/session/prompt.ts`**
  - Added `renderAsAssistant` to `PromptInput` schema
  - Passed field through to user message creation

- **`packages/sdk/js/src/v2/gen/types.gen.ts`**
  - Regenerated SDK types to include new field

- **`packages/sdk/js/src/v2/gen/sdk.gen.ts`**
  - Regenerated SDK to support new field

### Frontend (UI)

- **`packages/ui/src/components/message-part.tsx`**
  - Modified `Message` component to check `renderAsAssistant` field
  - When `renderAsAssistant: true`, renders user messages with `AssistantMessageDisplay` component
  - Preserves normal user message styling when field is absent or false

- **`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`**
  - Updated TUI to respect `renderAsAssistant` field for consistent rendering

## Usage Example

### Plugin Code (plan-mode.ts)

```typescript
const displayPlan: ToolFunction = async (args, context) => {
  const planContent = await context.fs.readTextFile(planFilePath);
  
  // Send user message with assistant styling
  await context.addUserMessage({
    content: `# Implementation Plan\n\n${planContent}`,
    renderAsAssistant: true  // ← This makes it render beautifully
  });
  
  return "Plan displayed to user with assistant styling.";
};
```

### Workflow

1. Plugin generates content (e.g., implementation plan)
2. Plugin calls `context.addUserMessage({ content: "...", renderAsAssistant: true })`
3. UI renders the message with assistant styling (indented, styled markdown)
4. User sees beautifully formatted content
5. Plugin or built-in tool can then request approval (e.g., via `plan_exit`)

## Testing

### Setup

Enable experimental plan mode to test the full workflow:

```bash
export OPENCODE_EXPERIMENTAL_PLAN_MODE=true
```

### Test Steps

1. **Install plan-mode plugin** at `~/.config/opencode/plugins/plan-mode.ts` (see example above)
2. **Restart OpenCode** to load the plugin
3. **Switch to plan agent**: `/agent plan`
4. **Create a plan**: Agent will use `write_plan`, `edit_plan`, `read_plan` tools
5. **Display plan**: Agent calls `display_plan` (plugin tool)
   - ✅ Verify plan appears with **assistant styling** (not regular user message)
   - ✅ Verify plan content is beautifully formatted
6. **Request approval**: Agent calls `plan_exit` (built-in tool)
   - ✅ Verify Yes/No buttons appear
   - ✅ Click "Yes" → verify switches to build agent

### Manual Testing

Without the full plugin workflow, you can test the field directly:

```typescript
// In any plugin or tool
await context.addUserMessage({
  content: "## Test Content\n\nThis should render with assistant styling.",
  renderAsAssistant: true
});
```

Expected: Message appears indented with assistant styling, not as a regular user message.

## Backward Compatibility

- ✅ **Fully backward compatible** - field is optional
- ✅ Existing user messages (without `renderAsAssistant`) render normally
- ✅ No breaking changes to message schema or UI components

## Dependencies

This feature works standalone but is designed to integrate with:
- `OPENCODE_EXPERIMENTAL_PLAN_MODE=true` flag (enables `plan_exit` built-in tool)
- Plan-mode plugin (uses `renderAsAssistant` for plan display)

The plugin is not part of this PR but demonstrates the primary use case.

## Notes

- The `renderAsAssistant` field only affects UI rendering, not message semantics
- Messages are still user messages in the conversation history
- The field is primarily intended for plugin-generated content display
- Built-in tools could also use this field if needed

## Checklist

- [x] Backend schema changes (message-v2.ts, prompt.ts)
- [x] Frontend UI changes (message-part.tsx, TUI)
- [x] SDK regenerated (types.gen.ts, sdk.gen.ts)
- [x] Type checking passes
- [x] No breaking changes
- [x] Backward compatible