### PR TITLE
fix(opencode): user plugins override built-in plugins for same provider

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -43,11 +43,13 @@ export namespace Plugin {
       hooks.push(init)
     }
 
-    const plugins = [...(config.plugin ?? [])]
-    if (plugins.length) await Config.waitForDependencies()
+    const userPlugins = config.plugin ?? []
+    if (userPlugins.length) await Config.waitForDependencies()
+    const plugins: string[] = []
     if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {
       plugins.push(...BUILTIN)
     }
+    plugins.push(...userPlugins)
 
     for (let plugin of plugins) {
       // ignore old codex plugin since it is supported first party now


### PR DESCRIPTION
Fixes #12223

BUILTIN plugins are appended after user plugins in `plugin/index.ts`. Since `ProviderAuth.state()` uses `fromEntries()` (last-write-wins), built-ins silently override user plugins targeting the same provider.

This swaps the order so BUILTIN loads first and user plugins load after, giving user plugins priority.