### PR TITLE
feat(tui): improve session fork UX

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-fork-from-timeline.tsx
@@ -6,6 +6,7 @@ import { Locale } from "@/util/locale"
 import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { useDialog } from "../../ui/dialog"
+import { useToast } from "../../ui/toast"
 import type { PromptInfo } from "@tui/component/prompt/history"
 
 export function DialogForkFromTimeline(props: { sessionID: string; onMove: (messageID: string) => void }) {
@@ -13,6 +14,9 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
   const dialog = useDialog()
   const sdk = useSDK()
   const route = useRoute()
+  const toast = useToast()
+
+  const forkCurrentValue = "__fork_current__"
 
   onMount(() => {
     dialog.setSize("large")
@@ -32,10 +36,16 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
         value: message.id,
         footer: Locale.time(message.time.created),
         onSelect: async (dialog) => {
-          const forked = await sdk.client.session.fork({
-            sessionID: props.sessionID,
-            messageID: message.id,
-          })
+          dialog.clear()
+          const forked = await sdk.client.session
+            .fork({
+              sessionID: props.sessionID,
+              messageID: message.id,
+            })
+            .catch(() => {
+              toast.show({ message: "Failed to fork session", variant: "error" })
+            })
+          if (!forked?.data?.id) return
           const parts = sync.data.part[message.id] ?? []
           const initialPrompt = parts.reduce(
             (agg, part) => {
@@ -47,18 +57,53 @@ export function DialogForkFromTimeline(props: { sessionID: string; onMove: (mess
             },
             { input: "", parts: [] as PromptInfo["parts"] },
           )
+          toast.show({ message: `Created new session: ${forked.data.title}`, variant: "success" })
           route.navigate({
-            sessionID: forked.data!.id,
+            sessionID: forked.data.id,
             type: "session",
             initialPrompt,
           })
-          dialog.clear()
         },
       })
     }
+
+    // Quick option to fork the current session state (no message selection).
+    result.push({
+      title: "Fork current session",
+      value: forkCurrentValue,
+      footer: "Current",
+      onSelect: async (dialog) => {
+        dialog.clear()
+        const forked = await sdk.client.session
+          .fork({
+            sessionID: props.sessionID,
+          })
+          .catch(() => {
+            toast.show({ message: "Failed to fork session", variant: "error" })
+          })
+        if (!forked?.data?.id) return
+        toast.show({ message: `Created new session: ${forked.data.title}`, variant: "success" })
+        route.navigate({
+          sessionID: forked.data.id,
+          type: "session",
+        })
+      },
+    })
+
     result.reverse()
     return result
   })
 
-  return <DialogSelect onMove={(option) => props.onMove(option.value)} title="Fork from message" options={options()} />
+  const move = (value: string) => {
+    if (value !== forkCurrentValue) {
+      props.onMove(value)
+      return
+    }
+
+    const latest = (sync.data.message[props.sessionID] ?? []).findLast((x) => x.role === "user")?.id
+    if (!latest) return
+    props.onMove(latest)
+  }
+
+  return <DialogSelect onMove={(option) => move(option.value)} title="Fork from message" options={options()} />
 }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/dialog-message.tsx
@@ -5,6 +5,7 @@ import { useSDK } from "@tui/context/sdk"
 import { useRoute } from "@tui/context/route"
 import { Clipboard } from "@tui/util/clipboard"
 import type { PromptInfo } from "@tui/component/prompt/history"
+import { useToast } from "../../ui/toast"
 
 export function DialogMessage(props: {
   messageID: string
@@ -15,6 +16,7 @@ export function DialogMessage(props: {
   const sdk = useSDK()
   const message = createMemo(() => sync.data.message[props.sessionID]?.find((x) => x.id === props.messageID))
   const route = useRoute()
+  const toast = useToast()
 
   return (
     <DialogSelect
@@ -76,10 +78,16 @@ export function DialogMessage(props: {
           value: "session.fork",
           description: "create a new session",
           onSelect: async (dialog) => {
-            const result = await sdk.client.session.fork({
-              sessionID: props.sessionID,
-              messageID: props.messageID,
-            })
+            dialog.clear()
+            const result = await sdk.client.session
+              .fork({
+                sessionID: props.sessionID,
+                messageID: props.messageID,
+              })
+              .catch(() => {
+                toast.show({ message: "Failed to fork session", variant: "error" })
+              })
+            if (!result?.data?.id) return
             const initialPrompt = (() => {
               const msg = message()
               if (!msg) return undefined
@@ -95,12 +103,12 @@ export function DialogMessage(props: {
                 { input: "", parts: [] as PromptInfo["parts"] },
               )
             })()
+            toast.show({ message: `Created new session: ${result.data.title}`, variant: "success" })
             route.navigate({
-              sessionID: result.data!.id,
+              sessionID: result.data.id,
               type: "session",
               initialPrompt,
             })
-            dialog.clear()
           },
         },
       ]}

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -63,7 +63,7 @@ export function Header() {
   const { theme } = useTheme()
   const keybind = useKeybind()
   const command = useCommandDialog()
-  const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
+  const [hover, setHover] = createSignal<"parent" | "prev" | "next" | "fork" | null>(null)
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
 
@@ -130,6 +130,16 @@ export function Header() {
             <box flexDirection={narrow() ? "column" : "row"} justifyContent="space-between" gap={1}>
               <Title session={session} />
               <box flexDirection="row" gap={1} flexShrink={0}>
+                <box
+                  onMouseOver={() => setHover("fork")}
+                  onMouseOut={() => setHover(null)}
+                  onMouseUp={() => command.trigger("session.fork")}
+                  backgroundColor={hover() === "fork" ? theme.backgroundElement : theme.backgroundPanel}
+                >
+                  <text fg={theme.text}>
+                    Fork <span style={{ fg: theme.textMuted }}>{keybind.print("session_fork")}</span>
+                  </text>
+                </box>
                 <ContextInfo context={context} cost={cost} />
                 <text fg={theme.textMuted}>v{Installation.VERSION}</text>
               </box>


### PR DESCRIPTION
## What
- Add a visible "Fork" action in the session header.
- Add a "Fork current session" option to the fork dialog.
- Improve feedback/toasts and prevent double-submits when forking.

## Why
Forking currently feels like it might be switching sessions rather than creating a new one, and the quickest/common intent (fork current state) requires selecting a specific message. This makes discovery and confidence worse.

## How
- Header: provide a direct entrypoint for forking via `session.fork`.
- Fork dialog: add a synthetic "current session" option with a unique value to avoid collisions.
- Clear dialogs before awaiting async fork calls to avoid double-submits.

## Tests
- `cd packages/opencode && bun run typecheck`
- (sanity) `cd packages/opencode && bun test test/keybind.test.ts`

Closes #12580