### PR TITLE
fix(tui): keep /share available to copy existing link

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -314,26 +314,31 @@ export function Session() {
   const command = useCommandDialog()
   command.register(() => [
     {
-      title: "Share session",
+      title: session()?.share?.url ? "Copy share link" : "Share session",
       value: "session.share",
       suggested: route.type === "session",
       keybind: "session_share",
       category: "Session",
-      enabled: sync.data.config.share !== "disabled" && !session()?.share?.url,
+      enabled: sync.data.config.share !== "disabled",
       slash: {
         name: "share",
       },
       onSelect: async (dialog) => {
+        const copy = (url: string) =>
+          Clipboard.copy(url)
+            .then(() => toast.show({ message: "Share URL copied to clipboard!", variant: "success" }))
+            .catch(() => toast.show({ message: "Failed to copy URL to clipboard", variant: "error" }))
+        const url = session()?.share?.url
+        if (url) {
+          await copy(url)
+          dialog.clear()
+          return
+        }
         await sdk.client.session
           .share({
             sessionID: route.sessionID,
           })
-          .then((res) =>
-            Clipboard.copy(res.data!.share!.url).catch(() =>
-              toast.show({ message: "Failed to copy URL to clipboard", variant: "error" }),
-            ),
-          )
-          .then(() => toast.show({ message: "Share URL copied to clipboard!", variant: "success" }))
+          .then((res) => copy(res.data!.share!.url))
           .catch(() => toast.show({ message: "Failed to share session", variant: "error" }))
         dialog.clear()
       },


### PR DESCRIPTION
**before sharing**
<img width="910" height="200" alt="image" src="https://github.com/user-attachments/assets/b8c84890-7ce5-4942-af7c-8450742ca441" />

**after sharing**
<img width="917" height="213" alt="image" src="https://github.com/user-attachments/assets/e1ff362b-9477-4f32-aae4-19f30cf58602" />

## Summary
- keep `session.share` available in the TUI command dialog and slash list after a session is already shared
- make `/share` copy the existing share URL when present, and only call share API when no URL exists

## Related
- companion web PR: https://github.com/anomalyco/opencode/pull/12533

## Issue
- Refs #12535