### PR TITLE
Chore/remove model selector

### DIFF
--- a/packages/app/e2e/models/model-picker.spec.ts
+++ b/packages/app/e2e/models/model-picker.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "../fixtures"
 import { promptSelector } from "../selectors"
 import { clickListItem } from "../actions"
+import { modKey } from "../utils"
 
 test("smoke model selection updates prompt footer", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -14,29 +15,37 @@ test("smoke model selection updates prompt footer", async ({ page, gotoSession }
 
   await page.keyboard.press("Enter")
 
-  const dialog = page.getByRole("dialog")
-  await expect(dialog).toBeVisible()
+  const picker = page.locator('[data-component="model-selector"]').first()
+  await expect(picker).toBeVisible()
 
-  const input = dialog.getByRole("textbox").first()
-
-  const selected = dialog.locator('[data-slot="list-item"][data-selected="true"]').first()
+  const selected = picker.locator('[data-slot="list-item"][data-selected="true"]').first()
   await expect(selected).toBeVisible()
 
-  const other = dialog.locator('[data-slot="list-item"]:not([data-selected="true"])').first()
+  const other = picker.locator('[data-slot="list-item"]:not([data-selected="true"])').first()
   const target = (await other.count()) > 0 ? other : selected
 
   const key = await target.getAttribute("data-key")
   if (!key) throw new Error("Failed to resolve model key from list item")
 
   const name = (await target.locator("span").first().innerText()).trim()
-  const model = key.split(":").slice(1).join(":")
 
-  await input.fill(model)
+  await clickListItem(picker, { key })
 
-  await clickListItem(dialog, { key })
-
-  await expect(dialog).toHaveCount(0)
+  await expect(page.locator('[data-component="model-selector"]').first()).not.toBeVisible()
 
   const form = page.locator(promptSelector).locator("xpath=ancestor::form[1]")
   await expect(form.locator('[data-component="button"]').filter({ hasText: name }).first()).toBeVisible()
+})
+
+test("model chooser shortcut opens selector", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.press(`${modKey}+Quote`)
+
+  const picker = page.locator('[data-component="model-selector"]').first()
+  await expect(picker).toBeVisible()
+
+  await page.keyboard.press("Escape")
+  await expect(page.locator('[data-component="model-selector"]').first()).not.toBeVisible()
 })

