### PR TITLE
feat(core): add plan_exit to non-experimental plan agent

### DIFF
--- a/packages/opencode/src/session/prompt/plan.txt
+++ b/packages/opencode/src/session/prompt/plan.txt
@@ -23,4 +23,16 @@ Ask the user clarifying questions or ask for their opinion when weighing tradeof
 ## Important
 
 The user indicated that they do not want you to execute yet -- you MUST NOT make any edits, run any non-readonly tools (including changing configs or making commits), or otherwise make any changes to the system. This supersedes any other instructions you have received.
+
+---
+
+## Completing planning
+
+Use the question tool to ask clarifying questions as needed while refining your plan.
+
+When your plan is complete and there are no open questions, end your turn by calling the plan_exit tool.
+
+Do not use the question tool to ask "is this plan okay?". Use plan_exit for plan approval.
+
+Your turn should only end by either asking a needed question or calling plan_exit.
 </system-reminder>

--- a/packages/opencode/src/tool/plan-exit.txt
+++ b/packages/opencode/src/tool/plan-exit.txt
@@ -3,7 +3,7 @@ Use this tool when you have completed the planning phase and are ready to exit p
 This tool will ask the user if they want to switch to build agent to start implementing the plan.
 
 Call this tool:
-- After you have written a complete plan to the plan file
+- After you have written a complete plan (to a plan file when applicable)
 - After you have clarified any questions with the user
 - When you are confident the plan is ready for implementation
 

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -22,12 +22,15 @@ export const PlanExitTool = Tool.define("plan_exit", {
   parameters: z.object({}),
   async execute(_params, ctx) {
     const session = await Session.get(ctx.sessionID)
-    const plan = path.relative(Instance.worktree, Session.plan(session))
+    const planRel = path.relative(Instance.worktree, Session.plan(session))
+    const planExists = await Bun.file(Session.plan(session)).exists()
+    const done = planExists ? `Plan at ${planRel}` : "Planning"
+    const approved = planExists ? `The plan at ${planRel}` : "The plan"
     const answers = await Question.ask({
       sessionID: ctx.sessionID,
       questions: [
         {
-          question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
+          question: `${done} is complete. Would you like to switch to the build agent and start implementing?`,
           header: "Build Agent",
           custom: false,
           options: [
@@ -60,7 +63,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
       messageID: userMsg.id,
       sessionID: ctx.sessionID,
       type: "text",
-      text: `The plan at ${plan} has been approved, you can now edit files. Execute the plan`,
+      text: `${approved} has been approved, you can now edit files. Execute the plan.`,
       synthetic: true,
     } satisfies MessageV2.TextPart)
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -114,7 +114,8 @@ export namespace ToolRegistry {
       ApplyPatchTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
-      ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),
+      ...(Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool] : []),
+      ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanEnterTool] : []),
       ...custom,
     ]
   }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -40,6 +40,7 @@ test("build agent has correct default properties", async () => {
       expect(build?.native).toBe(true)
       expect(evalPerm(build, "edit")).toBe("allow")
       expect(evalPerm(build, "bash")).toBe("allow")
+      expect(evalPerm(build, "plan_exit")).toBe("deny")
     },
   })
 })
@@ -53,6 +54,7 @@ test("plan agent denies edits except .opencode/plans/*", async () => {
       expect(plan).toBeDefined()
       // Wildcard is denied
       expect(evalPerm(plan, "edit")).toBe("deny")
+      expect(evalPerm(plan, "plan_exit")).toBe("allow")
       // But specific path is allowed
       expect(PermissionNext.evaluate("edit", ".opencode/plans/foo.md", plan!.permission).action).toBe("allow")
     },

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -6,6 +6,44 @@ import { Instance } from "../../src/project/instance"
 import { ToolRegistry } from "../../src/tool/registry"
 
 describe("tool.registry", () => {
+  test("includes plan_exit on cli", async () => {
+    const client = process.env.OPENCODE_CLIENT
+    process.env.OPENCODE_CLIENT = "cli"
+    await using tmp = await tmpdir()
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).toContain("plan_exit")
+        },
+      })
+    } finally {
+      if (client === undefined) delete process.env.OPENCODE_CLIENT
+      else process.env.OPENCODE_CLIENT = client
+    }
+  })
+
+  test("does not include plan_exit outside cli", async () => {
+    const client = process.env.OPENCODE_CLIENT
+    process.env.OPENCODE_CLIENT = "app"
+    await using tmp = await tmpdir()
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const ids = await ToolRegistry.ids()
+          expect(ids).not.toContain("plan_exit")
+        },
+      })
+    } finally {
+      if (client === undefined) delete process.env.OPENCODE_CLIENT
+      else process.env.OPENCODE_CLIENT = client
+    }
+  })
+
   test("loads tools from .opencode/tool (singular)", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
### What does this PR do?

Enable the `plan_exit` tool in the non-experimental Plan mode.

### How did you verify your code works?

https://github.com/user-attachments/assets/d639b2b9-4f90-4229-9d93-8d6e2e1f7088

