### PR TITLE
fix: prevent opencode run crash on malformed tool inputs

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -390,20 +390,24 @@ export const RunCommand = cmd({
 
     async function execute(sdk: OpencodeClient) {
       function tool(part: ToolPart) {
-        if (part.tool === "bash") return bash(props<typeof BashTool>(part))
-        if (part.tool === "glob") return glob(props<typeof GlobTool>(part))
-        if (part.tool === "grep") return grep(props<typeof GrepTool>(part))
-        if (part.tool === "list") return list(props<typeof ListTool>(part))
-        if (part.tool === "read") return read(props<typeof ReadTool>(part))
-        if (part.tool === "write") return write(props<typeof WriteTool>(part))
-        if (part.tool === "webfetch") return webfetch(props<typeof WebFetchTool>(part))
-        if (part.tool === "edit") return edit(props<typeof EditTool>(part))
-        if (part.tool === "codesearch") return codesearch(props<typeof CodeSearchTool>(part))
-        if (part.tool === "websearch") return websearch(props<typeof WebSearchTool>(part))
-        if (part.tool === "task") return task(props<typeof TaskTool>(part))
-        if (part.tool === "todowrite") return todo(props<typeof TodoWriteTool>(part))
-        if (part.tool === "skill") return skill(props<typeof SkillTool>(part))
-        return fallback(part)
+        try {
+          if (part.tool === "bash") return bash(props<typeof BashTool>(part))
+          if (part.tool === "glob") return glob(props<typeof GlobTool>(part))
+          if (part.tool === "grep") return grep(props<typeof GrepTool>(part))
+          if (part.tool === "list") return list(props<typeof ListTool>(part))
+          if (part.tool === "read") return read(props<typeof ReadTool>(part))
+          if (part.tool === "write") return write(props<typeof WriteTool>(part))
+          if (part.tool === "webfetch") return webfetch(props<typeof WebFetchTool>(part))
+          if (part.tool === "edit") return edit(props<typeof EditTool>(part))
+          if (part.tool === "codesearch") return codesearch(props<typeof CodeSearchTool>(part))
+          if (part.tool === "websearch") return websearch(props<typeof WebSearchTool>(part))
+          if (part.tool === "task") return task(props<typeof TaskTool>(part))
+          if (part.tool === "todowrite") return todo(props<typeof TodoWriteTool>(part))
+          if (part.tool === "skill") return skill(props<typeof SkillTool>(part))
+          return fallback(part)
+        } catch {
+          return fallback(part)
+        }
       }
 
       function emit(type: string, data: Record<string, unknown>) {


### PR DESCRIPTION
Fixes #12978

The `tool()` display function in `run.ts` reads raw LLM input before Zod validates it — so if the model omits a required field (like `subagent_type` on `task`), it crashes with a TypeError. This also kills the self-healing retry loop since Zod never gets a chance to tell the model what it got wrong.

Fix: wrapped the dispatch body in a try/catch that falls back to the existing `fallback(part)` handler. Valid inputs behave exactly the same, malformed ones get the generic display instead of a crash.

I know the style guide prefers `.catch()` over try/catch — but `tool()` is synchronous, so using `.catch()` would mean wrapping it in a Promise which changes the execution timing from sync to async and could introduce new bugs. Didn't think it was worth it.

Tested by mocking all 12 tool display functions with missing required fields — 9 crashed before, 0 after.

Thanks to [@ariane-emory](https://github.com/ariane-emory) for helping me make my first PR to OpenCode.