### PR TITLE
docs: add OpenCode Manager to ecosystem projects list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -65,6 +65,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [OpenCode Manager](https://github.com/chriswritescode-dev/opencode-manager)                | Mobile-first PWA in a self-contained Docker container with multi-repo management, file editing, diff viewer, STT/TTS, and push notifications |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [OpenCode Manager](https://github.com/chriswritescode-dev/opencode-manager) to the Projects section of the ecosystem documentation

## Description
OpenCode Manager is a mobile-first PWA served from a self-contained Docker container. It provides a full-featured web interface for managing OpenCode agents from any device with multi-repo management, file editing, diff viewer, STT/TTS, and push notifications.

## Changes
- Added one entry to the Projects table in `packages/web/src/content/docs/ecosystem.mdx`