### PR TITLE
fix(test): git init with a default test user

### DIFF
--- a/packages/opencode/test/fixture/fixture.ts
+++ b/packages/opencode/test/fixture/fixture.ts
@@ -20,6 +20,8 @@ export async function tmpdir<T>(options?: TmpDirOptions<T>) {
   await fs.mkdir(dirpath, { recursive: true })
   if (options?.git) {
     await $`git init`.cwd(dirpath).quiet()
+    await $`git config user.name "Test User"`.cwd(dirpath).quiet()
+    await $`git config user.email "test@example.com"`.cwd(dirpath).quiet()
     await $`git commit --allow-empty -m "root commit ${dirpath}"`.cwd(dirpath).quiet()
   }
   if (options?.config) {


### PR DESCRIPTION
### What does this PR do?
when a user have $XDG_CONFIG_HOME set on their system, git looks for global config in the $XDG_CONFIG_HOME directory, since preload sets the $XDG_CONFIG_HOME to a temp directory, the git resolution fails leading to failing tests because init exited with an error.

*screenshot from my system below, I have $XDG_CONFIG_HOME set to the ~/.config directory*

<img width="2528" height="1533" alt="image" src="https://github.com/user-attachments/assets/650003a5-3718-4290-9c4e-baa3f78a1a61" />

### How did you verify your code works?
I have been using this default user setup for a while now so that I can run tests locally, but I am tired of keeping it staged and stashing for every branch, so decided to open the PR finally.

*screenrecording*

https://github.com/user-attachments/assets/7f4ab1d0-2885-4e49-8515-1b84bbf754e7


