### PR TITLE
fix: prevent rate limit errors from being misclassified as context overflow

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -19,8 +19,19 @@ export namespace ProviderError {
     /context window exceeds limit/i, // MiniMax
     /exceeded model token limit/i, // Kimi For Coding
     /context[_ ]length[_ ]exceeded/i, // Generic fallback
-    /too many tokens/i, // Generic fallback
+    /too many tokens(?! per (day|minute|hour|second))(?! processed)/i, // Generic fallback (excludes rate limit phrases)
     /token limit exceeded/i, // Generic fallback
+  ]
+
+  // Rate limit patterns that should NOT be treated as context overflow.
+  // These are checked before overflow patterns so that errors like
+  // "Too many tokens per day" (AWS Bedrock) and "too many tokens
+  // processed" (Cerebras) are correctly classified as retryable API errors.
+  const RATE_LIMIT_PATTERNS = [
+    /too many tokens per (day|minute|hour|second)/i, // AWS Bedrock daily/minute quota
+    /tokens per (day|minute|hour|second) limit/i, // Generic rate limit
+    /too many tokens processed/i, // Cerebras
+    /rate limit/i, // Generic rate limit
   ]
 
   function isOpenAiErrorRetryable(e: APICallError) {
@@ -30,9 +41,17 @@ export namespace ProviderError {
     return status === 404 || e.isRetryable
   }
 
+  function isRateLimit(message: string) {
+    return RATE_LIMIT_PATTERNS.some((p) => p.test(message))
+  }
+
   // Providers not reliably handled in this function:
   // - z.ai: can accept overflow silently (needs token-count/context-window checks)
   function isOverflow(message: string) {
+    // Rate limit errors should never be classified as context overflow,
+    // even if they contain phrases like "too many tokens".
+    if (isRateLimit(message)) return false
+
     if (OVERFLOW_PATTERNS.some((p) => p.test(message))) return true
 
     // Providers/status patterns handled outside of regex list:


### PR DESCRIPTION
## Summary

Fixes #13015

The `/too many tokens/i` regex in `OVERFLOW_PATTERNS` is too broad and matches rate limit / daily quota errors that contain "too many tokens" but are **not** context overflow errors.

## Affected Error Messages

| Error Message | Source | Before | After |
|---|---|---|---|
| "Too many tokens per day, please wait..." | AWS Bedrock | `context_overflow` | `api_error` (retryable) |
| "too many tokens processed" | Cerebras (#7463) | `context_overflow` | `api_error` (retryable) |
| "prompt is too long: 285744 tokens > 200000 maximum" | Anthropic | `context_overflow` | `context_overflow` (unchanged) |

## Root Cause

`isOverflow()` checks `OVERFLOW_PATTERNS` which includes `/too many tokens/i`. This matches rate limit errors → classified as `ContextOverflowError` → triggers compaction instead of retry → compaction also fails (same quota error) → user is stuck.

## Changes

Two complementary fixes in `packages/opencode/src/provider/error.ts`:

1. **Narrowed the regex**: Added negative lookahead to the "too many tokens" pattern so it excludes temporal qualifiers and "processed":
   ```
   /too many tokens(?! per (day|minute|hour|second))(?! processed)/i
   ```

2. **Added rate limit guard**: New `RATE_LIMIT_PATTERNS` list and `isRateLimit()` function checked **before** overflow patterns in `isOverflow()`. This provides defense-in-depth — even if the regex lookahead misses a new rate limit phrasing, the explicit rate limit check catches it.

## Test Plan

- [ ] Verify "Too many tokens per day, please wait before trying again." → classified as retryable `api_error`
- [ ] Verify "Tokens per minute limit exceeded - too many tokens processed" → classified as retryable `api_error`
- [ ] Verify "prompt is too long: 285744 tokens > 200000 maximum" → still classified as `context_overflow`
- [ ] Verify "maximum context length is 128000 tokens" → still classified as `context_overflow`

*Assisted by Claude Opus 4.6 max thinking*

Made with [Cursor](https://cursor.com)