### PR TITLE
fix(tui): use sender color for queued messages

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -17,7 +17,7 @@ import { useRoute, useRouteData } from "@tui/context/route"
 import { useSync } from "@tui/context/sync"
 import { SplitBorder } from "@tui/component/border"
 import { Spinner } from "@tui/component/spinner"
-import { useTheme } from "@tui/context/theme"
+import { selectedForeground, useTheme } from "@tui/context/theme"
 import {
   BoxRenderable,
   ScrollBoxRenderable,
@@ -1152,7 +1152,8 @@ function UserMessage(props: {
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
-  const color = createMemo(() => (queued() ? theme.accent : local.agent.color(props.message.agent)))
+  const color = createMemo(() => local.agent.color(props.message.agent))
+  const queuedFg = createMemo(() => selectedForeground(theme, color()))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 
   const compaction = createMemo(() => props.parts.find((x) => x.type === "compaction"))
@@ -1214,7 +1215,7 @@ function UserMessage(props: {
               }
             >
               <text fg={theme.textMuted}>
-                <span style={{ bg: theme.accent, fg: theme.backgroundPanel, bold: true }}> QUEUED </span>
+                <span style={{ bg: color(), fg: queuedFg(), bold: true }}> QUEUED </span>
               </text>
             </Show>
           </box>


### PR DESCRIPTION
### What does this PR do?
Closes #12831.

Queued user messages were using the global `theme.accent` color, which made them look disconnected from the mode/agent that sent them.
This PR updates queued message styling in the TUI to use the sender color (`local.agent.color(props.message.agent)`) for:
- the left message border
- the `QUEUED` badge background
It also uses `selectedForeground(theme, color())` for the `QUEUED` badge text so contrast stays readable across themes.
This works because it reuses the same sender-color path already used elsewhere in the TUI and relies on the shared foreground contrast helper instead of hardcoded colors.

### How did you verify your code works?
- Ran `bun run typecheck` in `packages/opencode` (passes).
- Manually verified queued messages now keep mode color instead of switching to accent.