### PR TITLE
fix(opencode): improve skills dialog readability

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-skill.tsx
@@ -18,9 +18,10 @@ export function DialogSkill(props: DialogSkillProps) {
 
   const options = createMemo<DialogSelectOption<string>[]>(() => {
     const list = skills() ?? []
+    const maxWidth = Math.max(0, ...list.map((s) => s.name.length))
     return list.map((skill) => ({
-      title: skill.name,
-      description: skill.description,
+      title: skill.name.padEnd(maxWidth),
+      description: skill.description?.replace(/\s+/g, " ").trim(),
       value: skill.name,
       category: "Skills",
       onSelect: () => {


### PR DESCRIPTION
The TUI skills dialog (`/skills`) renders skill names and descriptions with no visual separation — descriptions contain newlines, and names aren't aligned, making the list hard to scan.

This pads skill names to equal width and collapses multi-line descriptions into a single line. The description is already rendered in `textMuted` by the `Option` component.

Fixes #12350

## Before

<img width="1592" height="1554" alt="CleanShot 2026-02-05 at 23 09 51@2x" src="https://github.com/user-attachments/assets/0d5abab1-8b86-4152-823f-0bfcbcc6bf3f" />


## After

<img width="1408" height="1450" alt="CleanShot 2026-02-05 at 23 23 29@2x" src="https://github.com/user-attachments/assets/10453e6e-75ba-4f50-8282-b1f2a6342597" />
