### PR TITLE
fix(provider): respect thinking toggle for Gemini models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -598,9 +598,6 @@ export namespace ProviderTransform {
       result["usage"] = {
         include: true,
       }
-      if (input.model.api.id.includes("gemini-3")) {
-        result["reasoning"] = { effort: "high" }
-      }
     }
 
     if (
@@ -621,14 +618,6 @@ export namespace ProviderTransform {
       result["promptCacheKey"] = input.sessionID
     }
 
-    if (input.model.api.npm === "@ai-sdk/google" || input.model.api.npm === "@ai-sdk/google-vertex") {
-      result["thinkingConfig"] = {
-        includeThoughts: true,
-      }
-      if (input.model.api.id.includes("gemini-3")) {
-        result["thinkingConfig"]["thinkingLevel"] = "high"
-      }
-    }
 
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {


### PR DESCRIPTION
### What does this PR do?

The Gemini thinking toggle was busted. In transform.ts, the options() function always sent thinkingConfig: { includeThoughts: true } for Google/Vertex models - hardcoded, regardless of toggle state.

So turning thinking OFF did nothing. The API always got includeThoughts: true.

Fix: deleted the unconditional default. Now thinking config only gets set when you pick a variant (i.e., toggle it on). Same issue existed for Gemini 3 on OpenRouter with reasoning.effort: "high" - removed that too.

### How did you verify your code works?

options() returns base provider options
variants() returns thinking configs for each effort level
When toggle is ON → variant merges in → thinking enabled
When toggle is OFF → no variant → now nothing sets thinking (before: options() still did)
