### PR TITLE
docs: fix caution block alignment on Windows (WSL) page

### DIFF
--- a/packages/web/src/content/docs/windows-wsl.mdx
+++ b/packages/web/src/content/docs/windows-wsl.mdx
@@ -64,7 +64,6 @@ When using `--hostname 0.0.0.0`, set `OPENCODE_SERVER_PASSWORD` to secure the se
 ```bash
 OPENCODE_SERVER_PASSWORD=your-password opencode serve --hostname 0.0.0.0
 ```
-
 :::
 
 ---


### PR DESCRIPTION
### What does this PR do?

Fixes the misaligned code block in the caution admonition on the Windows (WSL) docs page.

The issue was an extra blank line before the closing `:::` marker, which caused the code block to render outside/misaligned from the caution box.

Fixes #12084

### How did you verify your code works?

- Reviewed the MDX syntax against other working admonitions in the docs
- Compared with similar caution blocks in `agents.mdx`, `config.mdx`, `enterprise.mdx` - none have blank lines before closing `:::`