### PR TITLE
feat(desktop): Allow empty prompt with review comments

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1132,7 +1132,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const images = imageAttachments().slice()
     const mode = store.mode
 
-    if (text.trim().length === 0 && images.length === 0) {
+    if (text.trim().length === 0 && images.length === 0 && commentCount() === 0) {
       if (working()) abort()
       return
     }
@@ -2068,7 +2068,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             >
               <IconButton
                 type="submit"
-                disabled={!prompt.dirty() && !working()}
+                disabled={!prompt.dirty() && !working() && commentCount() === 0}
                 icon={working() ? "stop" : "arrow-up"}
                 variant="primary"
                 class="h-6 w-4.5"


### PR DESCRIPTION
### What does this PR do?

Currently we don't allow empty prompt when attaching review comments, but file attachment does, which is similar.

This allows as the review comments should be enough.

### How did you verify your code works?

Before:

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/5612fc61-8eae-4ecb-9667-bf36dd44824f" />

After:

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/4c5005b3-f1eb-450b-81cd-fe67408b3924" />

