### PR TITLE
cli: add --thinking flag to show reasoning blocks in run command

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -277,6 +277,11 @@ export const RunCommand = cmd({
         type: "string",
         describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
       })
+      .option("thinking", {
+        type: "boolean",
+        describe: "show thinking blocks",
+        default: false,
+      })
   },
   handler: async (args) => {
     let message = [...args.message, ...(args["--"] || [])]
@@ -455,7 +460,7 @@ export const RunCommand = cmd({
               UI.empty()
             }
 
-            if (part.type === "reasoning" && part.time?.end) {
+            if (part.type === "reasoning" && part.time?.end && args.thinking) {
               if (emit("reasoning", { part })) continue
               const text = part.text.trim()
               if (!text) continue


### PR DESCRIPTION
## Summary
Add a `--thinking` flag to the `run` command that controls whether reasoning/thinking blocks are displayed.

## Changes
- Added `--thinking` boolean flag (defaults to `false`)
- Reasoning blocks are now hidden unless `--thinking` is explicitly passed

This allows users to opt-in to seeing model reasoning output while keeping the default output clean.