### PR TITLE
fix(provider): apply config headers to fetch requests

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1020,6 +1020,11 @@ export namespace Provider {
           }
         }
 
+        opts.headers = {
+          ...(typeof opts.headers === "object" ? opts.headers : {}),
+          ...options["headers"],
+        }
+
         return fetchFn(input, {
           ...opts,
           // @ts-ignore see here: https://github.com/oven-sh/bun/issues/16682

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2148,3 +2148,78 @@ test("custom model with variants enabled and disabled", async () => {
     },
   })
 })
+
+test("provider headers from config are applied to fetch requests", async () => {
+  let capturedHeaders: Record<string, string> | undefined
+
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              options: {
+                headers: {
+                  "X-Custom-Header": "custom-value",
+                  "User-Agent": "MyCustomAgent/1.0",
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      expect(providers["anthropic"]).toBeDefined()
+      // Verify headers are in provider options
+      expect(providers["anthropic"].options.headers).toBeDefined()
+      expect(providers["anthropic"].options.headers["X-Custom-Header"]).toBe("custom-value")
+      expect(providers["anthropic"].options.headers["User-Agent"]).toBe("MyCustomAgent/1.0")
+    },
+  })
+})
+
+test("model headers from config are merged with provider headers", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            anthropic: {
+              models: {
+                "claude-sonnet-4-20250514": {
+                  headers: {
+                    "X-Model-Header": "model-value",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("ANTHROPIC_API_KEY", "test-api-key")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const model = providers["anthropic"].models["claude-sonnet-4-20250514"]
+      expect(model.headers).toBeDefined()
+      expect(model.headers["X-Model-Header"]).toBe("model-value")
+    },
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #11789

Provider and model headers configured in `opencode.jsonc` were not being applied to actual API fetch requests.

## Problem

In `getSDK`, the custom fetch function receives `opts.headers` from the AI SDK's `init` parameter, but `options["headers"]` (which contains the configured provider/model headers) was never merged into it.

## Solution

Merge `options["headers"]` into `opts.headers` before calling fetch:

```typescript
opts.headers = {
  ...(typeof opts.headers === "object" ? opts.headers : {}),
  ...options["headers"],
};
```

## Changes

- `packages/opencode/src/provider/provider.ts`: Merge config headers into fetch request headers
- `packages/opencode/test/provider/provider.test.ts`: Add tests for header configuration

## Testing

- ✅ 68 tests pass
- ✅ Typecheck passes