### PR TITLE
fix: wait for dependencies before loading custom tools and plugins

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -44,6 +44,7 @@ export namespace Plugin {
     }
 
     const plugins = [...(config.plugin ?? [])]
+    if (plugins.length) await Config.waitForDependencies()
     if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {
       plugins.push(...BUILTIN)
     }

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -73,4 +73,50 @@ describe("tool.registry", () => {
       },
     })
   })
+
+  test("loads tools with external dependencies without crashing", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const opencodeDir = path.join(dir, ".opencode")
+        await fs.mkdir(opencodeDir, { recursive: true })
+
+        const toolsDir = path.join(opencodeDir, "tools")
+        await fs.mkdir(toolsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(opencodeDir, "package.json"),
+          JSON.stringify({
+            name: "custom-tools",
+            dependencies: {
+              "@opencode-ai/plugin": "^0.0.0",
+              cowsay: "^1.6.0",
+            },
+          }),
+        )
+
+        await Bun.write(
+          path.join(toolsDir, "cowsay.ts"),
+          [
+            "import { say } from 'cowsay'",
+            "export default {",
+            "  description: 'tool that imports cowsay at top level',",
+            "  args: { text: { type: 'string' } },",
+            "  execute: async ({ text }: { text: string }) => {",
+            "    return say({ text })",
+            "  },",
+            "}",
+            "",
+          ].join("\n"),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const ids = await ToolRegistry.ids()
+        expect(ids).toContain("cowsay")
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes a race condition where custom tools with external dependencies in their package.json would crash on import because dependencies weren't installed yet.

## Problem

When a custom tool file had an import like:
```typescript
import { say } from 'cowsay'
```
at the top level, and the tool directory had a package.json with cowsay as a dependency, the tool would crash with "Cannot find package 'cowsay'" because dependencies weren't installed before the module was imported.

## Solution

1. **Config.state()** now collects dependency installation promises in a `deps` array using `iife()`
2. Added **Config.waitForDependencies()** to await all installations before proceeding
3. **ToolRegistry** calls `waitForDependencies()` before loading custom tools (if tools exist)
4. **Plugin.list()** calls `waitForDependencies()` before loading plugins (if plugins exist)

## Changes

- `packages/opencode/src/config/config.ts`: Track deps array and add wait function
- `packages/opencode/src/tool/registry.ts`: Wait for deps before loading tools
- `packages/opencode/src/plugin/index.ts`: Wait for deps before loading plugins  
- `packages/opencode/test/tool/registry.test.ts`: Added test verifying tools with external deps (cowsay) load successfully

## Testing

Added a test that creates a tool with cowsay as a dependency and imports it at the top level. The test verifies the tool loads without crashing.