### PR TITLE
feat(app): session last updated time display in command pallete's search

### DIFF
--- a/packages/app/src/components/dialog-select-file.tsx
+++ b/packages/app/src/components/dialog-select-file.tsx
@@ -15,6 +15,7 @@ import { useLayout } from "@/context/layout"
 import { useFile } from "@/context/file"
 import { useLanguage } from "@/context/language"
 import { decode64 } from "@/utils/base64"
+import { getRelativeTime } from "@/utils/time"
 
 type EntryType = "command" | "file" | "session"
 
@@ -30,6 +31,7 @@ type Entry = {
   directory?: string
   sessionID?: string
   archived?: number
+  updated?: number
 }
 
 type DialogSelectFileMode = "all" | "files"
@@ -120,6 +122,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
     title: string
     description: string
     archived?: number
+    updated?: number
   }): Entry => ({
     id: `session:${input.directory}:${input.id}`,
     type: "session",
@@ -129,6 +132,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
     directory: input.directory,
     sessionID: input.id,
     archived: input.archived,
+    updated: input.updated,
   })
 
   const list = createMemo(() => allowed().map(commandItem))
@@ -214,6 +218,7 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
                 description,
                 directory,
                 archived: s.time?.archived,
+                updated: s.time?.updated,
               })),
           )
           .catch(() => [] as { id: string; title: string; description: string; directory: string; archived?: number }[])
@@ -384,6 +389,11 @@ export function DialogSelectFile(props: { mode?: DialogSelectFileMode; onOpenFil
                     </Show>
                   </div>
                 </div>
+                <Show when={item.updated}>
+                  <span class="text-12-regular text-text-weak whitespace-nowrap ml-2">
+                    {getRelativeTime(new Date(item.updated!).toISOString())}
+                  </span>
+                </Show>
               </div>
             </Match>
           </Switch>

--- a/packages/app/src/utils/time.ts
+++ b/packages/app/src/utils/time.ts
@@ -1,0 +1,14 @@
+export function getRelativeTime(dateString: string): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSeconds = Math.floor(diffMs / 1000)
+  const diffMinutes = Math.floor(diffSeconds / 60)
+  const diffHours = Math.floor(diffMinutes / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffSeconds < 60) return "Just now"
+  if (diffMinutes < 60) return `${diffMinutes}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  return `${diffDays}d ago`
+}


### PR DESCRIPTION
### What does this PR do?

-Adds last updated session time to session list (command pallete search) for easier session search
-Adds the getRealativeTime util in packages\app\src\utils\time.ts to show friendly timestamp

<img width="656" height="97" alt="image" src="https://github.com/user-attachments/assets/6148c586-830d-4a10-83bd-d3642a4d021d" />
<img width="654" height="248" alt="image" src="https://github.com/user-attachments/assets/c8220ac3-f966-4f58-8b71-854aebe77d0e" />
<img width="648" height="199" alt="image" src="https://github.com/user-attachments/assets/1e44b328-86dd-42c2-8802-1993935012ef" />


### How did you verify your code works?
manual testing to ensure time is correct, and that layout looks good
