### PR TITLE
fix(tui): Add right side padding to UserMessage

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1177,6 +1177,7 @@ function UserMessage(props: {
             paddingTop={1}
             paddingBottom={1}
             paddingLeft={2}
+            paddingRight={2}
             backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
             flexShrink={0}
           >


### PR DESCRIPTION
### What does this PR do?

Adds missing right padding to UserMessage component.

### How did you verify your code works?

**Before**:
<img width="862" height="94" alt="image" src="https://github.com/user-attachments/assets/3ce70318-bd77-4fa1-b337-b2eb82219aaf" />

**After**:
<img width="861" height="89" alt="image" src="https://github.com/user-attachments/assets/297d9b2c-ed23-4b2a-82e7-d3e9b9f3297d" />

Fixes #12173 