### PR TITLE
feat(tui): vim motions in prompt input

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -721,9 +721,9 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       },
     },
     {
-      title: vim() ? "Disable vim input" : "Enable vim input",
+      title: "Toggle vim mode",
       value: "input.vim.toggle",
-      category: "Settings",
+      category: "System",
       onSelect: (dialog) => {
         kv.set("input_vim_mode", !vim())
         dialog.clear()

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -63,6 +63,7 @@ import { createTuiApi } from "@/cli/cmd/tui/plugin/api"
 import { TuiPluginRuntime } from "@/cli/cmd/tui/plugin/runtime"
 import type { RouteMap } from "@/cli/cmd/tui/plugin/api"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { useVimEnabled } from "./component/vim"
 
 import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
@@ -254,6 +255,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     .finally(() => {
       setReady(true)
     })
+  const vim = useVimEnabled()
 
   useKeyboard((evt) => {
     if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
@@ -715,6 +717,15 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
           if (!next) renderer.setTerminalTitle("")
           return next
         })
+        dialog.clear()
+      },
+    },
+    {
+      title: vim() ? "Disable vim input" : "Enable vim input",
+      value: "input.vim.toggle",
+      category: "Settings",
+      onSelect: (dialog) => {
+        kv.set("input_vim_mode", !vim())
         dialog.clear()
       },
     },

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -238,7 +238,6 @@ export function Prompt(props: PromptProps) {
   })
   const vimState = createVimState({
     enabled: vimEnabled,
-    active: () => store.mode === "normal" && props.visible !== false && !props.disabled,
   })
   const vimIndicator = useVimIndicator({
     enabled: vimEnabled,
@@ -1161,7 +1160,7 @@ export function Prompt(props: PromptProps) {
                 } else if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
                     await exit()
-                    // Don't preventDefault - let textarea potentially handle the event
+                    // Prevent textarea from handling the key after exit
                     e.preventDefault()
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1155,12 +1155,11 @@ export function Prompt(props: PromptProps) {
                   setStore("extmarkToPartIndex", new Map())
                   return
                 }
-                if (vimEnabled() && store.mode === "normal" && vimState.mode() === "normal" && vimScroll(e)) {
-                  // Allow vim scroll keys to override app exit in normal mode
-                } else if (keybind.match("app_exit", e)) {
+                const isVimScrollOverride =
+                  vimEnabled() && store.mode === "normal" && vimState.mode() === "normal" && !!vimScroll(e)
+                if (!isVimScrollOverride && keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
                     await exit()
-                    // Prevent textarea from handling the key after exit
                     e.preventDefault()
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -332,6 +332,12 @@ export function Prompt(props: PromptProps) {
         onSelect: (dialog) => {
           if (autocomplete.visible) return
           if (!input.focused) return
+          if (vimEnabled() && store.mode === "normal" && vimState.isInsert()) {
+            vimState.setMode("normal")
+            setStore("interrupt", 0)
+            dialog.clear()
+            return
+          }
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -46,6 +46,7 @@ import { useArgs } from "@tui/context/args"
 import { useVimEnabled } from "../vim"
 import { createVimState } from "../vim/vim-state"
 import { createVimHandler } from "../vim/vim-handler"
+import { vimScroll } from "../vim/vim-scroll"
 
 export type PromptProps = {
   sessionID?: string
@@ -230,6 +231,14 @@ export function Prompt(props: PromptProps) {
     state: vimState,
     textarea: () => input,
     submit,
+    scroll(action) {
+      if (action === "line-down") command.trigger("session.line.down")
+      if (action === "line-up") command.trigger("session.line.up")
+      if (action === "half-down") command.trigger("session.half.page.down")
+      if (action === "half-up") command.trigger("session.half.page.up")
+      if (action === "page-down") command.trigger("session.page.down")
+      if (action === "page-up") command.trigger("session.page.up")
+    },
   })
 
   createEffect(
@@ -1118,7 +1127,9 @@ export function Prompt(props: PromptProps) {
                   setStore("extmarkToPartIndex", new Map())
                   return
                 }
-                if (keybind.match("app_exit", e)) {
+                if (vimEnabled() && store.mode === "normal" && vimState.mode() === "normal" && vimScroll(e)) {
+                  // Allow vim scroll keys to override app exit in normal mode
+                } else if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
                     await exit()
                     // Don't preventDefault - let textarea potentially handle the event

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -239,6 +239,10 @@ export function Prompt(props: PromptProps) {
       if (action === "page-down") command.trigger("session.page.down")
       if (action === "page-up") command.trigger("session.page.up")
     },
+    jump(action) {
+      if (action === "top") command.trigger("session.first")
+      if (action === "bottom") command.trigger("session.last")
+    },
   })
 
   createEffect(

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -44,7 +44,7 @@ import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-worksp
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
 import { useVimEnabled } from "../vim"
-import { createVimState } from "../vim/vim-state"
+import { createVimState, type VimMode } from "../vim/vim-state"
 import { createVimHandler } from "../vim/vim-handler"
 import { vimScroll } from "../vim/vim-scroll"
 import { useVimIndicator } from "../vim/vim-indicator"
@@ -84,6 +84,7 @@ function randomIndex(count: number) {
   if (count <= 0) return 0
   return Math.floor(Math.random() * count)
 }
+let lastVimMode: VimMode = "insert"
 
 function fadeColor(color: RGBA, alpha: number) {
   return RGBA.fromValues(color.r, color.g, color.b, color.a * alpha)
@@ -238,6 +239,10 @@ export function Prompt(props: PromptProps) {
   })
   const vimState = createVimState({
     enabled: vimEnabled,
+    initial: () => lastVimMode,
+  })
+  onCleanup(() => {
+    if (vimEnabled()) lastVimMode = vimState.mode()
   })
   const vimIndicator = useVimIndicator({
     enabled: vimEnabled,

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -266,6 +266,7 @@ export function Prompt(props: PromptProps) {
       if (action === "top") command.trigger("session.first")
       if (action === "bottom") command.trigger("session.last")
     },
+    autocomplete: () => autocomplete.visible,
   })
 
   createEffect(

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -43,6 +43,9 @@ import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceCreate, restoreWorkspaceSession } from "../dialog-workspace-create"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "@tui/context/args"
+import { useVimEnabled } from "../vim"
+import { createVimState } from "../vim/vim-state"
+import { createVimHandler } from "../vim/vim-handler"
 
 export type PromptProps = {
   sessionID?: string
@@ -138,6 +141,7 @@ export function Prompt(props: PromptProps) {
   const [auto, setAuto] = createSignal<AutocompleteRef>()
   const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const hasRightContent = createMemo(() => Boolean(props.right))
+  const vimEnabled = useVimEnabled()
 
   function promptModelWarning() {
     toast.show({
@@ -217,6 +221,15 @@ export function Prompt(props: PromptProps) {
     extmarkToPartIndex: new Map(),
     interrupt: 0,
   })
+  const vimState = createVimState({
+    enabled: vimEnabled,
+    active: () => store.mode === "normal" && props.visible !== false && !props.disabled,
+  })
+  const vim = createVimHandler({
+    enabled: vimEnabled,
+    state: vimState,
+    submit,
+  })
 
   createEffect(
     on(
@@ -268,7 +281,6 @@ export function Prompt(props: PromptProps) {
       {
         title: "Submit prompt",
         value: "prompt.submit",
-        keybind: "input_submit",
         category: "Prompt",
         hidden: true,
         onSelect: async (dialog) => {
@@ -309,6 +321,7 @@ export function Prompt(props: PromptProps) {
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")
+            vimState.reset()
             return
           }
           if (!props.sessionID) return
@@ -496,6 +509,7 @@ export function Prompt(props: PromptProps) {
     if (!input || input.isDestroyed) return
     if (props.visible === false || dialog.stack.length > 0) {
       if (input.focused) input.blur()
+      if (props.visible === false) vimState.reset()
       return
     }
 
@@ -518,6 +532,18 @@ export function Prompt(props: PromptProps) {
       status: store.mode === "shell" ? "SHELL" : undefined,
     }
   })
+
+  function submitFromTextarea() {
+    if (store.mode !== "normal") {
+      setTimeout(() => setTimeout(() => void submit(), 0), 0)
+      return
+    }
+    if (vimEnabled() && vimState.isInsert()) {
+      input.insertText("\n")
+      return
+    }
+    setTimeout(() => setTimeout(() => void submit(), 0), 0)
+  }
 
   function restoreExtmarksFromParts(parts: PromptInfo["parts"]) {
     input.extmarks.clear()
@@ -1108,11 +1134,14 @@ export function Prompt(props: PromptProps) {
                 if (store.mode === "shell") {
                   if ((e.name === "backspace" && input.visualCursor.offset === 0) || e.name === "escape") {
                     setStore("mode", "normal")
+                    vimState.reset()
                     e.preventDefault()
                     return
                   }
                 }
                 if (store.mode === "normal") autocomplete.onKeyDown(e)
+                if (e.defaultPrevented) return
+                if (store.mode === "normal" && vim.handleKey(e)) return
                 if (!autocomplete.visible) {
                   if (
                     (keybind.match("history_previous", e) && input.cursorOffset === 0) ||
@@ -1138,11 +1167,7 @@ export function Prompt(props: PromptProps) {
                     input.cursorOffset = input.plainText.length
                 }
               }}
-              onSubmit={() => {
-                // IME: double-defer so the last composed character (e.g. Korean
-                // hangul) is flushed to plainText before we read it for submission.
-                setTimeout(() => setTimeout(() => submit(), 0), 0)
-              }}
+              onSubmit={submitFromTextarea}
               onPaste={async (event: PasteEvent) => {
                 if (props.disabled) {
                   event.preventDefault()

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -359,7 +359,7 @@ export function Prompt(props: PromptProps) {
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")
-            vimState.reset()
+            vimState.clearPending()
             return
           }
           if (!props.sessionID) return
@@ -906,6 +906,7 @@ export function Prompt(props: PromptProps) {
         .catch(() => {})
       editor.clearSelection()
     }
+    vimState.clearPending()
     history.append({
       ...store.prompt,
       mode: currentMode,
@@ -1173,7 +1174,7 @@ export function Prompt(props: PromptProps) {
                 if (store.mode === "shell") {
                   if ((e.name === "backspace" && input.visualCursor.offset === 0) || e.name === "escape") {
                     setStore("mode", "normal")
-                    vimState.reset()
+                    vimState.clearPending()
                     e.preventDefault()
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -547,7 +547,7 @@ export function Prompt(props: PromptProps) {
     if (!input || input.isDestroyed) return
     if (props.visible === false || dialog.stack.length > 0) {
       if (input.focused) input.blur()
-      if (props.visible === false) vimState.reset()
+      if (props.visible === false) vimState.clearPending()
       return
     }
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1382,11 +1382,7 @@ export function Prompt(props: PromptProps) {
         <box width="100%" flexDirection="row" justifyContent="space-between">
           <box flexDirection="row" gap={1} flexGrow={1}>
             <Show when={vimIndicator()}>
-              {(indicator) => (
-                <text fg={indicator() === "INSERT" ? local.agent.color(local.agent.current().name) : theme.textMuted}>
-                  [{indicator()}]
-                </text>
-              )}
+              {(indicator) => <text fg={highlight()}>-- {indicator()} --</text>}
             </Show>
             <Show when={status().type !== "idle"} fallback={props.hint ?? <text />}>
             <box

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -228,6 +228,7 @@ export function Prompt(props: PromptProps) {
   const vim = createVimHandler({
     enabled: vimEnabled,
     state: vimState,
+    textarea: () => input,
     submit,
   })
 

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -47,6 +47,7 @@ import { useVimEnabled } from "../vim"
 import { createVimState } from "../vim/vim-state"
 import { createVimHandler } from "../vim/vim-handler"
 import { vimScroll } from "../vim/vim-scroll"
+import { useVimIndicator } from "../vim/vim-indicator"
 
 export type PromptProps = {
   sessionID?: string
@@ -180,6 +181,19 @@ export function Prompt(props: PromptProps) {
     if (!props.disabled) input.cursorColor = theme.text
   })
 
+  createEffect(() => {
+    if (!input || input.isDestroyed) return
+    if (vimEnabled() && store.mode === "normal") {
+      if (vimState.isInsert()) {
+        input.cursorStyle = { style: "line", blinking: true }
+        return
+      }
+      input.cursorStyle = { style: "block", blinking: false }
+      return
+    }
+    input.cursorStyle = { style: "block", blinking: true }
+  })
+
   const lastUserMessage = createMemo(() => {
     if (!props.sessionID) return undefined
     const messages = sync.data.message[props.sessionID]
@@ -225,6 +239,11 @@ export function Prompt(props: PromptProps) {
   const vimState = createVimState({
     enabled: vimEnabled,
     active: () => store.mode === "normal" && props.visible !== false && !props.disabled,
+  })
+  const vimIndicator = useVimIndicator({
+    enabled: vimEnabled,
+    active: () => store.mode === "normal",
+    state: vimState,
   })
   const vim = createVimHandler({
     enabled: vimEnabled,
@@ -1356,7 +1375,15 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between">
-          <Show when={status().type !== "idle"} fallback={props.hint ?? <text />}>
+          <box flexDirection="row" gap={1} flexGrow={1}>
+            <Show when={vimIndicator()}>
+              {(indicator) => (
+                <text fg={indicator() === "INSERT" ? local.agent.color(local.agent.current().name) : theme.textMuted}>
+                  {indicator()}
+                </text>
+              )}
+            </Show>
+            <Show when={status().type !== "idle"} fallback={props.hint ?? <text />}>
             <box
               flexDirection="row"
               gap={1}
@@ -1435,7 +1462,8 @@ export function Prompt(props: PromptProps) {
                 </span>
               </text>
             </box>
-          </Show>
+            </Show>
+          </box>
           <Show when={status().type !== "retry"}>
             <box gap={2} flexDirection="row">
               <Show when={editorFileLabelDisplay()}>{(file) => <text fg={theme.secondary}>{file()}</text>}</Show>

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1378,7 +1378,7 @@ export function Prompt(props: PromptProps) {
             <Show when={vimIndicator()}>
               {(indicator) => (
                 <text fg={indicator() === "INSERT" ? local.agent.color(local.agent.current().name) : theme.textMuted}>
-                  {indicator()}
+                  [{indicator()}]
                 </text>
               )}
             </Show>

--- a/packages/opencode/src/cli/cmd/tui/component/vim/index.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/index.ts
@@ -1,0 +1,15 @@
+import { createMemo } from "solid-js"
+import { useKV } from "../../context/kv"
+import { useSync } from "../../context/sync"
+
+export function useVimEnabled() {
+  const kv = useKV()
+  const sync = useSync()
+
+  return createMemo(() => {
+    const stored = kv.get("input_vim_mode")
+    if (stored !== undefined) return stored
+    const tui = sync.data.config.tui as { vim?: boolean } | undefined
+    return tui?.vim ?? false
+  })
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/index.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/index.ts
@@ -1,15 +1,14 @@
 import { createMemo } from "solid-js"
 import { useKV } from "../../context/kv"
-import { useSync } from "../../context/sync"
+import { useTuiConfig } from "../../context/tui-config"
 
 export function useVimEnabled() {
   const kv = useKV()
-  const sync = useSync()
+  const config = useTuiConfig()
 
   return createMemo(() => {
     const stored = kv.get("input_vim_mode")
     if (stored !== undefined) return stored
-    const tui = sync.data.config.tui as { vim?: boolean } | undefined
-    return tui?.vim ?? false
+    return config.vim ?? false
   })
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -4,7 +4,9 @@ import type { TextareaRenderable } from "@opentui/core"
 import {
   appendAfterCursor,
   appendLineEnd,
+  deleteLine,
   deleteUnderCursor,
+  deleteWord,
   insertLineStart,
   moveBigWordEnd,
   moveBigWordNext,
@@ -59,8 +61,45 @@ export function createVimHandler(input: {
       }
 
       const key = event.name ?? ""
+
+      if (key === "escape") {
+        if (!input.state.pending()) return false
+        input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+
+      if (input.state.pending() === "d") {
+        if (key === "d" && !event.shift && !hasModifier(event)) {
+          deleteLine(input.textarea())
+          input.state.clearPending()
+          event.preventDefault()
+          return true
+        }
+
+        if (key === "w" && !event.shift && !hasModifier(event)) {
+          deleteWord(input.textarea())
+          input.state.clearPending()
+          event.preventDefault()
+          return true
+        }
+
+        if (hasModifier(event)) {
+          input.state.clearPending()
+          return false
+        }
+
+        input.state.clearPending()
+      }
+
       if (key === "return" && !hasModifier(event)) {
         input.submit()
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "d" && !event.shift && !hasModifier(event)) {
+        input.state.setPending("d")
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -117,6 +117,7 @@ export function createVimHandler(input: {
 
       if (key === "return" && !hasModifier(event)) {
         input.submit()
+        input.state.reset()
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -1,6 +1,7 @@
 import type { Accessor } from "solid-js"
 import type { createVimState } from "./vim-state"
 import type { TextareaRenderable } from "@opentui/core"
+import { vimScroll, type VimScroll } from "./vim-scroll"
 import {
   appendAfterCursor,
   appendLineEnd,
@@ -36,6 +37,7 @@ export function createVimHandler(input: {
   state: ReturnType<typeof createVimState>
   textarea: Accessor<TextareaRenderable>
   submit: () => void
+  scroll: (action: VimScroll) => void
 }) {
   function hasModifier(event: VimEvent) {
     return !!event.ctrl || !!event.meta || !!event.super
@@ -61,6 +63,14 @@ export function createVimHandler(input: {
       }
 
       const key = event.name ?? ""
+
+      const scroll = vimScroll(event)
+      if (scroll) {
+        input.state.clearPending()
+        input.scroll(scroll)
+        event.preventDefault()
+        return true
+      }
 
       if (key === "escape") {
         if (!input.state.pending()) return false

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -1,7 +1,18 @@
 import type { Accessor } from "solid-js"
 import type { createVimState } from "./vim-state"
 import type { TextareaRenderable } from "@opentui/core"
-import { moveLeft, moveLineDown, moveLineUp, moveRight } from "./vim-motions"
+import {
+  moveBigWordEnd,
+  moveBigWordNext,
+  moveBigWordPrev,
+  moveLeft,
+  moveLineDown,
+  moveLineUp,
+  moveRight,
+  moveWordEnd,
+  moveWordNext,
+  moveWordPrev,
+} from "./vim-motions"
 
 export type VimEvent = {
   name?: string
@@ -24,6 +35,10 @@ export function createVimHandler(input: {
 
   function isPrintable(event: VimEvent) {
     return !!event.name && event.name.length === 1
+  }
+
+  function isShifted(event: VimEvent, key: string) {
+    return event.name === key.toUpperCase() || (event.name === key && !!event.shift)
   }
 
   return {
@@ -70,6 +85,42 @@ export function createVimHandler(input: {
 
       if (key === "k" && !event.shift && !hasModifier(event)) {
         moveLineUp(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "w" && !event.shift && !hasModifier(event)) {
+        moveWordNext(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "b" && !event.shift && !hasModifier(event)) {
+        moveWordPrev(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "e" && !event.shift && !hasModifier(event)) {
+        moveWordEnd(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "w") && !hasModifier(event)) {
+        moveBigWordNext(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "b") && !hasModifier(event)) {
+        moveBigWordPrev(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "e") && !hasModifier(event)) {
+        moveBigWordEnd(input.textarea())
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -1,0 +1,68 @@
+import type { Accessor } from "solid-js"
+import type { createVimState } from "./vim-state"
+
+export type VimEvent = {
+  name?: string
+  shift?: boolean
+  ctrl?: boolean
+  meta?: boolean
+  super?: boolean
+  preventDefault: () => void
+}
+
+export function createVimHandler(input: {
+  enabled: Accessor<boolean>
+  state: ReturnType<typeof createVimState>
+  submit: () => void
+}) {
+  function hasModifier(event: VimEvent) {
+    return !!event.ctrl || !!event.meta || !!event.super
+  }
+
+  function isPrintable(event: VimEvent) {
+    return !!event.name && event.name.length === 1
+  }
+
+  return {
+    handleKey(event: VimEvent) {
+      if (!input.enabled()) return false
+
+      if (input.state.isInsert()) {
+        if (event.name !== "escape") return false
+        input.state.setMode("normal")
+        event.preventDefault()
+        return true
+      }
+
+      const key = event.name ?? ""
+      if (key === "return" && !hasModifier(event)) {
+        input.submit()
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "i" && !event.shift && !hasModifier(event)) {
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "/" && !event.shift && !hasModifier(event)) {
+        input.state.setMode("insert")
+        return false
+      }
+
+      if (key === "backspace" || key === "delete") {
+        event.preventDefault()
+        return true
+      }
+
+      if (isPrintable(event) && !hasModifier(event)) {
+        event.preventDefault()
+        return true
+      }
+
+      return false
+    },
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -4,6 +4,7 @@ import type { TextareaRenderable } from "@opentui/core"
 import {
   appendAfterCursor,
   appendLineEnd,
+  deleteUnderCursor,
   insertLineStart,
   moveBigWordEnd,
   moveBigWordNext,
@@ -125,6 +126,12 @@ export function createVimHandler(input: {
 
       if (key === "k" && !event.shift && !hasModifier(event)) {
         moveLineUp(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "x" && !event.shift && !hasModifier(event)) {
+        deleteUnderCursor(input.textarea())
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -145,7 +145,7 @@ export function createVimHandler(input: {
 
       if (key === "return" && !hasModifier(event)) {
         input.submit()
-        input.state.reset()
+        input.state.clearPending()
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -13,10 +13,13 @@ import {
   moveBigWordEnd,
   moveBigWordNext,
   moveBigWordPrev,
+  moveFirstNonWhitespace,
   moveLeft,
+  moveLineBeginning,
   moveLineDown,
   moveLineUp,
   moveRight,
+  moveLineEnd,
   moveWordEnd,
   moveWordNext,
   moveWordPrev,
@@ -197,6 +200,24 @@ export function createVimHandler(input: {
 
       if (key === "k" && !event.shift && !hasModifier(event)) {
         moveLineUp(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "0" && !event.shift && !hasModifier(event)) {
+        moveLineBeginning(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "^" && !hasModifier(event)) {
+        moveFirstNonWhitespace(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "$" && !hasModifier(event)) {
+        moveLineEnd(input.textarea())
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -2,6 +2,7 @@ import type { Accessor } from "solid-js"
 import type { createVimState } from "./vim-state"
 import type { TextareaRenderable } from "@opentui/core"
 import { vimScroll, type VimScroll } from "./vim-scroll"
+import { vimJump, type VimJump } from "./vim-motion-jump"
 import {
   appendAfterCursor,
   appendLineEnd,
@@ -38,6 +39,7 @@ export function createVimHandler(input: {
   textarea: Accessor<TextareaRenderable>
   submit: () => void
   scroll: (action: VimScroll) => void
+  jump: (action: VimJump) => void
 }) {
   function hasModifier(event: VimEvent) {
     return !!event.ctrl || !!event.meta || !!event.super
@@ -68,6 +70,16 @@ export function createVimHandler(input: {
       if (scroll) {
         input.state.clearPending()
         input.scroll(scroll)
+        event.preventDefault()
+        return true
+      }
+
+      const jump = vimJump(event, input.state)
+      if (jump.handled) {
+        if (jump.action) {
+          input.state.clearPending()
+          input.jump(jump.action)
+        }
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -44,6 +44,7 @@ export function createVimHandler(input: {
   submit: () => void
   scroll: (action: VimScroll) => void
   jump: (action: VimJump) => void
+  autocomplete?: () => false | "@" | "/"
 }) {
   function hasModifier(event: VimEvent) {
     return !!event.ctrl || !!event.meta || !!event.super
@@ -146,6 +147,15 @@ export function createVimHandler(input: {
       if (key === "return" && !hasModifier(event)) {
         input.submit()
         input.state.clearPending()
+        event.preventDefault()
+        return true
+      }
+
+      if ((key === "/" || key === "@") && !hasModifier(event)) {
+        if (input.autocomplete?.() && input.textarea().cursorOffset === 0 && input.textarea().plainText.length === 0) {
+          input.state.setMode("insert")
+          return false
+        }
         event.preventDefault()
         return true
       }
@@ -293,11 +303,6 @@ export function createVimHandler(input: {
         moveBigWordEnd(input.textarea())
         event.preventDefault()
         return true
-      }
-
-      if (key === "/" && !event.shift && !hasModifier(event)) {
-        input.state.setMode("insert")
-        return false
       }
 
       if (key === "backspace" || key === "delete") {

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -95,6 +95,31 @@ export function createVimHandler(input: {
         return true
       }
 
+      if (input.state.pending() === "c") {
+        if (key === "c" && !event.shift && !hasModifier(event)) {
+          substituteLine(input.textarea())
+          input.state.clearPending()
+          input.state.setMode("insert")
+          event.preventDefault()
+          return true
+        }
+
+        if (key === "w" && !event.shift && !hasModifier(event)) {
+          deleteWord(input.textarea())
+          input.state.clearPending()
+          input.state.setMode("insert")
+          event.preventDefault()
+          return true
+        }
+
+        if (hasModifier(event)) {
+          input.state.clearPending()
+          return false
+        }
+
+        input.state.clearPending()
+      }
+
       if (input.state.pending() === "d") {
         if (key === "d" && !event.shift && !hasModifier(event)) {
           deleteLine(input.textarea())
@@ -121,6 +146,12 @@ export function createVimHandler(input: {
       if (key === "return" && !hasModifier(event)) {
         input.submit()
         input.state.reset()
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "c" && !event.shift && !hasModifier(event)) {
+        input.state.setPending("c")
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -1,5 +1,7 @@
 import type { Accessor } from "solid-js"
 import type { createVimState } from "./vim-state"
+import type { TextareaRenderable } from "@opentui/core"
+import { moveLeft, moveLineDown, moveLineUp, moveRight } from "./vim-motions"
 
 export type VimEvent = {
   name?: string
@@ -13,6 +15,7 @@ export type VimEvent = {
 export function createVimHandler(input: {
   enabled: Accessor<boolean>
   state: ReturnType<typeof createVimState>
+  textarea: Accessor<TextareaRenderable>
   submit: () => void
 }) {
   function hasModifier(event: VimEvent) {
@@ -43,6 +46,30 @@ export function createVimHandler(input: {
 
       if (key === "i" && !event.shift && !hasModifier(event)) {
         input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "h" && !event.shift && !hasModifier(event)) {
+        moveLeft(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "l" && !event.shift && !hasModifier(event)) {
+        moveRight(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "j" && !event.shift && !hasModifier(event)) {
+        moveLineDown(input.textarea())
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "k" && !event.shift && !hasModifier(event)) {
+        moveLineUp(input.textarea())
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -2,6 +2,9 @@ import type { Accessor } from "solid-js"
 import type { createVimState } from "./vim-state"
 import type { TextareaRenderable } from "@opentui/core"
 import {
+  appendAfterCursor,
+  appendLineEnd,
+  insertLineStart,
   moveBigWordEnd,
   moveBigWordNext,
   moveBigWordPrev,
@@ -12,6 +15,8 @@ import {
   moveWordEnd,
   moveWordNext,
   moveWordPrev,
+  openLineAbove,
+  openLineBelow,
 } from "./vim-motions"
 
 export type VimEvent = {
@@ -60,6 +65,41 @@ export function createVimHandler(input: {
       }
 
       if (key === "i" && !event.shift && !hasModifier(event)) {
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "i") && !hasModifier(event)) {
+        insertLineStart(input.textarea())
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "a" && !event.shift && !hasModifier(event)) {
+        appendAfterCursor(input.textarea())
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "a") && !hasModifier(event)) {
+        appendLineEnd(input.textarea())
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (key === "o" && !event.shift && !hasModifier(event)) {
+        openLineBelow(input.textarea())
+        input.state.setMode("insert")
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "o") && !hasModifier(event)) {
+        openLineAbove(input.textarea())
         input.state.setMode("insert")
         event.preventDefault()
         return true

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-handler.ts
@@ -22,6 +22,7 @@ import {
   moveWordPrev,
   openLineAbove,
   openLineBelow,
+  substituteLine,
 } from "./vim-motions"
 
 export type VimEvent = {
@@ -122,6 +123,14 @@ export function createVimHandler(input: {
 
       if (key === "d" && !event.shift && !hasModifier(event)) {
         input.state.setPending("d")
+        event.preventDefault()
+        return true
+      }
+
+      if (isShifted(event, "s") && !hasModifier(event)) {
+        input.state.clearPending()
+        substituteLine(input.textarea())
+        input.state.setMode("insert")
         event.preventDefault()
         return true
       }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
@@ -1,0 +1,13 @@
+import { createMemo, type Accessor } from "solid-js"
+import type { createVimState } from "./vim-state"
+
+export function useVimIndicator(input: {
+  enabled: Accessor<boolean>
+  active: Accessor<boolean>
+  state: ReturnType<typeof createVimState>
+}) {
+  return createMemo(() => {
+    if (!input.enabled() || !input.active()) return
+    return input.state.isInsert() ? "INSERT" : "NORMAL"
+  })
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-indicator.ts
@@ -8,6 +8,7 @@ export function useVimIndicator(input: {
 }) {
   return createMemo(() => {
     if (!input.enabled() || !input.active()) return
-    return input.state.isInsert() ? "INSERT" : "NORMAL"
+    if (input.state.isInsert()) return "INSERT"
+    return undefined
   })
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motion-jump.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motion-jump.ts
@@ -1,0 +1,32 @@
+import type { VimEvent } from "./vim-handler"
+import type { createVimState } from "./vim-state"
+
+export type VimJump = "top" | "bottom"
+
+export function vimJump(event: VimEvent, state: ReturnType<typeof createVimState>) {
+  const key = event.name ?? ""
+  const hasModifier = !!event.ctrl || !!event.meta || !!event.super
+
+  if (hasModifier) {
+    if (state.pending() === "g") state.clearPending()
+    return { handled: false }
+  }
+
+  if (key === "G" || (key === "g" && event.shift)) {
+    state.clearPending()
+    return { action: "bottom" as VimJump, handled: true }
+  }
+
+  if (key !== "g") {
+    if (state.pending() === "g") state.clearPending()
+    return { handled: false }
+  }
+
+  if (state.pending() === "g") {
+    state.clearPending()
+    return { action: "top" as VimJump, handled: true }
+  }
+
+  state.setPending("g")
+  return { handled: true }
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -136,3 +136,42 @@ export function moveBigWordEnd(textarea: TextareaRenderable) {
   const text = textarea.plainText
   textarea.cursorOffset = wordEnd(text, textarea.cursorOffset, true)
 }
+
+function firstNonWhitespace(text: string, offset: number) {
+  const start = lineStart(text, offset)
+  const end = lineEnd(text, offset)
+  let pos = start
+  while (pos < end && /\s/.test(text[pos])) pos++
+  return pos
+}
+
+export function appendAfterCursor(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const end = lineEnd(text, textarea.cursorOffset)
+  textarea.cursorOffset = Math.min(textarea.cursorOffset + 1, end)
+}
+
+export function appendLineEnd(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = lineEnd(text, textarea.cursorOffset)
+}
+
+export function insertLineStart(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = firstNonWhitespace(text, textarea.cursorOffset)
+}
+
+export function openLineBelow(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const end = lineEnd(text, textarea.cursorOffset)
+  textarea.cursorOffset = end
+  textarea.insertText("\n")
+}
+
+export function openLineAbove(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const start = lineStart(text, textarea.cursorOffset)
+  textarea.cursorOffset = start
+  textarea.insertText("\n")
+  textarea.cursorOffset = start
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -98,12 +98,19 @@ function prevWordStart(text: string, offset: number, big: boolean) {
 }
 
 function wordEnd(text: string, offset: number, big: boolean) {
+  if (text.length === 0) return 0
   const match = big ? isBigWord : isWord
   let pos = offset
-  if (pos < text.length) pos++
+  if (pos >= text.length) pos = text.length - 1
+
+  if (match(text[pos]) && (pos + 1 >= text.length || !match(text[pos + 1]))) {
+    pos++
+  }
+
   while (pos < text.length && !match(text[pos])) pos++
-  while (pos < text.length && match(text[pos])) pos++
-  if (pos > offset + 1) pos--
+  if (pos >= text.length) return text.length - 1
+
+  while (pos + 1 < text.length && match(text[pos + 1])) pos++
   return pos
 }
 

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -70,3 +70,69 @@ export function moveLineDown(textarea: TextareaRenderable) {
   const text = textarea.plainText
   textarea.cursorOffset = moveDown(text, textarea.cursorOffset)
 }
+
+function isWord(char: string) {
+  return /[A-Za-z0-9_]/.test(char)
+}
+
+function isBigWord(char: string) {
+  return !/\s/.test(char)
+}
+
+function nextWordStart(text: string, offset: number, big: boolean) {
+  const match = big ? isBigWord : isWord
+  let pos = offset
+  if (pos < text.length && match(text[pos])) {
+    while (pos < text.length && match(text[pos])) pos++
+  }
+  while (pos < text.length && !match(text[pos])) pos++
+  return pos
+}
+
+function prevWordStart(text: string, offset: number, big: boolean) {
+  const match = big ? isBigWord : isWord
+  let pos = offset
+  while (pos > 0 && !match(text[pos - 1])) pos--
+  while (pos > 0 && match(text[pos - 1])) pos--
+  return pos
+}
+
+function wordEnd(text: string, offset: number, big: boolean) {
+  const match = big ? isBigWord : isWord
+  let pos = offset
+  if (pos < text.length) pos++
+  while (pos < text.length && !match(text[pos])) pos++
+  while (pos < text.length && match(text[pos])) pos++
+  if (pos > offset + 1) pos--
+  return pos
+}
+
+export function moveWordNext(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = nextWordStart(text, textarea.cursorOffset, false)
+}
+
+export function moveWordPrev(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = prevWordStart(text, textarea.cursorOffset, false)
+}
+
+export function moveWordEnd(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = wordEnd(text, textarea.cursorOffset, false)
+}
+
+export function moveBigWordNext(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = nextWordStart(text, textarea.cursorOffset, true)
+}
+
+export function moveBigWordPrev(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = prevWordStart(text, textarea.cursorOffset, true)
+}
+
+export function moveBigWordEnd(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = wordEnd(text, textarea.cursorOffset, true)
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -107,6 +107,16 @@ function wordEnd(text: string, offset: number, big: boolean) {
   return pos
 }
 
+function deleteOffsets(textarea: TextareaRenderable, startOffset: number, endOffset: number) {
+  if (endOffset <= startOffset) return
+  textarea.cursorOffset = startOffset
+  const start = textarea.logicalCursor
+  textarea.cursorOffset = endOffset
+  const end = textarea.logicalCursor
+  textarea.deleteRange(start.row, start.col, end.row, end.col)
+  textarea.cursorOffset = startOffset
+}
+
 export function moveWordNext(textarea: TextareaRenderable) {
   const text = textarea.plainText
   textarea.cursorOffset = nextWordStart(text, textarea.cursorOffset, false)
@@ -181,11 +191,34 @@ export function deleteUnderCursor(textarea: TextareaRenderable) {
   const startOffset = textarea.cursorOffset
   const end = lineEnd(text, startOffset)
   if (startOffset >= end) return
+  deleteOffsets(textarea, startOffset, startOffset + 1)
+}
 
-  textarea.cursorOffset = startOffset
-  const start = textarea.logicalCursor
-  textarea.cursorOffset = startOffset + 1
-  const next = textarea.logicalCursor
-  textarea.deleteRange(start.row, start.col, next.row, next.col)
-  textarea.cursorOffset = startOffset
+export function deleteWord(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const startOffset = textarea.cursorOffset
+  const endOffset = nextWordStart(text, startOffset, false)
+  deleteOffsets(textarea, startOffset, endOffset)
+}
+
+export function deleteLine(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  if (!text.length) return
+
+  const offset = textarea.cursorOffset
+  const start = lineStart(text, offset)
+  const end = lineEnd(text, offset)
+
+  if (end < text.length) {
+    deleteOffsets(textarea, start, end + 1)
+    return
+  }
+
+  if (start > 0) {
+    deleteOffsets(textarea, start - 1, end)
+    textarea.cursorOffset = lineStart(textarea.plainText, textarea.cursorOffset)
+    return
+  }
+
+  deleteOffsets(textarea, start, end)
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -1,7 +1,8 @@
 import type { TextareaRenderable } from "@opentui/core"
 
 function lineStart(text: string, offset: number) {
-  const index = text.lastIndexOf("\n", Math.max(0, offset - 1))
+  if (offset <= 0) return 0
+  const index = text.lastIndexOf("\n", offset - 1)
   if (index === -1) return 0
   return index + 1
 }

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -55,6 +55,21 @@ export function moveLeft(textarea: TextareaRenderable) {
   textarea.cursorOffset = Math.max(start, textarea.cursorOffset - 1)
 }
 
+export function moveLineBeginning(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = lineStart(text, textarea.cursorOffset)
+}
+
+export function moveFirstNonWhitespace(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = firstNonWhitespace(text, textarea.cursorOffset)
+}
+
+export function moveLineEnd(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = lineLast(text, textarea.cursorOffset)
+}
+
 export function moveRight(textarea: TextareaRenderable) {
   const text = textarea.plainText
   const last = lineLast(text, textarea.cursorOffset)

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -222,3 +222,10 @@ export function deleteLine(textarea: TextareaRenderable) {
 
   deleteOffsets(textarea, start, end)
 }
+
+export function substituteLine(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const start = lineStart(text, textarea.cursorOffset)
+  const end = lineEnd(text, textarea.cursorOffset)
+  deleteOffsets(textarea, start, end)
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -1,0 +1,72 @@
+import type { TextareaRenderable } from "@opentui/core"
+
+function lineStart(text: string, offset: number) {
+  const index = text.lastIndexOf("\n", Math.max(0, offset - 1))
+  if (index === -1) return 0
+  return index + 1
+}
+
+function lineEnd(text: string, offset: number) {
+  const index = text.indexOf("\n", offset)
+  if (index === -1) return text.length
+  return index
+}
+
+function lineLast(text: string, offset: number) {
+  const start = lineStart(text, offset)
+  const end = lineEnd(text, offset)
+  if (end > start) return end - 1
+  return start
+}
+
+function prevLineStart(text: string, offset: number) {
+  const start = lineStart(text, offset)
+  if (start === 0) return undefined
+  return lineStart(text, start - 1)
+}
+
+function nextLineStart(text: string, offset: number) {
+  const end = lineEnd(text, offset)
+  if (end >= text.length) return undefined
+  return end + 1
+}
+
+function moveUp(text: string, offset: number) {
+  const currentStart = lineStart(text, offset)
+  const targetStart = prevLineStart(text, offset)
+  if (targetStart === undefined) return offset
+  const targetLast = lineLast(text, targetStart)
+  const col = offset - currentStart
+  return Math.min(targetStart + col, targetLast)
+}
+
+function moveDown(text: string, offset: number) {
+  const currentStart = lineStart(text, offset)
+  const targetStart = nextLineStart(text, offset)
+  if (targetStart === undefined) return offset
+  const targetLast = lineLast(text, targetStart)
+  const col = offset - currentStart
+  return Math.min(targetStart + col, targetLast)
+}
+
+export function moveLeft(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const start = lineStart(text, textarea.cursorOffset)
+  textarea.cursorOffset = Math.max(start, textarea.cursorOffset - 1)
+}
+
+export function moveRight(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const last = lineLast(text, textarea.cursorOffset)
+  textarea.cursorOffset = Math.min(last, textarea.cursorOffset + 1)
+}
+
+export function moveLineUp(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = moveUp(text, textarea.cursorOffset)
+}
+
+export function moveLineDown(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  textarea.cursorOffset = moveDown(text, textarea.cursorOffset)
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-motions.ts
@@ -175,3 +175,17 @@ export function openLineAbove(textarea: TextareaRenderable) {
   textarea.insertText("\n")
   textarea.cursorOffset = start
 }
+
+export function deleteUnderCursor(textarea: TextareaRenderable) {
+  const text = textarea.plainText
+  const startOffset = textarea.cursorOffset
+  const end = lineEnd(text, startOffset)
+  if (startOffset >= end) return
+
+  textarea.cursorOffset = startOffset
+  const start = textarea.logicalCursor
+  textarea.cursorOffset = startOffset + 1
+  const next = textarea.logicalCursor
+  textarea.deleteRange(start.row, start.col, next.row, next.col)
+  textarea.cursorOffset = startOffset
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-scroll.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-scroll.ts
@@ -1,0 +1,15 @@
+import type { VimEvent } from "./vim-handler"
+
+export type VimScroll = "line-down" | "line-up" | "half-down" | "half-up" | "page-down" | "page-up"
+
+export function vimScroll(event: VimEvent): VimScroll | undefined {
+  if (!event.ctrl || event.meta || event.super) return
+  const key = event.name ?? ""
+  if (key === "e") return "line-down"
+  if (key === "y") return "line-up"
+  if (key === "d") return "half-down"
+  if (key === "u") return "half-up"
+  if (key === "f") return "page-down"
+  if (key === "b") return "page-up"
+  return undefined
+}

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -3,11 +3,7 @@ import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 export type VimMode = "normal" | "insert"
 export type VimPending = "" | "d" | "g"
 
-export function createVimState(input: {
-  enabled: Accessor<boolean>
-  active: Accessor<boolean>
-  initial?: Accessor<VimMode | undefined>
-}) {
+export function createVimState(input: { enabled: Accessor<boolean>; initial?: Accessor<VimMode | undefined> }) {
   const [mode, setMode] = createSignal<VimMode>(input.initial?.() ?? "insert")
   const [pending, setPending] = createSignal<VimPending>("")
 

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,9 +1,20 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
 export type VimMode = "normal" | "insert"
+export type VimPending = "" | "d"
 
 export function createVimState(input: { enabled: Accessor<boolean>; active: Accessor<boolean> }) {
   const [mode, setMode] = createSignal<VimMode>("insert")
+  const [pending, setPending] = createSignal<VimPending>("")
+
+  function clearPending() {
+    if (pending()) setPending("")
+  }
+
+  function changeMode(next: VimMode) {
+    clearPending()
+    setMode(next)
+  }
 
   createEffect(() => {
     const enabled = input.enabled()
@@ -11,13 +22,18 @@ export function createVimState(input: { enabled: Accessor<boolean>; active: Acce
 
     if (!enabled || !active) {
       if (mode() !== "insert") setMode("insert")
+      clearPending()
     }
   })
 
   return {
     mode,
-    setMode,
+    setMode: changeMode,
+    pending,
+    setPending,
+    clearPending,
     reset() {
+      clearPending()
       setMode("insert")
     },
     isInsert: createMemo(() => mode() === "insert"),

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -3,8 +3,12 @@ import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 export type VimMode = "normal" | "insert"
 export type VimPending = "" | "d" | "g"
 
-export function createVimState(input: { enabled: Accessor<boolean>; active: Accessor<boolean> }) {
-  const [mode, setMode] = createSignal<VimMode>("insert")
+export function createVimState(input: {
+  enabled: Accessor<boolean>
+  active: Accessor<boolean>
+  initial?: Accessor<VimMode | undefined>
+}) {
+  const [mode, setMode] = createSignal<VimMode>(input.initial?.() ?? "insert")
   const [pending, setPending] = createSignal<VimPending>("")
 
   function clearPending() {
@@ -18,11 +22,11 @@ export function createVimState(input: { enabled: Accessor<boolean>; active: Acce
 
   createEffect(() => {
     const enabled = input.enabled()
-    const active = input.active()
 
-    if (!enabled || !active) {
+    if (!enabled) {
       if (mode() !== "insert") setMode("insert")
       clearPending()
+      return
     }
   })
 

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
 export type VimMode = "normal" | "insert"
-export type VimPending = "" | "d"
+export type VimPending = "" | "d" | "g"
 
 export function createVimState(input: { enabled: Accessor<boolean>; active: Accessor<boolean> }) {
   const [mode, setMode] = createSignal<VimMode>("insert")

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 
 export type VimMode = "normal" | "insert"
-export type VimPending = "" | "d" | "g"
+export type VimPending = "" | "c" | "d" | "g"
 
 export function createVimState(input: { enabled: Accessor<boolean>; initial?: Accessor<VimMode | undefined> }) {
   const [mode, setMode] = createSignal<VimMode>(input.initial?.() ?? "insert")

--- a/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
+++ b/packages/opencode/src/cli/cmd/tui/component/vim/vim-state.ts
@@ -1,0 +1,25 @@
+import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
+
+export type VimMode = "normal" | "insert"
+
+export function createVimState(input: { enabled: Accessor<boolean>; active: Accessor<boolean> }) {
+  const [mode, setMode] = createSignal<VimMode>("insert")
+
+  createEffect(() => {
+    const enabled = input.enabled()
+    const active = input.active()
+
+    if (!enabled || !active) {
+      if (mode() !== "insert") setMode("insert")
+    }
+  })
+
+  return {
+    mode,
+    setMode,
+    reset() {
+      setMode("insert")
+    },
+    isInsert: createMemo(() => mode() === "insert"),
+  }
+}

--- a/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
+++ b/packages/opencode/src/cli/cmd/tui/config/tui-schema.ts
@@ -24,6 +24,7 @@ export const TuiOptions = z.object({
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
   mouse: z.boolean().optional().describe("Enable or disable mouse capture (default: true)"),
+  vim: z.boolean().optional().describe("Enable vim-style input for the prompt"),
 })
 
 export const TuiInfo = z

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -5,6 +5,7 @@ import { createVimHandler } from "../../../src/cli/cmd/tui/component/vim/vim-han
 import { createVimState } from "../../../src/cli/cmd/tui/component/vim/vim-state"
 import type { VimScroll } from "../../../src/cli/cmd/tui/component/vim/vim-scroll"
 import { vimScroll } from "../../../src/cli/cmd/tui/component/vim/vim-scroll"
+import type { VimJump } from "../../../src/cli/cmd/tui/component/vim/vim-motion-jump"
 
 function rowColToOffset(text: string, row: number, col: number) {
   let index = 0
@@ -85,8 +86,9 @@ function createHandler(
   const textarea = createTextarea(text)
   const [enabled] = createSignal(options?.enabled ?? true)
   const [mode, setMode] = createSignal<"normal" | "insert">(options?.mode ?? "normal")
-  const [pending, setPending] = createSignal<"" | "d">("")
+  const [pending, setPending] = createSignal<"" | "d" | "g">("")
   const scrollCalls: VimScroll[] = []
+  const jumpCalls: VimJump[] = []
 
   function clearPending() {
     setPending("")
@@ -120,9 +122,12 @@ function createHandler(
     scroll(action) {
       scrollCalls.push(action)
     },
+    jump(action) {
+      jumpCalls.push(action)
+    },
   })
 
-  return { textarea, handler, state, scrollCalls }
+  return { textarea, handler, state, scrollCalls, jumpCalls }
 }
 
 describe("vim motion handler", () => {
@@ -352,6 +357,66 @@ describe("vim motion handler", () => {
     expect(ctx.handler.handleKey(evt.event)).toBe(false)
     expect(evt.prevented()).toBe(false)
     expect(ctx.scrollCalls.length).toBe(0)
+  })
+
+  test("g and G jump to top or bottom", () => {
+    const ctx = createHandler("abc")
+
+    const g = createEvent("g")
+    expect(ctx.handler.handleKey(g.event)).toBe(true)
+    expect(g.prevented()).toBe(true)
+    expect(ctx.jumpCalls.length).toBe(0)
+    expect(ctx.state.pending()).toBe("g")
+
+    const g2 = createEvent("g")
+    expect(ctx.handler.handleKey(g2.event)).toBe(true)
+    expect(g2.prevented()).toBe(true)
+    expect(ctx.jumpCalls.at(-1)).toBe("top")
+    expect(ctx.state.pending()).toBe("")
+
+    const G = createEvent("G")
+    expect(ctx.handler.handleKey(G.event)).toBe(true)
+    expect(G.prevented()).toBe(true)
+    expect(ctx.jumpCalls.at(-1)).toBe("bottom")
+  })
+
+  test("pending g cancels on other keys", () => {
+    const ctx = createHandler("abc")
+    expect(ctx.handler.handleKey(createEvent("g").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("g")
+
+    const w = createEvent("w")
+    expect(ctx.handler.handleKey(w.event)).toBe(true)
+    expect(w.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("pending d then G clears and jumps", () => {
+    const ctx = createHandler("abc")
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const G = createEvent("G")
+    expect(ctx.handler.handleKey(G.event)).toBe(true)
+    expect(G.prevented()).toBe(true)
+    expect(ctx.jumpCalls.at(-1)).toBe("bottom")
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("g not handled in insert mode", () => {
+    const ctx = createHandler("abc", { mode: "insert" })
+    const g = createEvent("g")
+    expect(ctx.handler.handleKey(g.event)).toBe(false)
+    expect(g.prevented()).toBe(false)
+    expect(ctx.jumpCalls.length).toBe(0)
+  })
+
+  test("g not handled when vim disabled", () => {
+    const ctx = createHandler("abc", { enabled: false })
+    const g = createEvent("g")
+    expect(ctx.handler.handleKey(g.event)).toBe(false)
+    expect(g.prevented()).toBe(false)
+    expect(ctx.jumpCalls.length).toBe(0)
   })
 })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -207,6 +207,55 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.cursorOffset).toBe(5)
   })
 
+  test("0 moves to line beginning", () => {
+    const ctx = createHandler("  hello")
+    ctx.textarea.cursorOffset = 4
+    ctx.handler.handleKey(createEvent("0").event)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("0 on multiline moves to current line start", () => {
+    const ctx = createHandler("abc\n  def")
+    ctx.textarea.cursorOffset = 7
+    ctx.handler.handleKey(createEvent("0").event)
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("^ moves to first non-whitespace", () => {
+    const ctx = createHandler("  hello")
+    ctx.textarea.cursorOffset = 5
+    ctx.handler.handleKey(createEvent("^").event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+  })
+
+  test("^ on line with no leading whitespace goes to column 0", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 3
+    ctx.handler.handleKey(createEvent("^").event)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("$ moves to last char of line", () => {
+    const ctx = createHandler("hello")
+    ctx.textarea.cursorOffset = 0
+    ctx.handler.handleKey(createEvent("$").event)
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("$ on multiline moves to last char of current line", () => {
+    const ctx = createHandler("abc\ndef")
+    ctx.textarea.cursorOffset = 0
+    ctx.handler.handleKey(createEvent("$").event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+  })
+
+  test("$ on single char stays put", () => {
+    const ctx = createHandler("a")
+    ctx.textarea.cursorOffset = 0
+    ctx.handler.handleKey(createEvent("$").event)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
   test("supports insert transitions for A I O", () => {
     const i0 = createHandler("abc")
     i0.textarea.cursorOffset = 1

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -82,6 +82,7 @@ function createHandler(
     enabled?: boolean
     mode?: "normal" | "insert"
     submit?: () => void
+    autocomplete?: () => false | "@" | "/"
   },
 ) {
   const textarea = createTextarea(text)
@@ -126,6 +127,7 @@ function createHandler(
     jump(action) {
       jumpCalls.push(action)
     },
+    autocomplete: options?.autocomplete,
   })
 
   return { textarea, handler, state, scrollCalls, jumpCalls }
@@ -424,6 +426,44 @@ describe("vim motion handler", () => {
     const esc = createEvent("escape")
     expect(ctx.handler.handleKey(esc.event)).toBe(true)
     expect(esc.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("/ and @ stay in normal mode without autocomplete", () => {
+    const ctx = createHandler("abc", { mode: "normal" })
+
+    const slash = createEvent("/")
+    expect(ctx.handler.handleKey(slash.event)).toBe(true)
+    expect(slash.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+
+    const at = createEvent("@")
+    expect(ctx.handler.handleKey(at.event)).toBe(true)
+    expect(at.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("/ enters insert on empty input with autocomplete visible", () => {
+    const ctx = createHandler("", {
+      mode: "normal",
+      autocomplete: () => "/",
+    })
+    const slash = createEvent("/")
+
+    expect(ctx.handler.handleKey(slash.event)).toBe(false)
+    expect(slash.prevented()).toBe(false)
+    expect(ctx.state.mode()).toBe("insert")
+  })
+
+  test("/ stays normal on non-empty input with autocomplete visible", () => {
+    const ctx = createHandler("abc", {
+      mode: "normal",
+      autocomplete: () => "/",
+    })
+    const slash = createEvent("/")
+
+    expect(ctx.handler.handleKey(slash.event)).toBe(true)
+    expect(slash.prevented()).toBe(true)
     expect(ctx.state.mode()).toBe("normal")
   })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test"
+import type { TextareaRenderable } from "@opentui/core"
+import { createSignal } from "solid-js"
+import { createVimHandler } from "../../../src/cli/cmd/tui/component/vim/vim-handler"
+import { createVimState } from "../../../src/cli/cmd/tui/component/vim/vim-state"
+
+function rowColToOffset(text: string, row: number, col: number) {
+  let index = 0
+  let current = 0
+  while (current < row) {
+    const next = text.indexOf("\n", index)
+    if (next === -1) return text.length
+    index = next + 1
+    current++
+  }
+  return Math.min(index + col, text.length)
+}
+
+function offsetToRowCol(text: string, offset: number) {
+  let row = 0
+  let col = 0
+  let index = 0
+  while (index < offset && index < text.length) {
+    if (text[index] === "\n") {
+      row++
+      col = 0
+      index++
+      continue
+    }
+    col++
+    index++
+  }
+  return { row, col }
+}
+
+function createTextarea(text: string) {
+  const textarea = {
+    plainText: text,
+    cursorOffset: 0,
+    get logicalCursor() {
+      return offsetToRowCol(textarea.plainText, textarea.cursorOffset)
+    },
+    insertText(value: string) {
+      const head = textarea.plainText.slice(0, textarea.cursorOffset)
+      const tail = textarea.plainText.slice(textarea.cursorOffset)
+      textarea.plainText = head + value + tail
+      textarea.cursorOffset += value.length
+    },
+    deleteRange(startRow: number, startCol: number, endRow: number, endCol: number) {
+      const start = rowColToOffset(textarea.plainText, startRow, startCol)
+      const end = rowColToOffset(textarea.plainText, endRow, endCol)
+      textarea.plainText = textarea.plainText.slice(0, start) + textarea.plainText.slice(end)
+      textarea.cursorOffset = start
+    },
+  }
+  return textarea as unknown as TextareaRenderable
+}
+
+function createEvent(name: string, options?: { shift?: boolean; ctrl?: boolean; meta?: boolean; super?: boolean }) {
+  let prevented = false
+  return {
+    event: {
+      name,
+      shift: options?.shift,
+      ctrl: options?.ctrl,
+      meta: options?.meta,
+      super: options?.super,
+      preventDefault() {
+        prevented = true
+      },
+    },
+    prevented: () => prevented,
+  }
+}
+
+function createHandler(text: string) {
+  const textarea = createTextarea(text)
+  const [enabled] = createSignal(true)
+  const [mode, setMode] = createSignal<"normal" | "insert">("normal")
+  const state: Pick<ReturnType<typeof createVimState>, "mode" | "setMode" | "reset" | "isInsert"> = {
+    mode,
+    setMode,
+    reset() {
+      setMode("insert")
+    },
+    isInsert: () => mode() === "insert",
+  }
+  const handler = createVimHandler({
+    enabled,
+    state,
+    textarea: () => textarea,
+    submit() {},
+  })
+
+  return { textarea, handler, state }
+}
+
+describe("vim motion handler", () => {
+  test("moves with h j k l and clamps to line", () => {
+    const ctx = createHandler("abc\nxy")
+
+    ctx.handler.handleKey(createEvent("l").event)
+    ctx.handler.handleKey(createEvent("l").event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+
+    ctx.handler.handleKey(createEvent("j").event)
+    expect(ctx.textarea.cursorOffset).toBe(5)
+
+    ctx.handler.handleKey(createEvent("h").event)
+    expect(ctx.textarea.cursorOffset).toBe(4)
+
+    ctx.handler.handleKey(createEvent("k").event)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("supports word and big-word key shapes", () => {
+    const ctx = createHandler("foo,bar baz")
+
+    const w = createEvent("w")
+    expect(ctx.handler.handleKey(w.event)).toBe(true)
+    expect(w.prevented()).toBe(true)
+    expect(ctx.textarea.cursorOffset).toBe(4)
+
+    const upperW = createEvent("W")
+    expect(ctx.handler.handleKey(upperW.event)).toBe(true)
+    expect(upperW.prevented()).toBe(true)
+    expect(ctx.textarea.cursorOffset).toBe(8)
+
+    ctx.textarea.cursorOffset = 0
+    const shiftW = createEvent("w", { shift: true })
+    expect(ctx.handler.handleKey(shiftW.event)).toBe(true)
+    expect(shiftW.prevented()).toBe(true)
+    expect(ctx.textarea.cursorOffset).toBe(8)
+
+    const upperE = createEvent("E")
+    expect(ctx.handler.handleKey(upperE.event)).toBe(true)
+    expect(upperE.prevented()).toBe(true)
+    expect(ctx.textarea.cursorOffset).toBe(10)
+
+    const upperB = createEvent("B")
+    expect(ctx.handler.handleKey(upperB.event)).toBe(true)
+    expect(upperB.prevented()).toBe(true)
+    expect(ctx.textarea.cursorOffset).toBe(8)
+  })
+
+  test("supports insert transitions for A I O", () => {
+    const i0 = createHandler("abc")
+    i0.textarea.cursorOffset = 1
+    expect(i0.handler.handleKey(createEvent("i").event)).toBe(true)
+    expect(i0.state.mode()).toBe("insert")
+    expect(i0.textarea.cursorOffset).toBe(1)
+
+    const i = createHandler("  abc")
+    i.textarea.cursorOffset = 1
+    expect(i.handler.handleKey(createEvent("I").event)).toBe(true)
+    expect(i.state.mode()).toBe("insert")
+    expect(i.textarea.cursorOffset).toBe(2)
+
+    const a = createHandler("  abc")
+    a.textarea.cursorOffset = 1
+    expect(a.handler.handleKey(createEvent("A").event)).toBe(true)
+    expect(a.state.mode()).toBe("insert")
+    expect(a.textarea.cursorOffset).toBe(5)
+
+    const o = createHandler("abc")
+    o.textarea.cursorOffset = 1
+    expect(o.handler.handleKey(createEvent("o", { shift: true }).event)).toBe(true)
+    expect(o.state.mode()).toBe("insert")
+    expect(o.textarea.plainText).toBe("\nabc")
+  })
+
+  test("x deletes under cursor and no-ops at end", () => {
+    const a = createHandler("abc")
+    a.textarea.cursorOffset = 1
+    const x = createEvent("x")
+    expect(a.handler.handleKey(x.event)).toBe(true)
+    expect(x.prevented()).toBe(true)
+    expect(a.textarea.plainText).toBe("ac")
+
+    const b = createHandler("ab\ncd")
+    b.textarea.cursorOffset = 2
+    expect(b.handler.handleKey(createEvent("x").event)).toBe(true)
+    expect(b.textarea.plainText).toBe("ab\ncd")
+  })
+
+  test("insert mode only handles escape", () => {
+    const ctx = createHandler("abc")
+    ctx.state.setMode("insert")
+
+    const w = createEvent("w")
+    expect(ctx.handler.handleKey(w.event)).toBe(false)
+    expect(w.prevented()).toBe(false)
+
+    const esc = createEvent("escape")
+    expect(ctx.handler.handleKey(esc.event)).toBe(true)
+    expect(esc.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+  })
+})

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -77,10 +77,28 @@ function createHandler(text: string) {
   const textarea = createTextarea(text)
   const [enabled] = createSignal(true)
   const [mode, setMode] = createSignal<"normal" | "insert">("normal")
-  const state: Pick<ReturnType<typeof createVimState>, "mode" | "setMode" | "reset" | "isInsert"> = {
+  const [pending, setPending] = createSignal<"" | "d">("")
+
+  function clearPending() {
+    setPending("")
+  }
+
+  function changeMode(next: "normal" | "insert") {
+    clearPending()
+    setMode(next)
+  }
+
+  const state: Pick<
+    ReturnType<typeof createVimState>,
+    "mode" | "setMode" | "reset" | "isInsert" | "pending" | "setPending" | "clearPending"
+  > = {
     mode,
-    setMode,
+    setMode: changeMode,
+    pending,
+    setPending,
+    clearPending,
     reset() {
+      clearPending()
       setMode("insert")
     },
     isInsert: () => mode() === "insert",
@@ -195,5 +213,86 @@ describe("vim motion handler", () => {
     expect(ctx.handler.handleKey(esc.event)).toBe(true)
     expect(esc.prevented()).toBe(true)
     expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("dd deletes current line", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    const d1 = createEvent("d")
+    expect(ctx.handler.handleKey(d1.event)).toBe(true)
+    expect(d1.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const d2 = createEvent("d")
+    expect(ctx.handler.handleKey(d2.event)).toBe(true)
+    expect(d2.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("one\nthree")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("dd on last line lands at resulting line start", () => {
+    const ctx = createHandler("one\ntwo")
+    ctx.textarea.cursorOffset = 5
+
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.textarea.plainText).toBe("one")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("dw deletes to next word and clears pending", () => {
+    const ctx = createHandler("hello world test")
+    ctx.textarea.cursorOffset = 0
+
+    const d = createEvent("d")
+    expect(ctx.handler.handleKey(d.event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const w = createEvent("w")
+    expect(ctx.handler.handleKey(w.event)).toBe(true)
+    expect(w.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("world test")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("pending d clears on escape", () => {
+    const ctx = createHandler("hello world")
+
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const esc = createEvent("escape")
+    expect(ctx.handler.handleKey(esc.event)).toBe(true)
+    expect(esc.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.textarea.plainText).toBe("hello world")
+  })
+
+  test("pending d clears on invalid key and key is handled normally", () => {
+    const ctx = createHandler("abc")
+
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const i = createEvent("i")
+    expect(ctx.handler.handleKey(i.event)).toBe(true)
+    expect(i.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.state.mode()).toBe("insert")
+  })
+
+  test("pending d clears on modifier key and event is not consumed", () => {
+    const ctx = createHandler("abc")
+
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const mod = createEvent("j", { ctrl: true })
+    expect(ctx.handler.handleKey(mod.event)).toBe(false)
+    expect(mod.prevented()).toBe(false)
+    expect(ctx.state.pending()).toBe("")
   })
 })

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -218,6 +218,40 @@ describe("vim motion handler", () => {
     expect(b.textarea.plainText).toBe("ab\ncd")
   })
 
+  test("S clears current line and enters insert", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+    const s = createEvent("S")
+
+    expect(ctx.handler.handleKey(s.event)).toBe(true)
+    expect(s.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("one\n\nthree")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("S clears single line", () => {
+    const ctx = createHandler("abc")
+    const s = createEvent("S")
+
+    expect(ctx.handler.handleKey(s.event)).toBe(true)
+    expect(s.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("S keeps empty buffer", () => {
+    const ctx = createHandler("")
+    const s = createEvent("S")
+
+    expect(ctx.handler.handleKey(s.event)).toBe(true)
+    expect(s.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
   test("insert mode only handles escape", () => {
     const ctx = createHandler("abc", { mode: "insert" })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -179,6 +179,34 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.cursorOffset).toBe(8)
   })
 
+  test("e stays on single-char word", () => {
+    const ctx = createHandler("a")
+    ctx.textarea.cursorOffset = 0
+    ctx.handler.handleKey(createEvent("e").event)
+    expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("e from end of word moves to next word end", () => {
+    const ctx = createHandler("a b")
+    ctx.textarea.cursorOffset = 0
+    ctx.handler.handleKey(createEvent("e").event)
+    expect(ctx.textarea.cursorOffset).toBe(2)
+  })
+
+  test("e from word end moves to next word end", () => {
+    const ctx = createHandler("ab cd")
+    ctx.textarea.cursorOffset = 1
+    ctx.handler.handleKey(createEvent("e").event)
+    expect(ctx.textarea.cursorOffset).toBe(4)
+  })
+
+  test("e from whitespace moves to next word end", () => {
+    const ctx = createHandler("ab  cd")
+    ctx.textarea.cursorOffset = 2
+    ctx.handler.handleKey(createEvent("e").event)
+    expect(ctx.textarea.cursorOffset).toBe(5)
+  })
+
   test("supports insert transitions for A I O", () => {
     const i0 = createHandler("abc")
     i0.textarea.cursorOffset = 1

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -87,7 +87,7 @@ function createHandler(
   const textarea = createTextarea(text)
   const [enabled] = createSignal(options?.enabled ?? true)
   const [mode, setMode] = createSignal<"normal" | "insert">(options?.mode ?? "normal")
-  const [pending, setPending] = createSignal<"" | "d" | "g">("")
+  const [pending, setPending] = createSignal<"" | "c" | "d" | "g">("")
   const scrollCalls: VimScroll[] = []
   const jumpCalls: VimJump[] = []
 
@@ -328,6 +328,66 @@ describe("vim motion handler", () => {
     expect(ctx.state.mode()).toBe("insert")
     expect(ctx.textarea.plainText).toBe("")
     expect(ctx.textarea.cursorOffset).toBe(0)
+  })
+
+  test("cc clears current line and enters insert", () => {
+    const ctx = createHandler("one\ntwo\nthree")
+    ctx.textarea.cursorOffset = 5
+
+    const c1 = createEvent("c")
+    expect(ctx.handler.handleKey(c1.event)).toBe(true)
+    expect(c1.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("c")
+
+    const c2 = createEvent("c")
+    expect(ctx.handler.handleKey(c2.event)).toBe(true)
+    expect(c2.prevented()).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.textarea.plainText).toBe("one\n\nthree")
+    expect(ctx.textarea.cursorOffset).toBe(4)
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("cw deletes to next word and enters insert", () => {
+    const ctx = createHandler("hello world test")
+    ctx.textarea.cursorOffset = 0
+
+    const c = createEvent("c")
+    expect(ctx.handler.handleKey(c.event)).toBe(true)
+    expect(ctx.state.pending()).toBe("c")
+
+    const w = createEvent("w")
+    expect(ctx.handler.handleKey(w.event)).toBe(true)
+    expect(w.prevented()).toBe(true)
+    expect(ctx.textarea.plainText).toBe("world test")
+    expect(ctx.textarea.cursorOffset).toBe(0)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("pending c clears on escape", () => {
+    const ctx = createHandler("hello world")
+
+    expect(ctx.handler.handleKey(createEvent("c").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("c")
+
+    const esc = createEvent("escape")
+    expect(ctx.handler.handleKey(esc.event)).toBe(true)
+    expect(esc.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+    expect(ctx.textarea.plainText).toBe("hello world")
+  })
+
+  test("pending c clears on modifier key", () => {
+    const ctx = createHandler("abc")
+
+    expect(ctx.handler.handleKey(createEvent("c").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("c")
+
+    const mod = createEvent("j", { ctrl: true })
+    expect(ctx.handler.handleKey(mod.event)).toBe(false)
+    expect(mod.prevented()).toBe(false)
+    expect(ctx.state.pending()).toBe("")
   })
 
   test("insert mode only handles escape", () => {

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -149,6 +149,30 @@ describe("vim motion handler", () => {
     expect(ctx.textarea.cursorOffset).toBe(0)
   })
 
+  test("j/k move across leading empty first line", () => {
+    const text = "\nline1\nline2\nline3\n"
+    const ctx = createHandler(text)
+    ctx.textarea.cursorOffset = rowColToOffset(text, 1, 0)
+
+    ctx.handler.handleKey(createEvent("k").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 0, 0))
+
+    ctx.handler.handleKey(createEvent("j").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 1, 0))
+  })
+
+  test("j/k move across trailing empty last line", () => {
+    const text = "\nline1\nline2\nline3\n"
+    const ctx = createHandler(text)
+    ctx.textarea.cursorOffset = rowColToOffset(text, 3, 0)
+
+    ctx.handler.handleKey(createEvent("j").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 4, 0))
+
+    ctx.handler.handleKey(createEvent("k").event)
+    expect(ctx.textarea.cursorOffset).toBe(rowColToOffset(text, 3, 0))
+  })
+
   test("supports word and big-word key shapes", () => {
     const ctx = createHandler("foo,bar baz")
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -3,6 +3,8 @@ import type { TextareaRenderable } from "@opentui/core"
 import { createSignal } from "solid-js"
 import { createVimHandler } from "../../../src/cli/cmd/tui/component/vim/vim-handler"
 import { createVimState } from "../../../src/cli/cmd/tui/component/vim/vim-state"
+import type { VimScroll } from "../../../src/cli/cmd/tui/component/vim/vim-scroll"
+import { vimScroll } from "../../../src/cli/cmd/tui/component/vim/vim-scroll"
 
 function rowColToOffset(text: string, row: number, col: number) {
   let index = 0
@@ -73,11 +75,18 @@ function createEvent(name: string, options?: { shift?: boolean; ctrl?: boolean; 
   }
 }
 
-function createHandler(text: string) {
+function createHandler(
+  text: string,
+  options?: {
+    enabled?: boolean
+    mode?: "normal" | "insert"
+  },
+) {
   const textarea = createTextarea(text)
-  const [enabled] = createSignal(true)
-  const [mode, setMode] = createSignal<"normal" | "insert">("normal")
+  const [enabled] = createSignal(options?.enabled ?? true)
+  const [mode, setMode] = createSignal<"normal" | "insert">(options?.mode ?? "normal")
   const [pending, setPending] = createSignal<"" | "d">("")
+  const scrollCalls: VimScroll[] = []
 
   function clearPending() {
     setPending("")
@@ -108,9 +117,12 @@ function createHandler(text: string) {
     state,
     textarea: () => textarea,
     submit() {},
+    scroll(action) {
+      scrollCalls.push(action)
+    },
   })
 
-  return { textarea, handler, state }
+  return { textarea, handler, state, scrollCalls }
 }
 
 describe("vim motion handler", () => {
@@ -202,8 +214,7 @@ describe("vim motion handler", () => {
   })
 
   test("insert mode only handles escape", () => {
-    const ctx = createHandler("abc")
-    ctx.state.setMode("insert")
+    const ctx = createHandler("abc", { mode: "insert" })
 
     const w = createEvent("w")
     expect(ctx.handler.handleKey(w.event)).toBe(false)
@@ -294,5 +305,65 @@ describe("vim motion handler", () => {
     expect(ctx.handler.handleKey(mod.event)).toBe(false)
     expect(mod.prevented()).toBe(false)
     expect(ctx.state.pending()).toBe("")
+  })
+
+  test("ctrl scroll keys trigger actions", () => {
+    const ctx = createHandler("abc")
+    const keys: Array<[string, VimScroll]> = [
+      ["e", "line-down"],
+      ["y", "line-up"],
+      ["d", "half-down"],
+      ["u", "half-up"],
+      ["f", "page-down"],
+      ["b", "page-up"],
+    ]
+
+    for (const [key, action] of keys) {
+      const evt = createEvent(key, { ctrl: true })
+      expect(ctx.handler.handleKey(evt.event)).toBe(true)
+      expect(evt.prevented()).toBe(true)
+      expect(ctx.scrollCalls.at(-1)).toBe(action)
+    }
+  })
+
+  test("ctrl scroll clears pending operator", () => {
+    const ctx = createHandler("abc")
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const evt = createEvent("d", { ctrl: true })
+    expect(ctx.handler.handleKey(evt.event)).toBe(true)
+    expect(evt.prevented()).toBe(true)
+    expect(ctx.scrollCalls.at(-1)).toBe("half-down")
+    expect(ctx.state.pending()).toBe("")
+  })
+
+  test("ctrl scroll not handled in insert mode", () => {
+    const ctx = createHandler("abc", { mode: "insert" })
+    const evt = createEvent("e", { ctrl: true })
+    expect(ctx.handler.handleKey(evt.event)).toBe(false)
+    expect(evt.prevented()).toBe(false)
+    expect(ctx.scrollCalls.length).toBe(0)
+  })
+
+  test("ctrl scroll not handled when vim disabled", () => {
+    const ctx = createHandler("abc", { enabled: false })
+    const evt = createEvent("e", { ctrl: true })
+    expect(ctx.handler.handleKey(evt.event)).toBe(false)
+    expect(evt.prevented()).toBe(false)
+    expect(ctx.scrollCalls.length).toBe(0)
+  })
+})
+
+describe("vim scroll mapping", () => {
+  test("vimScroll maps ctrl keys to actions", () => {
+    expect(vimScroll(createEvent("e", { ctrl: true }).event)).toBe("line-down")
+    expect(vimScroll(createEvent("y", { ctrl: true }).event)).toBe("line-up")
+    expect(vimScroll(createEvent("d", { ctrl: true }).event)).toBe("half-down")
+    expect(vimScroll(createEvent("u", { ctrl: true }).event)).toBe("half-up")
+    expect(vimScroll(createEvent("f", { ctrl: true }).event)).toBe("page-down")
+    expect(vimScroll(createEvent("b", { ctrl: true }).event)).toBe("page-up")
+    expect(vimScroll(createEvent("b", { ctrl: true, meta: true }).event)).toBe(undefined)
+    expect(vimScroll(createEvent("b", { ctrl: false }).event)).toBe(undefined)
   })
 })

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -403,7 +403,7 @@ describe("vim motion handler", () => {
     expect(ctx.state.mode()).toBe("normal")
   })
 
-  test("submit from normal resets mode and pending", () => {
+  test("submit from normal keeps mode and clears pending", () => {
     let calls = 0
     const ctx = createHandler("", {
       mode: "normal",
@@ -416,7 +416,7 @@ describe("vim motion handler", () => {
     ctx.handler.handleKey(createEvent("return").event)
 
     expect(calls).toBe(1)
-    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.mode()).toBe("normal")
     expect(ctx.state.pending()).toBe("")
   })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -231,6 +231,25 @@ describe("vim motion handler", () => {
     expect(ctx.state.mode()).toBe("normal")
   })
 
+  test("vim disabled does not intercept keys", () => {
+    const ctx = createHandler("abc", { enabled: false })
+    const keys = [
+      createEvent("h"),
+      createEvent("x"),
+      createEvent("d"),
+      createEvent("g"),
+      createEvent("d", { ctrl: true }),
+    ]
+
+    for (const key of keys) {
+      expect(ctx.handler.handleKey(key.event)).toBe(false)
+      expect(key.prevented()).toBe(false)
+    }
+
+    expect(ctx.scrollCalls.length).toBe(0)
+    expect(ctx.jumpCalls.length).toBe(0)
+  })
+
   test("dd deletes current line", () => {
     const ctx = createHandler("one\ntwo\nthree")
     ctx.textarea.cursorOffset = 5
@@ -298,6 +317,24 @@ describe("vim motion handler", () => {
     expect(i.prevented()).toBe(true)
     expect(ctx.state.pending()).toBe("")
     expect(ctx.state.mode()).toBe("insert")
+  })
+
+  test("mode switch clears pending state", () => {
+    const ctx = createHandler("abc")
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    expect(ctx.handler.handleKey(createEvent("i").event)).toBe(true)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.pending()).toBe("")
+
+    expect(ctx.handler.handleKey(createEvent("escape").event)).toBe(true)
+    expect(ctx.state.mode()).toBe("normal")
+    expect(ctx.state.pending()).toBe("")
+
+    const h = createEvent("h")
+    expect(ctx.handler.handleKey(h.event)).toBe(true)
+    expect(h.prevented()).toBe(true)
   })
 
   test("pending d clears on modifier key and event is not consumed", () => {
@@ -391,6 +428,24 @@ describe("vim motion handler", () => {
     expect(ctx.state.pending()).toBe("")
   })
 
+  test("pending transition d to g", () => {
+    const ctx = createHandler("abc")
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const g = createEvent("g")
+    expect(ctx.handler.handleKey(g.event)).toBe(true)
+    expect(g.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("g")
+
+    const g2 = createEvent("g")
+    expect(ctx.handler.handleKey(g2.event)).toBe(true)
+    expect(g2.prevented()).toBe(true)
+    expect(ctx.jumpCalls.at(-1)).toBe("top")
+    expect(ctx.scrollCalls.length).toBe(0)
+    expect(ctx.state.pending()).toBe("")
+  })
+
   test("pending d then G clears and jumps", () => {
     const ctx = createHandler("abc")
     expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
@@ -417,6 +472,40 @@ describe("vim motion handler", () => {
     expect(ctx.handler.handleKey(g.event)).toBe(false)
     expect(g.prevented()).toBe(false)
     expect(ctx.jumpCalls.length).toBe(0)
+  })
+
+  test("repeated ctrl scroll keeps pending clear", () => {
+    const ctx = createHandler("abc")
+    expect(ctx.handler.handleKey(createEvent("d").event)).toBe(true)
+    expect(ctx.state.pending()).toBe("d")
+
+    const first = createEvent("d", { ctrl: true })
+    expect(ctx.handler.handleKey(first.event)).toBe(true)
+    expect(first.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+
+    const second = createEvent("d", { ctrl: true })
+    expect(ctx.handler.handleKey(second.event)).toBe(true)
+    expect(second.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+
+    expect(ctx.scrollCalls).toEqual(["half-down", "half-down"])
+  })
+
+  test("repeated G does not create pending", () => {
+    const ctx = createHandler("abc")
+
+    const first = createEvent("G")
+    expect(ctx.handler.handleKey(first.event)).toBe(true)
+    expect(first.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+
+    const second = createEvent("G")
+    expect(ctx.handler.handleKey(second.event)).toBe(true)
+    expect(second.prevented()).toBe(true)
+    expect(ctx.state.pending()).toBe("")
+
+    expect(ctx.jumpCalls).toEqual(["bottom", "bottom"])
   })
 })
 

--- a/packages/opencode/test/cli/tui/vim-motions.test.ts
+++ b/packages/opencode/test/cli/tui/vim-motions.test.ts
@@ -81,6 +81,7 @@ function createHandler(
   options?: {
     enabled?: boolean
     mode?: "normal" | "insert"
+    submit?: () => void
   },
 ) {
   const textarea = createTextarea(text)
@@ -118,7 +119,7 @@ function createHandler(
     enabled,
     state,
     textarea: () => textarea,
-    submit() {},
+    submit: options?.submit ?? (() => {}),
     scroll(action) {
       scrollCalls.push(action)
     },
@@ -263,6 +264,23 @@ describe("vim motion handler", () => {
     expect(ctx.handler.handleKey(esc.event)).toBe(true)
     expect(esc.prevented()).toBe(true)
     expect(ctx.state.mode()).toBe("normal")
+  })
+
+  test("submit from normal resets mode and pending", () => {
+    let calls = 0
+    const ctx = createHandler("", {
+      mode: "normal",
+      submit() {
+        calls++
+      },
+    })
+    ctx.state.setPending("d")
+
+    ctx.handler.handleKey(createEvent("return").event)
+
+    expect(calls).toBe(1)
+    expect(ctx.state.mode()).toBe("insert")
+    expect(ctx.state.pending()).toBe("")
   })
 
   test("vim disabled does not intercept keys", () => {

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -279,6 +279,11 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
 
 Use `OPENCODE_TUI_CONFIG` to point to a custom TUI config file.
 
+- `scroll_acceleration.enabled` - Enable macOS-style scroll acceleration. **Takes precedence over `scroll_speed`.**
+- `scroll_speed` - Custom scroll speed multiplier (default: `3`, minimum: `1`). Ignored if `scroll_acceleration.enabled` is `true`.
+- `diff_style` - Control diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows single column.
+- `vim` - Enable vim-style prompt input in the TUI
+
 Legacy `theme`, `keybinds`, and `tui` keys in `opencode.json` are deprecated and automatically migrated when possible.
 
 ---

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -394,6 +394,32 @@ You can customize various aspects of the TUI view using the command palette (`ct
 
 ---
 
+## Vim mode
+
+Optional Vim-style prompt mode for the TUI. Disabled by default.
+Enable it from the command palette or in your config.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tui": {
+    "vim": true
+  }
+}
+```
+
+**Supported keys:**
+
+**Movement:** `h`, `j`, `k`, `l`, `0`, `^`, `$`; `w`, `b`, `e`, `W`, `B`, `E`
+
+**Insert / edit:** `i`, `I`, `a`, `A`, `o`, `O`; `x`; `S`, `cc`, `cw`; `dd`, `dw`
+
+**Navigation:** `gg`, `G`
+
+**Scrolling:** `Ctrl+e`, `Ctrl+y`; `Ctrl+d`, `Ctrl+u`; `Ctrl+f`, `Ctrl+b`
+
+---
+
 #### Username display
 
 Toggle whether your username appears in chat messages. Access this through:

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -397,14 +397,12 @@ You can customize various aspects of the TUI view using the command palette (`ct
 ## Vim mode
 
 Optional Vim-style prompt mode for the TUI. Disabled by default.
-Enable it from the command palette or in your config.
+Enable it from the command palette or in `tui.json`.
 
-```json title="opencode.json"
+```json title="tui.json"
 {
-  "$schema": "https://opencode.ai/config.json",
-  "tui": {
-    "vim": true
-  }
+  "$schema": "https://opencode.ai/tui.json",
+  "vim": true
 }
 ```
 


### PR DESCRIPTION
### What does this PR do?

Closes #1764
Closes #11111

Adds optional Vim motions to the prompt input. Enable with tui.vim: true or toggle from the menu. Disabled by default.

![demo](https://github.com/user-attachments/assets/2832c14b-07fc-4b49-b831-45f8e214a7bb)

Supported:
- Mode switching: `i I a A o O S`, `cc`, `cw`, `Esc`
- Motions: `h j k l`, `w b e`, `W B E`, `0 ^ $`
- Deletes: `x`, `dd`, `dw`
- Session navigation: `gg/G`
- Scrolling: `Ctrl+e/y/d/u/f/b`
- `Enter` in normal mode submits

Implementation: Vim state isolated in `/vim` module. Handler owns mode + pending operator state. Mode resets to insert after submit. Visual mode intentionally excluded.

I saw thdxr's concern in #1764 about partial Vim feeling incomplete. This PR covers only the core motions needed for prompt editing and is intentionally kept small to make review manageable. I have a fuller implementation with yank/paste, visual mode and other motions that I can split into follow-up PRs if this direction looks good or keep it at this core subset as it seems many people are satisfied with a minimal vim mode.

### How did you verify your code works?

I use the fuller implementation daily. Reimplemented the core subset for this PR and verified manually (editing, scrolling, session switching, edge cases with pending operators, empty buffers, multiline). Added targeted tests for mode transitions, motions, deletes, pending state, and submit reset. 

Not knowing when this will be reviewed - If you would like to use this now with a more complete vim mode, use [opencode-vim](https://github.com/leohenon/opencode).