### PR TITLE
fix: fixes issue where the autocomplete tui dialog flickers while typing

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -129,6 +129,25 @@ export function Autocomplete(props: {
     return props.input().getTextRange(store.index + 1, props.input().cursorOffset)
   })
 
+  // filter() reads reactive props.value plus non-reactive cursor/text state.
+  // On keypress those can be briefly out of sync, so filter() may return an empty/partial string.
+  // Copy it into search in an effect because effects run after reactive updates have/render and paint have
+  // been applied, so the input has settled and all consumers read the same stable value.
+  const [search, setSearch] = createSignal("")
+  createEffect(() => {
+    const next = filter()
+    if (next === undefined) {
+      setSearch("")
+      return
+    }
+    if (next === "") {
+      setSearch("")
+      return
+    }
+
+    setSearch(next)
+  })
+
   // When the filter changes due to how TUI works, the mousemove might still be triggered
   // via a synthetic event as the layout moves underneath the cursor. This is a workaround to make sure the input mode remains keyboard so
   // that the mouseover event doesn't trigger when filtering.
@@ -208,7 +227,7 @@ export function Autocomplete(props: {
   }
 
   const [files] = createResource(
-    () => filter(),
+    () => search(),
     async (query) => {
       if (!store.visible || store.visible === "/") return []
 
@@ -378,9 +397,9 @@ export function Autocomplete(props: {
     const mixed: AutocompleteOption[] =
       store.visible === "@" ? [...agentsValue, ...(filesValue || []), ...mcpResources()] : [...commandsValue]
 
-    const currentFilter = filter()
+    const searchValue = search()
 
-    if (!currentFilter) {
+    if (!searchValue) {
       return mixed
     }
 
@@ -388,7 +407,7 @@ export function Autocomplete(props: {
       return prev
     }
 
-    const result = fuzzysort.go(removeLineRange(currentFilter), mixed, {
+    const result = fuzzysort.go(removeLineRange(searchValue), mixed, {
       keys: [
         (obj) => removeLineRange((obj.value ?? obj.display).trimEnd()),
         "description",
@@ -398,7 +417,7 @@ export function Autocomplete(props: {
       scoreFn: (objResults) => {
         const displayResult = objResults[0]
         let score = objResults.score
-        if (displayResult && displayResult.target.startsWith(store.visible + currentFilter)) {
+        if (displayResult && displayResult.target.startsWith(store.visible + searchValue)) {
           score *= 2
         }
         const frecencyScore = objResults.obj.path ? frecency.getFrecency(objResults.obj.path) : 0

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -131,21 +131,12 @@ export function Autocomplete(props: {
 
   // filter() reads reactive props.value plus non-reactive cursor/text state.
   // On keypress those can be briefly out of sync, so filter() may return an empty/partial string.
-  // Copy it into search in an effect because effects run after reactive updates have/render and paint have
-  // been applied, so the input has settled and all consumers read the same stable value.
+  // Copy it into search in an effect because effects run after reactive updates have been rendered and painted
+  // so the input has settled and all consumers read the same stable value.
   const [search, setSearch] = createSignal("")
   createEffect(() => {
     const next = filter()
-    if (next === undefined) {
-      setSearch("")
-      return
-    }
-    if (next === "") {
-      setSearch("")
-      return
-    }
-
-    setSearch(next)
+    setSearch(next ? next : "");
   })
 
   // When the filter changes due to how TUI works, the mousemove might still be triggered


### PR DESCRIPTION
Fixes #11640 

### What does this PR do?

I noticed that when typing @ and `/` commands in the opencode TUI that you would see the dialog flickering as you type. This is especially true when you type pretty fast here. (For example while typing you'd see the `Opencode` logo flicker behind as the dialog opens and closes rapidly

This PR fixes that issue by making sure to only update the `search` value after the value of the `filter` has settled (i.e. has been flushed due to how Solid works). The issue was caused because the filter depends on both the value (reactive) and non-reactive values that need to be flushed (the input ref/cursor)


*Here is the "before" state with the flickering:* NOTE that due to framerate you might not see it as well as you would locally well here.

https://github.com/user-attachments/assets/5b7088bb-f22b-4515-aac6-4c01b6ac9989

Another better example:


https://github.com/user-attachments/assets/5a1a25a5-1181-4920-8144-d852846ada68




### How did you verify your code works?

I tested manually. GIFS below of after state


https://github.com/user-attachments/assets/c1222657-aecf-4f9c-a7fe-a1c314af7170

Another example with it fixed and simpler inputs


https://github.com/user-attachments/assets/c60949e4-e1a9-48d3-b8f3-5f33e744744d






Note: PR updated with better assets, but still framerate may make it difficult to see at times.

