### PR TITLE
feat: show startup progress instead of blank screen

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -2,7 +2,7 @@ import { render, useKeyboard, useRenderer, useTerminalDimensions } from "@opentu
 import { Clipboard } from "@tui/util/clipboard"
 import { TextAttributes } from "@opentui/core"
 import { RouteProvider, useRoute } from "@tui/context/route"
-import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on } from "solid-js"
+import { Switch, Match, createEffect, untrack, ErrorBoundary, createSignal, onMount, batch, Show, on, For, createMemo } from "solid-js"
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
@@ -36,6 +36,9 @@ import { ArgsProvider, useArgs, type Args } from "./context/args"
 import open from "open"
 import { writeHeapSnapshot } from "v8"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
+import { ProgressProvider, useProgress, type ProgressSource } from "./context/progress"
+import { Logo } from "@tui/component/logo"
+import { Spinner } from "@tui/component/spinner"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -99,18 +102,22 @@ async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
 
 import type { EventSource } from "./context/sdk"
 
+export { getTerminalBackgroundColor }
+
 export function tui(input: {
   url: string
   args: Args
+  mode: "dark" | "light"
   directory?: string
   fetch?: typeof fetch
   headers?: RequestInit["headers"]
   events?: EventSource
+  progress?: ProgressSource
   onExit?: () => Promise<void>
 }) {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
-    const mode = await getTerminalBackgroundColor()
+    const mode = input.mode
     const onExit = async () => {
       await input.onExit?.()
       resolve()
@@ -134,27 +141,29 @@ export function tui(input: {
                         headers={input.headers}
                         events={input.events}
                       >
-                        <SyncProvider>
-                          <ThemeProvider mode={mode}>
-                            <LocalProvider>
-                              <KeybindProvider>
-                                <PromptStashProvider>
-                                  <DialogProvider>
-                                    <CommandProvider>
-                                      <FrecencyProvider>
-                                        <PromptHistoryProvider>
-                                          <PromptRefProvider>
-                                            <App />
-                                          </PromptRefProvider>
-                                        </PromptHistoryProvider>
-                                      </FrecencyProvider>
-                                    </CommandProvider>
-                                  </DialogProvider>
-                                </PromptStashProvider>
-                              </KeybindProvider>
-                            </LocalProvider>
-                          </ThemeProvider>
-                        </SyncProvider>
+                        <ProgressProvider source={input.progress}>
+                          <SyncProvider>
+                            <ThemeProvider mode={mode}>
+                              <LocalProvider>
+                                <KeybindProvider>
+                                  <PromptStashProvider>
+                                    <DialogProvider>
+                                      <CommandProvider>
+                                        <FrecencyProvider>
+                                          <PromptHistoryProvider>
+                                            <PromptRefProvider>
+                                              <App />
+                                            </PromptRefProvider>
+                                          </PromptHistoryProvider>
+                                        </FrecencyProvider>
+                                      </CommandProvider>
+                                    </DialogProvider>
+                                  </PromptStashProvider>
+                                </KeybindProvider>
+                              </LocalProvider>
+                            </ThemeProvider>
+                          </SyncProvider>
+                        </ProgressProvider>
                       </SDKProvider>
                     </RouteProvider>
                   </ToastProvider>
@@ -707,6 +716,9 @@ function App() {
       }}
     >
       <Switch>
+        <Match when={sync.status === "loading"}>
+          <BootLog />
+        </Match>
         <Match when={route.data.type === "home"}>
           <Home />
         </Match>
@@ -714,6 +726,47 @@ function App() {
           <Session />
         </Match>
       </Switch>
+    </box>
+  )
+}
+
+function formatBootTime(ts: number) {
+  const d = new Date(ts)
+  const h = d.getHours().toString().padStart(2, "0")
+  const m = d.getMinutes().toString().padStart(2, "0")
+  const s = d.getSeconds().toString().padStart(2, "0")
+  return `${h}:${m}:${s}`
+}
+
+function BootLog() {
+  const { theme } = useTheme()
+  const progress = useProgress()
+  const dimensions = useTerminalDimensions()
+
+  const maxLines = createMemo(() => Math.max(dimensions().height - 8, 3))
+  const visibleLogs = createMemo(() => {
+    const logs = progress.logs
+    return logs.slice(Math.max(0, logs.length - maxLines()))
+  })
+
+  return (
+    <box flexDirection="column" flexGrow={1} paddingLeft={2} paddingRight={2} paddingTop={1}>
+      <Logo />
+      <box paddingTop={1} paddingBottom={1}>
+        <Spinner>Starting OpenCode...</Spinner>
+      </box>
+      <box flexDirection="column">
+        <For each={visibleLogs()}>
+          {(log, i) => {
+            const isLast = createMemo(() => i() === visibleLogs().length - 1)
+            return (
+              <text fg={isLast() ? theme.text : theme.textMuted}>
+                [{formatBootTime(log.time)}] {log.message}
+              </text>
+            )
+          }}
+        </For>
+      </box>
     </box>
   )
 }

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -1,5 +1,5 @@
 import { cmd } from "../cmd"
-import { tui } from "./app"
+import { tui, getTerminalBackgroundColor } from "./app"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -42,8 +42,10 @@ export const AttachCommand = cmd({
       const auth = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`
       return { Authorization: auth }
     })()
+    const mode = await getTerminalBackgroundColor()
     await tui({
       url: args.url,
+      mode,
       args: { sessionID: args.session },
       directory,
       headers,

--- a/packages/opencode/src/cli/cmd/tui/context/progress.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/progress.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, onCleanup, type JSX } from "solid-js"
+import { createStore, produce } from "solid-js/store"
+
+export type ProgressLog = { message: string; time: number }
+
+export type ProgressSource = {
+  logs: ProgressLog[]
+  subscribe(handler: (log: ProgressLog) => void): () => void
+}
+
+type ProgressContextValue = {
+  logs: ProgressLog[]
+  addLog: (message: string) => void
+}
+
+const ProgressContext = createContext<ProgressContextValue>({
+  logs: [],
+  addLog: () => {},
+})
+
+export function ProgressProvider(props: { source?: ProgressSource; children: JSX.Element }) {
+  const [store, setStore] = createStore<{ logs: ProgressLog[] }>({
+    logs: [...(props.source?.logs ?? [])],
+  })
+
+  const addLog = (message: string) => {
+    setStore(
+      "logs",
+      produce((draft) => {
+        draft.push({ message, time: Date.now() })
+      }),
+    )
+  }
+
+  // Subscribe immediately (not in onMount) to avoid missing events
+  // between initial render and mount
+  if (props.source) {
+    const unsub = props.source.subscribe((log) => {
+      setStore(
+        "logs",
+        produce((draft) => {
+          draft.push(log)
+        }),
+      )
+    })
+    onCleanup(unsub)
+  }
+
+  const value: ProgressContextValue = {
+    get logs() {
+      return store.logs
+    },
+    addLog,
+  }
+
+  return <ProgressContext.Provider value={value}>{props.children}</ProgressContext.Provider>
+}
+
+export function useProgress() {
+  return useContext(ProgressContext)
+}

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -28,6 +28,7 @@ import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
 import { Log } from "@/util/log"
 import type { Path } from "@opencode-ai/sdk"
+import { useProgress } from "./progress"
 
 export const { use: useSync, provider: SyncProvider } = createSimpleContext({
   name: "Sync",
@@ -103,6 +104,10 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
     })
 
     const sdk = useSDK()
+    const progress = useProgress()
+    function log(message: string) {
+      progress.addLog(message)
+    }
 
     sdk.event.listen((e) => {
       const event = e.details
@@ -330,15 +335,19 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
     async function bootstrap() {
       console.log("bootstrapping")
+      log("Connecting to server...")
       const start = Date.now() - 30 * 24 * 60 * 60 * 1000
       const sessionListPromise = sdk.client.session
         .list({ start: start })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
 
       // blocking - include session.list when continuing a session
+      log("Loading providers...")
       const providersPromise = sdk.client.config.providers({}, { throwOnError: true })
       const providerListPromise = sdk.client.provider.list({}, { throwOnError: true })
+      log("Loading agents...")
       const agentsPromise = sdk.client.app.agents({}, { throwOnError: true })
+      log("Loading configuration...")
       const configPromise = sdk.client.config.get({}, { throwOnError: true })
       const blockingRequests: Promise<unknown>[] = [
         providersPromise,
@@ -350,6 +359,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
 
       await Promise.all(blockingRequests)
         .then(() => {
+          log("Providers and configuration loaded")
           const providersResponse = providersPromise.then((x) => x.data!)
           const providerListResponse = providerListPromise.then((x) => x.data!)
           const agentsResponse = agentsPromise.then((x) => x.data ?? [])
@@ -380,6 +390,7 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           })
         })
         .then(() => {
+          log("Ready")
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           Promise.all([

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -1,5 +1,5 @@
 import { cmd } from "@/cli/cmd/cmd"
-import { tui } from "./app"
+import { tui, getTerminalBackgroundColor } from "./app"
 import { Rpc } from "@/util/rpc"
 import { type rpc } from "./worker"
 import path from "path"
@@ -7,8 +7,10 @@ import { UI } from "@/cli/ui"
 import { iife } from "@/util/iife"
 import { Log } from "@/util/log"
 import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
+import { logo } from "@/cli/logo"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
+import type { ProgressLog, ProgressSource } from "./context/progress"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -38,6 +40,39 @@ function createEventSource(client: RpcClient): EventSource {
   return {
     on: (handler) => client.on<Event>("event", handler),
   }
+}
+
+function plainLogo(): string[] {
+  // Convert logo mark characters to plain text equivalents:
+  // _ (shadow cell) → space, ^ (letter top + shadow bottom) → ▀, ~ (shadow top only) → space
+  // ~ is pure shadow with no letter content, so it becomes invisible in plain text
+  const convert = (line: string) => line.replace(/[_~]/g, " ").replace(/[\^]/g, "▀")
+  return logo.left.map((left, i) => convert(left) + " " + convert(logo.right[i]))
+}
+
+function showSplash() {
+  const out = process.stdout
+  out.write("\x1b[2J\x1b[H") // clear screen, cursor to top-left
+  out.write("\x1b[?25l") // hide cursor
+  out.write("\n")
+  for (const line of plainLogo()) {
+    out.write("  " + line + "\n")
+  }
+  out.write("\n  \x1b[2mStarting OpenCode...\x1b[0m\n\n")
+}
+
+function writeSplashLog(message: string) {
+  const d = new Date()
+  const pad = (n: number) => n.toString().padStart(2, "0")
+  const ts = `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+  process.stdout.write(`  \x1b[2m[${ts}]\x1b[0m ${message}\n`)
+}
+
+function cleanupSplash() {
+  // Clear screen (\x1b[2J), scrollback (\x1b[3J), and move cursor to top-left (\x1b[H)
+  // so the main buffer is fully clean when opentui exits alternate buffer
+  process.stdout.write("\x1b[2J\x1b[3J\x1b[H")
+  process.stdout.write("\x1b[?25h") // restore cursor
 }
 
 export const TuiThreadCommand = cmd({
@@ -82,6 +117,9 @@ export const TuiThreadCommand = cmd({
       process.exit(1)
     }
 
+    // Show splash screen immediately
+    showSplash()
+
     // Resolve relative paths against PWD to preserve behavior when using --cwd flag
     const baseCwd = process.env.PWD ?? process.cwd()
     const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
@@ -108,6 +146,24 @@ export const TuiThreadCommand = cmd({
       Log.Default.error(e)
     }
     const client = Rpc.client<typeof rpc>(worker)
+
+    // Collect startup progress logs from worker and stream to splash
+    let splashActive = true
+    const progressLogs: ProgressLog[] = []
+    const progressHandlers = new Set<(log: ProgressLog) => void>()
+    client.on<ProgressLog>("progress", (data) => {
+      progressLogs.push(data)
+      if (splashActive) writeSplashLog(data.message)
+      for (const handler of progressHandlers) handler(data)
+    })
+    const progressSource: ProgressSource = {
+      logs: progressLogs,
+      subscribe(handler) {
+        progressHandlers.add(handler)
+        return () => progressHandlers.delete(handler)
+      },
+    }
+
     process.on("uncaughtException", (e) => {
       Log.Default.error(e)
     })
@@ -149,10 +205,33 @@ export const TuiThreadCommand = cmd({
       events = createEventSource(client)
     }
 
+    // Warm up worker: trigger InstanceBootstrap (plugin install, LSP init, etc.)
+    // Run in parallel with terminal background color detection to save time.
+    writeSplashLog("Warming up...")
+    const warmupPromise = client
+      .call("fetch", {
+        url: "http://opencode.internal/v2/config",
+        method: "GET",
+        headers: {},
+      })
+      .catch(() => {})
+
+    const [mode] = await Promise.all([getTerminalBackgroundColor(), warmupPromise])
+    writeSplashLog("Ready")
+
+    // Stop writing to stdout before opentui takes over the alternate screen buffer
+    splashActive = false
+
+    // Clear main screen buffer before opentui enters alternate buffer,
+    // so the terminal is clean when the user exits.
+    cleanupSplash()
+
     const tuiPromise = tui({
       url,
+      mode,
       fetch: customFetch,
       events,
+      progress: progressSource,
       args: {
         continue: args.continue,
         sessionID: args.session,

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -22,6 +22,7 @@ import {
 import { Instance } from "../project/instance"
 import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
+import { Rpc } from "@/util/rpc"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
 import { constants, existsSync } from "fs"
@@ -250,6 +251,8 @@ export namespace Config {
   }
 
   export async function installDependencies(dir: string) {
+    const displayDir = path.basename(path.dirname(dir)) + "/" + path.basename(dir)
+    Rpc.progress(`Installing dependencies: ${displayDir}`)
     const pkg = path.join(dir, "package.json")
     const targetVersion = Installation.isLocal() ? "*" : Installation.VERSION
 
@@ -269,6 +272,7 @@ export namespace Config {
 
     // Install any additional dependencies defined in the package.json
     // This allows local plugins and custom tools to use external packages
+    Rpc.progress(`Running bun install: ${displayDir}`)
     await BunProc.run(
       [
         "install",

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -12,6 +12,7 @@ import { Session } from "../session"
 import { NamedError } from "@opencode-ai/util/error"
 import { CopilotAuthPlugin } from "./copilot"
 import { gitlabAuthPlugin as GitlabAuthPlugin } from "@gitlab/opencode-gitlab-auth"
+import { Rpc } from "@/util/rpc"
 
 export namespace Plugin {
   const log = Log.create({ service: "plugin" })
@@ -41,12 +42,16 @@ export namespace Plugin {
 
     for (const plugin of INTERNAL_PLUGINS) {
       log.info("loading internal plugin", { name: plugin.name })
+      Rpc.progress(`Loading internal plugin: ${plugin.name}`)
       const init = await plugin(input)
       hooks.push(init)
     }
 
     let plugins = config.plugin ?? []
-    if (plugins.length) await Config.waitForDependencies()
+    if (plugins.length) {
+      Rpc.progress("Installing plugin dependencies...")
+      await Config.waitForDependencies()
+    }
     if (!Flag.OPENCODE_DISABLE_DEFAULT_PLUGINS) {
       plugins = [...BUILTIN, ...plugins]
     }
@@ -54,12 +59,14 @@ export namespace Plugin {
     for (let plugin of plugins) {
       // ignore old codex plugin since it is supported first party now
       if (plugin.includes("opencode-openai-codex-auth") || plugin.includes("opencode-copilot-auth")) continue
+      const displayName = Config.getPluginName(plugin)
       log.info("loading plugin", { path: plugin })
       if (!plugin.startsWith("file://")) {
         const lastAtIndex = plugin.lastIndexOf("@")
         const pkg = lastAtIndex > 0 ? plugin.substring(0, lastAtIndex) : plugin
         const version = lastAtIndex > 0 ? plugin.substring(lastAtIndex + 1) : "latest"
         const builtin = BUILTIN.some((x) => x.startsWith(pkg + "@"))
+        Rpc.progress(`Installing plugin: ${displayName}`)
         plugin = await BunProc.install(pkg, version).catch((err) => {
           if (!builtin) throw err
 
@@ -79,6 +86,7 @@ export namespace Plugin {
         })
         if (!plugin) continue
       }
+      Rpc.progress(`Loading plugin: ${displayName}`)
       const mod = await import(plugin)
       // Prevent duplicate initialization when plugins export the same function
       // as both a named export and default export (e.g., `export const X` and `export default X`).

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -13,19 +13,27 @@ import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
 import { Snapshot } from "../snapshot"
 import { Truncate } from "../tool/truncation"
+import { Rpc } from "@/util/rpc"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
+  Rpc.progress("Initializing plugins...")
   await Plugin.init()
+  Rpc.progress("Initializing share...")
   Share.init()
   ShareNext.init()
+  Rpc.progress("Initializing formatter...")
   Format.init()
+  Rpc.progress("Initializing LSP servers...")
   await LSP.init()
+  Rpc.progress("Initializing file watcher...")
   FileWatcher.init()
   File.init()
+  Rpc.progress("Initializing VCS...")
   Vcs.init()
   Snapshot.init()
   Truncate.init()
+  Rpc.progress("Bootstrap complete")
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -17,6 +17,13 @@ export namespace Rpc {
     postMessage(JSON.stringify({ type: "rpc.event", event, data }))
   }
 
+  /** Emit a startup progress event. Safe to call outside Worker context. */
+  export function progress(message: string) {
+    try {
+      emit("progress", { message, time: Date.now() })
+    } catch {}
+  }
+
   export function client<T extends Definition>(target: {
     postMessage: (data: string) => void | null
     onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null


### PR DESCRIPTION
Fixes #12666

## Summary

When plugins (especially oh-my-opencode) are configured, startup can take several seconds with no visual feedback — a blank black screen that makes users think the app is frozen.

This PR adds a two-phase startup progress display:

1. **Splash phase** (pre-render): A plain-text splash screen with the opencode logo is shown immediately. Worker progress events (plugin install, LSP init, etc.) stream to stdout in real-time. The worker bootstrap is triggered early via a warmup RPC call, running in parallel with terminal background color detection.

2. **BootLog phase** (in-render): Once opentui takes over the alternate screen buffer, a SolidJS `BootLog` component shows any remaining progress from the TUI-side bootstrap (provider loading, config sync).

### Changes

- **`util/rpc.ts`**: Add `Rpc.progress()` helper for emitting progress events from worker context
- **`context/progress.tsx`** (new): SolidJS context that bridges worker progress events into the component tree
- **`thread.ts`**: Splash screen with logo + streaming progress logs; warmup worker bootstrap before `tui()` starts; run `getTerminalBackgroundColor()` in parallel with warmup
- **`app.tsx`**: Accept `mode` parameter; add `ProgressProvider` + `BootLog` component for in-TUI progress
- **`context/sync.tsx`**: Emit TUI-side progress logs during bootstrap
- **`bootstrap.ts`** / **`plugin/index.ts`** / **`config.ts`**: Emit progress events at each initialization step

### Bug fix

- Fix scoped npm package display name: `@scope/pkg` was rendered as empty string due to incorrect regex in `plugin/index.ts` (now uses `Config.getPluginName()`)

## Test plan

- [ ] Start opencode with multiple plugins configured (e.g. oh-my-opencode) — should see splash with streaming progress logs instead of black screen
- [ ] Verify splash clears cleanly when TUI takes over (no bleed-through into alternate buffer)
- [ ] Verify no splash remnants after exiting opencode
- [ ] `opencode attach <url>` still works (attach.ts updated)
- [ ] Start without plugins — splash should appear briefly then transition to TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)