### PR TITLE
docs: add opencode-plugin-auto-update to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-plugin-auto-update](https://github.com/AnganSamadder/opencode-plugin-auto-update)        | Keep plugins up to date in the background with safe locking and throttled checks                  |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #11871

Added [opencode-plugin-auto-update](https://github.com/AnganSamadder/opencode-plugin-auto-update) plugin to the Ecosystem plugins table.

## Changes

- `packages/web/src/content/docs/ecosystem.mdx`: Added opencode-plugin-auto-update entry to Plugins table

## Plugin Info

- **Name**: opencode-plugin-auto-update
- **Repo**: https://github.com/AnganSamadder/opencode-plugin-auto-update
- **npm**: https://www.npmjs.com/package/opencode-plugin-auto-update
- **Description**: Keep plugins up to date in the background with safe locking and throttled checks