### PR TITLE
feat(opencode): Show tool args on permission request

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { createMemo, For, Match, Show, Switch } from "solid-js"
-import { Portal, useKeyboard, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
+import { Portal, useKeyboard, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useKeybind } from "../../context/keybind"
 import { useTheme, selectedForeground } from "../../context/theme"
@@ -121,6 +121,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
   const sync = useSync()
   const [store, setStore] = createStore({
     stage: "permission" as PermissionStage,
+    expanded: false,
   })
 
   const session = createMemo(() => sync.data.session.find((s) => s.id === props.request.sessionID))
@@ -138,6 +139,28 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
   })
 
   const { theme } = useTheme()
+
+  const formatValue = (value: any, expanded: boolean = false) => {
+    if(value && (typeof value === "object" || typeof value === "string")){
+      if (typeof value === "object") {
+        if (expanded) {
+          // Show full content in fullscreen mode
+          return JSON.stringify(value, null, 2)
+        }
+        if (Array.isArray(value))
+          return `[${value.length} item${value.length === 1 ? "" : "s"}]`
+        return "{...}"
+      }
+      // String - truncate if too long (unless expanded)
+      const str = String(value)
+      if (expanded) return `"${str}"`
+      return str.length > 60 ? `"${str.slice(0, 57)}..."` : `"${str}"`
+    }
+    else{
+      return String(value)
+    }
+  }
+
 
   return (
     <Switch>
@@ -260,14 +283,39 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                     <TextBody icon="⟳" title="Continue after repeated failures" />
                   </Match>
                   <Match when={true}>
-                    <TextBody icon="⚙" title={`Call tool ` + props.request.permission} />
+                    <box flexDirection="column" gap={1}>
+                      <box flexDirection="row" gap={1} paddingLeft={1}>
+                        <text fg={theme.textMuted}>{"⚙"}</text>
+                        <text fg={theme.textMuted}>Call tool {props.request.permission}</text>
+                      </box>
+                      <Show when={Object.keys(input()).length > 0}>
+                        <box flexDirection="column" paddingLeft={4} gap={0}>
+                          <For each={Object.entries(input()).slice(0, store.expanded ? Infinity : 8)}>
+                            {([key, value]) => <box flexDirection="row" gap={1}>
+                                  <text fg={theme.text}>
+                                    <span style={{ bold: true }}>{key}:</span>
+                                  </text>
+                                  <text fg={theme.textMuted}>{formatValue(value, store.expanded)}</text>
+                                </box>
+                            }
+                          </For>
+                          <Show when={!store.expanded && Object.keys(input()).length > 8}>
+                            <text fg={theme.textMuted}>
+                              <span style={{ italic: true }}>... and {Object.keys(input()).length - 8} more</span>
+                            </text>
+                          </Show>
+                        </box>
+                      </Show>
+                    </box>
                   </Match>
                 </Switch>
               }
               options={{ once: "Allow once", always: "Allow always", reject: "Reject" }}
               escapeKey="reject"
