### PR TITLE
docs: add opencode-model-announcer to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -31,6 +31,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                       | Track OpenCode usage with Wakatime                                                                |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | Clean up markdown tables produced by LLMs                                                         |
+| [opencode-model-announcer](https://github.com/ramarivera/opencode-model-announcer)                         | Inject a synthetic model identity announcement into chat context                                  |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -31,7 +31,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                            | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations    |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                       | Track OpenCode usage with Wakatime                                                                |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | Clean up markdown tables produced by LLMs                                                         |
-| [opencode-model-announcer](https://github.com/ramarivera/opencode-model-announcer)                         | Inject a synthetic model identity announcement into chat context                                  |
+| [opencode-model-announcer](https://github.com/ramarivera/opencode-model-announcer)                        | Inject a synthetic model identity announcement into chat context                                  |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |


### PR DESCRIPTION
### What does this PR do?
Adds `opencode-model-announcer` to the Ecosystem `Plugins` table in the docs.

### How did you verify your code works?
- Confirmed the docs entry is present in `packages/web/src/content/docs/ecosystem.mdx`.
- Verified link + description formatting matches existing table rows.
- Manually checked the live docs rendering after running the docs server.