### PR TITLE
Add LLM boundary hooks for request/response

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -283,6 +283,7 @@ export namespace Agent {
     const cfg = await Config.get()
     const defaultModel = input.model ?? (await Provider.defaultModel())
     const model = await Provider.getModel(defaultModel.providerID, defaultModel.modelID)
+    const provider = await Provider.getProvider(defaultModel.providerID)
     const language = await Provider.getLanguage(model)
 
     const system = [PROMPT_GENERATE]
@@ -317,22 +318,33 @@ export namespace Agent {
       }),
     } satisfies Parameters<typeof generateObject>[0]
 
+    const ctx = {
+      model,
+      provider,
+    }
+
     if (defaultModel.providerID === "openai" && (await Auth.get(defaultModel.providerID))?.type === "oauth") {
-      const result = streamObject({
+      const call = {
         ...params,
         providerOptions: ProviderTransform.providerOptions(model, {
           instructions: SystemPrompt.instructions(),
           store: false,
         }),
         onError: () => {},
-      })
+      }
+      await Plugin.trigger("llm.request.before", { ...ctx, type: "stream" }, { params: call })
+      const result = streamObject(call)
       for await (const part of result.fullStream) {
+        await Plugin.trigger("llm.stream.chunk", { ...ctx, type: "stream" }, { part })
         if (part.type === "error") throw part.error
       }
+      await Plugin.trigger("llm.response.after", { ...ctx, type: "stream" }, { result: result.object })
       return result.object
     }
 
+    await Plugin.trigger("llm.request.before", { ...ctx, type: "generate" }, { params })
     const result = await generateObject(params)
+    await Plugin.trigger("llm.response.after", { ...ctx, type: "generate" }, { result: result.object })
     return result.object
   }
 }

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -180,7 +180,17 @@ export namespace LLM {
       })
     }
 
-    return streamText({
+    const ctx = {
+      sessionID: input.sessionID,
+      agent: input.agent,
+      model: input.model,
+      provider,
+      message: input.user,
+      requestID: input.user.id,
+      type: "stream",
+    }
+
+    const call = {
       onError(error) {
         l.error("stream error", {
           error,
@@ -262,7 +272,20 @@ export namespace LLM {
           sessionId: input.sessionID,
         },
       },
-    })
+    }
+
+    await Plugin.trigger("llm.request.before", ctx, { params: call })
+
+    const stream = await streamText(call)
+    const full = stream.fullStream
+    const fullStream = (async function* () {
+      for await (const part of full) {
+        await Plugin.trigger("llm.stream.chunk", ctx, { part })
+        yield part
+      }
+    })()
+
+    return { ...stream, fullStream }
   }
 
   async function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "user">) {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,6 +23,18 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type LlmPhase = "generate" | "stream"
+
+export type LlmContext = {
+  sessionID?: string
+  agent?: unknown
+  model?: Model
+  provider?: unknown
+  message?: UserMessage
+  requestID?: string
+  type: LlmPhase
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -176,6 +188,18 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
+  /**
+   * Last hook before the request is sent to the provider
+   */
+  "llm.request.before"?: (input: LlmContext, output: { params: Record<string, unknown> }) => Promise<void>
+  /**
+   * First hook after a non-stream response is received
+   */
+  "llm.response.after"?: (input: LlmContext, output: { result: unknown }) => Promise<void>
+  /**
+   * Stream chunk hook before opencode processing
+   */
+  "llm.stream.chunk"?: (input: LlmContext, output: { part: unknown }) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },


### PR DESCRIPTION
### What does this PR do?

Adds three plugin hooks at the LLM boundary: `llm.request.before`, `llm.stream.chunk`, and `llm.response.after`.  
They run immediately before a provider request is sent, and immediately after a response chunk/result is received, enabling last‑mile masking and first‑mile unmasking without affecting opencode internal processing.

Changes are minimal and scoped to:
- plugin hook types
- `LLM.stream` (pre‑send + per‑chunk hook)
- `Agent.generate` (streamObject + generateObject hooks)

### How did you verify your code works?

Manual test in my fork with a masking plugin:
- verified masking only happens right before request is sent
- verified unmasking happens before opencode processes streamed chunks
- verified non‑stream responses are unmasked at the boundary