### PR TITLE
docs: add new plugin to the ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-system-prompt-logger](https://github.com/tlinhart/opencode-system-prompt-logger)                | Log the system prompt before it's sent to the LLM                                                 |
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Adds opencode-system-prompt-logger to ecosystem documentation.