### PR TITLE
docs: add opentmux to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
+| [opentmux](https://github.com/AnganSamadder/opentmux)                                              | Smart tmux integration for OpenCode: auto-spawns subagent panes and streams real-time execution   |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #11872

Added [opentmux](https://github.com/AnganSamadder/opentmux) plugin to the Ecosystem plugins table.

## Changes

- `packages/web/src/content/docs/ecosystem.mdx`: Added opentmux entry to Plugins table

## Plugin Info

- **Name**: opentmux
- **Repo**: https://github.com/AnganSamadder/opentmux
- **npm**: https://www.npmjs.com/package/opentmux
- **Description**: Smart tmux integration for OpenCode: auto-spawns subagent panes and streams real-time execution