### PR TITLE
fix(provider): preserve redacted_thinking blocks and fix signature validation

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -47,7 +47,9 @@ export namespace ProviderTransform {
     options: Record<string, unknown>,
   ): ModelMessage[] {
     // Anthropic rejects messages with empty content - filter out empty string messages
-    // and remove empty text/reasoning parts from array content
+    // and remove empty text/reasoning parts from array content.
+    // NOTE: Redacted thinking blocks (with providerMetadata) must be PRESERVED even if empty -
+    // the Anthropic API requires all thinking blocks to be replayed exactly as received.
     if (model.api.npm === "@ai-sdk/anthropic") {
       msgs = msgs
         .map((msg) => {
@@ -57,7 +59,11 @@ export namespace ProviderTransform {
           }
           if (!Array.isArray(msg.content)) return msg
           const filtered = msg.content.filter((part) => {
-            if (part.type === "text" || part.type === "reasoning") {
+            if (part.type === "text") return part.text !== ""
+            if (part.type === "reasoning") {
+              // Preserve redacted_thinking blocks (they have providerMetadata but may have empty text)
+              if ((part as any).providerMetadata?.anthropic) return true
+              // Filter out regular empty reasoning blocks
               return part.text !== ""
             }
             return true
@@ -66,6 +72,16 @@ export namespace ProviderTransform {
           return { ...msg, content: filtered }
         })
         .filter((msg): msg is ModelMessage => msg !== undefined && msg.content !== "")
+
+      // Reorder content blocks: reasoning blocks must come first for Anthropic
+      msgs = msgs.map((msg) => {
+        if (msg.role === "assistant" && Array.isArray(msg.content)) {
+          const reasoning = msg.content.filter((part) => part.type === "reasoning")
+          const other = msg.content.filter((part) => part.type !== "reasoning")
+          return { ...msg, content: [...reasoning, ...other] }
+        }
+        return msg
+      })
     }
 
     if (model.api.id.includes("claude")) {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -617,6 +617,10 @@ export namespace MessageV2 {
               })
           }
           if (part.type === "reasoning") {
+            // Preserve ALL reasoning parts including redacted_thinking blocks.
+            // The Anthropic API requires previous assistant messages to be replayed
+            // exactly as received, including redacted_thinking blocks in their
+            // original positions. Filtering them causes signature validation errors.
             assistantMessage.parts.push({
               type: "reasoning",
               text: part.text,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -88,7 +88,10 @@ export namespace SessionProcessor {
                 case "reasoning-end":
                   if (value.id in reasoningMap) {
                     const part = reasoningMap[value.id]
-                    part.text = part.text.trimEnd()
+                    // Do NOT trimEnd() thinking text - the signature is computed on the
+                    // exact text including trailing whitespace. Modifying it invalidates
+                    // the signature, causing "Invalid data in redacted_thinking block"
+                    // errors when the thinking is replayed in subsequent API calls.
 
                     part.time = {
                       ...part.time,


### PR DESCRIPTION
## Summary

Fix "Invalid data in redacted_thinking block" errors when using extended thinking with Claude.

## Problem

When extended thinking is enabled, the Anthropic API returns `thinking` and `redacted_thinking` blocks with cryptographic signatures. Two issues caused these blocks to be rejected on subsequent API calls:

1. **`trimEnd()` on thinking text** — The signature is computed on the exact text including trailing whitespace. Trimming invalidates it.
2. **Block ordering** — The API requires thinking/redacted_thinking blocks to appear first in assistant message content arrays.

## Changes

- **processor.ts**: Remove `trimEnd()` call on thinking text to preserve signature integrity
- **transform.ts**: Add reordering logic to place reasoning blocks first in `normalizeMessages()`
- **message-v2.ts**: Preserve all reasoning blocks including redacted_thinking in `toModelMessages()`

## Testing

Reproduced the error by enabling extended thinking (High) with Claude Opus 4.5, triggering the error on the 2nd message of a session. After the fix, multi-turn conversations with extended thinking work without errors.

Closes #10970