### PR TITLE
fix: guard Intl.NumberFormat against non-finite values in TUI

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -44,7 +44,7 @@ export function Header() {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
-    }).format(total)
+    }).format(Number.isFinite(total) ? total : 0)
   })
 
   const context = createMemo(() => {

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -45,7 +45,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
-    }).format(total)
+    }).format(Number.isFinite(total) ? total : 0)
   })
 
   const context = createMemo(() => {


### PR DESCRIPTION
## Problem

The TUI crashes with a fatal error when `Intl.NumberFormat.format()` receives `NaN` or `Infinity`:

```
opentui: fatal: TypeError: Failed to format a number.
    at Intl.NumberFormat.format
    at header.tsx:72
```

Bun uses JavaScriptCore, which throws on non-finite values passed to `Intl.NumberFormat.format()` — unlike V8 which returns `"NaN"`.

## Root Cause

Both `header.tsx` and `sidebar.tsx` sum assistant message costs and pass the result directly to `Intl.NumberFormat.format()` without validating the total:

```typescript
const total = pipe(messages(), sumBy((x) => (x.role === "assistant" ? x.cost : 0)))
return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(total)
//                                                                                   ^^^^^
// Crashes if total is NaN (from any message with NaN cost)
```

If any message has a `NaN` or corrupted `cost` value, `sumBy()` / `reduce()` propagates `NaN` to the formatter, which throws.

## Fix

Apply the same `Number.isFinite()` guard already established in the codebase:

| Existing Pattern | Location |
|---|---|
| `if (!Number.isFinite(value)) return 0` | `session/index.ts:458-461` |
| `Number.isFinite(added) ? added : 0` | `snapshot/index.ts:243-244` |

```typescript
.format(Number.isFinite(total) ? total : 0)
```

Displaying `$0.00` is strictly better than crashing the entire TUI.

## Files Changed

- `packages/opencode/src/cli/cmd/tui/routes/session/header.tsx` — cost memo
- `packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx` — cost memo

## Verification

- TypeScript: all 12 workspace packages pass
- Tests: 902 pass, 1 skip, 1 pre-existing timeout failure (unrelated)

Fixes #12866