### PR TITLE
fix(nix): handle missing .bun directory in canonicalize-node-modules

### DIFF
--- a/nix/scripts/canonicalize-node-modules.ts
+++ b/nix/scripts/canonicalize-node-modules.ts
@@ -1,27 +1,38 @@
 import { lstat, mkdir, readdir, rm, symlink } from "fs/promises"
 import { join, relative } from "path"
 
-type SemverLike = {
-  valid: (value: string) => string | null
-  rcompare: (left: string, right: string) => number
-}
-
 type Entry = {
   dir: string
   version: string
   label: string
 }
 
+async function safeReadDir(path: string) {
+  try {
+    return await readdir(path)
+  } catch {
+    return []
+  }
+}
+
+async function isDirectory(path: string) {
+  try {
+    const info = await lstat(path)
+    return info.isDirectory()
+  } catch {
+    return false
+  }
+}
+
 const root = process.cwd()
 const bunRoot = join(root, "node_modules/.bun")
 const linkRoot = join(bunRoot, "node_modules")
-const directories = (await readdir(bunRoot)).sort()
+const directories = (await safeReadDir(bunRoot)).sort()
 const versions = new Map<string, Entry[]>()
 
 for (const entry of directories) {
   const full = join(bunRoot, entry)
-  const info = await lstat(full)
-  if (!info.isDirectory()) {
+  if (!(await isDirectory(full))) {
     continue
   }
   const parsed = parseEntry(entry)
@@ -33,32 +44,10 @@ for (const entry of directories) {
   versions.set(parsed.name, list)
 }
 
-const semverModule = (await import(join(bunRoot, "node_modules/semver"))) as
-  | SemverLike
-  | {
-      default: SemverLike
-    }
-const semver = "default" in semverModule ? semverModule.default : semverModule
 const selections = new Map<string, Entry>()
 
 for (const [slug, list] of versions) {
-  list.sort((a, b) => {
-    const left = semver.valid(a.version)
-    const right = semver.valid(b.version)
-    if (left && right) {
-      const delta = semver.rcompare(left, right)
-      if (delta !== 0) {
-        return delta
-      }
-    }
-    if (left && !right) {
-      return -1
-    }
-    if (!left && right) {
-      return 1
-    }
-    return b.version.localeCompare(a.version)
-  })
+  list.sort((a, b) => -Bun.semver.order(a.version, b.version))
   selections.set(slug, list[0])
 }
 
@@ -77,10 +66,7 @@ for (const [slug, entry] of Array.from(selections.entries()).sort((a, b) => a[0]
   await mkdir(parent, { recursive: true })
   const linkPath = join(parent, leaf)
   const desired = join(entry.dir, "node_modules", slug)
-  const exists = await lstat(desired)
-    .then((info) => info.isDirectory())
-    .catch(() => false)
-  if (!exists) {
+  if (!(await isDirectory(desired))) {
     continue
   }
   const relativeTarget = relative(parent, desired)

--- a/nix/scripts/canonicalize-node-modules.ts
+++ b/nix/scripts/canonicalize-node-modules.ts
@@ -28,6 +28,12 @@ const root = process.cwd()
 const bunRoot = join(root, "node_modules/.bun")
 const linkRoot = join(bunRoot, "node_modules")
 const directories = (await safeReadDir(bunRoot)).sort()
+
+if (directories.length === 0) {
+  console.log("[canonicalize-node-modules] no .bun directory, skipping")
+  process.exit(0)
+}
+
 const versions = new Map<string, Entry[]>()
 
 for (const entry of directories) {

--- a/nix/scripts/normalize-bun-binaries.ts
+++ b/nix/scripts/normalize-bun-binaries.ts
@@ -9,6 +9,12 @@ type PackageManifest = {
 const root = process.cwd()
 const bunRoot = join(root, "node_modules/.bun")
 const bunEntries = (await safeReadDir(bunRoot)).sort()
+
+if (bunEntries.length === 0) {
+  console.log("[normalize-bun-binaries] no .bun directory, skipping")
+  process.exit(0)
+}
+
 let rewritten = 0
 
 for (const entry of bunEntries) {
@@ -45,7 +51,7 @@ for (const entry of bunEntries) {
   }
 }
 
-console.log(`[normalize-bun-binaries] rewrote ${rewritten} links`)
+console.log(`[normalize-bun-binaries] rebuilt ${rewritten} links`)
 
 async function collectPackages(modulesRoot: string) {
   const found: string[] = []


### PR DESCRIPTION
## Summary
- Use `safeReadDir` and `isDirectory` helpers (consistent with `normalize-bun-binaries.ts`)
- Replace dynamic `semver` import with `Bun.semver.order`

## Problem
Since d29dfe31e ("chore: reduce nix fetching (#11660)" by @gigamonster256), bun install uses `--filter` flags which may not create the `node_modules/.bun` directory. This causes `canonicalize-node-modules.ts` to fail with:
```
ENOENT: no such file or directory, scandir '.../node_modules/.bun'
```

## Root Cause
The nix-desktop workflow was disabled in a92b7923c by @thdxr without replacement. Nix package builds are no longer tested in CI, allowing regressions like this to be merged.

A pre-merge nix-eval workflow like #12175 would have caught this.

## Solution
- Use `safeReadDir` to gracefully handle missing directory (same pattern as `normalize-bun-binaries.ts`)
- Use `Bun.semver.order` instead of importing semver from `.bun/node_modules`
- Add `isDirectory` helper for consistency

Fixes #12632, #12603, #12602