### PR TITLE
feat: add --yolo flag for auto-approving permissions in web/serve mode

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,6 +1,6 @@
 import { Server } from "../../server/server"
 import { cmd } from "./cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { withNetworkOptions, resolveNetworkOptions, applyYoloMode } from "../network"
 import { Flag } from "../../flag/flag"
 
 export const ServeCommand = cmd({
@@ -8,6 +8,7 @@ export const ServeCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "starts a headless opencode server",
   handler: async (args) => {
+    if (args.yolo) applyYoloMode()
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -1,7 +1,7 @@
 import { Server } from "../../server/server"
 import { UI } from "../ui"
 import { cmd } from "./cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { withNetworkOptions, resolveNetworkOptions, applyYoloMode } from "../network"
 import { Flag } from "../../flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
@@ -33,6 +33,7 @@ export const WebCommand = cmd({
   builder: (yargs) => withNetworkOptions(yargs),
   describe: "start opencode server and open web interface",
   handler: async (args) => {
+    if (args.yolo) applyYoloMode()
     if (!Flag.OPENCODE_SERVER_PASSWORD) {
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  " + "OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -28,6 +28,11 @@ const options = {
     describe: "additional domains to allow for CORS",
     default: [] as string[],
   },
+  yolo: {
+    type: "boolean" as const,
+    describe: "auto-approve all permissions (YOLO mode)",
+    default: false,
+  },
 }
 
 export type NetworkOptions = InferredOptionTypes<typeof options>
@@ -57,4 +62,26 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const cors = [...configCors, ...argsCors]
 
   return { hostname, port, mdns, mdnsDomain, cors }
+}
+
+export function applyYoloMode() {
+  process.env.OPENCODE_PERMISSION = JSON.stringify({
+    bash: "allow",
+    edit: "allow",
+    read: { "*": "allow" },
+    glob: { "*": "allow" },
+    grep: { "*": "allow" },
+    list: { "*": "allow" },
+    task: "allow",
+    external_directory: { "*": "allow" },
+    todowrite: "allow",
+    todoread: "allow",
+    question: "allow",
+    webfetch: "allow",
+    websearch: "allow",
+    codesearch: "allow",
+    lsp: { "*": "allow" },
+    doom_loop: "allow",
+    skill: { "*": "allow" },
+  })
 }


### PR DESCRIPTION
Add a `--yolo` CLI flag to both `opencode web` and `opencode serve` commands that automatically approves all permission requests without prompting the user.

This is useful for sandboxed environments to allow the user to run OpenCode in a similar fashion to `claude`'s `--dangerously-bypass-permissions`.

Implementation:
- Added `yolo` boolean option to shared network options in `network.ts`
- Created `applyYoloMode()` helper that sets `OPENCODE_PERMISSION` env var with all permissions set to "allow" (bash, edit, read, glob, grep, list, task, webfetch, websearch, lsp, skill, etc.)
- Both `web.ts` and `serve.ts` call `applyYoloMode()` before server startup

Usage:

```
opencode web --yolo 
opencode serve --yolo
```

Built exclusively with openrouter/pony-alpha and OpenCode.