### PR TITLE
feat(acp): include subagents in available modes response

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -973,11 +973,12 @@ export namespace ACP {
         .then((resp) => resp.data!)
 
       return agents
-        .filter((agent) => agent.mode !== "subagent" && !agent.hidden)
+        .filter((agent) => !agent.hidden)
         .map((agent) => ({
           id: agent.name,
           name: agent.name,
           description: agent.description,
+          mode: agent.mode,
         }))
     }
 


### PR DESCRIPTION
## Summary
- Include subagents in ACP available modes response

Closes #11576

## Changes

Remove subagent filter from `loadAvailableModes` and add `mode` field to response, letting clients decide what to display.

```diff
- .filter((agent) => agent.mode !== "subagent" && !agent.hidden)
+ .filter((agent) => !agent.hidden)
  .map((agent) => ({
    id: agent.name,
    name: agent.name,
    description: agent.description,
+   mode: agent.mode,
  }))
```

## Backward Compatibility

Same data shape, just with more entries and an additional `mode` field. Existing clients can filter by `mode` if needed.