### PR TITLE
feat(acp): expose subagents in available modes response

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -43,7 +43,7 @@ import { LoadAPIKeyError } from "ai"
 import type { AssistantMessage, Event, OpencodeClient, SessionMessageResponse } from "@opencode-ai/sdk/v2"
 import { applyPatch } from "diff"
 
-type ModeOption = { id: string; name: string; description?: string }
+type ModeOption = { id: string; name: string; description?: string; mode?: string }
 type ModelOption = { modelId: string; name: string }
 
 const DEFAULT_VARIANT_VALUE = "default"
@@ -1052,11 +1052,12 @@ export namespace ACP {
         .then((resp) => resp.data!)
 
       return agents
-        .filter((agent) => agent.mode !== "subagent" && !agent.hidden)
+        .filter((agent) => !agent.hidden)
         .map((agent) => ({
           id: agent.name,
           name: agent.name,
           description: agent.description,
+          mode: agent.mode,
         }))
     }
 


### PR DESCRIPTION
## Summary
Expose subagents in ACP available modes response for client-side access.

Closes #11576

## Problem
ACP clients (e.g., [agent-shell](https://github.com/xenodium/agent-shell) for Emacs) cannot access subagent information through ACP. Users need this to `@mention` specific subagents.

## Solution
- Add optional `mode` field to `ModeOption` type
- Remove server-side subagent filter
- Clients can filter by `mode` field if they only want primary agents

## Changes
```diff
- type ModeOption = { id: string; name: string; description?: string }
+ type ModeOption = { id: string; name: string; description?: string; mode?: string }
```

```diff
- .filter((agent) => agent.mode !== "subagent" && !agent.hidden)
+ .filter((agent) => !agent.hidden)
  .map((agent) => ({
    id: agent.name,
    name: agent.name,
    description: agent.description,
+   mode: agent.mode,
  }))
```

## Backward Compatibility
Existing clients continue to work. The `mode` field is optional and only adds information.