### PR TITLE
fix(tui): truncate agent descriptions in dialog

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -3,6 +3,11 @@ import { useLocal } from "@tui/context/local"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 
+function truncate(text: string | undefined, maxLength: number): string | undefined {
+  if (!text || text.length <= maxLength) return text
+  return text.slice(0, maxLength - 1) + "…"
+}
+
 export function DialogAgent() {
   const local = useLocal()
   const dialog = useDialog()
@@ -12,7 +17,7 @@ export function DialogAgent() {
       return {
         value: item.name,
         title: item.name,
-        description: item.native ? "native" : item.description,
+        description: item.native ? "native" : truncate(item.description, 60),
       }
     }),
   )


### PR DESCRIPTION
## Problem

Fixes #4825

When creating agents with `opencode agent create`, the generated descriptions are very long (meant for the model to understand when to use the agent). These descriptions break the `/agents` dialog layout, making it impossible to read.

## Solution

Added truncation for agent descriptions in the agent selection dialog. Descriptions are now capped at 60 characters with an ellipsis (…) appended when needed.

## Changes

- `dialog-agent.tsx`: Added `truncate()` helper function
- Descriptions longer than 60 chars are now truncated with '…'

## Screenshots

Before: Agent descriptions wrap multiple lines, breaking the dialog

After: Clean single-line descriptions that fit the dialog