### PR TITLE
fix(desktop): update server removal logic to clear default server URL if removed

### DIFF
--- a/packages/app/src/components/dialog-select-server.tsx
+++ b/packages/app/src/components/dialog-select-server.tsx
@@ -369,6 +369,9 @@ export function DialogSelectServer() {
 
   async function handleRemove(url: string) {
     server.remove(url)
+    if (await platform.getDefaultServerUrl?.() === url) {
+      platform.setDefaultServerUrl?.(null)
+    }
   }
 
   return (


### PR DESCRIPTION
### What does this PR do?

Just adds logic to reset the defaultServerUrl when that default server is being removed from the server list.

### How did you verify your code works?

Tested on my local env.