### PR TITLE
chore: update flake.lock to include bun 1.3.8+

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768393167,
-        "narHash": "sha256-n2063BRjHde6DqAz2zavhOOiLUwA3qXt7jQYHyETjX8=",
+        "lastModified": 1770169770,
+        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f594d5af95d4fdac67fba60376ec11e482041cb",
+        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates nixpkgs in flake.lock to a rev that includes bun 1.3.8+, fixing the build failure caused by the script requiring bun@^1.3.8 while the lock had bun 1.3.6.

The issue was introduced when the packageManager was updated to bun@1.3.8, but the flake.lock remained pinned to an older nixpkgs rev.

Fixes #12602