### PR TITLE
fix(config): fix variable replacement for files containing dollars

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1196,8 +1196,9 @@ export namespace Config {
               throw new InvalidError({ path: configFilepath, message: errMsg }, { cause: error })
             })
         ).trim()
-        // escape newlines/quotes, strip outer quotes
-        text = text.replace(match, JSON.stringify(fileContent).slice(1, -1))
+        // escape newlines/quotes, strip outer quotes, then escape $ for String.replace
+        const escaped = JSON.stringify(fileContent).slice(1, -1).replace(/\$/g, "$$$$")
+        text = text.replace(match, escaped)
       }
     }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -193,6 +193,46 @@ test("handles file inclusion substitution", async () => {
   })
 })
 
+test("handles file inclusion with dollar sign replacement patterns", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Content with $ followed by backtick - triggers String.replace() special replacement
+      await Bun.write(path.join(dir, "dollar.txt"), "regex pattern: `[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$`")
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        theme: "{file:dollar.txt}",
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("regex pattern: `[\\w-\\.]+@([\\w-]+\\.)+[\\w-]{2,4}$`")
+    },
+  })
+})
+
+test("handles file inclusion with all dollar sign patterns", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Test various $-patterns that have special meaning in String.replace()
+      await Bun.write(path.join(dir, "dollars.txt"), "Has $` and $' and $& and $$ and $1 patterns")
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        theme: "{file:dollars.txt}",
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("Has $` and $' and $& and $$ and $1 patterns")
+    },
+  })
+})
+
 test("validates config schema and throws on invalid fields", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### What does this PR do?

Fixes #11793.

Fixes OpenCode crash when configuration uses variable substitution with values containing JavaScript special replacement patterns.

### How did you verify your code works?

Manually tested the fix in a repository that has this issue.