### PR TITLE
fix(tui): deduplicate models in selector dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-model.tsx
@@ -1,7 +1,7 @@
 import { createMemo, createSignal } from "solid-js"
 import { useLocal } from "@tui/context/local"
 import { useSync } from "@tui/context/sync"
-import { map, pipe, flatMap, entries, filter, sortBy, take } from "remeda"
+import { map, pipe, flatMap, entries, filter, sortBy, take, uniqueBy } from "remeda"
 import { DialogSelect, type DialogSelectRef } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 import { createDialogProviderOptions, DialogProvider } from "./dialog-provider"
@@ -169,6 +169,17 @@ export function DialogModel(props: { providerID?: string }) {
             (x) => x.title,
           ),
         ),
+      ),
+      // Dedupe: if both "Model X" and "Model X (latest)" exist, keep "(latest)" version
+      sortBy(
+        (x) => x.title.replace(" (latest)", ""),
+        (x) => !x.title.includes("(latest)"),
+      ),
+      uniqueBy((x) => `${x.category}/${x.title.replace(" (latest)", "")}`),
+      // Re-sort for display
+      sortBy(
+        (x) => x.footer !== "Free",
+        (x) => x.title,
       ),
     )
 


### PR DESCRIPTION
## Summary

Removes duplicate model entries in the model selector dialog.

Fixes #12331

## Changes

- Added `uniqueBy` to dedupe models by category + base title
- When both "Model X" and "Model X (latest)" exist, keeps the (latest) version

## Verification

Tested locally - duplicate entries (e.g. Claude Opus 4.6 appearing twice) no longer show.