### PR TITLE
fix(keybind): handle sticky leader modifiers

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/keybind.tsx
@@ -20,23 +20,35 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
     })
     const [store, setStore] = createStore({
       leader: false,
+      mods: {
+        ctrl: false,
+        meta: false,
+        shift: false,
+        super: false,
+      },
     })
     const renderer = useRenderer()
 
     let focus: Renderable | null
     let timeout: NodeJS.Timeout
-    function leader(active: boolean) {
+    function leader(active: boolean, evt?: ParsedKey) {
       if (active) {
         setStore("leader", true)
+        const parsed = evt ? Keybind.fromParsedKey(evt) : undefined
+        setStore("mods", {
+          ctrl: !!parsed?.ctrl,
+          meta: !!parsed?.meta,
+          shift: !!parsed?.shift,
+          super: !!parsed?.super,
+        })
         focus = renderer.currentFocusedRenderable
         focus?.blur()
         if (timeout) clearTimeout(timeout)
         timeout = setTimeout(() => {
           if (!store.leader) return
           leader(false)
-          if (focus) {
-            focus.focus()
-          }
+          if (!focus || focus.isDestroyed) return
+          focus.focus()
         }, 2000)
         return
       }
@@ -46,12 +58,18 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
           focus.focus()
         }
         setStore("leader", false)
+        setStore("mods", {
+          ctrl: false,
+          meta: false,
+          shift: false,
+          super: false,
+        })
       }
     }
 
     useKeyboard(async (evt) => {
       if (!store.leader && result.match("leader", evt)) {
-        leader(true)
+        leader(true, evt)
         return
       }
 
@@ -73,21 +91,33 @@ export const { use: useKeybind, provider: KeybindProvider } = createSimpleContex
         return store.leader
       },
       parse(evt: ParsedKey): Keybind.Info {
-        // Handle special case for Ctrl+Underscore (represented as \x1F)
-        if (evt.name === "\x1F") {
-          return Keybind.fromParsedKey({ ...evt, name: "_", ctrl: true }, store.leader)
-        }
         return Keybind.fromParsedKey(evt, store.leader)
       },
       match(key: keyof KeybindsConfig, evt: ParsedKey) {
         const keybind = keybinds()[key]
         if (!keybind) return false
         const parsed: Keybind.Info = result.parse(evt)
-        for (const key of keybind) {
-          if (Keybind.match(key, parsed)) {
-            return true
-          }
+        for (const binding of keybind) {
+          if (Keybind.match(binding, parsed)) return true
         }
+
+        // If we're in leader mode, users often keep holding the leader modifiers
+        // (e.g. holding Ctrl for `ctrl+x` and then pressing the next key).
+        // Fall back to matching with the leader modifiers stripped.
+        if (!store.leader) return false
+
+        const stripped: Keybind.Info = {
+          ...parsed,
+          ctrl: store.mods.ctrl ? false : parsed.ctrl,
+          meta: store.mods.meta ? false : parsed.meta,
+          shift: store.mods.shift ? false : parsed.shift,
+          super: store.mods.super ? false : parsed.super,
+        }
+        for (const binding of keybind) {
+          if (Keybind.match(binding, stripped)) return true
+        }
+
+        return false
       },
       print(key: keyof KeybindsConfig) {
         const first = keybinds()[key]?.at(0)

--- a/packages/opencode/src/util/keybind.ts
+++ b/packages/opencode/src/util/keybind.ts
@@ -22,12 +22,41 @@ export namespace Keybind {
    * This helper ensures all required fields are present and avoids manual object creation.
    */
   export function fromParsedKey(key: ParsedKey, leader = false): Info {
+    const normalized = (() => {
+      if (typeof key.name !== "string") return key
+
+      // Some terminals encode Ctrl+<key> as an ASCII control character.
+      // Normalize those to the expected key name + ctrl modifier.
+      //
+      // NOTE: We intentionally avoid mapping ambiguous codes that commonly
+      // overlap with dedicated special keys in terminals.
+      const code = key.name.length === 1 ? key.name.charCodeAt(0) : -1
+
+      // Ctrl+Underscore is often represented as \x1F.
+      if (code === 0x1f) return { ...key, name: "_", ctrl: true }
+
+      // Map ASCII control codes 1..26 (Ctrl+A..Ctrl+Z) to letters.
+      // Skip: backspace (0x08), tab (0x09), linefeed (0x0A), carriage return (0x0D)
+      // because those are frequently emitted by non-ctrl special keys.
+      if (code >= 0x01 && code <= 0x1a && code !== 0x08 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+        return { ...key, name: String.fromCharCode(code + 0x60), ctrl: true }
+      }
+
+      // Normalize single-character names to lowercase for stable matching.
+      if (key.name.length === 1) {
+        const lower = key.name.toLowerCase()
+        if (lower !== key.name) return { ...key, name: lower }
+      }
+
+      return key
+    })()
+
     return {
-      name: key.name,
-      ctrl: key.ctrl,
-      meta: key.meta,
-      shift: key.shift,
-      super: key.super ?? false,
+      name: normalized.name,
+      ctrl: normalized.ctrl,
+      meta: normalized.meta,
+      shift: normalized.shift,
+      super: normalized.super ?? false,
       leader,
     }
   }

--- a/packages/opencode/test/keybind.test.ts
+++ b/packages/opencode/test/keybind.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "bun:test"
+import type { ParsedKey } from "@opentui/core"
 import { Keybind } from "../src/util/keybind"
 
 describe("Keybind.toString", () => {
@@ -172,6 +173,105 @@ describe("Keybind.match", () => {
     const a: Keybind.Info = { ctrl: true, meta: true, shift: true, super: true, leader: false, name: "a" }
     const b: Keybind.Info = { ctrl: true, meta: true, shift: true, super: false, leader: false, name: "a" }
     expect(Keybind.match(a, b)).toBe(false)
+  })
+})
+
+describe("Keybind.fromParsedKey", () => {
+  test("should normalize Ctrl+Underscore control code", () => {
+    const key = {
+      name: "\x1F",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+    } as ParsedKey
+    expect(Keybind.fromParsedKey(key)).toEqual({
+      name: "_",
+      ctrl: true,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+    })
+  })
+
+  test("should normalize Ctrl+letter ASCII control codes", () => {
+    const key = {
+      name: "\x07", // Ctrl+G
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+    } as ParsedKey
+    expect(Keybind.fromParsedKey(key)).toEqual({
+      name: "g",
+      ctrl: true,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+    })
+  })
+
+  test("should normalize single-letter names to lowercase", () => {
+    const key = {
+      name: "G",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+    } as ParsedKey
+    expect(Keybind.fromParsedKey(key).name).toBe("g")
+  })
+
+  test("should not normalize ambiguous control codes (tab/enter)", () => {
+    const tab = {
+      name: "\t",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+    } as ParsedKey
+    expect(Keybind.fromParsedKey(tab)).toEqual({
+      name: "\t",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+    })
+
+    const linefeed = {
+      name: "\n",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+    } as ParsedKey
+    expect(Keybind.fromParsedKey(linefeed)).toEqual({
+      name: "\n",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+    })
+
+    const carriageReturn = {
+      name: "\r",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+    } as ParsedKey
+    expect(Keybind.fromParsedKey(carriageReturn)).toEqual({
+      name: "\r",
+      ctrl: false,
+      meta: false,
+      shift: false,
+      super: false,
+      leader: false,
+    })
   })
 })
 


### PR DESCRIPTION
## What
- Improve keybind decoding for terminals that send Ctrl+letter as ASCII control codes.
- Make leader-chord matching resilient when users keep holding the leader modifier ("sticky" Ctrl/Meta/etc).

## Why
Some terminals emit Ctrl combinations as control bytes (e.g. `\x07`), and users often keep Ctrl held after pressing a leader chord (e.g. `ctrl+x` then `g`). This combination can cause the second key to be missed even though the chord intent is clear.

## How
- Normalize ASCII control codes in `Keybind.fromParsedKey()` (1..26 => `ctrl+a..z`, `0x1F` => `ctrl+_`), while intentionally skipping ambiguous codes (tab/enter/backspace/etc).
- When a leader is active, attempt exact match first; if that fails, retry after stripping the captured leader modifiers from the incoming key event.

## Tests
- `cd packages/opencode && bun test test/keybind.test.ts`
- `cd packages/opencode && bun run typecheck`

Fixes anomalyco/opencode#10444