### PR TITLE
fix(tui): add missing keybind for Toggle MCPs

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -415,6 +415,7 @@ function App() {
     {
       title: "Toggle MCPs",
       value: "mcp.list",
+      keybind: "mcp_list",
       category: "Agent",
       slash: {
         name: "mcps",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -817,6 +817,7 @@ export namespace Config {
       model_cycle_favorite_reverse: z.string().optional().default("none").describe("Previous favorite model"),
       command_list: z.string().optional().default("ctrl+p").describe("List available commands"),
       agent_list: z.string().optional().default("<leader>a").describe("List agents"),
+      mcp_list: z.string().optional().default("<leader>;").describe("Toggle MCPs"),
       agent_cycle: z.string().optional().default("tab").describe("Next agent"),
       agent_cycle_reverse: z.string().optional().default("shift+tab").describe("Previous agent"),
       variant_cycle: z.string().optional().default("ctrl+t").describe("Cycle model variants"),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1139,6 +1139,10 @@ export type KeybindsConfig = {
    */
   agent_list?: string
   /**
+   * Toggle MCPs
+   */
+  mcp_list?: string
+  /**
    * Next agent
    */
   agent_cycle?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -8675,6 +8675,11 @@
             "default": "<leader>a",
             "type": "string"
           },
+          "mcp_list": {
+            "description": "Toggle MCPs",
+            "default": "<leader>;",
+            "type": "string"
+          },
           "agent_cycle": {
             "description": "Next agent",
             "default": "tab",

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -54,6 +54,7 @@ OpenCode has a list of keybinds that you can customize through the OpenCode conf
     "variant_cycle": "ctrl+t",
     "command_list": "ctrl+p",
     "agent_list": "<leader>a",
+    "mcp_list": "<leader>;",
     "agent_cycle": "tab",
     "agent_cycle_reverse": "shift+tab",
     "input_clear": "ctrl+c",


### PR DESCRIPTION
### What does this PR do?

Fixes #12943
Adds a missing TUI keybind for `Toggle MCPs` by:
- adding `mcp_list` to the TUI keybind schema (default: `<leader>;`)
- wiring the `mcp.list` command to `keybind: "mcp_list"`
- documenting `mcp_list` in the keybind docs example
- regenerating OpenAPI/SDK generated types for the new config key
This reuses the same shortcut intent as the web app (`mod+;`), using the TUI equivalent `<leader>;` for consistency:
https://github.com/anomalyco/opencode/blob/dev/packages/app/src/pages/session/use-session-commands.tsx#L216

### How did you verify your code works?
- `bun run typecheck` (in `packages/opencode`)
- `bun test test/keybind.test.ts` (in `packages/opencode`)
- manual check in TUI: `Toggle MCPs` now shows and responds to `<leader>;`