### PR TITLE
fix: filter out OAuth-only codex models for API key auth

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -354,7 +354,16 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
       provider: "openai",
       async loader(getAuth, provider) {
         const auth = await getAuth()
-        if (auth.type !== "oauth") return {}
+        if (auth.type !== "oauth") {
+          // Some Codex models are only available via the ChatGPT Codex
+          // endpoint (OAuth) and not on the OpenAI API platform. Remove
+          // them for API key users to prevent 404 errors at runtime.
+          const oauthOnlyModels = ["gpt-5.3-codex"]
+          for (const modelId of oauthOnlyModels) {
+            delete provider.models[modelId]
+          }
+          return {}
+        }
 
         // Filter models to only allowed Codex models for OAuth
         const allowedModels = new Set([


### PR DESCRIPTION
gpt-5.3-codex is only accessible via the ChatGPT Codex endpoint (chatgpt.com/backend-api/codex/responses) which requires OAuth authentication. It is not available on the OpenAI API platform.

When a user authenticates with a standard OpenAI API key via 'opencode auth login', this model appears available but fails with a 404 error at runtime. Remove OAuth-only models from the provider model list for API key users.

Note: gpt-5.2-codex and other codex models that ARE available on the OpenAI API platform are intentionally kept.

### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the pr.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Fixes #12839