### PR TITLE
fix(app): make close comment button visible in prompt input 

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1799,7 +1799,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                           type="button"
                           icon="close-small"
                           variant="ghost"
-                          class="ml-auto size-3.5 opacity-0 group-hover:opacity-100 transition-all"
+                          class="ml-auto size-3.5 text-text-weak hover:text-text-strong transition-all"
                           onClick={(e) => {
                             e.stopPropagation()
                             if (item.commentID) comments.remove(item.path, item.commentID)


### PR DESCRIPTION
### What does this PR do?

makes the close comment button visible without having to hover on it

### How did you verify your code works?
manual test

## before
<img width="215" height="97" alt="close-comment-button-visibility_BEFORE" src="https://github.com/user-attachments/assets/42f6b811-28fb-4aa5-a391-c5fa69999bb4" />


## after
<img width="188" height="73" alt="close-comment-button-visibility_AFTER" src="https://github.com/user-attachments/assets/5be1e7a6-69b5-4a57-ade9-ff3235c2c16e" />
