### PR TITLE
ci: allow commits on top of beta PRs

### DIFF
--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    branches: [dev]
+    branches: [dev, beta]
     paths:
       - "bun.lock"
       - "package.json"

--- a/script/beta.ts
+++ b/script/beta.ts
@@ -128,10 +128,15 @@ async function main() {
   await $`git fetch origin beta`
 
   const localTree = await $`git rev-parse beta^{tree}`.text()
-  const remoteTree = await $`git rev-parse origin/beta^{tree}`.text()
+  const remoteTrees = (await $`git log origin/dev..origin/beta --format=%T`.text()).split("\n")
 
-  if (localTree.trim() === remoteTree.trim()) {
-    console.log("Beta branch has identical contents, no push needed")
+  const matchIdx = remoteTrees.indexOf(localTree.trim())
+  if (matchIdx !== -1) {
+    if (matchIdx !== 0) {
+      console.log(`Beta branch contains this sync, but additional commits exist after it. Leaving beta branch as is.`)
+    } else {
+      console.log("Beta branch has identical contents, no push needed")
+    }
     return
   }
 


### PR DESCRIPTION
any commits (CI or otherwise) on top of the authoritative beta PRs (ones with beta tag) would make tree hash mis-match and trigger a force push

the first commit relaxes this to allow the beta branch to remain as long as the beta branch history contains all beta PRs and is based on current dev branch

before:
only     dev..beta_PRs

after:
allows   dev..beta_PRs..extra_commits

the second commit takes advantage of this relaxation to apply nix-hash updates to the beta branch as needed

feel free to close if this is not the correct model for the beta branch

related: #11919 