### PR TITLE
feat: add opencode-dingtalk-notify plugin to web ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,7 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
-
+| [opencode-dingtalk-notify](https://github.com/faywong/opencode-dingtalk-notify)                           | DingTalk (钉钉) notifications for OpenCode – send task updates to your team                        |
 ---
 
 ## Projects


### PR DESCRIPTION
### What does this PR do?

Fixes #12638, Add [DingTalk](https://www.dingtalk.com/) notify support to OpenCode so as to ease the mobile life today.

DingTalk is used by 700 million people for work and study, and covers platforms such as Windows/Macos/Linux/Harmonyos/XR OS/Windows Accessibility.

### How did you verify your code works?
I verified it with my DingTak account and a real group chat(dingtalk chat robot included) and worked as expected.