### PR TITLE
fix(desktop): fix macOS orphaned process cleanup on startup

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -281,10 +281,23 @@ pub fn run() {
         )
         .expect("Failed to export typescript bindings");
 
+    // Kill any orphaned processes from previous runs on macOS
+    // This prevents memory accumulation from zombie processes
     #[cfg(all(target_os = "macos", not(debug_assertions)))]
-    let _ = std::process::Command::new("killall")
-        .arg("opencode-cli")
-        .output();
+    {
+        // Kill opencode server processes
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "OpenWork.app/Contents/MacOS/opencode"])
+            .output();
+        // Kill openwrk daemon processes
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "OpenWork.app/Contents/MacOS/openwrk"])
+            .output();
+        // Kill openwork-server processes
+        let _ = std::process::Command::new("pkill")
+            .args(["-f", "OpenWork.app/Contents/MacOS/openwork-server"])
+            .output();
+    }
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {


### PR DESCRIPTION
Fixes #12240

## Summary

Fix orphaned process cleanup on macOS that was causing white screen issues due to memory accumulation.

## Problem

The previous implementation used `killall opencode-cli` which doesn't match the actual process name (`opencode`). This caused:

- Orphaned processes accumulating across app restarts
- Memory leak (observed 5 opencode processes consuming 1.3GB RAM)
- WebView white screen when system memory pressure kills the render process

## Solution

- Use `pkill -f` to match processes by full path instead of process name
- Clean up all three process types: `opencode`, `openwrk`, `openwork-server`

## Changes

- `packages/desktop/src-tauri/src/lib.rs`: Replace `killall opencode-cli` with `pkill -f` commands for all OpenWork processes