### PR TITLE
docs: add opencode-plugin-auto-update to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -26,6 +26,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                                | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)          | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)         | Optimize token usage by pruning obsolete tool outputs                                             |
+| [opencode-plugin-auto-update](https://github.com/AnganSamadder/opencode-plugin-auto-update)               | Keep plugins up to date in the background with safe locking and throttled checks                  |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                        | Add native websearch support for supported providers with Google grounded style                   |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                              | Enables AI agents to run background processes in a PTY, send interactive input to them.           |
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |


### PR DESCRIPTION
Closes #11871

## What
- Adds `opencode-plugin-auto-update` to the Ecosystem Plugins table.

## Plugin
Auto-update helps keep OpenCode plugins current by:
- Checking for updates in the background
- Using safe locking to avoid concurrent update races
- Throttling checks to reduce noise

## Links
- Repo: https://github.com/AnganSamadder/opencode-plugin-auto-update
- npm: https://www.npmjs.com/package/opencode-plugin-auto-update

## Verification
- Link resolves
- Formatting matches existing Ecosystem table rows