### PR TITLE
feat: add per-session directory and /new <path> switching

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.ts
@@ -155,6 +155,7 @@ async function createToolContext(agent: Agent.Info) {
     abort: new AbortController().signal,
     messages: [],
     metadata: () => {},
+    directory: Instance.directory,
     async ask(req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) {
       for (const pattern of req.patterns) {
         const rule = PermissionNext.evaluate(req.permission, pattern, ruleset)

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -106,6 +106,7 @@ export function tui(input: {
   fetch?: typeof fetch
   headers?: RequestInit["headers"]
   events?: EventSource
+  onSwitchDirectory?: (directory: string) => Promise<void>
   onExit?: () => Promise<void>
 }) {
   // promise to prevent immediate exit
@@ -133,6 +134,7 @@ export function tui(input: {
                         fetch={input.fetch}
                         headers={input.headers}
                         events={input.events}
+                        onSwitchDirectory={input.onSwitchDirectory}
                       >
                         <SyncProvider>
                           <ThemeProvider mode={mode}>
@@ -312,7 +314,6 @@ function App() {
       },
       onSelect: () => {
         const current = promptRef.current
-        // Don't require focus - if there's any text, preserve it
         const currentPrompt = current?.current?.input ? current.current : undefined
         route.navigate({
           type: "home",

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,6 +32,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import path from "path"
 
 export type PromptProps = {
   sessionID?: string
@@ -520,6 +521,65 @@ export function Prompt(props: PromptProps) {
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       exit()
       return
+    }
+
+    // Check for /new <path> or /clear <path> with directory argument
+    const newMatch = trimmed.match(/^\/(?:new|clear)\s+(.+)$/)
+    if (newMatch) {
+      const rawPath = newMatch[1].trim()
+      if (rawPath) {
+        // Resolve path
+        const homedir = process.env.HOME ?? process.env.USERPROFILE ?? "~"
+        const resolvedPath = rawPath.startsWith("~")
+          ? rawPath.replace("~", homedir)
+          : rawPath.startsWith("/")
+          ? rawPath
+          : path.resolve(sdk.directory ?? process.cwd(), rawPath)
+
+        // Validate path
+        const fs = await import("fs/promises")
+        const stat = await fs.stat(resolvedPath).catch(() => null)
+        if (!stat) {
+          toast.show({
+            variant: "error",
+            message: `Path does not exist: ${resolvedPath}`,
+            duration: 3000,
+          })
+          return
+        }
+        if (!stat.isDirectory()) {
+          toast.show({
+            variant: "error",
+            message: `Not a directory: ${resolvedPath}`,
+            duration: 3000,
+          })
+          return
+        }
+
+        // Execute directory switch
+        await sdk.switchDirectory(resolvedPath)
+        sync.reset()
+        await sync.bootstrap()
+
+        // Clear prompt and navigate to home
+        input.extmarks.clear()
+        setStore("prompt", {
+          input: "",
+          parts: [],
+        })
+        setStore("extmarkToPartIndex", new Map())
+        input.clear()
+
+        route.navigate({ type: "home" })
+
+        toast.show({
+          variant: "info",
+          message: `Switched to ${resolvedPath}`,
+          duration: 2000,
+        })
+
+        return
+      }
     }
     const selectedModel = local.model.current()
     if (!selectedModel) {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -33,6 +33,7 @@ import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
 import path from "path"
+import fs from "fs/promises"
 
 export type PromptProps = {
   sessionID?: string
@@ -526,25 +527,24 @@ export function Prompt(props: PromptProps) {
     }
 
     // Check for /new <path> or /clear <path> with directory argument
-    const newMatch = trimmed.match(/^\/(?:new|clear)\s+(.+)$/)
-    if (newMatch) {
-      const rawPath = newMatch[1].trim()
-      if (rawPath) {
+    const match = trimmed.match(/^\/(?:new|clear)\s+(.+)$/)
+    if (match) {
+      const raw = match[1].trim()
+      if (raw) {
         // Resolve path
-        const homedir = process.env.HOME ?? process.env.USERPROFILE ?? "~"
-        const resolvedPath = rawPath.startsWith("~")
-          ? rawPath.replace("~", homedir)
-          : rawPath.startsWith("/")
-          ? rawPath
-          : path.resolve(sdk.directory ?? process.cwd(), rawPath)
+        const home = process.env.HOME ?? process.env.USERPROFILE ?? "~"
+        const resolved = raw.startsWith("~")
+          ? raw.replace("~", home)
+          : raw.startsWith("/")
+          ? raw
+          : path.resolve(sdk.directory ?? process.cwd(), raw)
 
         // Validate path
-        const fs = await import("fs/promises")
-        const stat = await fs.stat(resolvedPath).catch(() => null)
+        const stat = await fs.stat(resolved).catch(() => null)
         if (!stat) {
           toast.show({
             variant: "error",
-            message: `Path does not exist: ${resolvedPath}`,
+            message: `Path does not exist: ${resolved}`,
             duration: 3000,
           })
           return
@@ -552,7 +552,7 @@ export function Prompt(props: PromptProps) {
         if (!stat.isDirectory()) {
           toast.show({
             variant: "error",
-            message: `Not a directory: ${resolvedPath}`,
+            message: `Not a directory: ${resolved}`,
             duration: 3000,
           })
           return
@@ -569,10 +569,10 @@ export function Prompt(props: PromptProps) {
         }
 
         switching = true
-        const oldDirectory = sdk.directory
+        const prev = sdk.directory
 
         try {
-          await sdk.switchDirectory(resolvedPath)
+          await sdk.switchDirectory(resolved)
           sync.reset()
           await sync.bootstrap()
 
@@ -589,13 +589,13 @@ export function Prompt(props: PromptProps) {
 
           toast.show({
             variant: "info",
-            message: `Switched to ${resolvedPath}`,
+            message: `Switched to ${resolved}`,
             duration: 2000,
           })
         } catch (error) {
           // Revert to old directory
-          if (oldDirectory) {
-            await sdk.switchDirectory(oldDirectory).catch(() => {})
+          if (prev) {
+            await sdk.switchDirectory(prev).catch(() => {})
             sync.reset()
             await sync.bootstrap().catch(() => {})
           }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -76,6 +76,8 @@ export function Prompt(props: PromptProps) {
   const { theme, syntax } = useTheme()
   const kv = useKV()
 
+  let switching = false
+
   function promptModelWarning() {
     toast.show({
       variant: "warning",
@@ -556,27 +558,55 @@ export function Prompt(props: PromptProps) {
           return
         }
 
-        // Execute directory switch
-        await sdk.switchDirectory(resolvedPath)
-        sync.reset()
-        await sync.bootstrap()
+        // Execute directory switch with locking and error recovery
+        if (switching) {
+          toast.show({
+            variant: "warning",
+            message: "Directory switch in progress",
+            duration: 2000,
+          })
+          return
+        }
 
-        // Clear prompt and navigate to home
-        input.extmarks.clear()
-        setStore("prompt", {
-          input: "",
-          parts: [],
-        })
-        setStore("extmarkToPartIndex", new Map())
-        input.clear()
+        switching = true
+        const oldDirectory = sdk.directory
 
-        route.navigate({ type: "home" })
+        try {
+          await sdk.switchDirectory(resolvedPath)
+          sync.reset()
+          await sync.bootstrap()
 
-        toast.show({
-          variant: "info",
-          message: `Switched to ${resolvedPath}`,
-          duration: 2000,
-        })
+          // Clear prompt and navigate to home
+          input.extmarks.clear()
+          setStore("prompt", {
+            input: "",
+            parts: [],
+          })
+          setStore("extmarkToPartIndex", new Map())
+          input.clear()
+
+          route.navigate({ type: "home" })
+
+          toast.show({
+            variant: "info",
+            message: `Switched to ${resolvedPath}`,
+            duration: 2000,
+          })
+        } catch (error) {
+          // Revert to old directory
+          if (oldDirectory) {
+            await sdk.switchDirectory(oldDirectory).catch(() => {})
+            sync.reset()
+            await sync.bootstrap().catch(() => {})
+          }
+          toast.show({
+            variant: "error",
+            message: `Failed to switch directory: ${error instanceof Error ? error.message : "Unknown error"}`,
+            duration: 3000,
+          })
+        } finally {
+          switching = false
+        }
 
         return
       }

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -15,6 +15,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     fetch?: typeof fetch
     headers?: RequestInit["headers"]
     events?: EventSource
+    onSwitchDirectory?: (directory: string) => Promise<void>
   }) => {
     const [directory, setDirectory] = createSignal(props.directory)
     const abort = new AbortController()
@@ -112,13 +113,24 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       )
     }
 
+    const switchDirectory = async (newDirectory: string) => {
+      if (props.onSwitchDirectory) {
+        await props.onSwitchDirectory(newDirectory)
+      }
+      updateDirectory(newDirectory)
+    }
+
     return {
       get client() {
         return client()
       },
+      get directory() {
+        return directory()
+      },
       event: emitter,
       url: props.url,
       setDirectory: updateDirectory,
+      switchDirectory,
     }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -1,7 +1,7 @@
 import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2"
 import { createSimpleContext } from "./helper"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
-import { batch, onCleanup, onMount } from "solid-js"
+import { batch, onCleanup, onMount, createSignal } from "solid-js"
 
 export type EventSource = {
   on: (handler: (event: Event) => void) => () => void
@@ -16,14 +16,17 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     headers?: RequestInit["headers"]
     events?: EventSource
   }) => {
+    const [directory, setDirectory] = createSignal(props.directory)
     const abort = new AbortController()
-    const sdk = createOpencodeClient({
-      baseUrl: props.url,
-      signal: abort.signal,
-      directory: props.directory,
-      fetch: props.fetch,
-      headers: props.headers,
-    })
+    const [client, setClient] = createSignal(
+      createOpencodeClient({
+        baseUrl: props.url,
+        signal: abort.signal,
+        directory: directory(),
+        fetch: props.fetch,
+        headers: props.headers,
+      }),
+    )
 
     const emitter = createGlobalEmitter<{
       [key in Event["type"]]: Extract<Event, { type: key }>
@@ -72,7 +75,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       // Fall back to SSE
       while (true) {
         if (abort.signal.aborted) break
-        const events = await sdk.event.subscribe(
+        const events = await client().event.subscribe(
           {},
           {
             signal: abort.signal,
@@ -96,6 +99,26 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       if (timer) clearTimeout(timer)
     })
 
-    return { client: sdk, event: emitter, url: props.url }
+    const updateDirectory = (newDirectory?: string) => {
+      setDirectory(newDirectory)
+      setClient(
+        createOpencodeClient({
+          baseUrl: props.url,
+          signal: abort.signal,
+          directory: newDirectory,
+          fetch: props.fetch,
+          headers: props.headers,
+        }),
+      )
+    }
+
+    return {
+      get client() {
+        return client()
+      },
+      event: emitter,
+      url: props.url,
+      setDirectory: updateDirectory,
+    }
   },
 })

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -415,6 +415,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     function reset() {
       batch(() => {
+        setStore("session", [])
         setStore("message", {})
         setStore("part", {})
         setStore("permission", {})

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -413,6 +413,20 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
       bootstrap()
     })
 
+    function reset() {
+      batch(() => {
+        setStore("message", {})
+        setStore("part", {})
+        setStore("permission", {})
+        setStore("question", {})
+        setStore("todo", {})
+        setStore("session_diff", {})
+        setStore("session_status", {})
+        setStore("status", "loading")
+      })
+      fullSyncedSessions.clear()
+    }
+
     const fullSyncedSessions = new Set<string>()
     const result = {
       data: store,
@@ -463,6 +477,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           fullSyncedSessions.add(sessionID)
         },
       },
+      reset,
       bootstrap,
     }
     return result

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -144,12 +144,16 @@ export const TuiThreadCommand = cmd({
       url,
       fetch: customFetch,
       events,
+      directory: cwd,
       args: {
         continue: args.continue,
         sessionID: args.session,
         agent: args.agent,
         model: args.model,
         prompt,
+      },
+      onSwitchDirectory: async (directory: string) => {
+        await client.call("switchDirectory", { directory })
       },
       onExit: async () => {
         await client.call("shutdown", undefined)

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -134,6 +134,10 @@ export const rpc = {
     Config.global.reset()
     await Instance.disposeAll()
   },
+  async switchDirectory(input: { directory: string }) {
+    startEventStream(input.directory)
+    return { success: true }
+  },
   async shutdown() {
     Log.Default.info("worker shutting down")
     if (eventStream.abort) eventStream.abort.abort()

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -96,6 +96,7 @@ export namespace SessionCompaction {
     abort: AbortSignal
     auto: boolean
   }) {
+    const session = await Session.get(input.sessionID)
     const userMessage = input.messages.findLast((m) => m.info.id === input.parentID)!.info as MessageV2.User
     const agent = await Agent.get("compaction")
     const model = agent.model
@@ -110,7 +111,7 @@ export namespace SessionCompaction {
       agent: "compaction",
       summary: true,
       path: {
-        cwd: Instance.directory,
+        cwd: session.directory,
         root: Instance.worktree,
       },
       cost: 0,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -387,6 +387,7 @@ export namespace SessionPrompt {
           agent: task.agent,
           messageID: assistantMessage.id,
           sessionID: sessionID,
+          directory: session.directory,
           abort,
           callID: part.callID,
           extra: { bypassAgentCheck: true },
@@ -667,6 +668,7 @@ export namespace SessionPrompt {
       abort: options.abortSignal!,
       messageID: input.processor.message.id,
       callID: options.toolCallId,
+      directory: input.session.directory,
       extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck },
       agent: input.agent.name,
       messages: input.messages,
@@ -831,6 +833,7 @@ export namespace SessionPrompt {
   }
 
   async function createUserMessage(input: PromptInput) {
+    const session = await Session.get(input.sessionID)
     const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
 
     const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
@@ -1030,6 +1033,7 @@ export namespace SessionPrompt {
                       abort: new AbortController().signal,
                       agent: input.agent!,
                       messageID: info.id,
+                      directory: session.directory,
                       extra: { bypassCwdCheck: true, model },
                       messages: [],
                       metadata: async () => {},
@@ -1092,6 +1096,7 @@ export namespace SessionPrompt {
                   abort: new AbortController().signal,
                   agent: input.agent!,
                   messageID: info.id,
+                  directory: session.directory,
                   extra: { bypassCwdCheck: true },
                   messages: [],
                   metadata: async () => {},

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -330,7 +330,7 @@ export namespace SessionPrompt {
           mode: task.agent,
           agent: task.agent,
           path: {
-            cwd: Instance.directory,
+            cwd: session.directory,
             root: Instance.worktree,
           },
           cost: 0,
@@ -534,7 +534,7 @@ export namespace SessionPrompt {
           mode: agent.name,
           agent: agent.name,
           path: {
-            cwd: Instance.directory,
+            cwd: session.directory,
             root: Instance.worktree,
           },
           cost: 0,
@@ -606,7 +606,7 @@ export namespace SessionPrompt {
         agent,
         abort,
         sessionID,
-        system: [...(await SystemPrompt.environment(model)), ...(await InstructionPrompt.system())],
+        system: [...(await SystemPrompt.environment(model, session.directory)), ...(await InstructionPrompt.system())],
         messages: [
           ...MessageV2.toModelMessages(sessionMessages, model),
           ...(isLastStep
@@ -1415,7 +1415,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       agent: input.agent,
       cost: 0,
       path: {
-        cwd: Instance.directory,
+        cwd: session.directory,
         root: Instance.worktree,
       },
       time: {
@@ -1505,7 +1505,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const matchingInvocation = invocations[shellName] ?? invocations[""]
     const args = matchingInvocation?.args
 
-    const cwd = Instance.directory
+    const cwd = session.directory
     const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
     const proc = spawn(shell, args, {
       cwd,

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -24,14 +24,14 @@ export namespace SystemPrompt {
     return [PROMPT_ANTHROPIC_WITHOUT_TODO]
   }
 
-  export async function environment(model: Provider.Model) {
+  export async function environment(model: Provider.Model, directory: string) {
     const project = Instance.project
     return [
       [
         `You are powered by the model named ${model.api.id}. The exact model ID is ${model.providerID}/${model.api.id}`,
         `Here is some useful information about the environment you are running in:`,
         `<env>`,
-        `  Working directory: ${Instance.directory}`,
+        `  Working directory: ${directory}`,
         `  Is directory a git repo: ${project.vcs === "git" ? "yes" : "no"}`,
         `  Platform: ${process.platform}`,
         `  Today's date: ${new Date().toDateString()}`,
@@ -40,7 +40,7 @@ export namespace SystemPrompt {
         `  ${
           project.vcs === "git" && false
             ? await Ripgrep.tree({
-                cwd: Instance.directory,
+                cwd: directory,
                 limit: 50,
               })
             : ""

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -58,7 +58,7 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
     let totalDiff = ""
 
     for (const hunk of hunks) {
-      const filePath = path.resolve(Instance.directory, hunk.path)
+      const filePath = path.resolve(ctx.directory, hunk.path)
       await assertExternalDirectory(ctx, filePath)
 
       switch (hunk.type) {
@@ -116,7 +116,7 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
             if (change.removed) deletions += change.count || 0
           }
 
-          const movePath = hunk.move_path ? path.resolve(Instance.directory, hunk.move_path) : undefined
+          const movePath = hunk.move_path ? path.resolve(ctx.directory, hunk.move_path) : undefined
           await assertExternalDirectory(ctx, movePath)
 
           fileChanges.push({

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -76,7 +76,7 @@ export const BashTool = Tool.define("bash", async () => {
         ),
     }),
     async execute(params, ctx) {
-      const cwd = params.workdir || Instance.directory
+      const cwd = params.workdir || ctx.directory
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -41,7 +41,7 @@ export const EditTool = Tool.define("edit", {
       throw new Error("oldString and newString must be different")
     }
 
-    const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filePath = path.isAbsolute(params.filePath) ? params.filePath : path.join(ctx.directory, params.filePath)
     await assertExternalDirectory(ctx, filePath)
 
     let diff = ""

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -28,8 +28,8 @@ export const GlobTool = Tool.define("glob", {
       },
     })
 
-    let search = params.path ?? Instance.directory
-    search = path.isAbsolute(search) ? search : path.resolve(Instance.directory, search)
+    let search = params.path ?? ctx.directory
+    search = path.isAbsolute(search) ? search : path.resolve(ctx.directory, search)
     await assertExternalDirectory(ctx, search, { kind: "directory" })
 
     const limit = 100

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -32,8 +32,8 @@ export const GrepTool = Tool.define("grep", {
       },
     })
 
-    let searchPath = params.path ?? Instance.directory
-    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(Instance.directory, searchPath)
+    let searchPath = params.path ?? ctx.directory
+    searchPath = path.isAbsolute(searchPath) ? searchPath : path.resolve(ctx.directory, searchPath)
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()

--- a/packages/opencode/src/tool/ls.ts
+++ b/packages/opencode/src/tool/ls.ts
@@ -42,7 +42,7 @@ export const ListTool = Tool.define("list", {
     ignore: z.array(z.string()).describe("List of glob patterns to ignore").optional(),
   }),
   async execute(params, ctx) {
-    const searchPath = path.resolve(Instance.directory, params.path || ".")
+    const searchPath = path.resolve(ctx.directory, params.path || ".")
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     await ctx.ask({

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -28,7 +28,7 @@ export const LspTool = Tool.define("lsp", {
     character: z.number().int().min(1).describe("The character offset (1-based, as shown in editors)"),
   }),
   execute: async (args, ctx) => {
-    const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(Instance.directory, args.filePath)
+    const file = path.isAbsolute(args.filePath) ? args.filePath : path.join(ctx.directory, args.filePath)
     await assertExternalDirectory(ctx, file)
 
     await ctx.ask({

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -24,7 +24,7 @@ export const ReadTool = Tool.define("read", {
   async execute(params, ctx) {
     let filepath = params.filePath
     if (!path.isAbsolute(filepath)) {
-      filepath = path.resolve(Instance.directory, filepath)
+      filepath = path.resolve(ctx.directory, filepath)
     }
     const title = path.relative(Instance.worktree, filepath)
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -69,7 +69,7 @@ export namespace ToolRegistry {
         execute: async (args, ctx) => {
           const pluginCtx = {
             ...ctx,
-            directory: Instance.directory,
+            directory: ctx.directory,
             worktree: Instance.worktree,
           } as unknown as PluginToolContext
           const result = await def.execute(args as any, pluginCtx)

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -17,6 +17,7 @@ export namespace Tool {
     sessionID: string
     messageID: string
     agent: string
+    directory: string
     abort: AbortSignal
     callID?: string
     extra?: { [key: string]: any }

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -23,7 +23,7 @@ export const WriteTool = Tool.define("write", {
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
   async execute(params, ctx) {
-    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
+    const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(ctx.directory, params.filePath)
     await assertExternalDirectory(ctx, filepath)
 
     const file = Bun.file(filepath)

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -13,6 +13,7 @@ const baseCtx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
 }
 
 type AskInput = {

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -46,10 +46,11 @@ const execute = async (params: { patchText: string }, ctx: ToolCtx) => {
   return tool.execute(params, ctx)
 }
 
-const makeCtx = () => {
+const makeCtx = (directory?: string) => {
   const calls: AskInput[] = []
   const ctx: ToolCtx = {
     ...baseCtx,
+    directory: directory || baseCtx.directory,
     ask: async (input) => {
       calls.push(input)
     },
@@ -77,7 +78,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("applies add/update/delete in one patch", async () => {
     await using fixture = await tmpdir({ git: true })
-    const { ctx, calls } = makeCtx()
+    const { ctx, calls } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -122,7 +123,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("permission metadata includes move file info", async () => {
     await using fixture = await tmpdir({ git: true })
-    const { ctx, calls } = makeCtx()
+    const { ctx, calls } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -152,7 +153,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("applies multiple hunks to one file", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -172,7 +173,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("inserts lines with insert-only hunk", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -191,7 +192,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("appends trailing newline on update", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -213,7 +214,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("moves file to a new directory", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -236,7 +237,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("moves file overwriting existing destination", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -261,7 +262,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("adds file overwriting existing file", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -279,7 +280,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects update when target file is missing", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -295,7 +296,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects delete when file is missing", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -309,7 +310,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects delete when target is a directory", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -326,7 +327,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects invalid hunk header", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -340,7 +341,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects update with missing context", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -358,7 +359,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("verification failure leaves no side effects", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -376,7 +377,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("supports end of file anchor", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -394,7 +395,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("rejects missing second chunk context", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -412,7 +413,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("disambiguates change context with @@ header", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -430,7 +431,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("EOF anchor matches from end of file first", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -452,7 +453,7 @@ describe("tool.apply_patch freeform", () => {
 
   test("parses heredoc-wrapped patch", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -473,7 +474,7 @@ EOF`
 
   test("parses heredoc-wrapped patch without cat", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -494,7 +495,7 @@ EOF`
 
   test("matches with trailing whitespace differences", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -514,7 +515,7 @@ EOF`
 
   test("matches with leading whitespace differences", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,
@@ -534,7 +535,7 @@ EOF`
 
   test("matches with Unicode punctuation differences", async () => {
     await using fixture = await tmpdir()
-    const { ctx } = makeCtx()
+    const { ctx } = makeCtx(fixture.path)
 
     await Instance.provide({
       directory: fixture.path,

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "../fixture/fixture"
 import type { PermissionNext } from "../../src/permission/next"
 import { Truncate } from "../../src/tool/truncation"
 
+const projectRoot = path.join(__dirname, "../..")
+
 const ctx = {
   sessionID: "test",
   messageID: "",
@@ -14,11 +16,9 @@ const ctx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
-  directory: process.cwd(),
+  directory: projectRoot,
   ask: async () => {},
 }
-
-const projectRoot = path.join(__dirname, "../..")
 
 describe("tool.bash", () => {
   test("basic", async () => {
@@ -50,6 +50,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -77,6 +78,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -105,6 +107,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -131,6 +134,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -164,6 +168,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -194,6 +199,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -224,6 +230,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -251,6 +258,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -277,6 +285,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },
@@ -298,6 +307,7 @@ describe("tool.bash permissions", () => {
         const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
         const testCtx = {
           ...ctx,
+          directory: tmp.path,
           ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
             requests.push(req)
           },

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -14,6 +14,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
   ask: async () => {},
 }
 

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -13,6 +13,7 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
 }
 
 describe("tool.assertExternalDirectory", () => {

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -12,6 +12,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
   ask: async () => {},
 }
 

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -11,6 +11,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
   ask: async () => {},
 }
 

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -16,6 +16,7 @@ const ctx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
   ask: async () => {},
 }
 

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -15,6 +15,7 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => {},
+  directory: process.cwd(),
 }
 
 describe("tool.skill", () => {


### PR DESCRIPTION
Fixes #2177

Adds the ability to switch working directories from the TUI without restarting. Type `/new ~/other-project` (or `/clear ~/other-project`) and press Enter to switch.

**What changed:**

- Tools now resolve paths from `session.directory` via `Tool.Context` instead of the global `Instance.directory`. This is concurrency-safe and follows the existing context-passing pattern.
- The TUI prompt intercepts `/new <path>`, validates the target, restarts the worker event stream, recreates the SDK client, and re-bootstraps all project data for the new directory.
- Error recovery rolls back to the previous directory on failure.

`/new` with no args still works as before.