### PR TITLE
fix: auto-resume agent loop after context compaction

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -164,7 +164,8 @@ export namespace SessionCompaction {
       model,
     })
 
-    if (result === "continue" && input.auto) {
+    if (processor.message.error) return "stop"
+    if (input.auto) {
       const continueMsg = await Session.updateMessage({
         id: Identifier.ascending("message"),
         role: "user",
@@ -188,7 +189,6 @@ export namespace SessionCompaction {
         },
       })
     }
-    if (processor.message.error) return "stop"
     Bus.publish(Event.Compacted, { sessionID: input.sessionID })
     return "continue"
   }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -47,6 +47,7 @@ export namespace SessionProcessor {
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
+          if (input.abort.aborted) break
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
@@ -343,7 +344,7 @@ export namespace SessionProcessor {
             })
             const error = MessageV2.fromError(e, { providerID: input.model.providerID })
             const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
+            if (retry !== undefined && !input.abort.aborted) {
               attempt++
               const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
               SessionStatus.set(input.sessionID, {
@@ -353,9 +354,11 @@ export namespace SessionProcessor {
                 next: Date.now() + delay,
               })
               await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              if (!input.abort.aborted) continue
             }
-            input.assistantMessage.error = error
+            input.assistantMessage.error = input.abort.aborted
+              ? new MessageV2.AbortedError({ message: "Aborted" }).toObject()
+              : error
             Bus.publish(Session.Event.Error, {
               sessionID: input.assistantMessage.sessionID,
               error: input.assistantMessage.error,
@@ -397,9 +400,11 @@ export namespace SessionProcessor {
           await Session.updateMessage(input.assistantMessage)
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
+          if (input.abort.aborted) return "stop"
           if (input.assistantMessage.error) return "stop"
           return "continue"
         }
+        return "stop"
       },
     }
     return result

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -306,6 +306,7 @@ export namespace SessionPrompt {
       if (
         lastAssistant?.finish &&
         !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
+        !lastAssistant.summary &&
         lastUser.id < lastAssistant.id
       ) {
         log.info("exiting loop", { sessionID })


### PR DESCRIPTION
## Summary

Fixes #12780

After context compaction triggers, the agent sometimes stops and waits for the user to say "continue" instead of automatically resuming. The behavior is inconsistent because it depends on the processor's return value during compaction, which can vary based on response size and model behavior.

**Root cause (two issues):**

1. `SessionCompaction.process()` gated the synthetic "Continue" user message on `result === "continue"`. If the processor returned anything else (e.g. `"compact"` when the compaction response itself was large enough to trigger overflow detection), the synthetic message was skipped. Without this message, the main loop's exit condition (`lastUser.id < lastAssistant.id`) would see the compaction assistant as newer than the last user message and break out of the loop, stopping the agent.

2. The main agent loop exit condition did not exclude compaction summary messages. A compaction assistant message with a non-tool-call finish reason (e.g. `"stop"`, `"end_turn"`) would trigger the exit even though the agent should continue processing after compaction.

**Fix:**

- Move the error check (`processor.message.error`) before the synthetic message creation, and remove the `result === "continue"` gate. The synthetic "Continue" user message is now always created when `auto=true` and there is no error.
- Add `!lastAssistant.summary` to the loop exit condition so the loop never breaks on a compaction summary message.

Related: #11301, #3053, #6068, #8394

## Test plan

- [ ] Trigger context compaction by running a long session that exceeds the model's context window
- [ ] Verify the agent automatically resumes after compaction without requiring user to type "continue"
- [ ] Verify the agent still correctly stops when compaction encounters an error
- [ ] Verify manual compaction (`auto: false`) still works as before (no synthetic continue message)
- [ ] Existing compaction tests pass