### PR TITLE
fix(config): prevent agent frontmatter fields from leaking into LLM API requests

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -725,10 +725,16 @@ export namespace Config {
         "tools",
       ])
 
-      // Extract unknown properties into options
+      // Extract explicitly declared options (from frontmatter `options:` field)
       const options: Record<string, unknown> = { ...agent.options }
+
+      // Store unknown frontmatter fields in metadata (NOT options) to prevent
+      // them from leaking into LLM API request bodies via mergeDeep in llm.ts.
+      // Strict APIs (OpenAI, Vertex AI, etc.) reject extra fields in the request body.
+      // See: https://github.com/anomalyco/opencode/issues/4282
+      const metadata: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(agent)) {
-        if (!knownKeys.has(key)) options[key] = value
+        if (!knownKeys.has(key)) metadata[key] = value
       }
 
       // Convert legacy tools config to permissions
@@ -747,8 +753,9 @@ export namespace Config {
       // Convert legacy maxSteps to steps
       const steps = agent.steps ?? agent.maxSteps
 
-      return { ...agent, options, permission, steps } as typeof agent & {
+      return { ...agent, options, metadata, permission, steps } as typeof agent & {
         options?: Record<string, unknown>
+        metadata?: Record<string, unknown>
         permission?: Permission
         steps?: number
       }


### PR DESCRIPTION
## Summary

Unknown YAML frontmatter fields in custom agent `.md` files (e.g. `tts`, `permissions`, `voice`) are collected into `agent.options` and merged into LLM API request bodies via `mergeDeep` in `llm.ts`. Strict providers (OpenAI, Vertex AI, OpenRouter) reject extra fields, causing agents to silently fail.

This PR stores unknown fields in a separate `metadata` property instead, so only explicitly declared `options:` fields reach the API.

Fixes #12964
Related: #4282, #12950

## What Changed

**One file:** `packages/opencode/src/config/config.ts`

- Unknown frontmatter fields now go into `metadata` instead of `options`
- Explicitly declared `options:` in frontmatter still works as before
- `metadata` is available on the agent object for hooks/plugins that need it

## Testing

Verified with 6 agent types across 3 LLM providers (Kimi K2.5, MiniMax M2.1, GLM 4.7 via Zen). All agents that previously failed with empty responses now work correctly.

The `@opencode-ai/desktop#typecheck` failure in CI is pre-existing (missing `@tauri-apps/plugin-clipboard-manager` dependency) and unrelated to this change.