### PR TITLE
feat(vscode): connect to any opencodes running in current working directory

### DIFF
--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,26 +1,26 @@
 // This method is called when your extension is deactivated
 export function deactivate() {}
 
-import * as vscode from "vscode";
-import { resolve } from "./resolve";
+import * as vscode from "vscode"
+import { resolve } from "./resolve"
 
-const TERMINAL_NAME = "opencode";
+const TERMINAL_NAME = "opencode"
 
 export function activate(context: vscode.ExtensionContext) {
   let openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
-    await openTerminal();
-  });
+    await openTerminal()
+  })
 
   let openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
     // An opencode terminal already exists => focus it
-    const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME);
+    const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME)
     if (existingTerminal) {
-      existingTerminal.show();
-      return;
+      existingTerminal.show()
+      return
     }
 
-    await openTerminal();
-  });
+    await openTerminal()
+  })
 
   let addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
     const result = await resolve(
@@ -30,35 +30,37 @@ export function activate(context: vscode.ExtensionContext) {
       })),
       vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
       discover,
-    );
+    )
 
     if (result.action === "spawn") {
-      await openTerminal();
-      return;
+      await openTerminal()
+      return
     }
 
-    const fileRef = getActiveFile(result.action === "external");
-    if (!fileRef) {return;}
+    const fileRef = getActiveFile()
+    if (!fileRef) {
+      return
+    }
 
     if (result.action === "native") {
-      const terminal = vscode.window.terminals.find((t) => terminalPort(t) === result.port)!;
+      const terminal = vscode.window.terminals.find((t) => terminalPort(t) === result.port)!
       try {
-        await appendPrompt(result.port, fileRef);
+        await appendPrompt(result.port, fileRef)
       } catch {
-        terminal.sendText(fileRef, false);
+        terminal.sendText(fileRef, false)
       }
-      terminal.show();
-      return;
+      terminal.show()
+      return
     }
 
-    await appendPrompt(result.port, fileRef);
-  });
+    await appendPrompt(result.port, fileRef)
+  })
 
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable);
+  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
 
   async function openTerminal() {
     // Create a new terminal in split screen
-    const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384;
+    const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
     const terminal = vscode.window.createTerminal({
       name: TERMINAL_NAME,
       iconPath: {
@@ -73,34 +75,34 @@ export function activate(context: vscode.ExtensionContext) {
         _EXTENSION_OPENCODE_PORT: port.toString(),
         OPENCODE_CALLER: "vscode",
       },
-    });
+    })
 
-    terminal.show();
-    terminal.sendText(`opencode --port ${port}`);
+    terminal.show()
+    terminal.sendText(`opencode --port ${port}`)
 
-    const fileRef = getActiveFile();
+    const fileRef = getActiveFile()
     if (!fileRef) {
-      return;
+      return
     }
 
     // Wait for the terminal to be ready
-    let tries = 10;
-    let connected = false;
+    let tries = 10
+    let connected = false
     do {
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await new Promise((resolve) => setTimeout(resolve, 200))
       try {
-        await fetch(`http://localhost:${port}/app`);
-        connected = true;
-        break;
+        await fetch(`http://localhost:${port}/app`)
+        connected = true
+        break
       } catch (e) {}
 
-      tries--;
-    } while (tries > 0);
+      tries--
+    } while (tries > 0)
 
     // If connected, append the prompt to the terminal
     if (connected) {
-      await appendPrompt(port, `In ${fileRef}`);
-      terminal.show();
+      await appendPrompt(port, `In ${fileRef}`)
+      terminal.show()
     }
   }
 
@@ -111,64 +113,59 @@ export function activate(context: vscode.ExtensionContext) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ text }),
-    });
+    })
   }
 
   function terminalPort(t: vscode.Terminal) {
-    const raw = (t.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"];
-    return raw ? parseInt(raw) : undefined;
+    const raw = (t.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"]
+    return raw ? parseInt(raw) : undefined
   }
 
   async function discover(workspace: string) {
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 1000);
-      const res = await fetch("http://localhost:4096/path", { signal: controller.signal });
-      clearTimeout(timeout);
-      const data = (await res.json()) as { directory: string; worktree: string };
-      if (data.directory === workspace || data.worktree === workspace) {return 4096;}
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 1000)
+      const res = await fetch("http://localhost:4096/path", { signal: controller.signal })
+      clearTimeout(timeout)
+      const data = (await res.json()) as { directory: string; worktree: string }
+      if (data.directory === workspace || data.worktree === workspace) {
+        return 4096
+      }
     } catch {}
-    return undefined;
+    return undefined
   }
 
