### PR TITLE
fix: revert "feat(app): add web input focus shortcut (#12493)"

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,6 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode",

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import solidPlugin from "../../../node_modules/@opentui/solid/scripts/solid-plugin"
+import solidPlugin from "../node_modules/@opentui/solid/scripts/solid-plugin"
 import path from "path"
 import fs from "fs"
 import { $ } from "bun"


### PR DESCRIPTION
This partially reverts commit 805207e096a174083f06e5426d31b7a0f37b15ca.

switches back to an isolated install and fixes node_modules path

not sure why the original PR (#12493) made this change, possibly using an old version of bun?

fixes #12632
