### PR TITLE
fix(provider): remove obsolete copilot model enablement instructions

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -816,12 +816,6 @@ export namespace ProviderTransform {
     if (providerID.includes("github-copilot") && error.statusCode === 403) {
       return "Please reauthenticate with the copilot provider to ensure your credentials work properly with OpenCode."
     }
-    if (providerID.includes("github-copilot") && message.includes("The requested model is not supported")) {
-      return (
-        message +
-        "\n\nMake sure the model is enabled in your copilot settings: https://github.com/settings/copilot/features"
-      )
-    }
 
     return message
   }

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -791,8 +791,6 @@ To use your GitHub Copilot subscription with opencode:
 :::note
 Some models might need a [Pro+
 subscription](https://github.com/features/copilot/plans) to use.
-
-Some models need to be manually enabled in your [GitHub Copilot settings](https://docs.github.com/en/copilot/how-tos/use-ai-models/configure-access-to-ai-models#setup-for-individual-use).
 :::
 
 1. Run the `/connect` command and search for GitHub Copilot.


### PR DESCRIPTION
### What does this PR do?

Closes #12737 (created issue for correctly following CONTRIBUTING.md)

Deletes 6 lines of code and 2 lines of docs because Github Copilot deprecated this "enabling models". Now new models are automatically enabled

Sources:
https://github.blog/changelog/2026-02-03-simplified-copilot-model-enablement-experience-for-individual-users/
https://www.reddit.com/r/GithubCopilot/comments/1qwt7lh/claude_opus_46_is_now_available_on_github_copilot/
And in your this don't appear anymore https://github.com/settings/copilot/features

### How did you verify your code works?

For provider changes: 

```bash
cd packages/opencode
bun test test/provider/transform.test.ts
```

But as far as I know there is no tests that cover that specific thing

For docs changed:

```bash
bun i
bun run --cwd packages/web dev
```

Result:
<img width="830" height="268" alt="image" src="https://github.com/user-attachments/assets/88fe1bf3-170b-47bd-89e3-4ba0e31307d3" />

A future improvement could provide a more context-aware error for enterprise users. Now that the error "The requested model is not supported" shouldn't be reachable for individual users

I don't want contributor for this. This is too shallow