### PR TITLE
docs(web): document /commit command workflow

### DIFF
--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -195,6 +195,47 @@ Commands run in your project's root directory and their output becomes part of t
 
 ---
 
+## Generate a commit message
+
+You can create a command that turns your current git changes into a ready-to-paste commit message.
+
+Create `.opencode/commands/commitmsg.md`:
+
+```md title=".opencode/commands/commitmsg.md"
+---
+description: Generate a git commit message
+---
+
+You are generating a git commit message.
+
+Here are the current changes:
+
+- Unstaged diff:
+!`git diff`
+
+- Staged diff:
+!`git diff --cached`
+
+- Status:
+!`git status --short`
+
+Write a concise commit message.
+
+Constraints:
+- Use a single subject line (no more than ~72 chars)
+- Use present tense ("add", "fix", "refactor")
+- If there are multiple concerns, prefer the most important one
+- Output ONLY the commit message text (no code blocks, no extra commentary)
+```
+
+Run it in the TUI:
+
+```bash frame="none"
+/commitmsg
+```
+
+---
+
 ### File references
 
 Include files in your command using `@` followed by the filename.

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -195,7 +195,7 @@ Commands run in your project's root directory and their output becomes part of t
 
 ---
 
-## Generate a commit message
+### Generate a commit message
 
 You can create a command that turns your current git changes into a ready-to-paste commit message.
 

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -195,43 +195,52 @@ Commands run in your project's root directory and their output becomes part of t
 
 ---
 
-### Generate a commit message
+### Commit (generate message + commit)
 
-You can create a command that turns your current git changes into a ready-to-paste commit message.
+You can create a command that generates a commit message from your current changes and (by default) runs `git commit`.
 
-Create `.opencode/commands/commitmsg.md`:
+Create `.opencode/commands/commit.md`:
 
-```md title=".opencode/commands/commitmsg.md"
+```md title=".opencode/commands/commit.md"
 ---
-description: Generate a git commit message
+description: Generate a commit message and commit
 ---
 
-You are generating a git commit message.
+You are helping me create a git commit.
 
-Here are the current changes:
+Input flags: $ARGUMENTS
 
-- Unstaged diff:
-!`git diff`
+First, inspect the current repo state:
 
 - Staged diff:
 !`git diff --cached`
 
+- Unstaged diff:
+!`git diff`
+
 - Status:
 !`git status --short`
 
-Write a concise commit message.
+Rules:
+- Prefer committing ONLY staged changes.
+- If there is no staged diff, stop and tell me to run `git add ...` first.
+- If `$ARGUMENTS` contains `--dry`, output ONLY the commit message text and stop.
+- If `$ARGUMENTS` contains `--ask`, output the proposed `git commit -m "<message>"` command and ask me to confirm before running it.
+- Otherwise, run `git commit -m "<message>"`.
+- Never run `git push`. Never use `--no-verify`. Do not amend unless explicitly requested.
 
-Constraints:
-- Use a single subject line (no more than ~72 chars)
-- Use present tense ("add", "fix", "refactor")
-- If there are multiple concerns, prefer the most important one
-- Output ONLY the commit message text (no code blocks, no extra commentary)
+Commit message constraints:
+- Single subject line (<= ~72 chars)
+- Present tense ("add", "fix", "refactor")
+- If there are multiple concerns, pick the most important one
 ```
 
 Run it in the TUI:
 
 ```bash frame="none"
-/commitmsg
+/commit
+/commit --dry
+/commit --ask
 ```
 
 ---


### PR DESCRIPTION
## What
- Document a copy/paste custom command (`/commit`) that generates a commit subject from git diffs/status.
- Default behavior runs `git commit -m \"...\"` using staged changes; supports `--dry` (message only) and `--ask` (prompt before committing).

## Why
- Gives new users a safe, repeatable commit flow without adding opinionated built-in behavior.

## How
- Add a new section to the Commands docs with an example `.opencode/commands/commit.md`.