### PR TITLE
fix(app): handle crypto.randomUUID failure in non-secure browser contexts

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -31,7 +31,13 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
       const dataUrl = reader.result as string
       const attachment: ImageAttachmentPart = {
         type: "image",
-        id: crypto.randomUUID?.() ?? Math.random().toString(16).slice(2),
+        id: (() => {
+          try {
+            return crypto.randomUUID()
+          } catch {
+            return Math.random().toString(16).slice(2)
+          }
+        })(),
         filename: file.name,
         mime: file.type,
         dataUrl,

--- a/packages/app/src/context/comments.tsx
+++ b/packages/app/src/context/comments.tsx
@@ -53,7 +53,13 @@ function createCommentSessionState(store: Store<CommentStore>, setStore: SetStor
 
   const add = (input: Omit<LineComment, "id" | "time">) => {
     const next: LineComment = {
-      id: crypto.randomUUID?.() ?? Math.random().toString(16).slice(2),
+      id: (() => {
+        try {
+          return crypto.randomUUID()
+        } catch {
+          return Math.random().toString(16).slice(2)
+        }
+      })(),
       time: Date.now(),
       ...input,
     }

--- a/packages/app/src/utils/perf.ts
+++ b/packages/app/src/utils/perf.ts
@@ -16,7 +16,13 @@ const key = (dir: string | undefined, to: string) => `${dir ?? ""}:${to}`
 
 const now = () => performance.now()
 
-const uid = () => crypto.randomUUID?.() ?? Math.random().toString(16).slice(2)
+const uid = () => {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return Math.random().toString(16).slice(2)
+  }
+}
 
 const navs = new Map<string, Nav>()
 const pending = new Map<string, string>()


### PR DESCRIPTION
Fixes #12989

`crypto.randomUUID()` throws a `DOMException` when called in a non-secure browser context (plain HTTP, not HTTPS). This crashes the web UI when attaching images and in a couple other spots.

The existing code used optional chaining (`crypto.randomUUID?.()`) but that doesn't help — the method exists on the `crypto` object, it just throws when the context isn't secure.

**Fix:**

Replace optional chaining with try/catch in the 3 browser-context usages:
- `packages/app/src/components/prompt-input/attachments.ts`
- `packages/app/src/context/comments.tsx`
- `packages/app/src/utils/perf.ts`

Falls back to `Math.random().toString(16).slice(2)` on failure (same fallback as before, just actually reachable now).

Server-side usages (packages/opencode, packages/enterprise) are unaffected since Node/Bun always has a secure context.

**Testing:**

Ran the web UI locally over HTTP, confirmed image attachment works without the randomUUID crash.