### PR TITLE
fix: provider headers from config not applied to fetch requests

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -992,6 +992,12 @@ export namespace Provider {
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
 
+        // Merge configured headers into request headers
+        opts.headers = {
+          ...(typeof opts.headers === 'object' ? opts.headers : {}),
+          ...options["headers"],
+        }
+
         if (options["timeout"] !== undefined && options["timeout"] !== null) {
           const signals: AbortSignal[] = []
           if (opts.signal) signals.push(opts.signal)


### PR DESCRIPTION
Fixed #11789 

When configuring custom headers (including User-Agent) for a provider or model in opencode.jsonc, the headers are not actually sent with the API requests.

For example, this configuration does not work:

```json
    {
      "provider": {
        "myprovider": {
           "options": {
              "apiKey": "sk-xxx",
              "baseURL": "https://apis.iflow.cn/v1",
              "headers": {
                 "user-agent": "MyCustomAgent/1.0" // custom user-agent
              }
           },
          "models": {
            "my-model": {
              "headers": {
                "User-Agent": "MyCustomAgent/2.0" //  custom user-agent (higher priority)
              }
            }
          }
        }
      }
    }
```

In packages/opencode/src/provider/provider.ts, the getSDK function correctly merges model.headers into options["headers"]:

```ts
if (model.headers)
      options["headers"] = {
        ...options["headers"],
        ...model.headers,
      }
```

However, in the custom fetch function, opts.headers comes from the init parameter passed by the AI SDK, not from options["headers"]. This means the configured headers are never actually included in the request.


Solution

Update the custom fetch function to merge options["headers"] into opts.headers:

```ts
        opts.headers = {
          ...(typeof opts.headers === 'object' ? opts.headers : {}),
          ...options["headers"],
        };
```

