### PR TITLE
fix: preserve session content when creating new session

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -15,10 +15,9 @@ import { Installation } from "@/installation"
 import { useKV } from "../context/kv"
 import { useCommandDialog } from "../component/dialog-command"
 
-// TODO: what is the best way to do this?
-let once = false
-
 export function Home() {
+  // TODO: what is the best way to do this?
+  let once = false
   const sync = useSync()
   const kv = useKV()
   const { theme } = useTheme()


### PR DESCRIPTION
## Issue

When clicking "New Session" from the command dialog (Ctrl+P), session content was only preserved once. After the first time, content would be lost on subsequent new sessions.

## Root Cause

The "once" variable was defined at module level outside the Home component. This meant it could only work once across the entire app lifecycle.

## Fix

Move the "once" variable inside the Home component function scope so it resets properly on each component mount. This ensures content is always preserved when opening a new session.


Fixes: [#12239](https://github.com/anomalyco/opencode/issues/12239)

## Changes

- Moved "let once = false" from module scope into Home() component function