### PR TITLE
fix(opencode): set session status before async operations

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -762,7 +762,11 @@ export const SessionRoutes = lazy(() =>
         return stream(c, async () => {
           const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+          SessionStatus.set(sessionID, { type: "busy" })
+          SessionPrompt.prompt({ ...body, sessionID }).catch((error) => {
+            log.error("prompt_async failed", { sessionID, error })
+            SessionStatus.set(sessionID, { type: "idle" })
+          })
         })
       },
     )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -851,7 +851,10 @@ export namespace SessionPrompt {
   }
 
   async function createUserMessage(input: PromptInput) {
-    const agent = await Agent.get(input.agent ?? (await Agent.defaultAgent()))
+    const agentName = input.agent ?? (await Agent.defaultAgent())
+    const agent = await Agent.get(agentName)
+    if (!agent) throw new Error(`Agent not found: "${agentName}"`)
+
 
     const model = input.model ?? agent.model ?? (await lastModel(input.sessionID))
     const full =


### PR DESCRIPTION
## Summary
- Set `SessionStatus` to `busy` before the fire-and-forget `SessionPrompt.prompt()` call in the `prompt_async` route, so clients see the correct status immediately
- Add error handler to reset status to `idle` if the async prompt fails
- Add null check for `Agent.get()` in `createUserMessage` to throw a clear error when an invalid agent name is provided

Closes #12860

## Test plan
- [ ] Call `prompt_async` and verify `SessionStatus` is `busy` immediately after the call returns
- [ ] Verify that when the prompt completes, status transitions correctly
- [ ] Verify that if the prompt fails, status resets to `idle`
- [ ] Pass an invalid agent name and verify a clear error message is returned instead of a crash