### PR TITLE
chore: add scoop install command in the index route tab component

### DIFF
--- a/packages/console/app/src/routes/index.tsx
+++ b/packages/console/app/src/routes/index.tsx
@@ -110,6 +110,9 @@ export default function Home() {
                   <Tabs.Trigger value="paru" data-slot="tab">
                     paru
                   </Tabs.Trigger>
+                  <Tabs.Trigger value="scoop" data-slot="tab">
+                    scoop
+                  </Tabs.Trigger>
                   <Tabs.Indicator />
                 </Tabs.List>
                 <div data-slot="panels">
@@ -155,6 +158,15 @@ export default function Home() {
                     <button data-copy data-slot="command" onClick={handleCopyClick}>
                       <span>
                         <span data-slot="protocol">paru -S </span>
+                        <span data-slot="highlight">opencode</span>
+                      </span>
+                      <CopyStatus />
+                    </button>
+                  </Tabs.Content>
+                  <Tabs.Content as="pre" data-slot="panel" value="scoop">
+                    <button data-copy data-slot="command" onClick={handleCopyClick}>
+                      <span>
+                        <span data-slot="protocol">scoop install </span>
                         <span data-slot="highlight">opencode</span>
                       </span>
                       <CopyStatus />


### PR DESCRIPTION
### What does this PR do?

This PR fixes #12986 by adding Scoop installation support to the OpenCode console's index page.

- Adds a new "scoop" tab alongside the existing "paru" tab
- Includes the installation command: `scoop install opencode`


Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

The index page was missing the installation snippet for Scoop, so I made the changes in the index routes's to render it alongside paru

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

I verified this code by running the local server.


<img width="1904" height="956" alt="image" src="https://github.com/user-attachments/assets/e23303d2-92a3-4018-8ed3-cba2d0fd2448" />

