### PR TITLE
fix(server): exempt /global/health from auth middleware

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -80,6 +80,7 @@ export namespace Server {
         .use((c, next) => {
           const password = Flag.OPENCODE_SERVER_PASSWORD
           if (!password) return next()
+          if (c.req.path === "/global/health") return next()
           const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
           return basicAuth({ username, password })(c, next)
         })


### PR DESCRIPTION
## Summary

- When `OPENCODE_SERVER_PASSWORD` is set, the Basic Auth middleware was applied to all routes, including `/global/health`. Health check endpoints should be publicly accessible so monitoring tools and load balancers can verify the server is running without needing credentials.
- Added a path check in the auth middleware to skip authentication for `/global/health`.

Fixes #12805

## Test plan

- [ ] Start server with `OPENCODE_SERVER_PASSWORD` set
- [ ] Verify `GET /global/health` returns 200 without credentials
- [ ] Verify other endpoints still require Basic Auth when `OPENCODE_SERVER_PASSWORD` is set
- [ ] Verify all endpoints work normally when `OPENCODE_SERVER_PASSWORD` is not set