### PR TITLE
feat(app): add toggle-all switch in manage models

### DIFF
--- a/packages/app/src/components/dialog-manage-models-state.ts
+++ b/packages/app/src/components/dialog-manage-models-state.ts
@@ -1,0 +1,23 @@
+type Item = {
+  id: string
+  provider: {
+    id: string
+  }
+}
+
+type Key = {
+  modelID: string
+  providerID: string
+}
+
+function modelKey(item: Item): Key {
+  return {
+    modelID: item.id,
+    providerID: item.provider.id,
+  }
+}
+
+export function allModelsVisible(list: Item[], visible: (model: Key) => boolean) {
+  if (list.length === 0) return false
+  return list.every((item) => visible(modelKey(item)))
+}

--- a/packages/app/src/components/dialog-manage-models.test.ts
+++ b/packages/app/src/components/dialog-manage-models.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test"
+import { allModelsVisible } from "./dialog-manage-models-state"
+
+const list = [
+  { id: "a", provider: { id: "p1" } },
+  { id: "b", provider: { id: "p2" } },
+]
+
+describe("dialog manage models", () => {
+  test("allModelsVisible is false for empty list", () => {
+    expect(allModelsVisible([], () => true)).toBe(false)
+  })
+
+  test("allModelsVisible only returns true when every item is visible", () => {
+    expect(allModelsVisible(list, () => true)).toBe(true)
+    expect(allModelsVisible(list, (item) => item.modelID !== "b")).toBe(false)
+  })
+})

--- a/packages/app/src/components/dialog-manage-models.tsx
+++ b/packages/app/src/components/dialog-manage-models.tsx
@@ -2,17 +2,22 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
 import { Switch } from "@opencode-ai/ui/switch"
 import { Button } from "@opencode-ai/ui/button"
-import type { Component } from "solid-js"
+import { createMemo, type Component } from "solid-js"
 import { useLocal } from "@/context/local"
 import { popularProviders } from "@/hooks/use-providers"
 import { useLanguage } from "@/context/language"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { DialogSelectProvider } from "./dialog-select-provider"
+import { allModelsVisible } from "./dialog-manage-models-state"
 
 export const DialogManageModels: Component = () => {
   const local = useLocal()
   const language = useLanguage()
   const dialog = useDialog()
+
+  const all = createMemo(() => {
+    return allModelsVisible(local.model.list(), local.model.visible)
+  })
 
   const handleConnectProvider = () => {
     dialog.show(() => <DialogSelectProvider />)
@@ -21,7 +26,20 @@ export const DialogManageModels: Component = () => {
   return (
     <Dialog
       title={language.t("dialog.model.manage")}
-      description={language.t("dialog.model.manage.description")}
+      description={
+        <div class="w-full flex items-center justify-between gap-x-3">
+          <span class="flex-1">{language.t("dialog.model.manage.description")}</span>
+          <div class="flex items-center gap-x-2">
+            <span class="text-11-medium text-text-dimmed">{language.t("dialog.model.manage.all")}</span>
+            <Switch
+              checked={all()}
+              onChange={(checked) => {
+                local.model.setVisibilityAll(checked)
+              }}
+            />
+          </div>
+        </div>
+      }
       action={
         <Button class="h-7 -my-1 text-14-medium" icon="plus-small" tabIndex={-1} onClick={handleConnectProvider}>
           {language.t("command.provider.connect")}

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -183,6 +183,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         setVisibility(model: ModelKey, visible: boolean) {
           models.setVisibility(model, visible)
         },
+        setVisibilityAll(visible: boolean) {
+          models.setVisibilityAll(
+            models.list().map((item) => ({
+              modelID: item.id,
+              providerID: item.provider.id,
+            })),
+            visible,
+          )
+        },
         variant: {
           current() {
             const m = current()

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -103,6 +103,23 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       update(model, state ? "show" : "hide")
     }
 
+    const setVisibilityAll = (models: ModelKey[], state: boolean) => {
+      if (models.length === 0) return
+      const next: Visibility = state ? "show" : "hide"
+      const key = (item: ModelKey) => `${item.providerID}:${item.modelID}`
+      const map = new Map(models.map((item) => [key(item), item]))
+      const user = store.user.map((item) => {
+        const model = map.get(key(item))
+        if (!model) return item
+        map.delete(key(item))
+        if (item.visibility === next) return item
+        return { ...item, visibility: next }
+      })
+      const add = Array.from(map.values()).map((item) => ({ ...item, visibility: next }))
+      if (add.length === 0 && user.every((item, index) => item === store.user[index])) return
+      setStore("user", [...user, ...add])
+    }
+
     const push = (model: ModelKey) => {
       const uniq = uniqueBy([model, ...store.recent], (x) => x.providerID + x.modelID)
       if (uniq.length > 5) uniq.pop()
@@ -127,6 +144,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       find,
       visible,
       setVisibility,
+      setVisibilityAll,
       recent: {
         list: createMemo(() => store.recent),
         push,

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -108,6 +108,7 @@ export const dict = {
   "dialog.model.empty": "No model results",
   "dialog.model.manage": "Manage models",
   "dialog.model.manage.description": "Customize which models appear in the model selector.",
+  "dialog.model.manage.all": "All",
 
   "dialog.model.unpaid.freeModels.title": "Free models provided by OpenCode",
   "dialog.model.unpaid.addMore.title": "Add more models from popular providers",


### PR DESCRIPTION
### What does this PR do?

Adds an **All** toggle in Manage Models so users can enable/disable visibility for all models in one action.

### Why

When many models are connected (Zen, ChatGPT, OpenRouter, etc.), turning them off one-by-one is slow and annoying.

### Result

Manage Models now supports a bulk toggle for model visibility.

### How did you verify your code works?

- Tested in web (`packages/app`)
- Tested in desktop (Tauri wrapper over app)
- Verified the toggle updates all model visibility as expected

### Issue

Closes #12540

### Screenshots/Videos

See screenshot in issue #12540.