### PR TITLE
fix(desktop): nix - add missing dep

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -45,8 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rustc
     jq
     makeWrapper
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook4 ];
 
   buildInputs = lib.optionals stdenv.isLinux [
     dbus
@@ -61,6 +60,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
   ];
 
   strictDeps = true;


### PR DESCRIPTION
new feature requires gst-plugins-bad

WebKit wasn't able to find a WebVTT encoder.
Subtitles handling will be degraded unless gst-plugins-bad is installed.
