### PR TITLE
fix(opencode): support dynamic bash timeout via OPENCODE_BASH_TIMEOUT env var

### DIFF
--- a/packages/opencode/src/flag/flag.ts
+++ b/packages/opencode/src/flag/flag.ts
@@ -40,7 +40,7 @@ export namespace Flag {
   export const OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT = truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT")
   export const OPENCODE_ENABLE_EXA =
     truthy("OPENCODE_ENABLE_EXA") || OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_EXA")
-  export const OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS = number("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS")
+  export declare const OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: number | undefined
   export const OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX = number("OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX")
   export const OPENCODE_EXPERIMENTAL_OXFMT = OPENCODE_EXPERIMENTAL || truthy("OPENCODE_EXPERIMENTAL_OXFMT")
   export const OPENCODE_EXPERIMENTAL_LSP_TY = truthy("OPENCODE_EXPERIMENTAL_LSP_TY")
@@ -87,6 +87,20 @@ Object.defineProperty(Flag, "OPENCODE_CONFIG_DIR", {
 Object.defineProperty(Flag, "OPENCODE_CLIENT", {
   get() {
     return process.env["OPENCODE_CLIENT"] ?? "cli"
+  },
+  enumerable: true,
+  configurable: false,
+})
+
+// Dynamic getter for OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS
+// This must be evaluated at access time, not module load time,
+// because the env var may be set after module initialization
+Object.defineProperty(Flag, "OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS", {
+  get() {
+    const value = process.env["OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"]
+    if (!value) return undefined
+    const parsed = Number(value)
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
   },
   enumerable: true,
   configurable: false,

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -19,7 +19,7 @@ import { Truncate } from "./truncation"
 import { Plugin } from "@/plugin"
 
 const MAX_METADATA_LENGTH = 30_000
-const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
+const getDefaultTimeout = () => Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
 
 export const log = Log.create({ service: "bash-tool" })
 
@@ -80,7 +80,7 @@ export const BashTool = Tool.define("bash", async () => {
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
-      const timeout = params.timeout ?? DEFAULT_TIMEOUT
+      const timeout = params.timeout ?? getDefaultTimeout()
       const tree = await parser().then((p) => p.parse(params.command))
       if (!tree) {
         throw new Error("Failed to parse command")


### PR DESCRIPTION
## Summary
- Change `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` from a static `const` (evaluated once at module load) to a dynamic getter via `Object.defineProperty`, so the env var is read at access time
- Update `bash.ts` to use a `getDefaultTimeout()` function instead of the static `DEFAULT_TIMEOUT` constant

Closes #12762

## Test plan
- [ ] Set `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=5000` before launching opencode, verify bash commands time out after 5 seconds
- [ ] Verify default 2-minute timeout still applies when the env var is unset
- [ ] Verify invalid values (negative, non-integer, non-numeric) are ignored and the default timeout is used