### PR TITLE
fix(desktop): Refresh file contents when changing workspaces to not have stale contents

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -8,6 +8,7 @@ import { getFilename } from "@opencode-ai/util/path"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
 import { useLanguage } from "@/context/language"
+import { decode64 } from "@/utils/base64"
 import { Persist, persisted } from "@/utils/persist"
 
 export type FileSelection = {
@@ -275,9 +276,9 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
     const params = useParams()
     const language = useLanguage()
 
-    const scope = createMemo(() => sdk.directory)
+    const directory = createMemo(() => decode64(params.dir) ?? sdk.directory)
 
-    const directory = createMemo(() => sync.data.path.directory)
+    const scope = createMemo(() => directory())
 
     function normalize(input: string) {
       const root = directory()
@@ -414,7 +415,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       return entry.value
     }
 
-    const view = createMemo(() => loadView(params.dir!, params.id))
+    const view = createMemo(() => loadView(directory(), params.id))
 
     function ensure(path: string) {
       if (!path) return

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1309,6 +1309,22 @@ export default function Page() {
     void file.tree.list("")
   })
 
+  createEffect(
+    on(
+      () => params.dir,
+      () => {
+        void file.tree.list("")
+
+        const active = tabs().active()
+        if (!active) return
+        const path = file.pathFromTab(active)
+        if (!path) return
+        void file.load(path, { force: true })
+      },
+      { defer: true },
+    ),
+  )
+
   const autoScroll = createAutoScroll({
     working: () => true,
     overflowAnchor: "dynamic",


### PR DESCRIPTION
Fixes #11727

### What does this PR do?

This PR fixes the stale file contents that occur when switching workspaces. Before this PR, switching workspaces and opening files would reflect stale file content not the latest file content for that worktree.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Ran desktop app, made changes in both worktrees, verified they showed up differently
