### PR TITLE
feat(app): add Formatters to the status in the Desktop app

### DIFF
--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -109,6 +109,8 @@ export function StatusPopover() {
   const lspCount = createMemo(() => lspItems().length)
   const plugins = createMemo(() => sync.data.config.plugin ?? [])
   const pluginCount = createMemo(() => plugins().length)
+  const formatterItems = createMemo(() => (sync.data.formatter ?? []).filter((f) => f.enabled))
+  const formatterCount = createMemo(() => formatterItems().length)
 
   const overallHealthy = createMemo(() => {
     const serverHealthy = server.healthy() === true
@@ -171,7 +173,10 @@ export function StatusPopover() {
           defaultValue="servers"
           variant="alt"
         >
-          <Tabs.List data-slot="tablist" class="bg-transparent border-b-0 px-4 pt-2 pb-0 gap-4 h-10">
+          <Tabs.List
+            data-slot="tablist"
+            class="bg-transparent border-b-0 px-4 pt-2 pb-0 gap-2 h-10 overflow-x-auto no-scrollbar"
+          >
             <Tabs.Trigger value="servers" data-slot="tab" class="text-12-regular">
               {serverCount() > 0 ? `${serverCount()} ` : ""}
               {language.t("status.popover.tab.servers")}
@@ -183,6 +188,10 @@ export function StatusPopover() {
             <Tabs.Trigger value="lsp" data-slot="tab" class="text-12-regular">
               {lspCount() > 0 ? `${lspCount()} ` : ""}
               {language.t("status.popover.tab.lsp")}
+            </Tabs.Trigger>
+            <Tabs.Trigger value="formatters" data-slot="tab" class="text-12-regular">
+              {formatterCount() > 0 ? `${formatterCount()} ` : ""}
+              {language.t("status.popover.tab.formatters")}
             </Tabs.Trigger>
             <Tabs.Trigger value="plugins" data-slot="tab" class="text-12-regular">
               {pluginCount() > 0 ? `${pluginCount()} ` : ""}
@@ -321,6 +330,30 @@ export function StatusPopover() {
                           }}
                         />
                         <span class="text-14-regular text-text-base truncate">{item.name || item.id}</span>
+                      </div>
+                    )}
+                  </For>
+                </Show>
+              </div>
+            </div>
+          </Tabs.Content>
+
+          <Tabs.Content value="formatters">
+            <div class="flex flex-col px-2 pb-2">
+              <div class="flex flex-col p-3 bg-background-base rounded-sm min-h-14">
+                <Show
+                  when={formatterItems().length > 0}
+                  fallback={
+                    <div class="text-14-regular text-text-base text-center my-auto">
+                      {language.t("dialog.formatters.empty")}
+                    </div>
+                  }
+                >
+                  <For each={formatterItems()}>
+                    {(item) => (
+                      <div class="flex items-center gap-2 w-full px-2 py-1">
+                        <div class="size-1.5 rounded-full shrink-0 bg-icon-success-base" />
+                        <span class="text-14-regular text-text-base truncate">{item.name}</span>
                       </div>
                     )}
                   </For>

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -144,6 +144,7 @@ export async function bootstrapDirectory(input: {
     input.loadSessions(input.directory),
     input.sdk.mcp.status().then((x) => input.setStore("mcp", x.data!)),
     input.sdk.lsp.status().then((x) => input.setStore("lsp", x.data!)),
+    input.sdk.formatter.status().then((x) => input.setStore("formatter", x.data!)),
     input.sdk.vcs.get().then((x) => {
       const next = x.data ?? input.store.vcs
       input.setStore("vcs", next)

--- a/packages/app/src/context/global-sync/child-store.ts
+++ b/packages/app/src/context/global-sync/child-store.ts
@@ -177,6 +177,7 @@ export function createChildStoreManager(input: {
             question: {},
             mcp: {},
             lsp: [],
+            formatter: [],
             vcs: vcsStore.value,
             limit: 5,
             message: {},

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -3,6 +3,7 @@ import type {
   Command,
   Config,
   FileDiff,
+  FormatterStatus,
   LspStatus,
   McpStatus,
   Message,
@@ -62,6 +63,7 @@ export type State = {
     [name: string]: McpStatus
   }
   lsp: LspStatus[]
+  formatter: FormatterStatus[]
   vcs: VcsInfo | undefined
   limit: number
   message: {

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "تم الكشف تلقائيًا عن LSPs من أنواع الملفات",
   "dialog.plugins.empty": "الإضافات المكونة في opencode.json",
+  "dialog.formatters.empty": "لا توجد منسقات نشطة",
 
   "mcp.status.connected": "متصل",
   "mcp.status.failed": "فشل",
@@ -451,6 +452,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "الإضافات",
+  "status.popover.tab.formatters": "المنسقات",
   "status.popover.action.manageServers": "إدارة الخوادم",
 
   "session.share.popover.title": "نشر على الويب",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSPs detectados automaticamente pelos tipos de arquivo",
   "dialog.plugins.empty": "Plugins configurados em opencode.json",
+  "dialog.formatters.empty": "Nenhum formatador ativo",
   "mcp.status.connected": "conectado",
   "mcp.status.failed": "falhou",
   "mcp.status.needs_auth": "precisa de autenticação",
@@ -452,6 +453,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formatadores",
   "status.popover.action.manageServers": "Gerenciar servidores",
 
   "session.share.popover.title": "Publicar na web",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -250,6 +250,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSP-ovi se automatski otkrivaju prema tipu datoteke",
   "dialog.plugins.empty": "Plugini su konfigurisani u opencode.json",
+  "dialog.formatters.empty": "Nema aktivnih formatera",
 
   "mcp.status.connected": "povezano",
   "mcp.status.failed": "neuspjelo",
@@ -481,6 +482,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugini",
+  "status.popover.tab.formatters": "Formatatori",
   "status.popover.action.manageServers": "Upravljaj serverima",
 
   "session.share.popover.title": "Objavi na webu",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSP'er registreret automatisk fra filtyper",
   "dialog.plugins.empty": "Plugins konfigureret i opencode.json",
+  "dialog.formatters.empty": "Ingen aktive formateringsværktøjer",
 
   "mcp.status.connected": "forbundet",
   "mcp.status.failed": "mislykkedes",
@@ -453,6 +454,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formateringsværktøjer",
   "status.popover.action.manageServers": "Administrer servere",
 
   "session.share.popover.title": "Udgiv på nettet",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -285,6 +285,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSPs automatisch nach Dateityp erkannt",
   "dialog.plugins.empty": "In opencode.json konfigurierte Plugins",
+  "dialog.formatters.empty": "Keine aktiven Formatierer",
 
   "mcp.status.connected": "verbunden",
   "mcp.status.failed": "fehlgeschlagen",
@@ -495,6 +496,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formatierer",
   "status.popover.action.manageServers": "Server verwalten",
 
   "session.share.popover.title": "Im Web veröffentlichen",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -287,6 +287,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSPs auto-detected from file types",
   "dialog.plugins.empty": "Plugins configured in opencode.json",
+  "dialog.formatters.empty": "No active formatters",
 
   "mcp.status.connected": "connected",
   "mcp.status.failed": "failed",
@@ -523,6 +524,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formatters",
   "status.popover.action.manageServers": "Manage servers",
 
   "session.share.popover.title": "Publish on web",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSPs detectados automáticamente por tipo de archivo",
   "dialog.plugins.empty": "Plugins configurados en opencode.json",
+  "dialog.formatters.empty": "No hay formateadores activos",
 
   "mcp.status.connected": "conectado",
   "mcp.status.failed": "fallido",
@@ -455,6 +456,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formateadores",
   "status.popover.action.manageServers": "Administrar servidores",
 
   "session.share.popover.title": "Publicar en web",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSPs détectés automatiquement par type de fichier",
   "dialog.plugins.empty": "Plugins configurés dans opencode.json",
+  "dialog.formatters.empty": "Aucun formateur actif",
 
   "mcp.status.connected": "connecté",
   "mcp.status.failed": "échoué",
@@ -460,6 +461,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formateurs",
   "status.popover.action.manageServers": "Gérer les serveurs",
 
   "session.share.popover.title": "Publier sur le web",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -241,6 +241,7 @@ export const dict = {
 
   "dialog.lsp.empty": "ファイルタイプから自動検出されたLSP",
   "dialog.plugins.empty": "opencode.jsonで設定されたプラグイン",
+  "dialog.formatters.empty": "アクティブなフォーマッタがありません",
 
   "mcp.status.connected": "接続済み",
   "mcp.status.failed": "失敗",
@@ -447,6 +448,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "プラグイン",
+  "status.popover.tab.formatters": "フォーマッタ",
   "status.popover.action.manageServers": "サーバーを管理",
 
   "session.share.popover.title": "ウェブで公開",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -245,6 +245,7 @@ export const dict = {
 
   "dialog.lsp.empty": "파일 유형에서 자동 감지된 LSP",
   "dialog.plugins.empty": "opencode.json에 구성된 플러그인",
+  "dialog.formatters.empty": "활성 포맷터 없음",
 
   "mcp.status.connected": "연결됨",
   "mcp.status.failed": "실패",
@@ -454,6 +455,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "플러그인",
+  "status.popover.tab.formatters": "포맷터",
   "status.popover.action.manageServers": "서버 관리",
 
   "session.share.popover.title": "웹에 게시",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -245,6 +245,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSP-er automatisk oppdaget fra filtyper",
   "dialog.plugins.empty": "Plugins konfigurert i opencode.json",
+  "dialog.formatters.empty": "Ingen aktive formaterere",
 
   "mcp.status.connected": "tilkoblet",
   "mcp.status.failed": "mislyktes",
@@ -455,6 +456,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Plugins",
+  "status.popover.tab.formatters": "Formaterere",
   "status.popover.action.manageServers": "Administrer servere",
 
   "session.share.popover.title": "Publiser på nett",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSP wykryte automatycznie na podstawie typów plików",
   "dialog.plugins.empty": "Wtyczki skonfigurowane w opencode.json",
+  "dialog.formatters.empty": "Brak aktywnych formatów",
 
   "mcp.status.connected": "połączono",
   "mcp.status.failed": "niepowodzenie",
@@ -454,6 +455,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Wtyczki",
+  "status.popover.tab.formatters": "Formaty",
   "status.popover.action.manageServers": "Zarządzaj serwerami",
 
   "session.share.popover.title": "Opublikuj w sieci",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -242,6 +242,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSP автоматически обнаружены по типам файлов",
   "dialog.plugins.empty": "Плагины настроены в opencode.json",
+  "dialog.formatters.empty": "Нет активных форматтеров",
 
   "mcp.status.connected": "подключено",
   "mcp.status.failed": "ошибка",
@@ -456,6 +457,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "Плагины",
+  "status.popover.tab.formatters": "Форматтеры",
   "status.popover.action.manageServers": "Управлять серверами",
 
   "session.share.popover.title": "Опубликовать в интернете",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -247,6 +247,7 @@ export const dict = {
 
   "dialog.lsp.empty": "LSPs ตรวจจับอัตโนมัติจากประเภทไฟล์",
   "dialog.plugins.empty": "ปลั๊กอินที่กำหนดค่าใน opencode.json",
+  "dialog.formatters.empty": "ไม่มีตัวจัดรูปแบบที่ใช้งานอยู่",
 
   "mcp.status.connected": "เชื่อมต่อแล้ว",
   "mcp.status.failed": "ล้มเหลว",
@@ -458,6 +459,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "ปลั๊กอิน",
+  "status.popover.tab.formatters": "ตัวจัดรูปแบบ",
   "status.popover.action.manageServers": "จัดการเซิร์ฟเวอร์",
 
   "session.share.popover.title": "เผยแพร่บนเว็บ",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -283,6 +283,7 @@ export const dict = {
 
   "dialog.lsp.empty": "已从文件类型自动检测到 LSPs",
   "dialog.plugins.empty": "在 opencode.json 中配置的插件",
+  "dialog.formatters.empty": "没有活动的格式化工具",
 
   "mcp.status.connected": "已连接",
   "mcp.status.failed": "失败",
@@ -491,6 +492,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "插件",
+  "status.popover.tab.formatters": "格式化工具",
   "status.popover.action.manageServers": "管理服务器",
 
   "session.share.popover.title": "发布到网页",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -280,6 +280,7 @@ export const dict = {
 
   "dialog.lsp.empty": "已從檔案類型自動偵測到 LSPs",
   "dialog.plugins.empty": "在 opencode.json 中設定的外掛程式",
+  "dialog.formatters.empty": "沒有活動的格式化工具",
 
   "mcp.status.connected": "已連線",
   "mcp.status.failed": "失敗",
@@ -488,6 +489,7 @@ export const dict = {
   "status.popover.tab.mcp": "MCP",
   "status.popover.tab.lsp": "LSP",
   "status.popover.tab.plugins": "外掛程式",
+  "status.popover.tab.formatters": "格式化工具",
   "status.popover.action.manageServers": "管理伺服器",
 
   "session.share.popover.title": "發佈到網頁",


### PR DESCRIPTION
### What does this PR do?

Adds a Formatters tab to the status popover in the Desktop app (fixes #11528).

The Desktop app was missing visibility into which formatters are active. This PR adds a new tab that displays enabled formatters with a green status indicator, similar to how LSPs and Plugins are shown.


### How did you verify your code works?
Built the app

<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/60097372-604a-4ad4-a677-2ea6efcfc03b" />
