### PR TITLE
docs(ko): improve translations for intro, cli, and commands

### DIFF
--- a/packages/web/src/content/docs/ko/cli.mdx
+++ b/packages/web/src/content/docs/ko/cli.mdx
@@ -1,17 +1,17 @@
 ---
 title: CLI
-description: opencode CLI options and commands.
+description: opencode CLI 옵션과 명령어.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components"
 
-기본적으로 opencode CLI는 어떤 인수 없이 실행할 때 [TUI](/docs/tui)를 시작합니다.
+opencode CLI는 인수 없이 실행하면 기본적으로 [TUI](/docs/tui)를 시작합니다.
 
 ```bash
 opencode
 ```
 
-그러나이 페이지에서 문서로 명령을받습니다. opencode programmatically와 상호 작용할 수 있습니다.
+이 페이지에 나온 것처럼 명령을 함께 전달할 수도 있습니다. 이를 통해 opencode를 프로그래밍 방식으로 사용할 수 있습니다.
 
 ```bash
 opencode run "Explain how closures work in JavaScript"
@@ -19,38 +19,38 @@ opencode run "Explain how closures work in JavaScript"
 
 ---
 
-### 튜이
+### tui
 
-opencode terminal 사용자 인터페이스를 시작합니다.
+OpenCode 터미널 사용자 인터페이스를 시작합니다.
 
 ```bash
 opencode [project]
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그       | 짧은 이름 | 설명                                                              |
-| ------------ | --------- | ----------------------------------------------------------------- |
-| `--continue` | `-c`      | 마지막 세션 계속하기                                              |
-| `--session`  | `-s`      | 계속할 세션 ID                                                    |
-| `--fork`     |           | 계속 시 세션 포크하기 (`--continue` 또는 `--session`과 함께 사용) |
-| `--prompt`   |           | 사용할 프롬프트                                                   |
-| `--model`    | `-m`      | `provider/model` 형식의 모델                                      |
-| `--agent`    |           | 사용할 에이전트                                                   |
-| `--port`     |           | 수신 대기할 포트                                                  |
-| `--hostname` |           | 수신 대기할 호스트명                                              |
-
----
-
-## 명령
-
-opencode CLI에는 다음과 같은 명령이 있습니다.
+| 플래그       | 축약 | 설명                                                                   |
+| ------------ | ---- | ---------------------------------------------------------------------- |
+| `--continue` | `-c` | 마지막 세션 이어서 실행                                                |
+| `--session`  | `-s` | 이어서 실행할 세션 ID                                                  |
+| `--fork`     |      | 세션을 이어갈 때 포크 생성 (`--continue` 또는 `--session`과 함께 사용) |
+| `--prompt`   |      | 사용할 프롬프트                                                        |
+| `--model`    | `-m` | 사용할 모델 (`provider/model` 형식)                                    |
+| `--agent`    |      | 사용할 에이전트                                                        |
+| `--port`     |      | 수신 포트                                                              |
+| `--hostname` |      | 수신 호스트명                                                          |
 
 ---
 
-## 에이전트
+## Commands
 
-opencode에 대한 에이전트 관리.
+opencode CLI는 아래 명령들도 제공합니다.
+
+---
+
+### agent
+
+opencode용 에이전트를 관리합니다.
 
 ```bash
 opencode agent [command]
@@ -58,15 +58,15 @@ opencode agent [command]
 
 ---
 
-### 첨부
+### attach
 
-`serve` 또는 `web` 명령을 통해 이미 실행되는 opencode 백엔드 서버에 terminal을 첨부합니다.
+`serve` 또는 `web` 명령으로 이미 실행 중인 opencode 백엔드 서버에 터미널을 연결합니다.
 
 ```bash
 opencode attach [url]
 ```
 
-리모트 opencode 백엔드를 사용하여 TUI를 사용할 수 있습니다. 예를 들면:
+원격 opencode 백엔드와 TUI를 연결해 사용할 수 있습니다. 예:
 
 ```bash
 # Start the backend server for web/mobile access
@@ -76,30 +76,30 @@ opencode web --port 4096 --hostname 0.0.0.0
 opencode attach http://10.20.30.40:4096
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그      | 플래그 | Description                  |
-| ----------- | ------ | ---------------------------- |
-| `--dir`     |        | TUI를 시작하는 작업 디렉토리 |
-| `--session` | `-s`   | 세션 ID                      |
+| 플래그      | 축약 | 설명                       |
+| ----------- | ---- | -------------------------- |
+| `--dir`     |      | TUI를 시작할 작업 디렉터리 |
+| `--session` | `-s` | 이어서 실행할 세션 ID      |
 
 ---
 
-#### 생성
+#### create
 
-사용자 정의 구성으로 새로운 에이전트를 만듭니다.
+커스텀 설정으로 새 에이전트를 만듭니다.
 
 ```bash
 opencode agent create
 ```
 
-이 명령은 사용자 정의 시스템 프롬프트 및 도구 구성으로 새로운 에이전트를 만들기 위해 안내합니다.
+이 명령은 커스텀 시스템 프롬프트와 도구 설정을 사용해 새 에이전트를 만드는 과정을 안내합니다.
 
 ---
 
-#### 리스트
+#### list
 
-모든 사용 가능한 에이전트 목록.
+사용 가능한 모든 에이전트를 표시합니다.
 
 ```bash
 opencode agent list
@@ -109,7 +109,7 @@ opencode agent list
 
 ### auth
 
-credentials 및 로그인을 관리하는 명령.
+provider 인증 정보와 로그인을 관리합니다.
 
 ```bash
 opencode auth [command]
@@ -117,27 +117,27 @@ opencode auth [command]
 
 ---
 
-#### 로그인
+#### login
 
