### PR TITLE
fix(opencode): coalesce stream updates and add reconnect backoff

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sdk.tsx
@@ -31,14 +31,16 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
 
     let queue: Event[] = []
     let timer: Timer | undefined
-    let last = 0
+
+    const STREAM_BATCH_MS = 32
+    const EVENT_BATCH_MS = 12
+    const MAX_QUEUE_BEFORE_FLUSH = 100
 
     const flush = () => {
       if (queue.length === 0) return
       const events = queue
       queue = []
       timer = undefined
-      last = Date.now()
       // Batch all event emissions so all store updates result in a single render
       batch(() => {
         for (const event of events) {
@@ -49,16 +51,16 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
 
     const handleEvent = (event: Event) => {
       queue.push(event)
-      const elapsed = Date.now() - last
 
-      if (timer) return
-      // If we just flushed recently (within 16ms), batch this with future events
-      // Otherwise, process immediately to avoid latency
-      if (elapsed < 16) {
-        timer = setTimeout(flush, 16)
+      if (queue.length >= MAX_QUEUE_BEFORE_FLUSH) {
+        if (timer) clearTimeout(timer)
+        flush()
         return
       }
-      flush()
+
+      if (timer) return
+      const wait = event.type === "message.part.updated" ? STREAM_BATCH_MS : EVENT_BATCH_MS
+      timer = setTimeout(flush, wait)
     }
 
     onMount(async () => {
@@ -70,17 +72,29 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       }
 
       // Fall back to SSE
+      let retry = 250
       while (true) {
         if (abort.signal.aborted) break
-        const events = await sdk.event.subscribe(
-          {},
-          {
-            signal: abort.signal,
-          },
-        )
+        try {
+          const events = await sdk.event.subscribe(
+            {},
+            {
+              signal: abort.signal,
+            },
+          )
 
-        for await (const event of events.stream) {
-          handleEvent(event)
+          retry = 250
+          for await (const event of events.stream) {
+            handleEvent(event)
+          }
+
+          if (!abort.signal.aborted) {
+            await Bun.sleep(100)
+          }
+        } catch {
+          if (abort.signal.aborted) break
+          await Bun.sleep(retry)
+          retry = Math.min(retry * 2, 2_000)
         }
 
         // Flush any remaining events

--- a/packages/opencode/src/cli/cmd/tui/context/sync.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/sync.tsx
@@ -286,7 +286,8 @@ export const { use: useSync, provider: SyncProvider } = createSimpleContext({
           }
           const result = Binary.search(parts, event.properties.part.id, (p) => p.id)
           if (result.found) {
-            setStore("part", event.properties.part.messageID, result.index, reconcile(event.properties.part))
+            if (parts[result.index] === event.properties.part) break
+            setStore("part", event.properties.part.messageID, result.index, event.properties.part)
             break
           }
           setStore(

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1354,17 +1354,14 @@ function ReasoningPart(props: { last: boolean; part: ReasoningPart; message: Ass
 function TextPart(props: { last: boolean; part: TextPart; message: AssistantMessage }) {
   const ctx = use()
   const { theme, syntax } = useTheme()
+  const content = createMemo(() => props.part.text)
+
   return (
-    <Show when={props.part.text.trim()}>
+    <Show when={content().length > 0}>
       <box id={"text-" + props.part.id} paddingLeft={3} marginTop={1} flexShrink={0}>
         <Switch>
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
-            <markdown
-              syntaxStyle={syntax()}
-              streaming={true}
-              content={props.part.text.trim()}
-              conceal={ctx.conceal()}
-            />
+            <markdown syntaxStyle={syntax()} streaming={true} content={content()} conceal={ctx.conceal()} />
           </Match>
           <Match when={!Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <code
@@ -1372,7 +1369,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
               drawUnstyledText={false}
               streaming={true}
               syntaxStyle={syntax()}
-              content={props.part.text.trim()}
+              content={content()}
               conceal={ctx.conceal()}
               fg={theme.text}
             />


### PR DESCRIPTION
## Summary

This PR narrows the scope to surgical TUI performance fixes in the existing OpenTUI path. It focuses on stream event coalescing, reconnect backoff, and lower-cost part updates during streaming.

Related to #13027.

## What Changed

### 1) Redraw coalescing for stream updates

- File: `packages/opencode/src/cli/cmd/tui/context/sdk.tsx`
- `message.part.updated` events now use a slightly longer batch window than non-stream events.
- Non-stream events still flush quickly.
- Added a queue cap that forces an immediate flush to avoid unbounded backlog.

### 2) Idle CPU guard for SSE reconnects

- File: `packages/opencode/src/cli/cmd/tui/context/sdk.tsx`
- Added reconnect delay/backoff after stream failures.
- Added a short pause after stream completion before reconnecting.
- This avoids tight reconnect loops when the stream drops repeatedly.

### 3) Lower-cost stream part updates

- File: `packages/opencode/src/cli/cmd/tui/context/sync.tsx`
- For existing parts, use direct replacement instead of `reconcile(...)` on every `message.part.updated` event.
- Skip no-op replacement when object identity is unchanged.

### 4) Stream append path optimization in message rendering

- File: `packages/opencode/src/cli/cmd/tui/routes/session/index.tsx`
- Removed per-render `trim()` calls on streaming text content.
- Reused a memoized `content` accessor for markdown/code renderables.
- This avoids repeated full-string scans/copies as streamed text grows.

## Why This Scope

The previous branch attempted a broader architecture path. This version keeps the implementation in the current renderer/data flow and addresses known hotspots directly.

## Notes

- No new rendering subsystem.
- No framework rewrite.
- No behavior change to message ordering or event semantics.
- The branch now contains a single focused commit touching 3 files.

## Related Context

These changes align with common TUI guidance to avoid continuous redraw pressure and busy reconnect loops:

- Ratatui high draw-rate CPU issue (`terminal.draw`): https://github.com/ratatui/ratatui/issues/1338
- Streaming markdown optimization via partial updates (Will McGugan): https://willmcgugan.github.io/streaming-markdown/

## Validation

I ran local typecheck, but the workspace currently has many unrelated baseline errors in this environment. The changes in this PR are small and isolated to TUI event/render paths.
