### PR TITLE
fix(opencode): require double Ctrl+C to exit in TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -32,6 +32,7 @@ import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
+import { ExitGuard } from "../../util/exit-guard"
 
 export type PromptProps = {
   sessionID?: string
@@ -74,6 +75,7 @@ export function Prompt(props: PromptProps) {
   const renderer = useRenderer()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+  const [exitPendingAt, setExitPendingAt] = createSignal<number | undefined>()
 
   function promptModelWarning() {
     toast.show({
@@ -843,8 +845,24 @@ export function Prompt(props: PromptProps) {
                 }
                 if (keybind.match("app_exit", e)) {
                   if (store.prompt.input === "") {
+                    const parsed = keybind.parse(e)
+                    const result = ExitGuard.consume({
+                      key: parsed,
+                      pendingAt: exitPendingAt(),
+                      now: Date.now(),
+                    })
+                    if (result.action === "confirm") {
+                      setExitPendingAt(result.pendingAt)
+                      toast.show({
+                        variant: "info",
+                        message: "Press Ctrl+C again to exit",
+                        duration: 1500,
+                      })
+                      e.preventDefault()
+                      return
+                    }
+                    setExitPendingAt(undefined)
                     await exit()
-                    // Don't preventDefault - let textarea potentially handle the event
                     e.preventDefault()
                     return
                   }

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -77,6 +77,7 @@ import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
+import { ExitGuard } from "../../util/exit-guard"
 import { UI } from "@/cli/ui.ts"
 
 addDefaultParsers(parsers.parsers)
@@ -223,6 +224,7 @@ export function Session() {
 
   // Allow exit when in child session (prompt is hidden)
   const exit = useExit()
+  let exitPendingAt: number | undefined
 
   createEffect(() => {
     const title = Locale.truncate(session()?.title ?? "", 50)
@@ -239,6 +241,22 @@ export function Session() {
   useKeyboard((evt) => {
     if (!session()?.parentID) return
     if (keybind.match("app_exit", evt)) {
+      const parsed = keybind.parse(evt)
+      const result = ExitGuard.consume({
+        key: parsed,
+        pendingAt: exitPendingAt,
+        now: Date.now(),
+      })
+      if (result.action === "confirm") {
+        exitPendingAt = result.pendingAt
+        toast.show({
+          variant: "info",
+          message: "Press Ctrl+C again to exit",
+          duration: 1500,
+        })
+        return
+      }
+      exitPendingAt = undefined
       exit()
     }
   })

--- a/packages/opencode/src/cli/cmd/tui/util/exit-guard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/exit-guard.ts
@@ -1,0 +1,33 @@
+import type { Keybind } from "@/util/keybind"
+
+export const WINDOW_MS = 1500
+
+export namespace ExitGuard {
+  export function isCtrlC(info: Keybind.Info): boolean {
+    return info.name === "c" && info.ctrl && !info.meta && !info.shift && !info.super && !info.leader
+  }
+
+  export function consume(input: {
+    key: Keybind.Info
+    pendingAt?: number
+    now: number
+    windowMs?: number
+  }): {
+    action: "confirm" | "exit"
+    pendingAt?: number
+  } {
+    if (!isCtrlC(input.key)) {
+      return { action: "exit" }
+    }
+
+    if (input.pendingAt === undefined) {
+      return { action: "confirm", pendingAt: input.now }
+    }
+
+    if (input.now - input.pendingAt <= (input.windowMs ?? WINDOW_MS)) {
+      return { action: "exit" }
+    }
+
+    return { action: "confirm", pendingAt: input.now }
+  }
+}

--- a/packages/opencode/test/cli/tui/exit-guard.test.ts
+++ b/packages/opencode/test/cli/tui/exit-guard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { ExitGuard, WINDOW_MS } from "../../../src/cli/cmd/tui/util/exit-guard"
+import type { Keybind } from "../../../src/util/keybind"
+
+function key(partial: Partial<Keybind.Info>): Keybind.Info {
+  return {
+    name: "",
+    ctrl: false,
+    meta: false,
+    shift: false,
+    super: false,
+    leader: false,
+    ...partial,
+  }
+}
+
+describe("exit guard", () => {
+  test("identifies exact Ctrl+C", () => {
+    expect(ExitGuard.isCtrlC(key({ name: "c", ctrl: true }))).toBe(true)
+    expect(ExitGuard.isCtrlC(key({ name: "d", ctrl: true }))).toBe(false)
+    expect(ExitGuard.isCtrlC(key({ name: "c", ctrl: true, shift: true }))).toBe(false)
+    expect(ExitGuard.isCtrlC(key({ name: "c", ctrl: true, leader: true }))).toBe(false)
+  })
+
+  test("first Ctrl+C confirms", () => {
+    const result = ExitGuard.consume({ key: key({ name: "c", ctrl: true }), now: 1000 })
+    expect(result).toEqual({ action: "confirm", pendingAt: 1000 })
+  })
+
+  test("second Ctrl+C within window exits", () => {
+    const result = ExitGuard.consume({
+      key: key({ name: "c", ctrl: true }),
+      pendingAt: 1000,
+      now: 1000 + WINDOW_MS,
+    })
+    expect(result).toEqual({ action: "exit" })
+  })
+
+  test("second Ctrl+C after timeout confirms again", () => {
+    const result = ExitGuard.consume({
+      key: key({ name: "c", ctrl: true }),
+      pendingAt: 1000,
+      now: 1000 + WINDOW_MS + 1,
+    })
+    expect(result).toEqual({ action: "confirm", pendingAt: 1000 + WINDOW_MS + 1 })
+  })
+
+  test("non-Ctrl+C exits immediately", () => {
+    const result = ExitGuard.consume({ key: key({ name: "d", ctrl: true }), now: 1000 })
+    expect(result).toEqual({ action: "exit" })
+  })
+
+  test("non-Ctrl+C clears pending confirmation", () => {
+    const result = ExitGuard.consume({
+      key: key({ name: "q", leader: true }),
+      pendingAt: 1000,
+      now: 1100,
+    })
+    expect(result).toEqual({ action: "exit" })
+  })
+})


### PR DESCRIPTION
## Summary
- add a dedicated TUI exit guard for exact `Ctrl+C` that requires a second press within 1.5s
- apply the guard in prompt and child-session keyboard handlers so first `Ctrl+C` shows `Press Ctrl+C again to exit`
- keep other `app_exit` bindings (for example `Ctrl+D` / `<leader>q`) as immediate exits
- add focused unit tests for guard timing and key-matching behavior

## Scope
- Fixes #9041
- Partially addresses #12664 (`Ctrl+C`-triggered behavior)
- The separate "garbling over time" path in #12664 is not resolved in this PR

## Verification
- `bun run --cwd packages/opencode test test/cli/tui/exit-guard.test.ts` (pass)
- `bun run --cwd packages/opencode typecheck` (pass)
- `bun typecheck` (pass)

Refs #12664