### PR TITLE
feat: add OPENCODE_RESPECT_LSP_DIAGNOSTICS flag to ensure LSP diagnostics are always processed

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -55,6 +55,7 @@ export namespace Flag {
   export const OPENCODE_EXPERIMENTAL_OXFMT = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_OXFMT")
   export const OPENCODE_EXPERIMENTAL_LSP_TY = truthy("OPENCODE_EXPERIMENTAL_LSP_TY")
   export const OPENCODE_EXPERIMENTAL_LSP_TOOL = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_LSP_TOOL")
+  export const OPENCODE_RESPECT_LSP_DIAGNOSTICS = level("OPENCODE_RESPECT_LSP_DIAGNOSTICS")
   export const OPENCODE_DISABLE_FILETIME_CHECK = truthy("OPENCODE_DISABLE_FILETIME_CHECK")
   export const OPENCODE_EXPERIMENTAL_PLAN_MODE = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_PLAN_MODE")
   export const OPENCODE_EXPERIMENTAL_MARKDOWN = !falsy("OPENCODE_EXPERIMENTAL_MARKDOWN")
@@ -66,6 +67,13 @@ export namespace Flag {
     if (!value) return undefined
     const parsed = Number(value)
     return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
+  }
+
+  function level(key: string) {
+    const value = process.env[key]
+    if (!value) return 0
+    const parsed = Number(value)
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : 0
   }
 }
 

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -12,8 +12,11 @@ import { NamedError } from "@opencode-ai/util/error"
 import { withTimeout } from "../util/timeout"
 import { Instance } from "../project/instance"
 import { Filesystem } from "../util/filesystem"
+import { Flag } from "../flag/flag"
 
-const DIAGNOSTICS_DEBOUNCE_MS = 150
+const SECS = Flag.OPENCODE_RESPECT_LSP_DIAGNOSTICS
+const RESPECT = SECS > 0
+const DIAGNOSTICS_DEBOUNCE_MS = RESPECT ? 0 : 150
 
 export namespace LSPClient {
   const log = Log.create({ service: "lsp.client" })
@@ -57,7 +60,7 @@ export namespace LSPClient {
       })
       const exists = diagnostics.has(filePath)
       diagnostics.set(filePath, params.diagnostics)
-      if (!exists && input.serverID === "typescript") return
+      if (!RESPECT && !exists && input.serverID === "typescript") return
       Bus.publish(Event.Diagnostics, { path: filePath, serverID: input.serverID })
     })
     connection.onRequest("window/workDoneProgress/create", (params) => {
@@ -213,6 +216,7 @@ export namespace LSPClient {
         log.info("waiting for diagnostics", { path: normalizedPath })
         let unsub: () => void
         let debounceTimer: ReturnType<typeof setTimeout> | undefined
+        const timeoutMs = RESPECT ? SECS * 1000 : 3000
         return await withTimeout(
           new Promise<void>((resolve) => {
             unsub = Bus.subscribe(Event.Diagnostics, (event) => {
@@ -227,7 +231,7 @@ export namespace LSPClient {
               }
             })
           }),
-          3000,
+          timeoutMs,
         )
           .catch(() => {})
           .finally(() => {


### PR DESCRIPTION
## Summary
- Add `OPENCODE_RESPECT_LSP_DIAGNOSTICS` handling for LSP diagnostic flow.
- Follow-up update: interpret the flag as a numeric timeout value in seconds.
- Default is `0` (existing behavior; no timeout override mode).
- Any value `> 0` enables the override mode and uses that value as the timeout in seconds.

## Behavior
- `OPENCODE_RESPECT_LSP_DIAGNOSTICS=0` (or unset): existing behavior.
  - 150ms diagnostics debounce
  - 3s diagnostics wait timeout
  - TypeScript first-diagnostic skip remains
- `OPENCODE_RESPECT_LSP_DIAGNOSTICS=<N>` where `N > 0`:
  - 0ms diagnostics debounce
  - diagnostics wait timeout becomes `N` seconds
  - TypeScript first-diagnostic skip disabled

## Usage
```bash
export OPENCODE_RESPECT_LSP_DIAGNOSTICS=10
opencode
```

## Issue Addressed
Fixes #12288.

This follow-up update was made to satisfy the issue comment requesting numeric timeout semantics (value = seconds), where `3` is only an example value.

## Testing
- `bun test test/lsp/client.test.ts` (from `packages/opencode`) passes.
