### PR TITLE
feat:  add enabled_themes config option to restrict available themes

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -5,6 +5,7 @@ import { Select } from "@opencode-ai/ui/select"
 import { Switch } from "@opencode-ai/ui/switch"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme"
 import { showToast } from "@opencode-ai/ui/toast"
+import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 import { useSettings, monoFontFamily } from "@/context/settings"
@@ -31,6 +32,7 @@ const playDemoSound = (src: string) => {
 }
 
 export const SettingsGeneral: Component = () => {
+  const globalSync = useGlobalSync()
   const theme = useTheme()
   const language = useLanguage()
   const platform = usePlatform()
@@ -94,9 +96,12 @@ export const SettingsGeneral: Component = () => {
       .finally(() => setStore("checking", false))
   }
 
-  const themeOptions = createMemo(() =>
-    Object.entries(theme.themes()).map(([id, def]) => ({ id, name: def.name ?? id })),
-  )
+  const themeOptions = createMemo(() => {
+    const entries = Object.entries(theme.themes())
+    const enabled = globalSync.data.config.enabled_themes
+    const filtered = !enabled || enabled.length === 0 ? entries : entries.filter(([id]) => enabled.includes(id))
+    return filtered.map(([id, def]) => ({ id, name: def.name ?? id }))
+  })
 
   const colorSchemeOptions = createMemo((): { value: ColorScheme; label: string }[] => [
     { value: "system", label: language.t("theme.scheme.system") },

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -110,7 +110,12 @@ export default function Layout(props: ParentProps) {
   const theme = useTheme()
   const language = useLanguage()
   const initialDirectory = decode64(params.dir)
-  const availableThemeEntries = createMemo(() => Object.entries(theme.themes()))
+  const availableThemeEntries = createMemo(() => {
+    const entries = Object.entries(theme.themes())
+    const enabled = globalSync.data.config.enabled_themes
+    if (!enabled || enabled.length === 0) return entries
+    return entries.filter(([id]) => enabled.includes(id))
+  })
   const colorSchemeOrder: ColorScheme[] = ["system", "light", "dark"]
   const colorSchemeKey: Record<ColorScheme, "theme.scheme.system" | "theme.scheme.light" | "theme.scheme.dark"> = {
     system: "theme.scheme.system",

--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -369,7 +369,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
         return store.active
       },
       all() {
-        return store.themes
+        const enabled = sync.data.config.enabled_themes
+        if (!enabled || enabled.length === 0) return store.themes
+        return Object.fromEntries(Object.entries(store.themes).filter(([id]) => enabled.includes(id)))
       },
       syntax,
       subtleSyntax,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -958,6 +958,10 @@ export namespace Config {
     .object({
       $schema: z.string().optional().describe("JSON schema reference for configuration validation"),
       theme: z.string().optional().describe("Theme name to use for the interface"),
+      enabled_themes: z
+        .array(z.string())
+        .optional()
+        .describe("When set, only these themes will be available for selection. All other themes will be hidden"),
       keybinds: Keybinds.optional().describe("Custom keybind configurations"),
       logLevel: Log.Level.optional().describe("Log level"),
       tui: TUI.optional().describe("TUI specific settings"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1606,6 +1606,10 @@ export type Config = {
    * Theme name to use for the interface
    */
   theme?: string
+  /**
+   * When set, only these themes will be available for selection. All other themes will be hidden
+   */
+  enabled_themes?: Array<string>
   keybinds?: KeybindsConfig
   logLevel?: LogLevel
   /**

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -314,6 +314,23 @@ You can configure the theme you want to use in your OpenCode config through the 
 
 ---
 
+### Enabled themes
+
+You can specify an allowlist of themes through the `enabled_themes` option. When set, only the specified themes will appear in the theme selector.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "enabled_themes": ["opencode", "tokyonight"]
+}
+```
+
+This is useful for enforcing a consistent look across a team or limiting theme choices to a curated selection. If `enabled_themes` is not set or is an empty array, all themes remain available.
+
+[Learn more here](/docs/themes#restricting-available-themes).
+
+---
+
 ### Agents
 
 You can configure specialized agents for specific tasks through the `agent` option.

--- a/packages/web/src/content/docs/themes.mdx
+++ b/packages/web/src/content/docs/themes.mdx
@@ -72,6 +72,27 @@ You can select a theme by bringing up the theme select with the `/theme` command
 
 ---
 
+## Restricting available themes
+
+You can restrict the available themes to a specific subset using the `enabled_themes` option. When set, only the specified themes will appear in the theme selector.
+
+```json title="opencode.json" {3}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "enabled_themes": ["opencode", "tokyonight"]
+}
+```
+
+This is useful for:
+
+- Enforcing a consistent look across a team or organization
+- Limiting choices to only themes that work well with your terminal
+- Creating a simplified theme selection experience
+
+If `enabled_themes` is not set or is an empty array, all themes remain available.
+
+---
+
 ## Custom themes
 
 OpenCode supports a flexible JSON-based theme system that allows users to create and customize themes easily.


### PR DESCRIPTION
Add a new configuration option that allows users to specify an allowlist of themes. When set, only the specified themes appear in the theme selector.

This is useful for:
- Enforcing consistent theming across teams/organizations
- Limiting choices to themes that work well with specific terminals
- Creating a simplified theme selection experience

Changes:
- Add enabled_themes schema option in config.ts
- Filter themes in TUI context based on config
- Filter themes in Desktop/Web app based on config
- Regenerate SDK types
- Update documentation in themes.mdx and config.mdx

EXAMPLE
<img width="2259" height="1379" alt="image" src="https://github.com/user-attachments/assets/e6fdad5c-4ed3-4bc7-9368-7b75aa32c279" />


Fixes #12006