### PR TITLE
fix(desktop): windows clipboard images come thru as data not file

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -974,7 +974,20 @@ export namespace SessionPrompt {
               log.info("file", { mime: part.mime })
               // have to normalize, symbol search returns absolute paths
               // Decode the pathname since URL constructor doesn't automatically decode it
-              const filepath = fileURLToPath(part.url)
+              let filepath: string | undefined
+              try {
+                filepath = fileURLToPath(part.url)
+              } catch (error) {
+                log.warn("non-file url in file part", { url: part.url, error })
+                return [
+                  {
+                    id: part.id ?? Identifier.ascending("part"),
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    ...part,
+                  },
+                ]
+              }
               const stat = await Bun.file(filepath)
                 .stat()
                 .catch(() => undefined)


### PR DESCRIPTION
### What does this PR do?

Fixes a crash on Windows when pasting images from the clipboard. 

The prompt pipeline treated clipboard images as `file:` URLs which throws on non‑file schemes like `data:` - for example a random screenshot using Snipping Tool file url path:

`data:image/png;base64,iVBORw0KG....`

If the URL isn’t a real file path, we log a warning and pass the file part through without attempting to read from disk. This prevents the hard failure while keeping existing behavior unchanged for valid file URLs.

### How did you verify your code works?

- Manually pasted an image from the clipboard on Windows 11; the prompt no longer crashes.
- Verified normal file attachments still work as before.

Fixes #12547 