### PR TITLE
Fix Apply on Invalid 'messages[68].tool_calls[0].id': string too long…

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -130,6 +130,27 @@ export namespace ProviderTransform {
       return result
     }
 
+    // OpenAI and GitHub Copilot (OpenAI-compatible) allow max 40 chars for tool_calls[].id
+    const openAiLikeNpm = ["@ai-sdk/openai", "@ai-sdk/github-copilot", "@ai-sdk/openai-compatible"]
+    if (openAiLikeNpm.includes(model.api.npm ?? "")) {
+      const MAX_TOOL_CALL_ID_LENGTH = 40
+      msgs = msgs.map((msg) => {
+        if ((msg.role === "assistant" || msg.role === "tool") && Array.isArray(msg.content)) {
+          return {
+            ...msg,
+            content: msg.content.map((part: any) => {
+              if ((part.type === "tool-call" || part.type === "tool-result") && part.toolCallId) {
+                const id = part.toolCallId.replace(/[^a-zA-Z0-9_-]/g, "_")
+                return { ...part, toolCallId: id.length > MAX_TOOL_CALL_ID_LENGTH ? id.slice(0, MAX_TOOL_CALL_ID_LENGTH) : id }
+              }
+              return part
+            }),
+          }
+        }
+        return msg
+      })
+    }
+
     if (typeof model.capabilities.interleaved === "object" && model.capabilities.interleaved.field) {
       const field = model.capabilities.interleaved.field
       return msgs.map((msg) => {


### PR DESCRIPTION
…. Expected a string with maximum length 40, but got a string with length 46 instead. #12653

The issue is specific for arch linux environment, and I add this method to allow  40 up character for the message. If the call is triggered, it allows to pass through.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.

The issue is specific for arch linux environment, and I add this method to allow  40 up character for the message. If the call is triggered, it allows to pass through.

### How did you verify your code works?
I simulate the env and test it through the step