### PR TITLE
fix(shell): Fix Windows terminal compatibility and Unix command support

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1138,6 +1138,10 @@ export namespace Config {
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
         })
         .optional(),
+      terminal: z
+        .string()
+        .optional()
+        .describe("Shell to use for executing commands. On Windows, use 'git-bash' for Unix commands or 'cmd' for Windows commands."),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1138,6 +1138,14 @@ export namespace Config {
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
         })
         .optional(),
+      terminal: z
+        .string()
+        .optional()
+        .describe(
+          "Terminal shell to use for PTY sessions. On Windows, use 'cmd.exe', 'powershell.exe', or a full path. " +
+            "Defaults to PowerShell on Windows if available, otherwise cmd.exe. " +
+            "Git bash.exe is NOT recommended due to compatibility issues with OpenCode's PTY implementation.",
+        ),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -37,14 +37,9 @@ export namespace Shell {
 
   function fallback() {
     if (process.platform === "win32") {
+      // On Windows, default to cmd.exe/PowerShell to avoid Git bash.exe crashes
+      // This prevents ACCESS_VIOLATION (0xC0000005) crashes with OpenCode's PTY
       if (Flag.OPENCODE_GIT_BASH_PATH) return Flag.OPENCODE_GIT_BASH_PATH
-      const git = Bun.which("git")
-      if (git) {
-        // git.exe is typically at: C:\Program Files\Git\cmd\git.exe
-        // bash.exe is at: C:\Program Files\Git\bin\bash.exe
-        const bash = path.join(git, "..", "..", "bin", "bash.exe")
-        if (Bun.file(bash).size) return bash
-      }
       return process.env.COMSPEC || "cmd.exe"
     }
     if (process.platform === "darwin") return "/bin/zsh"
@@ -64,4 +59,93 @@ export namespace Shell {
     if (s && !BLACKLIST.has(process.platform === "win32" ? path.win32.basename(s) : path.basename(s))) return s
     return fallback()
   })
+
+  /**
+   * Returns the appropriate shell for executing the given command.
+   * - Unix commands (sh, bash, awk, sed, grep, etc.) on Windows → Git bash
+   * - All other commands → Platform default shell
+   */
+  export function forCommand(command: string): string {
+    if (needsUnixShell(command)) {
+      // Unix commands need a Unix shell - use Git bash on Windows
+      const gitBashPath = getGitBashPath()
+      if (gitBashPath) return gitBashPath
+    }
+    return fallback()
+  }
+
+  /**
+   * Checks if the command is likely a Unix command that requires a Unix shell.
+   */
+  function needsUnixShell(command: string): boolean {
+    // Common Unix commands that need Unix shell features
+    const unixCommands = new Set([
+      "sh", "bash", "dash", "zsh", "fish",
+      "awk", "sed", "grep", "egrep", "fgrep",
+      "ls", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown", "cat", "echo",
+      "head", "tail", "cut", "sort", "uniq", "wc", "tr", "find", "xargs",
+      "tar", "gzip", "bzip2", "xz", "zip", "unzip",
+      "ssh", "scp", "rsync", "curl", "wget",
+      "make", "cmake", "npm", "yarn", "pnpm", "bun",
+      "git", "svn", "hg",
+      "ps", "kill", "killall", "jobs", "fg", "bg",
+      "alias", "export", "source", "eval", "test", "[", "[[",
+      "cd", "pwd", "export", "unset", "set", "env", "export",
+    ])
+    
+    // Simple heuristic: check if command starts with a known Unix command
+    const firstWord = command.trim().split(/\s+/)[0].toLowerCase()
+    return unixCommands.has(firstWord) || 
+           // Also check for pipes, redirects, and other shell features
+           command.includes("|") || 
+           command.includes(">") || 
+           command.includes("<") ||
+           command.includes("&&") ||
+           command.includes("||") ||
+           command.includes("$((")
+  }
+
+  /**
+   * Gets the Git bash executable path on Windows.
+   * Returns undefined if not found.
+   */
+  function getGitBashPath(): string | undefined {
+    if (process.platform !== "win32") return undefined
+    
+    // Check OPENCODE_GIT_BASH_PATH flag first
+    if (Flag.OPENCODE_GIT_BASH_PATH) return Flag.OPENCODE_GIT_BASH_PATH
+    
+    // Try to find git bash
+    const git = Bun.which("git")
+    if (git) {
+      // git.exe is typically at: C:\Program Files\Git\cmd\git.exe
+      // bash.exe is at: C:\Program Files\Git\bin\bash.exe
+      const bash = path.join(git, "..", "..", "bin", "bash.exe")
+      if (Bun.file(bash).size) return bash
+    }
+    
+    return undefined
+  }
+
+  /**
+   * Gets all available shells for the current platform.
+   */
+  export function getAvailableShells(): string[] {
+    const shells: string[] = []
+    
+    if (process.platform === "win32") {
+      // Windows shells
+      const gitBash = getGitBashPath()
+      if (gitBash) shells.push(gitBash)
+      shells.push(process.env.COMSPEC || "cmd.exe")
+      shells.push(process.env.SystemRoot ? path.join(process.env.SystemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe") : "powershell.exe")
+    } else {
+      // Unix shells
+      shells.push("/bin/bash")
+      shells.push("/bin/zsh")
+      shells.push("/bin/sh")
+    }
+    
+    return shells
+  }
 }

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -2,6 +2,7 @@ import { Flag } from "@/flag/flag"
 import { lazy } from "@/util/lazy"
 import path from "path"
 import { spawn, type ChildProcess } from "child_process"
+import { Config } from "@/config/config"
 
 const SIGKILL_TIMEOUT_MS = 200
 
@@ -35,16 +36,49 @@ export namespace Shell {
   }
   const BLACKLIST = new Set(["fish", "nu"])
 
+  // Commands that require a Unix-like shell (Git bash on Windows)
+  const UNIX_COMMANDS = new Set([
+    "ls", "cat", "rm", "cp", "mv", "mkdir", "touch", "chmod", "chown", "grep", "sed", "awk",
+    "find", "sort", "uniq", "wc", "head", "tail", "tr", "cut", "paste", "join", "diff",
+    "bun", "npm", "pnpm", "yarn", "git", "ssh", "scp", "rsync", "curl", "wget", "tar",
+    "gzip", "bzip2", "xz", "zip", "unzip", "echo", "printf", "test", "[", "((", "[[",
+    "while", "for", "if", "case", "function", "source", "alias", "export", "unset",
+    "env", "printenv", "dirname", "basename", "realpath", "readlink", "ln", "symlink",
+  ])
+
+  function needsUnixShell(command: string): boolean {
+    // Check if the command is a known Unix command
+    const cmd = command.toLowerCase().trim()
+    if (UNIX_COMMANDS.has(cmd)) return true
+    // Check for common Unix command patterns
+    if (cmd.includes("|") || cmd.includes(">") || cmd.includes("<") || cmd.includes("&&") || cmd.includes("||")) {
+      return true
+    }
+    // Check for Unix-specific flags
+    if (cmd.includes(" -l") || cmd.includes(" --list") || cmd.includes(" -r") || cmd.includes("-r ")) {
+      return true
+    }
+    return false
+  }
+
+  function getGitBashPath(): string | undefined {
+    const git = Bun.which("git")
+    if (git) {
+      const bash = path.join(git, "..", "..", "bin", "bash.exe")
+      if (Bun.file(bash).size) return bash
+    }
+    return undefined
+  }
+
   function fallback() {
     if (process.platform === "win32") {
-      if (Flag.OPENCODE_GIT_BASH_PATH) return Flag.OPENCODE_GIT_BASH_PATH
-      const git = Bun.which("git")
-      if (git) {
-        // git.exe is typically at: C:\Program Files\Git\cmd\git.exe
-        // bash.exe is at: C:\Program Files\Git\bin\bash.exe
-        const bash = path.join(git, "..", "..", "bin", "bash.exe")
-        if (Bun.file(bash).size) return bash
-      }
+      // Prefer Windows native shells over Git bash to avoid compatibility issues
+      // Git's bash.exe can cause ACCESS_VIOLATION errors with OpenCode's PTY implementation
+      if (Flag.OPENCODE_TERMINAL) return Flag.OPENCODE_TERMINAL
+      // Check for PowerShell first (more feature-rich)
+      const powershell = Bun.which("powershell.exe")
+      if (powershell) return powershell
+      // Fall back to cmd.exe
       return process.env.COMSPEC || "cmd.exe"
     }
     if (process.platform === "darwin") return "/bin/zsh"
@@ -53,7 +87,11 @@ export namespace Shell {
     return "/bin/sh"
   }
 
-  export const preferred = lazy(() => {
+  export const preferred = lazy(async () => {
+    // Check config first for user preference
+    const config = await Config.get()
+    if (config.terminal) return config.terminal
+    // Fall back to environment variable
     const s = process.env.SHELL
     if (s) return s
     return fallback()
@@ -64,4 +102,85 @@ export namespace Shell {
     if (s && !BLACKLIST.has(process.platform === "win32" ? path.win32.basename(s) : path.basename(s))) return s
     return fallback()
   })
+
+  export function forCommand(command: string): string {
+    // For Windows, check if the command needs a Unix shell
+    if (process.platform === "win32") {
+      // Check for explicit user preference first
+      if (Flag.OPENCODE_TERMINAL) return Flag.OPENCODE_TERMINAL
+      // Check if command needs Unix shell
+      if (needsUnixShell(command)) {
+        const gitBash = getGitBashPath()
+        if (gitBash) return gitBash
+      }
+      // Check for PowerShell commands
+      if (command.toLowerCase().startsWith("powershell") || command.toLowerCase().startsWith("pwsh")) {
+        const powershell = Bun.which("powershell.exe") || Bun.which("pwsh.exe")
+        if (powershell) return powershell
+      }
+      // Default to native shell for Windows commands
+      return process.env.COMSPEC || "cmd.exe"
+    }
+    // On Unix/macOS, use the default shell
+    const s = process.env.SHELL
+    if (s) return s
+    if (process.platform === "darwin") return "/bin/zsh"
+    return Bun.which("bash") || "/bin/sh"
+  }
+
+  export function getAvailableShells(): { name: string; path: string; description: string }[] {
+    const shells: { name: string; path: string; description: string }[] = []
+
+    if (process.platform === "win32") {
+      // Git Bash
+      const gitBash = getGitBashPath()
+      if (gitBash) {
+        shells.push({
+          name: "Git Bash",
+          path: gitBash,
+          description: "Unix-like shell with Git. Supports ls, cat, bun, etc. May have compatibility issues with PTY.",
+        })
+      }
+
+      // PowerShell
+      const powershell = Bun.which("powershell.exe")
+      if (powershell) {
+        shells.push({
+          name: "PowerShell",
+          path: powershell,
+          description: "Modern Windows shell with advanced scripting capabilities. Recommended for stability.",
+        })
+      }
+
+      // Windows Terminal with PowerShell/CMD
+      shells.push({
+        name: "Windows Terminal (PowerShell)",
+        path: "powershell.exe",
+        description: "PowerShell running in Windows Terminal. Better experience than standalone PowerShell.",
+      })
+
+      shells.push({
+        name: "Command Prompt (CMD)",
+        path: process.env.COMSPEC || "cmd.exe",
+        description: "Traditional Windows command prompt. Compatible but limited features.",
+      })
+    } else {
+      shells.push({
+        name: "Zsh",
+        path: "/bin/zsh",
+        description: "Default shell on macOS. Powerful and feature-rich.",
+      })
+
+      const bashPath = Bun.which("bash")
+      if (bashPath) {
+        shells.push({
+          name: "Bash",
+          path: bashPath,
+          description: "GNU Bourne Again Shell. Widely used on Linux and macOS.",
+        })
+      }
+    }
+
+    return shells
+  }
 }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -52,7 +52,7 @@ const parser = lazy(async () => {
 
 // TODO: we may wanna rename this tool so it works better on other shells
 export const BashTool = Tool.define("bash", async () => {
-  const shell = Shell.acceptable()
+  const shell = Shell.forCommand("")
   log.info("bash tool using shell", { shell })
 
   return {

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -80,6 +80,12 @@ export const BashTool = Tool.define("bash", async () => {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
       const timeout = params.timeout ?? DEFAULT_TIMEOUT
+
+      // Use the appropriate shell for the command
+      // This will automatically use Git bash for Unix commands on Windows
+      const shell = Shell.forCommand(params.command)
+      log.info("bash tool using shell", { shell, command: params.command })
+
       const tree = await parser().then((p) => p.parse(params.command))
       if (!tree) {
         throw new Error("Failed to parse command")


### PR DESCRIPTION
## Summary

Fixes terminal crashes on Windows when using Git bash.exe with PTY, while maintaining support for Unix commands.

## Changes

### packages/opencode/src/shell/shell.ts
- Prefer native Windows shells (PowerShell/cmd.exe) for interactive PTY sessions
- Add intelligent shell detection for command execution

### packages/opencode/src/config/config.ts
- Add terminal config option

### packages/opencode/src/tool/bash.ts
- Use Shell.forCommand() for appropriate shell per command

## Testing

- Terminal opens without crash on Windows
- Unix commands work correctly

## Related Issues

Fixes #11954