### PR TITLE
fix: add missing English check in detectLocale()

### DIFF
--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -78,6 +78,7 @@ function detectLocale(): Locale {
   const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
   for (const language of languages) {
     if (!language) continue
+    if (language.toLowerCase().startsWith("en")) return "en"
     if (language.toLowerCase().startsWith("zh")) {
       if (language.toLowerCase().includes("hant")) return "zht"
       return "zh"

--- a/packages/desktop/src/i18n/index.ts
+++ b/packages/desktop/src/i18n/index.ts
@@ -44,6 +44,7 @@ function detectLocale(): Locale {
   const languages = navigator.languages?.length ? navigator.languages : [navigator.language]
   for (const language of languages) {
     if (!language) continue
+    if (language.toLowerCase().startsWith("en")) return "en"
     if (language.toLowerCase().startsWith("zh")) {
       if (language.toLowerCase().includes("hant")) return "zht"
       return "zh"


### PR DESCRIPTION
## Summary

- Add `en` check to `detectLocale()` in the web app and desktop app
- Without this, English entries in the browser's language list are silently skipped, and the first non-English supported language is selected instead

## Problem

`detectLocale()` iterates through `navigator.languages` and checks for `zh`, `ko`, `de`, `es`, `fr`, etc. — but not `en`. The `return "en"` default at the end only triggers if *no* supported language is found. If a user has `[en-IE, en-US, en-GB, en, it, es]`, all English entries fall through and `es` (Spanish, the least preferred) is selected.

## Fix

Add `if (language.toLowerCase().startsWith("en")) return "en"` as the first check in the loop, in both affected files:

- `packages/app/src/context/language.tsx` (web app)
- `packages/desktop/src/i18n/index.ts` (desktop app)

The enterprise package (`packages/enterprise/src/entry-server.tsx` and `app.tsx`) already checks for `en` explicitly and is not affected.

Fixes #12063