### PR TITLE
feat: Add Guide Mode for beginner onboarding

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -112,6 +112,52 @@ export namespace Agent {
         mode: "primary",
         native: true,
       },
+      guide: {
+        name: "guide",
+        description: "Guide mode for beginners. Interactive onboarding that asks discovery questions and teaches vibe coding principles.",
+        prompt: `You are a friendly coding mentor helping beginners learn "vibe coding" - the art of working with AI to build software.
+
+Start by greeting the user enthusiastically and asking: "What are you trying to build? Describe your idea in your own words."
+
+Then continue the conversation by asking these 4 additional questions ONE AT A TIME:
+
+1. "Who is this for? (Just me, Friends/Family, Public users, or Business?)"
+2. "What problem does this solve? Why do you need it?"
+3. "What's your experience level? (Beginner/Intermediate/Advanced)"
+4. "Any specific requirements? (Tech preferences, constraints, must-haves)"
+
+Guidelines:
+- Be encouraging: "Great idea!", "Awesome!", "I love this concept!"
+- Ask ONE question at a time and wait for their answer
+- After all 5 questions, create a refined project specification
+- Use the guide_exit tool to offer switching to plan or build mode
+- Be friendly and educational throughout`,
+        options: {},
+        permission: PermissionNext.merge(
+          defaults,
+          PermissionNext.fromConfig({
+            question: "allow",
+            plan_enter: "allow",
+            guide_exit: "allow",
+            read: {
+              "*": "allow",
+            },
+            edit: {
+              "*": "deny",
+            },
+            bash: {
+              "*": "deny",
+            },
+            write: {
+              "*": "deny",
+            },
+            webfetch: "allow",
+          }),
+          user,
+        ),
+        mode: "primary",
+        native: true,
+      },
       general: {
         name: "general",
         description: `General-purpose agent for researching complex questions and executing multi-step tasks. Use this agent to execute multiple units of work in parallel.`,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1276,6 +1276,46 @@ export namespace SessionPrompt {
       return input.messages
     }
 
+    // Entering guide mode
+    if (input.agent.name === "guide" && assistantMessage?.info.agent !== "guide") {
+      const part = await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMessage.info.id,
+        sessionID: userMessage.info.id,
+        type: "text",
+        text: `Hello! 👋 I'm excited to help you build something amazing!\n\nI'll ask you a few quick questions to understand what you want to build. This helps me give you better results. Let's start!\n\n**What are you trying to build?** Describe your idea in your own words.`,
+        synthetic: false,
+      })
+      userMessage.parts.push(part)
+
+      // Add system instructions for AI (not visible to user)
+      const systemPart = await Session.updatePart({
+        id: Identifier.ascending("part"),
+        messageID: userMessage.info.id,
+        sessionID: userMessage.info.id,
+        type: "text",
+        text: `<system-reminder>
+You are in GUIDE MODE. Your role is to act as a friendly coding mentor.
+
+Continue the conversation naturally:
+1. Wait for user to answer "What are you trying to build?"
+2. Acknowledge their answer and ask: "Who is this for? (Just me, Friends/Family, Public users, or Business?)"
+3. Ask: "What problem does this solve? Why do you need it?"
+4. Ask: "What's your experience level? (Beginner/Intermediate/Advanced)"
+5. Ask: "Any specific requirements? (Tech preferences, constraints, must-haves)"
+
+Guidelines:
+- Be encouraging and friendly (e.g., "Great idea!", "Awesome!", "I love this concept!")
+- Ask ONE question at a time and wait for answer
+- After all 5 questions, create a refined project specification
+- Use guide_exit tool to offer switching to plan or build mode
+</system-reminder>`,
+        synthetic: true,
+      })
+      userMessage.parts.push(systemPart)
+      return input.messages
+    }
+
     // Entering plan mode
     if (input.agent.name === "plan" && assistantMessage?.info.agent !== "plan") {
       const plan = Session.plan(input.session)

--- a/packages/opencode/src/tool/guide.ts
+++ b/packages/opencode/src/tool/guide.ts
@@ -1,0 +1,124 @@
+import z from "zod"
+import { Tool } from "./tool"
+import { Question } from "../question"
+import { Session } from "../session"
+import { MessageV2 } from "../session/message-v2"
+import { Identifier } from "../id/id"
+import { Provider } from "../provider/provider"
+
+async function getLastModel(sessionID: string) {
+  for await (const item of MessageV2.stream(sessionID)) {
+    if (item.info.role === "user" && item.info.model) return item.info.model
+  }
+  return Provider.defaultModel()
+}
+
+export const GuideEnterTool = Tool.define("guide_enter", {
+  description: "Switch to guide mode for interactive onboarding. Guide mode will ask discovery questions to understand what you want to build and teach you vibe coding principles.",
+  parameters: z.object({}),
+  async execute(_params, ctx) {
+    const answers = await Question.ask({
+      sessionID: ctx.sessionID,
+      questions: [
+        {
+          question: "Would you like to switch to guide mode for a guided, step-by-step onboarding experience?",
+          header: "Guide Mode",
+          custom: false,
+          options: [
+            { label: "Yes", description: "Switch to guide mode for interactive discovery and learning" },
+            { label: "No", description: "Stay with current agent" },
+          ],
+        },
+      ],
+      tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+    })
+
+    const answer = answers[0]?.[0]
+
+    if (answer === "No") throw new Question.RejectedError()
+
+    const model = await getLastModel(ctx.sessionID)
+
+    const userMsg: MessageV2.User = {
+      id: Identifier.ascending("message"),
+      sessionID: ctx.sessionID,
+      role: "user",
+      time: {
+        created: Date.now(),
+      },
+      agent: "guide",
+      model,
+    }
+    await Session.updateMessage(userMsg)
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: userMsg.id,
+      sessionID: ctx.sessionID,
+      type: "text",
+      text: "User has requested to enter guide mode. Switch to guide mode and begin the discovery process. Ask questions to understand what they want to build.",
+      synthetic: true,
+    } satisfies MessageV2.TextPart)
+
+    return {
+      title: "Switching to guide mode",
+      output: "User confirmed to switch to guide mode. Guide agent will help with discovery and onboarding.",
+      metadata: {},
+    }
+  },
+})
+
+export const GuideExitTool = Tool.define("guide_exit", {
+  description: "Exit guide mode and switch to plan or build mode after discovery is complete.",
+  parameters: z.object({}),
+  async execute(_params, ctx) {
+    const answers = await Question.ask({
+      sessionID: ctx.sessionID,
+      questions: [
+        {
+          question: "Discovery complete! What would you like to do next?",
+          header: "Guide Complete",
+          custom: false,
+          options: [
+            { label: "Create Plan", description: "Switch to plan mode to create a detailed implementation plan" },
+            { label: "Start Coding", description: "Switch to build mode and start implementing" },
+            { label: "Continue Guide", description: "Stay in guide mode to refine the discovery" },
+          ],
+        },
+      ],
+      tool: ctx.callID ? { messageID: ctx.messageID, callID: ctx.callID } : undefined,
+    })
+
+    const answer = answers[0]?.[0]
+    
+    if (answer === "Continue Guide") throw new Question.RejectedError()
+
+    const model = await getLastModel(ctx.sessionID)
+    const targetAgent = answer === "Create Plan" ? "plan" : "build"
+
+    const userMsg: MessageV2.User = {
+      id: Identifier.ascending("message"),
+      sessionID: ctx.sessionID,
+      role: "user",
+      time: {
+        created: Date.now(),
+      },
+      agent: targetAgent,
+      model,
+    }
+    await Session.updateMessage(userMsg)
+    await Session.updatePart({
+      id: Identifier.ascending("part"),
+      messageID: userMsg.id,
+      sessionID: ctx.sessionID,
+      type: "text",
+      text: `Discovery is complete. Switching to ${targetAgent} mode to continue with ${answer === "Create Plan" ? "planning" : "implementation"}.`,
+      synthetic: true,
+    } satisfies MessageV2.TextPart)
+
+    return {
+      title: `Switching to ${targetAgent} mode`,
+      output: `Discovery phase complete. Transitioning to ${targetAgent} mode for ${answer === "Create Plan" ? "planning" : "implementation"}.`,
+      metadata: {},
+    }
+  },
+})

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -26,6 +26,7 @@ import { Log } from "@/util/log"
 import { LspTool } from "./lsp"
 import { Truncate } from "./truncation"
 import { PlanExitTool, PlanEnterTool } from "./plan"
