### PR TITLE
fix(app): session tabs to open the previous opened

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -684,10 +684,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             const all = current.all.filter((x) => x !== tab)
             batch(() => {
               setStore("sessionTabs", session, "all", all)
-              if (current.active !== tab) return
+              const active = current.active
+              if (active && active !== tab && all.includes(active)) return
 
-              const index = current.all.findIndex((f) => f === tab)
-              const next = all[index - 1] ?? all[0]
+              const base = active && current.all.includes(active) ? active : tab
+              const index = current.all.findIndex((f) => f === base)
+              const next = index === -1 ? all[all.length - 1] : (all[index - 1] ?? all[index] ?? all[all.length - 1])
               setStore("sessionTabs", session, "active", next)
             })
           },

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -682,14 +682,15 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             if (!current) return
 
             const all = current.all.filter((x) => x !== tab)
+            if (current.active !== tab) {
+              setStore("sessionTabs", session, "all", all)
+              return
+            }
+
+            const index = current.all.findIndex((f) => f === tab)
+            const next = current.all[index - 1] ?? current.all[index + 1] ?? all[0]
             batch(() => {
               setStore("sessionTabs", session, "all", all)
-              const active = current.active
-              if (active && active !== tab && all.includes(active)) return
-
-              const base = active && current.all.includes(active) ? active : tab
-              const index = current.all.findIndex((f) => f === base)
-              const next = index === -1 ? all[all.length - 1] : (all[index - 1] ?? all[index] ?? all[all.length - 1])
               setStore("sessionTabs", session, "active", next)
             })
           },


### PR DESCRIPTION
fixed session file-tab selection so closing the active (especially last-opened) tab now focuses the adjacent previous tab instead of incorrectly jumping to the first tab.


