### PR TITLE
fix: show helpful message when free usage limit is exceeded

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -64,6 +64,8 @@ export namespace SessionRetry {
 
     if (MessageV2.APIError.isInstance(error)) {
       if (!error.data.isRetryable) return undefined
+      if (error.data.responseBody?.includes("FreeUsageLimitError"))
+        return `Free usage exceeded, add credits https://opencode.ai/zen`
       return error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message
     }
 


### PR DESCRIPTION
## Summary
Shows a helpful error message when users hit their free usage limit, directing them to add credits at https://opencode.ai/zen

## Changes
- Added check for `FreeUsageLimitError` in retry logic
- Displays actionable message pointing users to the billing page when free tier is exceeded