### PR TITLE
fix(tui): reset DialogSelect filter on Cmd+Delete

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -70,7 +70,15 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     ),
   )
 
-  let input: InputRenderable
+  let input: InputRenderable | undefined
+
+  function query(value: string) {
+    if (value === store.filter) return
+    batch(() => {
+      setStore("filter", value)
+      props.onFilter?.(value)
+    })
+  }
 
   const filtered = createMemo(() => {
     if (props.skipFilter) return props.options.filter((x) => x.disabled !== true)
@@ -241,10 +249,11 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         <box paddingTop={1}>
           <input
             onInput={(e) => {
-              batch(() => {
-                setStore("filter", e)
-                props.onFilter?.(e)
-              })
+              query(e)
+            }}
+            onContentChange={() => {
+              if (!input || input.isDestroyed) return
+              query(input.value)
             }}
             focusedBackgroundColor={theme.backgroundPanel}
             cursorColor={theme.primary}


### PR DESCRIPTION
Fixes #12559

### What does this PR do?

On macOS, pressing Cmd+Delete in any `DialogSelect` input clears the text visually but doesn't reset the filter. The list stays filtered on the old query even though the input is empty.

The root cause is that Cmd+Delete is a macOS line-kill that the terminal/input widget handles internally — it updates the input's content without firing the `onInput` event that `DialogSelect` relies on to sync filter state.

The fix adds an onContentChange handler alongside onInput. onContentChange fires whenever the input widget's underlying edit buffer changes, regardless of how it changed, so it catches Cmd+Delete. It reads the actual input.value and updates the filter. A dedup guard (`if (value === store.filter) return`) prevents redundant updates during normal typing where both events fire.

This pattern is already used in the prompt input component (`packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx`).

### How did you verify your code works?
Ran `bun dev` from source, tested with 2 different `DialogSelect` inputs (model picker and connect a new provider): typed a query to filter the list, then pressed Cmd+Delete. The input cleared and the list immediately returned to the unfiltered state.