--- a/packages/app/e2e/models/models-visibility.spec.ts
+++ b/packages/app/e2e/models/models-visibility.spec.ts
@@ -13,7 +13,7 @@ test("hiding a model removes it from the model picker", async ({ page, gotoSessi
   await command.hover()
   await page.keyboard.press("Enter")
 
-  const picker = page.getByRole("dialog")
+  const picker = page.locator('[data-component="model-selector"]').first()
   await expect(picker).toBeVisible()
 
   const target = picker.locator('[data-slot="list-item"]').first()
@@ -26,7 +26,7 @@ test("hiding a model removes it from the model picker", async ({ page, gotoSessi
   if (!name) throw new Error("Failed to resolve model name from list item")
 
   await page.keyboard.press("Escape")
-  await expect(picker).toHaveCount(0)
+  await expect(picker).not.toBeVisible()
 
   const settings = await openSettings(page)
 
@@ -50,12 +50,12 @@ test("hiding a model removes it from the model picker", async ({ page, gotoSessi
   await command.hover()
   await page.keyboard.press("Enter")
 
-  const pickerAgain = page.getByRole("dialog")
+  const pickerAgain = page.locator('[data-component="model-selector"]').first()
   await expect(pickerAgain).toBeVisible()
   await expect(pickerAgain.locator('[data-slot="list-item"]').first()).toBeVisible()
 
   await expect(pickerAgain.locator(`[data-slot="list-item"][data-key="${key}"]`)).toHaveCount(0)
 
   await page.keyboard.press("Escape")
-  await expect(pickerAgain).toHaveCount(0)
+  await expect(pickerAgain).not.toBeVisible()
 })

--- a/packages/app/e2e/settings/settings-models.spec.ts
+++ b/packages/app/e2e/settings/settings-models.spec.ts
@@ -13,7 +13,7 @@ test("hiding a model removes it from the model picker", async ({ page, gotoSessi
   await command.hover()
   await page.keyboard.press("Enter")
 
-  const picker = page.getByRole("dialog")
+  const picker = page.locator('[data-component="model-selector"]').first()
   await expect(picker).toBeVisible()
 
   const target = picker.locator('[data-slot="list-item"]').first()
@@ -26,7 +26,7 @@ test("hiding a model removes it from the model picker", async ({ page, gotoSessi
   if (!name) throw new Error("Failed to resolve model name from list item")
 
   await page.keyboard.press("Escape")
-  await expect(picker).toHaveCount(0)
+  await expect(picker).not.toBeVisible()
 
   const settings = await openSettings(page)
 
@@ -50,14 +50,14 @@ test("hiding a model removes it from the model picker", async ({ page, gotoSessi
   await command.hover()
   await page.keyboard.press("Enter")
 
-  const pickerAgain = page.getByRole("dialog")
+  const pickerAgain = page.locator('[data-component="model-selector"]').first()
   await expect(pickerAgain).toBeVisible()
   await expect(pickerAgain.locator('[data-slot="list-item"]').first()).toBeVisible()
 
   await expect(pickerAgain.locator(`[data-slot="list-item"][data-key="${key}"]`)).toHaveCount(0)
 
   await page.keyboard.press("Escape")
-  await expect(pickerAgain).toHaveCount(0)
+  await expect(pickerAgain).not.toBeVisible()
 })
 
 test("showing a hidden model restores it to the model picker", async ({ page, gotoSession }) => {
@@ -71,7 +71,7 @@ test("showing a hidden model restores it to the model picker", async ({ page, go
   await command.hover()
   await page.keyboard.press("Enter")
 
-  const picker = page.getByRole("dialog")
+  const picker = page.locator('[data-component="model-selector"]').first()
   await expect(picker).toBeVisible()
 
   const target = picker.locator('[data-slot="list-item"]').first()
@@ -84,7 +84,7 @@ test("showing a hidden model restores it to the model picker", async ({ page, go
   if (!name) throw new Error("Failed to resolve model name from list item")
 
   await page.keyboard.press("Escape")
-  await expect(picker).toHaveCount(0)
+  await expect(picker).not.toBeVisible()
 
   const settings = await openSettings(page)
 
@@ -112,11 +112,11 @@ test("showing a hidden model restores it to the model picker", async ({ page, go
   await command.hover()
   await page.keyboard.press("Enter")
 
-  const pickerAgain = page.getByRole("dialog")
+  const pickerAgain = page.locator('[data-component="model-selector"]').first()
   await expect(pickerAgain).toBeVisible()
 
   await expect(pickerAgain.locator(`[data-slot="list-item"][data-key="${key}"]`)).toBeVisible()
 
   await page.keyboard.press("Escape")
-  await expect(pickerAgain).toHaveCount(0)
+  await expect(pickerAgain).not.toBeVisible()
 })

--- a/packages/app/src/components/dialog-connect-provider.tsx
+++ b/packages/app/src/components/dialog-connect-provider.tsx
@@ -18,7 +18,6 @@ import { useLanguage } from "@/context/language"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { usePlatform } from "@/context/platform"
-import { DialogSelectModel } from "./dialog-select-model"
 import { DialogSelectProvider } from "./dialog-select-provider"
 
 export function DialogConnectProvider(props: { provider: string }) {

--- a/packages/app/src/components/dialog-select-model-unpaid.tsx
+++ b/packages/app/src/components/dialog-select-model-unpaid.tsx
@@ -38,91 +38,93 @@ export const DialogSelectModelUnpaid: Component = () => {
       title={language.t("dialog.model.select.title")}
       class="overflow-y-auto [&_[data-slot=dialog-body]]:overflow-visible [&_[data-slot=dialog-body]]:flex-none"
     >
-      <div class="flex flex-col gap-3 px-2.5">
-        <div class="text-14-medium text-text-base px-2.5">{language.t("dialog.model.unpaid.freeModels.title")}</div>
-        <List
-          class="[&_[data-slot=list-scroll]]:overflow-visible"
-          ref={(ref) => (listRef = ref)}
-          items={local.model.list}
-          current={local.model.current()}
-          key={(x) => `${x.provider.id}:${x.id}`}
-          itemWrapper={(item, node) => (
-            <Tooltip
-              class="w-full"
-              placement="right-start"
-              gutter={12}
-              value={
-                <ModelTooltip
-                  model={item}
-                  latest={item.latest}
-                  free={item.provider.id === "opencode" && (!item.cost || item.cost.input === 0)}
-                />
-              }
-            >
-              {node}
-            </Tooltip>
-          )}
-          onSelect={(x) => {
-            local.model.set(x ? { modelID: x.id, providerID: x.provider.id } : undefined, {
-              recent: true,
-            })
-            dialog.close()
-          }}
-        >
-          {(i) => (
-            <div class="w-full flex items-center gap-x-2.5">
-              <span>{i.name}</span>
-              <Tag>{language.t("model.tag.free")}</Tag>
-              <Show when={i.latest}>
-                <Tag>{language.t("model.tag.latest")}</Tag>
-              </Show>
-            </div>
-          )}
-        </List>
-      </div>
-      <div class="px-1.5 pb-1.5">
-        <div class="w-full rounded-sm border border-border-weak-base bg-surface-raised-base">
-          <div class="w-full flex flex-col items-start gap-4 px-1.5 pt-4 pb-4">
-            <div class="px-2 text-14-medium text-text-base">{language.t("dialog.model.unpaid.addMore.title")}</div>
-            <div class="w-full">
-              <List
-                class="w-full px-0"
-                key={(x) => x?.id}
-                items={providers.popular}
-                activeIcon="plus-small"
-                sortBy={(a, b) => {
-                  if (popularProviders.includes(a.id) && popularProviders.includes(b.id))
-                    return popularProviders.indexOf(a.id) - popularProviders.indexOf(b.id)
-                  return a.name.localeCompare(b.name)
-                }}
-                onSelect={(x) => {
-                  if (!x) return
-                  dialog.show(() => <DialogConnectProvider provider={x.id} />)
-                }}
+      <div data-component="model-selector">
+        <div class="flex flex-col gap-3 px-2.5">
+          <div class="text-14-medium text-text-base px-2.5">{language.t("dialog.model.unpaid.freeModels.title")}</div>
+          <List
+            class="[&_[data-slot=list-scroll]]:overflow-visible"
+            ref={(ref) => (listRef = ref)}
+            items={local.model.list}
+            current={local.model.current()}
+            key={(x) => `${x.provider.id}:${x.id}`}
+            itemWrapper={(item, node) => (
+              <Tooltip
+                class="w-full"
+                placement="right-start"
+                gutter={12}
+                value={
+                  <ModelTooltip
+                    model={item}
+                    latest={item.latest}
+                    free={item.provider.id === "opencode" && (!item.cost || item.cost.input === 0)}
+                  />
+                }
               >
-                {(i) => (
-                  <div class="w-full flex items-center gap-x-3">
-                    <ProviderIcon data-slot="list-item-extra-icon" id={i.id as IconName} />
-                    <span>{i.name}</span>
-                    <Show when={i.id === "opencode"}>
-                      <Tag>{language.t("dialog.provider.tag.recommended")}</Tag>
-                    </Show>
-                    <Show when={i.id === "anthropic"}>
-                      <div class="text-14-regular text-text-weak">{language.t("dialog.provider.anthropic.note")}</div>
-                    </Show>
-                  </div>
-                )}
-              </List>
-              <Button
-                variant="ghost"
-                class="w-full justify-start px-[11px] py-3.5 gap-4.5 text-14-medium"
-                icon="dot-grid"
-                onClick={() => {
-                  dialog.show(() => <DialogSelectProvider />)
-                }}
-              >
-                {language.t("dialog.provider.viewAll")}
-              </Button>
+                {node}
+              </Tooltip>
+            )}
+            onSelect={(x) => {
+              local.model.set(x ? { modelID: x.id, providerID: x.provider.id } : undefined, {
+                recent: true,
+              })
+              dialog.close()
+            }}
+          >
+            {(i) => (
+              <div class="w-full flex items-center gap-x-2.5">
+                <span>{i.name}</span>
+                <Tag>{language.t("model.tag.free")}</Tag>
+                <Show when={i.latest}>
+                  <Tag>{language.t("model.tag.latest")}</Tag>
+                </Show>
+              </div>
+            )}
+          </List>
+        </div>
+        <div class="px-1.5 pb-1.5">
+          <div class="w-full rounded-sm border border-border-weak-base bg-surface-raised-base">
+            <div class="w-full flex flex-col items-start gap-4 px-1.5 pt-4 pb-4">
+              <div class="px-2 text-14-medium text-text-base">{language.t("dialog.model.unpaid.addMore.title")}</div>
+              <div class="w-full">
+                <List
+                  class="w-full px-0"
+                  key={(x) => x?.id}
+                  items={providers.popular}
+                  activeIcon="plus-small"
+                  sortBy={(a, b) => {
+                    if (popularProviders.includes(a.id) && popularProviders.includes(b.id))
+                      return popularProviders.indexOf(a.id) - popularProviders.indexOf(b.id)
+                    return a.name.localeCompare(b.name)
+                  }}
+                  onSelect={(x) => {
+                    if (!x) return
+                    dialog.show(() => <DialogConnectProvider provider={x.id} />)
+                  }}
+                >
+                  {(i) => (
+                    <div class="w-full flex items-center gap-x-3">
+                      <ProviderIcon data-slot="list-item-extra-icon" id={i.id as IconName} />
+                      <span>{i.name}</span>
+                      <Show when={i.id === "opencode"}>
+                        <Tag>{language.t("dialog.provider.tag.recommended")}</Tag>
+                      </Show>
+                      <Show when={i.id === "anthropic"}>
+                        <div class="text-14-regular text-text-weak">{language.t("dialog.provider.anthropic.note")}</div>
+                      </Show>
+                    </div>
+                  )}
+                </List>
+                <Button
+                  variant="ghost"
+                  class="w-full justify-start px-[11px] py-3.5 gap-4.5 text-14-medium"
+                  icon="dot-grid"
+                  onClick={() => {
+                    dialog.show(() => <DialogSelectProvider />)
+                  }}
+                >
+                  {language.t("dialog.provider.viewAll")}
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -4,10 +4,8 @@ import { createStore } from "solid-js/store"
 import { useLocal } from "@/context/local"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { popularProviders } from "@/hooks/use-providers"
-import { Button } from "@opencode-ai/ui/button"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Tag } from "@opencode-ai/ui/tag"
-import { Dialog } from "@opencode-ai/ui/dialog"
 import { List } from "@opencode-ai/ui/list"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { DialogSelectProvider } from "./dialog-select-provider"
@@ -94,6 +92,8 @@ export function ModelSelectorPopover(props: {
   children?: JSX.Element
   triggerAs?: ValidComponent
   triggerProps?: ModelSelectorTriggerProps
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
 }) {
   const [store, setStore] = createStore<{
     open: boolean
@@ -107,20 +107,30 @@ export function ModelSelectorPopover(props: {
     content: undefined,
   })
   const dialog = useDialog()
+  const open = () => (props.open === undefined ? store.open : props.open)
+  const setOpen = (value: boolean) => {
+    if (props.open === undefined) setStore("open", value)
+    props.onOpenChange?.(value)
+  }
 
   const handleManage = () => {
-    setStore("open", false)
+    setOpen(false)
     dialog.show(() => <DialogManageModels />)
   }
 
   const handleConnectProvider = () => {
-    setStore("open", false)
+    setOpen(false)
     dialog.show(() => <DialogSelectProvider />)
   }
   const language = useLanguage()
 
   createEffect(() => {
-    if (!store.open) return
+    if (props.open !== true) return
+    setStore("dismiss", null)
+  })
+
+  createEffect(() => {
+    if (!open()) return
 
     const inside = (node: Node | null | undefined) => {
       if (!node) return false
@@ -134,7 +144,7 @@ export function ModelSelectorPopover(props: {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return
       setStore("dismiss", "escape")
-      setStore("open", false)
+      setOpen(false)
       event.preventDefault()
       event.stopPropagation()
     }
@@ -144,7 +154,7 @@ export function ModelSelectorPopover(props: {
       if (!(target instanceof Node)) return
       if (inside(target)) return
       setStore("dismiss", "outside")
-      setStore("open", false)
+      setOpen(false)
     }
 
     const onFocusIn = (event: FocusEvent) => {
@@ -153,7 +163,7 @@ export function ModelSelectorPopover(props: {
       if (!(target instanceof Node)) return
       if (inside(target)) return
       setStore("dismiss", "outside")
-      setStore("open", false)
+      setOpen(false)
     }
 
     window.addEventListener("keydown", onKeyDown, true)
@@ -169,10 +179,10 @@ export function ModelSelectorPopover(props: {
 
   return (
     <Kobalte
-      open={store.open}
+      open={open()}
       onOpenChange={(next) => {
         if (next) setStore("dismiss", null)
-        setStore("open", next)
+        setOpen(next)
       }}
       modal={false}
       placement="top-start"
@@ -183,21 +193,22 @@ export function ModelSelectorPopover(props: {
       </Kobalte.Trigger>
       <Kobalte.Portal>
         <Kobalte.Content
+          data-component="model-selector"
           ref={(el) => setStore("content", el)}
           class="w-72 h-80 flex flex-col p-2 rounded-md border border-border-base bg-surface-raised-stronger-non-alpha shadow-md z-50 outline-none overflow-hidden"
           onEscapeKeyDown={(event) => {
             setStore("dismiss", "escape")
-            setStore("open", false)
+            setOpen(false)
             event.preventDefault()
             event.stopPropagation()
           }}
           onPointerDownOutside={() => {
             setStore("dismiss", "outside")
-            setStore("open", false)
+            setOpen(false)
           }}
           onFocusOutside={() => {
             setStore("dismiss", "outside")
-            setStore("open", false)
+            setOpen(false)
           }}
           onCloseAutoFocus={(event) => {
             if (store.dismiss === "outside") event.preventDefault()
@@ -207,7 +218,7 @@ export function ModelSelectorPopover(props: {
           <Kobalte.Title class="sr-only">{language.t("dialog.model.select.title")}</Kobalte.Title>
           <ModelList
             provider={props.provider}
-            onSelect={() => setStore("open", false)}
+            onSelect={() => setOpen(false)}
             class="p-1"
             action={
               <div class="flex items-center gap-1">
@@ -237,35 +248,5 @@ export function ModelSelectorPopover(props: {
         </Kobalte.Content>
       </Kobalte.Portal>
     </Kobalte>
-  )
-}
-
-export const DialogSelectModel: Component<{ provider?: string }> = (props) => {
-  const dialog = useDialog()
-  const language = useLanguage()
-
-  return (
-    <Dialog
-      title={language.t("dialog.model.select.title")}
-      action={
-        <Button
-          class="h-7 -my-1 text-14-medium"
-          icon="plus-small"
-          tabIndex={-1}
-          onClick={() => dialog.show(() => <DialogSelectProvider />)}
-        >
-          {language.t("command.provider.connect")}
-        </Button>
-      }
-    >
-      <ModelList provider={props.provider} onSelect={() => dialog.close()} />
-      <Button
-        variant="ghost"
-        class="ml-3 mt-5 mb-6 text-text-base self-start"
-        onClick={() => dialog.show(() => <DialogManageModels />)}
-      >
-        {language.t("dialog.model.manage")}
-      </Button>
-    </Dialog>
   )
 }

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -52,6 +52,8 @@ interface PromptInputProps {
   newSessionWorktree?: string
   onNewSessionWorktreeReset?: () => void
   onSubmit?: () => void
+  modelSelectorOpen?: boolean
+  onModelSelectorOpenChange?: (open: boolean) => void
 }
 
 const EXAMPLES = [
@@ -289,6 +291,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
   createEffect(() => {
     if (!isFocused()) setStore("popover", null)
+  })
+
+  createEffect(() => {
+    if (!props.modelSelectorOpen) return
+    if (store.mode === "shell") setStore("mode", "normal")
+    if (providers.paid().length > 0) return
+    props.onModelSelectorOpenChange?.(false)
+    dialog.show(() => <DialogSelectModelUnpaid />)
   })
 
   // Safety: reset composing state on focus change to prevent stuck state
@@ -1061,6 +1071,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                     keybind={command.keybind("model.choose")}
                   >
                     <ModelSelectorPopover
+                      open={props.modelSelectorOpen}
+                      onOpenChange={props.onModelSelectorOpenChange}
                       triggerAs={Button}
                       triggerProps={{ variant: "ghost", class: "min-w-0 max-w-[240px]" }}
                     >

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -136,6 +136,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     requestAnimationFrame(scrollCursorIntoView)
   }
 
+  const handleModelSelectorOpenChange = (open: boolean) => {
+    props.onModelSelectorOpenChange?.(open)
+    if (open) return
+    requestAnimationFrame(() => {
+      if (dialog.active) return
+      editorRef?.focus()
+    })
+  }
+
   const sessionKey = createMemo(() => `${params.dir}${params.id ? "/" + params.id : ""}`)
   const tabs = createMemo(() => layout.tabs(sessionKey))
   const view = createMemo(() => layout.view(sessionKey))
@@ -1072,7 +1081,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   >
                     <ModelSelectorPopover
                       open={props.modelSelectorOpen}
-                      onOpenChange={props.onModelSelectorOpenChange}
+                      onOpenChange={handleModelSelectorOpenChange}
                       triggerAs={Button}
                       triggerProps={{ variant: "ghost", class: "min-w-0 max-w-[240px]" }}
                     >

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -555,6 +555,7 @@ export default function Page() {
     changes: "session" as "session" | "turn",
     newSessionWorktree: "main",
     promptHeight: 0,
+    modelSelectorOpen: false,
   })
 
   const turnDiffs = createMemo(() => lastUserMessage()?.summary?.diffs ?? [])
@@ -728,6 +729,7 @@ export default function Page() {
         setStore("messageId", undefined)
         setStore("expanded", {})
         setStore("changes", "session")
+        setStore("modelSelectorOpen", false)
         setUi("autoCreated", false)
       },
       { defer: true },
@@ -929,6 +931,10 @@ export default function Page() {
     setExpanded: (id, fn) => setStore("expanded", id, fn),
     setActiveMessage,
     addSelectionToContext,
+    openModelSelector: () => {
+      if (blocked()) return
+      setStore("modelSelectorOpen", true)
+    },
   })
 
   const openReviewFile = createOpenReviewFile({
@@ -1660,6 +1666,8 @@ export default function Page() {
               comments.clear()
               resumeScroll()
             }}
+            modelSelectorOpen={store.modelSelectorOpen}
+            onModelSelectorOpenChange={(open) => setStore("modelSelectorOpen", open)}
             setPromptDockRef={(el) => (promptDock = el)}
           />
 

--- a/packages/app/src/pages/session/session-prompt-dock.tsx
+++ b/packages/app/src/pages/session/session-prompt-dock.tsx
@@ -22,6 +22,8 @@ export function SessionPromptDock(props: {
   onNewSessionWorktreeReset: () => void
   onSubmit: () => void
   setPromptDockRef: (el: HTMLDivElement) => void
+  modelSelectorOpen: boolean
+  onModelSelectorOpenChange: (open: boolean) => void
 }) {
   return (
     <div
@@ -128,6 +130,8 @@ export function SessionPromptDock(props: {
               newSessionWorktree={props.newSessionWorktree}
               onNewSessionWorktreeReset={props.onNewSessionWorktreeReset}
               onSubmit={props.onSubmit}
+              modelSelectorOpen={props.modelSelectorOpen}
+              onModelSelectorOpenChange={props.onModelSelectorOpenChange}
             />
           </Show>
         </Show>

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -12,7 +12,6 @@ import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { useTerminal } from "@/context/terminal"
 import { DialogSelectFile } from "@/components/dialog-select-file"
-import { DialogSelectModel } from "@/components/dialog-select-model"
 import { DialogSelectMcp } from "@/components/dialog-select-mcp"
 import { DialogFork } from "@/components/dialog-fork"
 import { showToast } from "@opencode-ai/ui/toast"
@@ -48,6 +47,7 @@ export const useSessionCommands = (input: {
   setExpanded: (id: string, fn: (open: boolean | undefined) => boolean) => void
   setActiveMessage: (message: UserMessage | undefined) => void
   addSelectionToContext: (path: string, selection: FileSelection) => void
+  openModelSelector: () => void
 }) => {
   const sessionCommands = createMemo(() => [
     {
@@ -201,7 +201,7 @@ export const useSessionCommands = (input: {
       category: input.language.t("command.category.model"),
       keybind: "mod+'",
       slash: "model",
-      onSelect: () => input.dialog.show(() => <DialogSelectModel />),
+      onSelect: () => input.openModelSelector(),
     },
     {
       id: "mcp.toggle",


### PR DESCRIPTION
unifies model selection to a single existing ui path by routing model.choose (cmd+', slash /model, and command trigger flow) to the prompt footer model selector popover instead of opening a separate model dialog. it adds controlled open support to the selector, wires session-level state so commands can open it safely, removes redundant/unused model dialog code and dead imports, and updates e2e tests to target a stable shared selector hook plus a shortcut regression case. this reduces duplicate ui surface area, keeps behavior consistent across entry points, and lowers maintenance risk without changing model/provider business logic.

command + ' will open this.
<img width="1293" height="467" alt="image" src="https://github.com/user-attachments/assets/d38b18e3-c40f-4ad5-97af-2e8da422fb0a" />
