### PR TITLE
docs: fix logging example for plugin

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -296,10 +296,12 @@ Use `client.app.log()` instead of `console.log` for structured logging:
 ```ts title=".opencode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {
   await client.app.log({
-    service: "my-plugin",
-    level: "info",
-    message: "Plugin initialized",
-    extra: { foo: "bar" },
+    body: {
+      service: "my-plugin",
+      level: "info",
+      message: "Plugin initialized",
+      extra: { foo: "bar" },
+    },
   })
 }
 ```


### PR DESCRIPTION
### What does this PR do?

It fixes the example for logging from a plugin. According to the SDK documentation (https://opencode.ai/docs/sdk#examples-1), the fields need to be wrapped in a top-level `body` field.

### How did you verify your code works?

I tried to create a plugin and checked which approach works.