### PR TITLE
feat: Pass through data URLs directly and gracefully handle unknown U…

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -971,8 +971,7 @@ export namespace SessionPrompt {
                   },
                 ]
               }
-              // For non-text data URLs (images, PDFs from clipboard), pass through as-is
-              log.info("data url", { mime: part.mime })
+              // For non-text data URLs (images, PDFs from clipboard paste), pass through as-is
               return [
                 {
                   ...part,
@@ -1167,8 +1166,16 @@ export namespace SessionPrompt {
                 },
               ]
             default:
+<<<<<<< HEAD
               // Handle unknown protocols gracefully to prevent crashes
               log.warn("unsupported URL protocol", { protocol: url.protocol, url: part.url.slice(0, 100) })
+=======
+              // Unknown protocol - log and return part unchanged to prevent crashes
+              log.warn("unsupported URL protocol for file part", {
+                protocol: url.protocol,
+                url: part.url.slice(0, 100),
+              })
+>>>>>>> cfbf89264 (fix: handle non-text data URLs to prevent Windows clipboard paste crash)
               return [
                 {
                   ...part,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1166,16 +1166,11 @@ export namespace SessionPrompt {
                 },
               ]
             default:
-<<<<<<< HEAD
-              // Handle unknown protocols gracefully to prevent crashes
-              log.warn("unsupported URL protocol", { protocol: url.protocol, url: part.url.slice(0, 100) })
-=======
               // Unknown protocol - log and return part unchanged to prevent crashes
               log.warn("unsupported URL protocol for file part", {
                 protocol: url.protocol,
                 url: part.url.slice(0, 100),
               })
->>>>>>> cfbf89264 (fix: handle non-text data URLs to prevent Windows clipboard paste crash)
               return [
                 {
                   ...part,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -971,7 +971,16 @@ export namespace SessionPrompt {
                   },
                 ]
               }
-              break
+              // For non-text data URLs (images, PDFs from clipboard), pass through as-is
+              log.info("data url", { mime: part.mime })
+              return [
+                {
+                  ...part,
+                  id: part.id ?? Identifier.ascending("part"),
+                  messageID: info.id,
+                  sessionID: input.sessionID,
+                },
+              ]
             case "file:":
               log.info("file", { mime: part.mime })
               // have to normalize, symbol search returns absolute paths
@@ -1155,6 +1164,17 @@ export namespace SessionPrompt {
                   mime: part.mime,
                   filename: part.filename!,
                   source: part.source,
+                },
+              ]
+            default:
+              // Handle unknown protocols gracefully to prevent crashes
+              log.warn("unsupported URL protocol", { protocol: url.protocol, url: part.url.slice(0, 100) })
+              return [
+                {
+                  ...part,
+                  id: part.id ?? Identifier.ascending("part"),
+                  messageID: info.id,
+                  sessionID: input.sessionID,
                 },
               ]
           }


### PR DESCRIPTION
## Summary
Fixes #12547

**Error:** `TypeError: The URL must be of scheme file (ERR_INVALID_URL_SCHEME)`

## Root Cause
In [prompt.ts](cci:7://file:///Users/venom/opencode/packages/app/src/utils/prompt.ts:0:0-0:0), the switch statement at line 946 handles URL protocols:
- `case "data:"` only processes `text/plain` mime types, then `break`s
- For clipboard images (`image/png`), the condition fails and falls through to `case "file:"`
- `fileURLToPath()` is called on a `data:` URL → **crash**

## Changes

### [packages/opencode/src/session/prompt.ts](cci:7://file:///Users/venom/opencode/packages/opencode/src/session/prompt.ts:0:0-0:0)
- Added proper handling for non-text `data:` URLs (images, PDFs) - returns them as-is for the model
- Added [default](cci:1://file:///Users/venom/opencode/packages/opencode/src/provider/provider.ts:1222:2-1236:3) case to prevent silent fall-through for unknown protocols

## Why This Happens on Windows
Windows clipboard paste encodes images as `data:image/png;base64,...` URLs via `FileReader.readAsDataURL()`. The server-side switch statement wasn't handling this case properly.

## Testing
- [ ] Paste image from clipboard on Windows 11 - no crash, image attaches correctly
- [ ] File drop still works
- [ ] File picker still works  
- [ ] Paste text still works

## Checklist
- [x] Minimal fix addressing root cause
- [x] No try-catch band-aids
- [x] Follows existing code patterns