### PR TITLE
feat(opencode): add custom logo configuration

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/logo.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/logo.tsx
@@ -1,9 +1,11 @@
 import { BoxRenderable, MouseButton, MouseEvent, RGBA, TextAttributes } from "@opentui/core"
 import { useRenderer } from "@opentui/solid"
-import { For, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js"
+import { For, Show, createMemo, createResource, createSignal, onCleanup, onMount, type JSX } from "solid-js"
 import { useTheme, tint } from "@tui/context/theme"
 import * as Sound from "@tui/util/sound"
 import { go, logo } from "@/cli/logo"
+import { Logo as LogoConfig } from "@/cli/logo"
+import { useSDK } from "@tui/context/sdk"
 
 export type LogoShape = {
   left: string[]
@@ -552,10 +554,24 @@ function buildIdleState(t: number, ctx: LogoContext): IdleState {
   return { cfg, reach, rings, active }
 }
 
+// Strip ANSI escape codes from text (TUI uses its own color system)
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_REGEX, "")
+}
+
 export function Logo(props: { shape?: LogoShape; ink?: RGBA; idle?: boolean } = {}) {
   const ctx = props.shape ? build(props.shape) : DEFAULT
   const { theme } = useTheme()
   const renderer = useRenderer()
+  const sdk = useSDK()
+
+  const [customLogo] = createResource(async () => {
+    if (props.shape) return null
+    const result = await sdk.client.config.logo({}).catch(() => null)
+    return result?.data
+  })
+
   const [rings, setRings] = createSignal<Ring[]>([])
   const [hold, setHold] = createSignal<Hold>()
   const [release, setRelease] = createSignal<Release>()
@@ -853,7 +869,7 @@ export function Logo(props: { shape?: LogoShape; ink?: RGBA; idle?: boolean } = 
     }
   }
 
