### PR TITLE
feat(desktop): persist currentSidecarUrl in state when isSidecar prop is true

### DIFF
--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -105,12 +105,11 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
         // Add the new sidecar url
         if (props.isSidecar && props.defaultUrl) {
           add(props.defaultUrl)
+          setStore("currentSidecarUrl", props.defaultUrl)
         }
 
         setState("active", url)
       })
-
-      console.log(store.list)
     })
 
     const isReady = createMemo(() => ready() && !!state.active)


### PR DESCRIPTION


### What does this PR do?

Simply adds the value for the `currentSidecarUrl` and removes a uneeded log

### How did you verify your code works?
Tested on my local