### PR TITLE
fix(desktop): removed compression from rpm bundle to save 15m in CI

### DIFF
--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -42,6 +42,13 @@
     "active": true,
     "targets": ["deb", "rpm", "dmg", "nsis", "app"],
     "externalBin": ["sidecars/opencode-cli"],
+    "linux": {
+      "rpm": {
+	      "compression": {
+	        "type": "none"
+	      }
+      }
+    },
     "macOS": {
       "entitlements": "./entitlements.plist"
     },

--- a/packages/desktop/src-tauri/tauri.prod.conf.json
+++ b/packages/desktop/src-tauri/tauri.prod.conf.json
@@ -21,6 +21,11 @@
         "files": {
           "/usr/share/metainfo/ai.opencode.opencode.metainfo.xml": "release/appstream.metainfo.xml"
         }
+      },
+      "rpm": {
+        "compression": {
+          "type": "none"
+        }
       }
     }
   },


### PR DESCRIPTION
### What does this PR do?

The RPM artifact generation in the Desktop app (tauri) uses slow compression impl that takes **15-20 minutes** to build.
This PR disables compression for RPM bundle which makes it fast.

Only one caveat: now the RPM weights **200MB~** instead of **90MB~**

<img width="1382" height="420" alt="image" src="https://github.com/user-attachments/assets/00a35211-b0dc-4e93-ae7c-dcfe2fa00dc5" />
<img width="1201" height="176" alt="image" src="https://github.com/user-attachments/assets/43d10621-0bcd-4c69-a59d-805bfd15b4e6" />


### How did you verify your code works?


*After:*
<img width="861" height="212" alt="image" src="https://github.com/user-attachments/assets/945e83e4-f72f-44ae-a836-59627b4c5e0b" />
