### PR TITLE
feat(zen): enable 1M context window for Opus 4.6 and Sonnet 4.5

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/anthropic.test.ts
+++ b/packages/console/app/src/routes/zen/util/provider/anthropic.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "bun:test"
+import { supports1MContext } from "./anthropic"
+
+describe("supports1MContext", () => {
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return true for Opus 4.6 models
+
+  it("returns true for claude-opus-4-6", () => {
+    expect(supports1MContext("claude-opus-4-6")).toBe(true)
+  })
+
+  it("returns true for claude-opus-4-6 with snapshot date suffix", () => {
+    expect(supports1MContext("claude-opus-4-6-20260101")).toBe(true)
+  })
+
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return true for Sonnet 4.5 models
+
+  it("returns true for claude-sonnet-4-5", () => {
+    expect(supports1MContext("claude-sonnet-4-5")).toBe(true)
+  })
+
+  it("returns true for claude-sonnet-4-5 with snapshot date suffix", () => {
+    expect(supports1MContext("claude-sonnet-4-5-20250929")).toBe(true)
+  })
+
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return true for Sonnet 4 models (prefix match)
+
+  it("returns true for claude-sonnet-4 (canonical)", () => {
+    expect(supports1MContext("claude-sonnet-4")).toBe(true)
+  })
+
+  it("returns true for claude-sonnet-4-20250514", () => {
+    expect(supports1MContext("claude-sonnet-4-20250514")).toBe(true)
+  })
+
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return false for Opus 4.5 models (not supported)
+
+  it("returns false for claude-opus-4-5-20251101", () => {
+    expect(supports1MContext("claude-opus-4-5-20251101")).toBe(false)
+  })
+
+  it("returns false for claude-opus-4-5", () => {
+    expect(supports1MContext("claude-opus-4-5")).toBe(false)
+  })
+
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return false for older Opus models
+
+  it("returns false for claude-opus-4-1-20250805", () => {
+    expect(supports1MContext("claude-opus-4-1-20250805")).toBe(false)
+  })
+
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return false for Haiku models
+
+  it("returns false for claude-haiku-4-5-20251001", () => {
+    expect(supports1MContext("claude-haiku-4-5-20251001")).toBe(false)
+  })
+
+  it("returns false for claude-3-haiku-20240307", () => {
+    expect(supports1MContext("claude-3-haiku-20240307")).toBe(false)
+  })
+
+  //#given a model string
+  //#when checking if it supports 1M context
+  //#then return false for unknown models
+
+  it("returns false for unknown model", () => {
+    expect(supports1MContext("some-random-model")).toBe(false)
+  })
+
+  //#given an empty string
+  //#when checking if it supports 1M context
+  //#then return false
+
+  it("returns false for empty string", () => {
+    expect(supports1MContext("")).toBe(false)
+  })
+})

--- a/packages/console/app/src/routes/zen/util/provider/anthropic.ts
+++ b/packages/console/app/src/routes/zen/util/provider/anthropic.ts
@@ -16,11 +16,17 @@ type Usage = {
   }
 }
 
