### PR TITLE
feat: add OPENCODE_APP_URL for custom web app proxy

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -37,6 +37,7 @@ export namespace Flag {
   export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
   export const OPENCODE_ENABLE_QUESTION_TOOL = truthy("OPENCODE_ENABLE_QUESTION_TOOL")
+  export const OPENCODE_APP_URL = process.env["OPENCODE_APP_URL"]
 
   // Experimental
   export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL")

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -557,11 +557,13 @@ export namespace Server {
       .all("/*", async (c) => {
         const path = c.req.path
 
-        const response = await proxy(`https://app.opencode.ai${path}`, {
+        // Proxy to configured app URL or default to app.opencode.ai
+        const appUrl = Flag.OPENCODE_APP_URL ? new URL(Flag.OPENCODE_APP_URL) : new URL("https://app.opencode.ai")
+        const response = await proxy(`${appUrl.origin}${path}`, {
           ...c.req,
           headers: {
             ...c.req.raw.headers,
-            host: "app.opencode.ai",
+            host: appUrl.host,
           },
         })
         response.headers.set(


### PR DESCRIPTION
Add environment variable to proxy the web UI to a custom URL instead of app.opencode.ai. This enables enterprises to host the web UI internally and have users run the local server pointing to the internal instance.

The code changes are simple and self explanatory

- `OPENCODE_APP_URL` overrides the default `https://app.opencode.ai` base for the web UI proxy
- The full URL pathname is now preserved, so hosting on a subpath (e.g. GitHub Pages at `https://user.github.io/opencode`) works correctly

Fixes #12445