### PR TITLE
fix: prompt caching for opus on bedrock

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -179,7 +179,7 @@ export namespace ProviderTransform {
         cacheControl: { type: "ephemeral" },
       },
       bedrock: {
-        cachePoint: { type: "ephemeral" },
+        cachePoint: { type: "default" },
       },
       openaiCompatible: {
         cache_control: { type: "ephemeral" },
@@ -190,7 +190,8 @@ export namespace ProviderTransform {
     }
 
     for (const msg of unique([...system, ...final])) {
-      const shouldUseContentOptions = providerID !== "anthropic" && Array.isArray(msg.content) && msg.content.length > 0
+      const useMessageLevelOptions = providerID === "anthropic" || providerID.includes("bedrock")
+      const shouldUseContentOptions = !useMessageLevelOptions && Array.isArray(msg.content) && msg.content.length > 0
 
       if (shouldUseContentOptions) {
         const lastContent = msg.content[msg.content.length - 1]

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1166,7 +1166,7 @@ describe("ProviderTransform.message - claude w/bedrock custom inference profile"
     expect(result[0].providerOptions?.bedrock).toEqual(
       expect.objectContaining({
         cachePoint: {
-          type: "ephemeral",
+          type: "default",
         },
       }),
     )


### PR DESCRIPTION
fixes #11662 

basically just including the anthropic cache stuff on aws bedrock as well 


Evidence

  Before fix (read ~11k token file, then follow-up question):

  | Turn | Input | Cache Read | Cache Write |
  |------|-------|------------|-------------|
  | 1    | ~11k  | ~13k       | ~11k        |
  | 2    | ~11k  | ~13k       | 0           |

  After fix:

  | Turn | Input | Cache Read | Cache Write |
  |------|-------|------------|-------------|
  | 1    | 3     | 13,640     | 11,026      |
  | 2    | 0     | 24,821     | 316         |