### PR TITLE
fix(tui): add hover states to question tool tabs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { createMemo, For, Show } from "solid-js"
+import { createMemo, createSignal, For, Show } from "solid-js"
 import { useKeyboard } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
@@ -19,6 +19,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
   const tabs = createMemo(() => (single() ? 1 : questions().length + 1)) // questions + confirm tab (no confirm for single select)
+  const [tabHover, setTabHover] = createSignal<number | "confirm" | null>(null)
   const [store, setStore] = createStore({
     tab: 0,
     answers: [] as QuestionAnswer[],
@@ -269,7 +270,15 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                   <box
                     paddingLeft={1}
                     paddingRight={1}
-                    backgroundColor={isActive() ? theme.accent : theme.backgroundElement}
+                    backgroundColor={
+                      isActive()
+                        ? theme.accent
+                        : tabHover() === index()
+                          ? theme.backgroundElement
+                          : theme.backgroundPanel
+                    }
+                    onMouseOver={() => setTabHover(index())}
+                    onMouseOut={() => setTabHover(null)}
                     onMouseUp={() => selectTab(index())}
                   >
                     <text
@@ -290,7 +299,11 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
             <box
               paddingLeft={1}
               paddingRight={1}
-              backgroundColor={confirm() ? theme.accent : theme.backgroundElement}
+              backgroundColor={
+                confirm() ? theme.accent : tabHover() === "confirm" ? theme.backgroundElement : theme.backgroundPanel
+              }
+              onMouseOver={() => setTabHover("confirm")}
+              onMouseOut={() => setTabHover(null)}
               onMouseUp={() => selectTab(questions().length)}
             >
               <text fg={confirm() ? selectedForeground(theme, theme.accent) : theme.textMuted}>Confirm</text>


### PR DESCRIPTION
Adds mouse hover visual feedback to question tool tabs in the TUI, matching the existing pattern used for subagent navigation buttons.

### Problem
The question tool displays tabs for multiple questions and a "Confirm" button, but these tabs didn't have hover states like other interactive elements in the UI. This made it harder to see which tab was being clicked, unlike the subagent switching buttons which already had hover feedback.

### Changes
- Added tabHover signal to track which tab is being hovered
- Updated question tabs to show theme.backgroundElement on hover (darker) vs theme.backgroundPanel when not hovered (lighter)
- Active tabs keep their theme.accent color unchanged
- Same pattern applied to the Confirm tab

This follows the exact pattern used in header.tsx for the subagent navigation buttons (Parent, Prev, Next).

### How Verified
Tested by running bun dev and triggering the question tool. Hovering over non-active tabs now shows the same visual feedback as other interactive elements in the TUI.

## Screenshot with Highglight
<img width="921" height="323" alt="image" src="https://github.com/user-attachments/assets/fcbc77df-1893-4524-b498-854c9fdc9879" />


Fixes #12202