### PR TITLE
refine(app): tighten slash autocomplete matching

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -563,7 +563,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   } = useFilteredList<SlashCommand>({
     items: slashCommands,
     key: (x) => x?.id,
-    filterKeys: ["trigger", "title", "description"],
+    filterKeys: ["trigger", "title"],
     onSelect: handleSlashSelect,
   })
 


### PR DESCRIPTION
Closes #12648

This pull request refines the web slash command autocomplete to match only the trigger and title fields rather than the description, which created many low-signal suggestions.

**Before**
 
<img width="1087" height="563" alt="image" src="https://github.com/user-attachments/assets/fd1b45c4-4372-4181-99e6-41ed1198e7e8" />
(*It almost always includes every single skill*)

**After**

<img width="1204" height="410" alt="CleanShot 2026-02-07 at 21 26 57@2x" src="https://github.com/user-attachments/assets/d4e00768-c83d-4188-a77e-d33d37e4dbb7" />

(There are probably other cleverer ways of fuzzy matching on the description, then ranking and culling the results, but this seems to be a reasonable short-term solution.)