### PR TITLE
feat: add root-path for opencode web

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -103,7 +103,17 @@ export function AppInterface(props: { defaultUrl?: string }) {
       return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
     const rootPath = document.getElementById("root")?.dataset.rootPath || window.__OPENCODE__?.rootPath || ""
-    return (window.location.origin + rootPath).replace(/\/+$/, "")
+
+    // Properly normalize URL to avoid duplicate slashes
+    if (!rootPath) return window.location.origin
+
+    try {
+      const normalized = new URL(rootPath, window.location.origin).toString()
+      // Remove trailing slash
+      return normalized.replace(/\/+$/, "")
+    } catch {
+      return (window.location.origin + rootPath).replace(/\/+$/, "")
+    }
   }
 
   return (

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -43,7 +43,7 @@ function UiI18nBridge(props: ParentProps) {
 
 declare global {
   interface Window {
-    __OPENCODE__?: { updaterEnabled?: boolean; serverPassword?: string; deepLinks?: string[] }
+    __OPENCODE__?: { updaterEnabled?: boolean; serverPassword?: string; deepLinks?: string[]; rootPath?: string }
   }
 }
 
@@ -102,7 +102,8 @@ export function AppInterface(props: { defaultUrl?: string }) {
     if (import.meta.env.DEV)
       return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
 
-    return window.location.origin
+    const rootPath = document.getElementById("root")?.dataset.rootPath || window.__OPENCODE__?.rootPath || ""
+    return (window.location.origin + rootPath).replace(/\/+$/, "")
   }
 
   return (
@@ -111,6 +112,7 @@ export function AppInterface(props: { defaultUrl?: string }) {
         <GlobalSDKProvider>
           <GlobalSyncProvider>
             <Router
+              base={document.getElementById("root")?.dataset.rootPath || window.__OPENCODE__?.rootPath}
               root={(props) => (
                 <SettingsProvider>
                   <PermissionProvider>

--- a/packages/app/src/pages/directory-layout.tsx
+++ b/packages/app/src/pages/directory-layout.tsx
@@ -25,7 +25,7 @@ export default function Layout(props: ParentProps) {
     showToast({
       variant: "error",
       title: language.t("common.requestFailed"),
-      description: "Invalid directory in URL.",
+      description: `Invalid directory in URL (${params.dir}).`,
     })
     navigate("/")
   })

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -13,7 +13,10 @@ export const ServeCommand = cmd({
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    const displayUrl = opts.rootPath
+      ? `http://${server.hostname}:${server.port}${opts.rootPath}`
+      : `http://${server.hostname}:${server.port}`
+    console.log(`opencode server listening on ${displayUrl}`)
     await new Promise(() => {})
     await server.stop()
   },

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -13,7 +13,7 @@ export const ServeCommand = cmd({
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    const displayUrl = opts.rootPath ? `http://${server.hostname}:${server.port}${opts.rootPath}` : `http://${server.hostname}:${server.port}`
+    const displayUrl = opts.rootPath ? new URL(opts.rootPath, `http://${server.hostname}:${server.port}`).toString() : `http://${server.hostname}:${server.port}`
     console.log(`opencode server listening on ${displayUrl}`)
     await new Promise(() => {})
     await server.stop()

--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -13,9 +13,7 @@ export const ServeCommand = cmd({
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    const displayUrl = opts.rootPath
-      ? `http://${server.hostname}:${server.port}${opts.rootPath}`
-      : `http://${server.hostname}:${server.port}`
+    const displayUrl = opts.rootPath ? `http://${server.hostname}:${server.port}${opts.rootPath}` : `http://${server.hostname}:${server.port}`
     console.log(`opencode server listening on ${displayUrl}`)
     await new Promise(() => {})
     await server.stop()

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -37,7 +37,7 @@ export const WebCommand = cmd({
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = await resolveNetworkOptions(args)
-    const server = Server.listen(opts)
+    const server = await Server.listen(opts)
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -44,14 +44,14 @@ export const WebCommand = cmd({
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const baseUrl = opts.rootPath ? `http://localhost:${server.port}${opts.rootPath}` : `http://localhost:${server.port}`
+      const baseUrl = opts.rootPath ? new URL(opts.rootPath, `http://localhost:${server.port}`).toString() : `http://localhost:${server.port}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, baseUrl)
 
       // Show network IPs for remote access
       const networkIPs = getNetworkIPs()
       if (networkIPs.length > 0) {
         for (const ip of networkIPs) {
-          const networkUrl = opts.rootPath ? `http://${ip}:${server.port}${opts.rootPath}` : `http://${ip}:${server.port}`
+          const networkUrl = opts.rootPath ? new URL(opts.rootPath, `http://${ip}:${server.port}`).toString() : `http://${ip}:${server.port}`
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -69,14 +69,17 @@ export const WebCommand = cmd({
       }
 
       // Open localhost in browser
-      open(baseUrl.toString()).catch(() => {})
+      open(baseUrl.toString()).catch(() => { })
     } else {
-      const displayUrl = server.url.toString()
+      let displayUrl = server.url.toString()
+      if (opts.rootPath) {
+        displayUrl = new URL(opts.rootPath, server.url).toString()
+      }
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      open(displayUrl).catch(() => { })
     }
 
-    await new Promise(() => {})
+    await new Promise(() => { })
     await server.stop()
   },
 })

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -44,18 +44,14 @@ export const WebCommand = cmd({
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const baseUrl = opts.rootPath 
-        ? `http://localhost:${server.port}${opts.rootPath}`
-        : `http://localhost:${server.port}`
+      const baseUrl = opts.rootPath ? `http://localhost:${server.port}${opts.rootPath}` : `http://localhost:${server.port}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, baseUrl)
 
       // Show network IPs for remote access
       const networkIPs = getNetworkIPs()
       if (networkIPs.length > 0) {
         for (const ip of networkIPs) {
-          const networkUrl = opts.rootPath 
-            ? `http://${ip}:${server.port}${opts.rootPath}`
-            : `http://${ip}:${server.port}`
+          const networkUrl = opts.rootPath ? `http://${ip}:${server.port}${opts.rootPath}` : `http://${ip}:${server.port}`
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -44,17 +44,22 @@ export const WebCommand = cmd({
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
-      UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
+      const baseUrl = opts.rootPath 
+        ? `http://localhost:${server.port}${opts.rootPath}`
+        : `http://localhost:${server.port}`
+      UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, baseUrl)
 
       // Show network IPs for remote access
       const networkIPs = getNetworkIPs()
       if (networkIPs.length > 0) {
         for (const ip of networkIPs) {
+          const networkUrl = opts.rootPath 
+            ? `http://${ip}:${server.port}${opts.rootPath}`
+            : `http://${ip}:${server.port}`
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            networkUrl,
           )
         }
       }
@@ -68,7 +73,7 @@ export const WebCommand = cmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl.toString()).catch(() => {})
+      open(baseUrl.toString()).catch(() => {})
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -23,6 +23,11 @@ const options = {
     describe: "additional domains to allow for CORS",
     default: [] as string[],
   },
+  rootPath: {
+    type: "string" as const,
+    describe: "base path for reverse proxy",
+    default: "",
+  },
 }
 
 export type NetworkOptions = InferredOptionTypes<typeof options>
@@ -37,6 +42,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const hostnameExplicitlySet = process.argv.includes("--hostname")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const corsExplicitlySet = process.argv.includes("--cors")
+  const rootPathExplicitlySet = process.argv.includes("--root-path")
 
   const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
   const port = portExplicitlySet ? args.port : (config?.server?.port ?? args.port)
@@ -48,6 +54,9 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
+  const rootPath = rootPathExplicitlySet 
+    ? args.rootPath 
+    : (config?.server?.rootPath ?? args.rootPath)
 
-  return { hostname, port, mdns, cors }
+  return { hostname, port, mdns, cors, rootPath }
 }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -54,9 +54,11 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const configCors = config?.server?.cors ?? []
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
-  const rootPath = rootPathExplicitlySet 
-    ? args.rootPath 
-    : (config?.server?.rootPath ?? args.rootPath)
+  const rootPath = rootPathExplicitlySet ? args.rootPath : (config?.server?.rootPath ?? args.rootPath)
+
+  if (rootPath && !rootPath.startsWith("/")) {
+    throw new Error("rootPath must start with '/' if provided")
+  }
 
   return { hostname, port, mdns, cors, rootPath }
 }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -57,7 +57,10 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const rootPath = rootPathExplicitlySet ? args.rootPath : (config?.server?.rootPath ?? args.rootPath)
 
   if (rootPath && !rootPath.startsWith("/")) {
-    throw new Error(`rootPath must start with '/' if provided (got: '${rootPath}')`)
+    throw new Error(
+      `Invalid rootPath: must start with '/' (got: '${rootPath}')\n` +
+      `Example: --root-path /jupyter/proxy/opencode`
+    )
   }
 
   return { hostname, port, mdns, cors, rootPath }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -57,7 +57,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const rootPath = rootPathExplicitlySet ? args.rootPath : (config?.server?.rootPath ?? args.rootPath)
 
   if (rootPath && !rootPath.startsWith("/")) {
-    throw new Error("rootPath must start with '/' if provided")
+    throw new Error(`rootPath must start with '/' if provided (got: '${rootPath}')`)
   }
 
   return { hostname, port, mdns, cors, rootPath }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -854,6 +854,7 @@ export namespace Config {
       hostname: z.string().optional().describe("Hostname to listen on"),
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
       cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
+      rootPath: z.string().optional().describe("Base path for reverse proxy"),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/server/html-utils.ts
+++ b/packages/opencode/src/server/html-utils.ts
@@ -20,9 +20,19 @@ function escapeHtmlAttribute(value: string): string {
 
 /**
  * Safely injects rootPath configuration into index.html
- * - Prevents XSS by properly escaping values
- * - Checks for existing tags to avoid duplication
- * - Returns modified HTML or original on any error
+ * 
+ * Security measures:
+ * - HTML attribute escaping prevents XSS via DOM attributes
+ * - JSON.stringify prevents XSS via script injection
+ * - Duplicate tag detection prevents configuration conflicts
+ * 
+ * @param html - Original HTML content
+ * @param rootPath - Base path to inject (e.g., "/proxy")
+ * @returns Modified HTML with rootPath configuration, or original HTML on error
+ * 
+ * @example
+ * const html = await Bun.file("index.html").text()
+ * const modified = injectRootPath(html, "/jupyter/proxy")
  */
 export function injectRootPath(html: string, rootPath: string): string {
     if (!rootPath) return html

--- a/packages/opencode/src/server/html-utils.ts
+++ b/packages/opencode/src/server/html-utils.ts
@@ -1,0 +1,96 @@
+/**
+ * Utilities for safely modifying HTML with rootPath injection
+ */
+
+import { Log } from "../util/log"
+
+const log = Log.create({ service: "html-utils" })
+
+/**
+ * Escapes special characters for safe use in HTML attributes
+ */
+function escapeHtmlAttribute(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+}
+
+/**
+ * Safely injects rootPath configuration into index.html
+ * - Prevents XSS by properly escaping values
+ * - Checks for existing tags to avoid duplication
+ * - Returns modified HTML or original on any error
+ */
+export function injectRootPath(html: string, rootPath: string): string {
+    if (!rootPath) return html
+
+    try {
+        let modifiedHtml = html
+
+        // Check if base tag already exists
+        const hasBaseTag = /<base\s+href=/i.test(html)
+
+        // Safely escape rootPath for JSON injection (prevents XSS)
+        const safeRootPath = JSON.stringify(rootPath)
+
+        // Add base tag if it doesn't exist
+        if (!hasBaseTag) {
+            const baseTag = `<base href="${escapeHtmlAttribute(rootPath)}/">`
+            modifiedHtml = modifiedHtml.replace(/(<head[^>]*>)/i, `$1\n    ${baseTag}`)
+        }
+
+        // Add script tag with safely escaped rootPath
+        const scriptTag = `<script>
+      console.log("OPENCODE: Injecting rootPath", ${safeRootPath});
+      window.__OPENCODE__ = window.__OPENCODE__ || {};
+      window.__OPENCODE__.rootPath = ${safeRootPath};
+    </script>`
+        modifiedHtml = modifiedHtml.replace(/(<head[^>]*>)/i, `$1\n    ${scriptTag}`)
+
+        // Add data-root-path to root div if not already present
+        if (!/<div[^>]*id="root"[^>]*data-root-path=/i.test(modifiedHtml)) {
+            modifiedHtml = modifiedHtml.replace(
+                /(<div[^>]*id="root")/i,
+                `$1 data-root-path="${escapeHtmlAttribute(rootPath)}"`
+            )
+        }
+
+        return modifiedHtml
+    } catch (error) {
+        log.error("Failed to inject rootPath into HTML", { error })
+        return html // Return original HTML on error
+    }
+}
+
+/**
+ * Normalizes URL by removing duplicate slashes (except in protocol)
+ */
+export function normalizeUrl(baseUrl: string, path?: string): string {
+    if (!path) return baseUrl
+
+    try {
+        // Normalize path - remove leading extra slashes but keep one
+        const normalizedPath = path.replace(/^\/+/, "/")
+        const url = new URL(normalizedPath, baseUrl).toString()
+        // Replace multiple slashes with single slash, but preserve protocol://
+        return url.replace(/([^:]\/)\/+/g, "$1")
+    } catch (error) {
+        log.error("Failed to normalize URL", { error })
+        return baseUrl
+    }
+}
+
+/**
+ * Content Security Policy header value for serving HTML
+ */
+export const HTML_CSP_HEADER =
+    "default-src 'self'; " +
+    "script-src 'self' 'wasm-unsafe-eval'; " +
+    "style-src 'self' 'unsafe-inline'; " +
+    "img-src 'self' data: https:; " +
+    "font-src 'self' data:; " +
+    "media-src 'self' data:; " +
+    "connect-src 'self' data:"

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -563,13 +563,17 @@ export namespace Server {
     return result
   }
 
-  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
+  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; rootPath?: string }) {
     _corsWhitelist = opts.cors ?? []
+
+    const baseApp = opts.rootPath 
+      ? new Hono().basePath(opts.rootPath).route("/", App())
+      : App()
 
     const args = {
       hostname: opts.hostname,
       idleTimeout: 0,
-      fetch: App().fetch,
+      fetch: baseApp.fetch,
       websocket: websocket,
     } as const
     const tryServe = (port: number) => {
@@ -582,7 +586,9 @@ export namespace Server {
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
-    _url = server.url
+    _url = opts.rootPath 
+      ? new URL(`${server.url.origin}${opts.rootPath}`)
+      : server.url
 
     const shouldPublishMDNS =
       opts.mdns &&

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -566,9 +566,9 @@ export namespace Server {
   export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; rootPath?: string }) {
     _corsWhitelist = opts.cors ?? []
 
-    const baseApp = opts.rootPath 
-      ? new Hono().basePath(opts.rootPath).route("/", App())
-      : App()
+    // When rootPath is provided (for reverse proxy support), wrap the main app with a base path prefix.
+    // Hono's basePath() automatically prefixes all routes, including WebSocket upgrades.
+    const baseApp = opts.rootPath ? new Hono().basePath(opts.rootPath).route("/", App()) : App()
 
     const args = {
       hostname: opts.hostname,
@@ -586,9 +586,7 @@ export namespace Server {
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
-    _url = opts.rootPath 
-      ? new URL(`${server.url.origin}${opts.rootPath}`)
-      : server.url
+    _url = opts.rootPath ? new URL(`${server.url.origin}${opts.rootPath}`) : server.url
 
     const shouldPublishMDNS =
       opts.mdns &&

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -48,6 +48,11 @@ globalThis.AI_SDK_LOG_WARNINGS = false
 export namespace Server {
   const log = Log.create({ service: "server" })
 
+  // Constants for paths and URLs
+  const APP_DIST_PATH = "../app/dist"
+  const APP_INDEX_PATH = `${APP_DIST_PATH}/index.html`
+  const REMOTE_PROXY_URL = "https://app.opencode.ai"
+
   let _url: URL | undefined
   let _corsWhitelist: string[] = []
   let _rootPath: string = ""
@@ -532,7 +537,7 @@ export namespace Server {
             })
           },
         )
-        .use("/*", serveStatic({ root: "../app/dist" })) as unknown as Hono,
+        .use("/*", serveStatic({ root: APP_DIST_PATH })) as unknown as Hono,
   )
 
   export async function openapi() {
@@ -551,13 +556,49 @@ export namespace Server {
   }
 
   /**
+   * Creates a handler that serves static files locally if available,
+   * otherwise falls back to remote proxy
+   */
+  async function createStaticOrProxyHandler() {
+    const indexFile = Bun.file(APP_INDEX_PATH)
+    const localAppExists = await indexFile.exists()
+    
+    if (localAppExists) {
+      log.info("📦 Serving app from local build (../app/dist)")
+      return {
+        type: "local" as const,
+        handler: serveStatic({ root: APP_DIST_PATH })
+      }
+    } else {
+      log.warn("🌐 Local app build not found, falling back to remote proxy (https://app.opencode.ai)")
+      log.warn("   For better performance, build the app: cd packages/app && bun run build")
+      
+      return {
+        type: "proxy" as const,
+        handler: async (c: any) => {
+          const path = c.req.path
+          const response = await proxy(`${REMOTE_PROXY_URL}${path}`, {
+            ...c.req,
+            headers: {
+              ...c.req.raw.headers,
+              host: "app.opencode.ai",
+            },
+          })
+          response.headers.set("Content-Security-Policy", HTML_CSP_HEADER)
+          return response
+        }
+      }
+    }
+  }
+
+  /**
    * Creates a handler that serves index.html with rootPath injection
    * Centralizes HTML serving logic to avoid duplication
    */
   function createIndexHandler(rootPath: string) {
     return async (c: any) => {
       try {
-        const indexFile = Bun.file("../app/dist/index.html")
+        const indexFile = Bun.file(APP_INDEX_PATH)
         if (!(await indexFile.exists())) {
           log.warn("index.html not found at ../app/dist/index.html")
           return c.text("Not Found", 404)
@@ -576,12 +617,59 @@ export namespace Server {
     }
   }
 
-  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; rootPath?: string }) {
+  /**
+   * Creates app with common routes to avoid duplication
+   */
+  function createAppWithRoutes(
+    indexHandler: (c: any) => Promise<Response>,
+    staticHandler: any,
+    apiApp: Hono
+  ): Hono {
+    return new Hono()
+      .route("/", apiApp)
+      .get("/", indexHandler)
+      .get("/index.html", indexHandler)
+      .use("/*", staticHandler)
+      .all("/*", indexHandler) as unknown as Hono
+  }
+
+  /**
+   * Starts the OpenCode HTTP server
+   * 
+   * @param opts.rootPath - Base path for reverse proxy deployment (e.g., "/jupyter/proxy/opencode")
+   *                        When provided, requires local app build. Without it, falls back to remote proxy.
+   * 
+   * @example
+   * // Standard mode (auto fallback)
+   * listen({ port: 4096, hostname: "localhost" })
+   * 
+   * @example
+   * // Reverse proxy mode (requires local build)
+   * listen({ port: 4096, hostname: "0.0.0.0", rootPath: "/proxy" })
+   * 
+   * @throws {Error} If rootPath is provided but local app build is missing
+   */
+  export async function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; rootPath?: string }) {
     _corsWhitelist = opts.cors ?? []
     _rootPath = opts.rootPath ?? ""
 
+    // rootPath requires local build for reliable routing
+    if (opts.rootPath) {
+      const localAppExists = await Bun.file(APP_INDEX_PATH).exists()
+      if (!localAppExists) {
+        throw new Error(
+          "rootPath requires local app build.\n" +
+          "Build the app first: cd packages/app && bun run build\n" +
+          "Or run without --root-path to use remote proxy."
+        )
+      }
+    }
+    
+    const { type: serveType, handler: staticHandler } = await createStaticOrProxyHandler()
+
     // Create single index handler (no duplication!)
     const indexHandler = createIndexHandler(_rootPath)
+    const apiApp = App()
 
     // Setup routing based on whether rootPath is provided
     let baseApp: Hono
@@ -591,24 +679,16 @@ export namespace Server {
       // This ensures all routes including WebSocket work correctly
       const rootedApp = new Hono()
         .basePath(opts.rootPath)
-        .route("/", App())
-        .get("/", indexHandler)
-        .get("/index.html", indexHandler)
-        .use("/*", serveStatic({ root: "../app/dist" }))
-        .all("/*", indexHandler) // SPA fallback
-
+        .route("/", createAppWithRoutes(indexHandler, staticHandler, apiApp))
+      
       // Root app to handle both rooted and global asset paths
       baseApp = new Hono()
         .route("/", rootedApp)
         // Serve static assets that may use absolute paths (e.g., /assets/...)
-        .use("/*", serveStatic({ root: "../app/dist" }))
+        .use("/*", staticHandler)
     } else {
       // Standard setup without rootPath
-      baseApp = App()
-        .get("/", indexHandler)
-        .get("/index.html", indexHandler)
-        .use("/*", serveStatic({ root: "../app/dist" }))
-        .all("/*", indexHandler) as unknown as Hono
+      baseApp = createAppWithRoutes(indexHandler, staticHandler, apiApp)
     }
 
     const args = {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -33,7 +33,7 @@ import { lazy } from "../util/lazy"
 import { InstanceBootstrap } from "../project/bootstrap"
 import { Storage } from "../storage/storage"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
-import { websocket } from "hono/bun"
+import { websocket, serveStatic } from "hono/bun"
 import { HTTPException } from "hono/http-exception"
 import { errors } from "./error"
 import { QuestionRoutes } from "./routes/question"
@@ -49,6 +49,7 @@ export namespace Server {
 
   let _url: URL | undefined
   let _corsWhitelist: string[] = []
+  let _rootPath: string = ""
 
   export function url(): URL {
     return _url ?? new URL("http://localhost:4096")
@@ -530,21 +531,76 @@ export namespace Server {
             })
           },
         )
-        .all("/*", async (c) => {
-          const path = c.req.path
+        .get("/", async (c) => {
+          try {
+            const indexFile = Bun.file("../app/dist/index.html")
+            if (await indexFile.exists()) {
+              const html = await indexFile.text()
+              let modifiedHtml = html
 
-          const response = await proxy(`https://app.opencode.ai${path}`, {
-            ...c.req,
-            headers: {
-              ...c.req.raw.headers,
-              host: "app.opencode.ai",
-            },
-          })
-          response.headers.set(
-            "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:",
-          )
-          return response
+              if (_rootPath) {
+                const baseTag = `<base href="${_rootPath}/">`
+                // Inject script to provide rootPath to the frontend router
+                const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
+                modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
+                  .replace(/<div id="root"([^>]*)>/i, `<div id="root" data-root-path="${_rootPath}"$1>`)
+              }
+
+              return c.html(modifiedHtml, 200, {
+                "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+              })
+            }
+          } catch (e) {
+            // ignore
+          }
+          return c.text("Not Found", 404)
+        })
+        .get("/index.html", async (c) => {
+          try {
+            const indexFile = Bun.file("../app/dist/index.html")
+            if (await indexFile.exists()) {
+              const html = await indexFile.text()
+              let modifiedHtml = html
+
+              if (_rootPath) {
+                const baseTag = `<base href="${_rootPath}/">`
+                const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
+                modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
+                  .replace(/<div id="root"([^>]*)>/i, `<div id="root" data-root-path="${_rootPath}"$1>`)
+              }
+
+              return c.html(modifiedHtml, 200, {
+                "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+              })
+            }
+          } catch (e) {
+            // ignore
+          }
+          return c.text("Not Found", 404)
+        })
+        .use("/*", serveStatic({ root: "../app/dist" }))
+        .all("/*", async (c) => {
+          // SPA Fallback: serve index.html with rootPath injection
+          try {
+            const indexFile = Bun.file("../app/dist/index.html")
+            if (await indexFile.exists()) {
+              const html = await indexFile.text()
+              let modifiedHtml = html
+
+              if (_rootPath) {
+                const baseTag = `<base href="${_rootPath}/">`
+                const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
+                modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
+              }
+
+              return c.html(modifiedHtml, 200, {
+                "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+              })
+            }
+          } catch (e) {
+            // ignore
+          }
+          return c.text("Not Found", 404)
         }) as unknown as Hono,
   )
 
@@ -565,10 +621,58 @@ export namespace Server {
 
   export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; rootPath?: string }) {
     _corsWhitelist = opts.cors ?? []
+    _rootPath = opts.rootPath ?? ""
+
+    // Helper to serve index.html with rootPath injection
+    const serveIndexHtml = async (c: any) => {
+      try {
+        const indexFile = Bun.file("../app/dist/index.html")
+        if (await indexFile.exists()) {
+          const html = await indexFile.text()
+          let modifiedHtml = html
+
+          if (_rootPath) {
+            const baseTag = `<base href="${_rootPath}/">`
+            const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
+            modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
+              .replace(/<div id="root"([^>]*)>/i, `<div id="root" data-root-path="${_rootPath}"$1>`)
+          }
+
+          return c.html(modifiedHtml, 200, {
+            "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
+          })
+        }
+      } catch (e) {
+        // ignore
+      }
+      return c.text("Not Found", 404)
+    }
 
     // When rootPath is provided (for reverse proxy support), wrap the main app with a base path prefix.
     // Hono's basePath() automatically prefixes all routes, including WebSocket upgrades.
-    const baseApp = opts.rootPath ? new Hono().basePath(opts.rootPath).route("/", App()) : App()
+    // Also add a fallback at root level to proxy static assets that use absolute paths (e.g., /assets/...)
+    let baseApp: Hono
+    if (opts.rootPath) {
+      // 1. Create the app aimed at rootPath
+      const rootedApp = new Hono().basePath(opts.rootPath).route("/", App())
+        .get("/", serveIndexHtml) // Serve HTML at root
+        .get("/index.html", serveIndexHtml)
+        .use("/*", serveStatic({ root: "../app/dist" }))
+        .all("/*", serveIndexHtml) // SPA Fallback inside rooted path
+
+      // 2. Create a root-level app to perform dispatch
+      baseApp = new Hono()
+
+      // 3. Mount the rooted app. Requests starting with rootPath will be handled here.
+      baseApp.route("/", rootedApp)
+
+      // 4. Handle everything else (e.g. static assets /assets/...) by proxying to upstream
+      // Since this is on the root app without basePath, it catches all unmatched global paths.
+      // Note: We don't serve HTML here typically, but we should prioritize static assets.
+      baseApp.use("/*", serveStatic({ root: "../app/dist" }))
+    } else {
+      baseApp = App()
+    }
 
     const args = {
       hostname: opts.hostname,

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -586,7 +586,7 @@ export namespace Server {
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
-    _url = opts.rootPath ? new URL(opts.rootPath, server.url.origin) : server.url
+    _url = opts.rootPath ? new URL(opts.rootPath, server.url) : server.url
 
     const shouldPublishMDNS =
       opts.mdns &&

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -586,7 +586,7 @@ export namespace Server {
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
-    _url = opts.rootPath ? new URL(`${server.url.origin}${opts.rootPath}`) : server.url
+    _url = opts.rootPath ? new URL(opts.rootPath, server.url.origin) : server.url
 
     const shouldPublishMDNS =
       opts.mdns &&

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -40,6 +40,7 @@ import { QuestionRoutes } from "./routes/question"
 import { PermissionRoutes } from "./routes/permission"
 import { GlobalRoutes } from "./routes/global"
 import { MDNS } from "./mdns"
+import { injectRootPath, normalizeUrl, HTML_CSP_HEADER } from "./html-utils"
 
 // @ts-ignore This global is needed to prevent ai-sdk from logging warnings to stdout https://github.com/vercel/ai/blob/2dc67e0ef538307f21368db32d5a12345d98831b/packages/ai/src/logger/log-warnings.ts#L85
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -531,77 +532,7 @@ export namespace Server {
             })
           },
         )
-        .get("/", async (c) => {
-          try {
-            const indexFile = Bun.file("../app/dist/index.html")
-            if (await indexFile.exists()) {
-              const html = await indexFile.text()
-              let modifiedHtml = html
-
-              if (_rootPath) {
-                const baseTag = `<base href="${_rootPath}/">`
-                // Inject script to provide rootPath to the frontend router
-                const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
-                modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
-                  .replace(/<div id="root"([^>]*)>/i, `<div id="root" data-root-path="${_rootPath}"$1>`)
-              }
-
-              return c.html(modifiedHtml, 200, {
-                "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
-              })
-            }
-          } catch (e) {
-            // ignore
-          }
-          return c.text("Not Found", 404)
-        })
-        .get("/index.html", async (c) => {
-          try {
-            const indexFile = Bun.file("../app/dist/index.html")
-            if (await indexFile.exists()) {
-              const html = await indexFile.text()
-              let modifiedHtml = html
-
-              if (_rootPath) {
-                const baseTag = `<base href="${_rootPath}/">`
-                const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
-                modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
-                  .replace(/<div id="root"([^>]*)>/i, `<div id="root" data-root-path="${_rootPath}"$1>`)
-              }
-
-              return c.html(modifiedHtml, 200, {
-                "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
-              })
-            }
-          } catch (e) {
-            // ignore
-          }
-          return c.text("Not Found", 404)
-        })
-        .use("/*", serveStatic({ root: "../app/dist" }))
-        .all("/*", async (c) => {
-          // SPA Fallback: serve index.html with rootPath injection
-          try {
-            const indexFile = Bun.file("../app/dist/index.html")
-            if (await indexFile.exists()) {
-              const html = await indexFile.text()
-              let modifiedHtml = html
-
-              if (_rootPath) {
-                const baseTag = `<base href="${_rootPath}/">`
-                const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
-                modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
-              }
-
-              return c.html(modifiedHtml, 200, {
-                "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
-              })
-            }
-          } catch (e) {
-            // ignore
-          }
-          return c.text("Not Found", 404)
-        }) as unknown as Hono,
+        .use("/*", serveStatic({ root: "../app/dist" })) as unknown as Hono,
   )
 
   export async function openapi() {
@@ -619,59 +550,65 @@ export namespace Server {
     return result
   }
 
+  /**
+   * Creates a handler that serves index.html with rootPath injection
+   * Centralizes HTML serving logic to avoid duplication
+   */
+  function createIndexHandler(rootPath: string) {
+    return async (c: any) => {
+      try {
+        const indexFile = Bun.file("../app/dist/index.html")
+        if (!(await indexFile.exists())) {
+          log.warn("index.html not found at ../app/dist/index.html")
+          return c.text("Not Found", 404)
+        }
+
+        const html = await indexFile.text()
+        const modifiedHtml = injectRootPath(html, rootPath)
+
+        return c.html(modifiedHtml, 200, {
+          "Content-Security-Policy": HTML_CSP_HEADER,
+        })
+      } catch (error) {
+        log.error("Error serving index.html", { error })
+        return c.text("Internal Server Error", 500)
+      }
+    }
+  }
+
   export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; rootPath?: string }) {
     _corsWhitelist = opts.cors ?? []
     _rootPath = opts.rootPath ?? ""
 
-    // Helper to serve index.html with rootPath injection
-    const serveIndexHtml = async (c: any) => {
-      try {
-        const indexFile = Bun.file("../app/dist/index.html")
-        if (await indexFile.exists()) {
-          const html = await indexFile.text()
-          let modifiedHtml = html
+    // Create single index handler (no duplication!)
+    const indexHandler = createIndexHandler(_rootPath)
 
-          if (_rootPath) {
-            const baseTag = `<base href="${_rootPath}/">`
-            const scriptTag = `<script>console.log("OPENCODE: Injecting rootPath", "${_rootPath}"); window.__OPENCODE__ = window.__OPENCODE__ || {}; window.__OPENCODE__.rootPath = "${_rootPath}";</script>`
-            modifiedHtml = html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}${scriptTag}`)
-              .replace(/<div id="root"([^>]*)>/i, `<div id="root" data-root-path="${_rootPath}"$1>`)
-          }
-
-          return c.html(modifiedHtml, 200, {
-            "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; media-src 'self' data:; connect-src 'self' data:"
-          })
-        }
-      } catch (e) {
-        // ignore
-      }
-      return c.text("Not Found", 404)
-    }
-
-    // When rootPath is provided (for reverse proxy support), wrap the main app with a base path prefix.
-    // Hono's basePath() automatically prefixes all routes, including WebSocket upgrades.
-    // Also add a fallback at root level to proxy static assets that use absolute paths (e.g., /assets/...)
+    // Setup routing based on whether rootPath is provided
     let baseApp: Hono
+
     if (opts.rootPath) {
-      // 1. Create the app aimed at rootPath
-      const rootedApp = new Hono().basePath(opts.rootPath).route("/", App())
-        .get("/", serveIndexHtml) // Serve HTML at root
-        .get("/index.html", serveIndexHtml)
+      // When behind reverse proxy: mount app at rootPath
+      // This ensures all routes including WebSocket work correctly
+      const rootedApp = new Hono()
+        .basePath(opts.rootPath)
+        .route("/", App())
+        .get("/", indexHandler)
+        .get("/index.html", indexHandler)
         .use("/*", serveStatic({ root: "../app/dist" }))
-        .all("/*", serveIndexHtml) // SPA Fallback inside rooted path
+        .all("/*", indexHandler) // SPA fallback
 
-      // 2. Create a root-level app to perform dispatch
+      // Root app to handle both rooted and global asset paths
       baseApp = new Hono()
-
-      // 3. Mount the rooted app. Requests starting with rootPath will be handled here.
-      baseApp.route("/", rootedApp)
-
-      // 4. Handle everything else (e.g. static assets /assets/...) by proxying to upstream
-      // Since this is on the root app without basePath, it catches all unmatched global paths.
-      // Note: We don't serve HTML here typically, but we should prioritize static assets.
-      baseApp.use("/*", serveStatic({ root: "../app/dist" }))
+        .route("/", rootedApp)
+        // Serve static assets that may use absolute paths (e.g., /assets/...)
+        .use("/*", serveStatic({ root: "../app/dist" }))
     } else {
+      // Standard setup without rootPath
       baseApp = App()
+        .get("/", indexHandler)
+        .get("/index.html", indexHandler)
+        .use("/*", serveStatic({ root: "../app/dist" }))
+        .all("/*", indexHandler) as unknown as Hono
     }
 
     const args = {
@@ -690,7 +627,7 @@ export namespace Server {
     const server = opts.port === 0 ? (tryServe(4096) ?? tryServe(0)) : tryServe(opts.port)
     if (!server) throw new Error(`Failed to start server on port ${opts.port}`)
 
-    _url = opts.rootPath ? new URL(opts.rootPath, server.url) : server.url
+    _url = opts.rootPath ? new URL(normalizeUrl(server.url.toString(), opts.rootPath)) : server.url
 
     const shouldPublishMDNS =
       opts.mdns &&

--- a/packages/opencode/test/server/rootpath.test.ts
+++ b/packages/opencode/test/server/rootpath.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { Server } from "../../src/server/server"
+
+describe("rootPath support", () => {
+  test("server accepts rootPath option", () => {
+    // Test that listen function accepts rootPath parameter
+    const listenFn = Server.listen
+    expect(listenFn).toBeDefined()
+    
+    // This will test that the function signature is correct
+    // We can't actually start the server in tests, but we can verify the types
+  })
+  
+  test("URL construction with rootPath", () => {
+    // Test URL construction logic
+    const testCases = [
+      { rootPath: "", expected: "http://localhost:4096" },
+      { rootPath: "/proxy", expected: "http://localhost:4096/proxy" },
+      { rootPath: "/jupyter/proxy/opencode", expected: "http://192.168.1.100:4096/jupyter/proxy/opencode" },
+    ]
+    
+    for (const { rootPath, expected } of testCases) {
+      const hostname = expected.includes("192.168") ? "192.168.1.100" : "localhost"
+      const port = 4096
+      
+      const url = rootPath 
+        ? new URL(rootPath, `http://${hostname}:${port}`).toString()
+        : `http://${hostname}:${port}`
+      
+      expect(url).toBe(expected)
+    }
+  })
+  
+  test("rootPath validation", () => {
+    // Test that rootPath must start with /
+    const invalidPaths = ["proxy", "test/path", "no-slash"]
+    const validPaths = ["/proxy", "/test/path", "/jupyter/proxy/opencode"]
+    
+    for (const path of invalidPaths) {
+      if (path && !path.startsWith("/")) {
+        // This should throw an error
+        expect(path.startsWith("/")).toBe(false)
+      }
+    }
+    
+    for (const path of validPaths) {
+      expect(path.startsWith("/")).toBe(true)
+    }
+  })
+  
+  test("server URL with rootPath", () => {
+    // Simulate server.url construction
+    const serverUrl = new URL("http://localhost:4096")
+    
+    // Test with rootPath
+    const rootPath = "/proxy"
+    const finalUrl = rootPath ? new URL(rootPath, serverUrl) : serverUrl
+    
+    expect(finalUrl.toString()).toBe("http://localhost:4096/proxy")
+    
+    // Test without rootPath
+    const noRootPath = ""
+    const finalUrl2 = noRootPath ? new URL(noRootPath, serverUrl) : serverUrl
+    
+    expect(finalUrl2.toString()).toBe("http://localhost:4096/")
+  })
+})

--- a/packages/opencode/test/server/rootpath.test.ts
+++ b/packages/opencode/test/server/rootpath.test.ts
@@ -154,3 +154,91 @@ describe("server URL with rootPath", () => {
     expect(finalUrl).toBe("http://localhost:4096/")
   })
 })
+
+describe("Special character handling", () => {
+  test("handles URL encoded characters", () => {
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, "/한글/경로")
+    
+    // Should properly escape in HTML attributes
+    expect(result).toContain('data-root-path=')
+    // Should safely encode in JavaScript
+    expect(result).toContain('window.__OPENCODE__.rootPath')
+  })
+  
+  test("handles spaces and special chars in rootPath", () => {
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const paths = ["/path with space", "/path-with-dash", "/path_with_underscore", "/path.with.dot"]
+    
+    for (const path of paths) {
+      const result = injectRootPath(html, path)
+      expect(result).toContain(JSON.stringify(path))
+    }
+  })
+  
+  test("handles paths with query-like characters", () => {
+    const maliciousPath = "/proxy?token=abc&key=xyz"
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, maliciousPath)
+    
+    // Should be safely escaped
+    expect(result).toContain(JSON.stringify(maliciousPath))
+  })
+})
+
+describe("URL normalization edge cases", () => {
+  test("handles multiple consecutive slashes", () => {
+    expect(normalizeUrl("http://localhost:4096", "///proxy///path///")).toBe(
+      "http://localhost:4096/proxy/path/"
+    )
+  })
+  
+  test("handles mixed slash patterns", () => {
+    expect(normalizeUrl("http://localhost:4096/", "//proxy/path")).toBe(
+      "http://localhost:4096/proxy/path"
+    )
+  })
+  
+  test("preserves trailing slash when explicitly provided", () => {
+    const result = normalizeUrl("http://localhost:4096", "/proxy/")
+    expect(result.endsWith("/")).toBe(true)
+  })
+})
+
+describe("WebSocket compatibility", () => {
+  test("WebSocket URL construction with rootPath", () => {
+    const serverUrl = "http://localhost:4096"
+    const rootPath = "/jupyter/proxy/opencode"
+    
+    // WebSocket should use same base path
+    const wsUrl = new URL(rootPath, serverUrl)
+    wsUrl.protocol = "ws:"
+    
+    expect(wsUrl.toString()).toBe("ws://localhost:4096/jupyter/proxy/opencode")
+  })
+  
+  test("WebSocket URL without rootPath", () => {
+    const serverUrl = "http://localhost:4096"
+    const wsUrl = new URL(serverUrl)
+    wsUrl.protocol = "ws:"
+    
+    expect(wsUrl.toString()).toBe("ws://localhost:4096/")
+  })
+})
+
+describe("Fallback strategy", () => {
+  test("validates fallback behavior when local build missing", () => {
+    // This test documents expected behavior
+    const scenarios = [
+      { hasLocalBuild: true, hasRootPath: false, expected: "local" },
+      { hasLocalBuild: false, hasRootPath: false, expected: "proxy" },
+      { hasLocalBuild: true, hasRootPath: true, expected: "local" },
+      { hasLocalBuild: false, hasRootPath: true, expected: "error" },
+    ]
+    
+    for (const scenario of scenarios) {
+      // Expected behavior documented
+      expect(scenario.expected).toBeDefined()
+    }
+  })
+})

--- a/packages/opencode/test/server/rootpath.test.ts
+++ b/packages/opencode/test/server/rootpath.test.ts
@@ -1,67 +1,156 @@
 import { describe, expect, test } from "bun:test"
-import { Server } from "../../src/server/server"
+import { injectRootPath, normalizeUrl } from "../../src/server/html-utils"
 
-describe("rootPath support", () => {
-  test("server accepts rootPath option", () => {
-    // Test that listen function accepts rootPath parameter
-    const listenFn = Server.listen
-    expect(listenFn).toBeDefined()
-    
-    // This will test that the function signature is correct
-    // We can't actually start the server in tests, but we can verify the types
+describe("rootPath HTML injection", () => {
+  test("injects rootPath into clean HTML", () => {
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, "/proxy")
+
+    expect(result).toContain('<base href="/proxy/">')
+    expect(result).toContain('window.__OPENCODE__.rootPath = "/proxy"')
+    expect(result).toContain('data-root-path="/proxy"')
   })
-  
-  test("URL construction with rootPath", () => {
-    // Test URL construction logic
-    const testCases = [
-      { rootPath: "", expected: "http://localhost:4096" },
-      { rootPath: "/proxy", expected: "http://localhost:4096/proxy" },
-      { rootPath: "/jupyter/proxy/opencode", expected: "http://192.168.1.100:4096/jupyter/proxy/opencode" },
-    ]
-    
-    for (const { rootPath, expected } of testCases) {
-      const hostname = expected.includes("192.168") ? "192.168.1.100" : "localhost"
-      const port = 4096
-      
-      const url = rootPath 
-        ? new URL(rootPath, `http://${hostname}:${port}`).toString()
-        : `http://${hostname}:${port}`
-      
-      expect(url).toBe(expected)
-    }
+
+  test("prevents XSS via malicious rootPath", () => {
+    const maliciousPath = '/test"onerror="alert(1)"'
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, maliciousPath)
+
+    // Should not contain unescaped quotes that could break out
+    expect(result).not.toContain('onerror="alert(1)"')
+    // Should contain escaped version
+    expect(result).toContain("&quot;")
+
+    // JSON.stringify should handle the script tag
+    expect(result).toContain(JSON.stringify(maliciousPath))
   })
-  
-  test("rootPath validation", () => {
-    // Test that rootPath must start with /
+
+  test("prevents XSS via script tag injection", () => {
+    const maliciousPath = "/test</script><script>alert(1)</script>"
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, maliciousPath)
+
+    // The value should be assigned via JSON string literal
+    // This makes it safe because it's never parsed as HTML within the script context
+    expect(result).toContain("window.__OPENCODE__.rootPath = ")
+
+    // Verify the base tag has properly escaped HTML attributes
+    expect(result).toContain("<base href=")
+    expect(result).toContain("&lt;/script&gt;") // HTML escaped in attribute
+  })
+
+  test("doesn't duplicate base tag", () => {
+    const html = '<html><head><base href="/existing/"></head><body></body></html>'
+    const result = injectRootPath(html, "/new")
+
+    const baseTagCount = (result.match(/<base/gi) || []).length
+    expect(baseTagCount).toBe(1)
+    expect(result).toContain('href="/existing/"')
+  })
+
+  test("doesn't duplicate data-root-path attribute", () => {
+    const html =
+      '<html><head></head><body><div id="root" data-root-path="/existing"></div></body></html>'
+    const result = injectRootPath(html, "/new")
+
+    const attrCount = (result.match(/data-root-path=/gi) || []).length
+    expect(attrCount).toBe(1)
+    expect(result).toContain('data-root-path="/existing"')
+  })
+
+  test("handles empty rootPath gracefully", () => {
+    const html = '<html><head></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, "")
+
+    expect(result).toBe(html)
+  })
+
+  test("handles HTML with attributes on head tag", () => {
+    const html = '<html><head lang="en"></head><body><div id="root"></div></body></html>'
+    const result = injectRootPath(html, "/proxy")
+
+    expect(result).toContain('<base href="/proxy/">')
+    expect(result).toContain("__OPENCODE__")
+  })
+
+  test("handles multiline HTML", () => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>`
+    const result = injectRootPath(html, "/proxy")
+
+    expect(result).toContain('<base href="/proxy/">')
+    expect(result).toContain('data-root-path="/proxy"')
+  })
+})
+
+describe("URL normalization", () => {
+  test("normalizes URLs with duplicate slashes", () => {
+    expect(normalizeUrl("http://localhost:4096", "//proxy//path/")).toBe(
+      "http://localhost:4096/proxy/path/"
+    )
+  })
+
+  test("preserves protocol slashes", () => {
+    const result = normalizeUrl("http://localhost:4096", "/proxy")
+    expect(result).toContain("http://")
+    expect(result).not.toContain("http:/localhost")
+  })
+
+  test("handles empty path", () => {
+    expect(normalizeUrl("http://localhost:4096", "")).toBe("http://localhost:4096")
+  })
+
+  test("handles undefined path", () => {
+    expect(normalizeUrl("http://localhost:4096")).toBe("http://localhost:4096")
+  })
+
+  test("handles complex paths", () => {
+    expect(normalizeUrl("http://localhost:4096", "/jupyter/proxy/opencode/")).toBe(
+      "http://localhost:4096/jupyter/proxy/opencode/"
+    )
+  })
+
+  test("handles trailing slashes correctly", () => {
+    const result = normalizeUrl("http://localhost:4096/", "/proxy")
+    expect(result).toBe("http://localhost:4096/proxy")
+  })
+})
+
+describe("rootPath validation", () => {
+  test("rootPath must start with /", () => {
     const invalidPaths = ["proxy", "test/path", "no-slash"]
     const validPaths = ["/proxy", "/test/path", "/jupyter/proxy/opencode"]
-    
+
     for (const path of invalidPaths) {
-      if (path && !path.startsWith("/")) {
-        // This should throw an error
-        expect(path.startsWith("/")).toBe(false)
-      }
+      expect(path.startsWith("/")).toBe(false)
     }
-    
+
     for (const path of validPaths) {
       expect(path.startsWith("/")).toBe(true)
     }
   })
-  
-  test("server URL with rootPath", () => {
-    // Simulate server.url construction
+})
+
+describe("server URL with rootPath", () => {
+  test("constructs URL correctly with rootPath", () => {
     const serverUrl = new URL("http://localhost:4096")
-    
-    // Test with rootPath
     const rootPath = "/proxy"
-    const finalUrl = rootPath ? new URL(rootPath, serverUrl) : serverUrl
-    
+    const finalUrl = new URL(normalizeUrl(serverUrl.toString(), rootPath))
+
     expect(finalUrl.toString()).toBe("http://localhost:4096/proxy")
-    
-    // Test without rootPath
-    const noRootPath = ""
-    const finalUrl2 = noRootPath ? new URL(noRootPath, serverUrl) : serverUrl
-    
-    expect(finalUrl2.toString()).toBe("http://localhost:4096/")
+  })
+
+  test("constructs URL correctly without rootPath", () => {
+    const serverUrl = new URL("http://localhost:4096")
+    const finalUrl = normalizeUrl(serverUrl.toString())
+
+    expect(finalUrl).toBe("http://localhost:4096/")
   })
 })

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -368,6 +368,7 @@ This starts an HTTP server that provides API access to opencode functionality wi
 | `--hostname` | Hostname to listen on                      |
 | `--mdns`     | Enable mDNS discovery                      |
 | `--cors`     | Additional browser origin(s) to allow CORS |
+| `--root-path` | Base path for reverse proxy                      |
 
 ---
 
@@ -464,6 +465,7 @@ This starts an HTTP server and opens a web browser to access OpenCode through a 
 | `--hostname` | Hostname to listen on                      |
 | `--mdns`     | Enable mDNS discovery                      |
 | `--cors`     | Additional browser origin(s) to allow CORS |
+| `--root-path` | Base path for reverse proxy                      |
 
 ---
 

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -368,7 +368,7 @@ This starts an HTTP server that provides API access to opencode functionality wi
 | `--hostname` | Hostname to listen on                      |
 | `--mdns`     | Enable mDNS discovery                      |
 | `--cors`     | Additional browser origin(s) to allow CORS |
-| `--root-path` | Base path for reverse proxy                      |
+| `--root-path` | Base path for reverse proxy               |
 
 ---
 
@@ -465,7 +465,7 @@ This starts an HTTP server and opens a web browser to access OpenCode through a 
 | `--hostname` | Hostname to listen on                      |
 | `--mdns`     | Enable mDNS discovery                      |
 | `--cors`     | Additional browser origin(s) to allow CORS |
-| `--root-path` | Base path for reverse proxy                      |
+| `--root-path` | Base path for reverse proxy               |
 
 ---
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -190,7 +190,8 @@ You can configure server settings for the `opencode serve` and `opencode web` co
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
-    "cors": ["http://localhost:5173"]
+    "cors": ["http://localhost:5173"],
+    "rootPath": "/proxy"
   }
 }
 ```
@@ -201,6 +202,7 @@ Available options:
 - `hostname` - Hostname to listen on. When `mdns` is enabled and no hostname is set, defaults to `0.0.0.0`.
 - `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your OpenCode server.
 - `cors` - Additional origins to allow for CORS when using the HTTP server from a browser-based client. Values must be full origins (scheme + host + optional port), eg `https://app.example.com`.
+- `rootPath` - Base path for reverse proxy. All routes will be prefixed with this path.
 
 [Learn more about the server here](/docs/server).
 

--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -24,7 +24,7 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--root
 | `--hostname` | Hostname to listen on               | `127.0.0.1` |
 | `--mdns`     | Enable mDNS discovery               | `false`     |
 | `--cors`     | Additional browser origins to allow | `[]`        |
-| `--root-path` | Base path for reverse proxy                    | (empty)     |
+| `--root-path` | Base path for reverse proxy        | (empty)     |
 
 `--cors` can be passed multiple times:
 
@@ -32,10 +32,36 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--root
 opencode serve --cors http://localhost:5173 --cors https://app.example.com
 ```
 
-Use `--root-path` when running behind a reverse proxy:
+---
+
+### Deployment Modes
+
+OpenCode server supports two deployment modes:
+
+1. **Standard Mode** (default)
+   - Serves app from local build if available
+   - Falls back to remote proxy (https://app.opencode.ai) if local build missing
+   - Best for development and simple deployments
+
+2. **Reverse Proxy Mode** (with `--root-path`)
+   - Requires local app build (no fallback)
+   - All routes prefixed with specified path
+   - Best for Jupyter, corporate proxies, and multi-tenant environments
 
 ```bash
+# Standard mode with auto-fallback
+opencode serve
+
+# Behind reverse proxy (requires: cd packages/app && bun run build)
 opencode serve --root-path /jupyter/proxy/opencode
+```
+
+⚠️ **Note**: When using `--root-path`, ensure the app is built first:
+```bash
+cd packages/app
+bun run build
+cd ../../packages/opencode
+opencode serve --root-path /your/path
 ```
 
 ---

--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -34,38 +34,6 @@ opencode serve --cors http://localhost:5173 --cors https://app.example.com
 
 ---
 
-### Deployment Modes
-
-OpenCode server supports two deployment modes:
-
-1. **Standard Mode** (default)
-   - Serves app from local build if available
-   - Falls back to remote proxy (https://app.opencode.ai) if local build missing
-   - Best for development and simple deployments
-
-2. **Reverse Proxy Mode** (with `--root-path`)
-   - Requires local app build (no fallback)
-   - All routes prefixed with specified path
-   - Best for Jupyter, corporate proxies, and multi-tenant environments
-
-```bash
-# Standard mode with auto-fallback
-opencode serve
-
-# Behind reverse proxy (requires: cd packages/app && bun run build)
-opencode serve --root-path /jupyter/proxy/opencode
-```
-
-⚠️ **Note**: When using `--root-path`, ensure the app is built first:
-```bash
-cd packages/app
-bun run build
-cd ../../packages/opencode
-opencode serve --root-path /your/path
-```
-
----
-
 ### Authentication
 
 Set `OPENCODE_SERVER_PASSWORD` to protect the server with HTTP basic auth. The username defaults to `opencode`, or set `OPENCODE_SERVER_USERNAME` to override it. This applies to both `opencode serve` and `opencode web`.

--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -13,7 +13,7 @@ The `opencode serve` command runs a headless HTTP server that exposes an OpenAPI
 ### Usage
 
 ```bash
-opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
+opencode serve [--port <number>] [--hostname <string>] [--cors <origin>] [--root-path <path>]
 ```
 
 #### Options
@@ -24,11 +24,18 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 | `--hostname` | Hostname to listen on               | `127.0.0.1` |
 | `--mdns`     | Enable mDNS discovery               | `false`     |
 | `--cors`     | Additional browser origins to allow | `[]`        |
+| `--root-path` | Base path for reverse proxy                    | (empty)     |
 
 `--cors` can be passed multiple times:
 
 ```bash
 opencode serve --cors http://localhost:5173 --cors https://app.example.com
+```
+
+Use `--root-path` when running behind a reverse proxy:
+
+```bash
+opencode serve --root-path /jupyter/proxy/opencode
 ```
 
 ---


### PR DESCRIPTION
### Summary
This pull request adds robust support for deploying the OpenCode web app behind a reverse proxy at a configurable base path (`rootPath`). It introduces a new CLI/config option for `rootPath`, ensures all URLs and static assets are correctly resolved relative to this path, and injects the configuration into the frontend.

related issues:
https://github.com/anomalyco/opencode/issues/7624
https://github.com/anomalyco/opencode/issues/6336
and else...

### Changes
**Reverse Proxy & Root Path Support**
* Added a new `rootPath` option to CLI (`--root-path`), config, and network options, allowing the app to be served at a custom base path for reverse proxy scenarios. 
* Server startup now requires a local build when `rootPath` is set, enforcing this with a clear error message if the build is missing.
* All URLs (including those shown in CLI output and used by the frontend) are normalized to respect the `rootPath`, avoiding duplicate slashes and ensuring correct asset resolution.

**Frontend Integration**
* Injects the `rootPath` into the frontend via a `<base>` tag, a script setting `window.__OPENCODE__.rootPath`, and a `data-root-path` attribute on the root div, using the new `injectRootPath` utility.
* Frontend router and API base URL logic updated to use the injected `rootPath`, ensuring proper navigation and resource loading.
* Refactored server code to centralize static file serving and index.html handling, with clear separation between local and remote fallback modes.

### Testing
```bash
git clone https://github.com/DaehoYang/opencode
cd opencode
bun install
cd packages/app
bun run build
cd ../..
bun run dev web --root-path /proxy
```