### PR TITLE
fix(opencode): ACP File write should create the file if it doesn't exist

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -227,8 +227,8 @@ export namespace ACP {
                 const metadata = permission.metadata || {}
                 const filepath = typeof metadata["filepath"] === "string" ? metadata["filepath"] : ""
                 const diff = typeof metadata["diff"] === "string" ? metadata["diff"] : ""
-
-                const content = await Bun.file(filepath).text()
+                const file = Bun.file(filepath)
+                const content = await file.exists() ? await file.text() : ""
                 const newContent = getNewContent(content, diff)
 
                 if (newContent) {


### PR DESCRIPTION
Fixes #12850 

### What does this PR do?

File creation through the ACP interface was not working, as it tried to read the file before writing it, even if it didn't exist

Bun.file() can be constructed on a file that doesn't exist, but reading the file will throw a NOENT error.

Now, we only read the file if it exists, setting content to emptystring otherwise.

### How did you verify your code works?

Ran ACP through CodeCompanion.nvim, and had it create a file.