### PR TITLE
feat(app): add dedicated Linux File Manager icon

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -146,7 +146,7 @@ export function SessionHeader() {
     }
 
     return [
-      { id: "finder", label: "File Manager", icon: "finder" },
+      { id: "finder", label: "File Manager", icon: "file-manager" },
       ...LINUX_APPS.filter((app) => exists[app.id]),
     ] as const
   })

--- a/packages/ui/src/assets/icons/app/file-manager.svg
+++ b/packages/ui/src/assets/icons/app/file-manager.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+</svg>

--- a/packages/ui/src/components/app-icon.tsx
+++ b/packages/ui/src/components/app-icon.tsx
@@ -6,6 +6,7 @@ import androidStudio from "../assets/icons/app/android-studio.svg"
 import antigravity from "../assets/icons/app/antigravity.svg"
 import cursor from "../assets/icons/app/cursor.svg"
 import fileExplorer from "../assets/icons/app/file-explorer.svg"
+import fileManager from "../assets/icons/app/file-manager.svg"
 import finder from "../assets/icons/app/finder.png"
 import ghostty from "../assets/icons/app/ghostty.svg"
 import iterm2 from "../assets/icons/app/iterm2.svg"
@@ -22,6 +23,7 @@ const icons = {
   cursor,
   zed,
   "file-explorer": fileExplorer,
+  "file-manager": fileManager,
   finder,
   terminal,
   iterm2,

--- a/packages/ui/src/components/app-icons/types.ts
+++ b/packages/ui/src/components/app-icons/types.ts
@@ -5,6 +5,7 @@ export const iconNames = [
   "cursor",
   "zed",
   "file-explorer",
+  "file-manager",
   "finder",
   "terminal",
   "iterm2",


### PR DESCRIPTION
Fixes #12615

On Linux, the File Manager option in the session header was using the macOS Finder icon. This PR adds a new svg folder icon (Heroicon "folder") specifically for Linux.

**Changes:**
- Add `file-manager.svg` icon asset (Heroicon folder icon)
- Register icon in `app-icon.tsx` and `types.ts`
- Update Linux option in `session-header.tsx` to use `file-manager` icon
- Keep `id: "finder"` unchanged for backward compatibility with saved preferences

**Before:** Linux showed macOS Finder icon
**After:** Linux shows generic folder icon (consistent with Windows File Explorer icon pattern)

Screenshot:
<img width="706" height="85" alt="image" src="https://github.com/user-attachments/assets/3030b621-9625-4133-aab0-7c4f5520839f" />