-  return (
+  const defaultLogo = (
     <box ref={(item: BoxRenderable) => (box = item)}>
       <box
         position="absolute"
@@ -886,6 +902,29 @@ export function Logo(props: { shape?: LogoShape; ink?: RGBA; idle?: boolean } = 
         )}
       </For>
     </box>
+  )
+
+  if (props.shape) return defaultLogo
+
+  return (
+    <Show when={!customLogo()?.disabled} fallback={null}>
+      <Show
+        when={customLogo()?.content}
+        fallback={defaultLogo}
+      >
+        <box>
+          <For each={stripAnsi(customLogo()!.content!).split("\n")}>
+            {(line) => (
+              <box flexDirection="row">
+                <text fg={theme.text} selectable={false}>
+                  {line}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+      </Show>
+    </Show>
   )
 }
 

--- a/packages/opencode/src/cli/cmd/uninstall.ts
+++ b/packages/opencode/src/cli/cmd/uninstall.ts
@@ -53,7 +53,8 @@ export const UninstallCommand = {
 
   handler: async (args: UninstallArgs) => {
     UI.empty()
-    UI.println(UI.logo("  "))
+    const logoText = await UI.logoAsync("  ")
+    if (logoText) UI.println(logoText)
     UI.empty()
     prompts.intro("Uninstall OpenCode")
 

--- a/packages/opencode/src/cli/cmd/upgrade.ts
+++ b/packages/opencode/src/cli/cmd/upgrade.ts
@@ -22,7 +22,8 @@ export const UpgradeCommand = {
   },
   handler: async (args: { target?: string; method?: string }) => {
     UI.empty()
-    UI.println(UI.logo("  "))
+    const logoText = await UI.logoAsync("  ")
+    if (logoText) UI.println(logoText)
     UI.empty()
     prompts.intro("Upgrade")
     const detectedMethod = await Installation.method()

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -43,7 +43,8 @@ export const WebCommand = effectCmd({
     const opts = yield* Effect.promise(() => resolveNetworkOptions(args))
     const server = yield* Effect.promise(() => Server.listen(opts))
     UI.empty()
-    UI.println(UI.logo("  "))
+    const logoText = await UI.logoAsync("  ")
+    if (logoText) UI.println(logoText)
     UI.empty()
 
     if (opts.hostname === "0.0.0.0") {

--- a/packages/opencode/src/cli/logo.ts
+++ b/packages/opencode/src/cli/logo.ts
@@ -1,7 +1,56 @@
-export const logo = {
-  left: ["                   ", "█▀▀█ █▀▀█ █▀▀█ █▀▀▄", "█__█ █__█ █^^^ █__█", "▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀~~▀"],
-  right: ["             ▄     ", "█▀▀▀ █▀▀█ █▀▀█ █▀▀█", "█___ █__█ █__█ █^^^", "▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀"],
+import path from "path"
+import { Config } from "../config/config"
+import { AppRuntime } from "../effect/app-runtime"
+
+export namespace Logo {
+  // Default OpenCode logo glyphs
+  // Special characters: _ = bg fill, ^ = fg on bg half block, ~ = shadow half block
+  export const glyphs = {
+    left: ["                   ", "█▀▀█ █▀▀█ █▀▀█ █▀▀▄", "█__█ █__█ █^^^ █__█", "▀▀▀▀ █▀▀▀ ▀▀▀▀ ▀~~▀"],
+    right: ["             ▄     ", "█▀▀▀ █▀▀█ █▀▀█ █▀▀█", "█___ █__█ █__█ █^^^", "▀▀▀▀ ▀▀▀▀ ▀▀▀▀ ▀▀▀▀"],
+  }
+
+  export const marks = "_^~,"
+
+  export type Custom = string | false | undefined
+
+  /**
+   * Load a custom logo from the configured path.
+   * Returns the logo content as a string, or undefined to use default, or false to disable.
+   * Gracefully falls back to global config if instance context is not available.
+   */
+  type LogoConfig = { logo?: string | false }
+
+  function parseInlineConfig(): LogoConfig {
+    const inline = process.env.OPENCODE_CONFIG_CONTENT
+    if (!inline) return {}
+    return JSON.parse(inline) as LogoConfig
+  }
+
+  export async function load(): Promise<Custom> {
+    // Try full config first, fall back to global config, then inline config env var
+    const config: LogoConfig = await AppRuntime.runPromise(Config.Service.use((cfg) => cfg.get()))
+      .catch(() => AppRuntime.runPromise(Config.Service.use((cfg) => cfg.getGlobal())))
+      .catch(() => parseInlineConfig())
+      .catch(() => ({}))
+    if (config.logo === false) return false
+    if (!config.logo) return undefined
+
+    const logoPath = config.logo.startsWith("~")
+      ? path.join(process.env.HOME || "", config.logo.slice(1))
+      : path.isAbsolute(config.logo)
+        ? config.logo
+        : path.resolve(config.logo)
+
+    return Bun.file(logoPath)
+      .text()
+      .then((content) => content.trimEnd())
+      .catch(() => undefined)
+  }
 }
+
+// Legacy export for backwards compatibility
+export const logo = Logo.glyphs
 
 export const go = {
   left: ["    ", "█▀▀▀", "█_^█", "▀▀▀▀"],

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -2,6 +2,7 @@ import z from "zod"
 import { EOL } from "os"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { logo as glyphs } from "./logo"
+import { Logo } from "./logo"
 
 const wordmark = [
   `⠀                                ▄     `,
@@ -57,6 +58,28 @@ export function logo(pad?: string) {
     return result.join("").trimEnd()
   }
 
+  return renderDefaultLogo(pad)
+}
+
+/**
+ * Load and render logo based on config (async version).
+ * Uses custom logo if configured, otherwise falls back to default.
+ * Returns empty string if logo is disabled.
+ */
+export async function logoAsync(pad?: string): Promise<string> {
+  const custom = await Logo.load()
+  if (custom === false) return ""
+  if (custom) return renderCustomLogo(custom, pad)
+  return renderDefaultLogo(pad)
+}
+
+function renderCustomLogo(content: string, pad?: string): string {
+  const lines = content.split("\n")
+  if (!pad) return lines.join(EOL)
+  return lines.map((line) => pad + line).join(EOL)
+}
+
+function renderDefaultLogo(pad?: string): string {
   const result: string[] = []
   const reset = "\x1b[0m"
   const left = {

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -104,6 +104,10 @@ export const Info = Schema.Struct({
   shell: Schema.optional(Schema.String).annotate({
     description: "Default shell to use for terminal and bash tool",
   }),
+  logo: Schema.optional(Schema.Union([Schema.Literal(false), Schema.String])).annotate({
+    description:
+      "Custom logo configuration. Set to false to disable, or provide a path to a text file containing the logo (supports ANSI escape codes).",
+  }),
   logLevel: Schema.optional(LogLevelRef).annotate({ description: "Log level" }),
   server: Schema.optional(ConfigServer.Server).annotate({
     description: "Server configuration for opencode serve and web commands",

--- a/packages/opencode/src/server/routes/instance/config.ts
+++ b/packages/opencode/src/server/routes/instance/config.ts
@@ -1,9 +1,11 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
+import z from "zod"
 import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
 import { InstanceStore } from "@/project/instance-store"
 import { Provider } from "@/provider/provider"
+import { Logo } from "@/cli/logo"
 import { errors } from "../../error"
 import { lazy } from "@/util/lazy"
 import { jsonRequest, runRequest } from "./trace"
@@ -77,6 +79,36 @@ export const ConfigRoutes = lazy(() =>
           ),
         )
         return response
+      },
+    )
+    .get(
+      "/logo",
+      describeRoute({
+        summary: "Get custom logo",
+        description: "Get the custom logo content if configured, or null to use the default logo.",
+        operationId: "config.logo",
+        responses: {
+          200: {
+            description: "Logo content",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    content: z.string().nullable().describe("Custom logo content, or null to use default"),
+                    disabled: z.boolean().describe("Whether the logo is disabled"),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        const custom = await Logo.load()
+        return c.json({
+          content: custom === false ? null : (custom ?? null),
+          disabled: custom === false,
+        })
       },
     )
     .get(

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -587,6 +587,58 @@
         ]
       }
     },
+    "/config/logo": {
+      "get": {
+        "operationId": "config.logo",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Get custom logo",
+        "description": "Get the custom logo content if configured, or null to use the default logo.",
+        "responses": {
+          "200": {
+            "description": "Logo content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "content": {
+                      "description": "Custom logo content, or null to use default",
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "disabled": {
+                      "description": "Whether the logo is disabled",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["content", "disabled"]
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.config.logo({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/config/providers": {
       "get": {
         "tags": ["config"],
@@ -11542,6 +11594,18 @@
           },
           "shell": {
             "type": "string"
+          },
+          "logo": {
+            "description": "Custom logo configuration. Set to false to disable, or provide a path to a text file containing the logo (supports ANSI escape codes).",
+            "anyOf": [
+              {
+                "type": "boolean",
+                "const": false
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "logLevel": {
             "$ref": "#/components/schemas/LogLevel"

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -435,6 +435,41 @@ Set your UI theme in `tui.json`.
 
 ---
 
+### Logo
+
+You can customize or disable the CLI logo through the `logo` option. This is useful for enterprise deployments or custom branding.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "logo": "~/.config/opencode/my-logo.txt"
+}
+```
+
+The logo file should contain plain text ASCII art:
+
+```text title="my-logo.txt"
+╔═══════════════════════════╗
+║    ACME Corporation       ║
+║    Powered by OpenCode    ║
+╚═══════════════════════════╝
+```
+
+To disable the logo entirely:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "logo": false
+}
+```
+
+:::note
+The custom logo appears in the TUI home screen and CLI commands like `opencode web`, `opencode upgrade`, and `opencode uninstall`. The CLI help (`--help`) always shows the default OpenCode logo. ANSI escape codes for colors are supported in CLI output but are stripped in the TUI.
+:::
+
+---
+
 ### Agents
 
 You can configure specialized agents for specific tasks through the `agent` option.


### PR DESCRIPTION
Add the ability to customize or disable the CLI/TUI logo via config.

- Add 'logo' field to config schema (false to disable, string path to custom file)
- Add Logo.load() function to load custom logo from configured path
- Add UI.logoAsync() for async logo loading with config support
- Add /config/logo API endpoint to serve custom logo content
- Update TUI logo component to support custom logos (strips ANSI codes)
- Update web, upgrade, uninstall commands to use async logo loading
- Add documentation for logo configuration

### How did you verify your code works?

<img width="1692" height="1337" alt="image" src="https://github.com/user-attachments/assets/e56e694a-ad13-442d-a7dd-4a8e1a066e44" />

Fixes #12016