### PR TITLE
tui: show discord link for bug reports in preview sessions

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -232,7 +232,7 @@ export function Session() {
       `  █▀▀█  ${UI.Style.TEXT_DIM}${title}${UI.Style.TEXT_NORMAL}`,
       `  █  █  ${UI.Style.TEXT_DIM}opencode -s ${session()?.id}${UI.Style.TEXT_NORMAL}`,
     ]
-    if (Installation.isPreview()) {
+    if (Installation.CHANNEL === "beta") {
       lines.push(
         `  ▀▀▀▀  ${UI.Style.TEXT_DIM}found a bug? report it on discord at https://opencode.ai/discord${UI.Style.TEXT_NORMAL}`,
       )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
+import { Installation } from "@/installation"
 
 addDefaultParsers(parsers.parsers)
 
@@ -226,14 +227,19 @@ export function Session() {
 
   createEffect(() => {
     const title = Locale.truncate(session()?.title ?? "", 50)
-    return exit.message.set(
-      [
-        ``,
-        `  █▀▀█  ${UI.Style.TEXT_DIM}${title}${UI.Style.TEXT_NORMAL}`,
-        `  █  █  ${UI.Style.TEXT_DIM}opencode -s ${session()?.id}${UI.Style.TEXT_NORMAL}`,
-        `  ▀▀▀▀  `,
-      ].join("\n"),
-    )
+    const lines = [
+      ``,
+      `  █▀▀█  ${UI.Style.TEXT_DIM}${title}${UI.Style.TEXT_NORMAL}`,
+      `  █  █  ${UI.Style.TEXT_DIM}opencode -s ${session()?.id}${UI.Style.TEXT_NORMAL}`,
+    ]
+    if (Installation.isPreview()) {
+      lines.push(
+        `  ▀▀▀▀  ${UI.Style.TEXT_DIM}found a bug? report it on discord at https://opencode.ai/discord${UI.Style.TEXT_NORMAL}`,
+      )
+    } else {
+      lines.push(`  ▀▀▀▀  `)
+    }
+    return exit.message.set(lines.join("\n"))
   })
 
   useKeyboard((evt) => {

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -53,6 +53,10 @@ export namespace Installation {
     return CHANNEL !== "latest"
   }
 
+  export function isBeta() {
+    return CHANNEL === "beta"
+  }
+
   export function isLocal() {
     return CHANNEL === "local"
   }

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -53,10 +53,6 @@ export namespace Installation {
     return CHANNEL !== "latest"
   }
 
-  export function isBeta() {
-    return CHANNEL === "beta"
-  }
-
   export function isLocal() {
     return CHANNEL === "local"
   }


### PR DESCRIPTION
## Summary
- Shows a Discord link for bug reports in the session exit summary when running preview/beta versions
- Helps beta testers easily find where to report issues they encounter