### PR TITLE
fix(opencode): allow experimental plan mode to gather external context before exploring the codebase

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1299,12 +1299,15 @@ You should build your plan incrementally by writing to or editing this file. NOT
 Goal: Gain a comprehensive understanding of the user's request by reading through code and asking them questions. Critical: In this phase you should only use the explore subagent type.
 
 1. Focus on understanding the user's request and the code associated with their request
+   - If the user’s request references external resources and the needed details aren’t already in the prompt, use the appropriate tools to retrieve that information BEFORE exploring the codebase. This ensures your codebase exploration is focused and informed by the full context of the user's request.
+   - If no suitable tool exists, ask a question first.
 
 2. **Launch up to 3 explore agents IN PARALLEL** (single message, multiple tool calls) to efficiently explore the codebase.
    - Use 1 agent when the task is isolated to known files, the user provided specific file paths, or you're making a small targeted change.
    - Use multiple agents when: the scope is uncertain, multiple areas of the codebase are involved, or you need to understand existing patterns before planning.
    - Quality over quantity - 3 agents maximum, but you should try to use the minimum number of agents necessary (usually just 1)
    - If using multiple agents: Provide each agent with a specific search focus or area to explore. Example: One agent searches for existing implementations, another explores related components, a third investigates testing patterns
+   - Provide each agent with any context you gathered above so they can search effectively
 
 3. After exploring the code, use the question tool to clarify ambiguities in the user request up front.
 


### PR DESCRIPTION
### What does this PR do?

Fixes #12037

Please see the issue for a detailed description of the problem.

Tldr, when using experimental plan mode with the GPT-5.x codex models, they seem to follow instructions quite rigorously and refuse to pull additional critical information before launching their explore agents. This leads to an extremely sub-par exploration of the codebase, causing issues with the plan down the line.
I believe this happens due to the `Critical: In this phase you should only use the explore subagent type.` line in the prompt.

The Claude series models don't seem to suffer from this, and are smart enough to pull the relevant info before exploring the codebase.

### How did you verify your code works?

My testing mostly involved rerunning the previously identified problem prompts against an internal codebase to verify the new vs old behavior. I've tested it with other models (Claude), but my main testing focused on the GPT 5.2-codex models since they exhibited the issue most prominently.

I used the command `OPENCODE_EXPERIMENTAL=1 bun dev ~/work/yield-platform` to test the changes locally.

#### Prompt output when using the existing prompt on the `dev` branch

<img width="1728" height="1022" alt="current-experimental-plan-output" src="https://github.com/user-attachments/assets/57302d6b-9d49-4ada-8534-4bb6378a2a00" />

This showcases a behavior of  GPT that I specified in the issue, where it tries to launch the MR retrieval inside an explore task, which fails.

#### Output with the amended prompt

https://github.com/user-attachments/assets/14a6d17d-4ce0-48f7-8040-1610a74fd128

#### Output when required tool is not available

https://github.com/user-attachments/assets/564200c8-0e38-4991-82c4-1943266d3b8e