-  function getActiveFile(absolute: boolean = false) {
-    const activeEditor = vscode.window.activeTextEditor;
+  function getActiveFile() {
+    const activeEditor = vscode.window.activeTextEditor
     if (!activeEditor) {
-      return;
+      return
     }
 
-    const document = activeEditor.document;
-
-    // Get the path based on absolute flag
-    let path: string;
-    if (absolute) {
-      path = document.uri.fsPath;
-    } else {
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-      if (!workspaceFolder) {
-        return;
-      }
-      path = vscode.workspace.asRelativePath(document.uri);
+    const document = activeEditor.document
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)
+    if (!workspaceFolder) {
+      return
     }
+    const path = vscode.workspace.asRelativePath(document.uri)
 
-    let filepathWithAt = `@${path}`;
+    let filepathWithAt = `@${path}`
 
     // Check if there's a selection and add line numbers
-    const selection = activeEditor.selection;
+    const selection = activeEditor.selection
     if (!selection.isEmpty) {
       // Convert to 1-based line numbers
-      const startLine = selection.start.line + 1;
-      const endLine = selection.end.line + 1;
+      const startLine = selection.start.line + 1
+      const endLine = selection.end.line + 1
 
       if (startLine === endLine) {
         // Single line selection
-        filepathWithAt += `#L${startLine}`;
+        filepathWithAt += `#L${startLine}`
       } else {
         // Multi-line selection
-        filepathWithAt += `#L${startLine}-${endLine}`;
+        filepathWithAt += `#L${startLine}-${endLine}`
       }
     }
 
-    return filepathWithAt;
+    return filepathWithAt
   }
 }

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -22,38 +22,52 @@ export function activate(context: vscode.ExtensionContext) {
   })
 
   let addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
-    const terminal = vscode.window.activeTerminal
-    if (!terminal) {
+    // Step 1: Active terminal is a native opencode terminal
+    const active = vscode.window.activeTerminal
+    if (active) {
+      const port = terminalPort(active)
+      if (port) {
+        const fileRef = getActiveFile()
+        if (!fileRef) return
+        try {
+          await appendPrompt(port, fileRef)
+        } catch {
+          active.sendText(fileRef, false)
+        }
+        active.show()
+        return
+      }
+    }
+
+    // Step 2: Any opencode terminal in VS Code
+    for (const t of vscode.window.terminals) {
+      const port = terminalPort(t)
+      if (!port) continue
+      const fileRef = getActiveFile()
+      if (!fileRef) return
+      try {
+        await appendPrompt(port, fileRef)
+      } catch {
+        t.sendText(fileRef, false)
+      }
+      t.show()
       return
     }
 
-    const port = (terminal.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"]
-
-    if (port) {
-      // Native opencode terminal - use relative path with HTTP
-      const fileRef = getActiveFile(false)
-      if (!fileRef) {
+    // Step 3: External opencode instance (e.g. tmux) with same CWD
+    const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+    if (folder) {
+      const port = await discover(folder)
+      if (port) {
+        const fileRef = getActiveFile(true)
+        if (!fileRef) return
+        await appendPrompt(port, fileRef)
         return
       }
-
-      try {
-        await appendPrompt(parseInt(port), fileRef)
-      } catch {
-        terminal.sendText(fileRef, false)
-      }
-    } else {
-      // External terminal - use absolute path with text paste
-      const fileRef = getActiveFile(true)
-      if (!fileRef) {
-        return
-      }
-
-      // Wrap paths with spaces in quotes
-      const text = fileRef.includes(" ") ? `"${fileRef}"` : fileRef
-      terminal.sendText(text, false)
     }
 
-    terminal.show()
+    // Step 4: No opencode found — spawn new terminal
+    await openTerminal()
   })
 
   context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
@@ -114,6 +128,23 @@ export function activate(context: vscode.ExtensionContext) {
       },
       body: JSON.stringify({ text }),
     })
+  }
+
+  function terminalPort(t: vscode.Terminal) {
+    const raw = (t.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"]
+    return raw ? parseInt(raw) : undefined
+  }
+
+  async function discover(workspace: string) {
+    try {
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 1000)
+      const res = await fetch("http://localhost:4096/path", { signal: controller.signal })
+      clearTimeout(timeout)
+      const data = (await res.json()) as { directory: string; worktree: string }
+      if (data.directory === workspace || data.worktree === workspace) return 4096
+    } catch {}
+    return undefined
   }
 
   function getActiveFile(absolute: boolean = false) {

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -22,22 +22,38 @@ export function activate(context: vscode.ExtensionContext) {
   })
 
   let addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
