### PR TITLE
feat(app): add Cmd+[/] keybinds for session history navigation

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -68,12 +68,14 @@ export function Titlebar() {
       id: "common.goBack",
       title: language.t("common.goBack"),
       category: language.t("command.category.view"),
+      keybind: "mod+[",
       onSelect: back,
     },
     {
       id: "common.goForward",
       title: language.t("common.goForward"),
       category: language.t("command.category.view"),
+      keybind: "mod+]",
       onSelect: forward,
     },
   ])

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -208,8 +208,8 @@ export const dict = {
   "model.tooltip.context": "Context limit {{limit}}",
 
   "common.search.placeholder": "Search",
-  "common.goBack": "Back",
-  "common.goForward": "Forward",
+  "common.goBack": "Navigate back",
+  "common.goForward": "Navigate forward",
   "common.loading": "Loading",
   "common.loading.ellipsis": "...",
   "common.cancel": "Cancel",


### PR DESCRIPTION
Closes #12881

### What does this PR do?

Adds Cmd+[ / Cmd+] keybinds to the existing `common.goBack` / `common.goForward` commands for browser-style session history navigation. Renames them to "Navigate back/forward" to distinguish from "Previous/Next session" which navigates by list order.

### How did you verify your code works?

Tested in the Tauri desktop app in dev mode.