### PR TITLE
docs: add agent-compatible paths to skills documentation

### DIFF
--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -17,15 +17,17 @@ OpenCode searches these locations:
 - Global config: `~/.config/opencode/skills/<name>/SKILL.md`
 - Project Claude-compatible: `.claude/skills/<name>/SKILL.md`
 - Global Claude-compatible: `~/.claude/skills/<name>/SKILL.md`
+- Project agent-compatible: `.agents/skills/<name>/SKILL.md`
+- Global agent-compatible: `~/.agents/skills/<name>/SKILL.md`
 
 ---
 
 ## Understand discovery
 
 For project-local paths, OpenCode walks up from your current working directory until it reaches the git worktree.
-It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` along the way.
+It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` or `.agents/skills/*/SKILL.md` along the way.
 
-Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md` and `~/.claude/skills/*/SKILL.md`.
+Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
 
 ---
 


### PR DESCRIPTION
This pull request updates the documentation in `skills.mdx` to clarify and expand the locations where OpenCode searches for skill definitions, including new support for agent-compatible skill paths.

Skill discovery documentation updates:

* Added `.agents/skills/<name>/SKILL.md` and `~/.agents/skills/<name>/SKILL.md` as new project and global agent-compatible search locations.
* Updated the description of project-local and global skill discovery to include agent-compatible paths alongside existing Claude-compatible and OpenCode-specific paths.