### PR TITLE
fix(opencode): Improve "Read" tool output to aid subsequent uses of the "Edit" tool

### DIFF
--- a/packages/opencode/src/tool/edit.txt
+++ b/packages/opencode/src/tool/edit.txt
@@ -2,7 +2,14 @@ Performs exact string replacements in files.
 
 Usage:
 - You must use your `Read` tool at least once in the conversation before editing. This tool will error if you attempt an edit without reading the file. 
-- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: spaces + line number + tab. Everything after that tab is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
+- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the `|` separator. The line number prefix format is: spaces + line number + tab. Everything after that `|` is the actual file content to match. Never include any part of the line number prefix in the oldString or newString.
+  - The format is: [line_number] |[actual_file_content]
+  - Everything before the `|` (including spaces) should be discarded
+  - Everything after the `|` (including ALL leading indentation) is the actual file content
+    Example:
+      42 |     function foo() {
+      ↑      ↑
+    metadata actual indentation (spaces/tabs to preserve)
 - ALWAYS prefer editing existing files in the codebase. NEVER write new files unless explicitly required.
 - Only use emojis if the user explicitly requests it. Avoid adding emojis to files unless asked.
 - The edit will FAIL if `oldString` is not found in the file with an error "oldString not found in content".

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -112,7 +112,7 @@ export const ReadTool = Tool.define("read", {
     }
 
     const content = raw.map((line, index) => {
-      return `${(index + offset + 1).toString().padStart(5, "0")}| ${line}`
+      return `${(index + offset + 1).toString().padStart(5, "0")} |${line}`
     })
     const preview = raw.slice(0, 20).join("\n")
 


### PR DESCRIPTION
### What does this PR do?

This PR helps models (tested with Haiku 4.5) use the "Edit" tool more effectively with regards to leading whitespace after reading context given by the "Read" tool. Fixes #10656

### How did you verify your code works?

I tasked agents with writing Haskell (white-space sensitive) and they improved considerably their success rate (to consistently perfect edits) when using the Edit tool as to not introduce leading-whitespace related errors