### PR TITLE
core: fix unhandled errors when aborting with queued messages

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -71,9 +71,6 @@ export namespace SessionPrompt {
     async (current) => {
       for (const item of Object.values(current)) {
         item.abort.abort()
-        for (const callback of item.callbacks) {
-          callback.reject(new DOMException("Aborted", "AbortError"))
-        }
       }
     },
   )
@@ -251,9 +248,6 @@ export namespace SessionPrompt {
       return
     }
     match.abort.abort()
-    for (const item of match.callbacks) {
-      item.reject(new DOMException("Aborted", "AbortError"))
-    }
     delete s[sessionID]
     SessionStatus.set(sessionID, { type: "idle" })
     return


### PR DESCRIPTION
## Summary

- Fixes unhandled promise rejection errors that occur when aborting a session that has a queued message waiting
- The issue was introduced in 6c9b2c37a which changed queued callback rejections from `reject()` to `reject(new DOMException("Aborted", "AbortError"))` — callers like `prompt_async` don't await/catch the returned promise, so the rejection propagated as unhandled errors
- Instead of rejecting queued callbacks on abort, we now simply drop them — the promises are GC'd and the already-persisted user messages remain in history for the next interaction