### PR TITLE
fix: encode non-ASCII directory path in v1 SDK client header

### DIFF
--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -19,9 +19,11 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   if (config?.directory) {
+    const isNonASCII = /[^\x00-\x7F]/.test(config.directory)
+    const encodedDirectory = isNonASCII ? encodeURIComponent(config.directory) : config.directory
     config.headers = {
       ...config.headers,
-      "x-opencode-directory": config.directory,
+      "x-opencode-directory": encodedDirectory,
     }
   }
 


### PR DESCRIPTION
## Problem

The v1 SDK client (`packages/sdk/js/src/client.ts`) passes the directory path directly to the `x-opencode-directory` HTTP header without encoding. When the path contains non-ASCII characters (Chinese, Japanese, Korean, etc.), the runtime's strict header validation rejects the value, causing a crash:

```
TypeError: Header x-opencode-directory has invalid value: C:\Users\baode\OneDrive\桌面
```

This is a regression introduced in v1.1.54+. Multiple users on Windows, macOS, and Linux are affected.

## Root Cause

The v2 SDK client already has the fix (added `isNonASCII` detection + `encodeURIComponent`), but the v1 SDK client was missed.

The server already handles decoding via `decodeURIComponent` (`server.ts:200`), so only the client-side encoding is needed.

## Fix

Apply the same encoding logic from v2 client to v1 client:

```typescript
if (config?.directory) {
  const isNonASCII = /[^\x00-\x7F]/.test(config.directory)
  const encodedDirectory = isNonASCII ? encodeURIComponent(config.directory) : config.directory
  config.headers = {
    ...config.headers,
    "x-opencode-directory": encodedDirectory,
  }
}
```

## Testing

- ASCII paths: no behavior change (bypass encoding)
- Non-ASCII paths (Chinese/Japanese/Korean): encoded via `encodeURIComponent`, decoded server-side via existing `decodeURIComponent`

Fixes #13023