### PR TITLE
fix(core): tolerate corrupted JSON in session storage

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -668,17 +668,26 @@ export namespace MessageV2 {
   export const stream = fn(Identifier.schema("session"), async function* (sessionID) {
     const list = await Array.fromAsync(await Storage.list(["message", sessionID]))
     for (let i = list.length - 1; i >= 0; i--) {
-      yield await get({
+      const msg = await get({
         sessionID,
         messageID: list[i][2],
+      }).catch((e) => {
+        if (Storage.NotFoundError.isInstance(e)) return undefined
+        throw e
       })
+      if (!msg) continue
+      yield msg
     }
   })
 
   export const parts = fn(Identifier.schema("message"), async (messageID) => {
     const result = [] as MessageV2.Part[]
     for (const item of await Storage.list(["part", messageID])) {
-      const read = await Storage.read<MessageV2.Part>(item)
+      const read = await Storage.read<MessageV2.Part>(item).catch((e) => {
+        if (Storage.NotFoundError.isInstance(e)) return undefined
+        throw e
+      })
+      if (!read) continue
       result.push(read)
     }
     result.sort((a, b) => (a.id > b.id ? 1 : -1))

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -204,6 +204,10 @@ export namespace Storage {
       if (errnoException.code === "ENOENT") {
         throw new NotFoundError({ message: `Resource not found: ${errnoException.path}` })
       }
+      if (e instanceof SyntaxError) {
+        log.warn("corrupted JSON detected", { error: e.message })
+        throw new NotFoundError({ message: `Corrupted JSON: ${e.message}` })
+      }
       throw e
     })
   }


### PR DESCRIPTION
Fixes #7607

When a crash or OOM occurs mid-write, session part files can be left truncated or empty (0 bytes). This causes `SyntaxError: Unexpected end of JSON input` which breaks the entire session.

**Changes:**
- `Storage.withErrorHandling` now converts `SyntaxError` to `NotFoundError` (matching the existing `ENOENT` pattern)
- `MessageV2.parts()` gracefully skips corrupted part entries instead of crashing
- `MessageV2.stream()` gracefully skips corrupted messages instead of crashing

**How I verified:**
- Truncated a session part file to 0 bytes on a live server
- Confirmed the `SyntaxError: Unexpected end of JSON input` in journalctl
- Applied the fix, restarted — session opened normally, only the corrupted part was skipped
- All 13 existing `message-v2.test.ts` tests pass
- Typecheck passes