### PR TITLE
fix: handle undefined MCP tool output in stream processor

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -172,19 +172,20 @@ export namespace SessionProcessor {
                 case "tool-result": {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
+                    const output = value.output ?? {}
                     await Session.updatePart({
                       ...match,
                       state: {
                         status: "completed",
                         input: value.input ?? match.state.input,
-                        output: value.output.output,
-                        metadata: value.output.metadata,
-                        title: value.output.title,
+                        output: output.output ?? "",
+                        metadata: output.metadata ?? {},
+                        title: output.title ?? "",
                         time: {
                           start: match.state.time.start,
                           end: Date.now(),
                         },
-                        attachments: value.output.attachments,
+                        attachments: output.attachments,
                       },
                     })
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -172,20 +172,45 @@ export namespace SessionProcessor {
                 case "tool-result": {
                   const match = toolcalls[value.toolCallId]
                   if (match && match.state.status === "running") {
-                    const output = value.output ?? {}
+                    const output = value.output
+                    const text =
+                      typeof output?.output === "string"
+                        ? output.output
+                        : Array.isArray(output?.content)
+                          ? output.content
+                              .map((item: unknown) =>
+                                item &&
+                                typeof item === "object" &&
+                                "type" in item &&
+                                item.type === "text" &&
+                                "text" in item &&
+                                typeof item.text === "string"
+                                  ? item.text
+                                  : "",
+                              )
+                              .filter(Boolean)
+                              .join("\n\n")
+                          : typeof output === "string"
+                            ? output
+                            : output === undefined
+                              ? ""
+                              : JSON.stringify(output)
                     await Session.updatePart({
                       ...match,
                       state: {
                         status: "completed",
                         input: value.input ?? match.state.input,
-                        output: output.output ?? "",
-                        metadata: output.metadata ?? {},
-                        title: output.title ?? "",
+                        output: text,
+                        metadata:
+                          typeof output?.metadata === "object" && output.metadata && !Array.isArray(output.metadata)
+                            ? output.metadata
+                            : {},
+                        title: typeof output?.title === "string" ? output.title : "",
                         time: {
                           start: match.state.time.start,
                           end: Date.now(),
                         },
-                        attachments: output.attachments,
+                        attachments: Array.isArray(output?.attachments) ? output.attachments : undefined,
                       },
                     })
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -798,7 +798,7 @@ export namespace SessionPrompt {
         const textParts: string[] = []
         const attachments: MessageV2.FilePart[] = []
 
-        for (const contentItem of result.content) {
+        for (const contentItem of result.content ?? []) {
           if (contentItem.type === "text") {
             textParts.push(contentItem.text)
           } else if (contentItem.type === "image") {
@@ -841,7 +841,7 @@ export namespace SessionPrompt {
           metadata,
           output: truncated.content,
           attachments,
-          content: result.content, // directly return content to preserve ordering when outputting to model
+          content: result.content ?? [], // directly return content to preserve ordering when outputting to model
         }
       }
       tools[key] = item


### PR DESCRIPTION
## Summary

Fixes #12987 — Kubernetes MCP server tools (and potentially other MCP servers) can fail with `TypeError: undefined is not an object (evaluating 'output.output.toLowerCase')` when tool-result payloads are not in the expected nested shape.

## Root Cause

`session/processor.ts` assumed every `tool-result` chunk had:

```ts
value.output = { output: string, metadata: object, title: string, ... }
```

For some dynamic/provider/MCP result shapes, that assumption can be false (e.g. raw `content[]` payloads), causing undefined access and downstream crashes.

## Changes

- **`packages/opencode/src/session/processor.ts`**
  - Normalize dynamic tool results safely before persisting:
    - use nested `output.output` when present
    - fallback to `content[]` text extraction when available
    - fallback to raw string output
    - final fallback to JSON stringification for unknown payloads
  - Guard metadata/title/attachments with shape checks to avoid unsafe property access.

- **`packages/opencode/src/session/prompt.ts`**
  - Guard MCP wrapper handling with `result.content ?? []` to avoid iterating undefined content.

## Verification

- `bun run typecheck` (package-level) ✅
- Push hook `bun turbo typecheck` (workspace-level) ✅
- Focused regression tests:
  - `bun test test/session/prompt-special-chars.test.ts test/session/prompt-missing-file.test.ts test/mcp/headers.test.ts` ✅