### PR TITLE
fix: add --no-config in rg args

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -340,7 +340,7 @@ export namespace Ripgrep {
     limit?: number
     follow?: boolean
   }) {
-    const args = [`${await filepath()}`, "--json", "--hidden", "--glob='!.git/*'"]
+    const args = [`${await filepath()}`, "--no-config", "--json", "--hidden", "--glob='!.git/*'"]
     if (input.follow) args.push("--follow")
 
     if (input.glob) {

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -37,7 +37,7 @@ export const GrepTool = Tool.define("grep", {
     await assertExternalDirectory(ctx, searchPath, { kind: "directory" })
 
     const rgPath = await Ripgrep.filepath()
-    const args = ["-nH", "--hidden", "--no-messages", "--field-match-separator=|", "--regexp", params.pattern]
+    const args = ["--no-config", "-nH", "--hidden", "--no-messages", "--field-match-separator=|", "--regexp", params.pattern]
     if (params.include) {
       args.push("--glob", params.include)
     }


### PR DESCRIPTION
### What does this PR do?

fix #12925

the issue is that: grep tool inherits user ripgrep config, which can silently alter search results

this fix adds `--no-config` to the rg command args list used in
- the grep tool used by llm
- the ripgrep used by tui server

from the below provided ripgrep documentation and source code we can see that `--no-config` will make sure `rg` doesn't read the global configuration file
https://github.com/BurntSushi/ripgrep/blob/0a88cccd5188074de96f54a4b6b44a63971ac157/GUIDE.md?plain=1#L621C1-L625C8
https://github.com/BurntSushi/ripgrep/blob/0a88cccd5188074de96f54a4b6b44a63971ac157/crates/core/flags/parse.rs#L88C1-L91C6

### How did you verify your code works?
#### these steps verifies that a global ripgreprc file still can't affect opencode tool call result output if `--no-config` is passed in the args

1. i have created two files `ripgreprc` and `testfile.txt`
```bash
$ tree
.
├── ripgreprc
└── testfile.txt

1 directory, 2 files

$ cat ripgreprc
--max-columns=10

$ cat testfile.txt
AAAAAAAAAA_FINDME_this_text_is_after_column_10
```

2. running `opencode debug agent build --tool grep` to see that tool execution
   output. we set `RIPGREP_CONFIG_PATH` to our `ripgreprc`. we can see that the tool call result output is stripped

```bash
$ RIPGREP_CONFIG_PATH="ripgreprc" opencode debug agent build --tool grep \
  --params '{"pattern":"FINDME","path":"/tmp/opencode-grep-test"}' | jq .result.output

## result output
"Found 1 matches\n/tmp/opencode-grep-test/testfile.txt:\n  Line 1: [Omitted long matching line]"
```
3. we build a localcode with the changes (having `--no-config` set), and use the localcode to run the command again. we can see that the tool cal result output is not stripped
```bash
$ RIPGREP_CONFIG_PATH="ripgreprc" ~/code/tmp/opencode/packages/opencode/dist/opencode-darwin-arm64/bin/opencode \
  debug agent build --tool grep \
  --params '{"pattern":"FINDME","path":"/tmp/opencode-grep-test"}' | jq .result.output

## result output
"Found 1 matches\n/tmp/opencode-grep-test/testfile.txt:\n  Line 1: AAAAAAAAAA_FINDME_this_text_is_after_column_10"
```

#### similarly, this verifies that the ripgrep search used by TUI server can't be affected by global configuration if `--no-config` is passed in the args

```bash
$ tree
.
├── ripgreprc
└── testfile.txt

1 directory, 2 files

$ cat testfile.txt
AAAAAAAAAA_FINDME_this_text_is_after_column_10

$ cat ripgreprc
--invert-match

$ RIPGREP_CONFIG_PATH="ripgreprc" opencode debug rg search "FINDME"
[
  {
    "path": {
      "text": "ripgreprc"
    },
    "lines": {
      "text": "--invert-match\n"
    },
    "line_number": 1,
    "absolute_offset": 0,
    "submatches": []
  }
]

$ RIPGREP_CONFIG_PATH="ripgreprc" ~/code/tmp/opencode/packages/opencode/dist/opencode-darwin-arm64/bin/opencode \
  debug rg search "FINDME"                                                                                                     [
  {
    "path": {
      "text": "testfile.txt"
    },
    "lines": {
      "text": "AAAAAAAAAA_FINDME_this_text_is_after_column_10\n"
    },
    "line_number": 1,
    "absolute_offset": 0,
    "submatches": [
      {
        "match": {
          "text": "FINDME"
        },
        "start": 11,
        "end": 17
      }
    ]
  }
]
```