-    const fileRef = getActiveFile()
-    if (!fileRef) {
-      return
-    }
-
     const terminal = vscode.window.activeTerminal
     if (!terminal) {
       return
     }
 
-    if (terminal.name === TERMINAL_NAME) {
-      // @ts-ignore
-      const port = terminal.creationOptions.env?.["_EXTENSION_OPENCODE_PORT"]
-      port ? await appendPrompt(parseInt(port), fileRef) : terminal.sendText(fileRef, false)
-      terminal.show()
+    const port = (terminal.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"]
+
+    if (port) {
+      // Native opencode terminal - use relative path with HTTP
+      const fileRef = getActiveFile(false)
+      if (!fileRef) {
+        return
+      }
+
+      try {
+        await appendPrompt(parseInt(port), fileRef)
+      } catch {
+        terminal.sendText(fileRef, false)
+      }
+    } else {
+      // External terminal - use absolute path with text paste
+      const fileRef = getActiveFile(true)
+      if (!fileRef) {
+        return
+      }
+
+      // Wrap paths with spaces in quotes
+      const text = fileRef.includes(" ") ? `"${fileRef}"` : fileRef
+      terminal.sendText(text, false)
     }
+
+    terminal.show()
   })
 
   context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
@@ -100,21 +116,27 @@ export function activate(context: vscode.ExtensionContext) {
     })
   }
 
-  function getActiveFile() {
+  function getActiveFile(absolute: boolean = false) {
     const activeEditor = vscode.window.activeTextEditor
     if (!activeEditor) {
       return
     }
 
     const document = activeEditor.document
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)
-    if (!workspaceFolder) {
-      return
+
+    // Get the path based on absolute flag
+    let path: string
+    if (absolute) {
+      path = document.uri.fsPath
+    } else {
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)
+      if (!workspaceFolder) {
+        return
+      }
+      path = vscode.workspace.asRelativePath(document.uri)
     }
 
-    // Get the relative path from workspace root
-    const relativePath = vscode.workspace.asRelativePath(document.uri)
-    let filepathWithAt = `@${relativePath}`
+    let filepathWithAt = `@${path}`
 
     // Check if there's a selection and add line numbers
     const selection = activeEditor.selection

--- a/sdks/vscode/src/extension.ts
+++ b/sdks/vscode/src/extension.ts
@@ -1,80 +1,64 @@
 // This method is called when your extension is deactivated
 export function deactivate() {}
 
-import * as vscode from "vscode"
+import * as vscode from "vscode";
+import { resolve } from "./resolve";
 
-const TERMINAL_NAME = "opencode"
+const TERMINAL_NAME = "opencode";
 
 export function activate(context: vscode.ExtensionContext) {
   let openNewTerminalDisposable = vscode.commands.registerCommand("opencode.openNewTerminal", async () => {
-    await openTerminal()
-  })
+    await openTerminal();
+  });
 
   let openTerminalDisposable = vscode.commands.registerCommand("opencode.openTerminal", async () => {
     // An opencode terminal already exists => focus it
-    const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME)
+    const existingTerminal = vscode.window.terminals.find((t) => t.name === TERMINAL_NAME);
     if (existingTerminal) {
-      existingTerminal.show()
-      return
+      existingTerminal.show();
+      return;
     }
 
-    await openTerminal()
-  })
+    await openTerminal();
+  });
 
   let addFilepathDisposable = vscode.commands.registerCommand("opencode.addFilepathToTerminal", async () => {
-    // Step 1: Active terminal is a native opencode terminal
-    const active = vscode.window.activeTerminal
-    if (active) {
-      const port = terminalPort(active)
-      if (port) {
-        const fileRef = getActiveFile()
-        if (!fileRef) return
-        try {
-          await appendPrompt(port, fileRef)
-        } catch {
-          active.sendText(fileRef, false)
-        }
-        active.show()
-        return
-      }
+    const result = await resolve(
+      vscode.window.terminals.map((t) => ({
+        port: terminalPort(t),
+        active: t === vscode.window.activeTerminal,
+      })),
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+      discover,
+    );
+
+    if (result.action === "spawn") {
+      await openTerminal();
+      return;
     }
 
-    // Step 2: Any opencode terminal in VS Code
-    for (const t of vscode.window.terminals) {
-      const port = terminalPort(t)
-      if (!port) continue
-      const fileRef = getActiveFile()
-      if (!fileRef) return
+    const fileRef = getActiveFile(result.action === "external");
+    if (!fileRef) {return;}
+
+    if (result.action === "native") {
+      const terminal = vscode.window.terminals.find((t) => terminalPort(t) === result.port)!;
       try {
-        await appendPrompt(port, fileRef)
+        await appendPrompt(result.port, fileRef);
       } catch {
-        t.sendText(fileRef, false)
+        terminal.sendText(fileRef, false);
       }
-      t.show()
-      return
+      terminal.show();
+      return;
     }
 
-    // Step 3: External opencode instance (e.g. tmux) with same CWD
-    const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
-    if (folder) {
-      const port = await discover(folder)
-      if (port) {
-        const fileRef = getActiveFile(true)
-        if (!fileRef) return
-        await appendPrompt(port, fileRef)
-        return
-      }
-    }
+    await appendPrompt(result.port, fileRef);
+  });
 
-    // Step 4: No opencode found — spawn new terminal
-    await openTerminal()
-  })
-
-  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable)
+  context.subscriptions.push(openTerminalDisposable, addFilepathDisposable);
 
   async function openTerminal() {
     // Create a new terminal in split screen
-    const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
+    const port = Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384;
     const terminal = vscode.window.createTerminal({
       name: TERMINAL_NAME,
       iconPath: {
@@ -89,34 +73,34 @@ export function activate(context: vscode.ExtensionContext) {
         _EXTENSION_OPENCODE_PORT: port.toString(),
         OPENCODE_CALLER: "vscode",
       },
-    })
+    });
 
