### PR TITLE
feat(cli): make prompt elements clickable to open dialogs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,6 +32,8 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { DialogAgent } from "../dialog-agent"
+import { DialogModel } from "../dialog-model"
 
 export type PromptProps = {
   sessionID?: string
@@ -974,18 +976,18 @@ export function Prompt(props: PromptProps) {
               syntaxStyle={syntax()}
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
-              <text fg={highlight()}>
+              <text fg={highlight()} onMouseUp={() => { if (store.mode !== "shell") dialog.replace(() => <DialogAgent />) }}>
                 {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
               </text>
               <Show when={store.mode === "normal"}>
                 <box flexDirection="row" gap={1}>
-                  <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
+                  <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text} onMouseUp={() => dialog.replace(() => <DialogModel />)}>
                     {local.model.parsed().model}
                   </text>
-                  <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
+                  <text fg={theme.textMuted} onMouseUp={() => dialog.replace(() => <DialogProviderConnect />)}>{local.model.parsed().provider}</text>
                   <Show when={showVariant()}>
                     <text fg={theme.textMuted}>·</text>
-                    <text>
+                    <text onMouseUp={() => local.model.variant.cycle()}>
                       <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
                     </text>
                   </Show>


### PR DESCRIPTION
### What does this PR do?

This PR addresses the issue where the prompt elements (agent name, model, provider, and variant) in the TUI are displayed as static text, making it harder for users to change them without keyboard shortcuts. I added click handlers to these elements so users can click them to open selection dialogs or cycle options, improving usability for mouse users.

The changes were made in index.tsx:
- Imported the necessary dialog components (`DialogAgent`, `DialogModel`).
- Added `onMouseUp` handlers to the `<text>` elements for agent, model, provider, and variant.
- For agent: Opens the agent dialog (only in normal mode).
- For model: Opens the model dialog.
- For provider: Opens the provider connection dialog.
- For variant: Cycles through variants using the existing cycle method.

### How did you verify your code works?

I verified by running `bun dev` locally, starting the TUI, and clicking each element to ensure the dialogs open or variants cycle as expected. I also tested that keyboard shortcuts (like agent cycling) still work and that the UI doesn't break in shell mode. No errors appeared, and the changes don't affect other parts of the app.

closes #12315 

https://github.com/user-attachments/assets/c8ab38cb-b466-4d19-96ca-7168a2f90f68