+const CONTEXT_1M_BETA = "context-1m-2025-08-07"
+
+export function supports1MContext(model: string): boolean {
+  const prefixes = ["claude-opus-4-6", "claude-sonnet-4-5", "claude-sonnet-4"]
+  return prefixes.some((prefix) => model.startsWith(prefix))
+}
+
 export const anthropicHelper: ProviderHelper = ({ reqModel, providerModel }) => {
   const isBedrockModelArn = providerModel.startsWith("arn:aws:bedrock:")
   const isBedrockModelID = providerModel.startsWith("global.anthropic.")
   const isBedrock = isBedrockModelArn || isBedrockModelID
-  const isSonnet = reqModel.includes("sonnet")
   return {
     format: "anthropic",
     modifyUrl: (providerApi: string, isStream?: boolean) =>
@@ -33,8 +39,8 @@ export const anthropicHelper: ProviderHelper = ({ reqModel, providerModel }) => 
       } else {
         headers.set("x-api-key", apiKey)
         headers.set("anthropic-version", headers.get("anthropic-version") ?? "2023-06-01")
-        if (body.model.startsWith("claude-sonnet-")) {
-          headers.set("anthropic-beta", "context-1m-2025-08-07")
+        if (supports1MContext(body.model)) {
+          headers.set("anthropic-beta", CONTEXT_1M_BETA)
         }
       }
     },
@@ -43,7 +49,7 @@ export const anthropicHelper: ProviderHelper = ({ reqModel, providerModel }) => 
       ...(isBedrock
         ? {
             anthropic_version: "bedrock-2023-05-31",
-            anthropic_beta: isSonnet ? "context-1m-2025-08-07" : undefined,
+            anthropic_beta: supports1MContext(reqModel) ? CONTEXT_1M_BETA : undefined,
             model: undefined,
             stream: undefined,
           }


### PR DESCRIPTION
## Summary

Extends the Anthropic 1M context window beta to Claude Opus 4.6 and Claude Sonnet 4.5 models. Previously only Sonnet 4 variants could leverage the extended context — this unlocks it for the newest high-capability models across both direct API and Bedrock paths.

## Problem & Solution

**Problem:** The `context-1m-2025-08-07` beta header was only sent for models matching `claude-sonnet-*`, so Opus 4.6 and Sonnet 4.5 users hit the default context limit despite the models supporting 1M tokens.

**Solution:** Replace the inline prefix check with a dedicated `supports1MContext()` predicate that matches all eligible model families, applied consistently to both API paths.

## Key Changes

- Introduce `supports1MContext()` — a single source of truth for which models get the 1M context beta
- Apply the beta flag consistently across direct Anthropic API and AWS Bedrock request paths
- Cover Opus 4.6, Sonnet 4.5, and Sonnet 4 model families (with snapshot date suffixes)

## System Design

### Beta Header Injection Flow

```mermaid
sequenceDiagram
    participant Client
    participant Handler as handler.ts
    participant Select as selectProvider()
    participant Helper as anthropicHelper
    participant API as Anthropic API / Bedrock

    Client->>Handler: POST /zen (model: claude-opus-4-6)
    Handler->>Select: selectProvider(model)
    Select-->>Handler: providerInfo (anthropicHelper)

    rect rgb(40, 40, 40)
        note right of Handler: Request modification
        Handler->>Helper: modifyHeaders(headers, body, apiKey)
        Helper->>Helper: supports1MContext(body.model)?
        alt Model supported
            Helper-->>Handler: set anthropic-beta: context-1m-2025-08-07
        else Model not supported
            Helper-->>Handler: no beta header
        end
        Handler->>Helper: modifyBody(body)
        note right of Helper: Bedrock: injects anthropic_beta field
    end

    Handler->>API: fetch(url, { headers, body })
    API-->>Client: Response (up to 1M context)
```

The change affects the decision point inside `modifyHeaders` and `modifyBody` — replacing a hardcoded `claude-sonnet-` prefix check with `supports1MContext()` that covers three model prefixes.

## Testing Strategy

The `supports1MContext()` helper is tested against all model families: positive cases for Opus 4.6, Sonnet 4.5, and Sonnet 4 (canonical and date-suffixed), negative cases for Opus 4.5, Opus 4.1, Haiku, unknown models, and empty strings.

## Reviewer Notes

- The prefix `"claude-sonnet-4"` (without trailing hyphen) matches both the canonical `claude-sonnet-4` model ID and date-suffixed variants like `claude-sonnet-4-20250514` — while `"claude-sonnet-4-5"` is listed separately to explicitly cover Sonnet 4.5
- Bedrock path previously used `isSonnet` (a loose `includes("sonnet")` check) — now uses the same `supports1MContext()` for consistency

Fixes #12452
Fixes #12438
Fixes #12338
Fixes #11267