-    terminal.show()
-    terminal.sendText(`opencode --port ${port}`)
+    terminal.show();
+    terminal.sendText(`opencode --port ${port}`);
 
-    const fileRef = getActiveFile()
+    const fileRef = getActiveFile();
     if (!fileRef) {
-      return
+      return;
     }
 
     // Wait for the terminal to be ready
-    let tries = 10
-    let connected = false
+    let tries = 10;
+    let connected = false;
     do {
-      await new Promise((resolve) => setTimeout(resolve, 200))
+      await new Promise((resolve) => setTimeout(resolve, 200));
       try {
-        await fetch(`http://localhost:${port}/app`)
-        connected = true
-        break
+        await fetch(`http://localhost:${port}/app`);
+        connected = true;
+        break;
       } catch (e) {}
 
-      tries--
-    } while (tries > 0)
+      tries--;
+    } while (tries > 0);
 
     // If connected, append the prompt to the terminal
     if (connected) {
-      await appendPrompt(port, `In ${fileRef}`)
-      terminal.show()
+      await appendPrompt(port, `In ${fileRef}`);
+      terminal.show();
     }
   }
 
@@ -127,64 +111,64 @@ export function activate(context: vscode.ExtensionContext) {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ text }),
-    })
+    });
   }
 
   function terminalPort(t: vscode.Terminal) {
-    const raw = (t.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"]
-    return raw ? parseInt(raw) : undefined
+    const raw = (t.creationOptions as { env?: Record<string, string> }).env?.["_EXTENSION_OPENCODE_PORT"];
+    return raw ? parseInt(raw) : undefined;
   }
 
   async function discover(workspace: string) {
     try {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 1000)
-      const res = await fetch("http://localhost:4096/path", { signal: controller.signal })
-      clearTimeout(timeout)
-      const data = (await res.json()) as { directory: string; worktree: string }
-      if (data.directory === workspace || data.worktree === workspace) return 4096
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 1000);
+      const res = await fetch("http://localhost:4096/path", { signal: controller.signal });
+      clearTimeout(timeout);
+      const data = (await res.json()) as { directory: string; worktree: string };
+      if (data.directory === workspace || data.worktree === workspace) {return 4096;}
     } catch {}
-    return undefined
+    return undefined;
   }
 
   function getActiveFile(absolute: boolean = false) {
-    const activeEditor = vscode.window.activeTextEditor
+    const activeEditor = vscode.window.activeTextEditor;
     if (!activeEditor) {
-      return
+      return;
     }
 
-    const document = activeEditor.document
+    const document = activeEditor.document;
 
     // Get the path based on absolute flag
-    let path: string
+    let path: string;
     if (absolute) {
-      path = document.uri.fsPath
+      path = document.uri.fsPath;
     } else {
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri)
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
       if (!workspaceFolder) {
-        return
+        return;
       }
-      path = vscode.workspace.asRelativePath(document.uri)
+      path = vscode.workspace.asRelativePath(document.uri);
     }
 
-    let filepathWithAt = `@${path}`
+    let filepathWithAt = `@${path}`;
 
     // Check if there's a selection and add line numbers
