### PR TITLE
fix: respect semver build identifiers for nix

### DIFF
--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -20,7 +20,7 @@ let
 in
 stdenvNoCC.mkDerivation {
   pname = "opencode-node_modules";
-  version = "${packageJson.version}-${rev}";
+  version = "${packageJson.version}+${lib.replaceString "-" "." rev}";
 
   src = lib.fileset.toSource {
     root = ../.;


### PR DESCRIPTION
fixes #11411

changes nix builds to correctly use semver build identifiers

makes it so that auto update functions don't see nix builds as inferior to official builds when they have git metadata in the version.