### PR TITLE
fix: add stream idle timeout to prevent sessions from hanging indefinitely

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1177,6 +1177,12 @@ export namespace Config {
             .positive()
             .optional()
             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+          stream_idle_timeout: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Timeout in milliseconds between stream chunks from LLM. If no data is received within this period, the request will be retried. Default is 60000 (60 seconds). Set to 0 to disable."),
         })
         .optional(),
     })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1,4 +1,4 @@
-import { MessageV2 } from "./message-v2"
+import { MessageV2, StreamIdleTimeoutError } from "./message-v2"
 import { Log } from "@/util/log"
 import { Identifier } from "@/id/id"
 import { Session } from "."
@@ -15,6 +15,62 @@ import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
+
+/**
+ * Wraps an async iterable with an idle timeout. If no value is yielded within
+ * the timeout period, throws a StreamIdleTimeoutError.
+ * 
+ * This prevents the streaming loop from hanging indefinitely when:
+ * - Network connection drops mid-stream (TCP half-open)
+ * - LLM provider stalls without closing the connection
+ * - Proxy/gateway timeouts that don't properly terminate the stream
+ */
+async function* withIdleTimeout<T>(
+  stream: AsyncIterable<T>,
+  timeoutMs: number,
+  abort: AbortSignal
+): AsyncGenerator<T> {
+  const iterator = stream[Symbol.asyncIterator]()
+  
+  while (true) {
+    abort.throwIfAborted()
+    
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let rejectTimeout: ((error: Error) => void) | undefined
+    
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      rejectTimeout = reject
+      timer = setTimeout(() => {
+        reject(new StreamIdleTimeoutError(timeoutMs))
+      }, timeoutMs)
+    })
+    
+    // Clean up timer when abort signal fires
+    const abortHandler = () => {
+      if (timer) clearTimeout(timer)
+    }
+    abort.addEventListener("abort", abortHandler, { once: true })
+    
+    try {
+      const result = await Promise.race([
+        iterator.next(),
+        timeoutPromise
+      ])
+      
+      // Clear the timer since we got a result
+      if (timer) clearTimeout(timer)
+      abort.removeEventListener("abort", abortHandler)
+      
+      if (result.done) return
+      yield result.value
+    } catch (e) {
+      // Clean up on error too
+      if (timer) clearTimeout(timer)
+      abort.removeEventListener("abort", abortHandler)
+      throw e
+    }
+  }
+}
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -45,14 +101,22 @@ export namespace SessionProcessor {
       async process(streamInput: LLM.StreamInput) {
         log.info("process")
         needsCompaction = false
-        const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
+        const config = await Config.get()
+        const shouldBreak = config.experimental?.continue_loop_on_deny !== true
+        // Default to 60 seconds between chunks, 0 disables the timeout
+        const streamIdleTimeout = config.experimental?.stream_idle_timeout ?? 60000
         while (true) {
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
             const stream = await LLM.stream(streamInput)
 
-            for await (const value of stream.fullStream) {
+            // Wrap the stream with idle timeout to prevent hanging on stalled connections
+            const wrappedStream = streamIdleTimeout > 0 
+              ? withIdleTimeout(stream.fullStream, streamIdleTimeout, input.abort)
+              : stream.fullStream
+
+            for await (const value of wrappedStream) {
               input.abort.throwIfAborted()
               switch (value.type) {
                 case "start":


### PR DESCRIPTION
## Problem

When network issues occur mid-stream (TCP half-open connections, stalled LLM providers, proxy timeouts), the streaming loop hangs forever waiting for the next chunk. Users report sessions getting stuck for hours.

Related issues: #8383, #2512, #2819, #4255

## Solution

Add a configurable idle timeout that detects when no data has been received for a period (default 60 seconds) and triggers automatic retry with exponential backoff.

## Changes

- Add `StreamIdleTimeoutError` class to `message-v2.ts`
- Add `withIdleTimeout()` async generator wrapper in `processor.ts`
- Wrap `stream.fullStream` with idle timeout in the process loop
- Mark `StreamIdleTimeoutError` as retryable so sessions recover automatically
- Add `stream_idle_timeout` config option under experimental settings
- Add additional network error types (`ETIMEDOUT`, `ENOTFOUND`, etc) as retryable

## Configuration

```yaml
# opencode.yaml (optional - defaults to 60 seconds)
experimental:
  stream_idle_timeout: 60
```

## Testing

Tested locally by simulating network interruptions mid-stream. Sessions now automatically retry instead of hanging indefinitely.