### PR TITLE
fix(ui): adjusts alignment of elements to prevent incomplete scroll

### DIFF
--- a/packages/ui/src/components/message-nav.css
+++ b/packages/ui/src/components/message-nav.css
@@ -103,7 +103,7 @@
   display: flex;
   padding: 4px 4px 6px 4px;
   justify-content: center;
-  align-items: center;
+  align-items: start;
   border-radius: var(--radius-md);
   background: var(--surface-raised-stronger-non-alpha);
   max-height: calc(100vh - 6rem);


### PR DESCRIPTION
### What does this PR do?

Fixes an UI issue where, on sessions with enough messages, the sidebar on `<ENTERPRISE_URL>/share/<SESSION_ID>`'s desktop viewport would fail to display the first few messages. 

Fixes #11650 

### How did you verify your code works?

1. Setup local opencode and enterprise
2. Import or generate a session with enough messages (40+ in my case)
3. Share the session with `/share`
4. Open in browser and check the sidebar's scroll results

## Demo video, comparing before/after side by side
https://github.com/user-attachments/assets/454861df-f211-47de-b8d9-eae63ec91b88

