### PR TITLE
fix: handle file stream event in session processor

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -331,9 +331,8 @@ export namespace SessionProcessor {
                     messageID: input.assistantMessage.id,
                     sessionID: input.assistantMessage.sessionID,
                     type: "file",
-                    mime: value.mediaType,
-                    url: value.url,
-                    filename: value.filename,
+                    mime: value.file.mediaType,
+                    url: `data:${value.file.mediaType};base64,${value.file.base64}`,
                   })
                   break
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -325,6 +325,18 @@ export namespace SessionProcessor {
                   currentText = undefined
                   break
 
+                case "file":
+                  await Session.updatePart({
+                    id: Identifier.ascending("part"),
+                    messageID: input.assistantMessage.id,
+                    sessionID: input.assistantMessage.sessionID,
+                    type: "file",
+                    mime: value.mediaType,
+                    url: value.url,
+                    filename: value.filename,
+                  })
+                  break
+
                 case "finish":
                   break
 


### PR DESCRIPTION
## Summary
- The stream processor in `processor.ts` handles many Vercel AI SDK event types but the `"file"` event fell through to the `default` case and was silently discarded
- Added a `case "file"` handler that creates a `MessageV2.FilePart` from the stream event's `mediaType`, `url`, and `filename` properties and persists it via `Session.updatePart`
- This allows model-generated images (and other file outputs) to be captured and displayed instead of being dropped

Fixes #12859

## Test plan
- [ ] Verify that a model capable of generating images (e.g., GPT-4o with image generation) now has its output images stored as `FilePart` entries in the session
- [ ] Confirm existing stream event handling (text, reasoning, tool calls, etc.) is unaffected
- [ ] Check that the `FilePart` appears in the message parts and is rendered correctly in the UI