### PR TITLE
fix: queued message indicator uses sender mode color instead of accent

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1155,7 +1155,7 @@ function UserMessage(props: {
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
   const queued = createMemo(() => props.pending && props.message.id > props.pending)
-  const color = createMemo(() => (queued() ? theme.accent : local.agent.color(props.message.agent)))
+  const color = createMemo(() => local.agent.color(props.message.agent))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
 
   const compaction = createMemo(() => props.parts.find((x) => x.type === "compaction"))
@@ -1217,7 +1217,7 @@ function UserMessage(props: {
               }
             >
               <text fg={theme.textMuted}>
-                <span style={{ bg: theme.accent, fg: theme.backgroundPanel, bold: true }}> QUEUED </span>
+                <span style={{ bg: color(), fg: theme.backgroundPanel, bold: true }}> QUEUED </span>
               </text>
             </Show>
           </box>


### PR DESCRIPTION
- Change left border color to always use sender mode color instead of theme.accent when queued
- Change QUEUED badge background to use sender mode color instead of theme.accent
- This ensures queued messages maintain visual identity with their sender context

Fixes #12831
