### PR TITLE
fix(tui): prevent path type error crash when plugins return objects

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import path from "path"
+import { coerceFsPath } from "@/util/coerce-path"
 import { useRoute, useRouteData } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { SplitBorder } from "@tui/component/border"
@@ -2100,12 +2101,13 @@ function Skill(props: ToolProps<typeof SkillTool>) {
   )
 }
 
-function normalizePath(input?: string) {
-  if (!input) return ""
-  if (path.isAbsolute(input)) {
-    return path.relative(process.cwd(), input) || "."
+function normalizePath(input?: unknown): string {
+  const p = coerceFsPath(input, "session route normalizePath")
+  if (!p) return ""
+  if (path.isAbsolute(p)) {
+    return path.relative(process.cwd(), p) || "."
   }
-  return input
+  return p
 }
 
 function input(input: Record<string, any>, omit?: string[]): string {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx
@@ -15,15 +15,17 @@ import { Keybind } from "@/util/keybind"
 import { Locale } from "@/util/locale"
 import { Global } from "@/global"
 import { useDialog } from "../../ui/dialog"
+import { coerceFsPath } from "@/util/coerce-path"
 
 type PermissionStage = "permission" | "always" | "reject"
 
-function normalizePath(input?: string) {
-  if (!input) return ""
+function normalizePath(input?: unknown): string {
+  const p = coerceFsPath(input, "permission route normalizePath")
+  if (!p) return ""
 
   const cwd = process.cwd()
   const home = Global.Path.home
-  const absolute = path.isAbsolute(input) ? input : path.resolve(cwd, input)
+  const absolute = path.isAbsolute(p) ? p : path.resolve(cwd, p)
   const relative = path.relative(cwd, absolute)
 
   if (!relative) return "."

--- a/packages/opencode/src/util/coerce-path.ts
+++ b/packages/opencode/src/util/coerce-path.ts
@@ -1,0 +1,84 @@
+import path from "path"
+
+/**
+ * Coerces an unknown value to a filesystem path string.
+ *
+ * Accepts:
+ * - string: returned as-is
+ * - undefined/null: returns ""
+ * - URL instance: returns pathname
+ * - Object with path/cwd/value/filePath property that is a string
+ * - Array of strings: joined with platform path separator
+ *
+ * Throws for any other type with a descriptive error.
+ *
+ * @param input - The value to coerce
+ * @param context - Optional context for error messages (e.g., "session route normalizePath")
+ * @returns A string path, or empty string for null/undefined
+ */
+export function coerceFsPath(input: unknown, context?: string): string {
+  // Handle null/undefined
+  if (input == null) {
+    return ""
+  }
+
+  // Handle string (most common case)
+  if (typeof input === "string") {
+    return input
+  }
+
+  // Handle URL instance
+  if (input instanceof URL) {
+    return input.pathname
+  }
+
+  // Handle arrays (join string segments)
+  if (Array.isArray(input)) {
+    if (input.length === 0) {
+      return ""
+    }
+    // Validate all elements are strings
+    for (let i = 0; i < input.length; i++) {
+      if (typeof input[i] !== "string") {
+        throw new TypeError(
+          `coerceFsPath: array element at index ${i} is not a string (got ${typeof input[i]})${context ? ` in ${context}` : ""}`,
+        )
+      }
+    }
+    return path.join(...(input as string[]))
+  }
+
+  // Handle objects with known path-like properties
+  if (typeof input === "object") {
+    const obj = input as Record<string, unknown>
+
+    // Check for common path-like properties in order of priority
+    const pathKeys = ["path", "filePath", "cwd", "value"] as const
+    for (const key of pathKeys) {
+      if (key in obj) {
+        const value = obj[key]
+        if (typeof value === "string") {
+          return value
+        }
+        if (value == null) {
+          return ""
+        }
+        // Property exists but is not a string or null
+        throw new TypeError(
+          `coerceFsPath: object.${key} is not a string (got ${typeof value})${context ? ` in ${context}` : ""}`,
+        )
+      }
+    }
+
+    // Object has no recognized path properties
+    const keys = Object.keys(obj).slice(0, 5).join(", ")
+    throw new TypeError(
+      `coerceFsPath: object has no recognized path property (keys: ${keys || "none"})${context ? ` in ${context}` : ""}`,
+    )
+  }
+
+  // Reject all other types
+  throw new TypeError(
+    `coerceFsPath: expected string or path-like object, got ${typeof input}${context ? ` in ${context}` : ""}`,
+  )
+}

--- a/packages/opencode/test/util/coerce-path.test.ts
+++ b/packages/opencode/test/util/coerce-path.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import { coerceFsPath } from "../../src/util/coerce-path"
+import path from "path"
+
+describe("coerceFsPath", () => {
+  describe("accepts valid inputs", () => {
+    test("returns empty string for undefined", () => {
+      expect(coerceFsPath(undefined)).toBe("")
+    })
+
+    test("returns empty string for null", () => {
+      expect(coerceFsPath(null)).toBe("")
+    })
+
+    test("returns string as-is", () => {
+      expect(coerceFsPath("/path/to/file")).toBe("/path/to/file")
+      expect(coerceFsPath("relative/path")).toBe("relative/path")
+      expect(coerceFsPath("")).toBe("")
+    })
+
+    test("extracts pathname from URL instance", () => {
+      const url = new URL("file:///path/to/file.txt")
+      expect(coerceFsPath(url)).toBe("/path/to/file.txt")
+    })
+
+    test("extracts path from object with path property", () => {
+      expect(coerceFsPath({ path: "/some/path" })).toBe("/some/path")
+    })
+
+    test("extracts filePath from object with filePath property", () => {
+      expect(coerceFsPath({ filePath: "/some/file.ts" })).toBe("/some/file.ts")
+    })
+
+    test("extracts cwd from object with cwd property", () => {
+      expect(coerceFsPath({ cwd: "/working/dir" })).toBe("/working/dir")
+    })
+
+    test("extracts value from object with value property", () => {
+      expect(coerceFsPath({ value: "/value/path" })).toBe("/value/path")
+    })
+
+    test("returns empty string for object with null path property", () => {
+      expect(coerceFsPath({ path: null })).toBe("")
+      expect(coerceFsPath({ filePath: undefined })).toBe("")
+    })
+
+    test("prioritizes path over other properties", () => {
+      expect(coerceFsPath({ path: "/a", cwd: "/b", value: "/c" })).toBe("/a")
+    })
+
+    test("falls back to filePath when path is missing", () => {
+      expect(coerceFsPath({ filePath: "/a", cwd: "/b" })).toBe("/a")
+    })
+
+    test("joins string array with path separator", () => {
+      const result = coerceFsPath(["path", "to", "file"])
+      expect(result).toBe(path.join("path", "to", "file"))
+    })
+
+    test("returns empty string for empty array", () => {
+      expect(coerceFsPath([])).toBe("")
+    })
+  })
+
+  describe("rejects invalid inputs", () => {
+    test("throws for number", () => {
+      expect(() => coerceFsPath(123)).toThrow(TypeError)
+      expect(() => coerceFsPath(123)).toThrow("expected string or path-like object, got number")
+    })
+
+    test("throws for boolean", () => {
+      expect(() => coerceFsPath(true)).toThrow(TypeError)
+      expect(() => coerceFsPath(true)).toThrow("expected string or path-like object, got boolean")
+    })
+
+    test("throws for function", () => {
+      expect(() => coerceFsPath(() => {})).toThrow(TypeError)
+      expect(() => coerceFsPath(() => {})).toThrow("expected string or path-like object, got function")
+    })
+
+    test("throws for object without recognized path property", () => {
+      expect(() => coerceFsPath({ foo: "bar" })).toThrow(TypeError)
+      expect(() => coerceFsPath({ foo: "bar" })).toThrow("no recognized path property")
+    })
+
+    test("throws for object with non-string path property", () => {
+      expect(() => coerceFsPath({ path: 123 })).toThrow(TypeError)
+      expect(() => coerceFsPath({ path: 123 })).toThrow("object.path is not a string")
+    })
+
+    test("throws for array with non-string element", () => {
+      expect(() => coerceFsPath(["a", 123, "b"])).toThrow(TypeError)
+      expect(() => coerceFsPath(["a", 123, "b"])).toThrow("array element at index 1 is not a string")
+    })
+
+    test("throws for object with nested object path", () => {
+      expect(() => coerceFsPath({ path: { nested: "value" } })).toThrow(TypeError)
+      expect(() => coerceFsPath({ path: { nested: "value" } })).toThrow("object.path is not a string")
+    })
+  })
+
+  describe("includes context in error messages", () => {
+    test("includes context for primitive type error", () => {
+      expect(() => coerceFsPath(123, "session route")).toThrow("in session route")
+    })
+
+    test("includes context for object property error", () => {
+      expect(() => coerceFsPath({ path: 123 }, "permission check")).toThrow("in permission check")
+    })
+
+    test("includes context for unrecognized object error", () => {
+      expect(() => coerceFsPath({ unknown: "value" }, "list tool")).toThrow("in list tool")
+    })
+
+    test("includes context for array element error", () => {
+      expect(() => coerceFsPath(["a", null], "glob tool")).toThrow("in glob tool")
+    })
+  })
+
+  describe("edge cases", () => {
+    test("handles empty path property", () => {
+      expect(coerceFsPath({ path: "" })).toBe("")
+    })
+
+    test("handles whitespace-only path", () => {
+      expect(coerceFsPath("   ")).toBe("   ")
+    })
+
+    test("handles path with special characters", () => {
+      expect(coerceFsPath("/path/with spaces/and-dashes")).toBe("/path/with spaces/and-dashes")
+    })
+
+    test("handles object toString that returns [object Object]", () => {
+      // This should NOT fall through to naive String() conversion
+      const badObject = { toString: () => "[object Object]" }
+      expect(() => coerceFsPath(badObject)).toThrow("no recognized path property")
+    })
+  })
+})


### PR DESCRIPTION
Fixes #12589 - adds coerceFsPath utility that safely handles various path-like input shapes (objects, URLs, arrays) before calling Node.js path functions.

I've fixed this issue. The root cause was that [normalizePath](cci:1://file:///Users/venom/opencode/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx:21:0-38:1) in [session/index.tsx](cci:7://file:///Users/venom/opencode/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:0:0-0:0) called `path.isAbsolute(input)` without validating that [input](cci:1://file:///Users/venom/opencode/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:1406:4-1408:5) was a string. When plugins like `opencode-antigravity-auth@latest` returned objects (e.g., `{ path: string }`) instead of raw strings, Node.js threw the TypeError.

**Fix:** Added a [coerceFsPath](cci:1://file:///Users/venom/opencode/packages/opencode/src/util/coerce-path.ts:2:0-83:1) utility that safely handles various path-like input shapes (objects, URLs, arrays) before calling Node.js path functions.

**Branch:** `fix-path-type-12589`

**Changes:**
- New: [src/util/coerce-path.ts](cci:7://file:///Users/venom/opencode/packages/opencode/src/util/coerce-path.ts:0:0-0:0) - Safe type coercion utility
- New: [test/util/coerce-path.test.ts](cci:7://file:///Users/venom/opencode/packages/opencode/test/util/coerce-path.test.ts:0:0-0:0) - Unit tests
- Updated: [session/index.tsx](cci:7://file:///Users/venom/opencode/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:0:0-0:0) and [session/permission.tsx](cci:7://file:///Users/venom/opencode/packages/opencode/src/cli/cmd/tui/routes/session/permission.tsx:0:0-0:0) to use the utility