### PR TITLE
docs(cli): add example for redirecting export output to file

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -427,6 +427,12 @@ opencode export [sessionID]
 
 If you don't provide a session ID, you'll be prompted to select from available sessions.
 
+You can redirect the output to save to a file for further investigation:
+
+```bash
+opencode export > export.json
+```
+
 ---
 
 ### import


### PR DESCRIPTION
## Summary
- Adds an example showing how to redirect `opencode export` output to a file for further investigation

```bash
opencode export > export.json
```