### PR TITLE
fix(plugin): user plugins override built-in plugins for same provider

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -44,11 +44,12 @@ export namespace Plugin {
       hooks.push(init)
     }
 
-    const plugins = [...(config.plugin ?? [])]
-    if (plugins.length) await Config.waitForDependencies()
+    const plugins: string[] = []
     if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {
       plugins.push(...BUILTIN)
     }
+    plugins.push(...(config.plugin ?? []))
+    if (plugins.length) await Config.waitForDependencies()
 
     for (let plugin of plugins) {
       // ignore old codex plugin since it is supported first party now


### PR DESCRIPTION
Fixes #12223

BUILTIN plugins are appended after user plugins in `plugin/index.ts`. Since `ProviderAuth.state()` uses `fromEntries()` (last-write-wins), built-ins silently override user plugins targeting the same provider. The only workaround is `OPENCODE_DISABLE_DEFAULT_PLUGINS=1`.

This swaps the order so BUILTIN loads first and user plugins load after, giving user plugins natural priority via last-write-wins.