### PR TITLE
feat: add splashscreen to TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -34,6 +34,7 @@ import { TuiEvent } from "./event"
 import { KVProvider, useKV } from "./context/kv"
 import { Provider } from "@/provider/provider"
 import { ArgsProvider, useArgs, type Args } from "./context/args"
+import { getDefaultColors, type Mode } from "./default-colors"
 import open from "open"
 import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
@@ -720,13 +721,7 @@ function ErrorComponent(props: {
   const issueURL = new URL("https://github.com/anomalyco/opencode/issues/new?template=bug-report.yml")
 
   // Choose safe fallback colors per mode since theme context may not be available
-  const isLight = props.mode === "light"
-  const colors = {
-    bg: isLight ? "#ffffff" : "#0a0a0a",
-    text: isLight ? "#1a1a1a" : "#eeeeee",
-    muted: isLight ? "#8a8a8a" : "#808080",
-    primary: isLight ? "#3b7dd8" : "#fab283",
-  }
+  const colors = getDefaultColors(props.mode ?? "dark")
 
   if (props.error.message) {
     issueURL.searchParams.set("title", `opentui: fatal: ${props.error.message}`)
@@ -748,29 +743,29 @@ function ErrorComponent(props: {
   }
 
   return (
-    <box flexDirection="column" gap={1} backgroundColor={colors.bg}>
+    <box flexDirection="column" gap={1} backgroundColor={colors.background}>
       <box flexDirection="row" gap={1} alignItems="center">
         <text attributes={TextAttributes.BOLD} fg={colors.text}>
           Please report an issue.
         </text>
         <box onMouseUp={copyIssueURL} backgroundColor={colors.primary} padding={1}>
-          <text attributes={TextAttributes.BOLD} fg={colors.bg}>
+          <text attributes={TextAttributes.BOLD} fg={colors.background}>
             Copy issue URL (exception info pre-filled)
           </text>
         </box>
-        {copied() && <text fg={colors.muted}>Successfully copied</text>}
+        {copied() && <text fg={colors.textMuted}>Successfully copied</text>}
       </box>
       <box flexDirection="row" gap={2} alignItems="center">
         <text fg={colors.text}>A fatal error occurred!</text>
         <box onMouseUp={props.reset} backgroundColor={colors.primary} padding={1}>
-          <text fg={colors.bg}>Reset TUI</text>
+          <text fg={colors.background}>Reset TUI</text>
         </box>
         <box onMouseUp={handleExit} backgroundColor={colors.primary} padding={1}>
-          <text fg={colors.bg}>Exit</text>
+          <text fg={colors.background}>Exit</text>
         </box>
       </box>
       <scrollbox height={Math.floor(term().height * 0.7)}>
-        <text fg={colors.muted}>{props.error.stack}</text>
+        <text fg={colors.textMuted}>{props.error.stack}</text>
       </scrollbox>
       <text fg={colors.text}>{props.error.message}</text>
     </box>

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -20,6 +20,7 @@ import { DialogAgent } from "@tui/component/dialog-agent"
 import { DialogSessionList } from "@tui/component/dialog-session-list"
 import { KeybindProvider } from "@tui/context/keybind"
 import { ThemeProvider, useTheme } from "@tui/context/theme"
+import { ModeProvider } from "@tui/context/mode"
 import { Home } from "@tui/routes/home"
 import { Session } from "@tui/routes/session"
 import { PromptHistoryProvider } from "./component/prompt/history"
@@ -122,45 +123,47 @@ export function tui(input: {
           <ErrorBoundary
             fallback={(error, reset) => <ErrorComponent error={error} reset={reset} onExit={onExit} mode={mode} />}
           >
-            <ArgsProvider {...input.args}>
-              <ExitProvider onExit={onExit}>
-                <KVProvider>
-                  <ToastProvider>
-                    <RouteProvider>
-                      <SDKProvider
-                        url={input.url}
-                        directory={input.directory}
-                        fetch={input.fetch}
-                        headers={input.headers}
-                        events={input.events}
-                      >
-                        <SyncProvider>
-                          <ThemeProvider mode={mode}>
-                            <LocalProvider>
-                              <KeybindProvider>
-                                <PromptStashProvider>
-                                  <DialogProvider>
-                                    <CommandProvider>
-                                      <FrecencyProvider>
-                                        <PromptHistoryProvider>
-                                          <PromptRefProvider>
-                                            <App />
-                                          </PromptRefProvider>
-                                        </PromptHistoryProvider>
-                                      </FrecencyProvider>
-                                    </CommandProvider>
-                                  </DialogProvider>
-                                </PromptStashProvider>
-                              </KeybindProvider>
-                            </LocalProvider>
-                          </ThemeProvider>
-                        </SyncProvider>
-                      </SDKProvider>
-                    </RouteProvider>
-                  </ToastProvider>
-                </KVProvider>
-              </ExitProvider>
-            </ArgsProvider>
+            <ModeProvider mode={mode}>
+              <ArgsProvider {...input.args}>
+                <ExitProvider onExit={onExit}>
+                  <KVProvider>
+                    <ToastProvider>
+                      <RouteProvider>
+                        <SDKProvider
+                          url={input.url}
+                          directory={input.directory}
+                          fetch={input.fetch}
+                          headers={input.headers}
+                          events={input.events}
+                        >
+                          <SyncProvider>
+                            <ThemeProvider>
+                              <LocalProvider>
+                                <KeybindProvider>
+                                  <PromptStashProvider>
+                                    <DialogProvider>
+                                      <CommandProvider>
+                                        <FrecencyProvider>
+                                          <PromptHistoryProvider>
+                                            <PromptRefProvider>
+                                              <App />
+                                            </PromptRefProvider>
+                                          </PromptHistoryProvider>
+                                        </FrecencyProvider>
+                                      </CommandProvider>
+                                    </DialogProvider>
+                                  </PromptStashProvider>
+                                </KeybindProvider>
+                              </LocalProvider>
+                            </ThemeProvider>
+                          </SyncProvider>
+                        </SDKProvider>
+                      </RouteProvider>
+                    </ToastProvider>
+                  </KVProvider>
+                </ExitProvider>
+              </ArgsProvider>
+            </ModeProvider>
           </ErrorBoundary>
         )
       },

--- a/packages/opencode/src/cli/cmd/tui/component/loading-screen.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/loading-screen.tsx
@@ -1,0 +1,30 @@
+import { TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/solid"
+import { useMode } from "@tui/context/mode"
+
+export function LoadingScreen(props: { message: string }) {
+  const dimensions = useTerminalDimensions()
+  const mode = useMode()
+  const isLight = mode === "light"
+  const bg = isLight ? "#ffffff" : "#0a0a0a"
+  const fg = isLight ? "#8a8a8a" : "#808080"
+  const textColor = isLight ? "#1a1a1a" : "#eeeeee"
+
+  return (
+    <box
+      width={dimensions().width}
+      height={dimensions().height}
+      backgroundColor={bg}
+      justifyContent="center"
+      alignItems="center"
+      flexDirection="column"
+    >
+      <text fg={textColor} attributes={TextAttributes.BOLD}>
+        opencode
+      </text>
+      <box paddingTop={1}>
+        <text fg={fg}>{props.message}</text>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/loading-screen.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/loading-screen.tsx
@@ -1,29 +1,25 @@
-import { TextAttributes } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useMode } from "@tui/context/mode"
+import { Logo } from "@tui/component/logo"
+import { getDefaultColors } from "@tui/default-colors"
 
 export function LoadingScreen(props: { message: string }) {
   const dimensions = useTerminalDimensions()
   const mode = useMode()
-  const isLight = mode === "light"
-  const bg = isLight ? "#ffffff" : "#0a0a0a"
-  const fg = isLight ? "#8a8a8a" : "#808080"
-  const textColor = isLight ? "#1a1a1a" : "#eeeeee"
+  const colors = getDefaultColors(mode)
 
   return (
     <box
       width={dimensions().width}
       height={dimensions().height}
-      backgroundColor={bg}
+      backgroundColor={colors.background}
       justifyContent="center"
       alignItems="center"
       flexDirection="column"
     >
-      <text fg={textColor} attributes={TextAttributes.BOLD}>
-        opencode
-      </text>
+      <Logo />
       <box paddingTop={1}>
-        <text fg={fg}>{props.message}</text>
+        <text fg={colors.textMuted}>{props.message}</text>
       </box>
     </box>
   )

--- a/packages/opencode/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/logo.tsx
@@ -1,7 +1,9 @@
 import { TextAttributes, RGBA } from "@opentui/core"
 import { For, type JSX } from "solid-js"
 import { useTheme, tint } from "@tui/context/theme"
+import { useMode } from "@tui/context/mode"
 import { logo, marks } from "@/cli/logo"
+import { getDefaultColors } from "@tui/default-colors"
 
 // Shadow markers (rendered chars in parens):
 // _ = full shadow cell (space with bg=shadow)
@@ -10,10 +12,26 @@ import { logo, marks } from "@/cli/logo"
 const SHADOW_MARKER = new RegExp(`[${marks}]`)
 
 export function Logo() {
-  const { theme } = useTheme()
+  let background: RGBA
+  let text: RGBA
+  let textMuted: RGBA
+
+  try {
+    const { theme } = useTheme()
+    background = theme.background
+    text = theme.text
+    textMuted = theme.textMuted
+  } catch {
+    // Theme context not available, use defaults based on mode
+    const mode = useMode()
+    const colors = getDefaultColors(mode)
+    background = colors.background
+    text = colors.text
+    textMuted = colors.textMuted
+  }
 
   const renderLine = (line: string, fg: RGBA, bold: boolean): JSX.Element[] => {
-    const shadow = tint(theme.background, fg, 0.25)
+    const shadow = tint(background, fg, 0.25)
     const attrs = bold ? TextAttributes.BOLD : undefined
     const elements: JSX.Element[] = []
     let i = 0
@@ -75,8 +93,8 @@ export function Logo() {
       <For each={logo.left}>
         {(line, index) => (
           <box flexDirection="row" gap={1}>
-            <box flexDirection="row">{renderLine(line, theme.textMuted, false)}</box>
-            <box flexDirection="row">{renderLine(logo.right[index()], theme.text, true)}</box>
+            <box flexDirection="row">{renderLine(line, textMuted, false)}</box>
+            <box flexDirection="row">{renderLine(logo.right[index()], text, true)}</box>
           </box>
         )}
       </For>

--- a/packages/opencode/src/cli/cmd/tui/context/helper.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/helper.tsx
@@ -1,4 +1,4 @@
-import { createContext, Show, useContext, type ParentProps } from "solid-js"
+import { createContext, Show, useContext, type JSX, type ParentProps } from "solid-js"
 
 export function createSimpleContext<T, Props extends Record<string, any>>(input: {
   name: string
@@ -10,8 +10,12 @@ export function createSimpleContext<T, Props extends Record<string, any>>(input:
     provider: (props: ParentProps<Props>) => {
       const init = input.init(props)
       return (
-        // @ts-expect-error
-        <Show when={init.ready === undefined || init.ready === true}>
+        <Show
+          // @ts-expect-error
+          when={init.ready === undefined || init.ready === true}
+          // @ts-expect-error
+          fallback={init.fallback}
+        >
           <ctx.Provider value={init}>{props.children}</ctx.Provider>
         </Show>
       )

--- a/packages/opencode/src/cli/cmd/tui/context/kv.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/kv.tsx
@@ -2,6 +2,7 @@ import { Global } from "@/global"
 import { createSignal, type Setter } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
+import { LoadingScreen } from "@tui/component/loading-screen"
 import path from "path"
 
 export const { use: useKV, provider: KVProvider } = createSimpleContext({
@@ -22,6 +23,7 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
       })
 
     const result = {
+      fallback: <LoadingScreen message="Loading preferences..." />,
       get ready() {
         return ready()
       },

--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -7,6 +7,7 @@ import path from "path"
 import { Global } from "@/global"
 import { iife } from "@/util/iife"
 import { createSimpleContext } from "./helper"
+import { LoadingScreen } from "@tui/component/loading-screen"
 import { useToast } from "../ui/toast"
 import { Provider } from "@/provider/provider"
 import { useArgs } from "./args"
@@ -393,9 +394,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     })
 
     const result = {
+      fallback: <LoadingScreen message="Loading models..." />,
       model,
       agent,
       mcp,
+      get ready() {
+        return model.ready
+      },
     }
     return result
   },

--- a/packages/opencode/src/cli/cmd/tui/context/mode.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/mode.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext, type ParentProps } from "solid-js"
+
+type Mode = "dark" | "light"
+
+const ModeContext = createContext<Mode>()
+
+export function ModeProvider(props: ParentProps<{ mode: Mode }>) {
+  return <ModeContext.Provider value={props.mode}>{props.children}</ModeContext.Provider>
+}
+
+export function useMode() {
+  const mode = useContext(ModeContext)
+  if (!mode) throw new Error("ModeProvider context must be used within a ModeProvider")
+  return mode
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -22,6 +22,7 @@ import { createStore, produce, reconcile } from "solid-js/store"
 import { useSDK } from "@tui/context/sdk"
 import { Binary } from "@opencode-ai/util/binary"
 import { createSimpleContext } from "./helper"
+import { LoadingScreen } from "@tui/component/loading-screen"
 import type { Snapshot } from "@/snapshot"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
@@ -415,6 +416,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     const fullSyncedSessions = new Set<string>()
     const result = {
+      fallback: <LoadingScreen message="Connecting to server..." />,
       data: store,
       set: setStore,
       get status() {

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -3,6 +3,8 @@ import path from "path"
 import { createEffect, createMemo, onMount } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { createSimpleContext } from "./helper"
+import { LoadingScreen } from "@tui/component/loading-screen"
+import { useMode } from "@tui/context/mode"
 import aura from "./theme/aura.json" with { type: "json" }
 import ayu from "./theme/ayu.json" with { type: "json" }
 import catppuccin from "./theme/catppuccin.json" with { type: "json" }
@@ -278,12 +280,13 @@ function ansiToRgba(code: number): RGBA {
 
 export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
   name: "Theme",
-  init: (props: { mode: "dark" | "light" }) => {
+  init: () => {
+    const mode = useMode()
     const sync = useSync()
     const kv = useKV()
     const [store, setStore] = createStore({
       themes: DEFAULT_THEMES,
-      mode: kv.get("theme_mode", props.mode),
+      mode: kv.get("theme_mode", mode),
       active: (sync.data.config.theme ?? kv.get("theme", "opencode")) as string,
       ready: false,
     })
@@ -359,6 +362,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const subtleSyntax = createMemo(() => generateSubtleSyntax(values()))
 
     return {
+      fallback: <LoadingScreen message="Loading theme..." />,
       theme: new Proxy(values(), {
         get(_target, prop) {
           // @ts-expect-error

--- a/packages/opencode/src/cli/cmd/tui/default-colors.ts
+++ b/packages/opencode/src/cli/cmd/tui/default-colors.ts
@@ -1,0 +1,26 @@
+import { RGBA } from "@opentui/core"
+
+/**
+ * Default opencode theme colors for use before the theme context is available.
+ * These match the "orng" theme which is the default opencode theme.
+ */
+export const DEFAULT_COLORS = {
+  dark: {
+    background: RGBA.fromHex("#0a0a0a"),
+    text: RGBA.fromHex("#eeeeee"),
+    textMuted: RGBA.fromHex("#808080"),
+    primary: RGBA.fromHex("#fab283"),
+  },
+  light: {
+    background: RGBA.fromHex("#ffffff"),
+    text: RGBA.fromHex("#1a1a1a"),
+    textMuted: RGBA.fromHex("#8a8a8a"),
+    primary: RGBA.fromHex("#3b7dd8"),
+  },
+} as const
+
+export type Mode = "dark" | "light"
+
+export function getDefaultColors(mode: Mode) {
+  return DEFAULT_COLORS[mode]
+}


### PR DESCRIPTION
### What does this PR do?

This fixes something that was bothering me a lot...when adding plugins the experience loading `opencode` can be rough since it takes a bit of time loading and the screen is just absolutely empty...this adds a small splashscreen that shows what's happening.

~Initially, I (and by "I" I mean "Claude") wanted to add the logo which would've been a nice touch but it needs the Theme which is only loaded as the third-forth provider. Maybe we could default to the basic theme and actually show that?~

*Edit: actually I just did that and it looks much better*

### How did you verify your code works?


https://github.com/user-attachments/assets/1a977e51-66e9-4abc-afac-81f2bd9b30f7