+import { GuideEnterTool, GuideExitTool } from "./guide"
 import { ApplyPatchTool } from "./apply_patch"
 
 export namespace ToolRegistry {
@@ -115,6 +116,8 @@ export namespace ToolRegistry {
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),
+      GuideEnterTool,
+      GuideExitTool,
       ...custom,
     ]
   }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -662,13 +662,14 @@ test("defaultAgent throws when all primary agents are disabled", async () => {
       agent: {
         build: { disable: true },
         plan: { disable: true },
+        guide: { disable: true },
       },
     },
   })
   await Instance.provide({
     directory: tmp.path,
     fn: async () => {
-      // build and plan are disabled, no primary-capable agents remain
+      // build, plan, and guide are disabled, no primary-capable agents remain
       await expect(Agent.defaultAgent()).rejects.toThrow("no primary visible agent found")
     },
   })


### PR DESCRIPTION
## Summary

This PR introduces **Guide Mode** - a new agent mode designed to help beginners learn "vibe coding" (AI-assisted development). 

Closes #12675

## Problem

New developers transitioning to AI-assisted coding struggle with:
- **Vague prompts**: \"Make a website\" leads to poor results
- **Unclear expectations**: Don't know what to ask AI for
- **Knowledge gaps**: Unfamiliar with technical terminology
- **Frustration**: First-time failures lead to abandonment

