### PR TITLE
docs: Add opencode-personality plugin to ecosystem docs

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-personality](https://github.com/joostvanwollingen/opencode-personality)                         | A configurable personality and mood system plugin for OpenCode                                    |
 
 ---
 


### PR DESCRIPTION
### What does this PR do?
Adding a plugin to the ecosystem page: [opencode-personality](https://github.com/joostvanwollingen/opencode-personality).

### How did you verify your code works?
opencode-personality should appear when visiting /docs/ecosystem#plugins
