### PR TITLE
add Cmd+Up/Down keyboard shortcuts to jump to start/end of prompt text

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -884,6 +884,16 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+      if (event.metaKey) {
+        event.preventDefault()
+        const textLength = promptLength(prompt.current())
+        if (event.key === "ArrowUp") {
+          setCursorPosition(editorRef, 0)
+        } else {
+          setCursorPosition(editorRef, textLength)
+        }
+        return
+      }
       if (event.altKey || event.ctrlKey || event.metaKey) return
       const { collapsed } = getCaretState()
       if (!collapsed) return


### PR DESCRIPTION
Users can now press Cmd+Up to jump to the beginning of their prompt and Cmd+Down to jump to the end, matching standard text editing behavior in most macOS applications.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
