### PR TITLE
chore: align windows test runner to blacksmith

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Mount Bun Cache
       uses: useblacksmith/stickydisk@v1
       with:
-        key: ${{ github.repository }}-bun-cache
+        key: ${{ github.repository }}-bun-cache-${{ runner.os }}
         path: ~/.bun
 
     - name: Setup Bun

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
               git config --global user.name "opencode"
               bun turbo test
           - name: windows
-            host: windows-latest
+            host: blacksmith-4vcpu-windows-2025
             playwright: bunx playwright install
             workdir: packages/app
             command: bun test:e2e:local


### PR DESCRIPTION
### What does this PR do?

Use the same blacksmith runner as the publish matrix to enable caching & faster windows tests

### How did you verify your code works?

cicd time + pass

from ~11 mins to ~2 mins