### PR TITLE
fix(config): handle $ character with {file:} pattern

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1267,7 +1267,7 @@ export namespace Config {
             })
         ).trim()
         // escape newlines/quotes, strip outer quotes
-        text = text.replace(match, JSON.stringify(fileContent).slice(1, -1))
+        text = text.replace(match, () => JSON.stringify(fileContent).slice(1, -1))
       }
     }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -193,6 +193,25 @@ test("handles file inclusion substitution", async () => {
   })
 })
 
+test("handles file inclusion with replacement tokens", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "included.md"), "const out = await Bun.$`echo hi`")
+      await writeConfig(dir, {
+        $schema: "https://opencode.ai/config.json",
+        theme: "{file:included.md}",
+      })
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const config = await Config.get()
+      expect(config.theme).toBe("const out = await Bun.$`echo hi`")
+    },
+  })
+})
+
 test("validates config schema and throws on invalid fields", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {


### PR DESCRIPTION
### What does this PR do?

- Fixes https://github.com/anomalyco/opencode/issues/5299
- Fixes https://github.com/anomalyco/opencode/issues/11793

This PR fixes an issue where files containing `$` would break opencode when your config used the `{file:x}` pattern. This is because `String.prototype.replace` treats `$` as a replacement character, which is not what we want in this use case. This PR instead uses a replacement function, so that `.replace` does a "dumb" string replacement.

There is an alternative PR: https://github.com/anomalyco/opencode/pull/11795 . I respectfully believe that that PR's approach is flawed as it tries to escape the `$`, instead of just treating the `$` as-is.

### How did you verify your code works?

```bash
# verified that this test fails without my fix
cd packages/opencode && bun test test/config/config.test.ts

# verified that this fix works in my project where I hit this bug
bun dev -- ~/my-proj-where-i-found-this-bug
```
