### PR TITLE
feat(plugin): add shell.env hook for manipulating environment in tools and shell

### DIFF
--- a/packages/opencode/src/pty/index.ts
+++ b/packages/opencode/src/pty/index.ts
@@ -8,6 +8,7 @@ import type { WSContext } from "hono/ws"
 import { Instance } from "../project/instance"
 import { lazy } from "@opencode-ai/util/lazy"
 import { Shell } from "@/shell/shell"
+import { Plugin } from "@/plugin"
 
 export namespace Pty {
   const log = Log.create({ service: "pty" })
@@ -102,9 +103,11 @@ export namespace Pty {
     }
 
     const cwd = input.cwd || Instance.directory
+    const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
     const env = {
       ...process.env,
       ...input.env,
+      ...shellEnv.env,
       TERM: "xterm-256color",
       OPENCODE_TERMINAL: "1",
     } as Record<string, string>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1500,12 +1500,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const matchingInvocation = invocations[shellName] ?? invocations[""]
     const args = matchingInvocation?.args
 
+    const cwd = Instance.directory
+    const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
     const proc = spawn(shell, args, {
-      cwd: Instance.directory,
+      cwd,
       detached: process.platform !== "win32",
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
+        ...shellEnv.env,
         TERM: "dumb",
       },
     })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -16,6 +16,7 @@ import { Shell } from "@/shell/shell"
 
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
+import { Plugin } from "@/plugin"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -162,11 +163,13 @@ export const BashTool = Tool.define("bash", async () => {
         })
       }
 
+      const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
       const proc = spawn(params.command, {
         shell,
         cwd,
         env: {
           ...process.env,
+          ...shellEnv.env,
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -185,6 +185,7 @@ export interface Hooks {
     input: { tool: string; sessionID: string; callID: string },
     output: { args: any },
   ) => Promise<void>
+  "shell.env"?: (input: { cwd: string }, output: { env: Record<string, string> }) => Promise<void>
   "tool.execute.after"?: (
     input: { tool: string; sessionID: string; callID: string },
     output: {

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -192,6 +192,10 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 - `todo.updated`
 
+#### Shell Events
+
+- `shell.env`
+
 #### Tool Events
 
 - `tool.execute.after`
@@ -247,6 +251,23 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
       if (input.tool === "read" && output.args.filePath.includes(".env")) {
         throw new Error("Do not read .env files")
       }
+    },
+  }
+}
+```
+
+---
+
+### Inject environment variables
+
+Inject environment variables into all shell execution (AI tools and user terminals):
+
+```javascript title=".opencode/plugins/inject-env.js"
+export const InjectEnvPlugin = async () => {
+  return {
+    "shell.env": async (input, output) => {
+      output.env.MY_API_KEY = "secret"
+      output.env.PROJECT_ROOT = input.cwd
     },
   }
 }


### PR DESCRIPTION
The motivation for this PR is the desire to run a single opencode server that can run against an arbitrary number of projects, and provide a different environment to tools run within each.  At present this can be done by informing the agent that it should, e.g., load .env or wrap calls in a doppler utility, but this is error prone and adds more things for the LLM to think about.

FWIW I'm shy about proposing a change to your plugin system so not at all concerned if this should go through some design critique from you guys before it totally fits your expectations.

### What does this PR do?

Introduces a `shell.env` plugin hook that allows a plugin to introduce environment variables that will be added to the env for (1) llm tool calls, (2) shell mode `!command`, and (3) PTY terminals.

I purposely avoided hooking into instance-level caching for three reasons:

- Preference for not making secrets into part of opencode's application state
- Preference for leaving _whether or not to cache values_ up to the plugin implementation 
- Preference for minimizing LOC touched on this PR

### How did you verify your code works?

1. Ran the pre-commit hooks
2. Created a temporary / bs tool that adds a single `shell.env` and ran `bun dev .`

```
export const TestShellEnvPlugin = async () => {
  return {
    "shell.env": async (input, output) => {
      output.env.PLUGIN_TEST_VAR = "it_works_456"
    },
  }
}
```

The screenshot below confirms that LLM tool calls contain the injected variable and so do `!command` commands

<img width="590" height="457" alt="Screenshot 2026-02-03 at 2 40 26 PM" src="https://github.com/user-attachments/assets/7d0702cf-4d08-44a2-b3d6-7cc46639d18b" />

Closes #12018
