### PR TITLE
fix(tui): rejecting any stacked permission of a subagent terminates it's session

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -184,7 +184,7 @@ export namespace PermissionNext {
               requestID: pending.info.id,
               reply: "reject",
             })
-            pending.reject(new RejectedError())
+            pending.reject(input.message ? new AutoRejectedError(input.message) : new RejectedError())
           }
         }
         return
@@ -262,6 +262,13 @@ export namespace PermissionNext {
   export class CorrectedError extends Error {
     constructor(message: string) {
       super(`The user rejected permission to use this specific tool call with the following feedback: ${message}`)
+    }
+  }
+
+  /** Auto-rejected due to another tool rejection with feedback - continues with guidance */
+  export class AutoRejectedError extends Error {
+    constructor(message?: string) {
+      super(`Permission to use this specific tool call was automatically rejected due to another rejected permission in the same message with the following feedback: ${message}`)
     }
   }
 

--- a/packages/opencode/test/permission/next.test.ts
+++ b/packages/opencode/test/permission/next.test.ts
@@ -649,6 +649,50 @@ test("reply - reject cancels all pending for same session", async () => {
   })
 })
 
+test("reply - reject with message propagates feedback to cascade rejections", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const askPromise1 = PermissionNext.ask({
+        id: "permission_test5a",
+        sessionID: "session_feedback",
+        permission: "bash",
+        patterns: ["bun run tauri dev"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      })
+
+      const askPromise2 = PermissionNext.ask({
+        id: "permission_test5b",
+        sessionID: "session_feedback",
+        permission: "edit",
+        patterns: ["important.ts"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      })
+
+      const result1 = askPromise1.catch((e) => e)
+      const result2 = askPromise2.catch((e) => e)
+
+      await PermissionNext.reply({
+        requestID: "permission_test5a",
+        reply: "reject",
+        message: "Keep that Desktop App out of my system!",
+      })
+
+      const error1 = await result1
+      const error2 = await result2
+
+      expect(error1).toBeInstanceOf(PermissionNext.CorrectedError)
+      expect(error2).toBeInstanceOf(PermissionNext.AutoRejectedError)
+      expect(error2.message).toContain("Keep that Desktop App out of my system!")
+    },
+  })
+})
+
 test("ask - checks all patterns and stops on first deny", async () => {
   await using tmp = await tmpdir({ git: true })
   await Instance.provide({


### PR DESCRIPTION
### What does this PR do?
fixes #11932 where rejecting one of subagent's stacked permissions cascades and terminates the session instead of continuing with the reason.

This is achieved by providing a proper cascading error message for rest of the permissions instead of `RejectedError` which terminates the session.

### How did you verify your code works?
- tested manually (screen recording and share link provided below)
- added a new test case to handle this case

*screen recording*

https://github.com/user-attachments/assets/62a5cbd8-f911-4a6f-a96c-56bfeb4e5eca


screen recording session share link: https://opncd.ai/share/2PdOHkY7