### PR TITLE
fix(ui): support cmd-click links in inline code

### DIFF
--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -210,8 +210,7 @@
   }
 }
 
-:root[data-link-modifier="true"] [data-component="markdown"] code[data-link-url]:hover {
+[data-component="markdown"] a.external-link:hover > code {
   text-decoration: underline;
   text-underline-offset: 2px;
-  cursor: pointer;
 }

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -209,3 +209,9 @@
     display: block;
   }
 }
+
+:root[data-link-modifier="true"] [data-component="markdown"] code[data-link-url]:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -50,10 +50,6 @@ type CopyLabels = {
 }
 
 const urlPattern = /^https?:\/\/[^\s<>()`"']+$/
-const linkModifierAttribute = "data-link-modifier"
-
-let linkModifierInstalled = false
-let linkModifierOn = false
 
 function codeUrl(text: string) {
   const href = text.trim().replace(/[),.;!?]+$/, "")
@@ -64,34 +60,6 @@ function codeUrl(text: string) {
   } catch {
     return
   }
-}
-
-function setLinkModifier(next: boolean) {
-  if (linkModifierOn === next) return
-  linkModifierOn = next
-  if (next) {
-    document.documentElement.setAttribute(linkModifierAttribute, "true")
-    return
-  }
-  document.documentElement.removeAttribute(linkModifierAttribute)
-}
-
-function updateLinkModifier(event: Pick<KeyboardEvent, "metaKey" | "ctrlKey">) {
-  setLinkModifier(event.metaKey || event.ctrlKey)
-}
-
-const handleModifierKeyDown = (event: KeyboardEvent) => updateLinkModifier(event)
-
-const handleModifierKeyUp = (event: KeyboardEvent) => updateLinkModifier(event)
-
-const handleModifierBlur = () => setLinkModifier(false)
-
-function ensureLinkModifier() {
-  if (linkModifierInstalled) return
-  linkModifierInstalled = true
-  document.addEventListener("keydown", handleModifierKeyDown, true)
-  document.addEventListener("keyup", handleModifierKeyUp, true)
-  window.addEventListener("blur", handleModifierBlur)
 }
 
 function createIcon(path: string, slot: string) {
@@ -159,31 +127,34 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     const codeNodes = Array.from(root.querySelectorAll(":not(pre) > code"))
     for (const code of codeNodes) {
       const href = codeUrl(code.textContent ?? "")
+      const parentLink =
+        code.parentElement instanceof HTMLAnchorElement && code.parentElement.classList.contains("external-link")
+          ? code.parentElement
+          : null
+
       if (!href) {
-        code.removeAttribute("data-link-url")
+        if (parentLink) parentLink.replaceWith(code)
         continue
       }
-      code.setAttribute("data-link-url", href)
+
+      if (parentLink) {
+        parentLink.href = href
+        continue
+      }
+
+      const link = document.createElement("a")
+      link.href = href
+      link.className = "external-link"
+      link.target = "_blank"
+      link.rel = "noopener noreferrer"
+      code.parentNode?.replaceChild(link, code)
+      link.appendChild(code)
     }
   }
 
   const handleClick = async (event: MouseEvent) => {
     const target = event.target
     if (!(target instanceof Element)) return
-
-    const codeEl = target.closest("code[data-link-url]")
-    if (codeEl instanceof HTMLElement) {
-      if (event.defaultPrevented) return
-      if (event.button !== 0) return
-      if (!event.metaKey && !event.ctrlKey) return
-      if (event.altKey || event.shiftKey) return
-      const href = codeEl.getAttribute("data-link-url")
-      if (!href) return
-      event.preventDefault()
-      event.stopPropagation()
-      window.open(href, "_blank", "noopener,noreferrer")
-      return
-    }
 
     const button = target.closest('[data-slot="markdown-copy-button"]')
     if (!(button instanceof HTMLButtonElement)) return
@@ -211,7 +182,6 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     if (button instanceof HTMLButtonElement) updateLabel(button)
   }
 
-  ensureLinkModifier()
   root.addEventListener("click", handleClick)
 
   return () => {

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -49,6 +49,51 @@ type CopyLabels = {
   copied: string
 }
 
+const urlPattern = /^https?:\/\/[^\s<>()`"']+$/
+const linkModifierAttribute = "data-link-modifier"
+
+let linkModifierInstalled = false
+let linkModifierOn = false
+
+function codeUrl(text: string) {
+  const href = text.trim().replace(/[),.;!?]+$/, "")
+  if (!urlPattern.test(href)) return
+  try {
+    const url = new URL(href)
+    return url.toString()
+  } catch {
+    return
+  }
+}
+
+function setLinkModifier(next: boolean) {
+  if (linkModifierOn === next) return
+  linkModifierOn = next
+  if (next) {
+    document.documentElement.setAttribute(linkModifierAttribute, "true")
+    return
+  }
+  document.documentElement.removeAttribute(linkModifierAttribute)
+}
+
+function updateLinkModifier(event: Pick<KeyboardEvent, "metaKey" | "ctrlKey">) {
+  setLinkModifier(event.metaKey || event.ctrlKey)
+}
+
+const handleModifierKeyDown = (event: KeyboardEvent) => updateLinkModifier(event)
+
+const handleModifierKeyUp = (event: KeyboardEvent) => updateLinkModifier(event)
+
+const handleModifierBlur = () => setLinkModifier(false)
+
+function ensureLinkModifier() {
+  if (linkModifierInstalled) return
+  linkModifierInstalled = true
+  document.addEventListener("keydown", handleModifierKeyDown, true)
+  document.addEventListener("keyup", handleModifierKeyUp, true)
+  window.addEventListener("blur", handleModifierBlur)
+}
+
 function createIcon(path: string, slot: string) {
   const icon = document.createElement("div")
   icon.setAttribute("data-component", "icon")
@@ -110,9 +155,36 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
     wrapper.appendChild(createCopyButton(labels))
   }
 
