### PR TITLE
fix: session title generation with OpenAI models.

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -658,11 +658,18 @@ export namespace ProviderTransform {
   }
 
   export function smallOptions(model: Provider.Model) {
-    if (model.providerID === "openai" || model.api.id.includes("gpt-5")) {
-      if (model.api.id.includes("5.")) {
-        return { reasoningEffort: "low" }
+    if (
+      model.providerID === "openai" ||
+      model.api.npm === "@ai-sdk/openai" ||
+      model.api.npm === "@ai-sdk/github-copilot"
+    ) {
+      if (model.api.id.includes("gpt-5")) {
+        if (model.api.id.includes("5.")) {
+          return { store: false, reasoningEffort: "low" }
+        }
+        return { store: false, reasoningEffort: "minimal" }
       }
-      return { reasoningEffort: "minimal" }
+      return { store: false }
     }
     if (model.providerID === "google") {
       // gemini-3 uses thinkingLevel, gemini-2.5 uses thinkingBudget


### PR DESCRIPTION
## Summary

Fix session title generation with OpenAI models.

## Problem

When using OpenAI models (e.g., `openai/gpt-5.1-codex-mini`) as the `small_model` config for title generation, the API call fails with:
```
"Store must be set to false"
```

The codebase has two paths for provider options:
1. `options()` - Used for normal messages, correctly sets `store: false`
2. `smallOptions()` - Used for title generation, was missing `store: false`

## Solution

Added `store: false` to the return values in `smallOptions()` for OpenAI models

Similar logic used in: 
https://github.com/anomalyco/opencode/blob/91f2ac3cb27c209532ef104cfcab139279881ace/packages/opencode/src/provider/transform.ts#L585-L592

## Fixes

- Fixes #11442
- Fixes #7965
- Fixes #2966