### PR TITLE
fix(app): sidebar not updating on project change

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -2874,7 +2874,9 @@ export default function Layout(props: ParentProps) {
         </div>
 
         <Show when={expanded()}>
-          <SidebarPanel project={currentProject()} mobile={sidebarProps.mobile} />
+          <Show when={currentProject()} keyed>
+            {(project) => <SidebarPanel project={project} mobile={sidebarProps.mobile} />}
+          </Show>
         </Show>
       </div>
     )


### PR DESCRIPTION
### What does this PR do?

Fixes session list not updating when switching projects in the sidebar. The LocalWorkspace component was binding to the project store on mount only, so it kept showing the first project's sessions. Added keyed to force remount when project changes.

How did you verify your code works?

Tested switching between multiple projects and session list now updates correctly.


this closes #11964