### PR TITLE
fix: prevent snapshot from tracking large files

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/snapshot.ts
+++ b/packages/opencode/src/cli/cmd/debug/snapshot.ts
@@ -1,11 +1,13 @@
 import { Snapshot } from "../../../snapshot"
+import { Instance } from "../../../project/instance"
 import { bootstrap } from "../../bootstrap"
 import { cmd } from "../cmd"
 
 export const SnapshotCommand = cmd({
   command: "snapshot",
   describe: "snapshot debugging utilities",
-  builder: (yargs) => yargs.command(TrackCommand).command(PatchCommand).command(DiffCommand).demandCommand(),
+  builder: (yargs) =>
+    yargs.command(TrackCommand).command(PruneCommand).command(PatchCommand).command(DiffCommand).demandCommand(),
   async handler() {},
 })
 
@@ -15,6 +17,19 @@ const TrackCommand = cmd({
   async handler() {
     await bootstrap(process.cwd(), async () => {
       console.log(await Snapshot.track())
+    })
+  },
+})
+
+const PruneCommand = cmd({
+  command: "prune",
+  describe: "prune snapshot state",
+  async handler() {
+    await Instance.provide({
+      directory: process.cwd(),
+      fn: async () => {
+        console.log(await Snapshot.cleanup())
+      },
     })
   },
 })

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -422,6 +422,7 @@ export namespace Snapshot {
 
   async function gitAddFiltered(git: string): Promise<string[]> {
     const env = gitenv(git)
+    await syncExclude(git)
 
     // -N (`--intent-to-add`) records new paths without staging file contents.
     const intent = await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true add -N -- .`
@@ -525,6 +526,35 @@ export namespace Snapshot {
 
     log.info("removing large files from snapshot", { files })
     await Promise.all([execGitRmCached(), updateGitExclude()])
+  }
+
+  async function syncExclude(git: string) {
+    const file = await excludes()
+    const target = path.join(git, "info", "exclude")
+    await fs.mkdir(path.join(git, "info"), { recursive: true })
+    if (!file) {
+      await Bun.write(target, "")
+      return
+    }
+    const text = await Bun.file(file)
+      .text()
+      .catch(() => "")
+    await Bun.write(target, text)
+  }
+
+  async function excludes() {
+    const file = await $`git rev-parse --path-format=absolute --git-path info/exclude`
+      .quiet()
+      .cwd(Instance.worktree)
+      .nothrow()
+      .text()
+    if (!file.trim()) return
+    const exists = await fs
+      .stat(file.trim())
+      .then(() => true)
+      .catch(() => false)
+    if (!exists) return
+    return file.trim()
   }
 
   async function findOversizedObjects(env: Env): Promise<Oversized> {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -8,18 +8,27 @@ import z from "zod"
 import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { Scheduler } from "../scheduler"
+import { EOL } from "os"
+import { readNull } from "../util/stream"
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const hour = 60 * 60 * 1000
   const prune = "7.days"
   const sizeThreshold = 1 * 1024 * 1024 * 1024 // 1 GB
+
   type Env = Record<string, string | undefined>
   type Oversized = {
     failed: boolean
     count: number
     sample: string[]
   }
+  type Spawned = {
+    exitCode: number
+    stderr: string
+    signalCode: number | string | null
+  }
+
   export type Cleanup = {
     status: "gc" | "reset" | "skipped" | "failed"
     reason?: "vcs" | "client" | "disabled" | "missing" | "reset" | "gc"
@@ -32,14 +41,6 @@ export namespace Snapshot {
     error?: string
   }
 
-  function gitenv(git = gitdir()): Env {
-    return {
-      ...process.env,
-      GIT_DIR: git,
-      GIT_WORK_TREE: Instance.worktree,
-    }
-  }
-
   export function init() {
     Scheduler.register({
       id: "snapshot.cleanup",
@@ -49,148 +50,6 @@ export namespace Snapshot {
       },
       scope: "instance",
     })
-  }
-
-  async function gitAddFiltered() {
-    const env = gitenv()
-
-    // -N (`--intent-to-add`) records new paths without staging file contents.
-    const intent = await $`git add -N .`.cwd(Instance.directory).env(env).quiet().nothrow()
-    if (intent.exitCode !== 0) {
-      log.warn("git add -N failed", { exitCode: intent.exitCode, stderr: intent.stderr.toString() })
-      return intent
-    }
-
-    const stagedFiles = await listStagedFiles(env)
-    if (stagedFiles) {
-      const largeFiles = await findLargeFiles(stagedFiles)
-      await unstageAndExclude(env, largeFiles)
-    }
-
-    const addOutput = await $`git add .`.cwd(Instance.directory).env(env).quiet().nothrow()
-    if (addOutput.exitCode !== 0) {
-      log.warn("git add failed", { exitCode: addOutput.exitCode, stderr: addOutput.stderr.toString() })
-    }
-    return addOutput
-  }
-
-  async function listStagedFiles(env: Env) {
-    const output = await $`git ls-files -z --cached --others --exclude-standard`
-      .cwd(Instance.directory)
-      .env(env)
-      .quiet()
-      .nothrow()
-    if (output.exitCode !== 0) {
-      log.warn("git ls-files failed", { exitCode: output.exitCode, stderr: output.stderr.toString() })
-      return undefined
-    }
-    return output.stdout.toString().split("\0").filter(Boolean)
-  }
-
-  async function findLargeFiles(files: string[]) {
-    const checks = await Promise.all(
-      files.map(async (file) => {
-        const full = path.join(Instance.worktree, file)
-        // Keep symlinks by checking link size, not target size.
-        const stat = await fs.lstat(full).catch(() => null)
-        return { file, large: stat ? stat.size > sizeThreshold : false }
-      }),
-    )
-    return checks.filter((item) => item.large).map((item) => item.file)
-  }
-
-  async function unstageAndExclude(env: Env, files: string[]) {
-    if (files.length === 0) return
-    log.info("removing large files from snapshot", { files })
-    const signal = AbortSignal.timeout(3_000)
-    const proc = Bun.spawn(["git", "rm", "--cached", "--ignore-unmatch", "--", ...files], {
-      cwd: Instance.directory,
-      env,
-      signal,
-      stdout: "ignore",
-      stderr: "ignore",
-    })
-    const code = await proc.exited
-    if (code !== 0) {
-      log.warn("git rm --cached failed", { code, timeout: signal.aborted })
-    }
-
-    const exclude = path.join(gitdir(), "info", "exclude")
-    await fs.mkdir(path.dirname(exclude), { recursive: true })
-    const current = await fs.readFile(exclude, "utf8").catch(() => "")
-    const existing = new Set(current.split("\n").filter(Boolean))
-    const added = files.map(ignoreEscape).filter((file) => !existing.has(file))
-    if (added.length === 0) return
-    const base = current.length === 0 || current.endsWith("\n") ? current : `${current}\n`
-    await fs.writeFile(exclude, `${base}${added.join("\n")}\n`)
-  }
-
-  async function findOversizedObjects(env: Env): Promise<Oversized> {
-    const proc = Bun.spawn(
-      ["git", "cat-file", "--batch-all-objects", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
-      {
-        cwd: Instance.directory,
-        env,
-        stdout: "pipe",
-        stderr: "ignore",
-      },
-    )
-    let count = 0
-    const sample: string[] = []
-
-    const read = async (stream: ReadableStream<Uint8Array>, onLine: (line: string) => void) => {
-      const reader = stream.getReader()
-      const decoder = new TextDecoder()
-      let rest = ""
-      while (true) {
-        const chunk = await reader.read()
-        if (chunk.done) break
-        const lines = `${rest}${decoder.decode(chunk.value, { stream: true })}`.split("\n")
-        rest = lines.pop() ?? ""
-        lines.forEach(onLine)
-      }
-      rest = `${rest}${decoder.decode()}`
-      if (rest) onLine(rest)
-    }
-
-    await read(proc.stdout, (line) => {
-      if (!line) return
-      const [hash, type, raw] = line.trim().split(" ")
-      if (!hash || type !== "blob" || !raw) return
-      const size = Number.parseInt(raw, 10)
-      if (!Number.isFinite(size) || size <= sizeThreshold) return
-      count += 1
-      if (sample.length < 5) sample.push(`${hash}:${size}`)
-    })
-
-    const code = await proc.exited
-    if (code !== 0) {
-      log.warn("git cat-file failed", { exitCode: code })
-      return {
-        failed: true,
-        count: 0,
-        sample: [] as string[],
-      }
-    }
-
-    return {
-      failed: false,
-      count,
-      sample,
-    }
-  }
-
-  /**
-   * Escape gitignore metacharacters so file paths are matched literally.
-   * Replaces backslashes, glob chars (* ? [ ]), trailing spaces, and leading #/!.
-   */
-  function ignoreEscape(file: string) {
-    const escaped = file
-      .replaceAll("\\", "\\\\")
-      .replace(/([*?\[\]])/g, "\\$1")
-      .replace(/ +$/g, (spaces) => "\\ ".repeat(spaces.length))
-    if (escaped.startsWith("#") || escaped.startsWith("!")) return `\\${escaped}`
-    return escaped
   }
 
   export async function cleanup(input?: { findOversized?: (env: Env) => Promise<Oversized> }): Promise<Cleanup> {
@@ -256,29 +115,23 @@ export namespace Snapshot {
         sample: oversized.sample,
       }
     }
-    const proc = Bun.spawn(["git", "gc", `--prune=${prune}`], {
-      cwd: Instance.directory,
-      env,
-      stdout: "ignore",
-      stderr: "pipe",
-      // git gc --prune can run very slowly and use lots of memory when snapshot repos bloat with unfiltered large files.
-      timeout: 120_000,
+    const output = await spawn(["git", "gc", `--prune=${prune}`], env, {
+      // git gc --prune can run very slowly and use lots of memory
+      // when snapshot repos bloat with unfiltered large files.
+      timeout: 60_000,
     })
-    const stderrText = proc.stderr ? new Response(proc.stderr).text() : Promise.resolve("")
-    const exitCode = await proc.exited
-    const stderr = (await stderrText).trim()
-    if (exitCode !== 0) {
+    if (output.exitCode !== 0) {
       log.warn("cleanup failed", {
-        exitCode,
-        signalCode: proc.signalCode,
-        stderr,
+        exitCode: output.exitCode,
+        signalCode: output.signalCode,
+        stderr: output.stderr,
       })
       return {
         status: "failed",
         reason: "gc",
-        exitCode,
+        exitCode: output.exitCode,
         prune,
-        stderr,
+        stderr: output.stderr,
       }
     }
     log.info("cleanup", { prune })
@@ -303,7 +156,7 @@ export namespace Snapshot {
       await $`git config core.fsmonitor false`.env(env).quiet().nothrow()
       log.info("initialized")
     }
-    await gitAddFiltered()
+    await gitAddFiltered(git)
     const hash = await $`git write-tree`.env(env).quiet().cwd(Instance.directory).nothrow().text()
     log.info("tracking", { hash, cwd: Instance.directory, git })
     return hash.trim()
@@ -318,7 +171,7 @@ export namespace Snapshot {
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
     const env = gitenv(git)
-    await gitAddFiltered()
+    await gitAddFiltered(git)
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --name-only ${hash} -- .`
         .env(env)
@@ -403,7 +256,7 @@ export namespace Snapshot {
   export async function diff(hash: string) {
     const git = gitdir()
     const env = gitenv(git)
-    await gitAddFiltered()
+    await gitAddFiltered(git)
     const result =
       await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff ${hash} -- .`
         .env(env)
@@ -501,40 +354,199 @@ export namespace Snapshot {
     return path.join(Global.Path.data, "snapshot", project.id)
   }
 
-  async function add(git: string) {
-    await syncExclude(git)
-    await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} add .`
-      .quiet()
-      .cwd(Instance.directory)
-      .nothrow()
-  }
-
-  async function syncExclude(git: string) {
-    const file = await excludes()
-    const target = path.join(git, "info", "exclude")
-    await fs.mkdir(path.join(git, "info"), { recursive: true })
-    if (!file) {
-      await Bun.write(target, "")
-      return
+  function gitenv(git: string): Env {
+    return {
+      ...process.env,
+      GIT_DIR: git,
+      GIT_WORK_TREE: Instance.worktree,
     }
-    const text = await Bun.file(file)
-      .text()
-      .catch(() => "")
-    await Bun.write(target, text)
   }
 
-  async function excludes() {
-    const file = await $`git rev-parse --path-format=absolute --git-path info/exclude`
+  async function spawn(cmds: string[], env: Env, options?: Parameters<typeof Bun.spawn>[1]): Promise<Spawned> {
+    const proc = Bun.spawn(cmds, {
+      cwd: Instance.directory,
+      env,
+      stdout: "ignore",
+      stderr: "pipe",
+      ...options,
+    })
+
+    const stderr = proc.stderr instanceof ReadableStream ? new Response(proc.stderr).text() : Promise.resolve("")
+    const exitCode = await proc.exited
+
+    return {
+      exitCode,
+      stderr: (await stderr).trim(),
+      signalCode: proc.signalCode,
+    }
+  }
+
+  async function gitAddFiltered(git: string): Promise<string[]> {
+    const env = gitenv(git)
+
+    // -N (`--intent-to-add`) records new paths without staging file contents.
+    const intent = await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true add -N -- .`
+      .cwd(Instance.directory)
+      .env(env)
       .quiet()
-      .cwd(Instance.worktree)
       .nothrow()
-      .text()
-    if (!file.trim()) return
-    const exists = await fs
-      .stat(file.trim())
-      .then(() => true)
-      .catch(() => false)
-    if (!exists) return
-    return file.trim()
+    if (intent.exitCode !== 0) {
+      log.warn("git add -N failed", { exitCode: intent.exitCode, stderr: intent.stderr.toString() })
+      return []
+    }
+
+    const stagedFiles = await listStagedFiles(env).catch((err) => {
+      log.warn("failed to list staged files", { error: err })
+      return [] as string[]
+    })
+
+    if (stagedFiles.length === 0) {
+      log.info("no files to stage")
+      return []
+    }
+
+    const largeFiles = await findLargeFiles(stagedFiles)
+    await unstageAndExclude(env, largeFiles)
+
+    const filesWithoutLarge = stagedFiles.filter((file) => !largeFiles.includes(file))
+    const addOutput = await spawn(
+      [
+        "git",
+        "-c",
+        "core.autocrlf=false",
+        "-c",
+        "core.longpaths=true",
+        "-c",
+        "core.symlinks=true",
+        "add",
+        "--",
+        ...filesWithoutLarge,
+      ],
+      env,
+    )
+    if (addOutput.exitCode !== 0) {
+      log.warn("git add failed", { exitCode: addOutput.exitCode, stderr: addOutput.stderr })
+    }
+
+    return filesWithoutLarge
+  }
+
+  async function listStagedFiles(env: Env): Promise<string[]> {
+    const output =
+      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true diff --name-only -z --diff-filter=AMD -- .`
+        .cwd(Instance.directory)
+        .env(env)
+        .quiet()
+
+    return output.stdout.toString().split("\0").filter(Boolean)
+  }
+
+  async function findLargeFiles(files: string[]) {
+    const checks = await Promise.all(
+      files.map(async (file) => {
+        const full = path.join(Instance.worktree, file)
+        // Keep symlinks by checking link size, not target size.
+        const stat = await fs.lstat(full).catch(() => null)
+        return { file, large: stat ? stat.size > sizeThreshold : false }
+      }),
+    )
+    return checks.filter((item) => item.large).map((item) => item.file)
+  }
+
+  async function unstageAndExclude(env: Env, files: string[]) {
+    if (files.length === 0) return
+
+    async function execGitRmCached() {
+      const output = await spawn(
+        [
+          "git",
+          "-c",
+          "core.autocrlf=false",
+          "-c",
+          "core.longpaths=true",
+          "-c",
+          "core.symlinks=true",
+          "rm",
+          "--cached",
+          "--ignore-unmatch",
+          "--",
+          ...files,
+        ],
+        env,
+        {
+          stderr: "ignore",
+        },
+      )
+
+      if (output.exitCode !== 0) {
+        log.warn("git rm --cached failed", { code: output.exitCode })
+      }
+    }
+
+    async function updateGitExclude() {
+      const exclude = path.join(gitdir(), "info", "exclude")
+      await fs.mkdir(path.dirname(exclude), { recursive: true })
+      const current = await fs.readFile(exclude, "utf8").catch(() => "")
+      const existing = new Set(current.split(EOL).filter(Boolean))
+      const added = files.map(ignoreEscape).filter((file) => !existing.has(file))
+      if (added.length === 0) return
+      const base = current.length === 0 || current.endsWith(EOL) ? current : `${current}${EOL}`
+      await fs.writeFile(exclude, `${base}${added.join(EOL)}${EOL}`)
+    }
+
+    log.info("removing large files from snapshot", { files })
+    await Promise.all([execGitRmCached(), updateGitExclude()])
+  }
+
+  async function findOversizedObjects(env: Env): Promise<Oversized> {
+    const proc = Bun.spawn(
+      ["git", "cat-file", "-Z", "--batch-all-objects", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+      {
+        cwd: Instance.directory,
+        env,
+        stdout: "pipe",
+        stderr: "ignore",
+      },
+    )
+    let count = 0
+    const sample: string[] = []
+
+    for await (const line of readNull(proc.stdout)) {
+      const [hash, type, raw] = line.split(" ")
+      if (!hash || type !== "blob" || !raw) continue
+      const size = Number.parseInt(raw, 10)
+      if (!Number.isFinite(size) || size <= sizeThreshold) continue
+      count += 1
+      if (sample.length < 5) sample.push(`${hash}:${size}`)
+    }
+
+    const code = await proc.exited
+    if (code !== 0) {
+      log.warn("git cat-file failed", { exitCode: code })
+      return {
+        failed: true,
+        count: 0,
+        sample: [] as string[],
+      }
+    }
+
+    return {
+      failed: false,
+      count,
+      sample,
+    }
+  }
+
+  /**
+   * Escape gitignore metacharacters so file paths are matched literally.
+   * Replaces backslashes, glob chars (* ? [ ]), trailing spaces, and leading #/!.
+   */
+  function ignoreEscape(file: string) {
+    const escaped = file
+      .replaceAll("\\", "\\\\")
+      .replace(/([*?\[\]])/g, "\\$1")
+      .replace(/ +$/g, (spaces) => "\\ ".repeat(spaces.length))
+    if (escaped.startsWith("#") || escaped.startsWith("!")) return `\\${escaped}`
+    return escaped
   }
 }

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -15,6 +15,11 @@ export namespace Snapshot {
   const prune = "7.days"
   const sizeThreshold = 1 * 1024 * 1024 * 1024 // 1 GB
   type Env = Record<string, string | undefined>
+  type Oversized = {
+    failed: boolean
+    count: number
+    sample: string[]
+  }
 
   function gitenv(git = gitdir()): Env {
     return {
@@ -106,6 +111,48 @@ export namespace Snapshot {
     await fs.writeFile(exclude, `${base}${added.join("\n")}\n`)
   }
 
+  async function findOversizedObjects(env: Env): Promise<Oversized> {
+    const proc = Bun.spawn(
+      ["git", "cat-file", "--batch-all-objects", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+      {
+        cwd: Instance.directory,
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    )
+    const out = await Bun.readableStreamToText(proc.stdout)
+    const err = await Bun.readableStreamToText(proc.stderr)
+    const code = await proc.exited
+
+    if (code !== 0) {
+      log.warn("git cat-file failed", { exitCode: code, stderr: err })
+      return {
+        failed: true,
+        count: 0,
+        sample: [] as string[],
+      }
+    }
+
+    let count = 0
+    const sample: string[] = []
+    for (const line of out.split("\n")) {
+      if (!line) continue
+      const [hash, type, raw] = line.trim().split(" ")
+      if (!hash || type !== "blob" || !raw) continue
+      const size = Number.parseInt(raw, 10)
+      if (!Number.isFinite(size) || size <= sizeThreshold) continue
+      count += 1
+      if (sample.length < 5) sample.push(`${hash}:${size}`)
+    }
+
+    return {
+      failed: false,
+      count,
+      sample,
+    }
+  }
+
   /**
    * Escape gitignore metacharacters so file paths are matched literally.
    * Replaces backslashes, glob chars (* ? [ ]), trailing spaces, and leading #/!.
@@ -119,7 +166,7 @@ export namespace Snapshot {
     return escaped
   }
 
-  export async function cleanup() {
+  export async function cleanup(input?: { findOversized?: (env: Env) => Promise<Oversized> }) {
     if (Instance.project.vcs !== "git" || Flag.OPENCODE_CLIENT === "acp") return
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
@@ -130,6 +177,25 @@ export namespace Snapshot {
       .then(() => true)
       .catch(() => false)
     if (!exists) return
+    const oversized = await (input?.findOversized ?? findOversizedObjects)(env)
+    if (oversized.failed) return
+    if (oversized.count > 0) {
+      log.warn("cleanup reset snapshot due to oversized objects", {
+        count: oversized.count,
+        threshold: sizeThreshold,
+        sample: oversized.sample,
+      })
+      const removed = await fs
+        .rm(git, { recursive: true, force: true })
+        .then(() => true)
+        .catch((error) => {
+          log.warn("cleanup failed to reset snapshot", { error })
+          return false
+        })
+      if (!removed) return
+      log.info("cleanup reset snapshot")
+      return
+    }
     // git gc --prune can run very slowly and use lots of memory when snapshot repos bloat with unfiltered large files.
     const proc = Bun.spawn(["git", "gc", `--prune=${prune}`], {
       cwd: Instance.directory,

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -451,9 +451,11 @@ export namespace Snapshot {
     const checks = await Promise.all(
       files.map(async (file) => {
         const full = path.join(Instance.worktree, file)
-        // Keep symlinks by checking link size, not target size.
         const stat = await fs.lstat(full).catch(() => null)
-        return { file, large: stat ? stat.size > sizeThreshold : false }
+        return {
+          file,
+          large: stat ? !stat.isSymbolicLink() && stat.size > sizeThreshold : false,
+        }
       }),
     )
     return checks.filter((item) => item.large).map((item) => item.file)

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -23,7 +23,6 @@ export namespace Snapshot {
     ["core.fsmonitor", "false"],
     ["core.quotepath", "false"],
   ] as const
-  const ready = new Set<string>()
 
   type Env = Record<string, string | undefined>
   type Oversized = {
@@ -335,16 +334,6 @@ export namespace Snapshot {
 
   async function setup(git: string) {
     const env = gitenv(git)
-    const config = path.join(git, "config")
-
-    if (ready.has(git)) {
-      const exists = await fs
-        .stat(config)
-        .then(() => true)
-        .catch(() => false)
-      if (exists) return env
-      ready.delete(git)
-    }
 
     await fs.mkdir(git, { recursive: true })
     const init = await $`git init`.env(env).quiet().nothrow()
@@ -353,15 +342,14 @@ export namespace Snapshot {
       return env
     }
 
-    const output = await Promise.all(
-      settings.map(([key, value]) => $`git config ${key} ${value}`.env(env).quiet().nothrow()),
-    )
-    const failed = output.flatMap((item, index) => (item.exitCode === 0 ? [] : [settings[index]![0]]))
+    const failed: string[] = []
+    for (const [key, value] of settings) {
+      const output = await $`git config ${key} ${value}`.env(env).quiet().nothrow()
+      if (output.exitCode !== 0) failed.push(key)
+    }
     if (failed.length > 0) {
       log.warn("git config failed", { failed })
     }
-
-    ready.add(git)
     return env
   }
 

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -9,13 +9,21 @@ import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { Scheduler } from "../scheduler"
 import { EOL } from "os"
-import { readNull } from "../util/stream"
+import { readNullTerminated } from "../util/stream"
 
 export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const hour = 60 * 60 * 1000
   const prune = "7.days"
   const sizeThreshold = 1 * 1024 * 1024 * 1024 // 1 GB
+  const settings = [
+    ["core.autocrlf", "false"],
+    ["core.longpaths", "true"],
+    ["core.symlinks", "true"],
+    ["core.fsmonitor", "false"],
+    ["core.quotepath", "false"],
+  ] as const
+  const ready = new Set<string>()
 
   type Env = Record<string, string | undefined>
   type Oversized = {
@@ -56,16 +64,10 @@ export namespace Snapshot {
   }
 
   export async function cleanup(input?: { findOversized?: (env: Env) => Promise<Oversized> }): Promise<Cleanup> {
-    if (Instance.project.vcs !== "git") {
+    if (Instance.project.vcs !== "git" || Flag.OPENCODE_CLIENT === "acp") {
       return {
         status: "skipped",
-        reason: "vcs",
-      }
-    }
-    if (Flag.OPENCODE_CLIENT === "acp") {
-      return {
-        status: "skipped",
-        reason: "client",
+        reason: Instance.project.vcs !== "git" ? "vcs" : "client",
       }
     }
     const cfg = await Config.get()
@@ -149,17 +151,8 @@ export namespace Snapshot {
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
-    const env = gitenv(git)
-    if (await fs.mkdir(git, { recursive: true })) {
-      await $`git init`.env(env).quiet().nothrow()
-      // Configure git to not convert line endings on Windows
-      await $`git config core.autocrlf false`.env(env).quiet().nothrow()
-      await $`git config core.longpaths true`.env(env).quiet().nothrow()
-      await $`git config core.symlinks true`.env(env).quiet().nothrow()
-      await $`git config core.fsmonitor false`.env(env).quiet().nothrow()
-      log.info("initialized")
-    }
-    await gitAddFiltered(git)
+    const env = await setup(git)
+    await gitAddFiltered(git, env)
     const hash = await $`git write-tree`.env(env).quiet().cwd(Instance.directory).nothrow().text()
     log.info("tracking", { hash, cwd: Instance.directory, git })
     return hash.trim()
@@ -173,14 +166,13 @@ export namespace Snapshot {
 
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
-    const env = gitenv(git)
-    await gitAddFiltered(git)
-    const result =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --name-only ${hash} -- .`
-        .env(env)
-        .quiet()
-        .cwd(Instance.directory)
-        .nothrow()
+    const env = await setup(git)
+    await gitAddFiltered(git, env)
+    const result = await $`git diff --no-ext-diff --name-only ${hash} -- .`
+      .env(env)
+      .quiet()
+      .cwd(Instance.directory)
+      .nothrow()
 
     // If git diff fails, return empty patch
     if (result.exitCode !== 0) {
@@ -203,13 +195,12 @@ export namespace Snapshot {
   export async function restore(snapshot: string) {
     log.info("restore", { commit: snapshot })
     const git = gitdir()
-    const env = gitenv(git)
-    const result =
-      await $`git -c core.longpaths=true -c core.symlinks=true read-tree ${snapshot} && git -c core.longpaths=true -c core.symlinks=true checkout-index -a -f`
-        .env(env)
-        .quiet()
-        .cwd(Instance.worktree)
-        .nothrow()
+    const env = await setup(git)
+    const result = await $`git read-tree ${snapshot} && git checkout-index -a -f`
+      .env(env)
+      .quiet()
+      .cwd(Instance.worktree)
+      .nothrow()
 
     if (result.exitCode !== 0) {
       log.error("failed to restore snapshot", {
@@ -224,24 +215,19 @@ export namespace Snapshot {
   export async function revert(patches: Patch[]) {
     const files = new Set<string>()
     const git = gitdir()
-    const env = gitenv(git)
+    const env = await setup(git)
     for (const item of patches) {
       for (const file of item.files) {
         if (files.has(file)) continue
         log.info("reverting", { file, hash: item.hash })
-        const result = await $`git -c core.longpaths=true -c core.symlinks=true checkout ${item.hash} -- ${file}`
-          .env(env)
-          .quiet()
-          .cwd(Instance.worktree)
-          .nothrow()
+        const result = await $`git checkout ${item.hash} -- ${file}`.env(env).quiet().cwd(Instance.worktree).nothrow()
         if (result.exitCode !== 0) {
           const relativePath = path.relative(Instance.worktree, file)
-          const checkTree =
-            await $`git -c core.longpaths=true -c core.symlinks=true ls-tree ${item.hash} -- ${relativePath}`
-              .env(env)
-              .quiet()
-              .cwd(Instance.worktree)
-              .nothrow()
+          const checkTree = await $`git ls-tree ${item.hash} -- ${relativePath}`
+            .env(env)
+            .quiet()
+            .cwd(Instance.worktree)
+            .nothrow()
           if (checkTree.exitCode === 0 && checkTree.text().trim()) {
             log.info("file existed in snapshot but checkout failed, keeping", {
               file,
@@ -258,14 +244,9 @@ export namespace Snapshot {
 
   export async function diff(hash: string) {
     const git = gitdir()
-    const env = gitenv(git)
-    await gitAddFiltered(git)
-    const result =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff ${hash} -- .`
-        .env(env)
-        .quiet()
-        .cwd(Instance.worktree)
-        .nothrow()
+    const env = await setup(git)
+    await gitAddFiltered(git, env)
+    const result = await $`git diff --no-ext-diff ${hash} -- .`.env(env).quiet().cwd(Instance.worktree).nothrow()
 
     if (result.exitCode !== 0) {
       log.warn("failed to get diff", {
@@ -295,17 +276,16 @@ export namespace Snapshot {
   export type FileDiff = z.infer<typeof FileDiff>
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
     const git = gitdir()
-    const env = gitenv(git)
+    const env = await setup(git)
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 
-    const statuses =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --name-status --no-renames ${from} ${to} -- .`
-        .env(env)
-        .quiet()
-        .cwd(Instance.directory)
-        .nothrow()
-        .text()
+    const statuses = await $`git diff --no-ext-diff --name-status --no-renames ${from} ${to} -- .`
+      .env(env)
+      .quiet()
+      .cwd(Instance.directory)
+      .nothrow()
+      .text()
 
     for (const line of statuses.trim().split("\n")) {
       if (!line) continue
@@ -315,7 +295,7 @@ export namespace Snapshot {
       status.set(file, kind)
     }
 
-    for await (const line of $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
+    for await (const line of $`git diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
       .env(env)
       .quiet()
       .cwd(Instance.directory)
@@ -324,20 +304,8 @@ export namespace Snapshot {
       if (!line) continue
       const [additions, deletions, file] = line.split("\t")
       const isBinaryFile = additions === "-" && deletions === "-"
-      const before = isBinaryFile
-        ? ""
-        : await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true show ${from}:${file}`
-            .env(env)
-            .quiet()
-            .nothrow()
-            .text()
-      const after = isBinaryFile
-        ? ""
-        : await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true show ${to}:${file}`
-            .env(env)
-            .quiet()
-            .nothrow()
-            .text()
+      const before = isBinaryFile ? "" : await $`git show ${from}:${file}`.env(env).quiet().nothrow().text()
+      const after = isBinaryFile ? "" : await $`git show ${to}:${file}`.env(env).quiet().nothrow().text()
       const added = isBinaryFile ? 0 : parseInt(additions)
       const deleted = isBinaryFile ? 0 : parseInt(deletions)
       result.push({
@@ -363,6 +331,38 @@ export namespace Snapshot {
       GIT_DIR: git,
       GIT_WORK_TREE: Instance.worktree,
     }
+  }
+
+  async function setup(git: string) {
+    const env = gitenv(git)
+    const config = path.join(git, "config")
+
+    if (ready.has(git)) {
+      const exists = await fs
+        .stat(config)
+        .then(() => true)
+        .catch(() => false)
+      if (exists) return env
+      ready.delete(git)
+    }
+
+    await fs.mkdir(git, { recursive: true })
+    const init = await $`git init`.env(env).quiet().nothrow()
+    if (init.exitCode !== 0) {
+      log.warn("git init failed", { exitCode: init.exitCode, stderr: init.stderr.toString() })
+      return env
+    }
+
+    const output = await Promise.all(
+      settings.map(([key, value]) => $`git config ${key} ${value}`.env(env).quiet().nothrow()),
+    )
+    const failed = output.flatMap((item, index) => (item.exitCode === 0 ? [] : [settings[index]![0]]))
+    if (failed.length > 0) {
+      log.warn("git config failed", { failed })
+    }
+
+    ready.add(git)
+    return env
   }
 
   async function spawn(cmds: string[], env: Env, options?: SpawnOptions): Promise<Spawned> {
@@ -420,16 +420,11 @@ export namespace Snapshot {
     })
   }
 
-  async function gitAddFiltered(git: string): Promise<string[]> {
-    const env = gitenv(git)
+  async function gitAddFiltered(git: string, env: Env): Promise<string[]> {
     await syncExclude(git)
 
     // -N (`--intent-to-add`) records new paths without staging file contents.
-    const intent = await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true add -N -- .`
-      .cwd(Instance.directory)
-      .env(env)
-      .quiet()
-      .nothrow()
+    const intent = await $`git add -N -- .`.cwd(Instance.directory).env(env).quiet().nothrow()
     if (intent.exitCode !== 0) {
       log.warn("git add -N failed", { exitCode: intent.exitCode, stderr: intent.stderr.toString() })
       return []
@@ -446,15 +441,11 @@ export namespace Snapshot {
     }
 
     const largeFiles = await findLargeFiles(stagedFiles)
-    await unstageAndExclude(env, largeFiles)
+    await unstageAndExclude(git, env, largeFiles)
 
     const large = new Set(largeFiles)
     const filesWithoutLarge = stagedFiles.filter((file) => !large.has(file))
-    const addOutput = await spawnPathspec(
-      ["git", "-c", "core.autocrlf=false", "-c", "core.longpaths=true", "-c", "core.symlinks=true", "add"],
-      env,
-      filesWithoutLarge,
-    )
+    const addOutput = await spawnPathspec(["git", "add"], env, filesWithoutLarge)
     if (addOutput.exitCode !== 0) {
       log.warn("git add failed", { exitCode: addOutput.exitCode, stderr: addOutput.stderr })
     }
@@ -463,11 +454,7 @@ export namespace Snapshot {
   }
 
   async function listStagedFiles(env: Env): Promise<string[]> {
-    const output =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true diff --name-only -z --diff-filter=AMD -- .`
-        .cwd(Instance.directory)
-        .env(env)
-        .quiet()
+    const output = await $`git diff --name-only -z --diff-filter=AMD -- .`.cwd(Instance.directory).env(env).quiet()
 
     return output.stdout.toString().split("\0").filter(Boolean)
   }
@@ -484,40 +471,24 @@ export namespace Snapshot {
     return checks.filter((item) => item.large).map((item) => item.file)
   }
 
-  async function unstageAndExclude(env: Env, files: string[]) {
+  async function unstageAndExclude(git: string, env: Env, files: string[]) {
     if (files.length === 0) return
 
     async function execGitRmCached() {
-      const output = await spawnPathspec(
-        [
-          "git",
-          "-c",
-          "core.autocrlf=false",
-          "-c",
-          "core.longpaths=true",
-          "-c",
-          "core.symlinks=true",
-          "rm",
-          "--cached",
-          "--ignore-unmatch",
-        ],
-        env,
-        files,
-        {
-          stderr: "ignore",
-        },
-      )
+      const output = await spawnPathspec(["git", "rm", "--cached", "--ignore-unmatch"], env, files, {
+        stderr: "ignore",
+      })
 
       if (output.exitCode !== 0) {
         log.warn("git rm --cached failed", { code: output.exitCode })
       }
     }
 
-    async function updateGitExclude() {
-      const exclude = path.join(gitdir(), "info", "exclude")
+    async function updateLargeExclude() {
+      const exclude = path.join(git, "info", "exclude.large")
       await fs.mkdir(path.dirname(exclude), { recursive: true })
       const current = await fs.readFile(exclude, "utf8").catch(() => "")
-      const existing = new Set(current.split(EOL).filter(Boolean))
+      const existing = new Set(current.split(/\r?\n/).filter(Boolean))
       const added = files.map(ignoreEscape).filter((file) => !existing.has(file))
       if (added.length === 0) return
       const base = current.length === 0 || current.endsWith(EOL) ? current : `${current}${EOL}`
@@ -525,21 +496,24 @@ export namespace Snapshot {
     }
 
     log.info("removing large files from snapshot", { files })
-    await Promise.all([execGitRmCached(), updateGitExclude()])
+    await Promise.all([execGitRmCached(), updateLargeExclude()])
+    await syncExclude(git)
   }
 
   async function syncExclude(git: string) {
     const file = await excludes()
+    const custom = path.join(git, "info", "exclude.large")
     const target = path.join(git, "info", "exclude")
     await fs.mkdir(path.join(git, "info"), { recursive: true })
-    if (!file) {
-      await Bun.write(target, "")
-      return
-    }
-    const text = await Bun.file(file)
+
+    const text = await Bun.file(file ?? "")
       .text()
       .catch(() => "")
-    await Bun.write(target, text)
+    const large = await Bun.file(custom)
+      .text()
+      .catch(() => "")
+    const lines = [...new Set([...text.split(/\r?\n/).filter(Boolean), ...large.split(/\r?\n/).filter(Boolean)])]
+    await Bun.write(target, lines.length === 0 ? "" : `${lines.join(EOL)}${EOL}`)
   }
 
   async function excludes() {
@@ -570,7 +544,7 @@ export namespace Snapshot {
     let count = 0
     const sample: string[] = []
 
-    for await (const line of readNull(proc.stdout)) {
+    for await (const line of readNullTerminated(proc.stdout)) {
       const [hash, type, raw] = line.split(" ")
       if (!hash || type !== "blob" || !raw) continue
       const size = Number.parseInt(raw, 10)

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -20,6 +20,17 @@ export namespace Snapshot {
     count: number
     sample: string[]
   }
+  export type Cleanup = {
+    status: "gc" | "reset" | "skipped" | "failed"
+    reason?: "vcs" | "client" | "disabled" | "missing" | "reset" | "gc"
+    count?: number
+    threshold?: number
+    sample?: string[]
+    prune?: string
+    exitCode?: number
+    stderr?: string
+    error?: string
+  }
 
   function gitenv(git = gitdir()): Env {
     return {
@@ -33,7 +44,9 @@ export namespace Snapshot {
     Scheduler.register({
       id: "snapshot.cleanup",
       interval: hour,
-      run: cleanup,
+      run: async () => {
+        await cleanup()
+      },
       scope: "instance",
     })
   }
@@ -180,53 +193,99 @@ export namespace Snapshot {
     return escaped
   }
 
-  export async function cleanup(input?: { findOversized?: (env: Env) => Promise<Oversized> }) {
-    if (Instance.project.vcs !== "git" || Flag.OPENCODE_CLIENT === "acp") return
+  export async function cleanup(input?: { findOversized?: (env: Env) => Promise<Oversized> }): Promise<Cleanup> {
+    if (Instance.project.vcs !== "git") {
+      return {
+        status: "skipped",
+        reason: "vcs",
+      }
+    }
+    if (Flag.OPENCODE_CLIENT === "acp") {
+      return {
+        status: "skipped",
+        reason: "client",
+      }
+    }
     const cfg = await Config.get()
-    if (cfg.snapshot === false) return
+    if (cfg.snapshot === false) {
+      return {
+        status: "skipped",
+        reason: "disabled",
+      }
+    }
     const git = gitdir()
     const env = gitenv(git)
     const exists = await fs
       .stat(git)
       .then(() => true)
       .catch(() => false)
-    if (!exists) return
+    if (!exists) {
+      return {
+        status: "skipped",
+        reason: "missing",
+      }
+    }
     const oversized = await (input?.findOversized ?? findOversizedObjects)(env)
-    if (oversized.failed) return
-    if (oversized.count > 0) {
+    if (oversized.failed) {
+      log.warn("cleanup oversized scan failed, continuing with gc")
+    }
+    if (!oversized.failed && oversized.count > 0) {
       log.warn("cleanup reset snapshot due to oversized objects", {
         count: oversized.count,
         threshold: sizeThreshold,
         sample: oversized.sample,
       })
-      const removed = await fs
+      const resetError = await fs
         .rm(git, { recursive: true, force: true })
-        .then(() => true)
-        .catch((error) => {
-          log.warn("cleanup failed to reset snapshot", { error })
-          return false
-        })
-      if (!removed) return
+        .then(() => undefined)
+        .catch((error) => error)
+      if (resetError) {
+        const error = resetError instanceof Error ? resetError.message : String(resetError)
+        log.warn("cleanup failed to reset snapshot", { error })
+        return {
+          status: "failed",
+          reason: "reset",
+          error,
+        }
+      }
       log.info("cleanup reset snapshot")
-      return
+      return {
+        status: "reset",
+        count: oversized.count,
+        threshold: sizeThreshold,
+        sample: oversized.sample,
+      }
     }
-    // git gc --prune can run very slowly and use lots of memory when snapshot repos bloat with unfiltered large files.
     const proc = Bun.spawn(["git", "gc", `--prune=${prune}`], {
       cwd: Instance.directory,
       env,
       stdout: "ignore",
-      stderr: "ignore",
+      stderr: "pipe",
+      // git gc --prune can run very slowly and use lots of memory when snapshot repos bloat with unfiltered large files.
       timeout: 120_000,
     })
+    const stderrText = proc.stderr ? new Response(proc.stderr).text() : Promise.resolve("")
     const exitCode = await proc.exited
+    const stderr = (await stderrText).trim()
     if (exitCode !== 0) {
       log.warn("cleanup failed", {
         exitCode,
         signalCode: proc.signalCode,
+        stderr,
       })
-      return
+      return {
+        status: "failed",
+        reason: "gc",
+        exitCode,
+        prune,
+        stderr,
+      }
     }
     log.info("cleanup", { prune })
+    return {
+      status: "gc",
+      prune,
+    }
   }
 
   export async function track() {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -28,6 +28,9 @@ export namespace Snapshot {
     stderr: string
     signalCode: number | string | null
   }
+  type SpawnOptions = Omit<NonNullable<Parameters<typeof Bun.spawn>[1]>, "cwd" | "env"> & {
+    input?: string
+  }
 
   export type Cleanup = {
     status: "gc" | "reset" | "skipped" | "failed"
@@ -362,23 +365,59 @@ export namespace Snapshot {
     }
   }
 
-  async function spawn(cmds: string[], env: Env, options?: Parameters<typeof Bun.spawn>[1]): Promise<Spawned> {
-    const proc = Bun.spawn(cmds, {
-      cwd: Instance.directory,
-      env,
-      stdout: "ignore",
-      stderr: "pipe",
-      ...options,
-    })
+  async function spawn(cmds: string[], env: Env, options?: SpawnOptions): Promise<Spawned> {
+    const { input, ...opts } = options ?? {}
 
-    const stderr = proc.stderr instanceof ReadableStream ? new Response(proc.stderr).text() : Promise.resolve("")
-    const exitCode = await proc.exited
+    try {
+      const proc = Bun.spawn(cmds, {
+        cwd: Instance.directory,
+        env,
+        stdout: "ignore",
+        stderr: "pipe",
+        ...opts,
+        stdin: input === undefined ? opts.stdin : "pipe",
+      })
 
-    return {
-      exitCode,
-      stderr: (await stderr).trim(),
-      signalCode: proc.signalCode,
+      if (input !== undefined && proc.stdin && typeof proc.stdin !== "number") {
+        proc.stdin.write(input)
+        proc.stdin.end()
+      }
+
+      const stderr = proc.stderr instanceof ReadableStream ? new Response(proc.stderr).text() : Promise.resolve("")
+      const exitCode = await proc.exited
+
+      return {
+        exitCode,
+        stderr: (await stderr).trim(),
+        signalCode: proc.signalCode,
+      }
+    } catch (error) {
+      return {
+        exitCode: 1,
+        stderr: error instanceof Error ? error.message : String(error),
+        signalCode: null,
+      }
     }
+  }
+
+  async function spawnPathspec(
+    cmds: string[],
+    env: Env,
+    files: string[],
+    options?: Omit<SpawnOptions, "stdin" | "input">,
+  ): Promise<Spawned> {
+    if (files.length === 0) {
+      return {
+        exitCode: 0,
+        stderr: "",
+        signalCode: null,
+      }
+    }
+
+    return spawn([...cmds, "--pathspec-from-file=-", "--pathspec-file-nul"], env, {
+      ...options,
+      input: `${files.join("\0")}\0`,
+    })
   }
 
   async function gitAddFiltered(git: string): Promise<string[]> {
@@ -408,21 +447,12 @@ export namespace Snapshot {
     const largeFiles = await findLargeFiles(stagedFiles)
     await unstageAndExclude(env, largeFiles)
 
-    const filesWithoutLarge = stagedFiles.filter((file) => !largeFiles.includes(file))
-    const addOutput = await spawn(
-      [
-        "git",
-        "-c",
-        "core.autocrlf=false",
-        "-c",
-        "core.longpaths=true",
-        "-c",
-        "core.symlinks=true",
-        "add",
-        "--",
-        ...filesWithoutLarge,
-      ],
+    const large = new Set(largeFiles)
+    const filesWithoutLarge = stagedFiles.filter((file) => !large.has(file))
+    const addOutput = await spawnPathspec(
+      ["git", "-c", "core.autocrlf=false", "-c", "core.longpaths=true", "-c", "core.symlinks=true", "add"],
       env,
+      filesWithoutLarge,
     )
     if (addOutput.exitCode !== 0) {
       log.warn("git add failed", { exitCode: addOutput.exitCode, stderr: addOutput.stderr })
@@ -457,7 +487,7 @@ export namespace Snapshot {
     if (files.length === 0) return
 
     async function execGitRmCached() {
-      const output = await spawn(
+      const output = await spawnPathspec(
         [
           "git",
           "-c",
@@ -469,10 +499,9 @@ export namespace Snapshot {
           "rm",
           "--cached",
           "--ignore-unmatch",
-          "--",
-          ...files,
         ],
         env,
+        files,
         {
           stderr: "ignore",
         },

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -41,6 +41,7 @@ export namespace Snapshot {
   async function gitAddFiltered() {
     const env = gitenv()
 
+    // -N (`--intent-to-add`) records new paths without staging file contents.
     const intent = await $`git add -N .`.cwd(Instance.directory).env(env).quiet().nothrow()
     if (intent.exitCode !== 0) {
       log.warn("git add -N failed", { exitCode: intent.exitCode, stderr: intent.stderr.toString() })
@@ -118,32 +119,45 @@ export namespace Snapshot {
         cwd: Instance.directory,
         env,
         stdout: "pipe",
-        stderr: "pipe",
+        stderr: "ignore",
       },
     )
-    const out = await Bun.readableStreamToText(proc.stdout)
-    const err = await Bun.readableStreamToText(proc.stderr)
-    const code = await proc.exited
+    let count = 0
+    const sample: string[] = []
 
+    const read = async (stream: ReadableStream<Uint8Array>, onLine: (line: string) => void) => {
+      const reader = stream.getReader()
+      const decoder = new TextDecoder()
+      let rest = ""
+      while (true) {
+        const chunk = await reader.read()
+        if (chunk.done) break
+        const lines = `${rest}${decoder.decode(chunk.value, { stream: true })}`.split("\n")
+        rest = lines.pop() ?? ""
+        lines.forEach(onLine)
+      }
+      rest = `${rest}${decoder.decode()}`
+      if (rest) onLine(rest)
+    }
+
+    await read(proc.stdout, (line) => {
+      if (!line) return
+      const [hash, type, raw] = line.trim().split(" ")
+      if (!hash || type !== "blob" || !raw) return
+      const size = Number.parseInt(raw, 10)
+      if (!Number.isFinite(size) || size <= sizeThreshold) return
+      count += 1
+      if (sample.length < 5) sample.push(`${hash}:${size}`)
+    })
+
+    const code = await proc.exited
     if (code !== 0) {
-      log.warn("git cat-file failed", { exitCode: code, stderr: err })
+      log.warn("git cat-file failed", { exitCode: code })
       return {
         failed: true,
         count: 0,
         sample: [] as string[],
       }
-    }
-
-    let count = 0
-    const sample: string[] = []
-    for (const line of out.split("\n")) {
-      if (!line) continue
-      const [hash, type, raw] = line.trim().split(" ")
-      if (!hash || type !== "blob" || !raw) continue
-      const size = Number.parseInt(raw, 10)
-      if (!Number.isFinite(size) || size <= sizeThreshold) continue
-      count += 1
-      if (sample.length < 5) sample.push(`${hash}:${size}`)
     }
 
     return {

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -13,6 +13,16 @@ export namespace Snapshot {
   const log = Log.create({ service: "snapshot" })
   const hour = 60 * 60 * 1000
   const prune = "7.days"
+  const sizeThreshold = 1 * 1024 * 1024 * 1024 // 1 GB
+  type Env = Record<string, string | undefined>
+
+  function gitenv(git = gitdir()): Env {
+    return {
+      ...process.env,
+      GIT_DIR: git,
+      GIT_WORK_TREE: Instance.worktree,
+    }
+  }
 
   export function init() {
     Scheduler.register({
@@ -23,25 +33,116 @@ export namespace Snapshot {
     })
   }
 
+  async function gitAddFiltered() {
+    const env = gitenv()
+
+    const intent = await $`git add -N .`.cwd(Instance.directory).env(env).quiet().nothrow()
+    if (intent.exitCode !== 0) {
+      log.warn("git add -N failed", { exitCode: intent.exitCode, stderr: intent.stderr.toString() })
+      return intent
+    }
+
+    const stagedFiles = await listStagedFiles(env)
+    if (stagedFiles) {
+      const largeFiles = await findLargeFiles(stagedFiles)
+      await unstageAndExclude(env, largeFiles)
+    }
+
+    const addOutput = await $`git add .`.cwd(Instance.directory).env(env).quiet().nothrow()
+    if (addOutput.exitCode !== 0) {
+      log.warn("git add failed", { exitCode: addOutput.exitCode, stderr: addOutput.stderr.toString() })
+    }
+    return addOutput
+  }
+
+  async function listStagedFiles(env: Env) {
+    const output = await $`git ls-files -z --cached --others --exclude-standard`
+      .cwd(Instance.directory)
+      .env(env)
+      .quiet()
+      .nothrow()
+    if (output.exitCode !== 0) {
+      log.warn("git ls-files failed", { exitCode: output.exitCode, stderr: output.stderr.toString() })
+      return undefined
+    }
+    return output.stdout.toString().split("\0").filter(Boolean)
+  }
+
+  async function findLargeFiles(files: string[]) {
+    const checks = await Promise.all(
+      files.map(async (file) => {
+        const full = path.join(Instance.worktree, file)
+        // Keep symlinks by checking link size, not target size.
+        const stat = await fs.lstat(full).catch(() => null)
+        return { file, large: stat ? stat.size > sizeThreshold : false }
+      }),
+    )
+    return checks.filter((item) => item.large).map((item) => item.file)
+  }
+
+  async function unstageAndExclude(env: Env, files: string[]) {
+    if (files.length === 0) return
+    log.info("removing large files from snapshot", { files })
+    const signal = AbortSignal.timeout(3_000)
+    const proc = Bun.spawn(["git", "rm", "--cached", "--ignore-unmatch", "--", ...files], {
+      cwd: Instance.directory,
+      env,
+      signal,
+      stdout: "ignore",
+      stderr: "ignore",
+    })
+    const code = await proc.exited
+    if (code !== 0) {
+      log.warn("git rm --cached failed", { code, timeout: signal.aborted })
+    }
+
+    const exclude = path.join(gitdir(), "info", "exclude")
+    await fs.mkdir(path.dirname(exclude), { recursive: true })
+    const current = await fs.readFile(exclude, "utf8").catch(() => "")
+    const existing = new Set(current.split("\n").filter(Boolean))
+    const added = files.map(ignoreEscape).filter((file) => !existing.has(file))
+    if (added.length === 0) return
+    const base = current.length === 0 || current.endsWith("\n") ? current : `${current}\n`
+    await fs.writeFile(exclude, `${base}${added.join("\n")}\n`)
+  }
+
+  /**
+   * Escape gitignore metacharacters so file paths are matched literally.
+   * Replaces backslashes, glob chars (* ? [ ]), trailing spaces, and leading #/!.
+   */
+  function ignoreEscape(file: string) {
+    const escaped = file
+      .replaceAll("\\", "\\\\")
+      .replace(/([*?\[\]])/g, "\\$1")
+      .replace(/ +$/g, (spaces) => "\\ ".repeat(spaces.length))
+    if (escaped.startsWith("#") || escaped.startsWith("!")) return `\\${escaped}`
+    return escaped
+  }
+
   export async function cleanup() {
     if (Instance.project.vcs !== "git" || Flag.OPENCODE_CLIENT === "acp") return
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
+    const env = gitenv(git)
     const exists = await fs
       .stat(git)
       .then(() => true)
       .catch(() => false)
     if (!exists) return
-    const result = await $`git --git-dir ${git} --work-tree ${Instance.worktree} gc --prune=${prune}`
-      .quiet()
-      .cwd(Instance.directory)
-      .nothrow()
-    if (result.exitCode !== 0) {
+    // git gc --prune can run very slowly and use lots of memory when snapshot repos bloat with unfiltered large files.
+    const proc = Bun.spawn(["git", "gc", `--prune=${prune}`], {
+      cwd: Instance.directory,
+      env,
+      stdout: "ignore",
+      stderr: "ignore",
+      timeout: 120_000,
+    })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
       log.warn("cleanup failed", {
-        exitCode: result.exitCode,
-        stderr: result.stderr.toString(),
-        stdout: result.stdout.toString(),
+        exitCode,
+        signalCode: proc.signalCode,
       })
       return
     }
@@ -53,28 +154,18 @@ export namespace Snapshot {
     const cfg = await Config.get()
     if (cfg.snapshot === false) return
     const git = gitdir()
+    const env = gitenv(git)
     if (await fs.mkdir(git, { recursive: true })) {
-      await $`git init`
-        .env({
-          ...process.env,
-          GIT_DIR: git,
-          GIT_WORK_TREE: Instance.worktree,
-        })
-        .quiet()
-        .nothrow()
+      await $`git init`.env(env).quiet().nothrow()
       // Configure git to not convert line endings on Windows
-      await $`git --git-dir ${git} config core.autocrlf false`.quiet().nothrow()
-      await $`git --git-dir ${git} config core.longpaths true`.quiet().nothrow()
-      await $`git --git-dir ${git} config core.symlinks true`.quiet().nothrow()
-      await $`git --git-dir ${git} config core.fsmonitor false`.quiet().nothrow()
+      await $`git config core.autocrlf false`.env(env).quiet().nothrow()
+      await $`git config core.longpaths true`.env(env).quiet().nothrow()
+      await $`git config core.symlinks true`.env(env).quiet().nothrow()
+      await $`git config core.fsmonitor false`.env(env).quiet().nothrow()
       log.info("initialized")
     }
-    await add(git)
-    const hash = await $`git --git-dir ${git} --work-tree ${Instance.worktree} write-tree`
-      .quiet()
-      .cwd(Instance.directory)
-      .nothrow()
-      .text()
+    await gitAddFiltered()
+    const hash = await $`git write-tree`.env(env).quiet().cwd(Instance.directory).nothrow().text()
     log.info("tracking", { hash, cwd: Instance.directory, git })
     return hash.trim()
   }
@@ -87,9 +178,11 @@ export namespace Snapshot {
 
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
-    await add(git)
+    const env = gitenv(git)
+    await gitAddFiltered()
     const result =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
+      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --name-only ${hash} -- .`
+        .env(env)
         .quiet()
         .cwd(Instance.directory)
         .nothrow()
@@ -115,8 +208,10 @@ export namespace Snapshot {
   export async function restore(snapshot: string) {
     log.info("restore", { commit: snapshot })
     const git = gitdir()
+    const env = gitenv(git)
     const result =
-      await $`git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} read-tree ${snapshot} && git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} checkout-index -a -f`
+      await $`git -c core.longpaths=true -c core.symlinks=true read-tree ${snapshot} && git -c core.longpaths=true -c core.symlinks=true checkout-index -a -f`
+        .env(env)
         .quiet()
         .cwd(Instance.worktree)
         .nothrow()
@@ -134,19 +229,21 @@ export namespace Snapshot {
   export async function revert(patches: Patch[]) {
     const files = new Set<string>()
     const git = gitdir()
+    const env = gitenv(git)
     for (const item of patches) {
       for (const file of item.files) {
         if (files.has(file)) continue
         log.info("reverting", { file, hash: item.hash })
-        const result =
-          await $`git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} checkout ${item.hash} -- ${file}`
-            .quiet()
-            .cwd(Instance.worktree)
-            .nothrow()
+        const result = await $`git -c core.longpaths=true -c core.symlinks=true checkout ${item.hash} -- ${file}`
+          .env(env)
+          .quiet()
+          .cwd(Instance.worktree)
+          .nothrow()
         if (result.exitCode !== 0) {
           const relativePath = path.relative(Instance.worktree, file)
           const checkTree =
-            await $`git -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} ls-tree ${item.hash} -- ${relativePath}`
+            await $`git -c core.longpaths=true -c core.symlinks=true ls-tree ${item.hash} -- ${relativePath}`
+              .env(env)
               .quiet()
               .cwd(Instance.worktree)
               .nothrow()
@@ -166,9 +263,11 @@ export namespace Snapshot {
 
   export async function diff(hash: string) {
     const git = gitdir()
-    await add(git)
+    const env = gitenv(git)
+    await gitAddFiltered()
     const result =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- .`
+      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff ${hash} -- .`
+        .env(env)
         .quiet()
         .cwd(Instance.worktree)
         .nothrow()
@@ -201,11 +300,13 @@ export namespace Snapshot {
   export type FileDiff = z.infer<typeof FileDiff>
   export async function diffFull(from: string, to: string): Promise<FileDiff[]> {
     const git = gitdir()
+    const env = gitenv(git)
     const result: FileDiff[] = []
     const status = new Map<string, "added" | "deleted" | "modified">()
 
     const statuses =
-      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-status --no-renames ${from} ${to} -- .`
+      await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --name-status --no-renames ${from} ${to} -- .`
+        .env(env)
         .quiet()
         .cwd(Instance.directory)
         .nothrow()
@@ -219,7 +320,8 @@ export namespace Snapshot {
       status.set(file, kind)
     }
 
-    for await (const line of $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
+    for await (const line of $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true -c core.quotepath=false diff --no-ext-diff --no-renames --numstat ${from} ${to} -- .`
+      .env(env)
       .quiet()
       .cwd(Instance.directory)
       .nothrow()
@@ -229,13 +331,15 @@ export namespace Snapshot {
       const isBinaryFile = additions === "-" && deletions === "-"
       const before = isBinaryFile
         ? ""
-        : await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} show ${from}:${file}`
+        : await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true show ${from}:${file}`
+            .env(env)
             .quiet()
             .nothrow()
             .text()
       const after = isBinaryFile
         ? ""
-        : await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true --git-dir ${git} --work-tree ${Instance.worktree} show ${to}:${file}`
+        : await $`git -c core.autocrlf=false -c core.longpaths=true -c core.symlinks=true show ${to}:${file}`
+            .env(env)
             .quiet()
             .nothrow()
             .text()

--- a/packages/opencode/src/util/stream.ts
+++ b/packages/opencode/src/util/stream.ts
@@ -1,0 +1,22 @@
+export async function* readNull(stream: ReadableStream<Uint8Array>) {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  let rest = ""
+
+  while (true) {
+    const chunk = await reader.read()
+    if (chunk.done) break
+
+    const parts = `${rest}${decoder.decode(chunk.value, { stream: true })}`.split("\0")
+    rest = parts.pop() ?? ""
+
+    for (const part of parts) {
+      if (!part) continue
+      yield part
+    }
+  }
+
+  const tail = `${rest}${decoder.decode()}`
+  if (!tail) return
+  yield tail
+}

--- a/packages/opencode/src/util/stream.ts
+++ b/packages/opencode/src/util/stream.ts
@@ -1,4 +1,4 @@
-export async function* readNull(stream: ReadableStream<Uint8Array>) {
+export async function* readNullTerminated(stream: ReadableStream<Uint8Array>) {
   const reader = stream.getReader()
   const decoder = new TextDecoder()
   let rest = ""

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -220,8 +220,8 @@ test("patch ignores files larger than snapshot threshold", async () => {
       await Bun.write(small, "small")
 
       const patch = await Snapshot.patch(before!)
-      expect(patch.files).toContain(small)
-      expect(patch.files).not.toContain(big)
+      expect(patch.files).toContain(fwd(tmp.path, "small.txt"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "big.bin"))
       expect(await Bun.file(big).exists()).toBe(true)
     },
   })
@@ -244,9 +244,9 @@ test("patch ignores large files with spaces and leading dashes", async () => {
       await Bun.write(small, "small")
 
       const patch = await Snapshot.patch(before!)
-      expect(patch.files).toContain(small)
-      expect(patch.files).not.toContain(spaced)
-      expect(patch.files).not.toContain(dashed)
+      expect(patch.files).toContain(fwd(tmp.path, "small.txt"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "big file.bin"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "-big.bin"))
       expect(await Bun.file(spaced).exists()).toBe(true)
       expect(await Bun.file(dashed).exists()).toBe(true)
     },
@@ -272,10 +272,10 @@ test("patch ignores large files with gitignore metacharacters", async () => {
       await Bun.write(small, "small")
 
       const patch = await Snapshot.patch(before!)
-      expect(patch.files).toContain(small)
-      expect(patch.files).not.toContain(hashed)
-      expect(patch.files).not.toContain(negated)
-      expect(patch.files).not.toContain(bracket)
+      expect(patch.files).toContain(fwd(tmp.path, "small.txt"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "#big.bin"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "!big.bin"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "big[1].bin"))
       expect(await Bun.file(hashed).exists()).toBe(true)
       expect(await Bun.file(negated).exists()).toBe(true)
       expect(await Bun.file(bracket).exists()).toBe(true)
@@ -296,13 +296,13 @@ test("patch keeps symlink to large file", async () => {
       const small = `${tmp.path}/small.txt`
 
       await writeLarge(big)
-      await $`ln -s ${big} ${link}`.quiet()
+      await fs.symlink(big, link, "file")
       await Bun.write(small, "small")
 
       const patch = await Snapshot.patch(before!)
-      expect(patch.files).toContain(link)
-      expect(patch.files).toContain(small)
-      expect(patch.files).not.toContain(big)
+      expect(patch.files).toContain(fwd(tmp.path, "big-link.bin"))
+      expect(patch.files).toContain(fwd(tmp.path, "small.txt"))
+      expect(patch.files).not.toContain(fwd(tmp.path, "big.bin"))
       expect(await Bun.file(link).exists()).toBe(true)
     },
   })
@@ -415,8 +415,8 @@ test("patch handles large staged file sets without argv overflow", async () => {
 
       const patch = await Snapshot.patch(before!)
       expect(patch.files.length).toBe(files.length)
-      expect(patch.files).toContain(files[0]!)
-      expect(patch.files).toContain(files[files.length - 1]!)
+      expect(patch.files).toContain(files[0]!.replaceAll("\\", "/"))
+      expect(patch.files).toContain(files[files.length - 1]!.replaceAll("\\", "/"))
     },
   })
 })

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -394,8 +394,31 @@ test("cleanup keeps snapshot dir when no oversized objects are found", async () 
       const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
       expect(await exists(git)).toBe(true)
 
-      await Snapshot.cleanup()
+      const result = await Snapshot.cleanup()
+      expect(result.status).toBe("gc")
 
+      expect(await exists(git)).toBe(true)
+    },
+  })
+})
+
+test("cleanup continues with gc when oversized scan fails", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      expect(await Snapshot.track()).toBeTruthy()
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      expect(await exists(git)).toBe(true)
+
+      const result = await Snapshot.cleanup({
+        findOversized: async () => ({
+          failed: true,
+          count: 0,
+          sample: [],
+        }),
+      })
+      expect(result.status).toBe("gc")
       expect(await exists(git)).toBe(true)
     },
   })
@@ -410,13 +433,14 @@ test("cleanup resets snapshot dir when oversized objects are detected", async ()
       const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
       expect(await exists(git)).toBe(true)
 
-      await Snapshot.cleanup({
+      const result = await Snapshot.cleanup({
         findOversized: async () => ({
           failed: false,
           count: 1,
           sample: ["1111111111111111111111111111111111111111:1073741825"],
         }),
       })
+      expect(result.status).toBe("reset")
 
       expect(await exists(git)).toBe(false)
       expect(await Snapshot.track()).toBeTruthy()

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -31,6 +31,11 @@ async function bootstrap() {
   })
 }
 
+async function writeLarge(file: string) {
+  await Bun.write(file, "")
+  await fs.truncate(file, 1024 * 1024 * 1024 + 1)
+}
+
 test("tracks deleted files correctly", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({
@@ -188,6 +193,186 @@ test("large file handling", async () => {
       await Filesystem.write(`${tmp.path}/large.txt`, "x".repeat(1024 * 1024))
 
       expect((await Snapshot.patch(before!)).files).toContain(fwd(tmp.path, "large.txt"))
+    },
+  })
+})
+
+test("patch ignores files larger than snapshot threshold", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const big = `${tmp.path}/big.bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(big)
+      await Bun.write(small, "small")
+
+      const patch = await Snapshot.patch(before!)
+      expect(patch.files).toContain(small)
+      expect(patch.files).not.toContain(big)
+      expect(await Bun.file(big).exists()).toBe(true)
+    },
+  })
+})
+
+test("patch ignores large files with spaces and leading dashes", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const spaced = `${tmp.path}/big file.bin`
+      const dashed = `${tmp.path}/-big.bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(spaced)
+      await writeLarge(dashed)
+      await Bun.write(small, "small")
+
+      const patch = await Snapshot.patch(before!)
+      expect(patch.files).toContain(small)
+      expect(patch.files).not.toContain(spaced)
+      expect(patch.files).not.toContain(dashed)
+      expect(await Bun.file(spaced).exists()).toBe(true)
+      expect(await Bun.file(dashed).exists()).toBe(true)
+    },
+  })
+})
+
+test("patch ignores large files with gitignore metacharacters", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const hashed = `${tmp.path}/#big.bin`
+      const negated = `${tmp.path}/!big.bin`
+      const bracket = `${tmp.path}/big[1].bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(hashed)
+      await writeLarge(negated)
+      await writeLarge(bracket)
+      await Bun.write(small, "small")
+
+      const patch = await Snapshot.patch(before!)
+      expect(patch.files).toContain(small)
+      expect(patch.files).not.toContain(hashed)
+      expect(patch.files).not.toContain(negated)
+      expect(patch.files).not.toContain(bracket)
+      expect(await Bun.file(hashed).exists()).toBe(true)
+      expect(await Bun.file(negated).exists()).toBe(true)
+      expect(await Bun.file(bracket).exists()).toBe(true)
+    },
+  })
+})
+
+test("patch keeps symlink to large file", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const big = `${tmp.path}/big.bin`
+      const link = `${tmp.path}/big-link.bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(big)
+      await $`ln -s ${big} ${link}`.quiet()
+      await Bun.write(small, "small")
+
+      const patch = await Snapshot.patch(before!)
+      expect(patch.files).toContain(link)
+      expect(patch.files).toContain(small)
+      expect(patch.files).not.toContain(big)
+      expect(await Bun.file(link).exists()).toBe(true)
+    },
+  })
+})
+
+test("diff ignores files larger than snapshot threshold", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const big = `${tmp.path}/big.bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(big)
+      await Bun.write(small, "small")
+
+      const diff = await Snapshot.diff(before!)
+      expect(diff).toContain("small.txt")
+      expect(diff).not.toContain("big.bin")
+      expect(await Bun.file(big).exists()).toBe(true)
+    },
+  })
+})
+
+test("diff ignores large files with gitignore metacharacters", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const hashed = `${tmp.path}/#big.bin`
+      const negated = `${tmp.path}/!big.bin`
+      const bracket = `${tmp.path}/big[1].bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(hashed)
+      await writeLarge(negated)
+      await writeLarge(bracket)
+      await Bun.write(small, "small")
+
+      const diff = await Snapshot.diff(before!)
+      expect(diff).toContain("small.txt")
+      expect(diff).not.toContain("#big.bin")
+      expect(diff).not.toContain("!big.bin")
+      expect(diff).not.toContain("big[1].bin")
+      expect(await Bun.file(hashed).exists()).toBe(true)
+      expect(await Bun.file(negated).exists()).toBe(true)
+      expect(await Bun.file(bracket).exists()).toBe(true)
+    },
+  })
+})
+
+test("diffFull ignores files larger than snapshot threshold", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const big = `${tmp.path}/big.bin`
+      const small = `${tmp.path}/small.txt`
+
+      await writeLarge(big)
+      await Bun.write(small, "small")
+
+      const after = await Snapshot.track()
+      expect(after).toBeTruthy()
+
+      const diffs = await Snapshot.diffFull(before!, after!)
+      expect(diffs.length).toBe(1)
+      expect(diffs[0].file).toBe("small.txt")
+      expect(await Bun.file(big).exists()).toBe(true)
     },
   })
 })

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -3,6 +3,7 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import { Snapshot } from "../../src/snapshot"
+import { Global } from "../../src/global"
 import { Instance } from "../../src/project/instance"
 import { Filesystem } from "../../src/util/filesystem"
 import { tmpdir } from "../fixture/fixture"
@@ -34,6 +35,13 @@ async function bootstrap() {
 async function writeLarge(file: string) {
   await Bun.write(file, "")
   await fs.truncate(file, 1024 * 1024 * 1024 + 1)
+}
+
+async function exists(file: string) {
+  return fs
+    .stat(file)
+    .then(() => true)
+    .catch(() => false)
 }
 
 test("tracks deleted files correctly", async () => {
@@ -373,6 +381,46 @@ test("diffFull ignores files larger than snapshot threshold", async () => {
       expect(diffs.length).toBe(1)
       expect(diffs[0].file).toBe("small.txt")
       expect(await Bun.file(big).exists()).toBe(true)
+    },
+  })
+})
+
+test("cleanup keeps snapshot dir when no oversized objects are found", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      expect(await Snapshot.track()).toBeTruthy()
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      expect(await exists(git)).toBe(true)
+
+      await Snapshot.cleanup()
+
+      expect(await exists(git)).toBe(true)
+    },
+  })
+})
+
+test("cleanup resets snapshot dir when oversized objects are detected", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      expect(await Snapshot.track()).toBeTruthy()
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      expect(await exists(git)).toBe(true)
+
+      await Snapshot.cleanup({
+        findOversized: async () => ({
+          failed: false,
+          count: 1,
+          sample: ["1111111111111111111111111111111111111111:1073741825"],
+        }),
+      })
+
+      expect(await exists(git)).toBe(false)
+      expect(await Snapshot.track()).toBeTruthy()
+      expect(await exists(git)).toBe(true)
     },
   })
 })

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -385,6 +385,42 @@ test("diffFull ignores files larger than snapshot threshold", async () => {
   })
 })
 
+test("patch handles large staged file sets without argv overflow", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      // Regression test for Windows CI failure (ENAMETOOLONG in uv_spawn) when
+      // snapshot staging passed thousands of paths as argv to `git add`/`git rm`.
+      // Keep this large enough to stress command length and validate
+      // `--pathspec-from-file` handling.
+      const dir =
+        process.platform === "win32"
+          ? path.join(tmp.path, "bulk")
+          : path.join(tmp.path, "bulk", "x".repeat(96), "y".repeat(96), "z".repeat(96))
+      await fs.mkdir(dir, { recursive: true })
+
+      const count = process.platform === "win32" ? 800 : 6000
+      const files = Array.from({ length: count }, (_, i) =>
+        path.join(dir, `${i.toString().padStart(4, "0")}-${"n".repeat(64)}.txt`),
+      )
+
+      const step = 200
+      for (let i = 0; i < files.length; i += step) {
+        await Promise.all(files.slice(i, i + step).map((file) => Bun.write(file, "x")))
+      }
+
+      const patch = await Snapshot.patch(before!)
+      expect(patch.files.length).toBe(files.length)
+      expect(patch.files).toContain(files[0]!)
+      expect(patch.files).toContain(files[files.length - 1]!)
+    },
+  })
+})
+
 test("cleanup keeps snapshot dir when no oversized objects are found", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -869,6 +869,70 @@ test("git info exclude keeps global excludes", async () => {
   })
 })
 
+test("track configures snapshot git settings for existing snapshot repos", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      const env = {
+        ...process.env,
+        GIT_DIR: git,
+        GIT_WORK_TREE: tmp.path,
+      }
+
+      await fs.mkdir(git, { recursive: true })
+      await $`git init`.env(env).quiet()
+      await $`git config core.autocrlf true`.env(env).quiet()
+      await $`git config --unset-all core.longpaths`.env(env).quiet().nothrow()
+      await $`git config --unset-all core.symlinks`.env(env).quiet().nothrow()
+      await $`git config --unset-all core.fsmonitor`.env(env).quiet().nothrow()
+      await $`git config --unset-all core.quotepath`.env(env).quiet().nothrow()
+
+      expect(await Snapshot.track()).toBeTruthy()
+
+      const keys = ["core.autocrlf", "core.longpaths", "core.symlinks", "core.fsmonitor", "core.quotepath"]
+      const values = await Promise.all(keys.map((key) => $`git config --get ${key}`.env(env).quiet().text()))
+      expect(values.map((x) => x.trim())).toEqual(["false", "true", "true", "false", "false"])
+    },
+  })
+})
+
+test("git info exclude keeps large-file excludes after source exclude sync", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const git = path.join(Global.Path.data, "snapshot", Instance.project.id)
+      const source = `${tmp.path}/.git/info/exclude`
+      const target = path.join(git, "info", "exclude")
+      const big = `${tmp.path}/large.bin`
+
+      await writeLarge(big)
+      const first = await Snapshot.patch(before!)
+      expect(first.files).not.toContain(big)
+
+      const targetBefore = await Bun.file(target).text()
+      expect(targetBefore).toContain("large.bin")
+
+      await $`rm ${big}`.quiet()
+      const sourceText = await Bun.file(source).text()
+      await Bun.write(source, `${sourceText.trimEnd()}\nmanual.tmp\n`)
+      await Bun.write(`${tmp.path}/normal.txt`, "normal content")
+
+      const next = await Snapshot.patch(before!)
+      expect(next.files).toContain(fwd(tmp.path, "normal.txt"))
+
+      const targetAfter = await Bun.file(target).text()
+      expect(targetAfter).toContain("large.bin")
+      expect(targetAfter).toContain("manual.tmp")
+    },
+  })
+})
+
 test("concurrent file operations during patch", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({

--- a/packages/opencode/test/util/stream.test.ts
+++ b/packages/opencode/test/util/stream.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { readNull } from "../../src/util/stream"
+
+function stream(chunks: Uint8Array[]) {
+  let i = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const chunk = chunks[i]
+      if (!chunk) {
+        controller.close()
+        return
+      }
+      i += 1
+      controller.enqueue(chunk)
+    },
+  })
+}
+
+async function collect(input: AsyncIterable<string>) {
+  const result: string[] = []
+  for await (const item of input) {
+    result.push(item)
+  }
+  return result
+}
+
+describe("util.stream", () => {
+  test("readNull parses records across chunk boundaries", async () => {
+    const e = new TextEncoder()
+    const output = await collect(readNull(stream([e.encode("a\0b"), e.encode("c\0de"), e.encode("f\0")])))
+    expect(output).toEqual(["a", "bc", "def"])
+  })
+
+  test("readNull skips empty records and keeps trailing partial", async () => {
+    const e = new TextEncoder()
+    const output = await collect(readNull(stream([e.encode("\0a\0\0b\0c")])))
+    expect(output).toEqual(["a", "b", "c"])
+  })
+
+  test("readNull preserves multibyte utf-8 split across chunks", async () => {
+    const e = new TextEncoder()
+    const bytes = e.encode("x\0café\0")
+    const output = await collect(readNull(stream([bytes.slice(0, 6), bytes.slice(6, 8)])))
+    expect(output).toEqual(["x", "café"])
+  })
+})

--- a/packages/opencode/test/util/stream.test.ts
+++ b/packages/opencode/test/util/stream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { readNull } from "../../src/util/stream"
+import { readNullTerminated } from "../../src/util/stream"
 
 function stream(chunks: Uint8Array[]) {
   let i = 0
@@ -25,22 +25,22 @@ async function collect(input: AsyncIterable<string>) {
 }
 
 describe("util.stream", () => {
-  test("readNull parses records across chunk boundaries", async () => {
+  test("readNullTerminated parses records across chunk boundaries", async () => {
     const e = new TextEncoder()
-    const output = await collect(readNull(stream([e.encode("a\0b"), e.encode("c\0de"), e.encode("f\0")])))
+    const output = await collect(readNullTerminated(stream([e.encode("a\0b"), e.encode("c\0de"), e.encode("f\0")])))
     expect(output).toEqual(["a", "bc", "def"])
   })
 
-  test("readNull skips empty records and keeps trailing partial", async () => {
+  test("readNullTerminated skips empty records and keeps trailing partial", async () => {
     const e = new TextEncoder()
-    const output = await collect(readNull(stream([e.encode("\0a\0\0b\0c")])))
+    const output = await collect(readNullTerminated(stream([e.encode("\0a\0\0b\0c")])))
     expect(output).toEqual(["a", "b", "c"])
   })
 
-  test("readNull preserves multibyte utf-8 split across chunks", async () => {
+  test("readNullTerminated preserves multibyte utf-8 split across chunks", async () => {
     const e = new TextEncoder()
     const bytes = e.encode("x\0café\0")
-    const output = await collect(readNull(stream([bytes.slice(0, 6), bytes.slice(6, 8)])))
+    const output = await collect(readNullTerminated(stream([bytes.slice(0, 6), bytes.slice(6, 8)])))
     expect(output).toEqual(["x", "café"])
   })
 })


### PR DESCRIPTION
This PR prevents the `Snapshot.track()` flow from adding (untracked) big files into the snapshot system (git).

It changes the code to first do `git add -N .` which stage the files **without content**.
Next it iterates over the staged files to find any files larger then defined threshold (1 gig). unstages them AND adds them to $gitdir/info/exclude to prevent them from getting staged again.
Finally it calls `git add -- $stagedFiles` to stage the files content as well.

To handle existing bloated snapshot dirs, the cleanup method was updated to detect if any existing object blob is bigger then threshold -> nukes the whole snapshot dir.
Leaving the big files causes the `git gc --prune` process to blow up on memory and hog the system.

Additionally, this PR cleans up the Snapshot code a bit.

Don't be scared from the lines added, I've added tests too 😆

Fixes #6845 