### PR TITLE
docs: add --mdns-domain flag documentation

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -190,6 +190,7 @@ You can configure server settings for the `opencode serve` and `opencode web` co
     "port": 4096,
     "hostname": "0.0.0.0",
     "mdns": true,
+    "mdnsDomain": "myproject.local",
     "cors": ["http://localhost:5173"]
   }
 }
@@ -200,6 +201,7 @@ Available options:
 - `port` - Port to listen on.
 - `hostname` - Hostname to listen on. When `mdns` is enabled and no hostname is set, defaults to `0.0.0.0`.
 - `mdns` - Enable mDNS service discovery. This allows other devices on the network to discover your OpenCode server.
+- `mdnsDomain` - Custom domain name for mDNS service. Defaults to `opencode.local`. Useful for running multiple instances on the same network.
 - `cors` - Additional origins to allow for CORS when using the HTTP server from a browser-based client. Values must be full origins (scheme + host + optional port), eg `https://app.example.com`.
 
 [Learn more about the server here](/docs/server).

--- a/packages/web/src/content/docs/server.mdx
+++ b/packages/web/src/content/docs/server.mdx
@@ -18,12 +18,13 @@ opencode serve [--port <number>] [--hostname <string>] [--cors <origin>]
 
 #### Options
 
-| Flag         | Description                         | Default     |
-| ------------ | ----------------------------------- | ----------- |
-| `--port`     | Port to listen on                   | `4096`      |
-| `--hostname` | Hostname to listen on               | `127.0.0.1` |
-| `--mdns`     | Enable mDNS discovery               | `false`     |
-| `--cors`     | Additional browser origins to allow | `[]`        |
+| Flag            | Description                         | Default          |
+| --------------- | ----------------------------------- | ---------------- |
+| `--port`        | Port to listen on                   | `4096`           |
+| `--hostname`    | Hostname to listen on               | `127.0.0.1`      |
+| `--mdns`        | Enable mDNS discovery               | `false`          |
+| `--mdns-domain` | Custom domain name for mDNS service | `opencode.local` |
+| `--cors`        | Additional browser origins to allow | `[]`             |
 
 `--cors` can be passed multiple times:
 

--- a/packages/web/src/content/docs/web.mdx
+++ b/packages/web/src/content/docs/web.mdx
@@ -64,6 +64,12 @@ opencode web --mdns
 
 This automatically sets the hostname to `0.0.0.0` and advertises the server as `opencode.local`.
 
+You can customize the mDNS domain name to run multiple instances on the same network:
+
+```bash
+opencode web --mdns --mdns-domain myproject.local
+```
+
 ### CORS
 
 To allow additional domains for CORS (useful for custom frontends):


### PR DESCRIPTION
## Changes

- Add `--mdns-domain` flag to the server CLI options table in `server.mdx`
- Document customizing mDNS domain in `web.mdx` with usage example
- Add `mdnsDomain` config option to server configuration in `config.mdx`

## References

- Related to feat(server): add --mdns-domain flag to customize mDNS hostname (22710ee)