### PR TITLE
fix(tui): allow Enter to submit when no autocomplete matches

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -563,9 +563,16 @@ export function Autocomplete(props: {
             return
           }
           if (name === "return") {
-            select()
-            e.preventDefault()
-            return
+            // Only intercept Enter if there are matching options to select
+            // This allows paths like "/home/user" to be submitted when no commands match
+            if (options().length > 0) {
+              select()
+              e.preventDefault()
+              return
+            }
+            // No matching commands - user is typing a path, close autocomplete and allow submit
+            setStore("visible", false)
+            // Don't preventDefault() - let the normal submit handler process the input
           }
           if (name === "tab") {
             const selected = options()[store.selected]


### PR DESCRIPTION
Fixed a bug where typing paths starting with `/` (like `/home/user/file.txt read this file`) in the TUI input would show "No matching items" and block the Enter key from submitting. fix #11965 

**Root cause:** The `return` key handler in `autocomplete.tsx` unconditionally called `select()` and `e.preventDefault()`, even when there were no matching options. This prevented form submission.

**Fix:** Only intercept Enter when `options().length > 0`. When no commands match (user is typing a path), close the autocomplete panel and let the normal submit handler process the input without preventing default behavior.

Tested by inputting `/Users/hiro/opencode/README.md tell me what the file says` in TUI:
- Can type the full path
- Shows "No matching items" when no commands match
- Pressing Enter submits the input successfully
- Command autocomplete still works for actual commands like `/models`