### PR TITLE
fix: PATCH /config writes to correct project config file

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1355,10 +1355,20 @@ export namespace Config {
   }
 
   export async function update(config: Info) {
-    const filepath = path.join(Instance.directory, "config.json")
+    const filepath = projectConfigFile()
     const existing = await loadFile(filepath)
     await Bun.write(filepath, JSON.stringify(mergeDeep(existing, config), null, 2))
     await Instance.dispose()
+  }
+
+  function projectConfigFile() {
+    const candidates = ["opencode.jsonc", "opencode.json"].map((file) =>
+      path.join(Instance.directory, file),
+    )
+    for (const file of candidates) {
+      if (existsSync(file)) return file
+    }
+    return candidates[1]
   }
 
   function globalConfigFile() {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -549,7 +549,7 @@ test("updates config and writes to file", async () => {
       const newConfig = { model: "updated/model" }
       await Config.update(newConfig as any)
 
-      const writtenConfig = JSON.parse(await Bun.file(path.join(tmp.path, "config.json")).text())
+      const writtenConfig = JSON.parse(await Bun.file(path.join(tmp.path, "opencode.json")).text())
       expect(writtenConfig.model).toBe("updated/model")
     },
   })


### PR DESCRIPTION
## What does this PR do?

`Config.update()` writes to `config.json` in the project directory, but the config loader only reads `opencode.jsonc` and `opencode.json` — so project-level config updates via `PATCH /config` are silently lost.

This changes `update()` to use a new `projectConfigFile()` helper (mirrors the existing `globalConfigFile()` pattern) that picks whichever of `opencode.jsonc` / `opencode.json` already exists, defaulting to `opencode.json`.

Fixes #4194
Fixes #6984

## How did you verify your code works?

All 57 config tests pass (`bun test test/config/config.test.ts`). Updated the existing "updates config and writes to file" test to assert against `opencode.json` instead of `config.json`.