### PR TITLE
Ensure insights template runs opencode stats

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -4,6 +4,7 @@ import { Config } from "../config/config"
 import { Instance } from "../project/instance"
 import { Identifier } from "../id/id"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
+import PROMPT_INSIGHTS from "./template/insights.txt"
 import PROMPT_REVIEW from "./template/review.txt"
 import { MCP } from "../mcp"
 import { Skill } from "../skill"
@@ -53,6 +54,7 @@ export namespace Command {
 
   export const Default = {
     INIT: "init",
+    INSIGHTS: "insights",
     REVIEW: "review",
   } as const
 
@@ -78,6 +80,15 @@ export namespace Command {
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      },
+      [Default.INSIGHTS]: {
+        name: Default.INSIGHTS,
+        description: "generate usage insights and improvement tips",
+        source: "command",
+        get template() {
+          return PROMPT_INSIGHTS
+        },
+        hints: hints(PROMPT_INSIGHTS),
       },
     }
 

--- a/packages/opencode/src/command/template/insights.txt
+++ b/packages/opencode/src/command/template/insights.txt
@@ -1,0 +1,44 @@
+You are an LLM usage coach. Your job is to generate a concise, actionable usage report and tips that help the user get better outcomes from Opencode.
+
+---
+
+Input: $ARGUMENTS
+
+---
+
+## Gather Usage Data
+
+Run Opencode's built-in stats command and include the raw output below. If the user provides arguments, pass them through to stats (e.g. `--days 30 --models 5 --tools 10`).
+
+```
+!`opencode stats $ARGUMENTS`
+```
+
+If the stats command returns no data, explain that there is not enough usage to analyze and suggest trying again after a few sessions.
+
+---
+
+## Analysis Goals
+
+Focus on insights that help the user improve their LLM usage, such as:
+
+- Which models are used the most and whether the mix makes sense for cost vs. quality.
+- How tool usage (bash, mcp, etc.) correlates with cost or output.
+- Patterns in tokens per session or cost per day, and whether the cadence is efficient.
+- Opportunities to compact sessions or split tasks to reduce context.
+- Suggestions for better prompts, including clarity, scoping, and structured requests.
+
+Avoid generic advice. Every recommendation must reference evidence from the stats output.
+
+---
+
+## Output Format
+
+Provide the report in the following sections:
+
+1. **Overview**: 3-5 bullet summary of key metrics and trends.
+2. **Usage Insights**: bullet points that connect stats to concrete observations.
+3. **Recommendations**: prioritized list of 3-7 actionable tips.
+4. **Suggested Experiments**: 2-4 small experiments the user can try next week.
+
+Keep the tone practical and direct.


### PR DESCRIPTION
### What does this PR do?

Make the previously-added insights command actually collect real usage data by invoking the opencode stats tool so reports are evidence-backed rather than purely templated.

Updated the insights prompt template at packages/opencode/src/command/template/insights.txt to run opencode stats $ARGUMENTS inline (using the !backtick`` shell invocation) and include the raw output for analysis.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
