### PR TITLE
fix(provider): add APAC cross-region prefixes for AWS Bedrock

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -293,7 +293,7 @@ export namespace Provider {
               const isTokyoRegion = region === "ap-northeast-1"
               if (
                 isAustraliaRegion &&
-                ["anthropic.claude-sonnet-4-5", "anthropic.claude-haiku"].some((m) => modelID.includes(m))
+                ["claude", "nova-lite", "nova-micro", "nova-pro"].some((m) => modelID.includes(m))
               ) {
                 regionPrefix = "au"
                 modelID = `${regionPrefix}.${modelID}`

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1172,12 +1172,12 @@ export namespace Provider {
       }
       for (const item of priority) {
         if (providerID === "amazon-bedrock") {
-          const crossRegionPrefixes = ["global.", "us.", "eu."]
+          const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]
           const candidates = Object.keys(provider.models).filter((m) => m.includes(item))
 
           // Model selection priority:
           // 1. global. prefix (works everywhere)
-          // 2. User's region prefix (us., eu.)
+          // 2. User's region prefix (us., eu., jp., au., apac.)
           // 3. Unprefixed model
           const globalMatch = candidates.find((m) => m.startsWith("global."))
           if (globalMatch) return getModel(providerID, globalMatch)
@@ -1187,6 +1187,13 @@ export namespace Provider {
             const regionPrefix = region.split("-")[0]
             if (regionPrefix === "us" || regionPrefix === "eu") {
               const regionalMatch = candidates.find((m) => m.startsWith(`${regionPrefix}.`))
+              if (regionalMatch) return getModel(providerID, regionalMatch)
+            }
+            if (regionPrefix === "ap") {
+              const isTokyoRegion = region === "ap-northeast-1"
+              const isAustraliaRegion = ["ap-southeast-2", "ap-southeast-4"].includes(region)
+              const apacPrefix = isTokyoRegion ? "jp." : isAustraliaRegion ? "au." : "apac."
+              const regionalMatch = candidates.find((m) => m.startsWith(apacPrefix))
               if (regionalMatch) return getModel(providerID, regionalMatch)
             }
           }


### PR DESCRIPTION
## Summary
- Extend `crossRegionPrefixes` in `getSmallModel()` to include `"jp."`, `"apac."`, and `"au."`, matching what `getModel()` already supports
- Add region mapping logic for APAC regions: `ap-northeast-1` -> `jp.`, `ap-southeast-2`/`ap-southeast-4` -> `au.`, other `ap-*` -> `apac.`

Closes #12824

## Test plan
- [ ] Verify `getSmallModel()` resolves correctly for `ap-northeast-1` (Tokyo) region with `jp.` prefix
- [ ] Verify `getSmallModel()` resolves correctly for `ap-southeast-2` and `ap-southeast-4` (Australia) with `au.` prefix
- [ ] Verify `getSmallModel()` resolves correctly for other `ap-*` regions with `apac.` prefix
- [ ] Verify existing `us.` and `eu.` region behavior is unchanged
- [ ] Verify `global.` prefix still takes priority