### PR TITLE
fix: honor OPENCODE_INSTALL_DIR environment variable (anomalyco#3097)

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 يحترم سكربت التثبيت ترتيب الاولوية التالي لمسار التثبيت:
 
 1. `$OPENCODE_INSTALL_DIR` - مجلد تثبيت مخصص
-2. `$XDG_BIN_DIR` - مسار متوافق مع مواصفات XDG Base Directory
-3. `$HOME/bin` - مجلد الثنائيات القياسي للمستخدم (ان وجد او امكن انشاؤه)
-4. `$HOME/.opencode/bin` - المسار الافتراضي الاحتياطي
+2. `$HOME/.opencode/bin` - المسار الافتراضي الاحتياطي
 
 ```bash
 # امثلة
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.br.md
+++ b/README.br.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 O script de instalação respeita a seguinte ordem de prioridade para o caminho de instalação:
 
 1. `$OPENCODE_INSTALL_DIR` - Diretório de instalação personalizado
-2. `$XDG_BIN_DIR` - Caminho compatível com a especificação XDG Base Directory
-3. `$HOME/bin` - Diretório binário padrão do usuário (se existir ou puder ser criado)
-4. `$HOME/.opencode/bin` - Fallback padrão
+2. `$HOME/.opencode/bin` - Fallback padrão
 
 ```bash
 # Exemplos
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.bs.md
+++ b/README.bs.md
@@ -82,14 +82,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Instalacijska skripta koristi sljedeći redoslijed prioriteta za putanju instalacije:
 
 1. `$OPENCODE_INSTALL_DIR` - Prilagođeni instalacijski direktorij
-2. `$XDG_BIN_DIR` - Putanja usklađena sa XDG Base Directory specifikacijom
-3. `$HOME/bin` - Standardni korisnički bin direktorij (ako postoji ili se može kreirati)
-4. `$HOME/.opencode/bin` - Podrazumijevana rezervna lokacija
+2. `$HOME/.opencode/bin` - Podrazumijevana rezervna lokacija
 
 ```bash
 # Primjeri
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agenti

--- a/README.da.md
+++ b/README.da.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Installationsscriptet bruger følgende prioriteringsrækkefølge for installationsstien:
 
 1. `$OPENCODE_INSTALL_DIR` - Tilpasset installationsmappe
-2. `$XDG_BIN_DIR` - Sti der følger XDG Base Directory Specification
-3. `$HOME/bin` - Standard bruger-bin-mappe (hvis den findes eller kan oprettes)
-4. `$HOME/.opencode/bin` - Standard fallback
+2. `$HOME/.opencode/bin` - Standard fallback
 
 ```bash
 # Eksempler
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.de.md
+++ b/README.de.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Das Installationsskript beachtet die folgende Prioritätsreihenfolge für den Installationspfad:
 
 1. `$OPENCODE_INSTALL_DIR` - Benutzerdefiniertes Installationsverzeichnis
-2. `$XDG_BIN_DIR` - XDG Base Directory Specification-konformer Pfad
-3. `$HOME/bin` - Standard-Binärverzeichnis des Users (falls vorhanden oder erstellbar)
-4. `$HOME/.opencode/bin` - Standard-Fallback
+2. `$HOME/.opencode/bin` - Standard-Fallback
 
 ```bash
 # Beispiele
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.es.md
+++ b/README.es.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 El script de instalación respeta el siguiente orden de prioridad para la ruta de instalación:
 
 1. `$OPENCODE_INSTALL_DIR` - Directorio de instalación personalizado
-2. `$XDG_BIN_DIR` - Ruta compatible con la especificación XDG Base Directory
-3. `$HOME/bin` - Directorio binario estándar del usuario (si existe o se puede crear)
-4. `$HOME/.opencode/bin` - Alternativa por defecto
+2. `$HOME/.opencode/bin` - Alternativa por defecto
 
 ```bash
 # Ejemplos
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.fr.md
+++ b/README.fr.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Le script d'installation respecte l'ordre de priorité suivant pour le chemin d'installation :
 
 1. `$OPENCODE_INSTALL_DIR` - Répertoire d'installation personnalisé
-2. `$XDG_BIN_DIR` - Chemin conforme à la spécification XDG Base Directory
-3. `$HOME/bin` - Répertoire binaire utilisateur standard (s'il existe ou peut être créé)
-4. `$HOME/.opencode/bin` - Repli par défaut
+2. `$HOME/.opencode/bin` - Repli par défaut
 
 ```bash
 # Exemples
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.it.md
+++ b/README.it.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Lo script di installazione rispetta il seguente ordine di priorità per il percorso di installazione:
 
 1. `$OPENCODE_INSTALL_DIR` – Directory di installazione personalizzata
-2. `$XDG_BIN_DIR` – Percorso conforme alla XDG Base Directory Specification
-3. `$HOME/bin` – Directory binaria standard dell’utente (se esiste o può essere creata)
-4. `$HOME/.opencode/bin` – Fallback predefinito
+2. `$HOME/.opencode/bin` – Fallback predefinito
 
 ```bash
 # Esempi
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agenti

--- a/README.ja.md
+++ b/README.ja.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 インストールスクリプトは、インストール先パスを次の優先順位で決定します。
 
 1. `$OPENCODE_INSTALL_DIR` - カスタムのインストールディレクトリ
-2. `$XDG_BIN_DIR` - XDG Base Directory Specification に準拠したパス
-3. `$HOME/bin` - 標準のユーザー用バイナリディレクトリ（存在する場合、または作成できる場合）
-4. `$HOME/.opencode/bin` - デフォルトのフォールバック
+2. `$HOME/.opencode/bin` - デフォルトのフォールバック
 
 ```bash
 # 例
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.ko.md
+++ b/README.ko.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 설치 스크립트는 설치 경로를 다음 우선순위로 결정합니다.
 
 1. `$OPENCODE_INSTALL_DIR` - 사용자 지정 설치 디렉터리
-2. `$XDG_BIN_DIR` - XDG Base Directory Specification 준수 경로
-3. `$HOME/bin` - 표준 사용자 바이너리 디렉터리 (존재하거나 생성 가능할 경우)
-4. `$HOME/.opencode/bin` - 기본 폴백
+2. `$HOME/.opencode/bin` - 기본 폴백
 
 ```bash
 # 예시
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.md
+++ b/README.md
@@ -82,14 +82,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 The install script respects the following priority order for the installation path:
 
 1. `$OPENCODE_INSTALL_DIR` - Custom installation directory
-2. `$XDG_BIN_DIR` - XDG Base Directory Specification compliant path
-3. `$HOME/bin` - Standard user binary directory (if it exists or can be created)
-4. `$HOME/.opencode/bin` - Default fallback
+2. `$HOME/.opencode/bin` - Default fallback
 
 ```bash
 # Examples
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.no.md
+++ b/README.no.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Installasjonsskriptet bruker følgende prioritet for installasjonsstien:
 
 1. `$OPENCODE_INSTALL_DIR` - Egendefinert installasjonsmappe
-2. `$XDG_BIN_DIR` - Sti som følger XDG Base Directory Specification
-3. `$HOME/bin` - Standard brukerbinar-mappe (hvis den finnes eller kan opprettes)
-4. `$HOME/.opencode/bin` - Standard fallback
+2. `$HOME/.opencode/bin` - Standard fallback
 
 ```bash
 # Eksempler
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.pl.md
+++ b/README.pl.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Skrypt instalacyjny stosuje następujący priorytet wyboru ścieżki instalacji:
 
 1. `$OPENCODE_INSTALL_DIR` - Własny katalog instalacji
-2. `$XDG_BIN_DIR` - Ścieżka zgodna ze specyfikacją XDG Base Directory
-3. `$HOME/bin` - Standardowy katalog binarny użytkownika (jeśli istnieje lub można go utworzyć)
-4. `$HOME/.opencode/bin` - Domyślny fallback
+2. `$HOME/.opencode/bin` - Domyślny fallback
 
 ```bash
 # Przykłady
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.ru.md
+++ b/README.ru.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Скрипт установки выбирает путь установки в следующем порядке приоритета:
 
 1. `$OPENCODE_INSTALL_DIR` - Пользовательский каталог установки
-2. `$XDG_BIN_DIR` - Путь, совместимый со спецификацией XDG Base Directory
-3. `$HOME/bin` - Стандартный каталог пользовательских бинарников (если существует или можно создать)
-4. `$HOME/.opencode/bin` - Fallback по умолчанию
+2. `$HOME/.opencode/bin` - Fallback по умолчанию
 
 ```bash
 # Примеры
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.th.md
+++ b/README.th.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 สคริปต์การติดตั้งจะใช้ลำดับความสำคัญตามเส้นทางการติดตั้ง:
 
 1. `$OPENCODE_INSTALL_DIR` - ไดเรกทอรีการติดตั้งที่กำหนดเอง
-2. `$XDG_BIN_DIR` - เส้นทางที่สอดคล้องกับ XDG Base Directory Specification
-3. `$HOME/bin` - ไดเรกทอรีไบนารีผู้ใช้มาตรฐาน (หากมีอยู่หรือสามารถสร้างได้)
-4. `$HOME/.opencode/bin` - ค่าสำรองเริ่มต้น
+2. `$HOME/.opencode/bin` - ค่าสำรองเริ่มต้น
 
 ```bash
 # ตัวอย่าง
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### เอเจนต์

--- a/README.tr.md
+++ b/README.tr.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 Kurulum betiği (install script), kurulum yolu (installation path) için aşağıdaki öncelik sırasını takip eder:
 
 1. `$OPENCODE_INSTALL_DIR` - Özel kurulum dizini
-2. `$XDG_BIN_DIR` - XDG Base Directory Specification uyumlu yol
-3. `$HOME/bin` - Standart kullanıcı binary dizini (varsa veya oluşturulabiliyorsa)
-4. `$HOME/.opencode/bin` - Varsayılan yedek konum
+2. `$HOME/.opencode/bin` - Varsayılan yedek konum
 
 ```bash
 # Örnekler
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Ajanlar

--- a/README.zh.md
+++ b/README.zh.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 安装脚本按照以下优先级决定安装路径：
 
 1. `$OPENCODE_INSTALL_DIR` - 自定义安装目录
-2. `$XDG_BIN_DIR` - 符合 XDG 基础目录规范的路径
-3. `$HOME/bin` - 如果存在或可创建的用户二进制目录
-4. `$HOME/.opencode/bin` - 默认备用路径
+2. `$HOME/.opencode/bin` - 默认备用路径
 
 ```bash
 # 示例
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/README.zht.md
+++ b/README.zht.md
@@ -81,14 +81,11 @@ scoop bucket add extras; scoop install extras/opencode-desktop
 安裝腳本會依據以下優先順序決定安裝路徑：
 
 1. `$OPENCODE_INSTALL_DIR` - 自定義安裝目錄
-2. `$XDG_BIN_DIR` - 符合 XDG 基礎目錄規範的路徑
-3. `$HOME/bin` - 標準使用者執行檔目錄 (若存在或可建立)
-4. `$HOME/.opencode/bin` - 預設備用路徑
+2. `$HOME/.opencode/bin` - 預設備用路徑
 
 ```bash
 # 範例
 OPENCODE_INSTALL_DIR=/usr/local/bin curl -fsSL https://opencode.ai/install | bash
-XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ```
 
 ### Agents

--- a/install
+++ b/install
@@ -65,7 +65,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-INSTALL_DIR=$HOME/.opencode/bin
+# Determine installation directory
+if [ -n "${OPENCODE_INSTALL_DIR:-}" ]; then
+    INSTALL_DIR="$OPENCODE_INSTALL_DIR"
+else
+    INSTALL_DIR="$HOME/.opencode/bin"
+fi
 mkdir -p "$INSTALL_DIR"
 
 # If --binary is provided, skip all download/detection logic


### PR DESCRIPTION
The option to specify the opencode binary installation directory was first introduced with 01e7dc2d02e931be8dda945d44971c178a1a6a15, which also updated the `README*` files to show this option.

This change was later rolled back with c87a7469a006b789e7235e03f453bdd52464d9b4 but with no explanation, but the `README*` files were not rolled back, which leaves the `README*` and `install` out-of-sync.

This commit adds back the choice to specify the installation directory via the `OPENCODE_INSTALL_DIR` environment variable.

It also updates all `README*` files to reflect what is taken into account by `install`.

I tested the change by running the `install` script to verify the `opencode` executable is installed in the specified directory.