### PR TITLE
fix(nix): restore install script in fileset for desktop build

### DIFF
--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -30,6 +30,7 @@ stdenvNoCC.mkDerivation {
         ../bun.lock
         ../package.json
         ../patches
+        ../install # required by desktop build (cli.rs include_str!)
       ]
     );
   };


### PR DESCRIPTION
Fixes regression introduced in #12818.

Closes #12817
Closes #12811

## Summary
- Restores `../install` to the nix fileset in `node_modules.nix`
- The desktop build requires this file as `cli.rs` uses `include_str!("../../../../install")`

## Verification
The error reported in https://github.com/anomalyco/opencode/pull/12818#issuecomment-3872760241:
```
error: couldn't read `src/../../../../install`: No such file or directory (os error 2)
  --> src/cli.rs:56:30
   |
56 | const INSTALL_SCRIPT: &str = include_str!("../../../../install");
```