### PR TITLE
fix(app): make keyboard focus visible in settings

### DIFF
--- a/packages/ui/src/components/checkbox.css
+++ b/packages/ui/src/components/checkbox.css
@@ -79,9 +79,9 @@
     background-color: var(--surface-hover);
   }
 
-  &:focus-within:not([data-readonly]) [data-slot="checkbox-checkbox-control"] {
+  &:not([data-readonly]) [data-slot="checkbox-checkbox-input"]:focus-visible + [data-slot="checkbox-checkbox-control"] {
     border-color: var(--border-focus);
-    box-shadow: 0 0 0 2px var(--surface-focus);
+    box-shadow: var(--shadow-xs-border-focus);
   }
 
   &[data-checked] [data-slot="checkbox-checkbox-control"],

--- a/packages/ui/src/components/collapsible.css
+++ b/packages/ui/src/components/collapsible.css
@@ -32,6 +32,7 @@
     /* } */
     &:focus-visible {
       outline: none;
+      background-color: var(--surface-raised-base-hover);
     }
     &[data-disabled] {
       cursor: not-allowed;
@@ -70,6 +71,7 @@
       /* } */
       &:focus-visible {
         outline: none;
+        background-color: var(--surface-raised-base-hover);
       }
       &[data-disabled] {
         cursor: not-allowed;

--- a/packages/ui/src/components/select.css
+++ b/packages/ui/src/components/select.css
@@ -82,7 +82,7 @@
         box-shadow: var(--shadow-xs-border-base);
       }
 
-      &:not([data-expanded]):focus {
+      &:not([data-expanded]):not(:focus-visible):focus {
         background-color: transparent;
         box-shadow: none;
       }

--- a/packages/ui/src/components/switch.css
+++ b/packages/ui/src/components/switch.css
@@ -86,9 +86,9 @@
     background-color: var(--surface-hover);
   }
 
-  &:focus-within:not([data-readonly]) [data-slot="switch-control"] {
+  &:not([data-readonly]) [data-slot="switch-input"]:focus-visible ~ [data-slot="switch-control"] {
     border-color: var(--border-focus);
-    box-shadow: 0 0 0 2px var(--surface-focus);
+    box-shadow: var(--shadow-xs-border-focus);
   }
 
   &[data-checked] [data-slot="switch-control"] {

--- a/packages/ui/src/components/tabs.css
+++ b/packages/ui/src/components/tabs.css
@@ -429,6 +429,11 @@
           background-color: var(--surface-raised-base-hover);
         }
 
+        &:has([data-slot="tabs-trigger"]:focus-visible) {
+          background-color: var(--surface-raised-base-hover);
+          box-shadow: var(--shadow-xs-border-focus);
+        }
+
         &:has([data-selected]) {
           background-color: var(--surface-raised-base-active);
           color: var(--text-strong);


### PR DESCRIPTION
Fixes: #12611 

Keyboard users can now clearly see which settings control is active while tabbing, reducing missed toggles and navigation confusion across settings panels and tool cards.

Also adds a small focus visible state to the collapsible for tool calls.

### What does this PR do?

I noticed while working around the desktop app missing keyboard focus states in quite a few places. It seems some were actually unintentionally removed, or missed when doing some refactors. I went ahead and addressed the ones I could see primarily all in the settings menus. For example some referenced a css variable that didn't exist at all: `var(--surface-focus)`

I know the app is meant to be more click/interaction focused but I do still find myself using the keyboard for flows where I know how to get to something without using the mouse and saw some of these.

I reused the same styling that is applied to some of the places that do have correct keyboard focus styling just applied to some components that happen to only be used in settings.

I also added a focus visible styling to the "tool" collapsible topbar since that was also impossible to tell if it was focused.

### How did you verify your code works?

Manual testing. Will post gifs/vids below of mouse vs no-mouse

Settings with keyboard only

![settings-with-keyboard](https://github.com/user-attachments/assets/fed075cb-f60c-4479-828b-50d65c181b6d)


Settings menu - Mouse (for regression)

Important part is the focus visible states don't show which seems to be what the intent originally was. But some of these caused focus states to not show at all.

![settings-with-mouse](https://github.com/user-attachments/assets/f94c3d45-bdcf-4135-b00f-64095b5ab297)
