### PR TITLE
feat(opencode): add backend server selection options for acp mode

### DIFF
--- a/packages/opencode/src/cli/cmd/acp.ts
+++ b/packages/opencode/src/cli/cmd/acp.ts
@@ -6,6 +6,7 @@ import { ACP } from "@/acp/agent"
 import { Server } from "@/server/server"
 import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { Flag } from "@/flag/flag"
 
 const log = Log.create({ service: "acp-command" })
 
@@ -13,21 +14,37 @@ export const AcpCommand = cmd({
   command: "acp",
   describe: "start ACP (Agent Client Protocol) server",
   builder: (yargs) => {
-    return withNetworkOptions(yargs).option("cwd", {
-      describe: "working directory",
-      type: "string",
-      default: process.cwd(),
-    })
+    return withNetworkOptions(yargs)
+      .option("cwd", {
+        describe: "working directory",
+        type: "string",
+        default: process.cwd(),
+      })
+      .option("connect", {
+        describe: "URL of an existing OpenCode server to connect to (can also use OPENCODE_SERVER_URL env var)",
+        type: "string",
+      })
   },
   handler: async (args) => {
     process.env.OPENCODE_CLIENT = "acp"
     await bootstrap(process.cwd(), async () => {
-      const opts = await resolveNetworkOptions(args)
-      const server = Server.listen(opts)
+      // Check for external server URL from CLI flag or environment variable
+      const externalServerUrl = args.connect || Flag.OPENCODE_SERVER_URL
 
-      const sdk = createOpencodeClient({
-        baseUrl: `http://${server.hostname}:${server.port}`,
-      })
+      let serverUrl: string
+      let ownedServer: ReturnType<typeof Server.listen> | null = null
+
+      if (externalServerUrl) {
+        log.info(`Connecting to external OpenCode server at ${externalServerUrl}`)
+        serverUrl = externalServerUrl
+      } else {
+        const opts = await resolveNetworkOptions(args)
+        ownedServer = Server.listen(opts)
+        serverUrl = `http://${ownedServer.hostname}:${ownedServer.port}`
+        log.info(`Started embedded OpenCode server at ${serverUrl}`)
+      }
+
+      const sdk = createOpencodeClient({ baseUrl: serverUrl })
 
       const input = new WritableStream<Uint8Array>({
         write(chunk) {

--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -30,6 +30,7 @@ export namespace Flag {
   export declare const OPENCODE_CLIENT: string
   export const OPENCODE_SERVER_PASSWORD = process.env["OPENCODE_SERVER_PASSWORD"]
   export const OPENCODE_SERVER_USERNAME = process.env["OPENCODE_SERVER_USERNAME"]
+  export const OPENCODE_SERVER_URL = process.env["OPENCODE_SERVER_URL"]
 
   // Experimental
   export const OPENCODE_EXPERIMENTAL = truthy("OPENCODE_EXPERIMENTAL")


### PR DESCRIPTION
### What does this PR do?

Allows app connections to specify a shared server backend for open code.  This means you can have one server process, multiple acp connections.

### How did you verify your code works?

Started server with `opencode serve --port 4097` connected two acp clients to it from separate neovim by specifying `opencode app --connect http://localhost:4097` for the launch lines of the acp clients in CodeCompanion.

Fixes #12853