## Solution

Guide Mode provides a structured, educational onboarding experience through natural conversation.

### How It Works

1. **Enter Guide Mode**: `opencode --agent guide`
2. **Answer 5 Discovery Questions** (natural conversation):
   - \"What are you trying to build?\"
   - \"Who is this for?\"
   - \"What problem does this solve?\"
   - \"What's your experience level?\"
   - \"Any specific requirements?\"
3. **Get Refined Specification** - AI transforms vague ideas into detailed prompts
4. **Choose Next Step** - Switch to Plan mode, Build mode, or continue refining

### Changes

**packages/opencode/src/agent/agent.ts:**
- Add 'guide' agent with conversational prompt and read-only permissions

**packages/opencode/src/tool/guide.ts:**
- GuideEnterTool - Switch to guide mode
- GuideExitTool - Exit guide mode to plan/build

**packages/opencode/src/tool/registry.ts:**
- Register guide mode switching tools

**packages/opencode/src/session/prompt.ts:**
- Guide mode initialization with greeting and system instructions

## Benefits

**For Users:**
- ✅ Higher quality results from better prompts
- ✅ Learn vibe coding principles naturally
- ✅ Understand what information AI needs
- ✅ Build confidence, avoid frustration

**For OpenCode:**
- ✅ Higher user satisfaction and retention
- ✅ Reduced \"AI didn't understand me\" complaints
- ✅ Educational value = word of mouth
- ✅ Differentiator from other AI coding tools

## Testing

Guide Mode has been tested with various scenarios including:
- Todo apps (beginner projects)
- Portfolio websites (professional projects)
- API integrations (intermediate projects)

The natural conversation flow works reliably across different use cases.

## Example Usage

```bash
$ opencode --agent guide

AI: Hello! 👋 I'm excited to help you build something amazing!
    
    What are you trying to build?

User: I want a todo app

AI: Great idea! Who is this for?

... (continues through all 5 questions)

AI: [Creates refined specification]
    
    Would you like to:
    1) Switch to Plan mode
    2) Switch to Build mode
    3) Stay in Guide mode
```

---

I've opened issue #12675 describing this feature and am submitting this implementation for review. Happy to make any adjustments based on feedback!