### PR TITLE
fix(web): keep /share available to copy existing link

### DIFF
--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -360,30 +360,41 @@ export const useSessionCommands = (input: {
     return [
       {
         id: "session.share",
-        title: input.language.t("command.session.share"),
-        description: input.language.t("command.session.share.description"),
+        title: input.info()?.share?.url ? "Copy share link" : input.language.t("command.session.share"),
+        description: input.info()?.share?.url
+          ? "Copy share URL to clipboard"
+          : input.language.t("command.session.share.description"),
         category: input.language.t("command.category.session"),
         slash: "share",
-        disabled: !input.params.id || !!input.info()?.share?.url,
+        disabled: !input.params.id,
         onSelect: async () => {
           if (!input.params.id) return
-          await input.sdk.client.session
-            .share({ sessionID: input.params.id })
-            .then((res) => {
-              navigator.clipboard.writeText(res.data!.share!.url).catch(() =>
+          const copy = (url: string, existing: boolean) =>
+            navigator.clipboard
+              .writeText(url)
+              .then(() =>
+                showToast({
+                  title: existing
+                    ? input.language.t("session.share.copy.copied")
+                    : input.language.t("toast.session.share.success.title"),
+                  description: input.language.t("toast.session.share.success.description"),
+                  variant: "success",
+                }),
+              )
+              .catch(() =>
                 showToast({
                   title: input.language.t("toast.session.share.copyFailed.title"),
                   variant: "error",
                 }),
               )
-            })
-            .then(() =>
-              showToast({
-                title: input.language.t("toast.session.share.success.title"),
-                description: input.language.t("toast.session.share.success.description"),
-                variant: "success",
-              }),
-            )
+          const url = input.info()?.share?.url
+          if (url) {
+            await copy(url, true)
+            return
+          }
+          await input.sdk.client.session
+            .share({ sessionID: input.params.id })
+            .then((res) => copy(res.data!.share!.url, false))
             .catch(() =>
               showToast({
                 title: input.language.t("toast.session.share.failed.title"),


### PR DESCRIPTION
**before sharing**
<img width="597" height="101" alt="image" src="https://github.com/user-attachments/assets/b937ec37-775a-4368-972e-1b58ccdc310c" />

**after sharing**
<img width="597" height="117" alt="image" src="https://github.com/user-attachments/assets/885496a3-93c9-46f3-8b49-31f859a14e34" />

## Summary
- keep `session.share` available in web command palette + slash suggestions after a session is already shared
- make `/share` copy the existing share URL when present, and only call share API when no URL exists

## Related
- companion TUI PR: https://github.com/anomalyco/opencode/pull/12532

## Issue
- Refs #12535