### PR TITLE
fix(app): restore middle mouse button click to close review/file tabs

### DIFF
--- a/packages/app/src/components/session/session-sortable-tab.tsx
+++ b/packages/app/src/components/session/session-sortable-tab.tsx
@@ -48,6 +48,9 @@ export function SortableTab(props: { tab: string; onTabClose: (tab: string) => v
           }
           hideCloseButton
           onMiddleClick={() => props.onTabClose(props.tab)}
+          onMouseDown={(e) => {
+            if (e.button === 1) e.preventDefault()
+          }}
         >
           <Show when={path()}>{(p) => <FileVisual path={p()} />}</Show>
         </Tabs.Trigger>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2255,6 +2255,9 @@ export default function Page() {
                               }
                               hideCloseButton
                               onMiddleClick={() => tabs().close("context")}
+                              onMouseDown={(e) => {
+                                if (e.button === 1) e.preventDefault()
+                              }}
                             >
                               <div class="flex items-center gap-2">
                                 <SessionContextUsage variant="indicator" />


### PR DESCRIPTION
closes #11633 

#11070 implemented scrollable tabs in review/file view section, but introduced an issue where middle clicking on a tab would enter scroll mode instead of closing the tab, unless the tabs are not scrollable (too few tabs)

### What does this PR do?
This PR fixes the above bug so middle-click closes tabs like before.

**The fix**: Adding onMouseDown={(e) => { if (e.button === 1) e.preventDefault() }} prevents the default scroll-mode behavior at the mousedown event, before the browser enters scroll mode

## Before

https://github.com/user-attachments/assets/4808a45b-7738-4e8a-962a-06a8dd2b25d8


## After

https://github.com/user-attachments/assets/6ea25fe6-9189-4c8f-9eb8-fb4bccc5ac21



### How did you verify your code works?
e2e local test suite - same results before/after

manual testing:
1. create many tabs so they can be scrolled
2. press middle mouse button on a tab
3. tab is closed


