### PR TITLE
feat(core): Set variant in assistant messages too

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -108,6 +108,7 @@ export namespace SessionCompaction {
       sessionID: input.sessionID,
       mode: "compaction",
       agent: "compaction",
+      variant: userMessage.variant,
       summary: true,
       path: {
         cwd: Instance.directory,

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -387,6 +387,7 @@ export namespace MessageV2 {
         write: z.number(),
       }),
     }),
+    variant: z.string().optional(),
     finish: z.string().optional(),
   }).meta({
     ref: "AssistantMessage",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -323,6 +323,7 @@ export namespace SessionPrompt {
           sessionID,
           mode: task.agent,
           agent: task.agent,
+          variant: lastUser.variant,
           path: {
             cwd: Instance.directory,
             root: Instance.worktree,
@@ -526,6 +527,7 @@ export namespace SessionPrompt {
           role: "assistant",
           mode: agent.name,
           agent: agent.name,
+          variant: lastUser.variant,
           path: {
             cwd: Instance.directory,
             root: Instance.worktree,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -197,6 +197,7 @@ export type AssistantMessage = {
       write: number
     }
   }
+  variant?: string
   finish?: string
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds model variant selection in assistant messages

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

Manual Testing

```
{
        "info": {
            "id": "msg_c350253fd0019aBhGUrMTWePEU",
            "sessionID": "ses_3cafea7a4ffeUaTmwCrT2sZWuY",
            "role": "assistant",
            "time": {
                "created": 1770415870973,
                "completed": 1770415872871
            },
            "parentID": "msg_c350253cc0013P2nFF9JZp240k",
            "modelID": "gpt-5.3-codex",
            "providerID": "openai",
            "mode": "build",
            "agent": "build",
            "path": {
                "cwd": "/Users/shantur/Coding/tasmotizer",
                "root": "/Users/shantur/Coding/tasmotizer"
            },
            "cost": 0,
            "tokens": {
                "input": 10988,
                "output": 33,
                "reasoning": 15,
                "cache": {
                    "read": 0,
                    "write": 0
                }
            },
            "variant": "high",
            "finish": "stop"
        },
```
