### PR TITLE
feat(desktop): add keyboard shortcuts to switch projects (Cmd+1-9)

### DIFF
--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "أرشفة الجلسة",
+  "command.project.switch": "التبديل إلى المشروع {{number}}",
 
   "command.palette": "لوحة الأوامر",
 

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Arquivar sessão",
+  "command.project.switch": "Mudar para o projeto {{number}}",
 
   "command.palette": "Paleta de comandos",
 

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Arkivér session",
+  "command.project.switch": "Skift til projekt {{number}}",
 
   "command.palette": "Kommandopalette",
 

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -35,6 +35,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Sitzung archivieren",
+  "command.project.switch": "Zu Projekt {{number}} wechseln",
 
   "command.palette": "Befehlspalette",
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Archive session",
+  "command.project.switch": "Switch to project {{number}}",
 
   "command.palette": "Command palette",
 

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Archivar sesión",
+  "command.project.switch": "Cambiar al proyecto {{number}}",
 
   "command.palette": "Paleta de comandos",
 

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Archiver la session",
+  "command.project.switch": "Basculer vers le projet {{number}}",
 
   "command.palette": "Palette de commandes",
 

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "セッションをアーカイブ",
+  "command.project.switch": "プロジェクト {{number}} に切り替え",
 
   "command.palette": "コマンドパレット",
 

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -35,6 +35,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "세션 보관",
+  "command.project.switch": "프로젝트 {{number}}로 전환",
 
   "command.palette": "명령 팔레트",
 

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -34,6 +34,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Arkiver sesjon",
+  "command.project.switch": "Bytt til prosjekt {{number}}",
 
   "command.palette": "Kommandopalett",
 

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Zarchiwizuj sesję",
+  "command.project.switch": "Przełącz na projekt {{number}}",
 
   "command.palette": "Paleta poleceń",
 

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "Архивировать сессию",
+  "command.project.switch": "Переключиться на проект {{number}}",
 
   "command.palette": "Палитра команд",
 

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -31,6 +31,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "จัดเก็บเซสชัน",
+  "command.project.switch": "สลับไปโปรเจกต์ {{number}}",
 
   "command.palette": "คำสั่งค้นหา",
 

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -35,6 +35,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "归档会话",
+  "command.project.switch": "切换到项目 {{number}}",
 
   "command.palette": "命令面板",
 

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -35,6 +35,7 @@ export const dict = {
   "command.session.previous.unseen": "Previous unread session",
   "command.session.next.unseen": "Next unread session",
   "command.session.archive": "封存工作階段",
+  "command.project.switch": "切換到專案 {{number}}",
 
   "command.palette": "命令面板",
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1220,6 +1220,21 @@ export default function Layout(props: ParentProps) {
       })
     }
 
+    const projects = layout.projects.list()
+    for (let i = 0; i < 9; i++) {
+      const project = projects[i]
+      commands.push({
+        id: `project.switch.${i}`,
+        title: language.t("command.project.switch", { number: i + 1 }),
+        category: language.t("command.category.project"),
+        keybind: `mod+${i + 1}`,
+        disabled: !project,
+        onSelect: () => {
+          if (project) navigateToProject(project.worktree)
+        },
+      })
+    }
+
     return commands
   })
 


### PR DESCRIPTION
## Summary

- Add Window menu with Cmd+1 through Cmd+9 shortcuts to quickly switch between open projects
- Similar to browser tab switching behavior (Chrome, Safari, VS Code)
- Includes translations for all 14 supported languages

Closes #11837