### PR TITLE
fix(app): disable 3 safari prompt-input annoyances

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -983,6 +983,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             aria-multiline="true"
             aria-label={placeholder()}
             contenteditable="true"
+            autocapitalize="off"
+            autocorrect="off"
+            spellcheck={false}
             onInput={handleInput}
             onPaste={handlePaste}
             onCompositionStart={() => setComposing(true)}


### PR DESCRIPTION
### What does this PR do?

Safari on desktop and iOS (any iOS browser is Safari) makes the prompt input behave very annoyingly. 
By default the input has auto capitalize, autocorrect, and spellcheck. I disabled all 3 as they are frustrating when prompting & writing shell commands.

### How did you verify your code works?
#### Before
https://github.com/user-attachments/assets/3976a972-0758-44e6-b3c9-ab4ab7f4553f

#### After


https://github.com/user-attachments/assets/2496ef5a-3138-418f-858e-001086b81beb

Fixes: https://github.com/anomalyco/opencode/issues/12555