-    const selection = activeEditor.selection
+    const selection = activeEditor.selection;
     if (!selection.isEmpty) {
       // Convert to 1-based line numbers
-      const startLine = selection.start.line + 1
-      const endLine = selection.end.line + 1
+      const startLine = selection.start.line + 1;
+      const endLine = selection.end.line + 1;
 
       if (startLine === endLine) {
         // Single line selection
-        filepathWithAt += `#L${startLine}`
+        filepathWithAt += `#L${startLine}`;
       } else {
         // Multi-line selection
-        filepathWithAt += `#L${startLine}-${endLine}`
+        filepathWithAt += `#L${startLine}-${endLine}`;
       }
     }
 
-    return filepathWithAt
+    return filepathWithAt;
   }
 }

--- a/sdks/vscode/src/resolve.test.ts
+++ b/sdks/vscode/src/resolve.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "./resolve";
+
+const noop = async () => undefined;
+
+describe("resolve", () => {
+  test("active terminal with port returns native", async () => {
+    const result = await resolve([{ port: 12345, active: true }], "/workspace", noop);
+    expect(result).toEqual({ action: "native", port: 12345 });
+  });
+
+  test("prefers active terminal over non-active", async () => {
+    const result = await resolve(
+      [
+        { port: 111, active: false },
+        { port: 222, active: true },
+      ],
+      "/workspace",
+      noop,
+    );
+    expect(result).toEqual({ action: "native", port: 222 });
+  });
+
+  test("non-active terminal with port returns native", async () => {
+    const result = await resolve([{ active: true }, { port: 54321, active: false }], "/workspace", noop);
+    expect(result).toEqual({ action: "native", port: 54321 });
+  });
+
+  test("external instance with matching CWD returns external", async () => {
+    const result = await resolve([], "/workspace", async () => 4096);
+    expect(result).toEqual({ action: "external", port: 4096 });
+  });
+
+  test("external instance with non-matching CWD returns spawn", async () => {
+    const result = await resolve([], "/workspace", noop);
+    expect(result).toEqual({ action: "spawn" });
+  });
+
+  test("no workspace skips discovery and returns spawn", async () => {
+    const result = await resolve([], undefined, async () => 4096);
+    expect(result).toEqual({ action: "spawn" });
+  });
+
+  test("no terminals and no external returns spawn", async () => {
+    const result = await resolve([], undefined, noop);
+    expect(result).toEqual({ action: "spawn" });
+  });
+
+  test("native preferred over external", async () => {
+    const result = await resolve([{ port: 9999, active: false }], "/workspace", async () => 4096);
+    expect(result).toEqual({ action: "native", port: 9999 });
+  });
+
+  test("terminals without ports fall through to external", async () => {
+    const result = await resolve([{ active: true }, { active: false }], "/workspace", async () => 4096);
+    expect(result).toEqual({ action: "external", port: 4096 });
+  });
+});

--- a/sdks/vscode/src/resolve.ts
+++ b/sdks/vscode/src/resolve.ts
@@ -1,0 +1,25 @@
+export type Resolution = { action: "native"; port: number } | { action: "external"; port: number } | { action: "spawn" }
+
+export interface TerminalInfo {
+  port?: number
+  active: boolean
+}
+
+export async function resolve(
+  terminals: TerminalInfo[],
+  workspace: string | undefined,
+  discover: (path: string) => Promise<number | undefined>,
+): Promise<Resolution> {
+  const active = terminals.find((t) => t.active && t.port);
+  if (active?.port) {return { action: "native", port: active.port };}
+
+  const any = terminals.find((t) => t.port);
+  if (any?.port) {return { action: "native", port: any.port };}
+
+  if (workspace) {
+    const port = await discover(workspace);
+    if (port) {return { action: "external", port };}
+  }
+
+  return { action: "spawn" };
+}

--- a/sdks/vscode/tsconfig.json
+++ b/sdks/vscode/tsconfig.json
@@ -12,5 +12,6 @@
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-  }
+  },
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
### What does this PR do?

Currently, this extension cannot detect an existing opencode instance running in the same current working directory. It keeps spawning a new opencode instance alongside the text editor, even though I already have one running in tmux.

So I’m trying to make the extension recognize my current session:

1. Native opencode terminal -> send via HTTP
2. Any vscode opencode terminal -> focus then send via HTTP
3. External opencode (same CWD in tmux) -> detect and send via HTTP
4. No opencode found -> spawn new integrated terminal (default behavior we have before my PR)

### How did you verify your code works?
I had opencode generate some tests, and I also tested it manually myself. Video attachment below

https://github.com/user-attachments/assets/6c450336-8be7-492a-8f7f-0fd4407ff6ea

Closes #13083 



