### PR TITLE
fix(desktop): support desktop titlebar double-click maximize

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -87,7 +87,14 @@ export function Titlebar() {
 
     const tauri = (
       window as unknown as {
-        __TAURI__?: { window?: { getCurrentWindow?: () => { startDragging?: () => Promise<void> } } }
+        __TAURI__?: {
+          window?: {
+            getCurrentWindow?: () => {
+              startDragging?: () => Promise<void>
+              toggleMaximize?: () => Promise<void>
+            }
+          }
+        }
       }
     ).__TAURI__
     if (!tauri?.window?.getCurrentWindow) return
@@ -133,10 +140,23 @@ export function Titlebar() {
     void win.startDragging().catch(() => undefined)
   }
 
+  const maximize = (e: MouseEvent) => {
+    if (platform.platform !== "desktop") return
+    if (interactive(e.target)) return
+    if (e.target instanceof Element && e.target.closest("[data-tauri-decorum-tb]")) return
+
+    const win = getWin()
+    if (!win?.toggleMaximize) return
+
+    e.preventDefault()
+    void win.toggleMaximize().catch(() => undefined)
+  }
+
   return (
     <header
       class="h-10 shrink-0 bg-background-base relative grid grid-cols-[auto_minmax(0,1fr)_auto] items-center"
       style={{ "min-height": minHeight() }}
+      onDblClick={maximize}
     >
       <div
         classList={{


### PR DESCRIPTION
Fixes #12458

Apologies if this is not something that you want! But I'm super used to clicking on the title bar and having it maximise.

## Summary
- add double-click maximise/unmaximise behaviour to the custom desktop titlebar
- keep behaviour scoped to desktop and non-interactive titlebar areas
- avoid triggering maximise from window controls / interactive elements

## Verification
- run desktop app (`bun run --cwd packages/desktop tauri dev`)
- double-click non-interactive titlebar area toggles maximise/unmaximise
- double-clicking buttons/controls does not trigger maximise



https://github.com/user-attachments/assets/46e21a5b-3928-477a-9f4a-2bf783610d67

