### PR TITLE
fix: opencode hanging when using client.app.log() during initialization

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -185,12 +185,15 @@ export namespace Server {
           },
         )
         .use(async (c, next) => {
-          let directory = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
-          try {
-            directory = decodeURIComponent(directory)
-          } catch {
-            // fallback to original value
-          }
+          if (c.req.path === "/log") return next()
+          const raw = c.req.query("directory") || c.req.header("x-opencode-directory") || process.cwd()
+          const directory = (() => {
+            try {
+              return decodeURIComponent(raw)
+            } catch {
+              return raw
+            }
+          })()
           return Instance.provide({
             directory,
             init: InstanceBootstrap,


### PR DESCRIPTION
### What does this PR do?

Fixes #7741. OpenCode plugins hang indefinitely when calling `client.app.log()` during plugin initialization, preventing OpenCode from starting properly. The hang happens because client.app.log calls the server /log route, and the server middleware wrapped every request in Instance.provide, which triggers InstanceBootstrap → Plugin.init → your plugin → client.app.log again. That creates a circular dependency during startup. The change skips Instance.provide for /log, so /log no longer bootstraps the instance or plugins to fix it.

### How did you verify your code works?
<img width="1091" height="66" alt="image" src="https://github.com/user-attachments/assets/3626e732-87ea-4a6a-9e38-d008b700debc" />
