### PR TITLE
fix: apply schema transformation to MCP tools for Gemini compatibility

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -1,4 +1,6 @@
 import { dynamicTool, type Tool, jsonSchema, type JSONSchema7 } from "ai"
+import { ProviderTransform } from "../provider/transform"
+import { Provider } from "../provider/provider"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
@@ -117,20 +119,30 @@ export namespace MCP {
   }
 
   // Convert MCP tool definition to AI SDK Tool type
-  async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
+  async function convertMcpTool(
+    mcpTool: MCPToolDef,
+    client: MCPClient,
+    timeout?: number,
+    model?: Provider.Model,
+  ): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
 
     // Spread first, then override type to ensure it's always "object"
-    const schema: JSONSchema7 = {
+    let schema: JSONSchema7 = {
       ...(inputSchema as JSONSchema7),
       type: "object",
       properties: (inputSchema.properties ?? {}) as JSONSchema7["properties"],
       additionalProperties: false,
     }
 
+    // Apply provider-specific schema transformations (e.g., Gemini nested array fix)
+    if (model) {
+      schema = ProviderTransform.schema(model, schema as any) as JSONSchema7
+    }
+
     return dynamicTool({
       description: mcpTool.description ?? "",
-      inputSchema: jsonSchema(schema),
+      inputSchema: jsonSchema(schema as any),
       execute: async (args: unknown) => {
         return client.callTool(
           {
@@ -563,7 +575,7 @@ export namespace MCP {
     s.status[name] = { status: "disabled" }
   }
 
-  export async function tools() {
+  export async function tools(model?: Provider.Model) {
     const result: Record<string, Tool> = {}
     const s = await state()
     const cfg = await Config.get()
@@ -596,7 +608,7 @@ export namespace MCP {
       for (const mcpTool of toolsResult.tools) {
         const sanitizedClientName = clientName.replace(/[^a-zA-Z0-9_-]/g, "_")
         const sanitizedToolName = mcpTool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
-        result[sanitizedClientName + "_" + sanitizedToolName] = await convertMcpTool(mcpTool, client, timeout)
+        result[sanitizedClientName + "_" + sanitizedToolName] = await convertMcpTool(mcpTool, client, timeout, model)
       }
     }
     return result

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -734,7 +734,7 @@ export namespace SessionPrompt {
       })
     }
 
-    for (const [key, item] of Object.entries(await MCP.tools())) {
+    for (const [key, item] of Object.entries(await MCP.tools(input.model))) {
       const execute = item.execute
       if (!execute) continue
 


### PR DESCRIPTION
## Summary

Follow-up fix to #11952 - MCP tools were **bypassing** the schema transformation pipeline entirely, so the nested array fix wasn't being applied to them.

## Problem

PR #11952 added nested array handling to `sanitizeGemini`, but MCP tools still failed with Gemini because:

1. MCP tools are created via `convertMcpTool()` in `mcp/index.ts`
2. They were added directly to the tools object **without** going through `ProviderTransform.schema()`
3. The nested array fix in `sanitizeGemini` was never applied to MCP tool schemas

## Error (still occurring without this fix)

```
GenerateContentRequest.tools[0].function_declarations[49].parameters.properties[values].items.items: missing field.
GenerateContentRequest.tools[0].function_declarations[50].parameters.properties[values].items.items: missing field.
GenerateContentRequest.tools[0].function_declarations[54].parameters.properties[initialData].items.items: missing field.
```

## Solution

- Add optional `model` parameter to `MCP.tools()` and `convertMcpTool()` functions
- Apply `ProviderTransform.schema()` to MCP tool schemas before registration
- Pass `input.model` from `prompt.ts` to `MCP.tools()` call

## Files Changed

| File | Change |
|------|--------|
| `packages/opencode/src/mcp/index.ts` | Add model parameter, apply schema transformation |
| `packages/opencode/src/session/prompt.ts` | Pass model to `MCP.tools()` |

## Testing

Verified with `google-docs-mcp` + Gemini 3 Flash on VPS:

**Before (with only #11952 merged):**
```
0.0.0-fix/gemini-nested-array-items-202602031444

Error: * GenerateContentRequest.tools[0].function_declarations[49].parameters.properties[values].items.items: missing field.
```

**After (with this PR):**
```
0.0.0-fix/mcp-tools-schema-transform-202602031607

> build · gemini-3-flash

Hello! How can I help you today?
```

### Problematic MCP Tools (now fixed)

| Tool | Parameter | Schema |
|------|-----------|--------|
| `writeSpreadsheet` | `values` | `array<array<any>>` (2D array) |
| `appendSpreadsheetRows` | `values` | `array<array<any>>` (2D array) |
| `createSpreadsheet` | `initialData` | `array<array<any>>` (2D array) |

## Related

- Fixes the remaining issue from #5832
- Follow-up to #11952