### PR TITLE
Add opencode-zombie-monitor plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -36,6 +36,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | AI-powered automatic Zellij session naming based on OpenCode context                              |
+| [opencode-zombie-monitor](https://github.com/Matroskin86/opencode-zombie-monitor)                         | Auto-kill orphaned opencode processes eating your RAM                                             |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                       | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                             | Persistent memory across sessions using Supermemory                                               |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin)        | Interactive plan review with visual annotation and private/offline sharing                        |


### PR DESCRIPTION
Adds [opencode-zombie-monitor](https://github.com/Matroskin86/opencode-zombie-monitor) to the plugins list.

**What it does:** Auto-kills orphaned opencode processes that stay alive after closing terminal without `q`, freeing up RAM.

- npm: https://www.npmjs.com/package/opencode-zombie-monitor
- Platforms: macOS, Linux
- Features: auto-kill or manual mode, configurable threshold