### PR TITLE
feat: tool/agent status indicator

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1514,6 +1514,8 @@ function InlineTool(props: {
   const ctx = use()
   const sync = useSync()
 
+  const status = createMemo(() => props.part.state.status)
+
   const permission = createMemo(() => {
     const callID = sync.data.permission[ctx.sessionID]?.at(0)?.tool?.callID
     if (!callID) return false
@@ -1522,8 +1524,21 @@ function InlineTool(props: {
 
   const fg = createMemo(() => {
     if (permission()) return theme.warning
-    if (props.complete) return theme.textMuted
+    if (status() === "completed") return theme.textMuted
     return theme.text
+  })
+
+  const badge = createMemo(() => {
+    if (permission()) return { glyph: "!", color: theme.warning }
+
+    return (
+      {
+        pending: { glyph: "○", color: theme.textMuted },
+        running: { glyph: "●", color: theme.success },
+        completed: { glyph: "✓", color: theme.success },
+        error: { glyph: "✗", color: theme.error },
+      } satisfies Record<ToolPart["state"]["status"], { glyph: string; color: RGBA }>
+    )[status()]
   })
 
   const error = createMemo(() => (props.part.state.status === "error" ? props.part.state.error : undefined))
@@ -1563,6 +1578,7 @@ function InlineTool(props: {
       }}
     >
       <text paddingLeft={3} fg={fg()} attributes={denied() ? TextAttributes.STRIKETHROUGH : undefined}>
+        <span style={{ fg: badge().color }}>{badge().glyph}</span>{" "}
         <Show fallback={<>~ {props.pending}</>} when={props.complete}>
           <span style={{ fg: props.iconColor }}>{props.icon}</span> {props.children}
         </Show>
@@ -1585,6 +1601,20 @@ function BlockTool(props: {
   const renderer = useRenderer()
   const [hover, setHover] = createSignal(false)
   const error = createMemo(() => (props.part?.state.status === "error" ? props.part.state.error : undefined))
+
+  const badge = createMemo(() => {
+    const status = props.part?.state.status
+    if (!status) return
+
+    return (
+      {
+        pending: { glyph: "○", color: theme.textMuted },
+        running: { glyph: "●", color: theme.success },
+        completed: { glyph: "✓", color: theme.success },
+        error: { glyph: "✗", color: theme.error },
+      } satisfies Record<ToolPart["state"]["status"], { glyph: string; color: RGBA }>
+    )[status]
+  })
   return (
     <box
       border={["left"]}
@@ -1607,6 +1637,13 @@ function BlockTool(props: {
         when={props.spinner}
         fallback={
           <text paddingLeft={3} fg={theme.textMuted}>
+            <Show when={badge()}>
+              {(b) => (
+                <>
+                  <span style={{ fg: b().color }}>{b().glyph}</span>{" "}
+                </>
+              )}
+            </Show>
             {props.title}
           </text>
         }

--- a/packages/opencode/test/cli/tui/tool-status-badge.test.ts
+++ b/packages/opencode/test/cli/tui/tool-status-badge.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test"
+import type { ToolPart } from "@opencode-ai/sdk/v2"
+
+// Badge configuration for tool status visibility
+// These mappings ensure tools always display their current status
+const TOOL_STATUS_BADGES: Record<ToolPart["state"]["status"], { glyph: string; color: string }> = {
+  pending: { glyph: "○", color: "textMuted" },
+  running: { glyph: "●", color: "success" },
+  completed: { glyph: "✓", color: "success" },
+  error: { glyph: "✗", color: "error" },
+}
+
+const PERMISSION_BADGE = { glyph: "!", color: "warning" }
+
+describe("tool status badges", () => {
+  describe("status badge mapping", () => {
+    test("pending status shows empty circle glyph", () => {
+      const badge = TOOL_STATUS_BADGES["pending"]
+      expect(badge.glyph).toBe("○")
+      expect(badge.color).toBe("textMuted")
+    })
+
+    test("running status shows filled circle glyph", () => {
+      const badge = TOOL_STATUS_BADGES["running"]
+      expect(badge.glyph).toBe("●")
+      expect(badge.color).toBe("success")
+    })
+
+    test("completed status shows checkmark glyph", () => {
+      const badge = TOOL_STATUS_BADGES["completed"]
+      expect(badge.glyph).toBe("✓")
+      expect(badge.color).toBe("success")
+    })
+
+    test("error status shows x mark glyph", () => {
+      const badge = TOOL_STATUS_BADGES["error"]
+      expect(badge.glyph).toBe("✗")
+      expect(badge.color).toBe("error")
+    })
+  })
+
+  describe("permission badge", () => {
+    test("permission pending shows exclamation glyph", () => {
+      expect(PERMISSION_BADGE.glyph).toBe("!")
+      expect(PERMISSION_BADGE.color).toBe("warning")
+    })
+  })
+
+  describe("all statuses have badges", () => {
+    test("every possible tool status has a badge defined", () => {
+      const statuses: ToolPart["state"]["status"][] = ["pending", "running", "completed", "error"]
+
+      for (const status of statuses) {
+        const badge = TOOL_STATUS_BADGES[status]
+        expect(badge).toBeDefined()
+        expect(badge.glyph).toBeTruthy()
+        expect(badge.color).toBeTruthy()
+      }
+    })
+  })
+
+  describe("badge visibility requirements", () => {
+    test("glyphs are single characters for consistent display", () => {
+      for (const [status, badge] of Object.entries(TOOL_STATUS_BADGES)) {
+        expect(badge.glyph.length).toBe(1)
+      }
+    })
+
+    test("each status has a distinct glyph", () => {
+      const glyphs = Object.values(TOOL_STATUS_BADGES).map((b) => b.glyph)
+      const uniqueGlyphs = new Set(glyphs)
+      expect(uniqueGlyphs.size).toBe(glyphs.length)
+    })
+
+    test("glyphs are visually distinct (different symbols)", () => {
+      // Ensure we have different visual representations
+      const { pending, running, completed, error } = TOOL_STATUS_BADGES
+      expect(pending.glyph).not.toBe(running.glyph)
+      expect(running.glyph).not.toBe(completed.glyph)
+      expect(completed.glyph).not.toBe(error.glyph)
+      expect(error.glyph).not.toBe(pending.glyph)
+    })
+  })
+})
+
+// Helper type for testing component props
+type ToolPartLike = {
+  state: {
+    status: "pending" | "running" | "completed" | "error"
+  }
+}
+
+describe("InlineTool badge logic", () => {
+  function getInlineBadge(part: ToolPartLike, hasPermission: boolean): { glyph: string; color: string } {
+    if (hasPermission) return PERMISSION_BADGE
+    return TOOL_STATUS_BADGES[part.state.status]
+  }
+
+  test("returns permission badge when permission is pending", () => {
+    const part = { state: { status: "pending" as const } }
+    const badge = getInlineBadge(part, true)
+    expect(badge.glyph).toBe("!")
+    expect(badge.color).toBe("warning")
+  })
+
+  test("returns status badge when no permission pending", () => {
+    const part = { state: { status: "running" as const } }
+    const badge = getInlineBadge(part, false)
+    expect(badge.glyph).toBe("●")
+    expect(badge.color).toBe("success")
+  })
+
+  test("prioritizes permission badge over error status", () => {
+    // Even if tool has error, permission takes precedence
+    const part = { state: { status: "error" as const } }
+    const badge = getInlineBadge(part, true)
+    expect(badge.glyph).toBe("!")
+    expect(badge.color).toBe("warning")
+  })
+})
+
+describe("BlockTool badge logic", () => {
+  function getBlockBadge(part: ToolPartLike | undefined): { glyph: string; color: string } | undefined {
+    const status = part?.state.status
+    if (!status) return undefined
+    return TOOL_STATUS_BADGES[status]
+  }
+
+  test("returns badge for pending status", () => {
+    const part = { state: { status: "pending" as const } }
+    const badge = getBlockBadge(part)
+    expect(badge?.glyph).toBe("○")
+    expect(badge?.color).toBe("textMuted")
+  })
+
+  test("returns badge for running status", () => {
+    const part = { state: { status: "running" as const } }
+    const badge = getBlockBadge(part)
+    expect(badge?.glyph).toBe("●")
+    expect(badge?.color).toBe("success")
+  })
+
+  test("returns badge for completed status", () => {
+    const part = { state: { status: "completed" as const } }
+    const badge = getBlockBadge(part)
+    expect(badge?.glyph).toBe("✓")
+    expect(badge?.color).toBe("success")
+  })
+
+  test("returns badge for error status", () => {
+    const part = { state: { status: "error" as const } }
+    const badge = getBlockBadge(part)
+    expect(badge?.glyph).toBe("✗")
+    expect(badge?.color).toBe("error")
+  })
+
+  test("returns undefined when part is undefined", () => {
+    const badge = getBlockBadge(undefined)
+    expect(badge).toBeUndefined()
+  })
+
+  test("always visible for all tool states", () => {
+    // Block tools should show badges for ALL statuses
+    const statuses: ToolPart["state"]["status"][] = ["pending", "running", "completed", "error"]
+
+    for (const status of statuses) {
+      const part = { state: { status } }
+      const badge = getBlockBadge(part)
+      expect(badge).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Closes #10339 - Running / Completed / Failed status indicator for agents and tools.

Now, next to the title of any tool call or agent, there is a glyph clearly indicating its status (see next to `# General Task` in the screenshots).

Before:

<img width="1882" height="932" alt="status_indicator_before" src="https://github.com/user-attachments/assets/303c6032-71b7-4c11-8b8f-9c8a3189cd3e" />

After:

<img width="1838" height="746" alt="status_indicator" src="https://github.com/user-attachments/assets/cca33772-0b26-426e-be2d-cffde62193c5" />

<img width="1847" height="602" alt="status_indicator_2" src="https://github.com/user-attachments/assets/bb11dc24-0d9b-42f7-8daa-05db9dbc71a3" />

### How did you verify your code works?

Unit tests + manually run the local build (as can be seen in the screenshots).
