### PR TITLE
fix: clean up orphaned store data on session deletion and message removal

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -194,7 +194,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           break
 
         case "session.deleted": {
-          const result = Binary.search(store.session, event.properties.info.id, (s) => s.id)
+          const sessionID = event.properties.info.id
+          const result = Binary.search(store.session, sessionID, (s) => s.id)
           if (result.found) {
             setStore(
               "session",
@@ -203,6 +204,23 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
               }),
             )
           }
+          setStore(
+            produce((draft) => {
+              const messages = draft.message[sessionID]
+              if (messages) {
+                for (const msg of messages) {
+                  if (msg?.id) delete draft.part[msg.id]
+                }
+              }
+              delete draft.message[sessionID]
+              delete draft.session_diff[sessionID]
+              delete draft.todo[sessionID]
+              delete draft.permission[sessionID]
+              delete draft.question[sessionID]
+              delete draft.session_status[sessionID]
+            }),
+          )
+          fullSyncedSessions.delete(sessionID)
           break
         }
         case "session.updated": {
@@ -269,10 +287,9 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           const result = Binary.search(messages, event.properties.messageID, (m) => m.id)
           if (result.found) {
             setStore(
-              "message",
-              event.properties.sessionID,
               produce((draft) => {
-                draft.splice(result.index, 1)
+                draft.message[event.properties.sessionID].splice(result.index, 1)
+                delete draft.part[event.properties.messageID]
               }),
             )
           }


### PR DESCRIPTION
Fixes #12351

The `session.deleted` handler in the TUI sync store only removes the session from `store.session[]` but leaves everything else behind — `message`, `part`, `session_diff`, `todo`, `permission`, `question`, `session_status` all stick around as orphaned entries. Over time this leaks memory with every deleted session.

The web app already handles this properly in `cleanupSessionCaches()` (`packages/app/src/context/global-sync.tsx` lines 676-706), the TUI just never got the same treatment.

Also fixed `message.removed` — it was removing the message from the array but not cleaning up its `part` entries.

Changes:
- `session.deleted`: now cleans up all 7 keyed maps + removes from `fullSyncedSessions`
- `message.removed`: now also deletes orphaned `part[messageID]`