### PR TITLE
fix(ui): support emoji characters in avatar fallback

### DIFF
--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -36,7 +36,7 @@ export function Avatar(props: AvatarProps) {
         ...(!src && split.foreground ? { "--avatar-fg": split.foreground } : {}),
       }}
     >
-      <Show when={src} fallback={split.fallback?.[0]}>
+      <Show when={src} fallback={[...split.fallback]?.[0]}>
         {(src) => <img src={src()} draggable={false} data-slot="avatar-image" />}
       </Show>
     </div>


### PR DESCRIPTION
Fixes #12441

## Summary

- Use spread operator to iterate by Unicode code points instead of UTF-16 code units

## Verification

Tested in desktop app with project names starting with emojis (e.g., "😀Test") - emoji now displays correctly in the avatar.

#### Before:

<img width="483" height="515" alt="Screenshot 2026-02-06 at 09 08 57" src="https://github.com/user-attachments/assets/7e6c704a-e29a-44b4-9905-a03b867527d8" />

<img width="357" height="148" alt="Screenshot 2026-02-06 at 09 08 46" src="https://github.com/user-attachments/assets/b84d4fb1-d3b0-4bc5-a423-bceb95b64cac" />


#### After:

<img width="487" height="517" alt="Screenshot 2026-02-06 at 09 21 38" src="https://github.com/user-attachments/assets/876e1643-1927-4480-9aab-e2d4c163f47f" />

<img width="295" height="120" alt="Screenshot 2026-02-06 at 09 21 30" src="https://github.com/user-attachments/assets/e2043c64-1077-4047-b510-b9f301664f79" />
