### PR TITLE
fix(tui): dismiss dialogs with ctrl+c

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog.tsx
@@ -57,7 +57,7 @@ function init() {
   })
 
   useKeyboard((evt) => {
-    if (evt.name === "escape" && store.stack.length > 0) {
+    if ((evt.name === "escape" || (evt.ctrl && evt.name === "c")) && store.stack.length > 0) {
       const current = store.stack.at(-1)!
       current.onClose?.()
       setStore("stack", store.stack.slice(0, -1))


### PR DESCRIPTION
Ctrl+C now dismisses dialogs, same as Escape. Both are standard TUI conventions.

One-line change in the existing `useKeyboard` handler in `dialog.tsx`.

To verify: open any dialog (e.g. command palette), press Ctrl+C — it dismisses.

Fixes #12883