### PR TITLE
fix: add signal handlers to prevent orphaned processes

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -26,6 +26,7 @@ import { EOL } from "os"
 import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
+import { registerSignalHandlers } from "./signal"
 
 process.on("unhandledRejection", (e) => {
   Log.Default.error("rejection", {
@@ -38,6 +39,8 @@ process.on("uncaughtException", (e) => {
     e: e instanceof Error ? e.message : e,
   })
 })
+
+registerSignalHandlers()
 
 const cli = yargs(hideBin(process.argv))
   .parserConfiguration({ "populate--": true })

--- a/packages/opencode/src/signal.ts
+++ b/packages/opencode/src/signal.ts
@@ -1,0 +1,45 @@
+import { Instance } from "./project/instance"
+import { Log } from "./util/log"
+
+const SHUTDOWN_TIMEOUT_MS = 5000
+
+const SIGNAL_EXIT_CODES: Record<string, number> = {
+  SIGTERM: 128 + 15,
+  SIGINT: 128 + 2,
+  SIGHUP: 128 + 1,
+}
+
+let shuttingDown = false
+
+async function gracefulShutdown(signal: string) {
+  if (shuttingDown) return
+  shuttingDown = true
+
+  const log = Log.create({ service: "signal" })
+  log.info("received signal, shutting down gracefully", { signal })
+
+  const timeout = setTimeout(() => {
+    log.warn("shutdown timeout, forcing exit", {
+      timeoutMs: SHUTDOWN_TIMEOUT_MS,
+      signal,
+    })
+    process.exit(SIGNAL_EXIT_CODES[signal] ?? 1)
+  }, SHUTDOWN_TIMEOUT_MS)
+
+  try {
+    await Instance.disposeAll()
+  } catch (error) {
+    log.error("error during shutdown", { error })
+  } finally {
+    clearTimeout(timeout)
+    process.exit(SIGNAL_EXIT_CODES[signal] ?? 0)
+  }
+}
+
+export function registerSignalHandlers() {
+  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(signal, () => {
+      void gracefulShutdown(signal)
+    })
+  }
+}

--- a/packages/opencode/src/signal.ts
+++ b/packages/opencode/src/signal.ts
@@ -7,6 +7,7 @@ const SIGNAL_EXIT_CODES: Record<string, number> = {
   SIGTERM: 128 + 15,
   SIGINT: 128 + 2,
   SIGHUP: 128 + 1,
+  SIGQUIT: 128 + 3,
 }
 
 let shuttingDown = false
@@ -25,6 +26,7 @@ async function gracefulShutdown(signal: string) {
     })
     process.exit(SIGNAL_EXIT_CODES[signal] ?? 1)
   }, SHUTDOWN_TIMEOUT_MS)
+  timeout.unref()
 
   try {
     await Instance.disposeAll()
@@ -37,7 +39,7 @@ async function gracefulShutdown(signal: string) {
 }
 
 export function registerSignalHandlers() {
-  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+  for (const signal of ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"]) {
     process.on(signal, () => {
       void gracefulShutdown(signal)
     })


### PR DESCRIPTION
## Summary
- Add global signal handlers (SIGTERM, SIGINT, SIGHUP) for graceful shutdown
- Calls `Instance.disposeAll()` to clean up LSP servers, MCP clients, PTY sessions, workers
- Uses 5-second timeout before force exit
- Uses standard Unix exit codes (128 + signal number)

## Fixes
- Fixes #11527 - OpenCode leaves an orphaned process when killed
- Fixes #12767 - Missing SIGHUP handler causes orphaned process accumulation
- Fixes #10563 - Orphaned processes when terminal closes without explicit exit