### PR TITLE
feat(cli): add plugin disable/enable commands

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -379,7 +379,7 @@ export const McpLogoutCommand = cmd({
   },
 })
 
-async function resolveConfigPath(baseDir: string, global = false) {
+export async function resolveConfigPath(baseDir: string, global = false) {
   // Check for existing config files (prefer .jsonc over .json, check .opencode/ subdirectory too)
   const candidates = [path.join(baseDir, "opencode.json"), path.join(baseDir, "opencode.jsonc")]
 

--- a/packages/opencode/src/cli/cmd/plugin.ts
+++ b/packages/opencode/src/cli/cmd/plugin.ts
@@ -1,0 +1,168 @@
+import { cmd } from "./cmd"
+import * as prompts from "@clack/prompts"
+import { UI } from "../ui"
+import { Config } from "../../config/config"
+import { Instance } from "../../project/instance"
+import { Global } from "../../global"
+import { modify, applyEdits } from "jsonc-parser"
+import { resolveConfigPath } from "./mcp"
+
+async function updateDisabledPlugins(plugins: string[], configPath: string) {
+  const file = Bun.file(configPath)
+
+  let text = "{}"
+  if (await file.exists()) {
+    text = await file.text()
+  }
+
+  const edits = modify(text, ["disabled_plugins"], plugins, {
+    formattingOptions: { tabSize: 2, insertSpaces: true },
+  })
+  const result = applyEdits(text, edits)
+
+  await Bun.write(configPath, result)
+}
+
+export const PluginCommand = cmd({
+  command: "plugin",
+  describe: "manage plugins",
+  builder: (yargs) =>
+    yargs.command(PluginListCommand).command(PluginDisableCommand).command(PluginEnableCommand).demandCommand(),
+  async handler() {},
+})
+
+export const PluginListCommand = cmd({
+  command: "list",
+  aliases: ["ls"],
+  describe: "list all configured plugins and their status",
+  async handler() {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Plugins")
+
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+        const disabled = new Set(config.disabled_plugins ?? [])
+
+        if (plugins.length === 0) {
+          prompts.log.warn("No plugins configured")
+          prompts.outro("Add plugins in opencode.json or via npm install")
+          return
+        }
+
+        for (const plugin of plugins) {
+          const name = Config.getPluginName(plugin)
+          const isDisabled = disabled.has(name)
+          const icon = isDisabled ? "○" : "✓"
+          const status = isDisabled ? "disabled" : "enabled"
+          prompts.log.info(`${icon} ${name} ${UI.Style.TEXT_DIM}${status}\n    ${UI.Style.TEXT_DIM}${plugin}`)
+        }
+
+        const enabledCount = plugins.filter((p) => !disabled.has(Config.getPluginName(p))).length
+        prompts.outro(`${enabledCount}/${plugins.length} plugin(s) enabled`)
+      },
+    })
+  },
+})
+
+export const PluginDisableCommand = cmd({
+  command: "disable <name>",
+  describe: "disable a plugin",
+  builder: (yargs) =>
+    yargs.positional("name", {
+      describe: "name of the plugin to disable",
+      type: "string",
+      demandOption: true,
+    }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Disable Plugin")
+
+        const config = await Config.get()
+        const plugins = config.plugin ?? []
+        const pluginName = args.name
+
+        if (plugins.length === 0) {
+          prompts.log.warn("No plugins configured")
+          prompts.outro("Done")
+          return
+        }
+
+        const pluginEntry = plugins.find((p) => Config.getPluginName(p) === pluginName)
+        if (!pluginEntry) {
+          prompts.log.error(`Plugin not found: ${pluginName}`)
+          prompts.outro("Done")
+          return
+        }
+
+        const disabled = config.disabled_plugins ?? []
+        if (disabled.includes(pluginName)) {
+          prompts.log.warn(`Plugin "${pluginName}" is already disabled`)
+          prompts.outro("Done")
+          return
+        }
+
+        const [projectConfigPath, globalConfigPath] = await Promise.all([
+          resolveConfigPath(Instance.worktree),
+          resolveConfigPath(Global.Path.config, true),
+        ])
+
+        const currentProject = Instance.project
+        const configPath = currentProject.vcs === "git" ? projectConfigPath : globalConfigPath
+        const nextDisabled = [...disabled, pluginName]
+        await updateDisabledPlugins(nextDisabled, configPath)
+
+        prompts.log.success(`Plugin "${pluginName}" disabled`)
+        prompts.outro("Done")
+      },
+    })
+  },
+})
+
+export const PluginEnableCommand = cmd({
+  command: "enable <name>",
+  describe: "enable a previously disabled plugin",
+  builder: (yargs) =>
+    yargs.positional("name", {
+      describe: "name of the plugin to enable",
+      type: "string",
+      demandOption: true,
+    }),
+  async handler(args) {
+    await Instance.provide({
+      directory: process.cwd(),
+      async fn() {
+        UI.empty()
+        prompts.intro("Enable Plugin")
+
+        const config = await Config.get()
+        const disabled = config.disabled_plugins ?? []
+        const pluginName = args.name
+
+        if (!disabled.includes(pluginName)) {
+          prompts.log.warn(`Plugin "${pluginName}" is not disabled`)
+          prompts.outro("Done")
+          return
+        }
+
+        const [projectConfigPath, globalConfigPath] = await Promise.all([
+          resolveConfigPath(Instance.worktree),
+          resolveConfigPath(Global.Path.config, true),
+        ])
+
+        const currentProject = Instance.project
+        const configPath = currentProject.vcs === "git" ? projectConfigPath : globalConfigPath
+        const nextDisabled = disabled.filter((p) => p !== pluginName)
+        await updateDisabledPlugins(nextDisabled, configPath)
+
+        prompts.log.success(`Plugin "${pluginName}" enabled`)
+        prompts.outro("Done")
+      },
+    })
+  },
+})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1022,6 +1022,12 @@ export namespace Config {
         })
         .optional(),
       plugin: z.string().array().optional(),
