### PR TITLE
feat(compaction): configurable threshold and model (global + per-model)

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -909,6 +909,17 @@ export namespace Config {
         .record(
           z.string(),
           ModelsDev.Model.partial().extend({
+            compaction_threshold: z
+              .number()
+              .int()
+              .min(1)
+              .max(100)
+              .optional()
+              .describe("Compact when context usage exceeds this percentage (1-100, overrides global threshold)"),
+            compaction_model: z
+              .string()
+              .optional()
+              .describe("Model to use for compaction (e.g., 'zhipu/glm-4-plus', overrides global compaction model)"),
             variants: z
               .record(
                 z.string(),
@@ -1115,6 +1126,19 @@ export namespace Config {
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),
           prune: z.boolean().optional().describe("Enable pruning of old tool outputs (default: true)"),
+          threshold: z
+            .number()
+            .int()
+            .min(1)
+            .max(100)
+            .optional()
+            .describe(
+              "Default compaction threshold percentage (1-100). Compaction triggers when context usage exceeds this percentage (default: 100)",
+            ),
+          model: z
+            .string()
+            .optional()
+            .describe("Default model to use for compaction (e.g., 'anthropic/claude-haiku-3-5-20241022')"),
         })
         .optional(),
       experimental: z

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -586,6 +586,8 @@ export namespace Provider {
       headers: z.record(z.string(), z.string()),
       release_date: z.string(),
       variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
+      compaction_threshold: z.number().int().min(1).max(100).optional(),
+      compaction_model: z.string().optional(),
     })
     .meta({
       ref: "Model",
@@ -810,6 +812,8 @@ export namespace Provider {
           family: model.family ?? existingModel?.family ?? "",
           release_date: model.release_date ?? existingModel?.release_date ?? "",
           variants: {},
+          compaction_threshold: model.compaction_threshold ?? existingModel?.compaction_threshold,
+          compaction_model: model.compaction_model ?? existingModel?.compaction_model,
         }
         const merged = mergeDeep(ProviderTransform.variants(parsedModel), model.variants ?? {})
         parsedModel.variants = mapValues(

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -18,6 +18,8 @@ import { Config } from "@/config/config"
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
 
+  export const THRESHOLD_DEFAULT = 100
+
   export const Event = {
     Compacted: BusEvent.define(
       "session.compacted",
@@ -35,7 +37,8 @@ export namespace SessionCompaction {
     const count = input.tokens.input + input.tokens.cache.read + input.tokens.output
     const output = Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) || SessionPrompt.OUTPUT_TOKEN_MAX
     const usable = input.model.limit.input || context - output
-    return count > usable
+    const threshold = input.model.compaction_threshold ?? config.compaction?.threshold ?? THRESHOLD_DEFAULT
+    return count > usable * (threshold / 100)
   }
 
   export const PRUNE_MINIMUM = 20_000
@@ -95,12 +98,18 @@ export namespace SessionCompaction {
     sessionID: string
     abort: AbortSignal
     auto: boolean
+    model: Provider.Model
   }) {
+    const config = await Config.get()
     const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
     const agent = await Agent.get("compaction")
-    const model = agent.model
-      ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
-      : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
+    const compactionModelStr = input.model.compaction_model ?? config.compaction?.model
+    const parsed = compactionModelStr ? Provider.parseModel(compactionModelStr) : undefined
+    const model = parsed
+      ? await Provider.getModel(parsed.providerID, parsed.modelID)
+      : agent.model
+        ? await Provider.getModel(agent.model.providerID, agent.model.modelID)
+        : await Provider.getModel(userMessage.model.providerID, userMessage.model.modelID)
     const msg = (await Session.updateMessage({
       id: Identifier.ascending("message"),
       role: "assistant",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -495,6 +495,7 @@ export namespace SessionPrompt {
           abort,
           sessionID,
           auto: task.auto,
+          model,
         })
         if (result === "stop") break
         continue

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1500,6 +1500,14 @@ export type ProviderConfig = {
           [key: string]: unknown | boolean | undefined
         }
       }
+      /**
+       * Compact when context usage exceeds this percentage (1-100, overrides global threshold)
+       */
+      compaction_threshold?: number
+      /**
+       * Model to use for compaction (e.g., 'zhipu/glm-4-plus', overrides global compaction model)
+       */
+      compaction_model?: string
     }
   }
   whitelist?: Array<string>
@@ -1786,6 +1794,14 @@ export type Config = {
      * Enable pruning of old tool outputs (default: true)
      */
     prune?: boolean
+    /**
+     * Default compaction threshold percentage (1-100). Compaction triggers when context usage exceeds this percentage (default: 100)
+     */
+    threshold?: number
+    /**
+     * Default model to use for compaction (e.g., 'anthropic/claude-haiku-3-5-20241022')
+     */
+    model?: string
   }
   experimental?: {
     disable_paste_summary?: boolean
@@ -1918,6 +1934,8 @@ export type Model = {
       [key: string]: unknown
     }
   }
+  compaction_threshold?: number
+  compaction_model?: string
 }
 
 export type Provider = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9284,6 +9284,16 @@
                     },
                     "additionalProperties": {}
                   }
+                },
+                "compaction_threshold": {
+                  "description": "Compact when context usage exceeds this percentage (1-100, overrides global threshold)",
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 100
+                },
+                "compaction_model": {
+                  "description": "Model to use for compaction (e.g., 'zhipu/glm-4-plus', overrides global compaction model)",
+                  "type": "string"
                 }
               }
             }
