### PR TITLE
fix: handle missing session files gracefully on startup

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -15,6 +15,7 @@ import { Snapshot } from "@/snapshot"
 import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { errors } from "../error"
+import { Storage } from "../../storage/storage"
 import { lazy } from "../../util/lazy"
 
 const log = Log.create({ service: "server" })
@@ -117,8 +118,15 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
         log.info("SEARCH", { url: c.req.url })
-        const session = await Session.get(sessionID)
-        return c.json(session)
+        try {
+          const session = await Session.get(sessionID)
+          return c.json(session)
+        } catch (e) {
+          if (e instanceof Storage.NotFoundError) {
+            return c.json(e.toObject(), { status: 404 })
+          }
+          throw e
+        }
       },
     )
     .get(

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -60,9 +60,11 @@ export namespace Server {
       // TODO: Break server.ts into smaller route files to fix type inference
       app
         .onError((err, c) => {
-          log.error("failed", {
-            error: err,
-          })
+          if (err instanceof Storage.NotFoundError) {
+            log.warn("not found", { error: err })
+          } else {
+            log.error("failed", { error: err })
+          }
           if (err instanceof NamedError) {
             let status: ContentfulStatusCode
             if (err instanceof Storage.NotFoundError) status = 404

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -678,7 +678,8 @@ export namespace MessageV2 {
   export const parts = fn(Identifier.schema("message"), async (messageID) => {
     const result = [] as MessageV2.Part[]
     for (const item of await Storage.list(["part", messageID])) {
-      const read = await Storage.read<MessageV2.Part>(item)
+      const read = await Storage.read<MessageV2.Part>(item).catch(() => undefined)
+      if (!read) continue
       result.push(read)
     }
     result.sort((a, b) => (a.id > b.id ? 1 : -1))

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -208,7 +208,7 @@ export namespace Storage {
     })
   }
 
-  const glob = new Bun.Glob("**/*")
+  const glob = new Bun.Glob("**/*.json")
   export async function list(prefix: string[]) {
     const dir = await state().then((x) => x.dir)
     try {


### PR DESCRIPTION
## Problem

When launching `opencode-desktop`, the app throws `NotFoundError` to stderr for session JSON files that no longer exist on disk:

```
NotFoundError: NotFoundError
 data: {
  message: "Resource not found: ~/.local/share/opencode/storage/session/global/ses_*.json",
}
      at <anonymous> (src/storage/storage.ts:205:15)
```

This happens because the frontend tries to restore previously active sessions (via `GET /session/:sessionID`) that have since been deleted or cleaned up. The error propagates through the Hono error handler and gets printed to stderr, making it look like a crash.

## Root Cause

1. The frontend persists session references (URLs, active session state) across restarts
2. When session files are deleted/cleaned up between runs, `Session.get()` throws `NotFoundError`
3. The global `onError` handler logs this at `error` level and Bun displays the full stack trace to stderr
4. `Storage.list()` uses a broad `**/*` glob that could match non-JSON files (lock files, temp files), creating phantom entries

## Changes

### `packages/opencode/src/server/routes/session.ts`
- Catch `NotFoundError` in `GET /session/:sessionID` and return a clean 404 response directly, bypassing the global error handler

### `packages/opencode/src/server/server.ts`
- Downgrade `NotFoundError` from `log.error` to `log.warn` in the global `onError` handler — 404s are expected operational behavior, not application errors

### `packages/opencode/src/storage/storage.ts`
- Narrow `Storage.list()` glob from `**/*` to `**/*.json` to prevent listing non-JSON files (lock files, temp files, etc.) as storage entries

### `packages/opencode/src/session/message-v2.ts`
- Add defensive `.catch()` in `MessageV2.parts()` to skip missing part files instead of failing the entire message load (consistent with the pattern used in `Session.list()` and `Session.children()`)

## Testing

- All 903 existing tests pass
- Full typecheck passes across all 12 packages

Closes #12889