-              fullscreen
+              expanded={store.expanded}
+              onExpandedToggle={() => setStore("expanded", (v) => !v)}
               onSelect={(option) => {
+                setStore("expanded", false);
                 if (option === "always") {
                   setStore("stage", "always")
                   return
@@ -375,7 +423,8 @@ function Prompt<const T extends Record<string, string>>(props: {
   body: JSX.Element
   options: T
   escapeKey?: keyof T
-  fullscreen?: boolean
+  expanded?: boolean
+  onExpandedToggle?: () => void
   onSelect: (option: keyof T) => void
 }) {
   const { theme } = useTheme()
@@ -384,7 +433,6 @@ function Prompt<const T extends Record<string, string>>(props: {
   const keys = Object.keys(props.options) as (keyof T)[]
   const [store, setStore] = createStore({
     selected: keys[0],
-    expanded: false,
   })
   const diffKey = Keybind.parse("ctrl+f")[0]
   const narrow = createMemo(() => dimensions().width < 80)
@@ -417,15 +465,14 @@ function Prompt<const T extends Record<string, string>>(props: {
       props.onSelect(props.escapeKey)
     }
 
-    if (props.fullscreen && diffKey && Keybind.match(diffKey, keybind.parse(evt))) {
+    if (props.onExpandedToggle && diffKey && Keybind.match(diffKey, keybind.parse(evt))) {
       evt.preventDefault()
       evt.stopPropagation()
-      setStore("expanded", (v) => !v)
+      props.onExpandedToggle?.()
     }
   })
 
-  const hint = createMemo(() => (store.expanded ? "minimize" : "fullscreen"))
-  const renderer = useRenderer()
+  const hint = createMemo(() => (props.expanded ? "minimize" : "fullscreen"))
 
   const content = () => (
     <box
@@ -433,7 +480,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       border={["left"]}
       borderColor={theme.warning}
       customBorderChars={SplitBorder.customBorderChars}
-      {...(store.expanded
+      {...(props.expanded
         ? { top: dimensions().height * -1 + 1, bottom: 1, left: 2, right: 2, position: "absolute" }
         : {
             top: 0,
@@ -484,7 +531,7 @@ function Prompt<const T extends Record<string, string>>(props: {
           </For>
         </box>
         <box flexDirection="row" gap={2} flexShrink={0}>
-          <Show when={props.fullscreen}>
+          <Show when={props.onExpandedToggle}>
             <text fg={theme.text}>
               {"ctrl+f"} <span style={{ fg: theme.textMuted }}>{hint()}</span>
             </text>
@@ -501,7 +548,7 @@ function Prompt<const T extends Record<string, string>>(props: {
   )
 
   return (
-    <Show when={!store.expanded} fallback={<Portal>{content()}</Portal>}>
+    <Show when={!props.expanded} fallback={<Portal>{content()}</Portal>}>
       {content()}
     </Show>
   )

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -140,6 +140,21 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
 
   const { theme } = useTheme()
 
+  const shouldShowParameters = createMemo(() => {
+    const mcpConfig = sync.data.config.tui?.mcp_show_parameters ?? "all"
+    const toolsList = sync.data.config.tui?.mcp_show_parameters_tools ?? []
+    switch(mcpConfig){
+      case "all":
+        return true;
+      case "none":
+        return false;
+      case "selected":
+        return toolsList.includes(props.request.permission);
+      default:
+        return true;
+    }
+  })
+
   const formatValue = (value: any, expanded: boolean = false) => {
     if(value && (typeof value === "object" || typeof value === "string")){
       if (typeof value === "object") {
@@ -288,7 +303,7 @@ export function PermissionPrompt(props: { request: PermissionRequest }) {
                         <text fg={theme.textMuted}>{"⚙"}</text>
                         <text fg={theme.textMuted}>Call tool {props.request.permission}</text>
                       </box>
-                      <Show when={Object.keys(input()).length > 0}>
+                      <Show when={shouldShowParameters() && Object.keys(input()).length > 0}>
                         <box flexDirection="column" paddingLeft={4} gap={0}>
                           <For each={Object.entries(input()).slice(0, store.expanded ? Infinity : 8)}>
                             {([key, value]) => <box flexDirection="row" gap={1}>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -926,6 +926,15 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    mcp_show_parameters: z
+      .enum(["all", "none", "selected"])
+      .optional()
+      .default("all")
+      .describe("Control MCP tool parameter visibility in permission prompts: 'all' shows all parameters, 'none' hides all parameters, 'selected' shows only parameters for tools in mcp_show_parameters_tools"),
+    mcp_show_parameters_tools: z
+      .array(z.string())
+      .optional()
+      .describe("List of MCP tool names to show parameters for when mcp_show_parameters is 'selected'"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1207,6 +1207,14 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Control MCP tool parameter visibility in permission prompts: 'all' shows all parameters, 'none' hides all parameters, 'selected' shows only parameters for tools in mcp_show_parameters_tools
+     */
+    mcp_show_parameters?: "all" | "none" | "selected"
+    /**
+     * List of MCP tool names to show parameters for when mcp_show_parameters is 'selected'
+     */
+    mcp_show_parameters_tools?: Array<string>
   }
   /**
    * Command configuration, see https://opencode.ai/docs/commands

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1640,6 +1640,14 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Control MCP tool parameter visibility in permission prompts: 'all' shows all parameters, 'none' hides all parameters, 'selected' shows only parameters for tools in mcp_show_parameters_tools
+     */
+    mcp_show_parameters?: "all" | "none" | "selected"
+    /**
+     * List of MCP tool names to show parameters for when mcp_show_parameters is 'selected'
+     */
+    mcp_show_parameters_tools?: Array<string>
   }
   server?: ServerConfig
   /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9503,6 +9503,19 @@
                 "description": "Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column",
                 "type": "string",
                 "enum": ["auto", "stacked"]
+              },
+              "mcp_show_parameters": {
+                "description": "Control MCP tool parameter visibility in permission prompts: 'all' shows all parameters, 'none' hides all parameters, 'selected' shows only parameters for tools in mcp_show_parameters_tools",
+                "type": "string",
+                "enum": ["all", "none", "selected"],
+                "default": "all"
+              },
+              "mcp_show_parameters_tools": {
+                "description": "List of MCP tool names to show parameters for when mcp_show_parameters is 'selected'",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             }
           },

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -164,7 +164,9 @@ You can configure TUI-specific settings through the `tui` option.
     "scroll_acceleration": {
       "enabled": true
     },
-    "diff_style": "auto"
+    "diff_style": "auto",
+    "mcp_show_parameters": "selected",
+    "mcp_show_parameters_tools": ["memory_create_entities", "memory_add_observations"]
   }
 }
 ```
@@ -174,6 +176,8 @@ Available options:
 - `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration. **Takes precedence over `scroll_speed`.**
 - `scroll_speed` - Custom scroll speed multiplier (default: `3`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
 - `diff_style` - Control diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows single column.
+- `mcp_show_parameters` - Control MCP tool parameter visibility in permission prompts. Options: `"all"` (default), `"none"`, or `"selected"`.
+- `mcp_show_parameters_tools` - Array of MCP tool names to show parameters for when `mcp_show_parameters` is `"selected"`.
 
 [Learn more about using the TUI here](/docs/tui).
 

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -373,6 +373,11 @@ You can customize TUI behavior through your OpenCode config file.
 
 - `scroll_acceleration` - Enable macOS-style scroll acceleration for smooth, natural scrolling. When enabled, scroll speed increases with rapid scrolling gestures and stays precise for slower movements. **This setting takes precedence over `scroll_speed` and overrides it when enabled.**
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `1`). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
+- `mcp_show_parameters` - Control MCP tool parameter visibility in permission prompts. Options:
+  - `"all"` (default) - Show parameters for all MCP tools
+  - `"none"` - Hide parameters for all MCP tools
+  - `"selected"` - Show parameters only for tools listed in `mcp_show_parameters_tools`
+- `mcp_show_parameters_tools` - Array of MCP tool names to show parameters for when `mcp_show_parameters` is set to `"selected"`. Example: `["memory_create_entities", "memory_add_observations"]`
 
 ---
 


### PR DESCRIPTION
Fixes #12111 

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.

Tool call arguments were not always very apparent in tool call approval requests through the TUI. This causes issues, as there are times when the arguments of the tool call are important for the context of if they should be approved or not.

While this information was sometimes provided in-line of the chat for primary agents, I found the subagent tool calls were completely blind in this regard. Also, it is a better UX if the user is able to see it presented in the approval selection UI.

Code is simple. Made an improved renderer for tool call args, truncating them if they are too long (or there are too many). On fullscreen, we do not do the truncation.  Also added configuration values, as requested by the issue, to enable this globally or selectively on specific MCP tools.

### How did you verify your code works?

Ran the TUI and tried MCP tool calls with various different datatypes. Ensured existing tool calls (e.g. read, write) were not impacted.  Also verified all 3 new configuration states worked as expected.



Before (or with mcp_show_parameters==="none"):
<img width="653" height="1294" alt="image" src="https://github.com/user-attachments/assets/ff799028-a3a7-4205-99a9-1b1c758597d7" />


After: 
<img width="710" height="1304" alt="image" src="https://github.com/user-attachments/assets/c5368b59-c082-450a-910a-ede1fed52395" />

