### PR TITLE
feat: base path support (rebased from #7625)

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -2,6 +2,7 @@ import { Server } from "../../server/server"
 import { cmd } from "./cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
+import { normalizeBasePath } from "../../util/base-path"
 
 export const ServeCommand = cmd({
   command: "serve",
@@ -13,7 +14,9 @@ export const ServeCommand = cmd({
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
-    console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
+    const basePath = normalizeBasePath(opts.basePath)
+    const pathSuffix = basePath ? `${basePath}/` : ""
+    console.log(`opencode server listening on http://${server.hostname}:${server.port}${pathSuffix}`)
     await new Promise(() => {})
     await server.stop()
   },

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -116,10 +116,17 @@ export const rpc = {
       body,
     }
   },
-  async server(input: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
+  async server(input: { port: number; hostname: string; mdns?: boolean; cors?: string[]; basePath?: string }) {
     if (server) await server.stop(true)
-    server = Server.listen(input)
-    return { url: server.url.toString() }
+    try {
+      server = Server.listen(input)
+      return {
+        url: Server.url().toString(),
+      }
+    } catch (e) {
+      console.error(e)
+      throw e
+    }
   },
   async checkUpgrade(input: { directory: string }) {
     await Instance.provide({

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -5,6 +5,7 @@ import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "../../flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
+import { normalizeBasePath } from "../../util/base-path"
 
 function getNetworkIPs() {
   const nets = networkInterfaces()
@@ -38,13 +39,16 @@ export const WebCommand = cmd({
     }
     const opts = await resolveNetworkOptions(args)
     const server = Server.listen(opts)
+    const basePath = normalizeBasePath(opts.basePath)
+    const pathSuffix = basePath ? `${basePath}/` : ""
+
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()
 
     if (opts.hostname === "0.0.0.0") {
       // Show localhost for local access
-      const localhostUrl = `http://localhost:${server.port}`
+      const localhostUrl = `http://localhost:${server.port}${pathSuffix}`
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Local access:      ", UI.Style.TEXT_NORMAL, localhostUrl)
 
       // Show network IPs for remote access
@@ -54,7 +58,7 @@ export const WebCommand = cmd({
           UI.println(
             UI.Style.TEXT_INFO_BOLD + "  Network access:    ",
             UI.Style.TEXT_NORMAL,
-            `http://${ip}:${server.port}`,
+            `http://${ip}:${server.port}${pathSuffix}`,
           )
         }
       }
@@ -67,11 +71,18 @@ export const WebCommand = cmd({
         )
       }
 
+      if (basePath) {
+        UI.println(UI.Style.TEXT_INFO_BOLD + "  Base path:         ", UI.Style.TEXT_NORMAL, basePath)
+      }
+
       // Open localhost in browser
       open(localhostUrl.toString()).catch(() => {})
     } else {
-      const displayUrl = server.url.toString()
+      const displayUrl = Server.url().toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
+      if (basePath) {
+        UI.println(UI.Style.TEXT_INFO_BOLD + "  Base path:         ", UI.Style.TEXT_NORMAL, basePath)
+      }
       open(displayUrl).catch(() => {})
     }
 

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -12,6 +12,11 @@ const options = {
     describe: "hostname to listen on",
     default: "127.0.0.1",
   },
+  "base-path": {
+    type: "string" as const,
+    describe: "base path prefix for all routes (e.g., /my-prefix/)",
+    default: "/",
+  },
   mdns: {
     type: "boolean" as const,
     describe: "enable mDNS service discovery (defaults hostname to 0.0.0.0)",
@@ -35,6 +40,7 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const config = await Config.global()
   const portExplicitlySet = process.argv.includes("--port")
   const hostnameExplicitlySet = process.argv.includes("--hostname")
+  const basePathExplicitlySet = process.argv.includes("--base-path")
   const mdnsExplicitlySet = process.argv.includes("--mdns")
   const corsExplicitlySet = process.argv.includes("--cors")
 
@@ -49,5 +55,13 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 
-  return { hostname, port, mdns, cors }
+  // Resolve base path: CLI arg > env var > config > default
+  const envBasePath = process.env.OPENCODE_BASE_PATH
+  const basePath = basePathExplicitlySet
+    ? args["base-path"]
+    : envBasePath
+      ? envBasePath
+      : (config?.server?.basePath ?? args["base-path"])
+
+  return { hostname, port, mdns, cors, basePath }
 }

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -796,6 +796,10 @@ export namespace Config {
     .object({
       port: z.number().int().positive().optional().describe("Port to listen on"),
       hostname: z.string().optional().describe("Hostname to listen on"),
+      basePath: z
+        .string()
+        .optional()
+        .describe("Base path prefix for all routes (e.g., /my-prefix/)"),
       mdns: z.boolean().optional().describe("Enable mDNS service discovery"),
       cors: z.array(z.string()).optional().describe("Additional domains to allow for CORS"),
     })

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -8,6 +8,7 @@ import { Instance } from "../../project/instance"
 import { Installation } from "@/installation"
 import { Log } from "../../util/log"
 import { lazy } from "../../util/lazy"
+import { Server } from "../server"
 
 const log = Log.create({ service: "server" })
 
@@ -26,14 +27,14 @@ export const GlobalRoutes = lazy(() =>
             description: "Health information",
             content: {
               "application/json": {
-                schema: resolver(z.object({ healthy: z.literal(true), version: z.string() })),
+                schema: resolver(z.object({ healthy: z.literal(true), version: z.string(), basePath: z.string().optional() })),
               },
             },
           },
         },
       }),
       async (c) => {
-        return c.json({ healthy: true, version: Installation.VERSION })
+        return c.json({ healthy: true, version: Installation.VERSION, basePath: Server.basePath() || undefined })
       },
     )
     .get(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -48,10 +48,19 @@ export namespace Server {
   const log = Log.create({ service: "server" })
 
   let _url: URL | undefined
+  let _basePath: string = ""
   let _corsWhitelist: string[] = []
 
   export function url(): URL {
-    return _url ?? new URL("http://localhost:4096")
+    const base = _url ?? new URL("http://localhost:4096")
+    if (_basePath) {
+      return new URL(_basePath + "/", base)
+    }
+    return base
+  }
+
+  export function basePath(): string {
+    return _basePath
   }
 
   export const Event = {
@@ -534,13 +543,35 @@ export namespace Server {
     return result
   }
 
-  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
+  export function listen(opts: { port: number; hostname: string; mdns?: boolean; cors?: string[]; basePath?: string }) {
     _corsWhitelist = opts.cors ?? []
+
+    // Normalize basePath: ensure leading slash, remove trailing slash
+    const rawBasePath = opts.basePath ?? "/"
+    _basePath =
+      rawBasePath === "/"
+        ? ""
+        : (rawBasePath.startsWith("/") ? rawBasePath : `/${rawBasePath}`).replace(/\/+$/, "")
+
+    // Create wrapper app for base path routing
+    const baseApp = new Hono()
+    const mainApp = App()
+
+    if (_basePath) {
+      // Mount the main app under the base path
+      baseApp.route(_basePath, mainApp)
+
+      // Also mount at root level to support reverse proxies that strip the basePath
+      // before forwarding requests (e.g., some Kubernetes ingress configurations)
+      baseApp.route("/", mainApp)
+    }
+
+    const appToServe = _basePath ? baseApp : mainApp
 
     const args = {
       hostname: opts.hostname,
       idleTimeout: 0,
-      fetch: App().fetch,
+      fetch: appToServe.fetch,
       websocket: websocket,
     } as const
     const tryServe = (port: number) => {

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -1,6 +1,7 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import { Log } from "../util/log"
+import { rewriteHtmlForBasePath, rewriteJsForBasePath, rewriteCssForBasePath } from "../util/base-path"
 import { describeRoute, generateSpecs, validator, resolver, openAPIRouteHandler } from "hono-openapi"
 import { Hono } from "hono"
 import { cors } from "hono/cors"
@@ -57,6 +58,10 @@ export namespace Server {
       return new URL(_basePath + "/", base)
     }
     return base
+  }
+
+  export function basePath(): string {
+    return _basePath
   }
 
   export function basePath(): string {
@@ -512,7 +517,12 @@ export namespace Server {
           },
         )
         .all("/*", async (c) => {
-          const path = c.req.path
+          // Strip basePath from the request path before proxying
+          let path = c.req.path
+          if (_basePath && path.startsWith(_basePath)) {
+            path = path.slice(_basePath.length) || "/"
+          }
+
           const response = await proxy(`https://app.opencode.ai${path}`, {
             ...c.req,
             headers: {
@@ -520,10 +530,45 @@ export namespace Server {
               host: "app.opencode.ai",
             },
           })
-          response.headers.set(
-            "Content-Security-Policy",
-            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'",
-          )
+
+          // Rewrite content for basePath support
+          const contentType = response.headers.get("content-type") || ""
+
+          if (_basePath && contentType.includes("text/html")) {
+            const html = rewriteHtmlForBasePath(await response.text(), _basePath)
+            return new Response(html, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
+          }
+
+          if (_basePath && (contentType.includes("javascript") || path.endsWith(".js"))) {
+            const js = rewriteJsForBasePath(await response.text(), _basePath)
+            return new Response(js, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
+          }
+
+          if (_basePath && (contentType.includes("text/css") || path.endsWith(".css"))) {
+            const css = rewriteCssForBasePath(await response.text(), _basePath)
+            return new Response(css, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
+          }
+
+          // Set CSP header only when not rewriting content (no basePath)
+          // When basePath is set, we inject inline scripts which would violate CSP
+          if (!_basePath) {
+            response.headers.set(
+              "Content-Security-Policy",
+              "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'",
+            )
+          }
           return response
         }) as unknown as Hono,
   )

--- a/packages/opencode/src/util/base-path.ts
+++ b/packages/opencode/src/util/base-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Normalizes a base path to ensure consistent format:
+ * - Returns empty string for root path or undefined
+ * - Ensures leading slash
+ * - Removes trailing slashes
+ */
+export function normalizeBasePath(path?: string): string {
+  if (!path || path === "/") return ""
+
+  // Ensure leading slash, remove trailing slashes
+  let normalized = path.startsWith("/") ? path : `/${path}`
+  normalized = normalized.replace(/\/+$/, "")
+
+  return normalized
+}
+
+/**
+ * Joins a base path with additional path segments.
+ * Handles normalization of the base path and proper joining of segments.
+ */
+export function joinPath(basePath: string, ...segments: string[]): string {
+  const base = normalizeBasePath(basePath)
+  const path = segments.join("/").replace(/\/+/g, "/")
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`
+}

--- a/packages/opencode/src/util/base-path.ts
+++ b/packages/opencode/src/util/base-path.ts
@@ -23,3 +23,96 @@ export function joinPath(basePath: string, ...segments: string[]): string {
   const path = segments.join("/").replace(/\/+/g, "/")
   return `${base}${path.startsWith("/") ? path : `/${path}`}`
 }
+
+/**
+ * Generates the JavaScript snippet that wraps history.pushState/replaceState
+ * to automatically prepend the basePath to URLs.
+ */
+export function generateBasePathScript(basePath: string): string {
+  return `<script>
+window.__OPENCODE_BASE_PATH__="${basePath}";
+(function() {
+  var basePath = window.__OPENCODE_BASE_PATH__ || "";
+  if (!basePath) return;
+
+  var origPushState = history.pushState.bind(history);
+  var origReplaceState = history.replaceState.bind(history);
+
+  function addBasePathIfNeeded(url) {
+    if (!url || typeof url !== "string") return url;
+    if (url.startsWith("/") && !url.startsWith(basePath)) {
+      return basePath + url;
+    }
+    return url;
+  }
+
+  history.pushState = function(state, title, url) {
+    return origPushState(state, title, addBasePathIfNeeded(url));
+  };
+
+  history.replaceState = function(state, title, url) {
+    return origReplaceState(state, title, addBasePathIfNeeded(url));
+  };
+})();
+</script>`
+}
+
+/**
+ * Rewrites HTML content to include basePath in asset references.
+ * - Rewrites href="/...", src="/...", content="/..." to include basePath
+ * - Injects the basePath script before </head>
+ * - Does NOT rewrite protocol-relative URLs (//...)
+ */
+export function rewriteHtmlForBasePath(html: string, basePath: string): string {
+  if (!basePath) return html
+
+  // Rewrite absolute paths in HTML to include basePath
+  // Matches href="/...", src="/...", content="/..." but not href="//..." (protocol-relative)
+  let result = html.replace(/(href|src|content)="\/(?!\/)/g, `$1="${basePath}/`)
+
+  // Inject basePath script before </head>
+  result = result.replace("</head>", `${generateBasePathScript(basePath)}</head>`)
+
+  return result
+}
+
+/**
+ * Rewrites JavaScript content to work with basePath.
+ * - Patches window.location.origin references to include basePath
+ * - Patches Vite's base path function for dynamic asset loading
+ *
+ * Note: The Vite patch is fragile and depends on minified output format.
+ */
+export function rewriteJsForBasePath(js: string, basePath: string): string {
+  if (!basePath) return js
+
+  let result = js
+
+  // Replace the pattern where the app determines the server URL
+  // In minified code it can appear as either:
+  //   :window.location.origin)  (inside function call)
+  //   :window.location.origin;  (end of ternary expression)
+  result = result.replace(
+    /:window\.location\.origin([;)])/g,
+    `:window.location.origin+(window.__OPENCODE_BASE_PATH__||"")$1`,
+  )
+
+  // Patch Vite's base path function to use our basePath instead of "/"
+  // The function looks like: function(t){return"/"+t}
+  // This handles all dynamic asset loading
+  result = result.replace(/function\(t\)\{return"\/"\+t\}/g, `function(t){return"${basePath}/"+t}`)
+
+  return result
+}
+
+/**
+ * Rewrites CSS content to include basePath in url() references.
+ * - Rewrites url(/...) to url(/basePath/...)
+ * - Does NOT rewrite protocol-relative URLs (//...)
+ */
+export function rewriteCssForBasePath(css: string, basePath: string): string {
+  if (!basePath) return css
+
+  // Rewrite url(/assets/...) to url(/basePath/assets/...)
+  return css.replace(/url\(\/(?!\/)/g, `url(${basePath}/`)
+}

--- a/packages/opencode/test/util/base-path.test.ts
+++ b/packages/opencode/test/util/base-path.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeBasePath, joinPath } from "../../src/util/base-path"
+
+describe("util.base-path", () => {
+  describe("normalizeBasePath", () => {
+    test("returns empty string for root", () => {
+      expect(normalizeBasePath("/")).toBe("")
+      expect(normalizeBasePath(undefined)).toBe("")
+    })
+
+    test("returns empty string for empty string", () => {
+      expect(normalizeBasePath("")).toBe("")
+    })
+
+    test("normalizes paths with leading slash", () => {
+      expect(normalizeBasePath("/prefix")).toBe("/prefix")
+      expect(normalizeBasePath("/notebook/namespace/name")).toBe("/notebook/namespace/name")
+    })
+
+    test("removes trailing slash", () => {
+      expect(normalizeBasePath("/prefix/")).toBe("/prefix")
+      expect(normalizeBasePath("/notebook/namespace/name/")).toBe("/notebook/namespace/name")
+    })
+
+    test("adds leading slash if missing", () => {
+      expect(normalizeBasePath("prefix")).toBe("/prefix")
+      expect(normalizeBasePath("notebook/namespace/name")).toBe("/notebook/namespace/name")
+    })
+
+    test("handles path without leading slash and with trailing slash", () => {
+      expect(normalizeBasePath("prefix/")).toBe("/prefix")
+      expect(normalizeBasePath("notebook/namespace/name/")).toBe("/notebook/namespace/name")
+    })
+
+    test("handles multiple trailing slashes", () => {
+      expect(normalizeBasePath("/prefix///")).toBe("/prefix")
+    })
+  })
+
+  describe("joinPath", () => {
+    test("joins base path with segments", () => {
+      expect(joinPath("/prefix", "api", "v1")).toBe("/prefix/api/v1")
+      expect(joinPath("/prefix", "/api", "/v1")).toBe("/prefix/api/v1")
+    })
+
+    test("handles empty base path", () => {
+      expect(joinPath("/", "api", "v1")).toBe("/api/v1")
+      expect(joinPath("", "api", "v1")).toBe("/api/v1")
+    })
+
+    test("normalizes multiple slashes", () => {
+      expect(joinPath("/prefix", "//api//", "//v1")).toBe("/prefix/api/v1")
+    })
+
+    test("handles segments with leading slashes", () => {
+      expect(joinPath("/prefix", "/session")).toBe("/prefix/session")
+    })
+
+    test("handles trailing slash on base path", () => {
+      expect(joinPath("/prefix/", "api")).toBe("/prefix/api")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Rebases base-path support from PR #7625 onto v1.2.13
- Adds `--base-path` CLI option, `OPENCODE_BASE_PATH` env var, and `server.basePath` config
- Rewrites HTML/JS/CSS responses at runtime to include the base path
- Injects `window.__OPENCODE_BASE_PATH__` into frontend for SolidJS Router compatibility

## What this PR does

This is a rebase of @prokube's excellent work in #7625 onto the latest release tag (v1.2.13), resolving conflicts that arose from 275+ commits of drift.

**Key features:**
- Configurable base path via CLI (`--base-path`), env var (`OPENCODE_BASE_PATH`), or config (`server.basePath`)
- Runtime rewriting of proxied frontend assets to work under any URL prefix
- History API wrapper to prepend base path to pushState/replaceState calls
- Vite base path function patching for dynamic asset loading
- Health endpoint now returns `basePath` for clients to discover the configuration

## Testing
```bash
# Start server with base path
opencode web --base-path /myapp

# Or via environment variable
OPENCODE_BASE_PATH=/myapp opencode web
```

Access at `http://localhost:4096/myapp/`

## Related
- Original PR: #7625
- Original issue: #7624

🤖 Generated with [Claude Code](https://claude.com/claude-code)