### PR TITLE
fix(app): implement helper for Windows app existence check using where.exe

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -165,9 +165,13 @@ fn check_app_exists(app_name: &str) -> bool {
 }
 
 #[cfg(target_os = "windows")]
-fn check_windows_app(_app_name: &str) -> bool {
-    // Check if command exists in PATH, including .exe
-    return true;
+fn check_windows_app(app_name: &str) -> bool {
+    // Check if command exists in PATH using where.exe
+    Command::new("where.exe")
+        .arg(app_name)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION


### What does this PR do?

Implements the helper to check if an app exists on the windows machine, used in the display of different apps one can open from on the desktop app.

Best to test using the application set for windows https://github.com/anomalyco/opencode/blob/dev/packages/app/src/components/session/session-header.tsx#L88

### How did you verify your code works?
