### PR TITLE
fix(mcp): strip non-standard JSON Schema formats to suppress AJV warnings

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -116,15 +116,56 @@ export namespace MCP {
     })
   }
 
+  // AJV-recognized formats; non-standard ones (e.g. "uint64" from Google APIs) are stripped to suppress warnings
+  const KNOWN_FORMATS = new Set([
+    "date-time",
+    "date",
+    "time",
+    "duration",
+    "email",
+    "idn-email",
+    "hostname",
+    "idn-hostname",
+    "ipv4",
+    "ipv6",
+    "uri",
+    "uri-reference",
+    "iri",
+    "iri-reference",
+    "uri-template",
+    "json-pointer",
+    "relative-json-pointer",
+    "regex",
+    "uuid",
+    "int32",
+    "int64",
+    "float",
+    "double",
+    "byte",
+    "binary",
+    "password",
+  ])
+
+  function stripUnknownFormats(obj: unknown): unknown {
+    if (Array.isArray(obj)) return obj.map(stripUnknownFormats)
+    if (obj === null || typeof obj !== "object") return obj
+    const result: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+      if (k === "format" && typeof v === "string" && !KNOWN_FORMATS.has(v)) continue
+      result[k] = stripUnknownFormats(v)
+    }
+    return result
+  }
+
   // Convert MCP tool definition to AI SDK Tool type
   async function convertMcpTool(mcpTool: MCPToolDef, client: MCPClient, timeout?: number): Promise<Tool> {
     const inputSchema = mcpTool.inputSchema
 
     // Spread first, then override type to ensure it's always "object"
     const schema: JSONSchema7 = {
-      ...(inputSchema as JSONSchema7),
+      ...(stripUnknownFormats(inputSchema) as JSONSchema7),
       type: "object",
-      properties: (inputSchema.properties ?? {}) as JSONSchema7["properties"],
+      properties: (stripUnknownFormats(inputSchema.properties ?? {}) as JSONSchema7["properties"]),
       additionalProperties: false,
     }
 


### PR DESCRIPTION
## Summary

Fixes #8581 — `unknown format "uint64" ignored in schema` warnings that spam the terminal on every startup when MCP servers (e.g. BigQuery) return schemas with non-standard JSON Schema formats.

## Problem

MCP tool schemas from providers like Google BigQuery include `"format": "uint64"`, `"format": "google-datetime"`, etc. These are valid for the provider but not recognized by AJV (JSON Schema validator used by Vercel AI SDK's `jsonSchema()`), causing noisy console warnings on every tool conversion.

**Call chain**: MCP Server → `convertMcpTool()` → `jsonSchema()` (Vercel AI SDK) → AJV v8 → warning

## Solution

Added `stripUnknownFormats()` in `packages/opencode/src/mcp/index.ts` that:
1. Defines a `KNOWN_FORMATS` Set with all standard JSON Schema formats (`date-time`, `email`, `uri`, etc.)
2. Recursively walks the schema tree and removes `format` fields not in the known set
3. Wraps `inputSchema` in `convertMcpTool()` before passing to `jsonSchema()`

This is a **non-breaking** change — it only strips format metadata that AJV cannot validate anyway, preserving all other schema properties.

## Testing

- Typecheck: `tsgo --noEmit` passes clean
- Build: `bun run build --single` succeeds
- Runtime: Patched binary produces zero AJV warnings with BigQuery MCP server

## Related

- Issue: #8581
- Root cause: AJV v8.17.1 warns on unregistered formats when `validateFormats: false` is not set
- Alternative considered: Registering custom formats with AJV — rejected because the format values are arbitrary and provider-dependent