### PR TITLE
feat(highlight): add javascript and typescript parser for jsx and tsx…

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -4,6 +4,37 @@ export default {
   //       marked with for example `; inherits: ecma` at the top of the file. Just put the dependencies before the actual query.
   //       ALSO: Some queries use breaking changes in the nvim-treesitter repo, that are not compatible with the (web-)tree-sitter parser.
   parsers: [
+    // Use javascript wasm and jsx highlights to parse jsx
+    {
+      filetype: "jsx",
+      wasm: "https://github.com/tree-sitter/tree-sitter-javascript/releases/download/v0.25.0/tree-sitter-javascript.wasm",
+      queries: {
+        highlights: [
+          "https://raw.githubusercontent.com/tree-sitter/tree-sitter-javascript/refs/heads/master/queries/highlights-jsx.scm",
+          "https://raw.githubusercontent.com/tree-sitter/tree-sitter-javascript/refs/heads/master/queries/highlights.scm",
+          "https://raw.githubusercontent.com/tree-sitter/tree-sitter-javascript/refs/heads/master/queries/highlights-params.scm",
+        ],
+      },
+    },
+    // Use typescript tsx wasm and typescript highlights to parse tsx
+    {
+      filetype: "tsx",
+      wasm: "https://github.com/tree-sitter/tree-sitter-typescript/releases/download/v0.23.2/tree-sitter-tsx.wasm",
+      queries: {
+        highlights: [
+          // TODO: Weigh in whether to use opentui typescript highlights, or
+          // nvim-treesitter
+          // "https://raw.githubusercontent.com/anomalyco/opentui/refs/heads/main/packages/core/src/lib/tree-sitter/assets/typescript/highlights.scm",
+          "https://raw.githubusercontent.com/tree-sitter/tree-sitter-javascript/refs/heads/master/queries/highlights-jsx.scm",
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/main/runtime/queries/typescript/highlights.scm",
+          "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/main/runtime/queries/ecma/highlights.scm",
+          // NOTE: Adding these highlights seems to break the whole
+          // highlighting
+          // "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/main/runtime/queries/jsx/highlights.scm",
+          // "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/main/runtime/queries/tsx/highlights.scm",
+        ],
+      },
+    },
     {
       filetype: "python",
       wasm: "https://github.com/tree-sitter/tree-sitter-python/releases/download/v0.23.6/tree-sitter-python.wasm",


### PR DESCRIPTION
packages/opencode/parser-config.ts

Closes #12211 

### What does this PR do?

Adds syntax highlighting to `jsx` and `tsx` code blocks within markdown by adding JSX and TSX parsers to `parser-config.ts`.

### How did you verify your code works?
Ran `bun dev` with a session that outputs `jsx` and `tsx` code blocks.

Before:
<img width="1012" height="727" alt="image" src="https://github.com/user-attachments/assets/20100e81-92b0-488d-be45-baf8616a640c" />
<img width="1010" height="888" alt="image" src="https://github.com/user-attachments/assets/48389998-dcf8-4018-9b97-8af415a5ac7d" />

After:
<img width="1020" height="737" alt="image" src="https://github.com/user-attachments/assets/50f169d4-c795-4ac4-9d64-cc7c20f5aae0" />
<img width="1009" height="840" alt="image" src="https://github.com/user-attachments/assets/98e5c00b-8735-4fc7-9d76-8642176daa19" />

### Remarks
Remarks:
- tree-sitter-javascript.wasm seems to be able to handle jsx
- tree-sitter-typescript highlights seems incomplete
- Maybe it's better to map `tsx` and `jsx` to markdown's infoMapString within `@opentui/core`.
> `jsx` and `tsx` files seem to be highlighted when part of Write tool output, so this might be only an issue for markdown-injected jsx and tsx.
