### PR TITLE
fix(core): install npm plugins into config directories instead of cache

### DIFF
--- a/packages/opencode/src/plugin/builtin.ts
+++ b/packages/opencode/src/plugin/builtin.ts
@@ -1,0 +1,2 @@
+/** Built-in npm plugins that are installed by default (unless OPENCODE_DISABLE_DEFAULT_PLUGINS is set) */
+export const BUILTIN_PLUGINS = ["opencode-anthropic-auth@0.0.13"]


### PR DESCRIPTION
## Summary

- Fixes #12222 — plugins are now installed into the config directory that declared them (e.g. `~/.config/opencode/` or `.opencode/`) instead of `~/.cache/opencode/`
- Built-in plugins are installed into `~/.config/opencode/` (the global config directory)
- Plugin data files now survive cache version bumps since they're no longer in the volatile cache directory

## Problem

Previously, all npm plugins (`oh-my-opencode`, `opencode-antigravity-auth`, etc.) were installed into `~/.cache/opencode/node_modules/` via `BunProc.install()`. This had several issues:

1. **Cache is volatile** — `~/.cache/opencode/` gets wiped on cache version bumps (`CACHE_VERSION` changes), destroying plugin data files
2. **No isolation** — all plugins from all config sources (global, project, `.opencode/`) shared a single flat `node_modules/`, so version conflicts were possible
3. **Confusing paths** — `installDependencies()` already ran `bun install` in each config directory but only installed `@opencode-ai/plugin` there, while actual user plugins went elsewhere

## Solution

- `installDependencies(dir, plugins?)` now accepts the list of npm plugins declared in that directory's config and adds them to the directory's `package.json` before running `bun install`
- `needsInstall(dir, plugins?)` checks whether any declared plugins are missing from the directory
- `plugin/index.ts` resolves npm plugins from config directories' `node_modules/` instead of calling `BunProc.install()` into cache
- Builtin plugins are assigned to the global config directory (`~/.config/opencode/`)
- `BUILTIN_PLUGINS` constant extracted to `plugin/builtin.ts` to avoid circular imports

## Testing

All 882 existing tests pass. The config test suite (57 tests) continues to pass with the new plugin installation logic.