### PR TITLE
fix(app): show friendly plugin names in status popover

### DIFF
--- a/packages/app/src/components/plugin-specifier.ts
+++ b/packages/app/src/components/plugin-specifier.ts
@@ -1,0 +1,20 @@
+export type PluginEntry = { raw: string; name: string; version?: string }
+
+export function parsePluginSpecifier(value: string): PluginEntry {
+  if (value.startsWith("file://")) {
+    const path = value.substring("file://".length)
+    const parts = path.split("/")
+    const file = parts.pop() || path
+    if (!file.includes(".")) return { raw: value, name: file }
+    const base = file.split(".")[0]
+    if (base !== "index") return { raw: value, name: base }
+    const dir = parts.pop()
+    return { raw: value, name: dir || base }
+  }
+
+  const index = value.lastIndexOf("@")
+  if (index <= 0) return { raw: value, name: value }
+  const name = value.substring(0, index)
+  const version = value.substring(index + 1)
+  return { raw: value, name, version }
+}

--- a/packages/app/src/components/status-popover.test.ts
+++ b/packages/app/src/components/status-popover.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { parsePluginSpecifier } from "./plugin-specifier"
+
+describe("parsePluginSpecifier", () => {
+  test("parses file plugin by basename", () => {
+    const result = parsePluginSpecifier("file:///path/to/prevent-sleep.ts")
+    expect(result).toEqual({
+      raw: "file:///path/to/prevent-sleep.ts",
+      name: "prevent-sleep",
+    })
+  })
+
+  test("parses file plugin index entry by directory", () => {
+    const result = parsePluginSpecifier("file:///path/to/opencode-caffeinate/index.ts")
+    expect(result).toEqual({
+      raw: "file:///path/to/opencode-caffeinate/index.ts",
+      name: "opencode-caffeinate",
+    })
+  })
+
+  test("parses npm plugin with version", () => {
+    const result = parsePluginSpecifier("opencode-caffeinate@0.1.3")
+    expect(result).toEqual({
+      raw: "opencode-caffeinate@0.1.3",
+      name: "opencode-caffeinate",
+      version: "0.1.3",
+    })
+  })
+
+  test("parses scoped npm plugin with version", () => {
+    const result = parsePluginSpecifier("@scope/plugin@1.2.3")
+    expect(result).toEqual({
+      raw: "@scope/plugin@1.2.3",
+      name: "@scope/plugin",
+      version: "1.2.3",
+    })
+  })
+
+  test("parses npm plugin without version", () => {
+    const result = parsePluginSpecifier("opencode-openai-codex-auth")
+    expect(result).toEqual({
+      raw: "opencode-openai-codex-auth",
+      name: "opencode-openai-codex-auth",
+    })
+  })
+})

--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -16,6 +16,7 @@ import { useLanguage } from "@/context/language"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { DialogSelectServer } from "./dialog-select-server"
 import { showToast } from "@opencode-ai/ui/toast"
+import { parsePluginSpecifier } from "./plugin-specifier"
 
 type ServerStatus = { healthy: boolean; version?: string }
 
@@ -121,7 +122,11 @@ export function StatusPopover() {
 
   const lspItems = createMemo(() => sync.data.lsp ?? [])
   const lspCount = createMemo(() => lspItems().length)
-  const plugins = createMemo(() => sync.data.config.plugin ?? [])
+  const plugins = createMemo(() =>
+    (sync.data.config.plugin ?? [])
+      .map(parsePluginSpecifier)
+      .toSorted((a, b) => a.name.localeCompare(b.name)),
+  )
   const pluginCount = createMemo(() => plugins().length)
 
   const overallHealthy = createMemo(() => {
@@ -402,12 +407,38 @@ export function StatusPopover() {
                   }
                 >
                   <For each={plugins()}>
-                    {(plugin) => (
-                      <div class="flex items-center gap-2 w-full px-2 py-1">
-                        <div class="size-1.5 rounded-full shrink-0 bg-icon-success-base" />
-                        <span class="text-14-regular text-text-base truncate">{plugin}</span>
-                      </div>
-                    )}
+                    {(plugin) => {
+                      const [truncated, setTruncated] = createSignal(false)
+                      let nameRef: HTMLSpanElement | undefined
+                      let versionRef: HTMLSpanElement | undefined
+
+                      onMount(() => {
+                        const check = () => {
+                          const nameTruncated = nameRef ? nameRef.scrollWidth > nameRef.clientWidth : false
+                          const versionTruncated = versionRef ? versionRef.scrollWidth > versionRef.clientWidth : false
+                          setTruncated(nameTruncated || versionTruncated)
+                        }
+                        check()
+                        window.addEventListener("resize", check)
+                        onCleanup(() => window.removeEventListener("resize", check))
+                      })
+
+                      return (
+                        <Tooltip value={plugin.raw} placement="top" inactive={!truncated()}>
+                          <div class="flex items-center gap-2 w-full px-2 py-1">
+                            <div class="size-1.5 rounded-full shrink-0 bg-icon-success-base" />
+                            <span ref={nameRef} class="text-14-regular text-text-base truncate min-w-0 flex-1">
+                              {plugin.name}
+                            </span>
+                            <Show when={plugin.version}>
+                              <span ref={versionRef} class="text-12-regular text-text-weak shrink-0">
+                                @{plugin.version}
+                              </span>
+                            </Show>
+                          </div>
+                        </Tooltip>
+                      )
+                    }}
                   </For>
                 </Show>
               </div>


### PR DESCRIPTION
Closes #12478

## Summary
- Normalize plugin display in App status popover to match TUI behavior.
- Parse `file://` plugin specifiers into readable local plugin names (`index.ts` resolves to parent directory name).
- Parse npm plugin specifiers into package name with optional version display.
- Show full raw plugin specifier in a tooltip only when plugin text is truncated.

## Testing
- `bun test src/components/status-popover.test.ts`
- `bun run typecheck`