### PR TITLE
docs: add opencode-token-tracker to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -38,6 +38,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | AI-powered automatic Zellij session naming based on OpenCode context                              |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                       | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                             | Persistent memory across sessions using Supermemory                                               |
+| [opencode-token-tracker](https://github.com/tongsh6/opencode-token-tracker)                               | Real-time token usage and cost tracking with Toast notifications and JSONL logging                |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin)        | Interactive plan review with visual annotation and private/offline sharing                        |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                                     | Extend opencode /commands into a powerful orchestration system with granular flow control         |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                                  | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                   |


### PR DESCRIPTION
## Summary

Add [opencode-token-tracker](https://github.com/tongsh6/opencode-token-tracker) to the ecosystem plugins list.

### What it does

- Real-time Toast notifications showing token usage and cost after each AI response
- Session-level cumulative statistics (total tokens, cost, message count, duration)
- Cost calculation with built-in pricing table for Claude, GPT, DeepSeek, and Gemini models
- JSONL logging to `~/.config/opencode/logs/token-tracker/tokens.jsonl` for analysis

### Links

- GitHub: https://github.com/tongsh6/opencode-token-tracker
- npm: https://www.npmjs.com/package/opencode-token-tracker