### PR TITLE
feat: Add .slnx to C#/F# LSP root detection

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -732,7 +732,7 @@ export namespace LSPServer {
 
   export const CSharp: Info = {
     id: "csharp",
-    root: NearestRoot([".sln", ".csproj", "global.json"]),
+    root: NearestRoot([".slnx", ".sln", ".csproj", "global.json"]),
     extensions: [".cs"],
     async spawn(root) {
       let bin = Bun.which("csharp-ls", {
@@ -772,7 +772,7 @@ export namespace LSPServer {
 
   export const FSharp: Info = {
     id: "fsharp",
-    root: NearestRoot([".sln", ".fsproj", "global.json"]),
+    root: NearestRoot([".slnx", ".sln", ".fsproj", "global.json"]),
     extensions: [".fs", ".fsi", ".fsx", ".fsscript"],
     async spawn(root) {
       let bin = Bun.which("fsautocomplete", {


### PR DESCRIPTION
### Summary

This PR includes ".slnx" in the NearestRoot arrays for both C# and F# LSP servers in addition to ".sln", ".csproj" (C#), ".fsproj" (F#) and "global.json". See [Introducing support for SLNX, a new, simpler solution file format in the .NET CLI](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/).

Closes #11929

### Changes

".slnx" was added to the `NearestRoot` array for both C# and F# LSP servers.

### Testing

Tested locally, no critical changes made.