+  const markCodeLinks = () => {
+    const codeNodes = Array.from(root.querySelectorAll(":not(pre) > code"))
+    for (const code of codeNodes) {
+      const href = codeUrl(code.textContent ?? "")
+      if (!href) {
+        code.removeAttribute("data-link-url")
+        continue
+      }
+      code.setAttribute("data-link-url", href)
+    }
+  }
+
   const handleClick = async (event: MouseEvent) => {
     const target = event.target
     if (!(target instanceof Element)) return
+
+    const codeEl = target.closest("code[data-link-url]")
+    if (codeEl instanceof HTMLElement) {
+      if (event.defaultPrevented) return
+      if (event.button !== 0) return
+      if (!event.metaKey && !event.ctrlKey) return
+      if (event.altKey || event.shiftKey) return
+      const href = codeEl.getAttribute("data-link-url")
+      if (!href) return
+      event.preventDefault()
+      event.stopPropagation()
+      window.open(href, "_blank", "noopener,noreferrer")
+      return
+    }
+
     const button = target.closest('[data-slot="markdown-copy-button"]')
     if (!(button instanceof HTMLButtonElement)) return
     const code = button.closest('[data-component="markdown-code"]')?.querySelector("code")
@@ -132,12 +204,14 @@ function setupCodeCopy(root: HTMLDivElement, labels: CopyLabels) {
   for (const block of blocks) {
     ensureWrapper(block)
   }
+  markCodeLinks()
 
   const buttons = Array.from(root.querySelectorAll('[data-slot="markdown-copy-button"]'))
   for (const button of buttons) {
     if (button instanceof HTMLButtonElement) updateLabel(button)
   }
 
+  ensureLinkModifier()
   root.addEventListener("click", handleClick)
 
   return () => {


### PR DESCRIPTION
Related issue: #12649

The robots often put links inside of backticks, and it would be very nice to command-click on them like we can in the terminal. (Another, perhaps simpler, solution would be to make backtick-enclosed URLs become links as well, regardless of command being pressed.)

![CleanShot 2026-02-06 at 21 10 51](https://github.com/user-attachments/assets/8d3a4b45-a2cb-4eda-81e9-49ba841bb608)


## Summary
- add Cmd/Ctrl-click opening for inline-code values that are exactly a URL in app markdown output
- show underline affordance only while the modifier key is held and the inline code URL is hovered