### PR TITLE
fix: prevent double-prefixing of Bedrock cross-region inference models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -239,7 +239,9 @@ export namespace Provider {
         options: providerOptions,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
           // Skip region prefixing if model already has a cross-region inference profile prefix
-          if (modelID.startsWith("global.") || modelID.startsWith("jp.")) {
+          // Models from models.dev may already include prefixes like us., eu., global., etc.
+          const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]
+          if (crossRegionPrefixes.some((prefix) => modelID.startsWith(prefix))) {
             return sdk.languageModel(modelID)
           }
 


### PR DESCRIPTION
## Summary

- Fixed issue where Bedrock models with pre-existing cross-region inference profile prefixes (us., eu., etc.) were being double-prefixed
- Added tests for cross-region prefix detection

## Problem

Models from models.dev may already include cross-region inference profile prefixes like:
- `us.anthropic.claude-opus-4-5-20251101-v1:0` → "Claude Opus 4.5 (US)"
- `eu.anthropic.claude-opus-4-5-20251101-v1:0` → "Claude Opus 4.5 (EU)"
- `global.anthropic.claude-opus-4-5-20251101-v1:0` → "Claude Opus 4.5 (Global)"

Previously, only `global.` and `jp.` prefixes were checked, causing models with `us.`, `eu.`, `apac.`, or `au.` prefixes to be double-prefixed (e.g., `us.us.anthropic.claude-...`), which AWS rejects as invalid.

## Solution

Expanded the prefix check to include all cross-region inference profile prefixes:
- `global.`
- `us.`
- `eu.`
- `jp.`
- `apac.`
- `au.`

Models that already have a regional prefix are now passed through to the SDK without modification, while models without prefixes continue to get prefixed based on the user's region.

## Backward Compatibility

This fix is backward compatible:
- Models **without** prefixes (e.g., `anthropic.claude-opus-4-5-20251101-v1:0`) will continue to be prefixed based on the user's AWS region
- Models **with** prefixes (e.g., `us.anthropic.claude-opus-4-5-20251101-v1:0`) will be used as-is

Fixes #12052