### PR TITLE
fix(vscode): prefix command titles with extension name

### DIFF
--- a/sdks/vscode/README.md
+++ b/sdks/vscode/README.md
@@ -21,7 +21,7 @@ This is an early release. If you encounter issues or have feedback, please creat
 
 1. `code sdks/vscode` - Open the `sdks/vscode` directory in VS Code. **Do not open from repo root.**
 2. `bun install` - Run inside the `sdks/vscode` directory.
-3. Press `F5` to start debugging - This launches a new VS Code window with the extension loaded.
+3. Run `Developer: Debug Extension Host In New Window` in the command palette.
 
 #### Making Changes
 

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -26,7 +26,7 @@
     "commands": [
       {
         "command": "opencode.openTerminal",
-        "title": "Open opencode",
+        "title": "OpenCode: Open",
         "icon": {
           "light": "images/button-dark.svg",
           "dark": "images/button-light.svg"
@@ -34,7 +34,7 @@
       },
       {
         "command": "opencode.openNewTerminal",
-        "title": "Open opencode in new tab",
+        "title": "OpenCode: Open in New Tab",
         "icon": {
           "light": "images/button-dark.svg",
           "dark": "images/button-light.svg"
@@ -42,7 +42,7 @@
       },
       {
         "command": "opencode.addFilepathToTerminal",
-        "title": "Add Filepath to Terminal"
+        "title": "OpenCode: Add Filepath to Terminal"
       }
     ],
     "menus": {


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/anomalyco/opencode/issues/11654

### How did you verify your code works?

> [!NOTE]
> The instructions in the `## Development` section were incorrect (they required some pre-existing debugger configuration that is not checked into the repository) so I fixed those as well

I ran the extension in VS Code:

<img width="1312" height="912" alt="image" src="https://github.com/user-attachments/assets/a9700682-c80d-4c36-89ea-a139152dffe7" />
