### PR TITLE
fix(opencode): restore inner shadow in TUI exit monogram

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -226,12 +226,13 @@ export function Session() {
 
   createEffect(() => {
     const title = Locale.truncate(session()?.title ?? "", 50)
+    const monogram = UI.logoMonogram("  ")
     return exit.message.set(
       [
         ``,
-        `  █▀▀█  ${UI.Style.TEXT_DIM}${title}${UI.Style.TEXT_NORMAL}`,
-        `  █  █  ${UI.Style.TEXT_DIM}opencode -s ${session()?.id}${UI.Style.TEXT_NORMAL}`,
-        `  ▀▀▀▀  `,
+        `${monogram[0]}  ${UI.Style.TEXT_DIM}${title}${UI.Style.TEXT_NORMAL}`,
+        `${monogram[1]}  ${UI.Style.TEXT_DIM}opencode -s ${session()?.id}${UI.Style.TEXT_NORMAL}`,
+        `${monogram[2]}  `,
       ].join("\n"),
     )
   })

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -6,6 +6,30 @@ import { logo as glyphs } from "./logo"
 export namespace UI {
   export const CancelledError = NamedError.create("UICancelledError", z.void())
 
+  const draw = (line: string, fg: string, shadow: string, bg: string, reset: string) => {
+    const parts: string[] = []
+    for (const char of line) {
+      if (char === "_") {
+        parts.push(bg, " ", reset)
+        continue
+      }
+      if (char === "^") {
+        parts.push(fg, bg, "▀", reset)
+        continue
+      }
+      if (char === "~") {
+        parts.push(shadow, "▀", reset)
+        continue
+      }
+      if (char === " ") {
+        parts.push(" ")
+        continue
+      }
+      parts.push(fg, char, reset)
+    }
+    return parts.join("")
+  }
+
   export const Style = {
     TEXT_HIGHLIGHT: "\x1b[96m",
     TEXT_HIGHLIGHT_BOLD: "\x1b[96m\x1b[1m",
@@ -40,6 +64,19 @@ export namespace UI {
     blank = true
   }
 
+  export function logoMonogram(pad = ""): [string, string, string] {
+    const monogram = ["█▀▀█", "█__█", "▀▀▀▀"] as const
+    const reset = "\x1b[0m"
+    const fg = reset
+    const shadow = "\x1b[38;5;238m"
+    const bg = "\x1b[48;5;238m"
+    return [
+      `${pad}${draw(monogram[0], fg, shadow, bg, reset)}`,
+      `${pad}${draw(monogram[1], fg, shadow, bg, reset)}`,
+      `${pad}${draw(monogram[2], fg, shadow, bg, reset)}`,
+    ]
+  }
+
   export function logo(pad?: string) {
     const result: string[] = []
     const reset = "\x1b[0m"
@@ -54,35 +91,12 @@ export namespace UI {
       bg: "\x1b[48;5;238m",
     }
     const gap = " "
-    const draw = (line: string, fg: string, shadow: string, bg: string) => {
-      const parts: string[] = []
-      for (const char of line) {
-        if (char === "_") {
-          parts.push(bg, " ", reset)
-          continue
-        }
-        if (char === "^") {
-          parts.push(fg, bg, "▀", reset)
-          continue
-        }
-        if (char === "~") {
-          parts.push(shadow, "▀", reset)
-          continue
-        }
-        if (char === " ") {
-          parts.push(" ")
-          continue
-        }
-        parts.push(fg, char, reset)
-      }
-      return parts.join("")
-    }
     glyphs.left.forEach((row, index) => {
       if (pad) result.push(pad)
-      result.push(draw(row, left.fg, left.shadow, left.bg))
+      result.push(draw(row, left.fg, left.shadow, left.bg, reset))
       result.push(gap)
       const other = glyphs.right[index] ?? ""
-      result.push(draw(other, right.fg, right.shadow, right.bg))
+      result.push(draw(other, right.fg, right.shadow, right.bg, reset))
       result.push(EOL)
     })
     return result.join("").trimEnd()


### PR DESCRIPTION
TOP: Before 😭

<img width="738" height="422" alt="image" src="https://github.com/user-attachments/assets/525a0e1d-da7b-4fc0-aa0b-cd50bf36a0f8" />

BOTTOM: After 🥰

## Summary
- restore the inner shadow for the single-symbol logo in the session exit banner
- add `UI.logoMonogram()` to render a typed 3-line monogram with the brighter palette used for this context
- remove fallback row logic in the exit banner and share glyph rendering logic via an internal `draw(...)` helper

Closes #12543