### PR TITLE
fix: exclude k2p5 from reasoning variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -333,7 +333,9 @@ export namespace ProviderTransform {
       id.includes("minimax") ||
       id.includes("glm") ||
       id.includes("mistral") ||
-      id.includes("kimi")
+      id.includes("kimi") ||
+      // TODO: Remove this after models.dev data is fixed to use "kimi-k2.5" instead of "k2p5"
+      id.includes("k2p5")
     )
       return {}
 


### PR DESCRIPTION
## Summary

- Add `k2p5` to the exclusion list in `variants()` function to prevent Kimi K2.5 from incorrectly getting `high`/`max` thinking variants

## Details

The Kimi For Coding provider uses `k2p5` as the model ID for Kimi K2.5, which does not contain the string "kimi". This causes it to bypass the exclusion logic and incorrectly receive thinking variants support.

**Confirmed with Moonshot official staff: Kimi-K2.5 does NOT support thinking budget configuration.**

This is a temporary workaround. The correct solution is to fix the model ID in `models.dev` data to use `kimi-k2.5` instead of `k2p5`.

Fixes #11917