### PR TITLE
fix: ensure that github copilot plugin properly sets headers when used in other clients than tui

### DIFF
--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -301,17 +301,20 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         },
       ],
     },
-    "chat.headers": async (input, output) => {
-      if (!input.model.providerID.includes("github-copilot")) return
+    "chat.headers": async (incoming, output) => {
+      if (!incoming.model.providerID.includes("github-copilot")) return
 
-      if (input.model.api.npm === "@ai-sdk/anthropic") {
+      if (incoming.model.api.npm === "@ai-sdk/anthropic") {
         output.headers["anthropic-beta"] = "interleaved-thinking-2025-05-14"
       }
 
       const session = await sdk.session
         .get({
           path: {
-            id: input.sessionID,
+            id: incoming.sessionID,
+          },
+          query: {
+            directory: input.directory,
           },
           throwOnError: true,
         })


### PR DESCRIPTION
Without this change, subagent sessions for github copilot on desktop app for example, would count subagent requests against ur quota (due to that header stuff).

Issue: sdk failed to find session since the server does not run in the same working directory as the client when using the desktop app. (setting the directory param ensures that sdk will find the session linked to the session id in all clients)