### PR TITLE
add braintrust trace-opencode plugin to ecosystem list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [@braintrust/trace-opencode](https://github.com/braintrustdata/braintrust-opencode-plugin)                | Automatically trace OpenCode conversations to [Braintrust](https://www.braintrust.dev/) for observability                        |
 
 ---
 


### PR DESCRIPTION
Hi, I'm the developer of the braintrust trace-opencode plugin. I was wondering if this plugin could be listed on your ecosystem page?

https://opencode.ai/docs/ecosystem/

https://github.com/braintrustdata/braintrust-opencode-plugin