@@ -9843,6 +9853,16 @@
               "prune": {
                 "description": "Enable pruning of old tool outputs (default: true)",
                 "type": "boolean"
+              },
+              "threshold": {
+                "description": "Default compaction threshold percentage (1-100). Compaction triggers when context usage exceeds this percentage (default: 100)",
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100
+              },
+              "model": {
+                "description": "Default model to use for compaction (e.g., 'anthropic/claude-haiku-3-5-20241022')",
+                "type": "string"
               }
             }
           },
@@ -10194,6 +10214,14 @@
               },
               "additionalProperties": {}
             }
+          },
+          "compaction_threshold": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "compaction_model": {
+            "type": "string"
           }
         },
         "required": [

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -488,13 +488,37 @@ You can control context compaction behavior through the `compaction` option.
   "$schema": "https://opencode.ai/config.json",
   "compaction": {
     "auto": true,
-    "prune": true
+    "prune": true,
+    "threshold": 80,
+    "model": "anthropic/claude-haiku-3-5-20241022"
   }
 }
 ```
 
 - `auto` - Automatically compact the session when context is full (default: `true`).
 - `prune` - Remove old tool outputs to save tokens (default: `true`).
+- `threshold` - Percentage of context usage that triggers compaction, from 1-100 (default: `100`). Lower values trigger compaction earlier, which can help maintain model performance in long sessions.
+- `model` - Model to use for generating the compaction summary. Defaults to the session's current model.
+
+You can also configure compaction per-model. This is useful when different models have different optimal context thresholds.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {
+      "models": {
+        "claude-opus-4-20250514": {
+          "compaction_threshold": 50,
+          "compaction_model": "anthropic/claude-haiku-3-5-20241022"
+        }
+      }
+    }
+  }
+}
+```
+
+Per-model settings override the global `compaction` config. This lets you use different thresholds and models for each provider/model combination.
 
 ---
 

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -105,6 +105,29 @@ The built-in provider and model names can be found on [Models.dev](https://model
 
 You can also configure these options for any agents that you are using. The agent config overrides any global options here. [Learn more](/docs/agents/#additional).
 
+You can also configure per-model compaction settings. This is useful when different models perform better with earlier compaction thresholds.
+
+```jsonc title="opencode.jsonc" {7-8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {
+      "models": {
+        "claude-opus-4-20250514": {
+          "compaction_threshold": 50,
+          "compaction_model": "anthropic/claude-haiku-3-5-20241022",
+        },
+      },
+    },
+  },
+}
+```
+
+- `compaction_threshold` - Percentage of context (1-100) that triggers compaction. Overrides the global setting.
+- `compaction_model` - Model to use for compaction. Useful for using a cheaper/faster model.
+
+[Learn more about compaction](/docs/config#compaction).
+
 You can also define custom variants that extend built-in ones. Variants let you configure different settings for the same model without creating duplicate entries:
 
 ```jsonc title="opencode.jsonc" {6-21}


### PR DESCRIPTION
Ever noticed how Opus gets kinda dumb around 50-60% context? Yeah, me too. Built this to escape the dumbzone.

Adds compaction settings at both global and per-model levels:
- `threshold` (1-100) - trigger compaction earlier, before models go stupid
- `model` - use a cheaper model for compaction (why waste Opus on summaries?)

**Global config:**
```json
{
  "compaction": {
    "threshold": 80,
    "model": "anthropic/claude-haiku-5-20260205"
  }
}
```

**Per-model config:**
```json
{
  "provider": {
    "anthropic": {
      "models": {
        "claude-opus-4-20250514": {
          "compaction_threshold": 50,
          "compaction_model": "zhipu/glm-4-plus"
        }
      }
    }
  }
}
```

Per-model overrides global. Default is 100 (current behavior).

Closes #11930
Relates to #11314, #8140, #10017, #8629