### PR TITLE
fix: expand Anthropic detection and strip whitespace-only text blocks

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -46,19 +46,26 @@ export namespace ProviderTransform {
     model: Provider.Model,
     options: Record<string, unknown>,
   ): ModelMessage[] {
-    // Anthropic rejects messages with empty content - filter out empty string messages
-    // and remove empty text/reasoning parts from array content
-    if (model.api.npm === "@ai-sdk/anthropic") {
+    const anthropic =
+      model.providerID === "anthropic" ||
+      model.api.id.includes("anthropic") ||
+      model.api.id.includes("claude") ||
+      model.id.includes("anthropic") ||
+      model.id.includes("claude") ||
+      model.api.npm === "@ai-sdk/anthropic"
+
+    // Anthropic rejects messages with empty content - remove empty/whitespace text blocks
+    if (anthropic) {
       msgs = msgs
         .map((msg) => {
           if (typeof msg.content === "string") {
-            if (msg.content === "") return undefined
+            if (msg.content.trim() === "") return undefined
             return msg
           }
           if (!Array.isArray(msg.content)) return msg
           const filtered = msg.content.filter((part) => {
             if (part.type === "text" || part.type === "reasoning") {
-              return part.text !== ""
+              return part.text.trim() !== ""
             }
             return true
           })


### PR DESCRIPTION
### What does this PR do?
When using Anthropic models through non-standard provider configurations (e.g.Github Copilot), the existing check model.api.npm === "@ai-sdk/anthropic" fails to detect them as Anthropic. This causes whitespace-only or empty text blocks to be sent to the API, which Anthropic rejects.

This PR:
- Expand Anthropic provider detection in normalizeMessages to cover all Claude/Anthropic model variants (checking providerID, api.id, model.id, and api.npm), not just @ai-sdk/anthropic
- Change empty content filtering from exact empty string (=== "") to whitespace-trimmed check (.trim() === ""), so whitespace-only text and reasoning blocks are also stripped

Should fix #2655 

### How did you verify your code works?
Manually test, verified I can continue with Claude model after a tool call cancel somehow insert an empty text block to request.