### PR TITLE
fix(tui): add isDestroyed guards to prevent EditBuffer crash on session switch

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -349,6 +349,7 @@ export function Prompt(props: PromptProps) {
       return store.prompt
     },
     focus() {
+      if (input.isDestroyed) return
       input.focus()
     },
     blur() {
@@ -375,7 +376,7 @@ export function Prompt(props: PromptProps) {
   }
 
   createEffect(() => {
-    if (props.visible !== false) input?.focus()
+    if (props.visible !== false && input && !input.isDestroyed) input.focus()
     if (props.visible === false) input?.blur()
   })
 

--- a/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
@@ -41,7 +41,7 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
       }
 
       if (!active) {
-        if (focus && !renderer.currentFocusedRenderable) {
+        if (focus && !focus.isDestroyed && !renderer.currentFocusedRenderable) {
           focus.focus()
         }
         setStore("leader", false)
@@ -56,7 +56,7 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
 
       if (store.leader && evt.name) {
         setImmediate(() => {
-          if (focus && renderer.currentFocusedRenderable === focus) {
+          if (focus && !focus.isDestroyed && renderer.currentFocusedRenderable === focus) {
             focus.focus()
           }
           leader(false)

--- a/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/question.tsx
@@ -381,6 +381,7 @@ export function QuestionPrompt(props: { request: QuestionRequest }) {
                         ref={(val: TextareaRenderable) => {
                           textarea = val
                           queueMicrotask(() => {
+                            if (val.isDestroyed) return
                             val.focus()
                             val.gotoLineEnd()
                           })


### PR DESCRIPTION
## Problem

When switching sessions via leader key + keybind, the TUI crashes with:

```
Error: EditBuffer is destroyed
    at guard (@opentui/core/index.js:332:17)
    at getText (@opentui/core/index.js:371:10)
    at focus (@opentui/core/index.js:6769:32)
    at <anonymous> (src/cli/cmd/tui/context/keybind.tsx:53:19)
```

## Root Cause

The `KeybindProvider` captures a reference to the currently focused `Renderable` when the leader key is activated. During session navigation, the old session's components are destroyed (including their `EditBuffer`s), but the captured reference still attempts to call `.focus()` on the destroyed renderable. The `focus()` method internally calls `editBuffer.getText()` → `guard()` → throws "EditBuffer is destroyed".

Three code paths in `keybind.tsx` called `focus.focus()` without checking `isDestroyed`:
1. **Leader deactivation** (line 44) — synchronous, no guard
2. **`setImmediate` callback** (line 59) — deferred execution, no guard  
3. **`setTimeout` callback** (line 37) — already had the guard ✅

Additionally, two other components had the same unguarded pattern:
- `prompt/index.tsx` — `PromptRef.focus()` and visibility effect
- `question.tsx` — `queueMicrotask` in textarea ref callback

## Fix

Added `isDestroyed` guards before every `.focus()` call on captured/deferred renderables, consistent with the existing pattern used in `dialog.tsx:75`, `dialog-select.tsx:256`, `dialog-export-options.tsx:72`, and `dialog-prompt.tsx:31`.

### Changes

| File | Location | Change |
|------|----------|--------|
| `keybind.tsx:44` | Leader deactivation | Added `!focus.isDestroyed` to condition |
| `keybind.tsx:59` | `setImmediate` callback | Added `!focus.isDestroyed` to condition |
| `prompt/index.tsx:351` | `PromptRef.focus()` | Added `if (input.isDestroyed) return` early guard |
| `prompt/index.tsx:379` | Visibility `createEffect` | Added `input && !input.isDestroyed` to condition |
| `question.tsx:384` | `queueMicrotask` in ref | Added `if (val.isDestroyed) return` early guard |

## Testing

- All 47 keybind tests pass
- Typecheck clean (pre-existing unrelated type errors only)
- Manual reproduction on old version and fixed version: working on it, will update this PR when ready ⏳
