### PR TITLE
docs: add opentmux to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [opentmux](https://github.com/AnganSamadder/opentmux)                                                     | Smart tmux integration for OpenCode: auto-spawns subagent panes and streams real-time execution   |
 
 ---
 


### PR DESCRIPTION
Closes #11872

## What
- Adds `opentmux` to the Ecosystem Plugins table.

## Plugin
OpenTmux is a tmux integration for OpenCode that:
- Automatically spawns tmux panes for subagents
- Streams agent execution output in real time
- Uses smart multi-column layouts to keep the main pane readable

## Links
- Repo: https://github.com/AnganSamadder/opentmux
- npm: https://www.npmjs.com/package/opentmux

## Verification
- Link resolves
- Formatting matches existing Ecosystem table rows