-opencode는 [Models.dev](https://models.dev)의 공급자 목록에 의해 구동되므로 `opencode auth login`를 사용하여 사용하려는 모든 공급자의 API 키를 구성할 수 있습니다. 이것은 `~/.local/share/opencode/auth.json`에서 저장됩니다.
+OpenCode는 [Models.dev](https://models.dev)의 provider 목록을 기반으로 동작하므로, `opencode auth login`으로 원하는 provider의 API 키를 설정할 수 있습니다. 인증 정보는 `~/.local/share/opencode/auth.json`에 저장됩니다.
 
 ```bash
 opencode auth login
 ```
 
-opencode가 시작하면 credentials 파일에서 공급자를로드합니다. 그리고 프로젝트에 있는 환경 또는 `.env` 파일에서 정의된 키가 있다면.
+OpenCode 시작 시 인증 파일에서 provider 정보를 불러오며, 시스템 환경 변수나 프로젝트의 `.env`에 정의된 키도 함께 로드합니다.
 
 ---
 
-#### 리스트
+#### list
 
-credentials 파일에 저장 한 모든 인증 된 제공 업체를 나열합니다.
+인증 파일에 저장된 provider 목록을 표시합니다.
 
 ```bash
 opencode auth list
 ```
 
-또는 짧은 버전.
+축약형도 사용할 수 있습니다.
 
 ```bash
 opencode auth ls
@@ -145,9 +145,9 @@ opencode auth ls
 
 ---
 
-### 로그아웃
+#### logout
 
-credentials 파일에서 삭제하여 공급자에서 로그.
+인증 파일에서 provider 정보를 제거해 로그아웃합니다.
 
 ```bash
 opencode auth logout
@@ -155,9 +155,9 @@ opencode auth logout
 
 ---
 
-#### github에
+### github
 
-저장소 자동화를 위한 GitHub 에이전트 관리.
+저장소 자동화를 위한 GitHub 에이전트를 관리합니다.
 
 ```bash
 opencode github [command]
@@ -165,7 +165,7 @@ opencode github [command]
 
 ---
 
-### 설치
+#### install
 
 저장소에 GitHub 에이전트를 설치합니다.
 
@@ -173,30 +173,30 @@ opencode github [command]
 opencode github install
 ```
 
-필요한 GitHub Actions 워크플로우를 설정하고 구성 프로세스를 통해 안내합니다. [더 알아보기](/docs/github).
+필요한 GitHub Actions 워크플로를 설정하고 구성 과정을 안내합니다. [더 알아보기](/docs/github).
 
 ---
 
-#### 실행
+#### run
 
-GitHub 에이전트를 실행합니다. 이것은 일반적으로 GitHub Actions에서 사용됩니다.
+GitHub 에이전트를 실행합니다. 보통 GitHub Actions에서 사용합니다.
 
 ```bash
 opencode github run
 ```
 
-##### 플래그
+##### Flags
 
-| 플래그    | 설명                    |
-| --------- | ----------------------- |
-| `--event` | GitHub 모의 이벤트      |
-| `--token` | GitHub 개인 액세스 토큰 |
+| 플래그    | 설명                      |
+| --------- | ------------------------- |
+| `--event` | 실행할 GitHub 모의 이벤트 |
+| `--token` | GitHub 개인 액세스 토큰   |
 
 ---
 
-#### mcp를
+### mcp
 
-Model Context Protocol 서버 관리
+Model Context Protocol 서버를 관리합니다.
 
 ```bash
 opencode mcp [command]
@@ -204,27 +204,27 @@ opencode mcp [command]
 
 ---
 
-#### 추가
+#### add
 
-MCP 서버를 구성에 추가합니다.
+구성에 MCP 서버를 추가합니다.
 
 ```bash
 opencode mcp add
 ```
 
-이 명령은 로컬 또는 원격 MCP 서버를 추가하여 안내합니다.
+이 명령은 로컬 또는 원격 MCP 서버를 추가하는 과정을 안내합니다.
 
 ---
 
-#### 리스트
+#### list
 
-모든 구성 MCP 서버와 연결 상태를 나열합니다.
+구성된 MCP 서버와 연결 상태를 표시합니다.
 
 ```bash
 opencode mcp list
 ```
 
-또는 짧은 버전을 사용합니다.
+축약형도 사용할 수 있습니다.
 
 ```bash
 opencode mcp ls
@@ -234,21 +234,21 @@ opencode mcp ls
 
 #### auth
 
-OAuth-enabled MCP 서버 인증
+OAuth를 지원하는 MCP 서버를 인증합니다.
 
 ```bash
 opencode mcp auth [name]
 ```
 
-서버 이름을 제공하지 않으면 OAuth-capable 서버에서 선택할 수 있습니다.
+서버 이름을 입력하지 않으면 OAuth 지원 서버 목록에서 선택하라는 안내가 표시됩니다.
 
-OAuth-capable 서버와 인증 상태를 나열할 수 있습니다.
+OAuth 지원 서버와 인증 상태를 목록으로 볼 수도 있습니다.
 
 ```bash
 opencode mcp auth list
 ```
 
-또는 짧은 버전을 사용합니다.
+축약형도 사용할 수 있습니다.
 
 ```bash
 opencode mcp auth ls
@@ -256,9 +256,9 @@ opencode mcp auth ls
 
 ---
 
-### 로그아웃
+#### logout
 
-MCP 서버의 OAuth 자격 제거.
+MCP 서버의 OAuth 인증 정보를 제거합니다.
 
 ```bash
 opencode mcp logout [name]
@@ -266,9 +266,9 @@ opencode mcp logout [name]
 
 ---
 
-### 디버그
+#### debug
 
-MCP 서버의 OAuth 연결 문제.
+MCP 서버의 OAuth 연결 문제를 디버그합니다.
 
 ```bash
 opencode mcp debug <name>
@@ -276,32 +276,32 @@ opencode mcp debug <name>
 
 ---
 
-## 모델
+### models
 
-구성 공급자에서 모든 가능한 모델을 나열합니다.
+구성된 provider에서 사용 가능한 모델 목록을 표시합니다.
 
 ```bash
 opencode models [provider]
 ```
 
-이 명령은 `provider/model` 형식으로 구성된 제공 업체에서 사용할 수있는 모든 모델을 표시합니다.
+이 명령은 구성된 provider 전체에서 사용 가능한 모델을 `provider/model` 형식으로 출력합니다.
 
-이것은 [your config](/docs/config/)에서 사용하는 정확한 모델 이름을 파악하는 데 유용합니다.
+[config](/docs/config/)에 지정할 정확한 모델명을 확인할 때 유용합니다.
 
-선택적으로 공급자 ID를 필터 모델로 전달할 수 있습니다.
+특정 provider ID를 넘겨 해당 provider의 모델만 필터링할 수도 있습니다.
 
 ```bash
 opencode models anthropic
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그      | 설명                                                        |
-| ----------- | ----------------------------------------------------------- |
-| `--refresh` | 모델 캐시를 모델에서 새로 고침                              |
-| `--verbose` | 더 많은 verbose 모델 출력 사용(비용과 같은 메타데이터 포함) |
+| 플래그      | 설명                                              |
+| ----------- | ------------------------------------------------- |
+| `--refresh` | models.dev에서 모델 캐시 새로고침                 |
+| `--verbose` | 더 자세한 모델 출력 사용(비용 등 메타데이터 포함) |
 
-`--refresh` 플래그를 사용하여 캐시 모델 목록을 업데이트합니다. 이것은 새로운 모델이 공급자에 추가되었을 때 유용합니다. opencode에서 그들을보고 싶습니다.
+`--refresh` 플래그를 사용하면 캐시된 모델 목록을 갱신할 수 있습니다. provider에 새 모델이 추가된 뒤 OpenCode에서 바로 확인하고 싶을 때 유용합니다.
 
 ```bash
 opencode models --refresh
@@ -309,21 +309,21 @@ opencode models --refresh
 
 ---
 
-### 실행
+### run
 
-직접 프롬프트를 통과하여 비동기 모드에서 opencode를 실행합니다.
+프롬프트를 직접 전달해 비대화형 모드로 opencode를 실행합니다.
 
 ```bash
 opencode run [message..]
 ```
 
-이것은 스크립트, 자동화 또는 전체 TUI를 실행하지 않고 빠른 응답을 원할 때 유용합니다. 예를 들어.
+스크립트, 자동화, 또는 전체 TUI를 띄우지 않고 빠른 응답이 필요할 때 유용합니다. 예:
 
 ```bash "opencode run"
 opencode run Explain the use of context in Go
 ```
 
-`opencode serve` 인스턴스를 실행하여 MCP 서버 콜드 부팅 시간을 각 실행할 수 있습니다.
+매번 MCP 서버 콜드 부트가 발생하지 않도록, 실행 중인 `opencode serve` 인스턴스에 붙어서 실행할 수도 있습니다.
 
 ```bash
 # Start a headless server in one terminal
@@ -333,48 +333,49 @@ opencode serve
 opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그       | 짧은 이름 | 설명                                                  |
-| ------------ | --------- | ----------------------------------------------------- |
-| `--command`  |           | 실행 중인 명령 사용(미지정 시 args의 메시지 사용)     |
-| `--continue` | `-c`      | 마지막 세션                                           |
-| `--session`  | `-s`      | 세션 ID                                               |
-| `--share`    |           | 세션 공유                                             |
-| `--model`    | `-m`      | `-m`의 형태로 사용 가능                               |
-| `--agent`    |           | 에이전트                                              |
-| `--file`     | `-f`      | 메시지 첨부 파일                                      |
-| `--format`   |           | 출력 형식: formatted 또는 json(raw JSON 이벤트)       |
-| `--title`    |           | 세션의 제목(제공되지 않은 경우 truncated prompt 사용) |
-| `--attach`   |           | 운영 개시 서버(예: http://localhost:4096)             |
-| `--port`     |           | 현지 서버 포트                                        |
+| 플래그       | 축약 | 설명                                                                   |
+| ------------ | ---- | ---------------------------------------------------------------------- |
+| `--command`  |      | 실행할 명령(인수는 message로 전달)                                     |
+| `--continue` | `-c` | 마지막 세션 이어서 실행                                                |
+| `--session`  | `-s` | 이어서 실행할 세션 ID                                                  |
+| `--fork`     |      | 세션을 이어갈 때 포크 생성 (`--continue` 또는 `--session`과 함께 사용) |
+| `--share`    |      | 세션 공유                                                              |
+| `--model`    | `-m` | 사용할 모델 (`provider/model` 형식)                                    |
+| `--agent`    |      | 사용할 에이전트                                                        |
+| `--file`     | `-f` | 메시지에 첨부할 파일                                                   |
+| `--format`   |      | 출력 형식: default(포맷됨) 또는 json(원시 JSON 이벤트)                 |
+| `--title`    |      | 세션 제목(값이 없으면 프롬프트를 잘라 자동 생성)                       |
+| `--attach`   |      | 실행 중인 opencode 서버에 연결(예: http://localhost:4096)              |
+| `--port`     |      | 로컬 서버 포트(기본값: 랜덤 포트)                                      |
 
 ---
 
-## 서비스
+### serve
 
-API 액세스를 위한 headless opencode 서버를 시작합니다. 완전한 HTTP 인터페이스를 위해 [server docs](/docs/server)를 체크하십시오.
+API 접근용 headless OpenCode 서버를 시작합니다. 전체 HTTP 인터페이스는 [server docs](/docs/server)를 참고하세요.
 
 ```bash
 opencode serve
 ```
 
-TUI 인터페이스없이 API 액세스를 제공하는 HTTP 서버를 시작합니다. `OPENCODE_SERVER_PASSWORD`를 설정하여 HTTP 기본 auth (`opencode`에 기본적으로 이름을 지정합니다).
+이 명령은 TUI 없이 opencode 기능에 접근할 수 있는 HTTP 서버를 시작합니다. `OPENCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
 
-#### 플래그
+#### Flags
 
-| 플래그       | 설명                               |
-| ------------ | ---------------------------------- |
-| `--port`     | 포트                               |
-| `--hostname` | 듣고 싶은 이름                     |
-| `--mdns`     | 엔터블 mDNS 검색                   |
-| `--cors`     | CORS를 허용하는 추가 브라우저 기원 |
+| 플래그       | 설명                              |
+| ------------ | --------------------------------- |
+| `--port`     | 수신 포트                         |
+| `--hostname` | 수신 호스트명                     |
+| `--mdns`     | mDNS 검색 활성화                  |
+| `--cors`     | 허용할 추가 브라우저 origin(CORS) |
 
 ---
 
-### 세션
+### session
 
-opencode 세션 관리.
+OpenCode 세션을 관리합니다.
 
 ```bash
 opencode session [command]
@@ -382,63 +383,63 @@ opencode session [command]
 
 ---
 
-#### 리스트
+#### list
 
-모든 opencode 세션 목록.
+OpenCode 세션 목록을 표시합니다.
 
 ```bash
 opencode session list
 ```
 
-##### 플래그
+##### Flags
 
-| 플래그        | 짧은 이름 | 설명                       |
-| ------------- | --------- | -------------------------- |
-| `--max-count` | `-n`      | 최근 세션에 제한           |
-| `--format`    |           | 출력 형식: table 또는 json |
+| 플래그        | 축약 | 설명                                   |
+| ------------- | ---- | -------------------------------------- |
+| `--max-count` | `-n` | 최근 N개 세션만 표시                   |
+| `--format`    |      | 출력 형식: table 또는 json(기본 table) |
 
 ---
 
-### 통계
+### stats
 
-opencode 세션에 대한 토큰 사용 및 비용 통계를 표시합니다.
+OpenCode 세션의 토큰 사용량과 비용 통계를 표시합니다.
 
 ```bash
 opencode stats
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그      | 설명                                                                |
-| ----------- | ------------------------------------------------------------------- |
-| `--days`    | 지난 N일간의 통계를 보여 주세요(모든 시간)                          |
-| `--tools`   | 쇼의 도구 수                                                        |
-| `--models`  | 모델 사용 내역(기본적으로 숨겨져 있음) 상단 N을 표시할 수 있는 번호 |
-| `--project` | 프로젝트별 필터링(모든 프로젝트, 빈 문자열: 현재 프로젝트)          |
+| 플래그      | 설명                                                         |
+| ----------- | ------------------------------------------------------------ |
+| `--days`    | 최근 N일 통계 표시(기본값: 전체 기간)                        |
+| `--tools`   | 표시할 도구 개수(기본값: 전체)                               |
+| `--models`  | 모델 사용량 상세 표시(기본 숨김). 숫자를 주면 상위 N개 표시  |
+| `--project` | 프로젝트 필터(기본: 전체 프로젝트, 빈 문자열: 현재 프로젝트) |
 
 ---
 
-### 수출
+### export
 
-JSON으로 세션 데이터를 내보내기.
+세션 데이터를 JSON으로 내보냅니다.
 
 ```bash
 opencode export [sessionID]
 ```
 
-세션 ID를 제공하지 않는 경우 사용 가능한 세션에서 선택할 수 있습니다.
+세션 ID를 지정하지 않으면 사용 가능한 세션에서 선택하라는 안내가 표시됩니다.
 
 ---
 
-### 가져오기
+### import
 
-JSON 파일 또는 opencode 공유 URL에서 세션 데이터를 가져옵니다.
+JSON 파일 또는 OpenCode 공유 URL에서 세션 데이터를 가져옵니다.
 
 ```bash
 opencode import <file>
 ```
 
-로컬 파일 또는 opencode 공유 URL에서 가져올 수 있습니다.
+로컬 파일이나 OpenCode 공유 URL에서 가져올 수 있습니다.
 
 ```bash
 opencode import session.json
@@ -447,24 +448,24 @@ opencode import https://opncd.ai/s/abc123
 
 ---
 
-#### 웹
+### web
 
-웹 인터페이스로 headless opencode 서버를 시작합니다.
+웹 인터페이스를 포함한 headless OpenCode 서버를 시작합니다.
 
 ```bash
 opencode web
 ```
 
-HTTP 서버를 시작하고 웹 인터페이스를 통해 opencode에 액세스하는 웹 브라우저를 엽니 다. `OPENCODE_SERVER_PASSWORD`를 설정하여 HTTP 기본 auth (`opencode`에 기본적으로 이름을 지정합니다).
+이 명령은 HTTP 서버를 시작하고 웹 브라우저를 열어 웹 인터페이스로 OpenCode에 접속합니다. `OPENCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
 
-#### 플래그
+#### Flags
 
-| 플래그       | 설명                               |
-| ------------ | ---------------------------------- |
-| `--port`     | 포트                               |
-| `--hostname` | 듣고 싶은 이름                     |
-| `--mdns`     | 엔터블 mDNS 검색                   |
-| `--cors`     | CORS를 허용하는 추가 브라우저 기원 |
+| 플래그       | 설명                              |
+| ------------ | --------------------------------- |
+| `--port`     | 수신 포트                         |
+| `--hostname` | 수신 호스트명                     |
+| `--mdns`     | mDNS 검색 활성화                  |
+| `--cors`     | 허용할 추가 브라우저 origin(CORS) |
 
 ---
 
@@ -476,127 +477,127 @@ ACP(Agent Client Protocol) 서버를 시작합니다.
 opencode acp
 ```
 
-이 명령은 nd-JSON을 사용하여 stdin/stdout을 통해 통신하는 ACP 서버를 시작합니다.
+이 명령은 nd-JSON 형식으로 stdin/stdout을 통해 통신하는 ACP 서버를 시작합니다.
 
-#### 플래그
+#### Flags
 
-| 플래그       | 설명           |
-| ------------ | -------------- |
-| `--cwd`      | 작업 디렉토리  |
-| `--port`     | 포트           |
-| `--hostname` | 듣고 싶은 이름 |
+| 플래그       | 설명          |
+| ------------ | ------------- |
+| `--cwd`      | 작업 디렉터리 |
+| `--port`     | 수신 포트     |
+| `--hostname` | 수신 호스트명 |
 
 ---
 
-## 제거
+### uninstall
 
-opencode 제거하고 관련 파일을 제거합니다.
+OpenCode를 제거하고 관련 파일을 삭제합니다.
 
 ```bash
 opencode uninstall
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그          | 플래그 | Description                |
-| --------------- | ------ | -------------------------- |
-| `--keep-config` | `-c`   | 구성 파일 유지             |
-| `--keep-data`   | `-d`   | 세션 데이터 및 스냅샷 유지 |
-| `--dry-run`     |        | 제거하지 않고 제거하는 것  |
-| `--force`       | `-f`   | 확인 프롬프트              |
+| 플래그          | 축약 | 설명                            |
+| --------------- | ---- | ------------------------------- |
+| `--keep-config` | `-c` | 설정 파일 유지                  |
+| `--keep-data`   | `-d` | 세션 데이터와 스냅샷 유지       |
+| `--dry-run`     |      | 실제 삭제 없이 삭제 대상만 표시 |
+| `--force`       | `-f` | 확인 프롬프트 건너뛰기          |
 
 ---
 
-### 업그레이드
+### upgrade
 
-업데이트 opencode 최신 버전 또는 특정 버전.
+opencode를 최신 버전 또는 특정 버전으로 업데이트합니다.
 
 ```bash
 opencode upgrade [target]
 ```
 
-최신 버전으로 업그레이드하십시오.
+최신 버전으로 업그레이드:
 
 ```bash
 opencode upgrade
 ```
 
-특정 버전으로 업그레이드하십시오.
+특정 버전으로 업그레이드:
 
 ```bash
 opencode upgrade v0.1.48
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그     | 플래그 | Description                                  |
-| ---------- | ------ | -------------------------------------------- |
-| `--method` | `-m`   | 사용중인 설치 방법; 컬, npm, pnpm, bun, brew |
-
----
-
-## 글로벌 플래그
-
-opencode CLI는 다음의 글로벌 플래그를 사용합니다.
-
-| 플래그         | 짧은 이름 | 설명                                |
-| -------------- | --------- | ----------------------------------- |
-| `--help`       | `-h`      | 디스플레이 도움말                   |
-| `--version`    | `-v`      | 인쇄판 번호                         |
-| `--print-logs` |           | 스터디로 로그인                     |
-| `--log-level`  |           | 로그 레벨(DEBUG, INFO, WARN, ERROR) |
+| 플래그     | 축약 | 설명                                       |
+| ---------- | ---- | ------------------------------------------ |
+| `--method` | `-m` | 설치 방식 지정: curl, npm, pnpm, bun, brew |
 
 ---
 
-## 환경 변수
+## Global Flags
 
-opencode는 환경 변수를 사용하여 구성할 수 있습니다.
+opencode CLI는 아래 전역 플래그를 지원합니다.
 
-| 변하기 쉬운                           | 유형    | 묘사                                      |
-| ------------------------------------- | ------- | ----------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | 불린    | 자동 공유 세션                            |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Windows에서 실행되는 Git Bash 경로        |
-| `OPENCODE_CONFIG`                     | string  | 설정파일 경로                             |
-| `OPENCODE_CONFIG_DIR`                 | string  | 구성 디렉토리 경로                        |
-| `OPENCODE_CONFIG_CONTENT`             | 문자열  | 인라인 json 구성 내용                     |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | 불린    | 자동 업데이트 체크 아웃                   |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | 오래된 자료의 무능                        |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | 불린    | 자동 단말 제목 업데이트                   |
-| `OPENCODE_PERMISSION`                 | 문자열  | 인라인 json 권한 설정                     |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | 불린    | 기본 플러그인 비활성화                    |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | 불린    | 자동 LSP 서버 다운로드                    |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | 불린    | 실험 모델                                 |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 자동 컨텍스트 컴팩트                      |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`(prompt + Skill)의 읽을 수 있음  |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | 불린    | `~/.claude/CLAUDE.md`를 읽을 수 있습니다  |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | 불린    | `.claude/skills` 적재 가능                |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 리모트 소스에서 모델에 익숙하지 않은 모델 |
-| `OPENCODE_FAKE_VCS`                   | string  | 시험용 VCS 제공업체                       |
-| `OPENCODE_DISABLE_FILETIME_CHECK`     | boolean | 최적화를 위한 파일 시간 검사              |
-| `OPENCODE_CLIENT`                     | string  | 클라이언트 식별자(`cli`와 동일)           |
-| `OPENCODE_ENABLE_EXA`                 | 불린    | 엑다 웹 검색 도구                         |
-| `OPENCODE_SERVER_PASSWORD`            | string  | `serve`/`web`에 대한 기본 요점            |
-| `OPENCODE_SERVER_USERNAME`            | string  | 기본 사용자 이름(기본 `opencode`)         |
-| `OPENCODE_MODELS_URL`                 | string  | 모델 구성의 맞춤 URL                      |
+| 플래그         | 축약 | 설명                                |
+| -------------- | ---- | ----------------------------------- |
+| `--help`       | `-h` | 도움말 표시                         |
+| `--version`    | `-v` | 버전 출력                           |
+| `--print-logs` |      | 로그를 stderr로 출력                |
+| `--log-level`  |      | 로그 레벨(DEBUG, INFO, WARN, ERROR) |
 
 ---
 
-### 실험
+## Environment variables
 
-이 환경변수는 변화하거나 제거될 수 있는 실험적인 특징을 가능하게 합니다.
+OpenCode는 환경 변수로도 구성할 수 있습니다.
 
-| 변하기 쉬운                                     | 유형    | 묘사                               |
-| ----------------------------------------------- | ------- | ---------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | 불린    | 모든 실험적인 특징                 |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 아이콘 검색                        |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | 불린    | TUI의 선택 해제                    |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | 번호    | ms에서 bash 명령의 기본 시간       |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | 번호    | LLM 응답을 위한 최대 Output Tokens |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 전체 디디터용 파일워커             |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | 불린    | 엔블 oxfmt 형식                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | 불린    | 실험적인 LSP 도구                  |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 사용 가능한 파일워커               |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 실험용 Exa 기능                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | 불린    | 실험적인 LSP형 검사                |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 실험용 마운팅 기능                 |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | 불린    | 플랜 모드                          |
+| 변수                                  | 타입    | 설명                                           |
+| ------------------------------------- | ------- | ---------------------------------------------- |
+| `OPENCODE_AUTO_SHARE`                 | boolean | 세션 자동 공유                                 |
+| `OPENCODE_GIT_BASH_PATH`              | string  | Windows에서 Git Bash 실행 파일 경로            |
+| `OPENCODE_CONFIG`                     | string  | 설정 파일 경로                                 |
+| `OPENCODE_CONFIG_DIR`                 | string  | 설정 디렉터리 경로                             |
+| `OPENCODE_CONFIG_CONTENT`             | string  | 인라인 JSON 설정 내용                          |
+| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | 자동 업데이트 확인 비활성화                    |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | 오래된 데이터 정리(prune) 비활성화             |
+| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | 터미널 제목 자동 업데이트 비활성화             |
+| `OPENCODE_PERMISSION`                 | string  | 인라인 JSON 권한 설정                          |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 기본 플러그인 비활성화                         |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | LSP 서버 자동 다운로드 비활성화                |
+| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 실험적 모델 활성화                             |
+| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 자동 컨텍스트 컴팩션 비활성화                  |
+| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`(프롬프트 + 스킬) 읽기 비활성화       |
+| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | `~/.claude/CLAUDE.md` 읽기 비활성화            |
+| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | `.claude/skills` 로드 비활성화                 |
+| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 원격 소스에서 모델 목록 가져오기 비활성화      |
+| `OPENCODE_FAKE_VCS`                   | string  | 테스트용 가짜 VCS provider                     |
+| `OPENCODE_DISABLE_FILETIME_CHECK`     | boolean | 최적화를 위한 파일 시간 검사 비활성화          |
+| `OPENCODE_CLIENT`                     | string  | 클라이언트 식별자(기본값: `cli`)               |
+| `OPENCODE_ENABLE_EXA`                 | boolean | Exa 웹 검색 도구 활성화                        |
+| `OPENCODE_SERVER_PASSWORD`            | string  | `serve`/`web` 기본 인증 활성화                 |
+| `OPENCODE_SERVER_USERNAME`            | string  | 기본 인증 사용자명 오버라이드(기본 `opencode`) |
+| `OPENCODE_MODELS_URL`                 | string  | 모델 설정을 가져올 사용자 지정 URL             |
+
+---
+
+### Experimental
+
+아래 환경 변수는 변경되거나 제거될 수 있는 실험 기능을 활성화합니다.
+
+| 변수                                            | 타입    | 설명                           |
+| ----------------------------------------------- | ------- | ------------------------------ |
+| `OPENCODE_EXPERIMENTAL`                         | boolean | 모든 실험 기능 활성화          |
+| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 아이콘 탐색 활성화             |
+| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | TUI에서 선택 시 복사 비활성화  |
+| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 명령 기본 타임아웃(ms)    |
+| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 응답 최대 출력 토큰 수     |
+| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 전체 디렉터리 파일 감시 활성화 |
+| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | oxfmt 포매터 활성화            |
+| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 실험적 LSP 도구 활성화         |
+| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 파일 감시 비활성화             |
+| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 실험적 Exa 기능 활성화         |
+| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | 실험적 LSP 타입 검사 활성화    |
+| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 실험적 Markdown 기능 활성화    |
+| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Plan mode 활성화               |

--- a/packages/web/src/content/docs/ko/commands.mdx
+++ b/packages/web/src/content/docs/ko/commands.mdx
@@ -3,21 +3,23 @@ title: Commands
 description: Create custom commands for repetitive tasks.
 ---
 
-사용자 지정 명령은 TUI에서 실행될 때 실행할 때 실행해야 합니다.
+커스텀 명령을 사용하면 TUI에서 해당 명령이 실행될 때 사용할 프롬프트를 미리 정의할 수 있습니다.
 
 ```bash frame="none"
 /my-command
 ```
 
-사용자 정의 명령은 `/init`, `/undo`, `/redo`, `/share`, `/share`, `/help`와 같은 내장된 명령 이외에 있습니다. [더 알아보기](/docs/tui#commands).
+---
+
+커스텀 명령은 `/init`, `/undo`, `/redo`, `/share`, `/help` 같은 내장 명령과 별도로 추가됩니다. [더 알아보기](/docs/tui#commands).
 
 ---
 
-## 명령 파일 생성
+## 명령 파일 만들기
 
-사용자 지정 명령을 정의하려면 `commands/` 디렉토리의 Markdown 파일을 만듭니다.
+커스텀 명령은 `commands/` 디렉터리에 Markdown 파일을 만들어 정의합니다.
 
-`.opencode/commands/test.md` 만들기:
+예: `.opencode/commands/test.md`
 
 ```md title=".opencode/commands/test.md"
 ---
@@ -30,9 +32,9 @@ Run the full test suite with coverage report and show any failures.
 Focus on the failing tests and suggest fixes.
 ```
 
-frontmatter 명령 속성을 정의합니다. 콘텐츠는 템플릿이 됩니다.
+프런트매터(frontmatter)에는 명령 속성을 정의하고, 본문은 템플릿 프롬프트가 됩니다.
 
-명령명에 따라 `/`를 입력하여 명령을 사용하십시오.
+명령 이름 앞에 `/`를 붙여 실행합니다.
 
 ```bash frame="none"
 "/test"
@@ -42,13 +44,13 @@ frontmatter 명령 속성을 정의합니다. 콘텐츠는 템플릿이 됩니�
 
 ## 구성
 
-opencode config를 통해 사용자 지정 명령을 추가하거나 `commands/` 디렉토리에 있는 Markdown 파일을 만들 수 있습니다.
+커스텀 명령은 OpenCode 설정으로 추가하거나, `commands/` 디렉터리에 Markdown 파일을 만들어 추가할 수 있습니다.
 
 ---
 
-### JSON 태그
+### JSON
 
-opencode [config](/docs/config)에서 `command` 옵션을 사용하십시오:
+OpenCode [config](/docs/config)의 `command` 옵션을 사용합니다.
 
 ```json title="opencode.jsonc" {4-12}
 {
@@ -67,7 +69,7 @@ opencode [config](/docs/config)에서 `command` 옵션을 사용하십시오:
 }
 ```
 
-이제 TUI에서이 명령을 실행할 수 있습니다.
+이제 TUI에서 다음처럼 실행할 수 있습니다.
 
 ```bash frame="none"
 /test
@@ -77,10 +79,10 @@ opencode [config](/docs/config)에서 `command` 옵션을 사용하십시오:
 
 ### Markdown
 
-Markdown 파일을 사용하여 명령을 정의할 수 있습니다. 그들에 게:
+Markdown 파일로도 명령을 정의할 수 있습니다. 아래 경로 중 하나에 두면 됩니다.
 
-- 글로벌: `~/.config/opencode/commands/`
-- 프로젝트: `.opencode/commands/`
+- 전역: `~/.config/opencode/commands/`
+- 프로젝트별: `.opencode/commands/`
 
 ```markdown title="~/.config/opencode/commands/test.md"
 ---
@@ -93,8 +95,7 @@ Run the full test suite with coverage report and show any failures.
 Focus on the failing tests and suggest fixes.
 ```
 
-markdown 파일 이름은 명령 이름입니다. 예를 들어, `test.md` lets
-당신은 실행:
+Markdown 파일명이 명령 이름이 됩니다. 예를 들어 `test.md`라면 아래처럼 실행합니다.
 
 ```bash frame="none"
 /test
@@ -102,15 +103,15 @@ markdown 파일 이름은 명령 이름입니다. 예를 들어, `test.md` lets
 
 ---
 
-## Prompt 구성
+## 프롬프트 구성
 
-사용자 정의 명령에 대한 프롬프트는 몇 가지 특별한 placeholders 및 구문을 지원합니다.
+커스텀 명령 프롬프트는 몇 가지 특수 플레이스홀더(placeholder)와 문법을 지원합니다.
 
 ---
 
-#### 가격
+### 인수(Arguments)
 
-`$ARGUMENTS` placeholder를 사용하여 명령을 전달합니다.
+`$ARGUMENTS` 플레이스홀더로 명령 인수를 전달할 수 있습니다.
 
 ```md title=".opencode/commands/component.md"
 ---
@@ -121,22 +122,22 @@ Create a new React component named $ARGUMENTS with TypeScript support.
 Include proper typing and basic structure.
 ```
 
-인수로 명령을 실행:
+인수를 넣어 실행하면:
 
 ```bash frame="none"
 /component Button
 ```
 
-그리고 `$ARGUMENTS`는 `Button`로 대체될 것입니다.
+`$ARGUMENTS`가 `Button`으로 치환됩니다.
 
-위치 매개 변수를 사용하여 개별 인수에 액세스 할 수 있습니다.
+위치 인수도 사용할 수 있습니다.
 
 - `$1` - 첫 번째 인수
 - `$2` - 두 번째 인수
 - `$3` - 세 번째 인수
-- 그래서 ...
+- 이후 동일
 
-예를 들면:
+예시:
 
 ```md title=".opencode/commands/create-file.md"
 ---
@@ -147,25 +148,25 @@ Create a file named $1 in the directory $2
 with the following content: $3
 ```
 
-명령을 실행:
+실행:
 
 ```bash frame="none"
 /create-file config.json src "{ \"key\": \"value\" }"
 ```
 
-이렇게 대체됩니다:
+치환 결과:
 
-- `$1`는 `config.json`
-- `$2`는 `src`
-- `$3`는 `{ "key": "value" }`
+- `$1` -> `config.json`
+- `$2` -> `src`
+- `$3` -> `{ "key": "value" }`
 
 ---
 
-### 포탄 산출
+### 셸 출력
 
-사용 !`command` 는 [bash command](/docs/tui#bash-commands)를 프롬프트로 출력합니다.
+_!`command`_ 문법으로 [bash 명령](/docs/tui#bash-commands)의 출력 결과를 프롬프트에 주입할 수 있습니다.
 
-예를 들어, 테스트 범위를 분석하는 사용자 정의 명령을 만들려면:
+예를 들어 테스트 커버리지 분석 명령을 만들면:
 
 ```md title=".opencode/commands/analyze-coverage.md"
 ---
@@ -178,7 +179,7 @@ Here are the current test results:
 Based on these results, suggest improvements to increase coverage.
 ```
 
-또는 최근 변경 사항 :
+최근 변경 리뷰용으로는:
 
 ```md title=".opencode/commands/review-changes.md"
 ---
@@ -191,13 +192,13 @@ Recent git commits:
 Review these changes and suggest any improvements.
 ```
 
-명령은 프로젝트의 루트 디렉토리에서 실행하고 출력은 프롬프트의 일부가됩니다.
+명령은 프로젝트 루트 디렉터리에서 실행되며, 출력 결과는 프롬프트 본문에 포함됩니다.
 
 ---
 
-## 파일 참조
+### 파일 참조
 
-파일명에 따라 `@`를 사용하여 명령에 파일이 포함되어 있습니다.
+`@` 뒤에 파일명을 붙여 명령에 파일을 포함할 수 있습니다.
 
 ```md title=".opencode/commands/review-component.md"
 ---
@@ -208,19 +209,19 @@ Review the component in @src/components/Button.tsx.
 Check for performance issues and suggest improvements.
 ```
 
-파일 콘텐츠는 자동으로 프롬프트에 포함되어 있습니다.
+파일 내용은 자동으로 프롬프트에 포함됩니다.
 
 ---
 
 ## 옵션
 
-구성 옵션을 자세히 살펴봅시다.
+구성 옵션을 자세히 살펴봅니다.
 
 ---
 
-### 템플릿
+### Template
 
-`template` 옵션은 명령이 실행될 때 LLM에 전송될 프롬프트를 정의합니다.
+`template` 옵션은 명령 실행 시 LLM에 전달할 프롬프트를 정의합니다.
 
 ```json title="opencode.json"
 {
@@ -232,13 +233,13 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-\*\* config 옵션이 필요합니다.
+이 옵션은 **필수**입니다.
 
 ---
 
-### 묘사
+### Description
 
-`description` 옵션을 사용하여 명령의 간단한 설명을 제공합니다.
+`description` 옵션으로 명령의 짧은 설명을 추가할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -250,15 +251,15 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-명령에 입력할 때 TUI의 설명으로 표시됩니다.
+이 설명은 TUI에서 명령을 입력할 때 표시됩니다.
 
 ---
 
-## 에이전트
+### Agent
 
-`agent` config를 선택적으로 지정합니다. [agent](/docs/agents)는 이 명령을 실행해야 합니다.
-이 경우 [subagent](/docs/agents/#subagents) 명령은 기본으로 시약을 트리거합니다.
-이 행동을 비활성화하려면 `subtask`를 `false`로 설정하십시오.
+`agent` 설정으로 이 명령을 실행할 [agent](/docs/agents)를 지정할 수 있습니다.
+지정한 값이 [subagent](/docs/agents/#subagents)면 기본적으로 subagent 호출이 실행됩니다.
+이 동작을 끄려면 `subtask`를 `false`로 설정하세요.
 
 ```json title="opencode.json"
 {
@@ -270,15 +271,14 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-** 옵션** 설정 옵션입니다. 지정된 경우, 현재 에이전트에 기본값.
+이 옵션은 **선택**입니다. 지정하지 않으면 현재 에이전트가 기본값으로 사용됩니다.
 
 ---
 
-### 서브스크랩
+### Subtask
 
-`subtask` boolean을 사용하여 명령을 강제로 [subagent](/docs/agents/#subagents) 호출합니다.
-이것은 당신이 명령을 원하지 않는 경우 유용합니다 당신의 기본 컨텍스트를 pollute하고 \*\* 에이전트는 시약으로 행동하는,
-`mode`가 [시약](/docs/시약) 구성에 `primary`로 설정되는 경우에도.
+`subtask` 불리언(boolean)을 사용하면 명령이 [subagent](/docs/agents/#subagents) 호출을 강제로 트리거합니다.
+주 컨텍스트를 오염시키고 싶지 않을 때 유용하며, [agent](/docs/agents) 설정의 `mode`가 `primary`여도 subagent로 실행합니다.
 
 ```json title="opencode.json"
 {
@@ -290,13 +290,13 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-** 옵션** 설정 옵션입니다.
+이 옵션은 **선택**입니다.
 
 ---
 
-### 모형
+### Model
 
-`model` config를 사용하여 이 명령의 기본 모델을 무시합니다.
+`model` 설정으로 이 명령의 기본 모델을 오버라이드할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -308,16 +308,16 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-** 옵션** 설정 옵션입니다.
+이 옵션은 **선택**입니다.
 
 ---
 
-## 내장
+## Built-in
 
-opencode는 `/init`, `/undo`, `/redo`, `/share`, `/help`, `/help`와 같은 몇몇 붙박이 명령을 포함합니다; [learn more](./tui#commands).
+OpenCode는 `/init`, `/undo`, `/redo`, `/share`, `/help` 등 여러 내장 명령을 제공합니다. [더 알아보기](/docs/tui#commands).
 
 :::note
-사용자 지정 명령은 내장 명령을 무시할 수 있습니다.
+커스텀 명령은 내장 명령을 덮어쓸 수 있습니다.
 :::
 
-같은 이름으로 사용자 정의 명령을 정의하면 내장 명령을 무시합니다.
+같은 이름으로 커스텀 명령을 정의하면 내장 명령보다 커스텀 명령이 우선합니다.

--- a/packages/web/src/content/docs/ko/index.mdx
+++ b/packages/web/src/content/docs/ko/index.mdx
@@ -7,40 +7,39 @@ import { Tabs, TabItem } from "@astrojs/starlight/components"
 import config from "../../../../config.mjs"
 export const console = config.console
 
-[**OpenCode**](/)는 오픈 소스 AI 코딩 에이전트입니다. terminal 기반 인터페이스, 데스크탑 앱 또는 IDE 확장으로 사용할 수 있습니다.
+[**OpenCode**](/)는 터미널 기반 인터페이스, 데스크톱 앱, IDE 확장 형태로 사용할 수 있는 오픈 소스 AI 코딩 에이전트입니다.
 
 ![opencode TUI with the opencode theme](../../../assets/lander/screenshot.png)
 
-시작합시다.
+바로 시작해 봅시다.
 
 ---
 
-### 필수품
+#### 사전 준비
 
-당신의 terminal에 있는 OpenCode를 사용하려면, 당신은 필요로 할 것입니다:
+터미널에서 OpenCode를 사용하려면 다음이 필요합니다.
 
-1. 현대 terminal 에뮬레이터는 좋아합니다:
+1. 최신 터미널 에뮬레이터(예:)
+   - [WezTerm](https://wezterm.org), 크로스 플랫폼
+   - [Alacritty](https://alacritty.org), 크로스 플랫폼
+   - [Ghostty](https://ghostty.org), Linux 및 macOS
+   - [Kitty](https://sw.kovidgoyal.net/kitty/), Linux 및 macOS
 
-- [WezTerm](https://wezterm.org), 크로스 플랫폼
-- [Alacritty](https://alacritty.org), 크로스 플랫폼
-- [Ghostty](https://ghostty.org), 리눅스 및 macOS
-- [Kitty](https://sw.kovidgoyal.net/kitty/), 리눅스 및 macOS
-
-2. 사용하려는 LLM 공급자를 위한 API 키.
+2. 사용할 LLM 제공자의 API 키
 
 ---
 
 ## 설치
 
-OpenCode를 설치하는 가장 쉬운 방법은 설치 스크립트를 통해 입니다.
+가장 쉬운 설치 방법은 설치 스크립트를 사용하는 것입니다.
 
 ```bash
 curl -fsSL https://opencode.ai/install | bash
 ```
 
-다음 명령으로 설치할 수도 있습니다:
+아래 명령으로도 설치할 수 있습니다.
 
-- ** Node.js** 사용
+- **Node.js 사용**
 
         <Tabs>
 
@@ -74,79 +73,78 @@ curl -fsSL https://opencode.ai/install | bash
 
   </Tabs>
 
-- ** macOS 및 Linux에서 Homebrew 사용 **
+- **macOS/Linux에서 Homebrew 사용**
 
   ```bash
   brew install anomalyco/tap/opencode
   ```
 
-> 최신 릴리스를 위해 OpenCode 탭을 사용하는 것이 좋습니다. 공식 `brew install opencode` 공식은 Homebrew 팀에 의해 유지되고 더 자주 업데이트됩니다.
+  > 최신 릴리스는 OpenCode tap 사용을 권장합니다. 공식 `brew install opencode` 포뮬러는 Homebrew 팀이 관리하므로 업데이트 주기가 더 긴 편입니다.
 
-- **Arch Linux에서 Paru를 사용 **
+- **Arch Linux에서 Paru 사용**
 
   ```bash
   paru -S opencode-bin
   ```
 
-#### 윈도우
+#### Windows
 
-:::tip[추천: WSL 사용]
-Windows에서 최고의 경험을 위해 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl)를 사용하는 것이 좋습니다. OpenCode의 기능으로 더 나은 성능과 전체 호환성을 제공합니다.
+:::tip[권장: WSL 사용]
+Windows에서는 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl)을 사용하는 것이 가장 좋습니다. OpenCode 기능과의 호환성이 높고 성능도 더 좋습니다.
 :::
 
-- ** Chocolatey **
+- **Chocolatey 사용**
 
   ```bash
   choco install opencode
   ```
 
-- ** Scoop를 사용 **
+- **Scoop 사용**
 
   ```bash
   scoop install opencode
   ```
 
-- ** npm **
+- **NPM 사용**
 
   ```bash
   npm install -g opencode-ai
   ```
 
-- **Mise**
+- **Mise 사용**
 
   ```bash
   mise use -g github:anomalyco/opencode
   ```
 
-- ** Docker 사용**
+- **Docker 사용**
 
   ```bash
   docker run -it --rm ghcr.io/anomalyco/opencode
   ```
 
-Bun을 사용하여 Windows에서 OpenCode 설치 지원은 현재 진행 중입니다.
+Windows에서 Bun을 통한 OpenCode 설치는 아직 지원되지 않으며, 현재 지원을 준비 중입니다.
 
-[Releases](https://github.com/anomalyco/opencode/releases)에서 이진을 할 수도 있습니다.
+[Releases](https://github.com/anomalyco/opencode/releases)에서 바이너리를 직접 받아 설치할 수도 있습니다.
 
 ---
 
 ## 구성
 
-OpenCode를 사용하면 API 키를 구성하여 LLM 공급자를 사용할 수 있습니다.
+OpenCode는 API 키를 설정하면 원하는 LLM 제공자를 사용할 수 있습니다.
 
-LLM 공급자를 사용하는 새로운 경우, [OpenCode Zen](/docs/zen)를 사용하는 것이 좋습니다.
-OpenCode에 의해 테스트 및 확인 된 모델의 큐레이터 목록입니다.
-팀.
+LLM 제공자(LLM Provider)를 처음 사용한다면 [OpenCode Zen](/docs/zen)을 추천합니다.
+OpenCode 팀이 테스트하고 검증한 모델 목록입니다.
 
-1. TUI에서 `/connect` 명령을 실행하고, opencode를 선택하고, [opencode.ai/auth](https://opencode.ai/auth)에 머리를 선택합니다.
+1. TUI에서 `/connect` 명령을 실행한 뒤 `opencode`를 선택하고 [opencode.ai/auth](https://opencode.ai/auth)로 이동합니다.
 
    ```txt
    /connect
    ```
 
-2. 로그인, 청구 세부 정보를 추가하고 API 키를 복사하십시오.
+2. 로그인 후 결제 정보를 입력하고 API 키를 복사합니다.
 
-3. API 키를 붙여.
+3. API 키를 붙여 넣습니다.
 
    ```txt
    ┌ API key
@@ -155,85 +153,79 @@ OpenCode에 의해 테스트 및 확인 된 모델의 큐레이터 목록입니�
    └ enter
    ```
 
-158| 또는 다른 공급자 중 하나를 선택할 수 있습니다. [더 알아보기](/docs/providers#directory).
+다른 제공자를 선택해도 됩니다. [더 알아보기](/docs/providers#directory).
 
 ---
 
 ## 초기화
 
-이제 공급자를 구성했습니다. 프로젝트로 이동할 수 있습니다.
-일하고 싶습니다.
+이제 제공자 구성이 끝났으니, 작업할 프로젝트 디렉터리로 이동합니다.
 
 ```bash
 cd /path/to/project
 ```
 
-OpenCode를 실행합니다.
+그리고 OpenCode를 실행합니다.
 
 ```bash
 opencode
 ```
 
-다음, 다음 명령을 실행하여 프로젝트의 OpenCode를 초기화합니다.
+다음 명령으로 프로젝트용 OpenCode 초기화를 진행합니다.
 
 ```bash frame="none"
 /init
 ```
 
-OpenCode를 사용하여 프로젝트를 분석하고 `AGENTS.md` 파일을 만들 수 있습니다.
-프로젝트 루트.
+이 명령은 프로젝트를 분석하고 루트에 `AGENTS.md` 파일을 생성합니다.
 
 :::tip
-프로젝트의 `AGENTS.md` 파일을 Git에 투입해야 합니다.
+프로젝트의 `AGENTS.md`는 Git에 커밋해 두는 것을 권장합니다.
 :::
 
-이 도움말 OpenCode는 프로젝트 구조와 코딩 패턴을 이해
-사용.
+그러면 OpenCode가 프로젝트 구조와 코딩 패턴을 더 잘 이해할 수 있습니다.
 
 ---
 
 ## 사용법
 
-OpenCode를 사용하여 프로젝트에 작업할 준비가 되어 있습니다. 자주 묻는 질문
-모두!
+이제 OpenCode로 프로젝트 작업을 시작할 준비가 되었습니다. 무엇이든 물어보세요.
 
-AI 코딩 에이전트를 사용하는 새로운 경우, 여기에 할 수있는 몇 가지 예입니다
-도움.
+AI 코딩 에이전트를 처음 쓰는 경우 도움이 되는 예시를 소개합니다.
 
 ---
 
-## 질문
+### 질문하기
 
-Codebase를 설명하기 위해 OpenCode를 요청할 수 있습니다.
+OpenCode에 코드베이스 설명을 요청할 수 있습니다.
 
 :::tip
-`@` 키를 사용하여 프로젝트에서 파일을 검색합니다.
+프로젝트 파일은 `@` 키로 퍼지 검색할 수 있습니다.
 :::
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 How is authentication handled in @packages/functions/src/api/index.ts
 ```
 
-이것은 당신이 작동하지 않은 코드베이스의 일부가 있다면 도움이된다.
+직접 작업하지 않은 코드 영역을 이해할 때 특히 유용합니다.
 
 ---
 
-### 추가 기능
+### 기능 추가
 
-프로젝트에 새로운 기능을 추가하려면 OpenCode를 요청할 수 있습니다. 우리는 먼저 계획을 만들 것을 묻는 것이 좋습니다.
+프로젝트에 새 기능을 추가해 달라고 요청할 수 있습니다. 다만 먼저 계획을 만들게 하는 것을 권장합니다.
 
-1. **플랜을 선택 **
+1. **계획 만들기**
 
-   OpenCode는 Plan mode 로 변경할 수 있는 능력을 비활성화하고
-   대신 제안 how 그것은 기능을 구현할 것입니다.
+   OpenCode에는 변경 작업을 비활성화하고 구현 방법을 제안만 하는 _Plan mode_가 있습니다.
 
-   **Tab** 키를 사용하여 전환합니다. 오른쪽 하단에 있는 이 지표를 볼 수 있습니다.
+   **Tab** 키로 전환하면 오른쪽 아래에 모드 표시가 나타납니다.
 
    ```bash frame="none" title="Switch to Plan mode"
    <TAB>
    ```
 
-   이제 우리가해야 할 일을 설명합니다.
+   이제 원하는 작업을 구체적으로 설명합니다.
 
    ```txt frame="none"
    When a user deletes a note, we'd like to flag it as deleted in the database.
@@ -241,17 +233,15 @@ How is authentication handled in @packages/functions/src/api/index.ts
    From this screen, the user can undelete a note or permanently delete it.
    ```
 
-   당신이 원하는 것을 이해하기 위해 OpenCode를 충분히 세부 정보를 제공하려는. 그것은 도움
-   팀의 주니어 개발자에게 이야기하고 싶습니다.
+   OpenCode가 정확히 이해할 만큼 충분한 맥락을 주는 것이 중요합니다. 팀의 주니어 개발자에게 설명하듯 요청하면 도움이 됩니다.
 
    :::tip
-   OpenCode를 많은 컨텍스트와 예제를 제공하여 당신이 무엇을 이해하는 데 도움이
-   이름 \*
+   맥락과 예시를 충분히 제공하면 원하는 결과를 얻기 쉽습니다.
    :::
 
-2. **플랜에 대해서 **
+2. **계획 다듬기**
 
-   플랜을 제공하면 피드백을 제공하거나 자세한 내용을 추가 할 수 있습니다.
+   계획이 나오면 피드백을 주거나 추가 요구사항을 붙일 수 있습니다.
 
    ```txt frame="none"
    We'd like to design this new screen using a design I've used before.
@@ -259,22 +249,20 @@ How is authentication handled in @packages/functions/src/api/index.ts
    ```
 
    :::tip
-   단말에 이미지를 드래그하고 드롭하여 프롬프트에 추가합니다.
+   이미지를 터미널에 드래그 앤 드롭하면 프롬프트에 첨부할 수 있습니다.
    :::
 
-   OpenCode는 어떤 이미지를 스캔할 수 있습니다. 당신은 할 수
-   이 작업을 수행하고 끝으로 이미지를 삭제합니다.
+   OpenCode는 첨부한 이미지를 분석해 프롬프트에 포함합니다.
 
-3. ** 기능 구축 **
+3. **기능 구현**
 
-   플랜으로 편안하게 느끼면 Build mode by
-   **Tab** 키를 다시 입력합니다.
+   계획이 충분히 만족스러우면 **Tab** 키를 다시 눌러 _Build mode_로 돌아갑니다.
 
    ```bash frame="none"
    <TAB>
    ```
 
-   그리고 변경을 요청합니다.
+   그리고 실제 변경을 요청합니다.
 
    ```bash frame="none"
    Sounds good! Go ahead and make the changes.
@@ -282,10 +270,9 @@ How is authentication handled in @packages/functions/src/api/index.ts
 
 ---
 
-### 변경
+### 바로 변경하기
 
-더 똑바른 변화를 위해, 당신은 OpenCode를 직접 그것을 건설할 수 있습니다
-첫 플랜을 검토하지 않고.
+비교적 단순한 변경은 계획 검토 없이 바로 구현하도록 요청해도 됩니다.
 
 ```txt frame="none" "@packages/functions/src/settings.ts" "@packages/functions/src/notes.ts"
 We need to add authentication to the /settings route. Take a look at how this is
@@ -293,40 +280,37 @@ handled in the /notes route in @packages/functions/src/notes.ts and implement
 the same logic in @packages/functions/src/settings.ts
 ```
 
-좋은 양의 세부 사항을 제공 하려면 OpenCode가 올바른
-이름 \*
+원하는 변경이 정확히 반영되도록, 필요한 맥락을 충분히 제공하세요.
 
 ---
 
-### Undo 변경
+### 변경 되돌리기
 
-OpenCode를 호출하면 변경 사항을 만들 수 있습니다.
+예를 들어 OpenCode에 변경을 요청했다고 가정해 보겠습니다.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-그러나 당신이 원하는 것은 아닙니다. ** 변경할 수 없습니다 **
-`/undo` 명령을 사용하여.
+결과가 기대와 다르면 `/undo` 명령으로 **되돌릴 수** 있습니다.
 
 ```bash frame="none"
 /undo
 ```
 
-OpenCode는 이제 당신이 만든 변경을 반전하고 원래 메시지를 표시
-다시.
+OpenCode는 방금 적용한 변경을 되돌리고 원래 메시지를 다시 보여줍니다.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-여기에서 당신은 신속하고 다시 시도 OpenCode를 요청할 수 있습니다.
+이 상태에서 프롬프트를 다듬어 다시 시도하면 됩니다.
 
 :::tip
-`/undo`를 여러 번 실행할 수 있습니다.
+`/undo`는 여러 번 연속으로 실행할 수 있습니다.
 :::
 
-또는 \*\* `/redo` 명령을 사용하여 변경할 수 있습니다.
+반대로 `/redo` 명령으로 **다시 적용**할 수도 있습니다.
 
 ```bash frame="none"
 /redo
@@ -336,24 +320,24 @@ Can you refactor the function in @packages/functions/src/api/index.ts?
 
 ## 공유
 
-opencode와 나눈 대화는 [팀과 공유](/docs/share)할 수 있습니다.
+OpenCode와의 대화는 [팀과 공유](/docs/share)할 수 있습니다.
 
 ```bash frame="none"
 /share
 ```
 
-현재 대화에 대한 링크를 만들고 클립보드에 복사합니다.
+현재 대화 링크를 생성하고 클립보드에 복사합니다.
 
 :::note
-대화는 기본적으로 공유되지 않습니다.
+대화는 기본값으로 공유되지 않습니다.
 :::
 
-여기 [example 대화](https://opencode.ai/s/4XP1fce5) 는 opencode 입니다.
+아래는 OpenCode [대화 예시](https://opencode.ai/s/4XP1fce5)입니다.
 
 ---
 
-## 사용자 정의
+## 커스터마이즈
 
-그리고 그게 다야! 이제 opencode를 사용하여 프로입니다.
+이제 OpenCode 사용의 기본은 끝났습니다.
 
-자신의 것을 만들기 위해, 우리는 [themes](/docs/themes), [keybinds](/docs/keybinds), [configuring code formatters](/docs/formatters), [creating custom commands](/docs/commands), 또는 [opencode config](/docs/config)와 함께 연주하는 것을 추천합니다.
+자신의 워크플로우에 맞추려면 [테마 선택](/docs/themes), [키바인드 커스터마이즈](/docs/keybinds), [코드 포매터 설정](/docs/formatters), [커스텀 명령 작성](/docs/commands), [OpenCode config 조정](/docs/config)을 추천합니다.


### PR DESCRIPTION
Fixes #13092

### What does this PR do?

The Korean docs for index.mdx, cli.mdx, and commands.mdx read quite literally in many places, which made parts of the documentation awkward and harder to follow.
This PR rewrites those sections into more natural Korean while keeping the original meaning and structure. I only changed wording (tone, phrasing, and terminology consistency), and preserved command examples, flags, links, and document structure.

Why this works: these files are documentation-only, so improving sentence quality directly improves readability without changing behavior. The technical content stays the same, just expressed more clearly in Korean.

I originally planned to revise all Korean docs in one pass, but for this PR I limited scope to these three pages to keep review focused. 

If this approach is approved, I plan to continue with the remaining Korean docs in follow-up PRs

### How did you verify your code works?

- Reviewed the diff file-by-file against the English source docs.
- Checked that MDX structure is intact (frontmatter, headings, tables, code blocks, links).
- Confirmed this PR only changes docs content (ko/index.mdx, ko/cli.mdx, ko/commands.mdx).

I did not change any runtime code.