### PR TITLE
Inject OPENCODE_SESSION_ID into shell env

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1511,6 +1511,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       env: {
         ...process.env,
         ...shellEnv.env,
+        OPENCODE_SESSION_ID: input.sessionID,
         TERM: "dumb",
       },
     })

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -170,6 +170,7 @@ export const BashTool = Tool.define("bash", async () => {
         env: {
           ...process.env,
           ...shellEnv.env,
+          OPENCODE_SESSION_ID: ctx.sessionID,
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: process.platform !== "win32",

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -37,6 +37,25 @@ describe("tool.bash", () => {
       },
     })
   })
+
+  test("injects session id into env", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const testCtx = { ...ctx, sessionID: "session-env-123" }
+        const result = await bash.execute(
+          {
+            command: "echo $OPENCODE_SESSION_ID",
+            description: "Echo session id",
+          },
+          testCtx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.output).toContain("session-env-123")
+      },
+    })
+  })
 })
 
 describe("tool.bash permissions", () => {


### PR DESCRIPTION
## Summary
- inject OPENCODE_SESSION_ID into bash tool env
- inject OPENCODE_SESSION_ID into user shell command env
- add bash tool test for session env

## Testing
- bun run typecheck (packages/opencode)
- bun run lint (packages/opencode)
- bun turbo typecheck (pre-push hook)

Fixes #12158
