### PR TITLE
fix: propagate abort signal to prevent TUI freeze during processing

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -47,6 +47,7 @@ export namespace SessionProcessor {
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
+          if (input.abort.aborted) break
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
@@ -343,7 +344,7 @@ export namespace SessionProcessor {
             })
             const error = MessageV2.fromError(e, { providerID: input.model.providerID })
             const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
+            if (retry !== undefined && !input.abort.aborted) {
               attempt++
               const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
               SessionStatus.set(input.sessionID, {
@@ -353,9 +354,11 @@ export namespace SessionProcessor {
                 next: Date.now() + delay,
               })
               await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              if (!input.abort.aborted) continue
             }
-            input.assistantMessage.error = error
+            input.assistantMessage.error = input.abort.aborted
+              ? new MessageV2.AbortedError({ message: "Aborted" }).toObject()
+              : error
             Bus.publish(Session.Event.Error, {
               sessionID: input.assistantMessage.sessionID,
               error: input.assistantMessage.error,
@@ -397,9 +400,11 @@ export namespace SessionProcessor {
           await Session.updateMessage(input.assistantMessage)
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
+          if (input.abort.aborted) return "stop"
           if (input.assistantMessage.error) return "stop"
           return "continue"
         }
+        return "stop"
       },
     }
     return result


### PR DESCRIPTION
Fixes #12834

## Problem

When a user aborts a request (e.g., via Ctrl+C or the abort button), the abort signal is not fully propagated through the processor's main loop. This causes the TUI to freeze because:

1. The processing loop continues iterating even after the abort signal fires
2. Retry logic still engages on errors caused by the abort, creating unnecessary retry/sleep cycles
3. The error assigned to the message doesn't reflect that it was an intentional abort
4. The loop can return "continue" instead of "stop" after an abort, causing the session to keep processing

## Solution

Propagate the abort signal at multiple critical points in the processor loop:

- **Break on abort at loop entry**: Check `input.abort.aborted` at the top of the `while(true)` loop so we exit immediately if already aborted
- **Skip retry on abort**: Add `!input.abort.aborted` guard to the retry condition so we don't retry requests that were intentionally cancelled
- **Skip continue on abort**: After `SessionRetry.sleep`, only `continue` if not aborted
- **Set proper abort error**: When aborted, assign `MessageV2.AbortedError` instead of the underlying network/API error, giving the TUI an accurate signal to stop
- **Return "stop" on abort**: After the loop body, check abort status and return `"stop"` to prevent the session from continuing
- **Fallback return**: Add `return "stop"` after the `while` loop as a safety net