### PR TITLE
feat: add support for custom commands in .agents/commands/

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -147,6 +147,10 @@ export namespace Config {
 
     const deps = []
 
+    // Load external commands from .agents/commands/ BEFORE .opencode/ directories
+    // so that .opencode/commands/ can override them
+    result.command = mergeDeep(result.command ?? {}, await loadExternalCommands())
+
     for (const dir of unique(directories)) {
       if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
         for (const file of ["opencode.jsonc", "opencode.json"]) {
@@ -336,41 +340,160 @@ export namespace Config {
   }
 
   const COMMAND_GLOB = new Bun.Glob("{command,commands}/**/*.md")
+  const AGENTS_COMMAND_GLOB = new Bun.Glob("commands/**/*.md")
+
+  async function loadCommandFromFile(item: string, result: Record<string, Command>, patterns: string[]) {
+    const md = await ConfigMarkdown.parse(item).catch(async (err) => {
+      const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+        ? err.data.message
+        : `Failed to parse command ${item}`
+      const { Session } = await import("@/session")
+      Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+      log.error("failed to load command", { command: item, err })
+      return undefined
+    })
+    if (!md) return
+
+    const file = rel(item, patterns) ?? path.basename(item)
+    const name = trim(file)
+
+    // Skip if command already exists (precedence: .opencode/commands/ > .agents/commands/)
+    if (result[name]) {
+      log.debug("skipping duplicate command", { name, location: item, existing: result[name] })
+      return
+    }
+
+    const config = {
+      name,
+      ...md.data,
+      template: md.content.trim(),
+    }
+    const parsed = Command.safeParse(config)
+    if (parsed.success) {
+      result[name] = parsed.data
+      return
+    }
+    throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+  }
+
   async function loadCommand(dir: string) {
     const result: Record<string, Command> = {}
+
+    // Scan .opencode/command/ directories (highest priority)
     for await (const item of COMMAND_GLOB.scan({
       absolute: true,
       followSymlinks: true,
       dot: true,
       cwd: dir,
     })) {
-      const md = await ConfigMarkdown.parse(item).catch(async (err) => {
-        const message = ConfigMarkdown.FrontmatterError.isInstance(err)
-          ? err.data.message
-          : `Failed to parse command ${item}`
-        const { Session } = await import("@/session")
-        Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
-        log.error("failed to load command", { command: item, err })
-        return undefined
-      })
-      if (!md) continue
-
-      const patterns = ["/.opencode/command/", "/.opencode/commands/", "/command/", "/commands/"]
-      const file = rel(item, patterns) ?? path.basename(item)
-      const name = trim(file)
-
-      const config = {
-        name,
-        ...md.data,
-        template: md.content.trim(),
-      }
-      const parsed = Command.safeParse(config)
-      if (parsed.success) {
-        result[config.name] = parsed.data
-        continue
-      }
-      throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      await loadCommandFromFile(item, result, [
+        "/.opencode/command/",
+        "/.opencode/commands/",
+        "/command/",
+        "/commands/",
+      ])
     }
+
+    return result
+  }
+
+  export async function loadExternalCommands(): Promise<Record<string, Command>> {
+    const result: Record<string, Command> = {}
+
+    if (Flag.OPENCODE_DISABLE_EXTERNAL_COMMANDS) {
+      return result
+    }
+
+    const patterns = ["/.agents/commands/", "/commands/"]
+
+    // Scan global ~/.agents/commands/ first (lower priority)
+    // Later loads (project-level) will overwrite these (matching skills behavior)
+    const globalAgentsDir = path.join(Global.Path.home, ".agents")
+    if (await Filesystem.isDir(globalAgentsDir)) {
+      for await (const item of AGENTS_COMMAND_GLOB.scan({
+        cwd: globalAgentsDir,
+        absolute: true,
+        followSymlinks: true,
+        dot: true,
+      })) {
+        const md = await ConfigMarkdown.parse(item).catch(async (err) => {
+          const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+            ? err.data.message
+            : `Failed to parse command ${item}`
+          const { Session } = await import("@/session")
+          Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+          log.error("failed to load command", { command: item, err })
+          return undefined
+        })
+        if (!md) continue
+
+        const file = rel(item, patterns) ?? path.basename(item)
+        const name = trim(file)
+
+        const config = {
+          name,
+          ...md.data,
+          template: md.content.trim(),
+        }
+        const parsed = Command.safeParse(config)
+        if (parsed.success) {
+          result[name] = parsed.data
+          continue
+        }
+        throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      }
+    }
+
+    // Scan project .agents/commands/ directories (higher priority than global)
+    // These will overwrite any global commands with the same name
+    for await (const dir of Filesystem.up({
+      targets: [".agents"],
+      start: Instance.directory,
+      stop: Instance.worktree,
+    })) {
+      for await (const item of AGENTS_COMMAND_GLOB.scan({
+        cwd: dir,
+        absolute: true,
+        followSymlinks: true,
+        dot: true,
+      })) {
+        const md = await ConfigMarkdown.parse(item).catch(async (err) => {
+          const message = ConfigMarkdown.FrontmatterError.isInstance(err)
+            ? err.data.message
+            : `Failed to parse command ${item}`
+          const { Session } = await import("@/session")
+          Bus.publish(Session.Event.Error, { error: new NamedError.Unknown({ message }).toObject() })
+          log.error("failed to load command", { command: item, err })
+          return undefined
+        })
+        if (!md) continue
+
+        const file = rel(item, patterns) ?? path.basename(item)
+        const name = trim(file)
+
+        // Warn on duplicate command names (same behavior as skills)
+        if (result[name]) {
+          log.warn("duplicate command name", {
+            name,
+            existing: result[name],
+            duplicate: item,
+          })
+        }
+
+        const config = {
+          name,
+          ...md.data,
+          template: md.content.trim(),
+        }
+        const parsed = Command.safeParse(config)
+        if (parsed.success) {
+          result[name] = parsed.data
+          continue
+        }
+        throw new InvalidError({ path: item, issues: parsed.error.issues }, { cause: parsed.error })
+      }
+    }
+
     return result
   }
 

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -25,6 +25,7 @@ export namespace Flag {
     OPENCODE_DISABLE_CLAUDE_CODE || truthy("OPENCODE_DISABLE_CLAUDE_CODE_SKILLS")
   export const OPENCODE_DISABLE_EXTERNAL_SKILLS =
     OPENCODE_DISABLE_CLAUDE_CODE_SKILLS || truthy("OPENCODE_DISABLE_EXTERNAL_SKILLS")
+  export const OPENCODE_DISABLE_EXTERNAL_COMMANDS = truthy("OPENCODE_DISABLE_EXTERNAL_COMMANDS")
   export declare const OPENCODE_DISABLE_PROJECT_CONFIG: boolean
   export const OPENCODE_FAKE_VCS = process.env["OPENCODE_FAKE_VCS"]
   export declare const OPENCODE_CLIENT: string
@@ -65,6 +66,17 @@ export namespace Flag {
 Object.defineProperty(Flag, "OPENCODE_DISABLE_PROJECT_CONFIG", {
   get() {
     return truthy("OPENCODE_DISABLE_PROJECT_CONFIG")
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_DISABLE_EXTERNAL_COMMANDS
+// This must be evaluated at access time, not module load time,
+// to allow tests to enable/disable external command loading
+Object.defineProperty(Flag, "OPENCODE_DISABLE_EXTERNAL_COMMANDS", {
+  get() {
+    return truthy("OPENCODE_DISABLE_EXTERNAL_COMMANDS")
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1583,6 +1583,217 @@ describe("deduplicatePlugins", () => {
   })
 })
 
+describe("external commands from .agents/commands/", () => {
+  test("discovers commands from project .agents/commands/ directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const agentsDir = path.join(dir, ".agents", "commands")
+        await fs.mkdir(agentsDir, { recursive: true })
+
+        await Bun.write(
+          path.join(agentsDir, "test-cmd.md"),
+          `---
+description: Test command from .agents
+---
+Test command template`,
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.command?.["test-cmd"]).toEqual({
+          description: "Test command from .agents",
+          template: "Test command template",
+        })
+      },
+    })
+  })
+
+  test("discovers commands from global ~/.agents/commands/ directory", async () => {
+    await using tmp = await tmpdir()
+    const homeDir = path.join(tmp.path, "home")
+    await fs.mkdir(homeDir, { recursive: true })
+
+    const globalAgentsDir = path.join(homeDir, ".agents", "commands")
+    await fs.mkdir(globalAgentsDir, { recursive: true })
+
+    await Bun.write(
+      path.join(globalAgentsDir, "global-cmd.md"),
+      `---
+description: Global test command
+---
+Global command template`,
+    )
+
+    const originalHome = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = homeDir
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const config = await Config.get()
+          expect(config.command?.["global-cmd"]).toEqual({
+            description: "Global test command",
+            template: "Global command template",
+          })
+        },
+      })
+    } finally {
+      if (originalHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = originalHome
+    }
+  })
+
+  test(".opencode/commands/ takes precedence over .agents/commands/", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        // Create .opencode/commands/ version (highest priority)
+        const opencodeDir = path.join(dir, ".opencode", "commands")
+        await fs.mkdir(opencodeDir, { recursive: true })
+        await Bun.write(
+          path.join(opencodeDir, "shared.md"),
+          `---
+description: From .opencode
+---
+Opencode template`,
+        )
+
+        // Create .agents/commands/ version (lower priority)
+        const agentsDir = path.join(dir, ".agents", "commands")
+        await fs.mkdir(agentsDir, { recursive: true })
+        await Bun.write(
+          path.join(agentsDir, "shared.md"),
+          `---
+description: From .agents
+---
+Agents template`,
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        // .opencode version should win
+        expect(config.command?.["shared"]).toEqual({
+          description: "From .opencode",
+          template: "Opencode template",
+        })
+      },
+    })
+  })
+
+  test("project .agents/commands/ takes precedence over global ~/.agents/commands/", async () => {
+    await using tmp = await tmpdir()
+
+    const homeDir = path.join(tmp.path, "home")
+    await fs.mkdir(homeDir, { recursive: true })
+
+    // Create global ~/.agents/commands/
+    const globalAgentsDir = path.join(homeDir, ".agents", "commands")
+    await fs.mkdir(globalAgentsDir, { recursive: true })
+    await Bun.write(
+      path.join(globalAgentsDir, "shared.md"),
+      `---
+description: Global command
+---
+Global template`,
+    )
+
+    // Create project .agents/commands/ (in tmp.path)
+    const projectAgentsDir = path.join(tmp.path, ".agents", "commands")
+    await fs.mkdir(projectAgentsDir, { recursive: true })
+    await Bun.write(
+      path.join(projectAgentsDir, "shared.md"),
+      `---
+description: Project command
+---
+Project template`,
+    )
+
+    const originalHome = process.env.OPENCODE_TEST_HOME
+    process.env.OPENCODE_TEST_HOME = homeDir
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const config = await Config.get()
+          // Project version should win
+          expect(config.command?.["shared"]).toEqual({
+            description: "Project command",
+            template: "Project template",
+          })
+        },
+      })
+    } finally {
+      if (originalHome === undefined) delete process.env.OPENCODE_TEST_HOME
+      else process.env.OPENCODE_TEST_HOME = originalHome
+    }
+  })
+
+  test("OPENCODE_DISABLE_EXTERNAL_COMMANDS flag disables .agents/commands/ loading", async () => {
+    const originalFlag = process.env.OPENCODE_DISABLE_EXTERNAL_COMMANDS
+    process.env.OPENCODE_DISABLE_EXTERNAL_COMMANDS = "true"
+
+    try {
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          const agentsDir = path.join(dir, ".agents", "commands")
+          await fs.mkdir(agentsDir, { recursive: true })
+          await Bun.write(
+            path.join(agentsDir, "should-not-load.md"),
+            `---
+description: Should not load
+---
+Template`,
+          )
+        },
+      })
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const config = await Config.get()
+          expect(config.command?.["should-not-load"]).toBeUndefined()
+        },
+      })
+    } finally {
+      if (originalFlag === undefined) delete process.env.OPENCODE_DISABLE_EXTERNAL_COMMANDS
+      else process.env.OPENCODE_DISABLE_EXTERNAL_COMMANDS = originalFlag
+    }
+  })
+
+  test("discovers nested commands from .agents/commands/ subdirectories", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const agentsDir = path.join(dir, ".agents", "commands")
+        await fs.mkdir(path.join(agentsDir, "nested"), { recursive: true })
+
+        await Bun.write(
+          path.join(agentsDir, "nested", "deep-cmd.md"),
+          `---
+description: Deep nested command
+---
+Nested template`,
+        )
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const config = await Config.get()
+        expect(config.command?.["nested/deep-cmd"]).toEqual({
+          description: "Deep nested command",
+          template: "Nested template",
+        })
+      },
+    })
+  })
+})
+
 describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {
   test("skips project config files when flag is set", async () => {
     const originalEnv = process.env["OPENCODE_DISABLE_PROJECT_CONFIG"]

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -569,6 +569,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | Disable reading from `.claude` (prompt + skills)  |
 | `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | Disable reading `~/.claude/CLAUDE.md`             |
 | `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | Disable loading `.claude/skills`                  |
+| `OPENCODE_DISABLE_EXTERNAL_COMMANDS`  | boolean | Disable loading commands from `.agents/commands/` |
 | `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | Disable fetching models from remote sources       |
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
 | `OPENCODE_DISABLE_FILETIME_CHECK`     | boolean | Disable file time checking for optimization       |

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -40,6 +40,43 @@ Use the command by typing `/` followed by the command name.
 
 ---
 
+## Co-host commands with skills
+
+If you're using the [Agent Skills](/docs/skills) standard with `.agents/skills/`, you can keep all your agentic coding instructions together by also placing commands in `.agents/commands/`:
+
+```
+my-project/
+├── .agents/
+│   ├── skills/
+│   │   ├── git-workflow/SKILL.md
+│   │   └── testing/SKILL.md
+│   └── commands/
+│       ├── pr-review.md
+│       ├── refactor.md
+│       └── release.md
+├── src/
+└── ...
+```
+
+This structure makes it easier to:
+
+- **Share configurations**: Distribute your entire `.agents/` folder to team members
+- **Version control**: Keep agent instructions in your repo without cluttering `.opencode/`
+- **Standardize**: Follow emerging agent standards across different AI coding tools
+
+### Location support
+
+OpenCode discovers commands from these locations (in priority order):
+
+1. **Project**: `.opencode/commands/` (highest priority)
+2. **Project**: `.agents/commands/`
+3. **Global**: `~/.config/opencode/commands/`
+4. **Global**: `~/.agents/commands/`
+
+If a command exists in multiple locations, the first one found wins. Use `.opencode/commands/` for project-specific overrides of shared agent commands.
+
+---
+
 ## Configure
 
 You can add custom commands through the OpenCode config or by creating markdown files in the `commands/` directory.
@@ -79,8 +116,8 @@ Now you can run this command in the TUI:
 
 You can also define commands using markdown files. Place them in:
 
-- Global: `~/.config/opencode/commands/`
-- Per-project: `.opencode/commands/`
+- **Global**: `~/.config/opencode/commands/` or `~/.agents/commands/`
+- **Per-project**: `.opencode/commands/` or `.agents/commands/`
 
 ```markdown title="~/.config/opencode/commands/test.md"
 ---

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -29,6 +29,10 @@ It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.cla
 
 Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
 
+:::tip Co-host your commands
+You can also host custom [commands](/docs/commands) in `.agents/commands/` to keep all your agentic coding instructions in one location. This makes it easier to share and version control your entire agent configuration alongside your codebase.
+:::
+
 ---
 
 ## Write frontmatter


### PR DESCRIPTION
# Summary
Add support for hosting custom commands in .agents/commands/ alongside skills, following the emerging agent standards. This allows teams to co-host all agentic coding instructions in a single location.

# Features:
- Discover commands from .agents/commands/ (project) and ~/.agents/commands/ (global)
- Precedence order: .opencode/commands/ > .agents/commands/ > ~/.agents/commands/
- Add OPENCODE_DISABLE_EXTERNAL_COMMANDS flag to disable loading
- Align loading behavior with skills (global first, then project overwrites)

# Changes:
- packages/opencode/src/flag/flag.ts: Add OPENCODE_DISABLE_EXTERNAL_COMMANDS flag
- packages/opencode/src/config/config.ts: Add loadExternalCommands() function
- packages/opencode/test/config/config.test.ts: Add comprehensive test suite
- packages/web/src/content/docs/commands.mdx: Document new feature
- packages/web/src/content/docs/skills.mdx: Add cross-reference tip
- packages/web/src/content/docs/cli.mdx: Document new environment variable

# Verification
The implementation has been tested with unit test and through local build verification

Fixes #12486
