### PR TITLE
feat: add permission.ask and prompt.submit plugin hooks

### DIFF
--- a/packages/opencode/src/permission/next.ts
+++ b/packages/opencode/src/permission/next.ts
@@ -12,6 +12,8 @@ import z from "zod"
 
 export namespace PermissionNext {
   const log = Log.create({ service: "permission" })
+  // Lazy import to avoid circular dependency: permission/next → plugin → session → permission/next
+  const plugin = () => import("@/plugin").then((m) => m.Plugin)
 
   function expand(pattern: string): string {
     if (pattern.startsWith("~/")) return os.homedir() + pattern.slice(1)
@@ -138,18 +140,51 @@ export namespace PermissionNext {
           throw new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission)))
         if (rule.action === "ask") {
           const id = input.id ?? Identifier.ascending("permission")
-          return new Promise<void>((resolve, reject) => {
-            const info: Request = {
-              id,
-              ...request,
-            }
+          const info: Request = {
+            id,
+            ...request,
+          }
+          const pending = new Promise<void>((resolve, reject) => {
             s.pending[id] = {
               info,
               resolve,
               reject,
             }
-            Bus.publish(Event.Asked, info)
           })
+          // Trigger plugin hook to let plugins override the decision.
+          // The pending entry is registered synchronously above so that
+          // reply() can find it even if called before the hook resolves.
+          plugin()
+            .then((Plugin) =>
+              Plugin.trigger(
+                "permission.ask",
+                {
+                  permission: request.permission,
+                  pattern,
+                  sessionID: request.sessionID,
+                  metadata: request.metadata,
+                  tool: request.tool,
+                },
+                { status: "ask" as "ask" | "deny" | "allow" },
+              ),
+            )
+            .then((hookResult) => {
+              const entry = s.pending[id]
+              if (!entry) return
+              if (hookResult.status === "allow") {
+                delete s.pending[id]
+                entry.resolve()
+              }
+              if (hookResult.status === "deny") {
+                delete s.pending[id]
+                entry.reject(new DeniedError(ruleset.filter((r) => Wildcard.match(request.permission, r.permission))))
+              }
+            })
+            .catch(() => {
+              // Plugin error - fall through to user prompt (fail-safe)
+            })
+          Bus.publish(Event.Asked, info)
+          return pending
         }
         if (rule.action === "allow") continue
       }
@@ -276,5 +311,10 @@ export namespace PermissionNext {
 
   export async function list() {
     return state().then((x) => Object.values(x.pending).map((x) => x.info))
+  }
+
+  export async function grant(rules: Ruleset) {
+    const s = await state()
+    s.approved.push(...rules)
   }
 }

--- a/packages/opencode/src/server/routes/permission.ts
+++ b/packages/opencode/src/server/routes/permission.ts
@@ -43,6 +43,31 @@ export const PermissionRoutes = lazy(() =>
         return c.json(true)
       },
     )
