### PR TITLE
feat(cli): add --dir option to run command

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -274,6 +274,10 @@ export const RunCommand = cmd({
         type: "string",
         describe: "attach to a running opencode server (e.g., http://localhost:4096)",
       })
+      .option("dir", {
+        type: "string",
+        describe: "directory to run in, path on remote server if attaching",
+      })
       .option("port", {
         type: "number",
         describe: "port for the local server (defaults to random port if no value provided)",
@@ -292,6 +296,18 @@ export const RunCommand = cmd({
     let message = [...args.message, ...(args["--"] || [])]
       .map((arg) => (arg.includes(" ") ? `"${arg.replace(/"/g, '\\"')}"` : arg))
       .join(" ")
+
+    const directory = (() => {
+      if (!args.dir) return undefined
+      if (args.attach) return args.dir
+      try {
+        process.chdir(args.dir)
+        return process.cwd()
+      } catch {
+        UI.error("Failed to change directory to " + args.dir)
+        process.exit(1)
+      }
+    })()
 
     const files: { type: "file"; url: string; filename: string; mime: string }[] = []
     if (args.file) {
@@ -582,7 +598,7 @@ export const RunCommand = cmd({
     }
 
     if (args.attach) {
-      const sdk = createOpencodeClient({ baseUrl: args.attach })
+      const sdk = createOpencodeClient({ baseUrl: args.attach, directory })
       return await execute(sdk)
     }
 


### PR DESCRIPTION
### What does this PR do?

I use opencode with a tailscale setup, sometimes I just want my opencode to run a `opencode run` on my remote server to do some stuff, attach has a `--dir` flag to set the directory, but `run` didnt, added that so I i can spawn a remote session in correct dir with run

On a seprate note, the server doesn't verify directory exists when creating a session with a non existent directory

### How did you verify your code works?

Manually running the command, with and without attach, found the bug with non existing dirs, but thats a seprate bug

Fixes #12444