### PR TITLE
feat(tui): show thinking indicator when reasoning is hidden

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1327,28 +1327,44 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
     // OpenRouter sends encrypted reasoning data that appears as [REDACTED]
     return props.part.text.replace("[REDACTED]", "").trim()
   })
+  const pending = createMemo(() => !props.part.time.end && !props.message.time.completed)
+  const color = createMemo(() =>
+    RGBA.fromInts(
+      Math.round(theme.markdownEmph.r * 255),
+      Math.round(theme.markdownEmph.g * 255),
+      Math.round(theme.markdownEmph.b * 255),
+      Math.round(theme.thinkingOpacity * 255),
+    ),
+  )
   return (
-    <Show when={content() && ctx.showThinking()}>
-      <box
-        id={"text-" + props.part.id}
-        paddingLeft={2}
-        marginTop={1}
-        flexDirection="column"
-        border={["left"]}
-        customBorderChars={SplitBorder.customBorderChars}
-        borderColor={theme.backgroundElement}
-      >
-        <code
-          filetype="markdown"
-          drawUnstyledText={false}
-          streaming={true}
-          syntaxStyle={subtleSyntax()}
-          content={"_Thinking:_ " + content()}
-          conceal={ctx.conceal()}
-          fg={theme.textMuted}
-        />
-      </box>
-    </Show>
+    <Switch>
+      <Match when={content() && ctx.showThinking()}>
+        <box
+          id={"text-" + props.part.id}
+          paddingLeft={2}
+          marginTop={1}
+          flexDirection="column"
+          border={["left"]}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.backgroundElement}
+        >
+          <code
+            filetype="markdown"
+            drawUnstyledText={false}
+            streaming={true}
+            syntaxStyle={subtleSyntax()}
+            content={"_Thinking:_ " + content()}
+            conceal={ctx.conceal()}
+            fg={theme.textMuted}
+          />
+        </box>
+      </Match>
+      <Match when={!ctx.showThinking() && pending()}>
+        <box paddingLeft={3} marginTop={1}>
+          <Spinner color={color()}>Thinking...</Spinner>
+        </box>
+      </Match>
+    </Switch>
   )
 }
 


### PR DESCRIPTION
### What does this PR do?

Closes #12028

When thinking visibility is toggled off (`/thinking`), the TUI previously showed nothing during the reasoning phase. This made it impossible to tell whether the model was actively thinking or stalled.

This changes the `ReasoningPart` component to render a collapsed single-line spinner (`⠹ Thinking...`) when thinking is hidden and reasoning is in progress. It uses the same braille spinner pattern as tools and subagents for visual consistency. The indicator disappears when reasoning finishes or the session is interrupted (esc 2x).

When thinking visibility is on, behavior is unchanged (full reasoning block renders as before).

<img width="1012" height="244" alt="image" src="https://github.com/user-attachments/assets/da3ae2df-07a5-4a18-8fa2-e88db231c8cd" />

Second screenshot shows the thinking line disappearing once reasoning is finished:

<img width="1024" height="210" alt="image" src="https://github.com/user-attachments/assets/5657168d-745f-4a74-ac00-0ae976026d99" />

### How did you verify your code works?

- Ran `bun dev` with a thinking model (Claude Sonnet), toggled `/thinking` off, sent a prompt, and confirmed the spinner appeared during reasoning and disappeared when text started streaming
- Verified esc 2x interrupt stops the spinner
- Toggled `/thinking` back on and confirmed full reasoning block renders normally
- `tsgo --noEmit` passes clean