### PR TITLE
fix(lsp): handle Java versions without minor/patch numbers

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1141,7 +1141,7 @@ export namespace LSPServer {
         .quiet()
         .nothrow()
         .then(({ stderr }) => {
-          const m = /"(\d+)\.\d+\.\d+"/.exec(stderr.toString())
+          const m = /"(\d+)(?:\.\d+)*"/.exec(stderr.toString())
           return !m ? undefined : parseInt(m[1])
         })
       if (javaMajorVersion == null || javaMajorVersion < 21) {


### PR DESCRIPTION
### What does this PR do?

Fixes Java version detection for JDTLS installation when `java -version` outputs only the major version.

**Problem:** The regex `/"(\d+)\.\d+\.\d+"/` expects format like `"21.0.0"`, but some distributions (e.g., Temurin-21+35) output just `"21"`:
```
openjdk version "21" 2023-09-19 LTS
```

**Fix:** Changed regex to `/"(\d+)(?:\.\d+)*"/` which matches both formats.

Fixes #12120

### How did you verify your code works?

Tested the regex against multiple Java version string formats:
```javascript
// All return the correct major version:
"21"     -> 21  ✓ (was failing before)
"21.0.0" -> 21  ✓
"21.0.5" -> 21  ✓
"17.0.2" -> 17  ✓
```