### PR TITLE
fix(app): respect terminal toggle keybind when terminal is focused

### DIFF
--- a/packages/app/e2e/settings/settings-keybinds.spec.ts
+++ b/packages/app/e2e/settings/settings-keybinds.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "../fixtures"
 import { openSettings, closeDialog, withSession } from "../actions"
-import { keybindButtonSelector } from "../selectors"
+import { keybindButtonSelector, terminalSelector } from "../selectors"
 import { modKey } from "../utils"
 
 test("changing sidebar toggle keybind works", async ({ page, gotoSession }) => {
@@ -267,11 +267,14 @@ test("changing terminal toggle keybind works", async ({ page, gotoSession }) => 
 
   await closeDialog(page, dialog)
 
-  await page.keyboard.press(`${modKey}+Y`)
-  await page.waitForTimeout(100)
+  const terminal = page.locator(terminalSelector)
+  await expect(terminal).not.toBeVisible()
 
-  const pageStable = await page.evaluate(() => document.readyState === "complete")
-  expect(pageStable).toBe(true)
+  await page.keyboard.press(`${modKey}+Y`)
+  await expect(terminal).toBeVisible()
+
+  await page.keyboard.press(`${modKey}+Y`)
+  await expect(terminal).not.toBeVisible()
 })
 
 test("changing command palette keybind works", async ({ page, gotoSession }) => {

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -3,6 +3,7 @@ import { ComponentProps, createEffect, createSignal, onCleanup, onMount, splitPr
 import { usePlatform } from "@/context/platform"
 import { useSDK } from "@/context/sdk"
 import { monoFontFamily, useSettings } from "@/context/settings"
+import { parseKeybind, matchKeybind } from "@/context/command"
 import { SerializeAddon } from "@/addons/serialize"
 import { LocalPTY } from "@/context/terminal"
 import { resolveThemeVariant, useTheme, withAlpha, type HexColor } from "@opencode-ai/ui/theme"
@@ -10,6 +11,8 @@ import { useLanguage } from "@/context/language"
 import { showToast } from "@opencode-ai/ui/toast"
 import { disposeIfDisposable, getHoveredLinkText, setOptionIfSupported } from "@/utils/runtime-adapters"
 
+const TOGGLE_TERMINAL_ID = "terminal.toggle"
+const DEFAULT_TOGGLE_TERMINAL_KEYBIND = "ctrl+`"
 export interface TerminalProps extends ComponentProps<"div"> {
   pty: LocalPTY
   onSubmit?: () => void
@@ -237,12 +240,11 @@ export const Terminal = (props: TerminalProps) => {
           return true
         }
 
-        // allow for ctrl-` to toggle terminal in parent
-        if (event.ctrlKey && key === "`") {
-          return true
-        }
+        // allow for toggle terminal keybinds in parent
+        const config = settings.keybinds.get(TOGGLE_TERMINAL_ID) ?? DEFAULT_TOGGLE_TERMINAL_KEYBIND
+        const keybinds = parseKeybind(config)
 
-        return false
+        return matchKeybind(keybinds, event)
       })
 
       const fit = new mod.FitAddon()


### PR DESCRIPTION
closes #12637

### What does this PR do?

If you change your keybinding for toggle terminal, you can't use it while the terminal is focused. This PR makes it so it looks for the user's keybind instead of the hardcoded default


### How did you verify your code works?
updated e2e test and ran locally to verify it works now.