+      disabled_plugins: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Plugins to disable. Can be plugin names (e.g., 'my-plugin') or package specifiers (e.g., '@scope/plugin@1.0.0')",
+        ),
       snapshot: z.boolean().optional(),
       share: z
         .enum(["manual", "auto", "disabled"])

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -31,6 +31,7 @@ import path from "path"
 import { Global } from "./global"
 import { JsonMigration } from "./storage/json-migration"
 import { Database } from "./storage/db"
+import { PluginCommand } from "./cli/cmd/plugin"
 
 process.on("unhandledRejection", (e) => {
   Log.Default.error("rejection", {
@@ -121,6 +122,7 @@ const cli = yargs(hideBin(process.argv))
   .completion("completion", "generate shell completion script")
   .command(AcpCommand)
   .command(McpCommand)
+  .command(PluginCommand)
   .command(TuiThreadCommand)
   .command(AttachCommand)
   .command(RunCommand)

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -51,6 +51,16 @@ export namespace Plugin {
       plugins = [...BUILTIN, ...plugins]
     }
 
+    const disabled = new Set(config.disabled_plugins ?? [])
+    plugins = plugins.filter((plugin) => {
+      const name = Config.getPluginName(plugin)
+      if (disabled.has(name)) {
+        log.info("skipping disabled plugin", { name, path: plugin })
+        return false
+      }
+      return true
+    })
+
     for (let plugin of plugins) {
       // ignore old codex plugin since it is supported first party now
       if (plugin.includes("opencode-openai-codex-auth") || plugin.includes("opencode-copilot-auth")) continue


### PR DESCRIPTION
## Summary

add CLI commands to list,enable or disable plugins without editing config file

## Changes

- Added `disabled_plugins` field to config schema
- Modified plugin loading to filter out disabled plugins  
- Added new CLI commands:
  - `opencode plugin list` - list all plugins and their status
  - `opencode plugin disable <name>` - disable a plugin
  - `opencode plugin enable <name>` - enable a previously disabled plugin

## Usage

```bash
# List all plugins and their status
opencode plugin list

# Disable a plugin
opencode plugin disable my-plugin

# Enable a previously disabled plugin
opencode plugin enable my-plugin
```

## Related Issues

Resolves #7687