### PR TITLE
fix(app): derive terminal WebSocket URL from browser origin instead o…

### DIFF
--- a/packages/app/src/components/terminal-url.test.ts
+++ b/packages/app/src/components/terminal-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { ptySocketUrl } from "./terminal-url"
+
+describe("ptySocketUrl", () => {
+  test("uses browser host instead of sdk host", () => {
+    const url = ptySocketUrl("http://localhost:4096", "pty_1", "/repo", {
+      host: "192.168.1.50:4096",
+      protocol: "http:",
+    })
+    expect(url.toString()).toBe("ws://192.168.1.50:4096/pty/pty_1/connect?directory=%2Frepo")
+  })
+
+  test("uses secure websocket on https", () => {
+    const url = ptySocketUrl("http://localhost:4096", "pty_1", "/repo", {
+      host: "opencode.local",
+      protocol: "https:",
+    })
+    expect(url.toString()).toBe("wss://opencode.local/pty/pty_1/connect?directory=%2Frepo")
+  })
+
+  test("preserves browser port", () => {
+    const url = ptySocketUrl("http://localhost:4096", "pty_1", "/repo", {
+      host: "opencode.local:8443",
+      protocol: "https:",
+    })
+    expect(url.toString()).toBe("wss://opencode.local:8443/pty/pty_1/connect?directory=%2Frepo")
+  })
+
+  test("handles slash base url", () => {
+    const url = ptySocketUrl("/", "pty_1", "/repo", {
+      host: "192.168.1.50:4096",
+      protocol: "http:",
+    })
+    expect(url.toString()).toBe("ws://192.168.1.50:4096/pty/pty_1/connect?directory=%2Frepo")
+  })
+})

--- a/packages/app/src/components/terminal-url.ts
+++ b/packages/app/src/components/terminal-url.ts
@@ -1,0 +1,10 @@
+export function ptySocketUrl(base: string, id: string, directory: string, origin: { host: string; protocol: string }) {
+  const root = `${origin.protocol}//${origin.host}`
+  const current = new URL(root)
+  const prefix = /^https?:\/\//.test(base) ? base : new URL(base || "/", root).toString()
+  const url = new URL(prefix.replace(/\/+$/, "") + `/pty/${id}/connect?directory=${encodeURIComponent(directory)}`)
+  url.hostname = current.hostname
+  url.port = current.port
+  url.protocol = origin.protocol === "https:" ? "wss:" : "ws:"
+  return url
+}

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -8,6 +8,7 @@ import { LocalPTY } from "@/context/terminal"
 import { resolveThemeVariant, useTheme, withAlpha, type HexColor } from "@opencode-ai/ui/theme"
 import { useLanguage } from "@/context/language"
 import { showToast } from "@opencode-ai/ui/toast"
+import { ptySocketUrl } from "./terminal-url"
 
 export interface TerminalProps extends ComponentProps<"div"> {
   pty: LocalPTY
@@ -163,8 +164,7 @@ export const Terminal = (props: TerminalProps) => {
 
       const once = { value: false }
 
-      const url = new URL(sdk.url + `/pty/${local.pty.id}/connect?directory=${encodeURIComponent(sdk.directory)}`)
-      url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
+      const url = ptySocketUrl(sdk.url, local.pty.id, sdk.directory, window.location)
       if (window.__OPENCODE__?.serverPassword) {
         url.username = "opencode"
         url.password = window.__OPENCODE__?.serverPassword


### PR DESCRIPTION
### What does this PR do?

Fixes #5844.

Terminal WebSocket URLs were built from `sdk.url` (often `localhost:4096`), which breaks when the web UI is opened from a network host (LAN/Tailscale IP). `--mdns` helps discovery by publishing a LAN hostname, but it does not change this WebSocket URL construction path.

This PR extracts terminal URL construction into a testable `ptySocketUrl()` helper and uses the browser origin (`window.location` host + protocol) so the terminal WebSocket connects to the same host/port that served the UI.

while this bothers me, maybe it was not changd upstream for a reason? If that's the case, will close. 

### How did you verify your code works?

- Added unit tests in `terminal-url.test.ts` covering: localhost -> LAN host replacement, `https` -> `wss`, port preservation, and `/` base URL edge case
- Manual verification on dev VM (proxmox nixos vm + tailscale).
<img width="1800" height="600" alt="image" src="https://github.com/user-attachments/assets/417bf8bf-e69b-48b8-b3f8-705f53dcd764" />

