### PR TITLE
fix(opencode): ACP sessions never get LLM-generated titles

### DIFF
--- a/packages/opencode/src/acp/session.ts
+++ b/packages/opencode/src/acp/session.ts
@@ -21,7 +21,6 @@ export class ACPSessionManager {
     const session = await this.sdk.session
       .create(
         {
-          title: `ACP Session ${crypto.randomUUID()}`,
           directory: cwd,
         },
         { throwOnError: true },


### PR DESCRIPTION
fixes #11442

### What does this PR do?
ACP sessions always have titles like `"ACP Session <UUID>"` instead of getting LLM-generated titles like TUI sessions do.
The root cause is in `packages/opencode/src/acp/session.ts` — when creating a new session, the title is hardcoded:
```ts
const session = await this.sdk.session.create({
  title: `ACP Session ${crypto.randomUUID()}`,
  directory: cwd,
}, { throwOnError: true })
```
After the first prompt, `ensureTitle()` in `session/prompt.ts` is supposed to ask the LLM for a proper title. But it first checks `Session.isDefaultTitle()`, which only recognizes `"New session - <date>"` and `"Child session - <date>"` as default titles. 

Since `"ACP Session ..."` doesn't match either pattern, `ensureTitle` bails immediately and the hardcoded title sticks forever.

The fix removes the explicit `title` field from the `session.create()` call. Without it, the session falls through to `createDefaultTitle()` which produces `"New session - <date>"` — a format `isDefaultTitle()` recognizes. Then `ensureTitle()` works as intended and replaces it with an LLM-generated title after the first exchange.

### How did you verify your code works?
1. `tsgo --noEmit` on `packages/opencode/` passes with zero errors
2. Started opencode, created an ACP session via `session/create`, sent a prompt via `message/create`, then checked `session/list` — the session initially shows `"New session - <date>"` and after the first response completes, `ensureTitle` kicks in and replaces it with an LLM-generated title