### PR TITLE
fix(opencode): expand Error properties in logs for better diagnostics

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -100,10 +100,10 @@ export const TuiThreadCommand = cmd({
     }
     const client = Rpc.client<typeof rpc>(worker)
     process.on("uncaughtException", (e) => {
-      Log.Default.error(e)
+      Log.Default.error("exception", { error: e })
     })
     process.on("unhandledRejection", (e) => {
-      Log.Default.error(e)
+      Log.Default.error("rejection", { error: e })
     })
     process.on("SIGUSR2", async () => {
       await client.call("reload", undefined)

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -21,15 +21,11 @@ await Log.init({
 })
 
 process.on("unhandledRejection", (e) => {
-  Log.Default.error("rejection", {
-    e: e instanceof Error ? e.message : e,
-  })
+  Log.Default.error("rejection", { error: e })
 })
 
 process.on("uncaughtException", (e) => {
-  Log.Default.error("exception", {
-    e: e instanceof Error ? e.message : e,
-  })
+  Log.Default.error("exception", { error: e })
 })
 
 // Subscribe to global events and forward them via RPC

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -28,15 +28,11 @@ import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
 
 process.on("unhandledRejection", (e) => {
-  Log.Default.error("rejection", {
-    e: e instanceof Error ? e.message : e,
-  })
+  Log.Default.error("rejection", { error: e })
 })
 
 process.on("uncaughtException", (e) => {
-  Log.Default.error("exception", {
-    e: e instanceof Error ? e.message : e,
-  })
+  Log.Default.error("exception", { error: e })
 })
 
 const cli = yargs(hideBin(process.argv))

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -212,7 +212,7 @@ export namespace MCP {
   // Helper function to fetch prompts for a specific client
   async function fetchPromptsForClient(clientName: string, client: Client) {
     const prompts = await client.listPrompts().catch((e) => {
-      log.error("failed to get prompts", { clientName, error: e.message })
+      log.error("failed to get prompts", { clientName, error: e })
       return undefined
     })
 
@@ -234,7 +234,7 @@ export namespace MCP {
 
   async function fetchResourcesForClient(clientName: string, client: Client) {
     const resources = await client.listResources().catch((e) => {
-      log.error("failed to get prompts", { clientName, error: e.message })
+      log.error("failed to get resources", { clientName, error: e })
       return undefined
     })
 
@@ -578,7 +578,7 @@ export namespace MCP {
       }
 
       const toolsResult = await client.listTools().catch((e) => {
-        log.error("failed to get tools", { clientName, error: e.message })
+        log.error("failed to get tools", { clientName, error: e })
         const failedStatus = {
           status: "failed" as const,
           error: e instanceof Error ? e.message : String(e),

--- a/packages/opencode/src/util/log.ts
+++ b/packages/opencode/src/util/log.ts
@@ -87,11 +87,14 @@ export namespace Log {
     await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})))
   }
 
-  function formatError(error: Error, depth = 0): string {
-    const result = error.message
-    return error.cause instanceof Error && depth < 10
-      ? result + " Caused by: " + formatError(error.cause, depth + 1)
-      : result
+  function formatError(error: Error): string[] {
+    return Object.getOwnPropertyNames(error).flatMap((k) => {
+      const v = (error as any)[k]
+      if (v == null) return []
+      if (v instanceof Error) return [`${k}=${v.name}: ${v.message}`, ...formatError(v).map((s) => `${k}.${s}`)]
+      if (typeof v === "object") return [`${k}=${JSON.stringify(v)}`]
+      return [`${k}=${v}`]
+    })
   }
 
   let last = Date.now()
@@ -111,12 +114,11 @@ export namespace Log {
         ...tags,
         ...extra,
       })
-        .filter(([_, value]) => value !== undefined && value !== null)
-        .map(([key, value]) => {
-          const prefix = `${key}=`
-          if (value instanceof Error) return prefix + formatError(value)
-          if (typeof value === "object") return prefix + JSON.stringify(value)
-          return prefix + value
+        .flatMap(([key, value]) => {
+          if (value == null) return []
+          if (value instanceof Error) return formatError(value)
+          if (typeof value === "object") return [`${key}=${JSON.stringify(value)}`]
+          return [`${key}=${value}`]
         })
         .join(" ")
       const next = new Date()


### PR DESCRIPTION
Fixes #12808

## What

Error logs previously only printed `e.message`, losing structured context like `providerID`, `modelID`, `url`, `statusCode`, `cause` chain, and stack traces.

## Changes

- `formatError` in `log.ts` now expands all own properties of an Error via `Object.getOwnPropertyNames`, recursing into nested Errors (e.g. `cause`)
- `build` calls `formatError` when a value is an `instanceof Error`, emitting each property as a separate `key=value` pair
- Updated `unhandledRejection`/`uncaughtException` handlers in `index.ts`, `worker.ts`, `thread.ts` to pass the full error object instead of `e.message`
- Updated MCP error logging to pass `e` instead of `e.message`
- Fixed a copy-paste bug: `fetchResourcesForClient` logged "failed to get prompts" instead of "failed to get resources"

## Backward compatible

Callers that still pass `e.message` (a string) work exactly as before. Only callers that pass an Error object get richer output.

## Verification

- `bun run typecheck` passes
- Before: `ERROR ... e=ProviderModelNotFoundError rejection`
- After: `ERROR ... name=ProviderModelNotFoundError message=ProviderModelNotFoundError data={"providerID":"openai","modelID":"gpt-5-turbo"} stack=... rejection`