### PR TITLE
fix: clipboard image paste on Linux (WebKitGTK)

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -76,17 +76,23 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
       return
     }
 
-    const plainText = clipboardData.getData("text/plain") ?? ""
-
-    // Desktop: Browser clipboard has no images and no text, try platform's native clipboard for images
-    if (input.readClipboardImage && !plainText) {
-      const file = await input.readClipboardImage()
-      if (file) {
-        await addImageAttachment(file)
-        return
+    // Desktop: try native clipboard for images before falling back to text.
+    // WebKitGTK does not expose clipboard images via DataTransfer (WebKit Bug #218519),
+    // so the browser path above will miss them. Always attempt the native read here
+    // regardless of whether text is also present in the clipboard.
+    if (input.readClipboardImage) {
+      try {
+        const file = await input.readClipboardImage()
+        if (file) {
+          await addImageAttachment(file)
+          return
+        }
+      } catch {
+        // Native clipboard read failed, fall through to text
       }
     }
 
+    const plainText = clipboardData.getData("text/plain") ?? ""
     if (!plainText) return
     input.addPart({ type: "text", content: plainText, start: 0, end: 0 })
   }

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -364,26 +364,40 @@ const createPlatform = (password: Accessor<string | null>): Platform => ({
   },
 
   async readClipboardImage() {
-    const image = await readImage().catch(() => null)
-    if (!image) return null
-    const bytes = await image.rgba().catch(() => null)
-    if (!bytes || bytes.length === 0) return null
-    const size = await image.size().catch(() => null)
-    if (!size) return null
-    const canvas = document.createElement("canvas")
-    canvas.width = size.width
-    canvas.height = size.height
-    const ctx = canvas.getContext("2d")
-    if (!ctx) return null
-    const imageData = ctx.createImageData(size.width, size.height)
-    imageData.data.set(bytes)
-    ctx.putImageData(imageData, 0, 0)
-    return new Promise<File | null>((resolve) => {
-      canvas.toBlob((blob) => {
-        if (!blob) return resolve(null)
-        resolve(new File([blob], `pasted-image-${Date.now()}.png`, { type: "image/png" }))
-      }, "image/png")
+    const image = await readImage().catch((e) => {
+      console.warn("[clipboard] readImage failed:", e)
+      return null
     })
+    if (!image) return null
+    const bytes = await image.rgba().catch((e) => {
+      console.warn("[clipboard] image.rgba() failed:", e)
+      return null
+    })
+    if (!bytes || bytes.length === 0) return null
+    const size = await image.size().catch((e) => {
+      console.warn("[clipboard] image.size() failed:", e)
+      return null
+    })
+    if (!size) return null
+    try {
+      const canvas = document.createElement("canvas")
+      canvas.width = size.width
+      canvas.height = size.height
+      const ctx = canvas.getContext("2d")
+      if (!ctx) return null
+      const imageData = ctx.createImageData(size.width, size.height)
+      imageData.data.set(bytes)
+      ctx.putImageData(imageData, 0, 0)
+      return new Promise<File | null>((resolve) => {
+        canvas.toBlob((blob) => {
+          if (!blob) return resolve(null)
+          resolve(new File([blob], `pasted-image-${Date.now()}.png`, { type: "image/png" }))
+        }, "image/png")
+      })
+    } catch (e) {
+      console.warn("[clipboard] canvas conversion failed:", e)
+      return null
+    }
   },
 })
 

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -113,6 +113,28 @@ export function BasicTool(props: BasicToolProps) {
   )
 }
 
-export function GenericTool(props: { tool: string; hideDetails?: boolean }) {
-  return <BasicTool icon="mcp" trigger={{ title: props.tool }} hideDetails={props.hideDetails} />
+export function GenericTool(props: {
+  tool: string
+  output?: string
+  hideDetails?: boolean
+  defaultOpen?: boolean
+  forceOpen?: boolean
+  locked?: boolean
+}) {
+  return (
+    <BasicTool
+      icon="mcp"
+      trigger={{ title: props.tool }}
+      hideDetails={props.hideDetails}
+      defaultOpen={props.defaultOpen}
+      forceOpen={props.forceOpen}
+      locked={props.locked}
+    >
+      <Show when={props.output}>
+        <div data-component="tool-output" data-scrollable>
+          <pre style={{ "white-space": "pre-wrap", "word-break": "break-word", margin: "0" }}>{props.output}</pre>
+        </div>
+      </Show>
+    </BasicTool>
+  )
 }

--- a/packages/ui/src/components/diff.tsx
+++ b/packages/ui/src/components/diff.tsx
@@ -523,20 +523,36 @@ export function Diff<T>(props: DiffProps<T>) {
     setCurrent(instance)
 
     container.innerHTML = ""
-    instance.render({
-      oldFile: {
-        ...local.before,
-        contents: beforeContents,
-        cacheKey: checksum(beforeContents),
-      },
-      newFile: {
-        ...local.after,
-        contents: afterContents,
-        cacheKey: checksum(afterContents),
-      },
-      lineAnnotations: annotations,
-      containerWrapper: container,
-    })
+    try {
+      instance.render({
+        oldFile: {
+          ...local.before,
+          contents: beforeContents,
+          cacheKey: checksum(beforeContents),
+        },
+        newFile: {
+          ...local.after,
+          contents: afterContents,
+          cacheKey: checksum(afterContents),
+        },
+        lineAnnotations: annotations,
+        containerWrapper: container,
+      })
+    } catch (e) {
+      console.warn("[diff] FileDiff.render() failed:", e)
+      // Render a basic text fallback when the diff library fails
+      const pre = document.createElement("pre")
+      pre.style.whiteSpace = "pre-wrap"
+      pre.style.wordBreak = "break-word"
+      pre.style.margin = "0"
+      pre.style.padding = "8px 12px"
+      pre.style.fontSize = "var(--font-size-small)"
+      pre.style.fontFamily = "var(--font-family-mono)"
+      pre.textContent = beforeContents !== afterContents
+        ? `--- ${local.before?.name ?? "before"}\n+++ ${local.after?.name ?? "after"}\n\nDiff rendering failed. Before: ${beforeContents.length} chars, After: ${afterContents.length} chars`
+        : "No changes"
+      container.appendChild(pre)
+    }
 
     applyScheme()
 

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1,5 +1,6 @@
 import {
   Component,
+  ErrorBoundary,
   createEffect,
   createMemo,
   createSignal,
@@ -1001,35 +1002,48 @@ ToolRegistry.register({
               }}
               onSubtitleClick={handleSubtitleClick}
             >
-              <div
-                ref={autoScroll.scrollRef}
-                onScroll={autoScroll.handleScroll}
-                data-component="tool-output"
-                data-scrollable
+              <Show
+                when={childToolParts().length > 0}
+                fallback={
+                  <Show when={props.output}>
+                    <div data-component="tool-output" data-scrollable>
+                      <pre style={{ "white-space": "pre-wrap", "word-break": "break-word", margin: "0" }}>
+                        {props.output}
+                      </pre>
+                    </div>
+                  </Show>
+                }
               >
-                <div ref={autoScroll.contentRef} data-component="task-tools">
-                  <For each={childToolParts()}>
-                    {(item) => {
-                      const info = createMemo(() => getToolInfo(item.tool, item.state.input))
-                      const subtitle = createMemo(() => {
-                        if (info().subtitle) return info().subtitle
-                        if (item.state.status === "completed" || item.state.status === "running") {
-                          return item.state.title
-                        }
-                      })
-                      return (
-                        <div data-slot="task-tool-item">
-                          <Icon name={info().icon} size="small" />
-                          <span data-slot="task-tool-title">{info().title}</span>
-                          <Show when={subtitle()}>
-                            <span data-slot="task-tool-subtitle">{subtitle()}</span>
-                          </Show>
-                        </div>
-                      )
-                    }}
-                  </For>
+                <div
+                  ref={autoScroll.scrollRef}
+                  onScroll={autoScroll.handleScroll}
+                  data-component="tool-output"
+                  data-scrollable
+                >
+                  <div ref={autoScroll.contentRef} data-component="task-tools">
+                    <For each={childToolParts()}>
+                      {(item) => {
+                        const info = createMemo(() => getToolInfo(item.tool, item.state.input))
+                        const subtitle = createMemo(() => {
+                          if (info().subtitle) return info().subtitle
+                          if (item.state.status === "completed" || item.state.status === "running") {
+                            return item.state.title
+                          }
+                        })
+                        return (
+                          <div data-slot="task-tool-item">
+                            <Icon name={info().icon} size="small" />
+                            <span data-slot="task-tool-title">{info().title}</span>
+                            <Show when={subtitle()}>
+                              <span data-slot="task-tool-subtitle">{subtitle()}</span>
+                            </Show>
+                          </div>
+                        )
+                      }}
+                    </For>
+                  </div>
                 </div>
-              </div>
+              </Show>
             </BasicTool>
           </Match>
         </Switch>
@@ -1093,19 +1107,31 @@ ToolRegistry.register({
           </div>
         }
       >
-        <Show when={props.metadata.filediff?.path || props.input.filePath}>
+        <Show when={props.metadata.filediff?.file || props.input.filePath}>
           <div data-component="edit-content">
-            <Dynamic
-              component={diffComponent}
-              before={{
-                name: props.metadata?.filediff?.file || props.input.filePath,
-                contents: props.metadata?.filediff?.before || props.input.oldString,
-              }}
-              after={{
-                name: props.metadata?.filediff?.file || props.input.filePath,
-                contents: props.metadata?.filediff?.after || props.input.newString,
-              }}
-            />
+            <ErrorBoundary
+              fallback={
+                <div data-component="tool-output" data-scrollable>
+                  <pre style={{ "white-space": "pre-wrap", "word-break": "break-word", margin: "0" }}>
+                    {props.metadata?.filediff?.before !== props.metadata?.filediff?.after
+                      ? `--- ${props.metadata?.filediff?.file || props.input.filePath}\n+++ ${props.metadata?.filediff?.file || props.input.filePath}\n\n${props.input.oldString ? `- ${props.input.oldString}` : ""}${props.input.newString ? `\n+ ${props.input.newString}` : ""}`
+                      : props.output ?? ""}
+                  </pre>
+                </div>
+              }
+            >
+              <Dynamic
+                component={diffComponent}
+                before={{
+                  name: props.metadata?.filediff?.file || props.input.filePath,
+                  contents: props.metadata?.filediff?.before || props.input.oldString,
+                }}
+                after={{
+                  name: props.metadata?.filediff?.file || props.input.filePath,
+                  contents: props.metadata?.filediff?.after || props.input.newString,
+                }}
+              />
+            </ErrorBoundary>
           </div>
         </Show>
         <DiagnosticsDisplay diagnostics={diagnostics()} />


### PR DESCRIPTION
## Summary

- Fix clipboard image paste not working on Linux desktop (WebKitGTK)
- Fix unregistered tools (MCP tools, background tasks) showing no expandable output
- Fix edit tool diff not rendering: correct filediff.path → filediff.file (matches FileDiff schema)
- Add ErrorBoundary + text fallback around diff component for when @pierre/diffs fails
- Add try-catch with console.warn in Diff component render effect
- Fix task agent showing empty content when child session data is unavailable — show output text as fallback
- Add error logging for clipboard read failures to aid debugging

## Details

### Clipboard paste (Linux/WebKitGTK)
WebKitGTK Bug #218519: `clipboardData.items` returns empty for images. The native `readClipboardImage()` fallback was gated behind `!plainText`, preventing it from running when clipboard also contained text (common with screenshot tools). Moved native clipboard attempt before plainText check.

### Edit tool diff
- `<Show when={props.metadata.filediff?.path}>` referenced nonexistent `path` field — FileDiff schema uses `file`. Fixed to `filediff?.file`.
- Added `ErrorBoundary` around the Dynamic diff component with a text-based fallback when the shadow DOM / web worker based diff rendering fails.
- Added try-catch in the Diff component's `createEffect` render loop so `FileDiff.render()` failures don't silently swallow errors.

### Task agent empty state
Task tool always rendered wrapper divs even when `childToolParts()` was empty (child session data not in store). Now conditionally renders: shows tool list when parts exist, falls back to `props.output` text when empty.

### GenericTool output
`GenericTool` (fallback for unregistered tools) was ignoring the `output` prop entirely. Now passes through `output`, `hideDetails`, `defaultOpen`, `forceOpen`, `locked` and renders output in a collapsible pre block.

## Test plan

- [ ] Screenshot tool (Spectacle/Flameshot) → copy image → Ctrl+V in prompt → image attaches
- [ ] Copy text with image in clipboard → Ctrl+V → image attaches (not just text)
- [ ] Edit tool shows diff content when expanded
- [ ] Task agent shows output when child session data is unavailable
- [ ] MCP/unregistered tools show expandable output
- [ ] Verify no TypeScript errors across all packages