### PR TITLE
fix(github): detect committed changes in branchIsDirty

### DIFF
--- a/github/index.ts
+++ b/github/index.ts
@@ -165,11 +165,13 @@ try {
     // Local PR
     if (prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner) {
       await checkoutLocalBranch(prData)
+      const head = (await $`git rev-parse HEAD`).stdout.toString().trim()
       const dataPrompt = buildPromptDataForPR(prData)
       const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
-      if (await branchIsDirty()) {
+      const { dirty, uncommittedChanges } = await branchIsDirty(head)
+      if (dirty) {
         const summary = await summarize(response)
-        await pushToLocalBranch(summary)
+        await pushToLocalBranch(summary, uncommittedChanges)
       }
       const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${useShareUrl()}/s/${shareId}`))
       await updateComment(`${response}${footer({ image: !hasShared })}`)
@@ -177,11 +179,13 @@ try {
     // Fork PR
     else {
       await checkoutForkBranch(prData)
+      const head = (await $`git rev-parse HEAD`).stdout.toString().trim()
       const dataPrompt = buildPromptDataForPR(prData)
       const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
-      if (await branchIsDirty()) {
+      const { dirty, uncommittedChanges } = await branchIsDirty(head)
+      if (dirty) {
         const summary = await summarize(response)
-        await pushToForkBranch(summary, prData)
+        await pushToForkBranch(summary, prData, uncommittedChanges)
       }
       const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${useShareUrl()}/s/${shareId}`))
       await updateComment(`${response}${footer({ image: !hasShared })}`)
@@ -190,12 +194,14 @@ try {
   // Issue
   else {
     const branch = await checkoutNewBranch()
+    const head = (await $`git rev-parse HEAD`).stdout.toString().trim()
     const issueData = await fetchIssue()
     const dataPrompt = buildPromptDataForIssue(issueData)
     const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
-    if (await branchIsDirty()) {
+    const { dirty, uncommittedChanges } = await branchIsDirty(head)
+    if (dirty) {
       const summary = await summarize(response)
-      await pushToNewBranch(summary, branch)
+      await pushToNewBranch(summary, branch, uncommittedChanges)
       const pr = await createPR(
         repoData.data.default_branch,
         branch,
@@ -713,45 +719,62 @@ function generateBranchName(type: "issue" | "pr") {
   return `opencode/${type}${useIssueId()}-${timestamp}`
 }
 
-async function pushToNewBranch(summary: string, branch: string) {
+async function pushToNewBranch(summary: string, branch: string, commit: boolean) {
   console.log("Pushing to new branch...")
   const actor = useContext().actor
 
-  await $`git add .`
-  await $`git commit -m "${summary}
+  if (commit) {
+    await $`git add .`
+    await $`git commit -m "${summary}
 
 Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
+  }
   await $`git push -u origin ${branch}`
 }
 
-async function pushToLocalBranch(summary: string) {
+async function pushToLocalBranch(summary: string, commit: boolean) {
   console.log("Pushing to local branch...")
   const actor = useContext().actor
 
-  await $`git add .`
-  await $`git commit -m "${summary}
+  if (commit) {
+    await $`git add .`
+    await $`git commit -m "${summary}
 
 Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
+  }
   await $`git push`
 }
 
-async function pushToForkBranch(summary: string, pr: GitHubPullRequest) {
+async function pushToForkBranch(summary: string, pr: GitHubPullRequest, commit: boolean) {
   console.log("Pushing to fork branch...")
   const actor = useContext().actor
 
   const remoteBranch = pr.headRefName
 
-  await $`git add .`
-  await $`git commit -m "${summary}
+  if (commit) {
+    await $`git add .`
+    await $`git commit -m "${summary}
 
 Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
+  }
   await $`git push fork HEAD:${remoteBranch}`
 }
 
-async function branchIsDirty() {
+async function branchIsDirty(originalHead: string) {
   console.log("Checking if branch is dirty...")
   const ret = await $`git status --porcelain`
-  return ret.stdout.toString().trim().length > 0
+  const status = ret.stdout.toString().trim()
+  if (status.length > 0) {
+    return {
+      dirty: true,
+      uncommittedChanges: true,
+    }
+  }
+  const head = await $`git rev-parse HEAD`
+  return {
+    dirty: head.stdout.toString().trim() !== originalHead,
+    uncommittedChanges: false,
+  }
 }
 
 async function assertPermissions() {


### PR DESCRIPTION
## Summary

The GitHub Action's `branchIsDirty()` in `github/index.ts` only checked `git status --porcelain`, which returns empty when the AI agent has already committed changes via `git commit`. This caused the push step to be skipped entirely, losing the commit.

## Root Cause

When the AI agent commits changes during a `/oc` command, the working tree becomes clean (`git status --porcelain` returns nothing). The old `branchIsDirty()` incorrectly reported `false`, so the push was never executed.

## Fix

Ported the fix from the CLI version (`packages/opencode/src/cli/cmd/github.ts`) to the GitHub Action version (`github/index.ts`):

- **Capture `HEAD`** before AI chat begins (`git rev-parse HEAD`)
- **Compare `HEAD`** after chat to detect new commits (even if working tree is clean)
- **Pass `uncommittedChanges` flag** to push functions so they conditionally run `git add . && git commit` only when needed
- **Always push** when `dirty=true`, regardless of whether changes are committed or not

This matches the behavior already implemented in the CLI version.

## Testing

The fix is a direct port of the working CLI implementation. The three push paths (local PR, fork PR, issue→new branch) all now correctly handle:
1. ✅ Uncommitted changes (existing behavior)
2. ✅ Already-committed changes (new behavior — was broken)

Fixes #1417