### PR TITLE
feat: add GitHub URL support for plugin installation

### DIFF
--- a/packages/opencode/src/bun/index.ts
+++ b/packages/opencode/src/bun/index.ts
@@ -77,8 +77,13 @@ export namespace BunProc {
     const modExists = await Filesystem.exists(mod)
     const cachedVersion = dependencies[pkg]
 
+    // For git URLs, always reinstall to get latest (no npm registry to check)
+    const isGitUrl = pkg.startsWith("github:") || pkg.startsWith("git+") || pkg.startsWith("git://")
     if (!modExists || !cachedVersion) {
       // continue to install
+    } else if (isGitUrl) {
+      // For git URLs, reinstall to fetch latest commits
+      log.info("Git URL detected, reinstalling to fetch latest", { pkg })
     } else if (version !== "latest" && cachedVersion === version) {
       return mod
     } else if (version === "latest") {
@@ -88,6 +93,8 @@ export namespace BunProc {
     }
 
     // Build command arguments
+    // For git URLs (github:, git+, git://), don't append @version
+    const pkgSpec = version ? `${pkg}@${version}` : pkg
     const args = [
       "add",
       "--force",
@@ -96,7 +103,7 @@ export namespace BunProc {
       ...(proxied() ? ["--no-cache"] : []),
       "--cwd",
       Global.Path.cache,
-      pkg + "@" + version,
+      pkgSpec,
     ]
 
     // Let Bun handle registry resolution:
@@ -122,7 +129,10 @@ export namespace BunProc {
     // Resolve actual version from installed package when using "latest"
     // This ensures subsequent starts use the cached version until explicitly updated
     let resolvedVersion = version
-    if (version === "latest") {
+    if (isGitUrl) {
+      // For git URLs, store a timestamp to track when it was installed
+      resolvedVersion = `git:${Date.now()}`
+    } else if (version === "latest") {
       const installedPkgJson = Bun.file(path.join(mod, "package.json"))
       const installedPkg = await installedPkgJson.json().catch(() => null)
       if (installedPkg?.version) {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -55,9 +55,19 @@ export namespace Plugin {
       if (plugin.includes("opencode-openai-codex-auth") || plugin.includes("opencode-copilot-auth")) continue
       log.info("loading plugin", { path: plugin })
       if (!plugin.startsWith("file://")) {
-        const lastAtIndex = plugin.lastIndexOf("@")
-        const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
-        const version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
+        // Check for GitHub/git URLs which don't use @version syntax
+        const isGitUrl = plugin.startsWith("github:") || plugin.startsWith("git+") || plugin.startsWith("git://")
+        let pkg: string
+        let version: string
+        if (isGitUrl) {
+          // For git URLs, pass the full URL as package, no version
+          pkg = plugin
+          version = ""
+        } else {
+          const lastAtIndex = plugin.lastIndexOf("@")
+          pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
+          version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
+        }
         const builtin = BUILTIN.some((x) => x.startsWith(pkg + "@"))
         plugin = await BunProc.install(pkg, version).catch((err) => {
           if (!builtin) throw err


### PR DESCRIPTION
Fixes #12378

## Summary

Adds support for installing plugins from GitHub URLs using bun's native git URL syntax.

## Changes

- Detect `github:`, `git+`, `git://` URL prefixes in plugin loader
- Skip `@version` suffix for git URLs (bun handles versioning via `#branch`)
- Always reinstall git URL plugins to fetch latest commits
- Store installation timestamp for git URL cache tracking

## Usage

```json
{
  "plugin": ["github:code-yeongyu/oh-my-opencode#dev"]
}
```

## Verification

1. Added `github:code-yeongyu/oh-my-opencode#dev` to config
2. Ran `bun dev` - plugin installed and loaded correctly
3. Confirmed git URLs bypass npm registry check
4. Verified reinstall on restart fetches latest commits