### PR TITLE
fix: Multiple jdtls LSPs eating memory in java monorepos

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1129,7 +1129,30 @@ export namespace LSPServer {
 
   export const JDTLS: Info = {
     id: "jdtls",
-    root: NearestRoot(["pom.xml", "build.gradle", "build.gradle.kts", ".project", ".classpath"]),
+    root: async (file) => {
+      // Without exclusions, NearestRoot defaults to instance directory so we can't
+      // distinguish between a) no project found and b) project found at instance dir.
+      // So we can't choose the root from (potential) monorepo markers first.
+      // Look for potential subproject markers first while excluding potential monorepo markers.
+      const settingsMarkers = ["settings.gradle", "settings.gradle.kts"]
+      const gradleMarkers = ["gradlew", "gradlew.bat"]
+      const exclusionsForMonorepos = gradleMarkers.concat(settingsMarkers)
+
+      const [projectRoot, wrapperRoot, settingsRoot] = await Promise.all([
+        NearestRoot(
+          ["pom.xml", "build.gradle", "build.gradle.kts", ".project", ".classpath"],
+          exclusionsForMonorepos,
+        )(file),
+        NearestRoot(gradleMarkers, settingsMarkers)(file),
+        NearestRoot(settingsMarkers)(file),
+      ])
+
+      // If projectRoot is undefined we know we are in a monorepo or no project at all.
+      // So can safely fall through to the other roots
+      if (projectRoot) return projectRoot
+      if (wrapperRoot) return wrapperRoot
+      if (settingsRoot) return settingsRoot
+    },
     extensions: [".java"],
     async spawn(root) {
       const java = Bun.which("java")


### PR DESCRIPTION
### What does this PR do?

In monorepos, starts `jdtls` at the project root* to let it discover and handle all submodules with a single process.

*Uses the project markers already used for [kotlin-ls](https://github.com/anomalyco/opencode/blob/af06175b1f293ea13d4165cee56db65fbbd56c65/packages/opencode/src/lsp/server.ts#L1235-L1245).

There's some complexity which I think is necessary to handle all cases - hopefully explained by the inline comments.

Fixes: https://github.com/anomalyco/opencode/issues/11368

### How did you verify your code works?

Ran in gradle monorepo, reading files from multiple modules:

Before:
```
LSP
jdtls module-a
jdtls module-b
jdtls module-c
```

After:
```
LSP
jdtls
```

Made edits and got correct diagnostics in tool results.

Ran in single project repo, made edits

Thanks

