### PR TITLE
docs: add opencode-morphllm to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-morphllm](https://github.com/VitoLin/opencode-morphllm)                                         | MorphLLM Plugin with 10,500 tokens/s edit, semantic code search, and intelligent model routing    |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the [opencode-morphllm](https://github.com/VitoLin/opencode-morphllm) plugin to the ecosystem documentation.

## Changes

- Added opencode-morphllm to the ecosystem table in `packages/web/src/content/docs/ecosystem.mdx`

## Plugin Details

- **Repository**: https://github.com/VitoLin/opencode-morphllm
- **Features**: MorphLLM Plugin with 10,500 tokens/s edit, semantic code search, and intelligent model routing