### PR TITLE
feat(task): pass variant to subagent so it inherits parent's thinking level

### DIFF
--- a/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts
@@ -444,15 +444,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV2 {
 
             const delta = choice.delta
 
-            // Capture reasoning_opaque for Copilot multi-turn reasoning
+            // Capture reasoning_opaque for Copilot multi-turn reasoning.
+            // The API may send reasoning_opaque in multiple delta chunks
+            // (e.g. once with reasoning text, once with tool calls), so
+            // accept the latest value instead of rejecting duplicates.
             if (delta.reasoning_opaque) {
-              if (reasoningOpaque != null) {
-                throw new InvalidResponseDataError({
-                  data: delta,
-                  message:
-                    "Multiple reasoning_opaque values received in a single response. Only one thinking part per response is supported.",
-                })
-              }
               reasoningOpaque = delta.reasoning_opaque
             }
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -108,6 +108,10 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         providerID: msg.info.providerID,
       }
 
+      // Inherit variant from parent user message when subagent has no explicit variant
+      const parentUser = await MessageV2.get({ sessionID: ctx.sessionID, messageID: msg.info.parentID })
+      const variant = !agent.variant && parentUser.info.role === "user" ? parentUser.info.variant : undefined
+
       ctx.metadata({
         title: params.description,
         metadata: {
@@ -133,6 +137,7 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           providerID: model.providerID,
         },
         agent: agent.name,
+        variant,
         tools: {
           todowrite: false,
           todoread: false,

--- a/packages/opencode/test/session/prompt-variant.test.ts
+++ b/packages/opencode/test/session/prompt-variant.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
 import { SessionPrompt } from "../../src/session/prompt"
+import { Agent } from "../../src/agent/agent"
 import { tmpdir } from "../fixture/fixture"
 
 describe("session.prompt agent variant", () => {
@@ -81,6 +82,101 @@ describe("session.prompt agent variant", () => {
         expect(msg.info.variant).toBe("high")
 
         await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("subagent inherits variant from parent session user message", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // 1. Create a parent session and send a user message with variant
+        const parent = await Session.create({})
+        const parentMsg = await SessionPrompt.prompt({
+          sessionID: parent.id,
+          variant: "high",
+          noReply: true,
+          parts: [{ type: "text", text: "use @general to explore the codebase" }],
+        })
+        if (parentMsg.info.role !== "user") throw new Error("expected user message")
+        expect(parentMsg.info.variant).toBe("high")
+
+        // 2. Simulate what task.ts does: read back the parent user message
+        //    and compute the inherited variant for the subagent
+        const agent = await Agent.get("general")
+        const resolved = !agent.variant && parentMsg.info.role === "user" ? parentMsg.info.variant : undefined
+        expect(resolved).toBe("high")
+
+        // 3. Create a child session (like task.ts does) and prompt with inherited variant
+        const child = await Session.create({ parentID: parent.id })
+        const childMsg = await SessionPrompt.prompt({
+          sessionID: child.id,
+          agent: "general",
+          variant: resolved,
+          noReply: true,
+          parts: [{ type: "text", text: "explore the project structure" }],
+        })
+        if (childMsg.info.role !== "user") throw new Error("expected user message")
+        expect(childMsg.info.variant).toBe("high")
+
+        await Session.remove(child.id)
+        await Session.remove(parent.id)
+      },
+    })
+  })
+
+  test("subagent does not inherit variant when agent has own variant", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+            variant: "xhigh",
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // 1. Parent message with variant="high"
+        const parent = await Session.create({})
+        const parentMsg = await SessionPrompt.prompt({
+          sessionID: parent.id,
+          variant: "high",
+          noReply: true,
+          parts: [{ type: "text", text: "use @build to compile" }],
+        })
+        if (parentMsg.info.role !== "user") throw new Error("expected user message")
+        expect(parentMsg.info.variant).toBe("high")
+
+        // 2. Agent "build" has its own variant="xhigh", so inheritance should NOT happen
+        const agent = await Agent.get("build")
+        const resolved = !agent.variant && parentMsg.info.role === "user" ? parentMsg.info.variant : undefined
+        expect(resolved).toBeUndefined()
+
+        // 3. When variant=undefined, the child session uses agent's own variant via prompt.ts
+        const child = await Session.create({ parentID: parent.id })
+        const childMsg = await SessionPrompt.prompt({
+          sessionID: child.id,
+          agent: "build",
+          variant: resolved,
+          noReply: true,
+          parts: [{ type: "text", text: "compile the project" }],
+        })
+        if (childMsg.info.role !== "user") throw new Error("expected user message")
+        // agent.variant="xhigh" is applied by prompt.ts since we're using the agent's model
+        expect(childMsg.info.variant).toBe("xhigh")
+
+        await Session.remove(child.id)
+        await Session.remove(parent.id)
       },
     })
   })

