### PR TITLE
fix(run): disable question tool in non-interactive mode

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -39,6 +39,7 @@ export namespace LLM {
     small?: boolean
     tools: Record<string, Tool>
     retries?: number
+    sessionPermission?: PermissionNext.Ruleset
   }
 
   export type StreamOutput = StreamTextResult<ToolSet, unknown>
@@ -265,8 +266,11 @@ export namespace LLM {
     })
   }
 
-  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {
-    const disabled = PermissionNext.disabled(Object.keys(input.tools), input.agent.permission)
+  async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user" | "sessionPermission">) {
+    const disabled = PermissionNext.disabled(
+      Object.keys(input.tools),
+      PermissionNext.merge(input.agent.permission, input.sessionPermission ?? []),
+    )
     for (const tool of Object.keys(input.tools)) {
       if (input.user.tools?.[tool] === false || disabled.has(tool)) {
         delete input.tools[tool]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -605,6 +605,7 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
+        sessionPermission: session.permission,
         system: [...(await SystemPrompt.environment(model)), ...(await InstructionPrompt.system())],
         messages: [
           ...MessageV2.toModelMessages(sessionMessages, model),


### PR DESCRIPTION
Fixes #11899

## Summary

- Fixed `opencode run` hanging when the model attempts to use the question tool
- The question tool is now properly excluded from the tools list in non-interactive mode

## Problem

When running `opencode run`, if the model tried to use the question tool, it would hang indefinitely because:

1. `run.ts` correctly sets session permission rules to deny the `question` permission
2. However, `LLM.resolveTools` only checked `agent.permission` when filtering disabled tools
3. Session permissions were ignored, so the question tool remained available
4. When called, `Question.ask()` waits forever for a response that never comes

## Solution

Updated `LLM.resolveTools` to merge both agent and session permissions when determining which tools should be disabled.

## Changes

- `packages/opencode/src/session/llm.ts`: Added `sessionPermission` to `StreamInput` type and updated `resolveTools` to merge it with agent permissions
- `packages/opencode/src/session/prompt.ts`: Pass `session.permission` when calling `processor.process()`

## Verification

Tested locally with `bun run dev run "ask me a question using the question tool"` - the model no longer attempts to use the question tool.