### PR TITLE
fix(session): avoid retry doom loop on context overflow

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -772,9 +772,34 @@ export namespace MessageV2 {
             metadata: parsed.metadata,
           },
           { cause: e },
-        ).toObject()
+          ).toObject()
       case e instanceof Error:
-        return new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
+        return iife(() => {
+          // Some providers (and some SDK wrappers) throw `Error` where `message` is a JSON-encoded stream error.
+          // Try to parse it so we can correctly classify context overflow and avoid retry doom loops.
+          const parsed = ProviderError.parseStreamError(e.message)
+          if (parsed) {
+            if (parsed.type === "context_overflow") {
+              return new MessageV2.ContextOverflowError(
+                {
+                  message: parsed.message,
+                  responseBody: parsed.responseBody,
+                },
+                { cause: e },
+              ).toObject()
+            }
+            return new MessageV2.APIError(
+              {
+                message: parsed.message,
+                isRetryable: parsed.isRetryable,
+                responseBody: parsed.responseBody,
+              },
+              { cause: e },
+            ).toObject()
+          }
+
+          return new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
+        })
       default:
         try {
           const parsed = ProviderError.parseStreamError(e)

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -342,25 +342,41 @@ export namespace SessionProcessor {
               stack: JSON.stringify(e.stack),
             })
             const error = MessageV2.fromError(e, { providerID: input.model.providerID })
-            const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
-              attempt++
-              const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
-              SessionStatus.set(input.sessionID, {
-                type: "retry",
-                attempt,
-                message: retry,
-                next: Date.now() + delay,
+
+            if (MessageV2.ContextOverflowError.isInstance(error)) {
+              // For context overflow, prefer compaction over retries.
+              // But if the compaction agent itself overflows, surface the error instead of looping.
+              if (streamInput.agent.name !== "compaction") {
+                needsCompaction = true
+              } else {
+                input.assistantMessage.error = error
+                Bus.publish(Session.Event.Error, {
+                  sessionID: input.assistantMessage.sessionID,
+                  error: input.assistantMessage.error,
+                })
+              }
+              SessionStatus.set(input.sessionID, { type: "idle" })
+            } else {
+              const retry = SessionRetry.retryable(error)
+              if (retry !== undefined) {
+                attempt++
+                const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
+                SessionStatus.set(input.sessionID, {
+                  type: "retry",
+                  attempt,
+                  message: retry,
+                  next: Date.now() + delay,
+                })
+                await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                continue
+              }
+              input.assistantMessage.error = error
+              Bus.publish(Session.Event.Error, {
+                sessionID: input.assistantMessage.sessionID,
+                error: input.assistantMessage.error,
               })
-              await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              SessionStatus.set(input.sessionID, { type: "idle" })
             }
-            input.assistantMessage.error = error
-            Bus.publish(Session.Event.Error, {
-              sessionID: input.assistantMessage.sessionID,
-              error: input.assistantMessage.error,
-            })
-            SessionStatus.set(input.sessionID, { type: "idle" })
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -83,6 +83,16 @@ export namespace SessionRetry {
       if (!json || typeof json !== "object") return undefined
       const code = typeof json.code === "string" ? json.code : ""
 
+      // Some providers surface context overflow as a JSON error string (instead of a typed ContextOverflowError).
+      // Do not retry in that case.
+      if ((json as Record<string, unknown>).type === "error") {
+        const err = (json as Record<string, unknown>).error
+        if (typeof err === "object" && err !== null) {
+          const ecode = (err as Record<string, unknown>).code
+          if (typeof ecode === "string" && ecode.includes("context_length_exceeded")) return undefined
+        }
+      }
+
       if (json.type === "error" && json.error?.type === "too_many_requests") {
         return "Too Many Requests"
       }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -805,6 +805,25 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("serializes context_length_exceeded when wrapped in Error message", () => {
+    const input = {
+      type: "error",
+      error: {
+        code: "context_length_exceeded",
+      },
+    }
+    const err = new Error(JSON.stringify(input))
+    const result = MessageV2.fromError(err, { providerID: "test" })
+
+    expect(result).toStrictEqual({
+      name: "ContextOverflowError",
+      data: {
+        message: "Input exceeds context window of this model",
+        responseBody: JSON.stringify(input),
+      },
+    })
+  })
+
   test("serializes response error codes", () => {
     const cases = [
       {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -92,6 +92,11 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error)).toBe("Too Many Requests")
   })
 
+  test("does not retry context_length_exceeded json messages", () => {
+    const error = wrap(JSON.stringify({ type: "error", error: { code: "context_length_exceeded" } }))
+    expect(SessionRetry.retryable(error)).toBeUndefined()
+  })
+
   test("maps overloaded provider codes", () => {
     const error = wrap(JSON.stringify({ code: "resource_exhausted" }))
     expect(SessionRetry.retryable(error)).toBe("Provider is overloaded")


### PR DESCRIPTION
### What does this PR do?


<img width="1796" height="976" alt="Screenshot 2026-02-08 at 8 47 04 AM" src="https://github.com/user-attachments/assets/1005c8a6-3c9e-4a81-b301-3a422f261fa5" />


Fixes a retry-doom-loop where context overflow errors (e.g. OpenAI `context_length_exceeded`) can be delivered as JSON in `Error.message`, get misclassified, and then be retried indefinitely instead of triggering compaction.

This has been hitting me on GPT-5.3 Codex via the ChatGPT Pro provider. The UI context meter can be misleading here because GPT-5.3 Codex has separate limits (context 400k, input 272k), so you can be ~68% of context while effectively at the input ceiling.

All this to say I was a bit skpetical of the AI fix that seemed to think that this was just a mistake in interpreting the error message and triggering the compact flow correctly.
Neither the less this has been running pretty stable for me and I hope you guys can validate if this seems like the right approach to the problem or if I'm just patching a weird symptom.

Changes:
- Parse stream-style JSON errors even when wrapped in `Error.message` so `context_length_exceeded` becomes `ContextOverflowError`
- Treat JSON error strings containing `context_length_exceeded` as non-retryable
- Prefer compaction over retry when we hit `ContextOverflowError` (and avoid looping if the compaction agent itself overflows)

Most likely related to #8089

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/retry.test.ts test/session/message-v2.test.ts`
- Built a local `opencode` binary and used it as my daily driver for a bit