### PR TITLE
fix(provider): preserve user-defined model variants from config

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -922,17 +922,14 @@ export namespace Provider {
         )
           delete provider.models[modelID]
 
-        model.variants = mapValues(ProviderTransform.variants(model), (v) => v)
-
-        // Filter out disabled variants from config
-        const configVariants = configProvider?.models?.[modelID]?.variants
-        if (configVariants && model.variants) {
-          const merged = mergeDeep(model.variants, configVariants)
-          model.variants = mapValues(
-            pickBy(merged, (v) => !v.disabled),
-            (v) => omit(v, ["disabled"]),
-          )
-        }
+        // Merge ProviderTransform variants with existing model variants (from config)
+        // User config variants take precedence over ProviderTransform defaults
+        const baseVariants = ProviderTransform.variants(model)
+        const mergedVariants = mergeDeep(baseVariants, model.variants ?? {})
+        model.variants = mapValues(
+          pickBy(mergedVariants, (v) => !v.disabled),
+          (v) => omit(v, ["disabled"]),
+        )
       }
 
       if (Object.keys(provider.models).length === 0) {


### PR DESCRIPTION
## Summary

Fixes a subtle bug where `model.variants` could be unintentionally overwritten when `ProviderTransform.variants()` returns `{}` for certain models (kimi, deepseek, minimax, etc.).

## The Problem

In `provider.ts`, the previous code would:
1. Overwrite `model.variants` with `ProviderTransform.variants(model)` result (which is `{}` for kimi models)
2. Then conditionally merge with `configVariants`

While this currently works, it has a subtle issue: if `configVariants` lookup fails or if variants were set in a previous processing step, they would be lost.

## The Fix

Instead of overwriting then merging, we now merge directly:
- `ProviderTransform.variants()` provides the base defaults
- `model.variants` (from user config) is merged on top, taking precedence
- User-defined variants are always preserved

## Changes

- Modified `packages/opencode/src/provider/provider.ts` (lines 925-932)
- Simplified variant merging logic
- Ensures user config always takes precedence over ProviderTransform defaults

## Testing

- Tested with custom provider configs (e.g., kimi-for-coding with kimi-k2.5 model)
- Verified that user-defined variants in config are properly preserved
- No breaking changes to existing behavior

## Related

Closes #12169