### PR TITLE
fix(tui): prevent home wordmark corruption in height-constrained terminals

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -93,10 +93,14 @@ export function Home() {
 
   return (
     <>
-      <box flexGrow={1} justifyContent="center" alignItems="center" paddingLeft={2} paddingRight={2} gap={1}>
-        <box height={3} />
-        <Logo />
-        <box width="100%" maxWidth={75} zIndex={1000} paddingTop={1}>
+      <box flexGrow={1} alignItems="center" paddingLeft={2} paddingRight={2}>
+        <box flexGrow={1} minHeight={0} />
+        <box height={4} minHeight={0} flexShrink={1} />
+        <box flexShrink={0}>
+          <Logo />
+        </box>
+        <box height={1} minHeight={0} flexShrink={1} />
+        <box width="100%" maxWidth={75} zIndex={1000} paddingTop={1} flexShrink={0}>
           <Prompt
             ref={(r) => {
               prompt = r
@@ -105,11 +109,12 @@ export function Home() {
             hint={Hint}
           />
         </box>
-        <box height={3} width="100%" maxWidth={75} alignItems="center" paddingTop={2}>
+        <box height={4} minHeight={0} width="100%" maxWidth={75} alignItems="center" paddingTop={3} flexShrink={1}>
           <Show when={showTips()}>
             <Tips />
           </Show>
         </box>
+        <box flexGrow={1} minHeight={0} />
         <Toast />
       </box>
       <box paddingTop={1} paddingBottom={1} paddingLeft={2} paddingRight={2} flexDirection="row" flexShrink={0} gap={2}>


### PR DESCRIPTION
### What does this PR do?
Fixes home-screen logo layout under height-constrained terminals to prevent wordmark corruption (e.g. `OPONCOO`).

Fixes #13067

BEFORE

<img width="893" height="554" alt="image" src="https://github.com/user-attachments/assets/2adf8454-96f0-4823-ba00-3a7af9622507" />

AFTER

<img width="866" height="518" alt="image" src="https://github.com/user-attachments/assets/1e33a213-03bb-41e0-9643-d8336f3573d0" />

Changes are layout-only in `Home`:
- Keep core logo/prompt block non-shrinking.
- Use shrinkable reserved spacers above and below to absorb height pressure first.
- Keep tips in a reserved slot so toggling tips does not shift alignment.

### How did you verify your code works?
- Reproduced by reducing terminal height on the TUI home screen.
- Confirmed the wordmark no longer corrupts under the constrained-height scenario from the issue.
