### PR TITLE
fix(cli): use spacebar for toggling multi-select items in Question Tool

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -237,9 +237,18 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
         moveTo((store.selected + 1) % total)
       }
 
-      if (evt.name === "return") {
+      if (evt.name === "space" && multi()) {
         evt.preventDefault()
         selectOption()
+      }
+
+      if (evt.name === "return") {
+        evt.preventDefault()
+        if (multi()) {
+          selectTab((store.tab + 1) % tabs())
+        } else {
+          selectOption()
+        }
       }
 
       if (evt.name === "escape" || keybind.match("app_exit", evt)) {
@@ -436,10 +445,15 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
               {"↑↓"} <span style={{ fg: theme.textMuted }}>select</span>
             </text>
           </Show>
+          <Show when={!confirm() && multi()}>
+            <text fg={theme.text}>
+              space <span style={{ fg: theme.textMuted }}>toggle</span>
+            </text>
+          </Show>
           <text fg={theme.text}>
             enter{" "}
             <span style={{ fg: theme.textMuted }}>
-              {confirm() ? "submit" : multi() ? "toggle" : single() ? "submit" : "confirm"}
+              {confirm() ? "submit" : multi() ? "next" : single() ? "submit" : "confirm"}
             </span>
           </text>
 


### PR DESCRIPTION
# fix(cli): use spacebar for toggling multi-select items in Question Tool

## Summary

- Resolves an inconsistency in the Question Tool's multi-select keyboard behavior where Enter was used to toggle checkbox items, deviating from the established pattern used across all other toggleable UI elements in the application
- Maps Spacebar to toggle checkbox items and Enter to advance to the next question/tab in multi-select mode, aligning with the command palette, MCP dialogs, and export options which all use Spacebar for toggling
- Updates the hint bar at the bottom of the Question Tool to accurately reflect the new keybindings (`space toggle`, `enter next`) for multi-select questions

## Motivation

The Question Tool is the primary interface through which agents ask users structured questions. In its multiple-choice mode, pressing Enter toggled checkbox items on and off. However, this was inconsistent with:

1. **Every other toggleable element in OpenCode** - The command palette, MCP tool authorization dialogs, and export options dialogs all use Spacebar to toggle items and Enter to confirm/submit.
2. **Standard browser behavior** - HTML checkboxes are toggled via Spacebar, not Enter. Enter is universally associated with form submission or advancing to the next step.
3. **User expectations** - Users familiar with terminal UIs (fzf, lazygit, etc.) expect Spacebar for selection/toggling in multi-select contexts.

This inconsistency caused confusion, particularly for users who switch between the Question Tool and other dialogs frequently.

## Changes

All changes are in `packages/opencode/src/cli/cmd/tui/routes/session/question.tsx`:

### Keyboard Handler Logic

**Before:**
- `Enter` in multi-select mode called `selectOption()` which triggered `toggle()` on the highlighted item
- No Spacebar handler existed

**After:**
- `Spacebar` in multi-select mode calls `selectOption()` which triggers `toggle()` on the highlighted item
- `Enter` in multi-select mode advances to the next tab/question via `selectTab((store.tab + 1) % tabs())`
- Single-select behavior is completely unchanged (Enter still picks and advances)
- Confirm tab behavior is completely unchanged (Enter still submits)

### Hint Bar

**Before:**
```
enter toggle    (shown in multi-select mode)
```

**After:**
```
space toggle    (shown only in multi-select mode)
enter next      (shown in multi-select mode)
```

The `space toggle` hint is conditionally rendered only when the user is on a multi-select question (not on the confirm tab), matching the pattern used in `dialog-export-options.tsx` which shows `Press space to toggle, return to confirm`.

## Behavioral Matrix

| Context | Spacebar | Enter |
|---------|----------|-------|
| Single-select question | No change | Picks option and submits |
| Multi-select question | **Toggles checkbox** (new) | **Advances to next question** (changed) |
| Multi-select custom "Other" | **Toggles custom answer** (new) | **Advances to next question** (changed) |
| Confirm tab | No change | Submits all answers |
| Editing custom text | No change (types space) | Confirms custom text input |

## Consistency Reference

This change aligns the Question Tool with the existing toggle pattern in the codebase:

```typescript
// dialog-export-options.tsx (existing pattern)
if (evt.name === "space") {
  if (store.active === "thinking") setStore("thinking", !store.thinking)
  // ...
}
// Hint: "Press space to toggle, return to confirm"
```

## Test Plan

- [ ] Open a session that triggers a multi-select question from an agent
- [ ] Verify Spacebar toggles checkbox items on/off
- [ ] Verify Enter advances to the next question tab (does not toggle)
- [ ] Verify the hint bar shows `space toggle` and `enter next` in multi-select mode
- [ ] Verify single-select questions still work with Enter to pick and advance
- [ ] Verify the Confirm tab still submits with Enter
- [ ] Verify Escape still dismisses the question prompt
- [ ] Verify number keys (1-9) still quick-select options
- [ ] Verify arrow keys and j/k still navigate options
- [ ] Verify Tab/Shift+Tab still cycle between question tabs
- [ ] Verify custom "Type your own answer" editing still works (Enter confirms text, Escape cancels)

closes #12296
