### PR TITLE
fix: use absolute paths for sidebar session navigation

### DIFF
--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -144,7 +144,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
 
   const item = (
     <A
-      href={`${props.slug}/session/${props.session.id}`}
+      href={`/${props.slug}/session/${props.session.id}`}
       class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 ${props.dense ? "py-0.5" : "py-1"}`}
       onPointerEnter={scheduleHoverPrefetch}
       onPointerLeave={cancelHoverPrefetch}
@@ -285,7 +285,7 @@ export const NewSessionItem = (props: {
   const tooltip = () => props.mobile || !props.sidebarExpanded()
   const item = (
     <A
-      href={`${props.slug}/session`}
+      href={`/${props.slug}/session`}
       end
       class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none ${props.dense ? "py-0.5" : "py-1"}`}
       onClick={() => {


### PR DESCRIPTION
## Problem

Sidebar session links use relative paths (`${slug}/session/${id}`) instead of absolute paths (`/${slug}/session/${id}`). When the SolidJS router resolves these relative paths from certain route contexts (e.g., the root `/`), it constructs invalid double-slash paths like `//session/ses_xxx`, causing:

```
Uncaught (in promise) Error: Path '//session/ses_3bce84db7ffe2FH9YBwWwq0ERS' is not a routable path
```

This prevents the first message from being sent in newly created sessions.

## Root Cause

In `sidebar-items.tsx`, both `SessionItem` (line 147) and `NewSessionItem` (line 288) construct hrefs without a leading `/`:

```tsx
// SessionItem
href={`${props.slug}/session/${props.session.id}`}

// NewSessionItem  
href={`${props.slug}/session`}
```

Every other navigation call in the codebase already uses the correct absolute path pattern:

| File | Pattern |
|------|---------|
| `layout.tsx:358` | `` `/${base64Encode(directory)}/session/${props.sessionID}` `` |
| `layout.tsx:1105` | `` `/${base64Encode(session.directory)}/session/${session.id}` `` |
| `notification.tsx:120` | `` `/${base64Encode(directory)}/session/${sessionID}` `` |
| `submit.ts:200` | `` `/${base64Encode(sessionDirectory)}/session/${session.id}` `` |
| `dialog-fork.tsx:73` | `` `/${base64Encode(sdk.directory)}/session/${forked.data.id}` `` |

## Fix

Add the missing leading `/` to both href constructions in `sidebar-items.tsx`.

## Verification

- TypeScript: all 12 workspace packages pass
- Tests: 902 pass, 1 skip, 1 pre-existing timeout failure (unrelated `installs dependencies` test)

Fixes #12840