### PR TITLE
fix: correct Copilot GPT-5.2 token limits

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -624,9 +624,9 @@ export namespace Provider {
       // models.dev currently reports incorrect limits for these Copilot models, causing premature compaction.
       return {
         ...model.limit,
-        context: 400_000,
-        input: 272_000,
-        output: 128_000,
+        context: 400000,
+        input: 272000,
+        output: 128000,
       }
     })
     const m: Model = {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -617,6 +617,18 @@ export namespace Provider {
   export type Info = z.infer<typeof Info>
 
   function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
+    const limit = iife(() => {
+      if (!provider.id.startsWith("github-copilot")) return model.limit
+      if (model.id !== "gpt-5.2" && model.id !== "gpt-5.2-codex") return model.limit
+
+      // models.dev currently reports incorrect limits for these Copilot models, causing premature compaction.
+      return {
+        ...model.limit,
+        context: 400_000,
+        input: 272_000,
+        output: 128_000,
+      }
+    })
     const m: Model = {
       id: model.id,
       providerID: provider.id,
@@ -649,9 +661,9 @@ export namespace Provider {
           : undefined,
       },
       limit: {
-        context: model.limit.context,
-        input: model.limit.input,
-        output: model.limit.output,
+        context: limit.context,
+        input: limit.input,
+        output: limit.output,
       },
       capabilities: {
         temperature: model.temperature,

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -27,6 +27,7 @@ import { LspTool } from "./lsp"
 import { Truncate } from "./truncation"
 import { PlanExitTool, PlanEnterTool } from "./plan"
 import { ApplyPatchTool } from "./apply_patch"
+import { pathToFileURL } from "url"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -38,12 +39,49 @@ export namespace ToolRegistry {
     const matches = await Config.directories().then((dirs) =>
       dirs.flatMap((dir) => [...glob.scanSync({ cwd: dir, absolute: true, followSymlinks: true, dot: true })]),
     )
-    if (matches.length) await Config.waitForDependencies()
+
+    const load = (filepath: string, cacheKey?: string) => {
+      const url = pathToFileURL(filepath).href
+      return import(cacheKey ? `${url}?opencode=${cacheKey}` : url)
+    }
+
+    const invalid = (id: string, filepath: string, error: unknown): Tool.Info => {
+      const message = error instanceof Error ? error.message : String(error)
+      return Tool.define(id, {
+        description: `Custom tool failed to load: ${id}`,
+        parameters: z.unknown(),
+        execute: async () => ({
+          title: "Tool Load Error",
+          output: `Failed to load custom tool '${id}' from ${filepath}:\n\n${message}`,
+          metadata: {},
+        }),
+      })
+    }
+
     for (const match of matches) {
       const namespace = path.basename(match, path.extname(match))
-      const mod = await import(match)
-      for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
-        custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
+      const mod = await load(match).catch(async (error) => {
+        log.error("Failed to load custom tool module", { match, error })
+        await Config.installDependencies(path.dirname(path.dirname(match))).catch(() => {})
+        return load(match, Date.now().toString()).catch((e) => {
+          log.error("Failed to load custom tool module after installing deps", { match, error: e })
+          return undefined
+        })
+      })
+
+      if (!mod) {
+        custom.push(invalid(namespace, match, "Module failed to load"))
+        continue
+      }
+
+      for (const [id, def] of Object.entries(mod as Record<string, ToolDefinition>)) {
+        const toolID = id === "default" ? namespace : `${namespace}_${id}`
+        try {
+          custom.push(fromPlugin(toolID, def))
+        } catch (error) {
+          log.error("Failed to load custom tool definition", { match, id: toolID, error })
+          custom.push(invalid(toolID, match, error))
+        }
       }
     }
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -27,7 +27,6 @@ import { LspTool } from "./lsp"
 import { Truncate } from "./truncation"
 import { PlanExitTool, PlanEnterTool } from "./plan"
 import { ApplyPatchTool } from "./apply_patch"
-import { pathToFileURL } from "url"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -39,49 +38,12 @@ export namespace ToolRegistry {
     const matches = await Config.directories().then((dirs) =>
       dirs.flatMap((dir) => [...glob.scanSync({ cwd: dir, absolute: true, followSymlinks: true, dot: true })]),
     )
-
-    const load = (filepath: string, cacheKey?: string) => {
-      const url = pathToFileURL(filepath).href
-      return import(cacheKey ? `${url}?opencode=${cacheKey}` : url)
-    }
-
-    const invalid = (id: string, filepath: string, error: unknown): Tool.Info => {
-      const message = error instanceof Error ? error.message : String(error)
-      return Tool.define(id, {
-        description: `Custom tool failed to load: ${id}`,
-        parameters: z.unknown(),
-        execute: async () => ({
-          title: "Tool Load Error",
-          output: `Failed to load custom tool '${id}' from ${filepath}:\n\n${message}`,
-          metadata: {},
-        }),
-      })
-    }
-
+    if (matches.length) await Config.waitForDependencies()
     for (const match of matches) {
       const namespace = path.basename(match, path.extname(match))
-      const mod = await load(match).catch(async (error) => {
-        log.error("Failed to load custom tool module", { match, error })
-        await Config.installDependencies(path.dirname(path.dirname(match))).catch(() => {})
-        return load(match, Date.now().toString()).catch((e) => {
-          log.error("Failed to load custom tool module after installing deps", { match, error: e })
-          return undefined
-        })
-      })
-
-      if (!mod) {
-        custom.push(invalid(namespace, match, "Module failed to load"))
-        continue
-      }
-
-      for (const [id, def] of Object.entries(mod as Record<string, ToolDefinition>)) {
-        const toolID = id === "default" ? namespace : `${namespace}_${id}`
-        try {
-          custom.push(fromPlugin(toolID, def))
-        } catch (error) {
-          log.error("Failed to load custom tool definition", { match, id: toolID, error })
-          custom.push(invalid(toolID, match, error))
-        }
+      const mod = await import(match)
+      for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
+        custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
       }
     }
 

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2148,3 +2148,40 @@ test("custom model with variants enabled and disabled", async () => {
     },
   })
 })
+
+test("github-copilot gpt-5.2 and gpt-5.2-codex token limits are overridden", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+        }),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    init: async () => {
+      Env.set("GITHUB_TOKEN", "test-token")
+    },
+    fn: async () => {
+      const providers = await Provider.list()
+      const copilot = providers["github-copilot"]
+      expect(copilot).toBeDefined()
+
+      const gpt52 = copilot.models["gpt-5.2"]
+      expect(gpt52).toBeDefined()
+      expect(gpt52.limit.context).toBe(400_000)
+      expect(gpt52.limit.input).toBe(272_000)
+      expect(gpt52.limit.output).toBe(128_000)
+
+      const gpt52codex = copilot.models["gpt-5.2-codex"]
+      expect(gpt52codex).toBeDefined()
+      expect(gpt52codex.limit.context).toBe(400_000)
+      expect(gpt52codex.limit.input).toBe(272_000)
+      expect(gpt52codex.limit.output).toBe(128_000)
+    },
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2173,15 +2173,15 @@ test("github-copilot gpt-5.2 and gpt-5.2-codex token limits are overridden", asy
 
       const gpt52 = copilot.models["gpt-5.2"]
       expect(gpt52).toBeDefined()
-      expect(gpt52.limit.context).toBe(400_000)
-      expect(gpt52.limit.input).toBe(272_000)
-      expect(gpt52.limit.output).toBe(128_000)
+      expect(gpt52.limit.context).toBe(400000)
+      expect(gpt52.limit.input).toBe(272000)
+      expect(gpt52.limit.output).toBe(128000)
 
       const gpt52codex = copilot.models["gpt-5.2-codex"]
       expect(gpt52codex).toBeDefined()
-      expect(gpt52codex.limit.context).toBe(400_000)
-      expect(gpt52codex.limit.input).toBe(272_000)
-      expect(gpt52codex.limit.output).toBe(128_000)
+      expect(gpt52codex.limit.context).toBe(400000)
+      expect(gpt52codex.limit.input).toBe(272000)
+      expect(gpt52codex.limit.output).toBe(128000)
     },
   })
 })


