### PR TITLE
fix(web): use prompt_async endpoint to avoid timeout over VPN/tunnel

### DIFF
--- a/packages/app/e2e/prompt/prompt-async.spec.ts
+++ b/packages/app/e2e/prompt/prompt-async.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "../fixtures"
+import { promptSelector } from "../selectors"
+import { sessionIDFromUrl } from "../actions"
+
+// Regression test for Issue #12453: the synchronous POST /message endpoint holds
+// the connection open while the agent works, causing "Failed to fetch" over
+// VPN/Tailscale. The fix switches to POST /prompt_async which returns immediately.
+test("prompt succeeds when sync message endpoint is unreachable", async ({ page, sdk, gotoSession }) => {
+  test.setTimeout(120_000)
+
+  // Simulate Tailscale/VPN killing the long-lived sync connection
+  await page.route("**/session/*/message", (route) => route.abort("connectionfailed"))
+
+  await gotoSession()
+
+  const token = `E2E_ASYNC_${Date.now()}`
+  await page.locator(promptSelector).click()
+  await page.keyboard.type(`Reply with exactly: ${token}`)
+  await page.keyboard.press("Enter")
+
+  await expect(page).toHaveURL(/\/session\/[^/?#]+/, { timeout: 30_000 })
+  const sessionID = sessionIDFromUrl(page.url())!
+
+  try {
+    // Agent response arrives via SSE despite sync endpoint being dead
+    await expect
+      .poll(
+        async () => {
+          const messages = await sdk.session.messages({ sessionID, limit: 50 }).then((r) => r.data ?? [])
+          return messages
+            .filter((m) => m.info.role === "assistant")
+            .flatMap((m) => m.parts)
+            .filter((p) => p.type === "text")
+            .map((p) => p.text)
+            .join("\n")
+        },
+        { timeout: 90_000 },
+      )
+      .toContain(token)
+  } finally {
+    await sdk.session.delete({ sessionID }).catch(() => undefined)
+  }
+})

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -385,7 +385,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const send = async () => {
       const ok = await waitForWorktree()
       if (!ok) return
-      await client.session.prompt({
+      await client.session.promptAsync({
         sessionID: session.id,
         agent,
         model,


### PR DESCRIPTION
### What does this PR do?

The web UI sends prompts via `POST /session/{id}/message`, which holds the HTTP connection open until the agent finishes. Over Tailscale/VPN, aggressive network stacks kill the idle connection before completion, showing "Failed to send prompt" even though the server received and processed it.

The fix switches to the existing `POST /session/{id}/prompt_async` endpoint which returns 204 immediately. Response data already arrives through the SSE event stream. One-word change in `submit.ts`: `.prompt()` → `.promptAsync()`. Parameters are identical and the return value was unused.

Includes an e2e regression test that blocks the sync endpoint and verifies the prompt still succeeds.

Closes #12453 
Closes #12748  

### How did you verify your code works?

- Reverted the fix, ran the new e2e test — it fails (sync endpoint blocked → "Failed to send prompt" toast)
- Applied the fix, ran the test — it passes (prompt succeeds, agent responds via SSE)
- Ran existing `prompt.spec.ts` — still passes, no regression
- Typecheck passes