### PR TITLE
fix(ui): Cmd+A works in inline diff comment editor textarea

### DIFF
--- a/packages/ui/src/components/line-comment.tsx
+++ b/packages/ui/src/components/line-comment.tsx
@@ -136,16 +136,15 @@ export const LineCommentEditor = (props: LineCommentEditorProps) => {
           value={split.value}
           onInput={(e) => split.onInput(e.currentTarget.value)}
           onKeyDown={(e) => {
+            e.stopPropagation()
             if (e.key === "Escape") {
               e.preventDefault()
-              e.stopPropagation()
               split.onCancel()
               return
             }
             if (e.key !== "Enter") return
             if (e.shiftKey) return
             e.preventDefault()
-            e.stopPropagation()
             submit()
           }}
         />


### PR DESCRIPTION
https://github.com/user-attachments/assets/8eb662d8-948a-4096-bee3-3e49c0962c83

### What does this PR do?

Fixes #12723. Cmd+A now selects all text in the inline diff comment editor textarea.

### How did you verify your code works?

Focused the inline diff comment editor textarea and confirmed Cmd+A selects all text.