+    .post(
+      "/grant",
+      describeRoute({
+        summary: "Grant permission rules",
+        description: "Dynamically inject permission rules into the approved ruleset.",
+        operationId: "permission.grant",
+        responses: {
+          200: {
+            description: "Rules granted successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", z.object({ rules: PermissionNext.Ruleset })),
+      async (c) => {
+        const json = c.req.valid("json")
+        await PermissionNext.grant(json.rules)
+        return c.json(true)
+      },
+    )
     .get(
       "/",
       describeRoute({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -153,6 +153,15 @@ export namespace SessionPrompt {
     const message = await createUserMessage(input)
     await Session.touch(input.sessionID)
 
+    // Fire prompt.submit hook for plugins (e.g., permission extraction from user language)
+    const text = input.parts
+      .filter((p): p is typeof p & { type: "text" } => p.type === "text")
+      .map((p) => p.text)
+      .join("\n")
+    if (text.trim()) {
+      await Plugin.trigger("prompt.submit", { sessionID: input.sessionID, text }, {})
+    }
+
     // this is backwards compatibility for allowing `tools` to be specified when
     // prompting
     const permissions: PermissionNext.Ruleset = []

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -176,7 +176,25 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
-  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  /**
+   * Called when a tool needs permission and the ruleset evaluates to "ask".
+   * Plugins can override the status to "allow" or "deny" to skip the user prompt.
+   */
+  "permission.ask"?: (
+    input: {
+      permission: string
+      pattern: string
+      sessionID: string
+      metadata: Record<string, any>
+      tool?: { messageID: string; callID: string }
+    },
+    output: { status: "ask" | "deny" | "allow" },
+  ) => Promise<void>
+  /**
+   * Called when the user submits a prompt, before the LLM processes it.
+   * Plugins can use this to extract permission grants from user language.
+   */
+  "prompt.submit"?: (input: { sessionID: string; text: string }, output: {}) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
     output: { parts: Part[] },


### PR DESCRIPTION
## Summary

Enables plugins to intercept permission decisions and user prompt submissions, unlocking LLM-driven tool policy gates and automated permission management.

## Motivation

OpenCode's current permission system evaluates tool calls against a static ruleset, and when the result is `"ask"`, it always prompts the user. There's no way for a plugin to programmatically make this decision.

This is a problem for users who want to build automated policy gates — for example, using a fast LLM (like Claude Haiku) to evaluate whether a bash command is safe before bothering the user. Claude Code supports this via its `PreToolUse` and `UserPromptSubmit` hooks, but OpenCode's `PermissionNext` system had no equivalent plugin integration point. The legacy `Permission` namespace had a `permission.ask` hook (at `permission/index.ts:134`), but `PermissionNext` — the active system — did not.

Similarly, there's no mechanism for plugins to react when a user submits a prompt, which is needed for extracting implicit permission grants from user language (e.g., "you can force push to any branch").

## Changes

### 1. `permission.ask` plugin hook (`packages/opencode/src/permission/next.ts`)

When `PermissionNext.evaluate()` returns `"ask"`, the new hook fires **before** creating the pending promise and publishing to the bus:

```
evaluate() returns "ask"
  → Plugin.trigger("permission.ask", { permission, pattern, sessionID, metadata, tool }, { status: "ask" })
  → if plugin sets status to "allow" → continue (skip user prompt)
  → if plugin sets status to "deny" → throw DeniedError
  → if status remains "ask" → fall through to existing user prompt behavior
```

This mirrors the pattern from the legacy `Permission` system but with richer context.

### 2. `prompt.submit` plugin hook (`packages/opencode/src/session/prompt.ts`)

Fires after `createUserMessage()` but before the agent loop starts. Extracts text parts from the user's input and passes them to plugins:

```ts
await Plugin.trigger("prompt.submit", { sessionID, text }, {})
```

### 3. `PermissionNext.grant()` (`packages/opencode/src/permission/next.ts`)

Public API for dynamically injecting allow rules into the approved ruleset at runtime. This lets the `prompt.submit` hook's handler add permission rules extracted from user language.

### 4. `POST /permission/grant` route (`packages/opencode/src/server/routes/permission.ts`)

HTTP endpoint exposing `grant()` for plugins that communicate via the server API.

### 5. Updated hook types (`packages/plugin/src/index.ts`)

- `permission.ask` hook now receives richer context: `{ permission, pattern, sessionID, metadata, tool? }`
- New `prompt.submit` hook type: `{ sessionID, text }`

## Example Plugin Usage

```ts
export default async function(input) {
  return {
    "permission.ask": async (info, output) => {
      // Call an LLM to evaluate whether this tool call is safe
      const decision = await evaluateWithLLM(info.permission, info.pattern, info.metadata)
      if (decision === "allow" || decision === "deny") {
        output.status = decision
      }
      // "ask" falls through to the normal user prompt
    },
    "prompt.submit": async (info, output) => {
      // Extract permission grants from user language
      const permissions = await extractPermissions(info.text)
      if (permissions.length > 0) {
        await fetch(`${input.serverUrl}permission/grant`, {
          method: "POST",
          headers: { "Content-Type": "application/json" },
          body: JSON.stringify({ rules: permissions.map(p => ({
            permission: "bash", pattern: `*${p}*`, action: "allow"
          })) }),
        })
      }
    },
  }
}
```

## Design Decisions

- **Plugin hook runs synchronously before the user prompt** — if the plugin says "allow", the user never sees the prompt. This is critical for a smooth experience with automated policy gates.
- **Fail-safe to "ask"** — if no plugin modifies the output, or if the plugin errors, the default behavior is unchanged (user gets prompted).
- **`grant()` is in-memory only** — consistent with the existing `reply("always")` behavior which also only writes to `s.approved` in memory (the TODO at line 223-225 to persist to disk is still pending).
- **No breaking changes** — the `permission.ask` hook type is updated with richer input fields, but the output shape `{ status }` is unchanged. Existing plugins using the old `Permission` type input would need to update, though no known plugins use this hook since it was never wired up in `PermissionNext`.