### PR TITLE
fix: replace non-null assertions on find() with proper null checks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -54,7 +54,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return agents()
         },
         current() {
-          return agents().find((x) => x.name === agentStore.current)!
+          const found = agents().find((x) => x.name === agentStore.current)
+          if (found) return found
+          const fallback = agents()[0]
+          setAgentStore("current", fallback.name)
+          return fallback
         },
         set(name: string) {
           if (!agents().some((x) => x.name === name))

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1048,7 +1048,11 @@ export namespace Provider {
 
       const mod = await import(installedPath)
 
-      const fn = mod[Object.keys(mod).find((key) => key.startsWith("create"))!]
+      const createKey = Object.keys(mod).find((key) => key.startsWith("create"))
+      if (!createKey) {
+        throw new Error(`Provider module ${model.api.npm} has no exported create function`)
+      }
+      const fn = mod[createKey]
       const loaded = fn({
         name: model.providerID,
         ...options,

--- a/packages/opencode/src/server/routes/tui.ts
+++ b/packages/opencode/src/server/routes/tui.ts
@@ -345,7 +345,9 @@ export const TuiRoutes = lazy(() =>
       ),
       async (c) => {
         const evt = c.req.valid("json")
-        await Bus.publish(Object.values(TuiEvent).find((def) => def.type === evt.type)!, evt.properties)
+        const def = Object.values(TuiEvent).find((def) => def.type === evt.type)
+        if (!def) return c.json(false, 400)
+        await Bus.publish(def, evt.properties)
         return c.json(true)
       },
     )

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -96,7 +96,11 @@ export namespace SessionCompaction {
     abort: AbortSignal
     auto: boolean
   }) {
-    const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
+    const parentMessage = input.messages.findLast((m) => m.info.id === input.parentID)
+    if (!parentMessage) {
+      throw new Error(`Parent message ${input.parentID} not found during compaction`)
+    }
+    const userMessage = parentMessage.info as MessageV2.User
     const agent = await Agent.get("compaction")
     const model = agent.model
       ? await Provider.getModel(agent.model.providerID, agent.model.modelID)

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -121,7 +121,11 @@ export namespace SessionSummary {
     const messages = input.messages.filter(
       (m) => m.info.id === input.messageID || (m.info.role === "assistant" && m.info.parentID === input.messageID),
     )
-    const msgWithParts = messages.find((m) => m.info.id === input.messageID)!
+    const msgWithParts = messages.find((m) => m.info.id === input.messageID)
+    if (!msgWithParts) {
+      log.warn("message not found for summarization", { messageID: input.messageID })
+      return
+    }
     const userMsg = msgWithParts.info as MessageV2.User
     const diffs = await computeDiff({ messages })
     userMsg.summary = {


### PR DESCRIPTION
### What does this PR do?

Replaces 5 unsafe `find()!` non-null assertion patterns across the codebase with proper null checks. These patterns crash at runtime with "Cannot read property of undefined" when the search predicate doesn't match any element.

The most impactful fix is in `local.tsx`, which is the direct cause of the fatal TUI crash reported in #11262 ("Cannot read property 'name' of undefined").

Each location is handled with an appropriate strategy for its context:

- **`local.tsx:57`** — Falls back to first agent and updates store (prevents TUI fatal crash)
- **`provider.ts:1051`** — Throws descriptive error if provider module has no `create*` export
- **`compaction.ts:99`** — Throws descriptive error if parent message is missing
- **`summary.ts:124`** — Logs warning and returns early if message not found
- **`tui.ts:348`** — Returns 400 if event type not found (defensive, Zod should prevent this)

Fixes #11702

### How did you verify your code works?

- `tsgo --noEmit` — typecheck passes across all 12 packages
- `bun test` — 835 tests pass (5 pre-existing failures in llm.test.ts/retry.test.ts unrelated to this change)
- `bun run build` — builds successfully for all platforms
- Verified each fix handles the null case with the appropriate strategy for its context