--- a/packages/opencode/test/session/prompt-variant.test.ts
+++ b/packages/opencode/test/session/prompt-variant.test.ts
@@ -57,4 +57,31 @@ describe("session.prompt agent variant", () => {
       },
     })
   })
+
+  test("explicit variant input takes effect without agent variant config", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {},
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        // Simulates what task.ts does: passing parent's variant as explicit input
+        const msg = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "general",
+          variant: "high",
+          noReply: true,
+          parts: [{ type: "text", text: "hello" }],
+        })
+        if (msg.info.role !== "user") throw new Error("expected user message")
+        expect(msg.info.variant).toBe("high")
+
+        await Session.remove(session.id)
+      },
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?

When a user sets a thinking variant (e.g. `"high"`) on their main session, subagents spawned via the Task tool don't inherit it — they always run at default thinking. This means if you're using Claude with extended thinking or any model with reasoning variants, your subagents silently drop that setting.

This PR fixes that by reading the parent user message's `variant` in `task.ts` and forwarding it to the child session's `SessionPrompt.prompt()` call. The inheritance only kicks in when the subagent doesn't already have its own `variant` configured (via agent config), so explicit per-agent variants are respected.

#### Related issues

| Issue | Title | Relevance |
|-------|-------|-----------|
| #7138 | Support default variant configuration per agent | Root feature request for per-agent variant control |
| #10320 | Specify sub-agent variant (thinking lvl) from script for token economy | Directly requests parent→child variant passthrough |
| #8123 | Can't set effort when configuring a sub-agent | User pain point this PR alleviates |
| #6645 | Support for Model Variants in (sub)agents | Original feature request for variant support in subagents |

#### Relationship with PR #7156 (agent-level config)

PR #7156 adds a static `variant` field to agent config so each agent can declare its own default. **This PR complements that** by handling the dynamic case: when no agent-level variant is configured, the subagent inherits the parent session's variant at spawn time.

Resolution order (with both PRs merged): **user input > agent config (#7156) > parent variant (this PR) > model default**

These two PRs are independent and merge cleanly; together they fully close the gap described in the issues above.

#### Changes

- **`packages/opencode/src/tool/task.ts`** — After resolving the subagent, read the parent user message and compute inherited variant. Pass it to `SessionPrompt.prompt()`.
- **`packages/opencode/src/provider/sdk/copilot/chat/openai-compatible-chat-language-model.ts`** — Fix `reasoning_opaque` handling: the Copilot API can send multiple `reasoning_opaque` deltas in a single response (e.g. one with reasoning text, another with tool calls). Previously this threw an `InvalidResponseDataError`; now it accepts the latest value. This fix is required because with thinking variants active, multi-turn Copilot responses hit this edge case.
- **`packages/opencode/test/session/prompt-variant.test.ts`** — Three new tests covering: explicit variant passthrough, parent→child variant inheritance, and no-inherit when agent has own variant.

**How it works:** `SessionPrompt.prompt()` already supports a `variant` parameter that gets stored on the user message and used when building the LLM request. The Task tool just wasn't passing it through. The fix reads the parent message (which `task.ts` already has access to via `msg.info.parentID`) and conditionally forwards its variant.

### How did you verify your code works?

1. `bun test packages/opencode/test/session/prompt-variant.test.ts` — all 5 tests pass (2 existing + 3 new)
2. Manual testing with GitHub Copilot provider using `variant: "high"` — confirmed subagents now show extended thinking output where they previously didn't

Closes #10320
Related: #7138, #8123, #6645, #7156