### PR TITLE
feat(tui): add Chrome-style tab system with status indicators

### DIFF
--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -25,3 +25,13 @@
 - **Logging**: Use `Log.create({ service: "name" })` pattern
 - **Storage**: Use `Storage` namespace for persistence
 - **API Client**: The TypeScript TUI (built with SolidJS + OpenTUI) communicates with the OpenCode server using `@opencode-ai/sdk`. When adding/modifying server endpoints in `packages/opencode/src/server/server.ts`, run `./script/generate.ts` to regenerate the SDK and related files.
+
+## Build & Install
+
+- `bun run build --single` builds a binary for the current platform only. Output: `dist/opencode-{os}-{arch}/bin/opencode`.
+- The installed binary lives at `~/.opencode/bin/opencode`. You cannot overwrite it while opencode is running (`Text file busy`); use rename-swap: copy to `.new`, rename old to `.old`, rename `.new` to target, then delete `.old`.
+- LSP shows many false errors for `@opentui/solid`, `solid-js/store`, `@opencode-ai/sdk/v2` due to Bun's `--conditions=browser` module resolution. `bun run typecheck` (tsgo) is the source of truth — ignore LSP module-resolution errors on these imports.
+
+## Config Schema ↔ SDK Coupling
+
+- Adding keybinds or config fields in `src/config/config.ts` requires running `./script/generate.ts` from repo root to regenerate `packages/sdk/js/src/v2/gen/types.gen.ts` and `packages/sdk/openapi.json`. All three files must change together.

--- a/packages/opencode/src/cli/cmd/tui/AGENTS.md
+++ b/packages/opencode/src/cli/cmd/tui/AGENTS.md
@@ -1,0 +1,26 @@
+# TUI Agent Guidelines
+
+## Context System
+
+- All TUI contexts use `createSimpleContext` from `context/helper.tsx` which returns `{ use, provider }` — a hook and a JSX provider component.
+- Provider tree ordering matters: a context provider can be high in the tree while its UI consumer renders deep inside `App` where other contexts (like `useSync`, `useTheme`) are available. Separate where state lives from where it's rendered.
+- `RouteProvider` supports an external driver via `RouteDriverContext`. Wrapping `RouteProvider` with a driver provider lets you intercept `route.navigate()` and `route.data` without modifying RouteProvider itself. The tab system uses this pattern.
+
+## Session Status
+
+- `SessionStatus` from the SDK is only `idle | busy | retry`. There is no `error`, `done`, or `attention` type.
+- To detect errors: check `message.error` on the last assistant message in `sync.data.message[sessionID]`.
+- To detect "requires attention": check `sync.data.permission[sessionID]` and `sync.data.question[sessionID]` arrays.
+- To detect "done/completed": the session is idle AND the last assistant message has `time.completed` set.
+- The legacy `sync.session.status()` method derives state from messages (not `session_status`); prefer `sync.data.session_status[id]` for the real server-reported status.
+
+## Persistent UI Preferences
+
+- Use `useKV()` for persistent UI toggles. It reads/writes `kv.json` in the state directory.
+- Pattern: `kv.get("key", defaultValue)` to read, `kv.set("key", value)` to write. Changes persist across sessions.
+- Existing keys include `animations_enabled`, `diff_wrap_mode`, `terminal_title_enabled`, `tab_bar_visible`.
+
+## Command Registration
+
+- Register commands via `command.register(() => [...])` in `App`. Each command can have `keybind`, `slash`, `category`, `hidden`, `enabled`, and `suggested` properties.
+- The `keybind` field must be a key of `KeybindsConfig` from the SDK types. Adding a new keybind requires updating `config.ts` and regenerating the SDK.

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -1,8 +1,20 @@
 import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { Clipboard } from "@tui/util/clipboard"
 import { TextAttributes } from "@opentui/core"
