### PR TITLE
fix: enable thinking for all reasoning models on alibaba-cn (DashScope)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -643,6 +643,20 @@ export namespace ProviderTransform {
       }
     }
 
+    // Enable thinking for reasoning models on alibaba-cn (DashScope).
+    // DashScope's OpenAI-compatible API requires `enable_thinking: true` in the request body
+    // to return reasoning_content. Without it, models like kimi-k2.5, qwen-plus, qwen3, qwq,
+    // deepseek-r1, etc. never output thinking/reasoning tokens.
+    // Note: kimi-k2-thinking is excluded as it returns reasoning_content by default.
+    if (
+      input.model.providerID === "alibaba-cn" &&
+      input.model.capabilities.reasoning &&
+      input.model.api.npm === "@ai-sdk/openai-compatible" &&
+      !modelId.includes("kimi-k2-thinking")
+    ) {
+      result["enable_thinking"] = true
+    }
+
     if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
       if (!input.model.api.id.includes("gpt-5-pro")) {
         result["reasoningEffort"] = "medium"


### PR DESCRIPTION
## Summary

Fixes all `alibaba-cn` reasoning models (kimi-k2.5, qwen-plus, qwen3, qwq, deepseek-r1, etc.) not producing reasoning/thinking output by adding `enable_thinking: true` to the request body

Closes #12771

## Problem

DashScope's OpenAI-compatible API requires `enable_thinking: true` in the request body for reasoning models to return `reasoning_content`. Without it, the field is either absent or empty and `tokens.reasoning` is always 0.

This affects **all** reasoning-capable models on the `alibaba-cn` provider, not just kimi-k2.5:
- `alibaba-cn/kimi-k2.5`
- `alibaba-cn/qwen-plus`
- `alibaba-cn/qwen-turbo`
- `alibaba-cn/qwen-flash`
- `alibaba-cn/qwen3-*` (8b, 14b, 32b, 235b)
- `alibaba-cn/qwq-plus`, `alibaba-cn/qwq-32b`
- `alibaba-cn/deepseek-r1*`
- `alibaba-cn/qvq-max`
- etc.

The only exception is `alibaba-cn/kimi-k2-thinking`, which returns `reasoning_content` by default without the parameter.

The existing code in `transform.ts` `options()` only handled thinking for:
1. `providerID === "opencode"` (via `chat_template_args.enable_thinking`)
2. `@ai-sdk/anthropic` SDK (via `thinking.type: "enabled"`)

But `alibaba-cn` uses `@ai-sdk/openai-compatible`, so neither path was taken.

## Change

Added a condition in `ProviderTransform.options()` that sets `enable_thinking: true` for all reasoning-capable models on `alibaba-cn` using `@ai-sdk/openai-compatible`, excluding `kimi-k2-thinking` (which works without it).

## Temporary Workaround (until PR merged)

Add this to your `~/.config/opencode/opencode.json`:

```json
{
  "provider": {
    "alibaba-cn": {
      "models": {
        "kimi-k2.5": { "options": { "enable_thinking": true } },
        "qwen-plus": { "options": { "enable_thinking": true } },
        "qwen-turbo": { "options": { "enable_thinking": true } },
        "qwen-flash": { "options": { "enable_thinking": true } },
        "qwen3-8b": { "options": { "enable_thinking": true } },
        "qwen3-14b": { "options": { "enable_thinking": true } },
        "qwen3-32b": { "options": { "enable_thinking": true } },
        "qwen3-235b-a22b": { "options": { "enable_thinking": true } },
        "qwv-plus": { "options": { "enable_thinking": true } },
        "qwq-32b": { "options": { "enable_thinking": true } },
        "qvq-max": { "options": { "enable_thinking": true } },
        "deepseek-r1": { "options": { "enable_thinking": true } },
        "deepseek-r1-0528": { "options": { "enable_thinking": true } },
        "deepseek-r1-distill-llama-8b": { "options": { "enable_thinking": true } },
        "deepseek-r1-distill-llama-70b": { "options": { "enable_thinking": true } },
        "deepseek-r1-distill-qwen-1-5b": { "options": { "enable_thinking": true } },
        "deepseek-r1-distill-qwen-7b": { "options": { "enable_thinking": true } },
        "deepseek-r1-distill-qwen-14b": { "options": { "enable_thinking": true } },
        "deepseek-r1-distill-qwen-32b": { "options": { "enable_thinking": true } },
        "qwen3-next-80b-a3b-thinking": { "options": { "enable_thinking": true } },
        "qwen3-omni-flash": { "options": { "enable_thinking": true } },
        "qwen3-vl-plus": { "options": { "enable_thinking": true } },
        "qwen3-vl-30b-a3b": { "options": { "enable_thinking": true } },
        "qwen3-vl-235b-a22b": { "options": { "enable_thinking": true } }
      }
    }
  }
}
```

Note: `alibaba-cn/kimi-k2-thinking` does NOT need this workaround as it returns reasoning content by default.

## Verified

Tested via raw DashScope API:

| Model | Without `enable_thinking` | With `enable_thinking: true` |
|-------|--------------------------|------------------------------|
| kimi-k2.5 | `reasoning_content: ""` | Has reasoning content |
| qwen-plus | No `reasoning_content` field | Has reasoning content |
| kimi-k2-thinking | Has reasoning content (always) | N/A |

Tested in OpenCode (`opencode run -m alibaba-cn/kimi-k2.5 --format json --thinking`):
- **Before**: `tokens.reasoning: 0`, no `type: "reasoning"` events
- **After**: `tokens.reasoning: 54`, reasoning content visible
