### PR TITLE
feat(tui): display detailed status messages in prompt

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -19,7 +19,7 @@ import { useRenderer } from "@opentui/solid"
 import { Editor } from "@tui/util/editor"
 import { useExit } from "../../context/exit"
 import { Clipboard } from "../../util/clipboard"
-import type { FilePart } from "@opencode-ai/sdk/v2"
+import type { FilePart, SessionStatus } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
@@ -1034,6 +1034,11 @@ export function Prompt(props: PromptProps) {
                     <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
                   </Show>
                 </box>
+                <Show when={status().type === "busy"}>
+                  <text fg={theme.textMuted}>
+                    {(status() as Extract<SessionStatus, { type: "busy" }>).message || "BUSY..."}
+                  </text>
+                </Show>
                 <box flexDirection="row" gap={1} flexShrink={0}>
                   {(() => {
                     const retry = createMemo(() => {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -15,6 +15,7 @@ import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
+import { SessionStatusMessage } from "./status-message"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -56,7 +57,7 @@ export namespace SessionProcessor {
               input.abort.throwIfAborted()
               switch (value.type) {
                 case "start":
-                  SessionStatus.set(input.sessionID, { type: "busy" })
+                  SessionStatus.set(input.sessionID, { type: "busy", message: "Thinking..." })
                   break
 
                 case "reasoning-start":
@@ -166,6 +167,10 @@ export namespace SessionProcessor {
                         ruleset: agent.permission,
                       })
                     }
+                    SessionStatus.set(input.sessionID, {
+                      type: "busy",
+                      message: SessionStatusMessage.generate(value.toolName, value.input),
+                    })
                   }
                   break
                 }
@@ -231,6 +236,7 @@ export namespace SessionProcessor {
                     snapshot,
                     type: "step-start",
                   })
+                  SessionStatus.set(input.sessionID, { type: "busy", message: "Processing..." })
                   break
 
                 case "finish-step":
@@ -253,6 +259,7 @@ export namespace SessionProcessor {
                     cost: usage.cost,
                   })
                   await Session.updateMessage(input.assistantMessage)
+                  SessionStatus.set(input.sessionID, { type: "idle" })
                   if (snapshot) {
                     const patch = await Snapshot.patch(snapshot)
                     if (patch.files.length) {
@@ -277,6 +284,7 @@ export namespace SessionProcessor {
                   break
 
                 case "text-start":
+                  SessionStatus.set(input.sessionID, { type: "busy", message: "Generating response..." })
                   currentText = {
                     id: Identifier.ascending("part"),
                     messageID: input.assistantMessage.id,
@@ -395,6 +403,7 @@ export namespace SessionProcessor {
           }
           input.assistantMessage.time.completed = Date.now()
           await Session.updateMessage(input.assistantMessage)
+          SessionStatus.set(input.sessionID, { type: "idle" })
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"

--- a/packages/opencode/src/session/status-message.ts
+++ b/packages/opencode/src/session/status-message.ts
@@ -1,0 +1,41 @@
+import { Log } from "@/util/log"
+
+export namespace SessionStatusMessage {
+  const TRUNCATE_LENGTH = 60
+  const log = Log.create({ service: "session.status-message" })
+
+  function truncate(str: string | undefined): string {
+    if (!str) return "..."
+    if (str.length <= TRUNCATE_LENGTH) return str
+    return str.slice(0, TRUNCATE_LENGTH) + "..."
+  }
+
+  function mask(cmd: string | undefined): string {
+    if (!cmd) return "..."
+    // Mask env var setting like TOKEN=abc -> TOKEN=***
+    return cmd.replace(/(\w+)=([^\s]+)/g, "$1=***")
+  }
+
+  const formatters: Record<string, (input: any) => string> = {
+    bash: (i) => `Running: ${truncate(mask(i?.command))}`,
+    read: (i) => `Reading: ${truncate(i?.filePath)}`,
+    write: (i) => `Writing: ${truncate(i?.filePath)}`,
+    edit: (i) => `Editing: ${truncate(i?.filePath)}`,
+    glob: (i) => `Finding: ${truncate(i?.pattern)}`,
+    grep: (i) => `Searching: ${truncate(i?.pattern)}`,
+    webfetch: (i) => `Fetching: ${truncate(i?.url)}`,
+    task: (i) => `Task: ${truncate(i?.description)}`,
+    question: (i) => `Question: ${truncate(i?.question)}`,
+  }
+
+  export function generate(tool: string, input: any): string {
+    try {
+      const fn = formatters[tool]
+      if (fn) return fn(input)
+      return `Using ${tool}...`
+    } catch (e) {
+      log.error("failed to generate status message", { tool, error: e })
+      return `Using ${tool}...`
+    }
+  }
+}

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -17,6 +17,7 @@ export namespace SessionStatus {
       }),
       z.object({
         type: z.literal("busy"),
+        message: z.string().optional(),
       }),
     ])
     .meta({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -550,6 +550,7 @@ export type SessionStatus =
     }
   | {
       type: "busy"
+      message?: string
     }
 
 export type EventSessionStatus = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -7408,6 +7408,9 @@
               "type": {
                 "type": "string",
                 "const": "busy"
+              },
+              "message": {
+                "type": "string"
               }
             },
             "required": ["type"]


### PR DESCRIPTION
## Summary
Displays detailed status messages in the TUI prompt (e.g., "Reading: src/index.ts", "Thinking...", "Generating response...").

## Changes
- Added `SessionStatusMessage` utility to format and redact tool inputs.
- Updated `SessionProcessor` to emit granular status updates for various session events (start, text gen, step start/finish).
- Updated `Prompt` component to display the formatted message.
- Updated SDK types and OpenAPI spec for the new `message` field in `SessionStatus`.
- After this PR:
   Before this PR | After this PR
   -- | --
   <img width="902" height="234" alt="e03afada24b34645329731cc557dc2c3" src="https://github.com/user-attachments/assets/3af2b7ab-a78e-458c-9d76-492ee55448d1" /> | <img width="1692" height="356" alt="image" src="https://github.com/user-attachments/assets/76b8d38e-fa4f-43b9-a829-260f92003e70" />

Fixes #12958


