### PR TITLE
fix(app): stabilize prompt focus and caret behavior

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -49,6 +49,7 @@ import { ImagePreview } from "@opencode-ai/ui/image-preview"
 interface PromptInputProps {
   class?: string
   ref?: (el: HTMLDivElement) => void
+  focusKey?: string
   newSessionWorktree?: string
   onNewSessionWorktreeReset?: () => void
   onSubmit?: () => void
@@ -273,7 +274,27 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
   }
 
+  const ensureCaret = () => {
+    requestAnimationFrame(() => {
+      const selection = window.getSelection()
+      if (selection && selection.rangeCount > 0 && editorRef.contains(selection.anchorNode)) return
+      setCursorPosition(editorRef, promptLength(prompt.current()))
+    })
+  }
+
   const isFocused = createFocusSignal(() => editorRef)
+
+  createEffect(
+    on(
+      () => props.focusKey,
+      () => {
+        requestAnimationFrame(() => {
+          editorRef.focus()
+          ensureCaret()
+        })
+      },
+    ),
+  )
 
   createEffect(() => {
     params.id
@@ -984,20 +1005,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             aria-label={placeholder()}
             contenteditable="true"
             onInput={handleInput}
+            onFocus={ensureCaret}
             onPaste={handlePaste}
             onCompositionStart={() => setComposing(true)}
             onCompositionEnd={() => setComposing(false)}
             onKeyDown={handleKeyDown}
             classList={{
               "select-text": true,
-              "w-full p-3 pr-12 text-14-regular text-text-strong focus:outline-none whitespace-pre-wrap": true,
+              "relative z-10 w-full p-3 pr-12 text-14-regular text-text-strong focus:outline-none whitespace-pre-wrap": true,
               "[&_[data-type=file]]:text-syntax-property": true,
               "[&_[data-type=agent]]:text-syntax-type": true,
               "font-mono!": store.mode === "shell",
             }}
           />
           <Show when={!prompt.dirty()}>
-            <div class="absolute top-0 inset-x-0 p-3 pr-12 text-14-regular text-text-weak pointer-events-none whitespace-nowrap truncate">
+            <div class="absolute z-0 top-0 inset-x-0 p-3 pr-12 text-14-regular text-text-weak pointer-events-none whitespace-nowrap truncate">
               {placeholder()}
             </div>
           </Show>

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1654,6 +1654,7 @@ export default function Page() {
             inputRef={(el) => {
               inputRef = el
             }}
+            focusKey={sessionKey()}
             newSessionWorktree={newSessionWorktree()}
             onNewSessionWorktreeReset={() => setStore("newSessionWorktree", "main")}
             onSubmit={() => {

--- a/packages/app/src/pages/session/session-prompt-dock.tsx
+++ b/packages/app/src/pages/session/session-prompt-dock.tsx
@@ -18,6 +18,7 @@ export function SessionPromptDock(props: {
   responding: boolean
   onDecide: (response: "once" | "always" | "reject") => void
   inputRef: (el: HTMLDivElement) => void
+  focusKey: string
   newSessionWorktree: string
   onNewSessionWorktreeReset: () => void
   onSubmit: () => void
@@ -125,6 +126,7 @@ export function SessionPromptDock(props: {
           >
             <PromptInput
               ref={props.inputRef}
+              focusKey={props.focusKey}
               newSessionWorktree={props.newSessionWorktree}
               onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
               onSubmit={props.onSubmit}


### PR DESCRIPTION
## Summary
- ensure prompt input refocuses when the active session route changes by wiring `sessionKey()` into `PromptInput` as a reactive focus key
- add a caret guard for the contenteditable prompt so focus always restores a visible insertion point when selection is missing
- keep placeholder text visible while empty without obscuring caret by adjusting prompt/placeholder stacking order

## Validation
- bun typecheck (packages/app)