### PR TITLE
docs: clarify that custom provider IDs must be unique

### DIFF
--- a/packages/web/src/content/docs/it/providers.mdx
+++ b/packages/web/src/content/docs/it/providers.mdx
@@ -1063,7 +1063,7 @@ You can configure opencode to use local models through [llama.cpp's](https://git
 
 In this example:
 
-- `llama.cpp` is the custom provider ID. This can be any string you want.
+- `llama.cpp` is the custom provider ID. This can be any string you want, but each provider ID must be unique.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.
@@ -1126,7 +1126,7 @@ You can configure opencode to use local models through LM Studio.
 
 In this example:
 
-- `lmstudio` is the custom provider ID. This can be any string you want.
+- `lmstudio` is the custom provider ID. This can be any string you want, but each provider ID must be unique.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.
@@ -1247,7 +1247,7 @@ Ollama can automatically configure itself for OpenCode. See the [Ollama integrat
 
 In this example:
 
-- `ollama` is the custom provider ID. This can be any string you want.
+- `ollama` is the custom provider ID. This can be any string you want, but each provider ID must be unique.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1062,7 +1062,7 @@ You can configure opencode to use local models through [llama.cpp's](https://git
 
 In this example:
 
-- `llama.cpp` is the custom provider ID. This can be any string you want.
+- `llama.cpp` is the custom provider ID. This can be any string you want, but each provider ID must be unique.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.
@@ -1125,7 +1125,7 @@ You can configure opencode to use local models through LM Studio.
 
 In this example:
 
-- `lmstudio` is the custom provider ID. This can be any string you want.
+- `lmstudio` is the custom provider ID. This can be any string you want, but each provider ID must be unique.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.
@@ -1246,7 +1246,7 @@ Ollama can automatically configure itself for OpenCode. See the [Ollama integrat
 
 In this example:
 
-- `ollama` is the custom provider ID. This can be any string you want.
+- `ollama` is the custom provider ID. This can be any string you want, but each provider ID must be unique.
 - `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
 - `name` is the display name for the provider in the UI.
 - `options.baseURL` is the endpoint for the local server.


### PR DESCRIPTION
## Summary

Clarifies in the provider documentation that custom provider IDs must be unique within the config.

## Problem

The docs for custom provider configuration (llama.cpp, LM Studio, Ollama) state that the provider ID "can be any string you want" without mentioning uniqueness. This is misleading when users configure multiple instances of the same provider type (e.g., multiple Ollama endpoints on different machines), as duplicate JSON keys silently override each other.

## Changes

Updated 3 occurrences in `providers.mdx` (and the Italian translation) to read:

> This can be any string you want, **but each provider ID must be unique**.

## Related

Fixes #12900