### PR TITLE
fix: always fall back to native clipboard after OSC52

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -148,8 +148,9 @@ export namespace Clipboard {
   export async function copy(text: string): Promise<void> {
     const renderer = rendererRef.current
     if (renderer) {
-      const copied = renderer.copyToClipboardOSC52(text)
-      if (copied) return
+      // Try OSC52 but don't early return - always fall back to native method
+      // OSC52 may report success but not actually work in all terminals
+      renderer.copyToClipboardOSC52(text)
     }
     await getCopyMethod()(text)
   }


### PR DESCRIPTION
## Problem
Clipboard copy stopped working in some terminals after #11744 introduced OSC52 clipboard support.

The issue is that `renderer.copyToClipboardOSC52()` returns `true` (indicating it wrote the escape sequence), but the terminal may not actually support or have OSC52 enabled. The previous code would early-return, skipping the native clipboard method.

## Solution
Remove the early return so both OSC52 and the native method (osascript on macOS, xclip/wl-copy on Linux) are always attempted. This ensures clipboard copy works reliably across all terminal configurations.

## Changes
- `packages/opencode/src/cli/cmd/tui/util/clipboard.ts` — remove early return after OSC52

## Testing
- Tested on macOS with iTerm2 (OSC52 disabled) ✅
- Clipboard copy now works reliably ✅