### PR TITLE
feat(tui): add number shortcuts for permission options

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -393,6 +393,15 @@ function Prompt<const T extends Record<string, string>>(props: {
   useKeyboard((evt) => {
     if (dialog.stack.length > 0) return
 
+    if (/^[1-9]$/.test(evt.name)) {
+      evt.preventDefault()
+      const idx = parseInt(evt.name) - 1
+      if (idx < keys.length) {
+        props.onSelect(keys[idx])
+        return
+      }
+    }
+
     if (evt.name === "left" || evt.name == "h") {
       evt.preventDefault()
       const idx = keys.indexOf(store.selected)
@@ -465,7 +474,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       >
         <box flexDirection="row" gap={1} flexShrink={0}>
           <For each={keys}>
-            {(option) => (
+            {(option, i) => (
               <box
                 paddingLeft={1}
                 paddingRight={1}
@@ -477,7 +486,7 @@ function Prompt<const T extends Record<string, string>>(props: {
                 }}
               >
                 <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
-                  {props.options[option]}
+                  {i() + 1 + ". " + props.options[option]}
                 </text>
               </box>
             )}


### PR DESCRIPTION
## Summary
Adds support for using number keys (1-9) to quickly select permission options in the TUI, similar to other CLI tools.

Fixes #11713

## Changes
- Updated `Prompt` component in `permission.tsx` to listen for number keys.
- Added visual indicators (e.g., "1. Allow once") to the options.

## Verification
1. Run `opencode` or `bun dev`.
2. Trigger a permission prompt (e.g., by running a command that requires approval).
3. Press `1`, `2`, or `3`.
4. Verify the corresponding option is selected immediately.