### PR TITLE
fix(opencode): use args.cwd in acp command handler

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -6,6 +6,7 @@ import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import path from "path"
 
 const log = Log.create({ service: "acp-command" })
 
@@ -21,7 +22,15 @@ export const AcpCommand = cmd({
   },
   handler: async (args) => {
     process.env.OPENCODE_CLIENT = "acp"
-    await bootstrap(process.cwd(), async () => {
+    const baseCwd = process.env.PWD ?? process.cwd()
+    const cwd = path.resolve(baseCwd, args.cwd)
+    try {
+      process.chdir(cwd)
+    } catch {
+      log.error("Failed to change directory", { cwd })
+      process.exit(1)
+    }
+    await bootstrap(cwd, async () => {
       const opts = await resolveNetworkOptions(args)
       const server = Server.listen(opts)
 


### PR DESCRIPTION
### What does this PR do?

Fixes #12193 

The `--cwd` flag is currently being ignored in the `opencode acp` command, even though it is defined as one of the command's flags. The handler ignores it and uses `process.cwd()` instead, silently ignoring the flag and starting `opencode acp` in the working directory.

The fix consists on resolving the relative path, verifying that it exists, and passing it to the bootstrap.

I followed the pattern in the TUI thread and relative paths against PWD to preserve behavior when using --cwd flag with relative paths.


### How did you verify your code works?

I tested by running the `acp`command with the `--print-logs` and `--cwd` flags and verified in the logs that the server correctly started in the path passed as a parameter