### PR TITLE
feat: add kimi-2.5 thinking support

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -334,9 +334,7 @@ export namespace ProviderTransform {
       id.includes("minimax") ||
       id.includes("glm") ||
       id.includes("mistral") ||
-      id.includes("kimi") ||
-      // TODO: Remove this after models.dev data is fixed to use "kimi-k2.5" instead of "k2p5"
-      id.includes("k2p5")
+      id.includes("kimi")
     )
       return {}
 
@@ -615,6 +613,16 @@ export namespace ProviderTransform {
         type: "enabled",
         clear_thinking: false,
       }
+    }
+
+    // kimi-k2.5 supports enabling thinking capability
+    // https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart
+    if (["k2p5", "kimi-k2.5"].includes(input.model.providerID) && input.model.api.npm === "@ai-sdk/openai-compatible") {
+      result["thinking"] = {
+        type: "enabled",
+        budgetTokens: 31999,
+      }
+      result["interleaved"] = { field: "reasoning_content" }
     }
 
     if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {


### PR DESCRIPTION
## What does this PR do?
Fixes #12090
This PR adds thinking support for Kimi 2.5 models by enabling the thinking capability and mapping interleaved reasoning content for the k2p5 / kimi-k2.5 provider IDs under the OpenAI-compatible API. It also removes the temporary k2p5 fallback in the availability check now that the mapping is handled explicitly. This works because Kimi 2.5 exposes its reasoning stream via reasoning_content, and the provider supports the thinking flag, so the transformation now passes the correct options to the backend.

## How did you verify your code works?
tested locally.
