### PR TITLE
fix(app): keep startup script field scrollable in edit project dialog

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -223,7 +223,7 @@ export function DialogEditProject(props: { project: LocalProject }) {
             value={store.startup}
             onChange={(v) => setStore("startup", v)}
             spellcheck={false}
-            class="max-h-40 w-full font-mono text-xs no-scrollbar"
+            class="max-h-14 w-full overflow-y-auto font-mono text-xs"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- cap the `Workspace startup script` textarea height in the Edit project dialog
- enable internal vertical scrolling for overflow content
- keep Save/Cancel actions visible when the script contains many lines

Fixes #12430

## How did you verify your code works?
- ran desktop app in dev mode (`TAURI_CLI_NO_DEV_SERVER_WAIT=true bun run dev:desktop`)
- opened Edit project and pasted 4+ lines into Workspace startup script
- confirmed the field scrolls internally and action buttons stay visible

Before: 
<img width="498" height="537" alt="Screenshot 2026-02-06 at 11 41 39 AM" src="https://github.com/user-attachments/assets/ad9d1544-98ac-4d74-a616-d51e532f7c9a" />


After : 
<img width="491" height="533" alt="Screenshot 2026-02-06 at 12 33 57 PM" src="https://github.com/user-attachments/assets/6ccd5fd8-3274-4a3b-bc60-ef004f198eb5" />
