### PR TITLE
fix: catch plugin event handler errors and provide logger to plugins

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -30,6 +30,7 @@ export namespace Plugin {
     })
     const config = await Config.get()
     const hooks: Hooks[] = []
+    const pluginLog = Log.create({ service: "plugin.user" })
     const input: PluginInput = {
       client,
       project: Instance.project,
@@ -37,6 +38,7 @@ export namespace Plugin {
       directory: Instance.directory,
       serverUrl: Server.url(),
       $: Bun.$,
+      log: pluginLog,
     }
 
     for (const plugin of INTERNAL_PLUGINS) {
@@ -129,9 +131,16 @@ export namespace Plugin {
     Bus.subscribeAll(async (input) => {
       const hooks = await state().then((x) => x.hooks)
       for (const hook of hooks) {
-        hook["event"]?.({
-          event: input,
-        })
+        try {
+          await hook["event"]?.({
+            event: input,
+          })
+        } catch (error) {
+          log.error("plugin event handler threw an error", {
+            eventType: input.type,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
       }
     })
   }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -23,6 +23,13 @@ export type ProviderContext = {
   options: Record<string, any>
 }
 
+export type PluginLogger = {
+  debug(message?: any, extra?: Record<string, any>): void
+  info(message?: any, extra?: Record<string, any>): void
+  warn(message?: any, extra?: Record<string, any>): void
+  error(message?: any, extra?: Record<string, any>): void
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -30,6 +37,11 @@ export type PluginInput = {
   worktree: string
   serverUrl: URL
   $: BunShell
+  /**
+   * Logger that writes to OpenCode's log file instead of stderr.
+   * Use this instead of `console.error()` to avoid corrupting the TUI display.
+   */
+  log: PluginLogger
 }
 
 export type Plugin = (input: PluginInput) => Promise<Hooks>


### PR DESCRIPTION
## Summary

- Wrap plugin `event` handler calls in try-catch so unhandled exceptions are logged to the log file instead of corrupting the TUI display
- Add `await` to the event handler call so async errors are properly caught
- Add a `log` property (`PluginLogger`) to `PluginInput`, giving plugins a proper way to log messages to OpenCode's log file instead of using `console.error()`

## Problem

When plugins call `console.error()` or throw unhandled errors in their `event` handlers, the output goes directly to stderr which corrupts the TUI display. For example, a Telegram notification plugin that fails an API call would show its error message inline in the chat window:

```
[telegram-notify] Failed to send message: {"ok":false,"error_code":400,"description":"Bad Request: can't parse entities..."}
```

## Changes

### `packages/opencode/src/plugin/index.ts`
- Added try-catch around `hook["event"]?.()` calls in `Bus.subscribeAll`
- Added `await` to ensure async errors are caught
- Errors are logged via `Log.create()` to the log file (not stderr)
- Created a `plugin.user` service logger passed to plugins via `PluginInput`

### `packages/plugin/src/index.ts`
- Added `PluginLogger` type with `debug`, `info`, `warn`, `error` methods
- Added `log: PluginLogger` to `PluginInput` with JSDoc explaining its purpose

## Backward Compatibility

- Fully backward compatible: existing plugins that don't use `log` continue to work unchanged
- The `log` property is additive to `PluginInput`
- Plugins using `console.error()` still work but their output still goes to stderr (the try-catch prevents crashes from unhandled exceptions)

## Testing

- All 903 existing tests pass
- Full turbo typecheck passes across all 12 packages