### PR TITLE
feat(config): add configBoundary option for parent config traversal

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -108,6 +108,9 @@ export const Flag = {
   get OPENCODE_CONFIG_DIR() {
     return process.env["OPENCODE_CONFIG_DIR"]
   },
+  get OPENCODE_CONFIG_BOUNDARY() {
+    return process.env["OPENCODE_CONFIG_BOUNDARY"] as "current" | "home" | "root" | "none" | undefined
+  },
   get OPENCODE_PURE() {
     return truthy("OPENCODE_PURE")
   },

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -203,6 +203,12 @@ export const Info = Schema.Struct({
   instructions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional instruction files or patterns to include",
   }),
+  configBoundary: Schema.optional(Schema.Literals(["current", "home", "root", "none"])).annotate({
+    description:
+      "Controls how far up the filesystem OpenCode searches for parent configs and instruction files. " +
+      "'current' (default) stops at the git worktree root. 'home' walks up to $HOME (useful for client-level MCP/AGENTS.md inheritance). " +
+      "'root' walks to /. 'none' disables parent config search entirely.",
+  }),
   layout: Schema.optional(ConfigLayout.Layout).annotate({ description: "@deprecated Always uses stretch layout." }),
   permission: Schema.optional(ConfigPermission.Info),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
@@ -279,6 +285,21 @@ export type Info = DeepMutable<Schema.Schema.Type<typeof Info>> & {
   // plugin_origins is derived state, not a persisted config field. It keeps each winning plugin spec together
   // with the file and scope it came from so later runtime code can make location-sensitive decisions.
   plugin_origins?: ConfigPlugin.Origin[]
+}
+
+export function getConfigStop(boundary?: Info["configBoundary"], worktree?: string): string {
+  const effective = Flag.OPENCODE_CONFIG_BOUNDARY ?? boundary ?? "current"
+  switch (effective) {
+    case "none":
+      return worktree ?? "/"
+    case "home":
+      return Global.Path.home
+    case "root":
+      return "/"
+    case "current":
+    default:
+      return worktree ?? "/"
+  }
 }
 
 type State = {
@@ -372,6 +393,13 @@ export const layer = Layer.effect(
       if (!("path" in options)) return data
 
       yield* Effect.promise(() => resolveLoadedPlugins(data, options.path))
+      if (data.instructions) {
+        const configDir = path.dirname(options.path)
+        data.instructions = data.instructions.map((instruction) => {
+          if (!instruction.startsWith("./") && !instruction.startsWith("../")) return instruction
+          return path.resolve(configDir, instruction)
+        })
+      }
       if (!data.$schema) {
         data.$schema = "https://opencode.ai/config.json"
         const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
@@ -515,8 +543,10 @@ export const layer = Layer.effect(
           log.debug("loaded custom config", { path: Flag.OPENCODE_CONFIG })
         }
 
+        const stop = getConfigStop(result.configBoundary, ctx.worktree)
+
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-          for (const file of yield* ConfigPaths.files("opencode", ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
+          for (const file of yield* ConfigPaths.files("opencode", ctx.directory, stop).pipe(Effect.orDie)) {
             yield* merge(file, yield* loadFile(file), "local")
           }
         }
@@ -525,7 +555,7 @@ export const layer = Layer.effect(
         result.mode = result.mode || {}
         result.plugin = result.plugin || []
 
-        const directories = yield* ConfigPaths.directories(ctx.directory, ctx.worktree)
+        const directories = yield* ConfigPaths.directories(ctx.directory, stop)
 
         if (Flag.OPENCODE_CONFIG_DIR) {
           log.debug("loading config from OPENCODE_CONFIG_DIR", { path: Flag.OPENCODE_CONFIG_DIR })

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { Effect, Layer, Context } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
-import { Config } from "@/config/config"
+import { Config, getConfigStop } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { AppFileSystem } from "@opencode-ai/core/filesystem"
@@ -72,11 +72,11 @@ export const layer: Layer.Layer<
       ),
     )
 
-    const relative = Effect.fnUntraced(function* (instruction: string) {
+    const relative = Effect.fnUntraced(function* (instruction: string, stop: string) {
       const ctx = yield* InstanceState.context
       if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
         return yield* fs
-          .globUp(instruction, ctx.directory, ctx.worktree)
+          .globUp(instruction, ctx.directory, stop)
           .pipe(Effect.catch(() => Effect.succeed([] as string[])))
       }
       return yield* fs
@@ -107,6 +107,7 @@ export const layer: Layer.Layer<
       const config = yield* cfg.get()
       const ctx = yield* InstanceState.context
       const paths = new Set<string>()
+      const stop = getConfigStop(config.configBoundary, ctx.worktree)
 
       for (const file of globalFiles) {
         if (yield* fs.existsSafe(file)) {
@@ -115,10 +116,9 @@ export const layer: Layer.Layer<
         }
       }
 
-      // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
       if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
         for (const file of FILES) {
-          const matches = yield* fs.findUp(file, ctx.directory, ctx.worktree)
+          const matches = yield* fs.findUp(file, ctx.directory, stop)
           if (matches.length > 0) {
             matches.forEach((item) => paths.add(path.resolve(item)))
             break
@@ -137,7 +137,7 @@ export const layer: Layer.Layer<
                   absolute: true,
                   include: "file",
                 })
-              : relative(instruction)
+              : relative(instruction, stop)
           ).pipe(Effect.catch(() => Effect.succeed([] as string[])))
           matches.forEach((item) => paths.add(path.resolve(item)))
         }


### PR DESCRIPTION
### Issue for this PR

Closes #10707
Related to #4479, #6479, #10025

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode currently stops searching for parent configs and instruction files at the git worktree root. That's fine for single-project repos, but breaks down the moment you have a client-level directory structure:

```
~/Projects/
├── ASU/
│   ├── opencode.jsonc     ← MCP servers, AGENTS.md for all ASU work
│   ├── project-alpha/.git/
│   └── project-beta/.git/
└── Expedia/
    ├── opencode.jsonc     ← different MCPs, different instructions
    └── some-repo/.git/
```

Right now those client-level configs are invisible. You'd have to copy MCP config into every single repo, or manage it some other way.

This PR adds a `configBoundary` field that controls how far up OpenCode walks:

```jsonc
// ~/.config/opencode/opencode.jsonc
{
  "configBoundary": "home"
}
```

| Value | Behavior |
|---|---|
| `"current"` | **Default.** Stop at git worktree root. Fully backward compatible. |
| `"home"` | Walk up to `$HOME`. Client-level inheritance. |
| `"root"` | Walk to `/`. |
| `"none"` | Stop immediately. No parent config inheritance at all. |

Also supports `OPENCODE_CONFIG_BOUNDARY` env var override.

Three files changed:
- `packages/core/src/flag/flag.ts` — adds `OPENCODE_CONFIG_BOUNDARY` env var
- `packages/opencode/src/config/config.ts` — adds `configBoundary` schema field, `getConfigStop()` helper, and fixes relative instruction paths (e.g. `"./my-agents.md"`) to resolve from the config file's directory
- `packages/opencode/src/session/instruction.ts` — uses `getConfigStop()` for AGENTS.md/CLAUDE.md discovery

### How did you verify your code works?

Tested with `configBoundary: "home"` set in global config, with an `opencode.jsonc` one directory above a git repo. Configs and AGENTS.md at the parent level are picked up correctly. Default behavior (`"current"`) is unchanged — existing tests pass.

### Screenshots / recordings

_No UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR