### PR TITLE
fix(clipboard): report actual copy result instead of always showing success

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -72,7 +72,8 @@ export namespace Clipboard {
       console.log("clipboard: using osascript")
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-        await $`osascript -e 'set the clipboard to "${escaped}"'`.nothrow().quiet()
+        const result = await $`osascript -e 'set the clipboard to "${escaped}"'`.nothrow().quiet()
+        if (result.exitCode !== 0) throw new Error("osascript failed")
       }
     }
 
@@ -83,7 +84,8 @@ export namespace Clipboard {
           const proc = Bun.spawn(["wl-copy"], { stdin: "pipe", stdout: "ignore", stderr: "ignore" })
           proc.stdin.write(text)
           proc.stdin.end()
-          await proc.exited.catch(() => {})
+          const code = await proc.exited
+          if (code !== 0) throw new Error("wl-copy failed")
         }
       }
       if (Bun.which("xclip")) {
@@ -96,7 +98,8 @@ export namespace Clipboard {
           })
           proc.stdin.write(text)
           proc.stdin.end()
-          await proc.exited.catch(() => {})
+          const code = await proc.exited
+          if (code !== 0) throw new Error("xclip failed")
         }
       }
       if (Bun.which("xsel")) {
@@ -109,9 +112,11 @@ export namespace Clipboard {
           })
           proc.stdin.write(text)
           proc.stdin.end()
-          await proc.exited.catch(() => {})
+          const code = await proc.exited
+          if (code !== 0) throw new Error("xsel failed")
         }
       }
+      throw new Error("No clipboard tool found. Install xclip, xsel, or wl-clipboard.")
     }
 
     if (os === "win32") {
@@ -135,13 +140,14 @@ export namespace Clipboard {
 
         proc.stdin.write(text)
         proc.stdin.end()
-        await proc.exited.catch(() => {})
+        const code = await proc.exited
+        if (code !== 0) throw new Error("powershell clipboard failed")
       }
     }
 
     console.log("clipboard: no native support")
     return async (text: string) => {
-      await clipboardy.write(text).catch(() => {})
+      await clipboardy.write(text)
     }
   })
 


### PR DESCRIPTION
                                                                                                                                                                                                                                  
Previously clipboard copy operations silently swallowed errors, showing                                                                                                                                                             
"Copied to clipboard" even when the copy failed. This was confusing on                                                                                                                                                              
Linux systems without xclip/xsel/wl-copy installed.                                                                                                                                                                                 
                                                                                                                                                                                                                                    
Changes:                                                                                                                                                                                                                            
- Check exit codes for all clipboard commands                                                                                                                                                                                       
- Throw descriptive errors on failure                                                                                                                                                                                               
- Show clear error message when no clipboard tool is available on Linux