### PR TITLE
feat: add Claude Opus 4.6 model support

### DIFF
--- a/packages/opencode/test/tool/fixtures/models-api.json
+++ b/packages/opencode/test/tool/fixtures/models-api.json
@@ -9378,6 +9378,28 @@
         "cost": { "input": 3, "output": 15 },
         "limit": { "context": 200000, "output": 8192 }
       },
+      "anthropic/claude-opus-4.6": {
+        "id": "anthropic/claude-opus-4.6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": { "input": 10, "output": 37.5, "cache_read": 1, "cache_write": 12.5 }
+        },
+        "limit": { "context": 200000, "output": 128000 }
+      },
       "anthropic/claude-opus-4.5": {
         "id": "anthropic/claude-opus-4.5",
         "name": "Claude Opus 4.5",
@@ -10814,6 +10836,28 @@
     "name": "Vertex (Anthropic)",
     "doc": "https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude",
     "models": {
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": { "input": 10, "output": 37.5, "cache_read": 1, "cache_write": 12.5 }
+        },
+        "limit": { "context": 200000, "output": 128000 }
+      },
       "claude-opus-4-5@20251101": {
         "id": "claude-opus-4-5@20251101",
         "name": "Claude Opus 4.5",
@@ -21115,6 +21159,29 @@
         "open_weights": true,
         "cost": { "input": 0, "output": 0 },
         "limit": { "context": 131072, "output": 131072 }
+      },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": { "input": 10, "output": 37.5, "cache_read": 1, "cache_write": 12.5 }
+        },
+        "limit": { "context": 200000, "output": 128000 },
+        "provider": { "npm": "@ai-sdk/anthropic" }
       },
       "claude-opus-4-5": {
         "id": "claude-opus-4-5",
@@ -32085,9 +32152,31 @@
         "cost": { "input": 0.8, "output": 4, "cache_read": 0.08, "cache_write": 1 },
         "limit": { "context": 200000, "output": 8192 }
       },
+      "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6 (latest)",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": { "input": 10, "output": 37.5, "cache_read": 1, "cache_write": 12.5 }
+        },
+        "limit": { "context": 200000, "output": 128000 }
+      },
       "claude-opus-4-5": {
         "id": "claude-opus-4-5",
-        "name": "Claude Opus 4.5 (latest)",
+        "name": "Claude Opus 4.5",
         "family": "claude-opus",
         "attachment": true,
         "reasoning": true,
@@ -35834,6 +35923,28 @@
         "open_weights": false,
         "cost": { "input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25 },
         "limit": { "context": 200000, "output": 64000 }
+      },
+      "anthropic.claude-opus-4-6-v1:0": {
+        "id": "anthropic.claude-opus-4-6-v1:0",
+        "name": "Claude Opus 4.6",
+        "family": "claude-opus",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "temperature": true,
+        "knowledge": "2025-05-31",
+        "release_date": "2026-02-05",
+        "last_updated": "2026-02-05",
+        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "open_weights": false,
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "context_over_200k": { "input": 10, "output": 37.5, "cache_read": 1, "cache_write": 12.5 }
+        },
+        "limit": { "context": 200000, "output": 128000 }
       },
       "cohere.command-light-text-v14": {
         "id": "cohere.command-light-text-v14",


### PR DESCRIPTION
## Summary

Adds Claude Opus 4.6 (`claude-opus-4-6`) model entries to the test fixture for all major providers, following the [Anthropic announcement](https://www.anthropic.com/news/claude-opus-4-6) on February 5, 2026.

- Adds model data to **anthropic**, **opencode/zen**, **google-vertex-anthropic**, **amazon-bedrock**, and **openrouter** providers in the `models-api.json` test fixture
- Includes long context pricing tier (`context_over_200k`) for the 1M token context window beta
- Model specs: 200K context (1M beta), 128K max output, $5/$25 per MTok, reasoning + tool use + vision

### Model entries added

| Provider | Model ID |
|----------|----------|
| anthropic | `claude-opus-4-6` |
| opencode (zen) | `claude-opus-4-6` |
| google-vertex-anthropic | `claude-opus-4-6` |
| amazon-bedrock | `anthropic.claude-opus-4-6-v1:0` |
| openrouter | `anthropic/claude-opus-4.6` |

No source code changes needed — the provider system is data-driven and handles new models generically through the existing transform/variant logic.

Closes #12323

## Test plan

- [ ] Verify `models-api.json` is valid JSON
- [ ] Existing provider tests continue to pass
- [ ] New model entries have correct pricing, limits, and capabilities matching [Anthropic docs](https://platform.claude.com/docs/en/about-claude/models/overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)