-import { RouteProvider, useRoute } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
+import { RouteProvider, RouteDriverContext, useRoute } from "@tui/context/route"
+import {
+  Switch,
+  Match,
+  createEffect,
+  untrack,
+  ErrorBoundary,
+  createSignal,
+  onMount,
+  batch,
+  Show,
+  on,
+  type ParentProps,
+} from "solid-js"
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -36,6 +48,10 @@ import { ArgsProvider, useArgs, type Args } from "./context/args"
 import open from "open"
 import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
+import { TabProvider, useTab } from "@tui/context/tab"
+import { TabBar } from "@tui/component/tab-bar"
+import { DialogTabList } from "@tui/component/dialog-tab-list"
+import type { KeybindsConfig } from "@opencode-ai/sdk/v2"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -99,6 +115,24 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
 
 import type { EventSource } from "./context/sdk"
 
+function TabRouteDriver(props: ParentProps) {
+  const tab = useTab()
+  return (
+    <RouteDriverContext.Provider
+      value={{
+        get data() {
+          return tab.active.route
+        },
+        navigate(route) {
+          tab.navigate(route)
+        },
+      }}
+    >
+      {props.children}
+    </RouteDriverContext.Provider>
+  )
+}
+
 export function tui(input: {
   url: string
   args: Args
@@ -126,37 +160,41 @@ export function tui(input: {
               <ExitProvider onExit={onExit}>
                 <KVProvider>
                   <ToastProvider>
-                    <RouteProvider>
-                      <SDKProvider
-                        url={input.url}
-                        directory={input.directory}
-                        fetch={input.fetch}
-                        headers={input.headers}
-                        events={input.events}
-                      >
-                        <SyncProvider>
-                          <ThemeProvider mode={mode}>
-                            <LocalProvider>
-                              <KeybindProvider>
-                                <PromptStashProvider>
-                                  <DialogProvider>
-                                    <CommandProvider>
-                                      <FrecencyProvider>
-                                        <PromptHistoryProvider>
-                                          <PromptRefProvider>
-                                            <App />
-                                          </PromptRefProvider>
-                                        </PromptHistoryProvider>
-                                      </FrecencyProvider>
-                                    </CommandProvider>
-                                  </DialogProvider>
-                                </PromptStashProvider>
-                              </KeybindProvider>
-                            </LocalProvider>
-                          </ThemeProvider>
-                        </SyncProvider>
-                      </SDKProvider>
-                    </RouteProvider>
+                    <TabProvider>
+                      <TabRouteDriver>
+                        <RouteProvider>
+                          <SDKProvider
+                            url={input.url}
+                            directory={input.directory}
+                            fetch={input.fetch}
+                            headers={input.headers}
+                            events={input.events}
+                          >
+                            <SyncProvider>
+                              <ThemeProvider mode={mode}>
+                                <LocalProvider>
+                                  <KeybindProvider>
+                                    <PromptStashProvider>
+                                      <DialogProvider>
+                                        <CommandProvider>
+                                          <FrecencyProvider>
+                                            <PromptHistoryProvider>
+                                              <PromptRefProvider>
+                                                <App />
+                                              </PromptRefProvider>
+                                            </PromptHistoryProvider>
+                                          </FrecencyProvider>
+                                        </CommandProvider>
+                                      </DialogProvider>
+                                    </PromptStashProvider>
+                                  </KeybindProvider>
+                                </LocalProvider>
+                              </ThemeProvider>
+                            </SyncProvider>
+                          </SDKProvider>
+                        </RouteProvider>
+                      </TabRouteDriver>
+                    </TabProvider>
                   </ToastProvider>
                 </KVProvider>
               </ExitProvider>
@@ -687,6 +725,90 @@ function App() {
     })
   })
 
+  const tab = useTab()
+
+  command.register(() => [
+    {
+      title: "List tabs",
+      value: "tab.list",
+      keybind: "tab_list",
+      category: "Tab",
+      suggested: tab.tabs.length > 1,
+      slash: {
+        name: "tabs",
+      },
+      onSelect: () => {
+        dialog.replace(() => <DialogTabList />)
+      },
+    },
+    {
+      title: "New tab",
+      value: "tab.new",
+      keybind: "tab_new",
+      category: "Tab",
+      slash: {
+        name: "tab",
+      },
+      onSelect: (dialog) => {
+        tab.create()
+        dialog.clear()
+      },
+    },
+    {
+      title: "Close tab",
+      value: "tab.close",
+      keybind: "tab_close",
+      category: "Tab",
+      enabled: tab.tabs.length > 1,
+      onSelect: (dialog) => {
+        tab.close()
+        dialog.clear()
+      },
+    },
+    {
+      title: "Next tab",
+      value: "tab.next",
+      keybind: "tab_next",
+      category: "Tab",
+      hidden: true,
+      onSelect: (dialog) => {
+        tab.next()
+        dialog.clear()
+      },
+    },
+    {
+      title: "Previous tab",
+      value: "tab.prev",
+      keybind: "tab_prev",
+      category: "Tab",
+      hidden: true,
+      onSelect: (dialog) => {
+        tab.prev()
+        dialog.clear()
+      },
+    },
+    {
+      title: kv.get("tab_bar_visible", true) ? "Hide tab bar" : "Always show tab bar",
+      value: "tab.toggle_bar",
+      category: "Tab",
+      onSelect: (dialog) => {
+        kv.set("tab_bar_visible", !kv.get("tab_bar_visible", true))
+        dialog.clear()
+      },
+    },
+    ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => ({
+      title: `Go to tab ${n}`,
+      value: `tab.${n}`,
+      keybind: `tab_${n}` as keyof KeybindsConfig,
+      category: "Tab" as const,
+      hidden: true,
+      onSelect: (dialog: ReturnType<typeof useDialog>) => {
+        tab.selectIndex(n - 1)
+        dialog.clear()
+      },
+    })),
+  ])
+
   return (
     <box
       width={dimensions().width}
@@ -706,6 +828,7 @@ function App() {
         }
       }}
     >
