### PR TITLE
ci: filter daily recaps to community-only and fix vouch workflow authentication

### DIFF
--- a/.github/workflows/daily-issues-recap.yml
+++ b/.github/workflows/daily-issues-recap.yml
@@ -48,8 +48,12 @@ jobs:
           TODAY'S DATE: ${TODAY}
 
           STEP 1: Gather today's issues
-          Search for all issues created today (${TODAY}) using:
-          gh issue list --repo ${{ github.repository }} --state all --search \"created:${TODAY}\" --json number,title,body,labels,state,comments,createdAt,author --limit 500
+          Search for all OPEN issues created today (${TODAY}) using:
+          gh issue list --repo ${{ github.repository }} --state open --search \"created:${TODAY}\" --json number,title,body,labels,state,comments,createdAt,author --limit 500
+
+          IMPORTANT: EXCLUDE all issues authored by Anomaly team members. Filter out issues where the author login matches ANY of these:
+          adamdotdevin, Brendonovich, fwang, Hona, iamdavidhill, jayair, kitlangton, kommander, MrMushrooooom, R44VC0RP, rekram1-node, thdxr
+          This recap is specifically for COMMUNITY (external) issues only.
 
           STEP 2: Analyze and categorize
           For each issue created today, categorize it:

--- a/.github/workflows/daily-pr-recap.yml
+++ b/.github/workflows/daily-pr-recap.yml
@@ -47,13 +47,17 @@ jobs:
           TODAY'S DATE: ${TODAY}
 
           STEP 1: Gather PR data
-          Run these commands to gather PR information. ONLY include PRs created or updated TODAY (${TODAY}):
+          Run these commands to gather PR information. ONLY include OPEN PRs created or updated TODAY (${TODAY}):
 
-          # PRs created today
-          gh pr list --repo ${{ github.repository }} --state all --search \"created:${TODAY}\" --json number,title,author,labels,createdAt,updatedAt,reviewDecision,isDraft,additions,deletions --limit 100
+          # Open PRs created today
+          gh pr list --repo ${{ github.repository }} --state open --search \"created:${TODAY}\" --json number,title,author,labels,createdAt,updatedAt,reviewDecision,isDraft,additions,deletions --limit 100
 
-          # PRs with activity today (updated today)
+          # Open PRs with activity today (updated today)
           gh pr list --repo ${{ github.repository }} --state open --search \"updated:${TODAY}\" --json number,title,author,labels,createdAt,updatedAt,reviewDecision,isDraft,additions,deletions --limit 100
+
+          IMPORTANT: EXCLUDE all PRs authored by Anomaly team members. Filter out PRs where the author login matches ANY of these:
+          adamdotdevin, Brendonovich, fwang, Hona, iamdavidhill, jayair, kitlangton, kommander, MrMushrooooom, R44VC0RP, rekram1-node, thdxr
+          This recap is specifically for COMMUNITY (external) contributions only.
 
 
 

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -18,10 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
       - uses: mitchellh/vouch/action/manage-by-issue@main
         with:
           issue-id: ${{ github.event.issue.number }}
           comment-id: ${{ github.event.comment.id }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.committer.outputs.token }}


### PR DESCRIPTION
## Summary

- **Daily recaps (issues + PRs)**: Filter to open-only and exclude Anomaly team members so recaps surface community contributions only
- **Vouch manage-by-issue**: Use GitHub App token (via `setup-git-committer`) instead of `GITHUB_TOKEN` to bypass branch protection rules when pushing `.vouch/` changes to `dev`