### PR TITLE
feat(tui): show expandable task output in session view

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1867,22 +1867,20 @@ function Task(props: ToolProps<typeof TaskTool>) {
           part={props.part}
           spinner={isRunning()}
         >
-          <box>
-            <text style={{ fg: theme.textMuted }}>
-              {props.input.description} ({tools().length} toolcalls)
-            </text>
-            <Show when={current()}>
-              {(item) => {
-                const title = item().state.status === "completed" ? (item().state as any).title : ""
-                return (
-                  <text style={{ fg: item().state.status === "error" ? theme.error : theme.textMuted }}>
-                    └ {Locale.titlecase(item().tool)}
-                    {title ? ` ${title}` : ""}
-                  </text>
-                )
-              }}
-            </Show>
-          </box>
+          <text style={{ fg: theme.textMuted }}>
+            {props.input.description} ({tools().length} toolcalls)
+          </text>
+          <Show when={current()}>
+            {(item) => {
+              const title = item().state.status === "completed" ? (item().state as any).title : ""
+              return (
+                <text style={{ fg: item().state.status === "error" ? theme.error : theme.textMuted }}>
+                  └ {Locale.titlecase(item().tool)}
+                  {title ? ` ${title}` : ""}
+                </text>
+              )
+            }}
+          </Show>
           <Show when={hasOutput()}>
             <box gap={1} marginTop={1} flexDirection="column">
               <code
@@ -1894,9 +1892,6 @@ function Task(props: ToolProps<typeof TaskTool>) {
                 conceal={ctx.conceal()}
                 fg={theme.text}
               />
-              <Show when={overflow()}>
-                <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
-              </Show>
             </box>
           </Show>
           <Show when={props.metadata.sessionId}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1814,6 +1814,7 @@ function Task(props: ToolProps<typeof TaskTool>) {
   const { navigate } = useRoute()
   const local = useLocal()
   const sync = useSync()
+  const [expanded, setExpanded] = createSignal(false)
 
   const tools = createMemo(() => {
     const sessionID = props.metadata.sessionId
@@ -1829,15 +1830,38 @@ function Task(props: ToolProps<typeof TaskTool>) {
 
   const isRunning = createMemo(() => props.part.state.status === "running")
 
+  const output = createMemo(() => {
+    if (props.part.state.status !== "completed") return ""
+    const sessionID = props.metadata.sessionId
+    if (!sessionID) return ""
+    const msgs = sync.data.message[sessionID] ?? []
+    const lastAssistant = msgs.findLast((m) => m.role === "assistant")
+    if (!lastAssistant) return ""
+    const parts = sync.data.part[lastAssistant.id] ?? []
+    const lastText = parts.findLast((p): p is TextPart => p.type === "text")
+    return stripAnsi(lastText?.text?.trim() ?? "")
+  })
+
+  const lines = createMemo(() => output().split("\n"))
+  const overflow = createMemo(() => lines().length > 10)
+  const limited = createMemo(() => {
+    if (expanded() || !overflow()) return output()
+    return [...lines().slice(0, 10), "…"].join("\n")
+  })
+
+  const hasOutput = createMemo(() => output().length > 0)
+
   return (
     <Switch>
       <Match when={props.input.description || props.input.subagent_type}>
         <BlockTool
           title={"# " + Locale.titlecase(props.input.subagent_type ?? "unknown") + " Task"}
           onClick={
-            props.metadata.sessionId
+            props.metadata.sessionId && !hasOutput()
               ? () => navigate({ type: "session", sessionID: props.metadata.sessionId! })
-              : undefined
+              : overflow()
+                ? () => setExpanded((prev) => !prev)
+                : undefined
           }
           part={props.part}
           spinner={isRunning()}
@@ -1857,6 +1881,14 @@ function Task(props: ToolProps<typeof TaskTool>) {
               }}
             </Show>
           </box>
+          <Show when={hasOutput()}>
+            <box gap={1} marginTop={1}>
+              <text fg={theme.text}>{limited()}</text>
+              <Show when={overflow()}>
+                <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
+              </Show>
+            </box>
+          </Show>
           <Show when={props.metadata.sessionId}>
             <text fg={theme.text}>
               {keybind.print("session_child_cycle")}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1809,7 +1809,8 @@ function WebSearch(props: ToolProps<any>) {
 }
 
 function Task(props: ToolProps<typeof TaskTool>) {
-  const { theme } = useTheme()
+  const ctx = use()
+  const { theme, syntax } = useTheme()
   const keybind = useKeybind()
   const { navigate } = useRoute()
   const local = useLocal()
@@ -1875,15 +1876,24 @@ function Task(props: ToolProps<typeof TaskTool>) {
                 const title = item().state.status === "completed" ? (item().state as any).title : ""
                 return (
                   <text style={{ fg: item().state.status === "error" ? theme.error : theme.textMuted }}>
-                    └ {Locale.titlecase(item().tool)} {title}
+                    └ {Locale.titlecase(item().tool)}
+                    {title ? ` ${title}` : ""}
                   </text>
                 )
               }}
             </Show>
           </box>
           <Show when={hasOutput()}>
-            <box gap={1} marginTop={1}>
-              <text fg={theme.text}>{limited()}</text>
+            <box gap={1} marginTop={1} flexDirection="column">
+              <code
+                filetype="markdown"
+                drawUnstyledText={false}
+                streaming={false}
+                syntaxStyle={syntax()}
+                content={limited()}
+                conceal={ctx.conceal()}
+                fg={theme.text}
+              />
               <Show when={overflow()}>
                 <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
               </Show>


### PR DESCRIPTION
## Summary

Add expandable task output preview in the TUI session view, similar to how bash tool output is displayed.

## Changes

- Show up to 10 lines of the final assistant message text from task subagent sessions
- Click to expand/collapse when output exceeds 10 lines
- Gets text content from the last text part of the last assistant message in the subagent session
- Uses stripAnsi to clean up any terminal formatting