### PR TITLE
tui: truncate session title in exit banner

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -225,10 +225,11 @@ export function Session() {
   const exit = useExit()
 
   createEffect(() => {
+    const title = Locale.truncate(session()?.title ?? "", 50)
     return exit.message.set(
       [
         ``,
-        `  █▀▀█  ${UI.Style.TEXT_DIM}${session()?.title}${UI.Style.TEXT_NORMAL}`,
+        `  █▀▀█  ${UI.Style.TEXT_DIM}${title}${UI.Style.TEXT_NORMAL}`,
         `  █  █  ${UI.Style.TEXT_DIM}opencode -s ${session()?.id}${UI.Style.TEXT_NORMAL}`,
         `  ▀▀▀▀  `,
       ].join("\n"),


### PR DESCRIPTION
## Summary
- cap session titles at 50 characters in the exit banner so long names don't overflow the TUI