### PR TITLE
feat: add /session-id command to copy session ID to clipboard

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -198,6 +198,26 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Copy session ID",
+        value: "session.copy_id",
+        category: "Session",
+        slash: {
+          name: "session-id",
+        },
+        enabled: !!props.sessionID,
+        onSelect: async (dialog) => {
+          if (props.sessionID) {
+            await Clipboard.copy(props.sessionID)
+            toast.show({
+              variant: "success",
+              message: `Copied: ${props.sessionID}`,
+              duration: 2000,
+            })
+          }
+          dialog.clear()
+        },
+      },
+      {
         title: "Interrupt session",
         value: "session.interrupt",
         keybind: "session_interrupt",


### PR DESCRIPTION
## Summary
Adds `/session-id` slash command that copies the current session ID to the system clipboard with a toast confirmation.
Fixes #11937
## Changes
- Added new command in `packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`
- Uses existing `Clipboard.copy()` utility
- Shows success toast with the copied session ID
- Only enabled when in an active session (`props.sessionID` exists)
## Testing
1. Open any session in TUI
2. Type `/session-id` or find "Copy session ID" in command palette
3. Session ID is copied to clipboard + toast confirms