### PR DESCRIPTION
### What does this PR do?

Fixes #11086

GitHub Copilot’s `gpt-5.2` / `gpt-5.2-codex` models are currently ingested from models.dev with incorrect `limit` values, which makes OpenCode think the context window is much smaller than it really is. Since OpenCode uses `model.limit.context` / `model.limit.output` for both the context meter and auto-compaction overflow checks, this shows an inflated % used and triggers  compaction far too early (e.g. ~90–100k tokens). (Refs #11086, duplicate #12247.)

This PR fixes that by overriding the token limits during models.dev -> `Provider.Model` conversion, but only for `providerID` starting with `github-copilot` and only for model IDs `gpt-5.2` and `gpt-5.2-codex`. The override sets:

- `context: 400000`
- `input: 272000`
- `output: 128000`

This works because every downstream consumer (UI usage, overflow/compaction thresholds, max output calculations) reads from `Provider.Model.limit`. Correcting the limits at ingestion time fixes behavior without changing session logic, and the scope is intentionally narrow to avoid impacting other Copilot models.

### How did you verify your code works?

- Added a regression test that asserts the override is applied for both `github-copilot/gpt-5.2` and `github-copilot/gpt-5.2-codex`.
- Ran `cd packages/opencode && bun test test/provider/provider.test.ts`.
