### PR TITLE
fix(opencode): preserve task metadata after truncation

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,6 +11,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { Truncate } from "@/tool/truncation"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -19,6 +20,19 @@ const parameters = z.object({
   session_id: z.string().describe("Existing Task session to continue").optional(),
   command: z.string().describe("The command that triggered this task").optional(),
 })
+
+export async function formatTaskOutput(text: string, sessionId: string, agent?: Agent.Info) {
+  const truncated = await Truncate.output(text, {}, agent)
+  const output = `${truncated.content}\n\n<task_metadata>\nsession_id: ${sessionId}\n</task_metadata>`
+
+  return {
+    output,
+    metadata: {
+      truncated: truncated.truncated,
+      ...(truncated.truncated ? { outputPath: truncated.outputPath } : {}),
+    },
+  }
+}
 
 export const TaskTool = Tool.define("task", async (ctx) => {
   const agents = await Agent.list().then((x) => x.filter((a) => a.mode !== "primary"))
@@ -175,8 +189,8 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           },
         }))
       const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
-
-      const output = text + "\n\n" + ["<task_metadata>", `session_id: ${session.id}`, "</task_metadata>"].join("\n")
+      const callerInfo = await Agent.get(ctx.agent)
+      const payload = await formatTaskOutput(text, session.id, callerInfo)
 
       return {
         title: params.description,
@@ -184,8 +198,9 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           summary,
           sessionId: session.id,
           model,
+          ...payload.metadata,
         },
-        output,
+        output: payload.output,
       }
     },
   }

--- a/packages/opencode/test/tool/task-truncation.test.ts
+++ b/packages/opencode/test/tool/task-truncation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { Truncate } from "../../src/tool/truncation"
+import { formatTaskOutput } from "../../src/tool/task"
+
+describe("tool.task truncation", () => {
+  test("keeps task_metadata after truncation", async () => {
+    const text = Array.from({ length: Truncate.MAX_LINES + 5 }, (_, i) => `line ${i}`).join("\n")
+    const result = await formatTaskOutput(text, "ses_test")
+
+    expect(result.metadata.truncated).toBe(true)
+    expect(result.output).toContain("<task_metadata>")
+    expect(result.output).toContain("session_id: ses_test")
+  })
+})


### PR DESCRIPTION
## Summary
- Truncate task output before appending <task_metadata> so session_id survives truncation.
- Add a unit test that asserts metadata is present when output is truncated.

## Testing
- bun test test/tool/task-truncation.test.ts

## Issue
Fixes #11903