+      <TabBar />
       <Switch>
         <Match when={route.data.type === "home"}>
           <Home />

--- a/packages/opencode/src/cli/cmd/tui/component/dialog-tab-list.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-tab-list.tsx
@@ -1,0 +1,57 @@
+import { useDialog } from "@tui/ui/dialog"
+import { DialogSelect } from "@tui/ui/dialog-select"
+import { useTab } from "@tui/context/tab"
+import { useSync } from "@tui/context/sync"
+import { createMemo } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import { useKeybind } from "@tui/context/keybind"
+import { tabTitle, tabStatus, tabStatusIndicator, STATUS_LABEL, type TabStatus } from "./tab-bar"
+
+function gutter(s: TabStatus, theme: ReturnType<typeof useTheme>["theme"]) {
+  const ind = tabStatusIndicator(s, theme)
+  if (!ind) return undefined
+  return <text fg={ind.color}>{ind.symbol}</text>
+}
+
+export function DialogTabList() {
+  const dialog = useDialog()
+  const tab = useTab()
+  const sync = useSync()
+  const { theme } = useTheme()
+  const keybind = useKeybind()
+
+  const options = createMemo(() =>
+    tab.tabs.map((t, idx) => {
+      const title = tabTitle(t.route, sync)
+      const s = tabStatus(t.route, sync)
+      const label = STATUS_LABEL[s]
+      return {
+        title: `${idx + 1}: ${title}`,
+        value: t.id,
+        description: s !== "idle" ? label : undefined,
+        gutter: gutter(s, theme),
+      }
+    }),
+  )
+
+  return (
+    <DialogSelect
+      title="Tabs"
+      options={options()}
+      current={tab.active.id}
+      onSelect={(option) => {
+        tab.select(option.value)
+        dialog.clear()
+      }}
+      keybind={[
+        {
+          keybind: keybind.all.tab_close?.[0],
+          title: "close",
+          onTrigger: (option) => {
+            tab.close(option.value)
+          },
+        },
+      ]}
+    />
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/component/tab-bar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tab-bar.tsx
@@ -1,0 +1,178 @@
+import { createMemo, createSignal, For, Show } from "solid-js"
+import { useTheme } from "@tui/context/theme"
+import { useTab, type Tab } from "@tui/context/tab"
+import { useSync } from "@tui/context/sync"
+import { Session } from "@/session"
+import { Locale } from "@/util/locale"
+import { useKV } from "@tui/context/kv"
+import { useTerminalDimensions } from "@opentui/solid"
+
+export type TabStatus = "idle" | "busy" | "attention" | "error" | "done"
+
+export function tabStatus(route: Tab["route"], sync: ReturnType<typeof useSync>): TabStatus {
+  if (route.type !== "session") return "idle"
+  const id = route.sessionID
+  const ss = sync.data.session_status?.[id]
+
+  const permissions = sync.data.permission[id]
+  const questions = sync.data.question[id]
+  if ((permissions && permissions.length > 0) || (questions && questions.length > 0)) return "attention"
+
+  if (ss?.type === "retry") return "error"
+  if (ss?.type === "busy") return "busy"
+
+  const messages = sync.data.message[id]
+  if (messages && messages.length > 0) {
+    const last = messages.at(-1)
+    if (last?.role === "assistant" && last.error && last.error.name !== "MessageAbortedError") return "error"
+    if (last?.role === "assistant" && last.time.completed) return "done"
+  }
+
+  return "idle"
+}
+
+export function tabStatusIndicator(s: TabStatus, theme: ReturnType<typeof useTheme>["theme"]) {
+  switch (s) {
+    case "busy":
+      return { symbol: "◉", color: theme.info }
+    case "attention":
+      return { symbol: "△", color: theme.warning }
+    case "error":
+      return { symbol: "✕", color: theme.error }
+    case "done":
+      return { symbol: "✓", color: theme.success }
+    default:
+      return undefined
+  }
+}
+
+export function tabTitle(route: Tab["route"], sync: ReturnType<typeof useSync>) {
+  if (route.type === "home") return "Home"
+  if (route.type === "session") {
+    const session = sync.session.get(route.sessionID)
+    if (!session) return "Session"
+    if (Session.isDefaultTitle(session.title)) return "New Session"
+    return session.title
+  }
+  return "Tab"
+}
+
+export const STATUS_LABEL: Record<TabStatus, string> = {
+  idle: "Idle",
+  busy: "Processing",
+  attention: "Needs attention",
+  error: "Error",
+  done: "Done",
+}
+
+// Compute max title length per tab given terminal width.
+// Priority (always reserved first → last):
+//   1. "+" button: 3 chars
+//   2. Dividers between tabs: count-1 chars
+//   3. Close buttons (when >1 tab): 2 chars each
+//   4. Indicator + number prefix " X N:": 5 chars each
+//   5. Padding around title " " + " ": 2 chars each
+//   6. Title: whatever remains, split evenly
+function budget(width: number, count: number, hasClose: boolean) {
+  const plus = 3
+  const dividers = Math.max(0, count - 1)
+  const close = hasClose ? count * 2 : 0
+  const prefix = count * 5 // " X N:"
+  const padding = count * 2 // space before indicator + space after title
+  const fixed = plus + dividers + close + prefix + padding
+  const remaining = Math.max(0, width - fixed)
+  return Math.max(0, Math.floor(remaining / Math.max(1, count)))
+}
+
+export function TabBar() {
+  const tab = useTab()
+  const sync = useSync()
+  const kv = useKV()
+  const { theme } = useTheme()
+  const dimensions = useTerminalDimensions()
+  const alwaysShow = createMemo(() => kv.get("tab_bar_visible", true))
+  const visible = createMemo(() => tab.tabs.length > 1 || alwaysShow())
+  const hasClose = createMemo(() => tab.tabs.length > 1)
+  const titleMax = createMemo(() => budget(dimensions().width, tab.tabs.length, hasClose()))
+
+  return (
+    <Show when={visible()}>
+      <box flexDirection="row" flexShrink={0} height={1}>
+        <box flexDirection="row" flexGrow={1} flexShrink={1} overflow="hidden">
+          <For each={tab.tabs}>
+            {(t, idx) => {
+              const active = createMemo(() => t.id === tab.active.id)
+              const title = createMemo(() => {
+                const limit = titleMax()
+                if (limit <= 0) return ""
+                const raw = tabTitle(t.route, sync)
+                if (raw.length <= limit) return raw
+                if (limit <= 1) return raw[0]
+                return Locale.truncate(raw, limit)
+              })
+              const ts = createMemo(() => tabStatus(t.route, sync))
+              const ind = createMemo(() => tabStatusIndicator(ts(), theme))
+              const [hover, setHover] = createSignal(false)
+              const [closeHover, setCloseHover] = createSignal(false)
+
+              return (
+                <box
+                  flexDirection="row"
+                  flexShrink={1}
+                  onMouseUp={() => tab.select(t.id)}
+                  onMouseOver={() => setHover(true)}
+                  onMouseOut={() => setHover(false)}
+                  backgroundColor={
+                    active() ? theme.backgroundPanel : hover() ? theme.backgroundElement : theme.background
+                  }
+                >
+                  <text fg={active() ? theme.text : theme.textMuted} wrapMode="none">
+                    {" "}
+                    <span style={{ fg: ind()?.color }}>{ind() ? ind()!.symbol : " "}</span> {idx() + 1}:{title()}{" "}
+                  </text>
+                  <Show when={hasClose()}>
+                    <box
+                      flexShrink={0}
+                      onMouseUp={(e) => {
+                        e.stopPropagation?.()
+                        tab.close(t.id)
+                      }}
+                      onMouseOver={() => setCloseHover(true)}
+                      onMouseOut={() => setCloseHover(false)}
+                    >
+                      <text fg={closeHover() ? theme.error : active() ? theme.textMuted : theme.border}>x </text>
+                    </box>
+                  </Show>
+                  <Show when={idx() < tab.tabs.length - 1}>
+                    <text fg={theme.border} wrapMode="none">
+                      │
+                    </text>
+                  </Show>
+                </box>
+              )
+            }}
+          </For>
+        </box>
+        <NewTabButton />
+      </box>
+    </Show>
+  )
+}
+
+function NewTabButton() {
+  const tab = useTab()
+  const { theme } = useTheme()
+  const [hover, setHover] = createSignal(false)
+
+  return (
+    <box
+      flexShrink={0}
+      onMouseUp={() => tab.create()}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+      backgroundColor={hover() ? theme.backgroundElement : theme.background}
+    >
+      <text fg={hover() ? theme.text : theme.textMuted}> + </text>
+    </box>
+  )
+}

--- a/packages/opencode/src/cli/cmd/tui/context/route.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/route.tsx
@@ -1,3 +1,4 @@
+import { createContext, useContext } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
 import type { PromptInfo } from "../component/prompt/history"
@@ -15,9 +16,22 @@ export type SessionRoute = {
 
 export type Route = HomeRoute | SessionRoute
 
+const DriverCtx = createContext<{
+  data: Route
+  navigate: (route: Route) => void
+}>()
+
+export function useRouteDriver() {
+  return useContext(DriverCtx)
+}
+
+export { DriverCtx as RouteDriverContext }
+
 export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
   name: "Route",
   init: () => {
+    const driver = useContext(DriverCtx)
+
     const [store, setStore] = createStore<Route>(
       process.env["OPENCODE_ROUTE"]
         ? JSON.parse(process.env["OPENCODE_ROUTE"])
@@ -25,6 +39,18 @@ export const { use: useRoute, provider: RouteProvider } = createSimpleContext({
             type: "home",
           },
     )
+
+    if (driver) {
+      return {
+        get data() {
+          return driver.data
+        },
+        navigate(route: Route) {
+          console.log("navigate", route)
+          driver.navigate(route)
+        },
+      }
+    }
 
     return {
       get data() {

--- a/packages/opencode/src/cli/cmd/tui/context/tab.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/tab.tsx
@@ -1,0 +1,97 @@
+import { batch, createMemo } from "solid-js"
+import { createStore, produce, reconcile } from "solid-js/store"
+import { createSimpleContext } from "./helper"
+import type { Route } from "./route"
+
+export type Tab = {
+  id: string
+  route: Route
+}
+
+let counter = 0
+function id() {
+  return "tab_" + counter++
+}
+
+export const { use: useTab, provider: TabProvider } = createSimpleContext({
+  name: "Tab",
+  init: () => {
+    const first = id()
+    const [store, setStore] = createStore<{
+      tabs: Tab[]
+      active: string
+    }>({
+      tabs: [{ id: first, route: { type: "home" } }],
+      active: first,
+    })
+
+    const active = createMemo(() => store.tabs.find((t) => t.id === store.active)!)
+    const idx = createMemo(() => store.tabs.findIndex((t) => t.id === store.active))
+
+    return {
+      get tabs() {
+        return store.tabs
+      },
+      get active() {
+        return active()
+      },
+      get index() {
+        return idx()
+      },
+      navigate(route: Route) {
+        setStore("tabs", idx(), "route", reconcile(route))
+      },
+      create(route?: Route) {
+        const tab: Tab = { id: id(), route: route ?? { type: "home" } }
+        batch(() => {
+          setStore(
+            "tabs",
+            produce((tabs) => {
+              tabs.splice(idx() + 1, 0, tab)
+            }),
+          )
+          setStore("active", tab.id)
+        })
+        return tab
+      },
+      close(tabID?: string) {
+        const target = tabID ?? store.active
+        if (store.tabs.length <= 1) return
+        const i = store.tabs.findIndex((t) => t.id === target)
+        if (i === -1) return
+        batch(() => {
+          if (store.active === target) {
+            const next = i < store.tabs.length - 1 ? store.tabs[i + 1].id : store.tabs[i - 1].id
+            setStore("active", next)
+          }
+          setStore(
+            "tabs",
+            produce((tabs) => {
+              tabs.splice(i, 1)
+            }),
+          )
+        })
+      },
+      select(tabID: string) {
+        if (store.tabs.some((t) => t.id === tabID)) {
+          setStore("active", tabID)
+        }
+      },
+      selectIndex(i: number) {
+        if (i >= 0 && i < store.tabs.length) {
+          setStore("active", store.tabs[i].id)
+        }
+      },
+      next() {
+        const i = idx()
+        const next = (i + 1) % store.tabs.length
+        setStore("active", store.tabs[next].id)
+      },
+      prev() {
+        const i = idx()
+        const prev = (i - 1 + store.tabs.length) % store.tabs.length
+        setStore("active", store.tabs[prev].id)
+      },
+    }
+  },
+})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -908,6 +908,20 @@ export namespace Config {
       terminal_title_toggle: z.string().optional().default("none").describe("Toggle terminal title"),
       tips_toggle: z.string().optional().default("<leader>h").describe("Toggle tips on home screen"),
       display_thinking: z.string().optional().default("none").describe("Toggle thinking blocks visibility"),
+      tab_list: z.string().optional().default("none").describe("List all open tabs"),
+      tab_new: z.string().optional().default("<leader>t").describe("Open a new tab"),
+      tab_close: z.string().optional().default("<leader>w").describe("Close the current tab"),
+      tab_next: z.string().optional().default("<leader>]").describe("Switch to the next tab"),
+      tab_prev: z.string().optional().default("<leader>[").describe("Switch to the previous tab"),
+      tab_1: z.string().optional().default("alt+1").describe("Go to tab 1"),
+      tab_2: z.string().optional().default("alt+2").describe("Go to tab 2"),
+      tab_3: z.string().optional().default("alt+3").describe("Go to tab 3"),
+      tab_4: z.string().optional().default("alt+4").describe("Go to tab 4"),
+      tab_5: z.string().optional().default("alt+5").describe("Go to tab 5"),
+      tab_6: z.string().optional().default("alt+6").describe("Go to tab 6"),
+      tab_7: z.string().optional().default("alt+7").describe("Go to tab 7"),
+      tab_8: z.string().optional().default("alt+8").describe("Go to tab 8"),
+      tab_9: z.string().optional().default("alt+9").describe("Go to tab 9"),
     })
     .strict()
     .meta({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1314,6 +1314,62 @@ export type KeybindsConfig = {
    * Toggle thinking blocks visibility
    */
   display_thinking?: string
+  /**
+   * List all open tabs
+   */
+  tab_list?: string
+  /**
+   * Open a new tab
+   */
+  tab_new?: string
+  /**
+   * Close the current tab
+   */
+  tab_close?: string
+  /**
+   * Switch to the next tab
+   */
+  tab_next?: string
+  /**
+   * Switch to the previous tab
+   */
+  tab_prev?: string
+  /**
+   * Go to tab 1
+   */
+  tab_1?: string
+  /**
+   * Go to tab 2
+   */
+  tab_2?: string
+  /**
+   * Go to tab 3
+   */
+  tab_3?: string
+  /**
+   * Go to tab 4
+   */
+  tab_4?: string
+  /**
+   * Go to tab 5
+   */
+  tab_5?: string
+  /**
+   * Go to tab 6
+   */
+  tab_6?: string
+  /**
+   * Go to tab 7
+   */
+  tab_7?: string
+  /**
+   * Go to tab 8
+   */
+  tab_8?: string
+  /**
+   * Go to tab 9
+   */
+  tab_9?: string
 }
 
 /**

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8891,6 +8891,76 @@
             "description": "Toggle thinking blocks visibility",
             "default": "none",
             "type": "string"
+          },
+          "tab_list": {
+            "description": "List all open tabs",
+            "default": "none",
+            "type": "string"
+          },
+          "tab_new": {
+            "description": "Open a new tab",
+            "default": "<leader>t",
+            "type": "string"
+          },
+          "tab_close": {
+            "description": "Close the current tab",
+            "default": "<leader>w",
+            "type": "string"
+          },
+          "tab_next": {
+            "description": "Switch to the next tab",
+            "default": "<leader>]",
+            "type": "string"
+          },
+          "tab_prev": {
+            "description": "Switch to the previous tab",
+            "default": "<leader>[",
+            "type": "string"
+          },
+          "tab_1": {
+            "description": "Go to tab 1",
+            "default": "alt+1",
+            "type": "string"
+          },
+          "tab_2": {
+            "description": "Go to tab 2",
+            "default": "alt+2",
+            "type": "string"
+          },
+          "tab_3": {
+            "description": "Go to tab 3",
+            "default": "alt+3",
+            "type": "string"
+          },
+          "tab_4": {
+            "description": "Go to tab 4",
+            "default": "alt+4",
+            "type": "string"
+          },
+          "tab_5": {
+            "description": "Go to tab 5",
+            "default": "alt+5",
+            "type": "string"
+          },
+          "tab_6": {
+            "description": "Go to tab 6",
+            "default": "alt+6",
+            "type": "string"
+          },
+          "tab_7": {
+            "description": "Go to tab 7",
+            "default": "alt+7",
+            "type": "string"
+          },
+          "tab_8": {
+            "description": "Go to tab 8",
+            "default": "alt+8",
+            "type": "string"
+          },
+          "tab_9": {
+            "description": "Go to tab 9",
+            "default": "alt+9",
+            "type": "string"
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
Fixes #12548

## Summary

- Chrome-style tab system allowing multiple simultaneous sessions
- Per-tab status indicators for background tabs (processing, requires attention, error, done)
- Priority-based tab bar layout: `+` button and dividers always visible, titles truncate dynamically
- `/tabs` dialog for navigating and managing all open tabs
- Persistent "always show tab bar" toggle (default: on)
- Keybinds: `<leader>t` new, `<leader>w` close, `<leader>[/]` prev/next, `alt+1-9` jump

## Verification

- Typechecks clean (`bun run typecheck`)
- Built and tested locally with `bun run build --single`
- Tested tab creation/closing/switching, status indicators, `/tabs` dialog, and narrow terminal truncation behavior