### PR TITLE
feat(prompt): mode-specific input placeholders

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,5 +1,5 @@
 import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, t, dim, fg } from "@opentui/core"
-import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, Show, Switch, Match } from "solid-js"
+import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import { useLocal } from "@tui/context/local"
 import { useTheme } from "@tui/context/theme"
@@ -54,6 +54,7 @@ export type PromptRef = {
 }
 
 const PLACEHOLDERS = ["Fix a TODO in the codebase", "What is the tech stack of this project?", "Fix broken tests"]
+const SHELL_PLACEHOLDERS = ["ls -la", "git status", "pwd"]
 
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
@@ -133,6 +134,16 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: new Map(),
     interrupt: 0,
   })
+
+  createEffect(
+    on(
+      () => props.sessionID,
+      () => {
+        setStore("placeholder", Math.floor(Math.random() * PLACEHOLDERS.length))
+      },
+      { defer: true },
+    ),
+  )
 
   // Initialize agent/model/variant from last user message when session changes
   let syncedSessionID: string | undefined
@@ -736,6 +747,15 @@ export function Prompt(props: PromptProps) {
     return !!current
   })
 
+  const placeholderText = createMemo(() => {
+    if (props.sessionID) return undefined
+    if (store.mode === "shell") {
+      const example = SHELL_PLACEHOLDERS[store.placeholder % SHELL_PLACEHOLDERS.length]
+      return `Run a command... "${example}"`
+    }
+    return `Ask anything... "${PLACEHOLDERS[store.placeholder % PLACEHOLDERS.length]}"`
+  })
+
   const spinnerDef = createMemo(() => {
     const color = local.agent.color(local.agent.current().name)
     return {
@@ -797,7 +817,7 @@ export function Prompt(props: PromptProps) {
             flexGrow={1}
           >
             <textarea
-              placeholder={props.sessionID ? undefined : `Ask anything... "${PLACEHOLDERS[store.placeholder]}"`}
+              placeholder={placeholderText()}
               textColor={keybind.leader ? theme.textMuted : theme.text}
               focusedTextColor={keybind.leader ? theme.textMuted : theme.text}
               minHeight={1}
@@ -850,6 +870,7 @@ export function Prompt(props: PromptProps) {
                   }
                 }
                 if (e.name === "!" && input.visualCursor.offset === 0) {
+                  setStore("placeholder", Math.floor(Math.random() * SHELL_PLACEHOLDERS.length))
                   setStore("mode", "shell")
                   e.preventDefault()
                   return


### PR DESCRIPTION
Shell mode will now show shell-relevant (*shellevant*) placeholders.

**BEFORE (WHAT!?)**
<img width="1614" height="388" alt="CleanShot 2026-02-05 at 20 19 48@2x" src="https://github.com/user-attachments/assets/38186bb1-946b-49cf-89c6-908004a19d70" />

**NEW (WOW!)**
<img width="806" height="203" alt="image" src="https://github.com/user-attachments/assets/616cfd7d-9fe8-4fd1-baf6-bc62e9c6329f" />


### Blocked by an opentui issue 🥲

Switching from a longer to shorter placeholder leaves stale trailing characters. This is blocked on an upstream fix: [anomalyco/opentui#634](https://github.com/anomalyco/opentui/pull/634)

<img width="483" height="299" alt="image" src="https://github.com/user-attachments/assets/a3c34b82-5b81-4e9c-aa0e-a34ca9ac10f7" />

### Dedication

[Dedicated to Connor on Twitter](https://x.com/ConnorStorer/status/2019421310863176062)

<img width="1504" height="500" alt="CleanShot 2026-02-05 at 20 23 21@2x" src="https://github.com/user-attachments/assets/df102091-af8a-4369-963f-af515481d5f3" />