### PR TITLE
chore: reduce nix fetching

### DIFF
--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,8 +1,8 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-3wRTDLo5FZoUc2Bwm1aAJZ4dNsekX8XoY6TwTmohgYo=",
+    "x86_64-linux": "sha256-06Otz3loT4vn0578VDxUqVudtzQvV7oM3EIzjZnsejo=",
     "aarch64-linux": "sha256-CKiuc6c52UV9cLEtccYEYS4QN0jYzNJv1fHSayqbHKo=",
-    "aarch64-darwin": "sha256-jGr2udrVeseioMWpIzpjYFfS1CN8GvNFwo6o92Aa5Oc=",
+    "aarch64-darwin": "sha256-x8dgCF0CJBWi2dZLDHMGdlTqys1X755ok0PM6x0HAGo=",
     "x86_64-darwin": "sha256-k5384Uun7tLjKkfJXXPcaZSXQ5jf/tMv21xi5cJU1rM="
   }
 }

--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -46,15 +46,16 @@ stdenvNoCC.mkDerivation {
 
   buildPhase = ''
     runHook preBuild
-    export HOME=$(mktemp -d)
     export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
     bun install \
       --cpu="${bunCpu}" \
       --os="${bunOs}" \
+      --filter '!./' \
+      --filter './packages/opencode' \
+      --filter './packages/desktop' \
       --frozen-lockfile \
       --ignore-scripts \
-      --no-progress \
-      --linker=isolated
+      --no-progress
     bun --bun ${./scripts/canonicalize-node-modules.ts}
     bun --bun ${./scripts/normalize-bun-binaries.ts}
     runHook postBuild


### PR DESCRIPTION
reduces the node_modules install size from 1.8GB on x86_64-linux to 1.6GB 

Note: we should be able to reduce it even further if we skip dev dependencies but the desktop app build process requires them in the form of tsgo and vite

cli and desktop apps tested on x86_64-linux and aarch64-darwin - CI should update the hashes for the other platforms
