### PR TITLE
fix(web): prevent language select label truncation

### DIFF
--- a/packages/web/src/components/Footer.astro
+++ b/packages/web/src/components/Footer.astro
@@ -17,45 +17,42 @@ const discord = config.social?.find((item) => item.icon === "discord")
     <footer class="doc">
       <div class="meta sl-flex">
         <div>
-          {
-            editUrl && (
-              <a href={editUrl} target="_blank" rel="noopener noreferrer" class="sl-flex">
-                <Icon name="pencil" size="1em" />
-                {Astro.locals.t("page.editLink")}
-              </a>
-            )
-          }
-          {
-            github && (
-              <a href={`${github.href}/issues/new`} target="_blank" rel="noopener noreferrer" class="sl-flex">
-                <Icon name={github.icon} size="1em" />
-                {issueLink}
-              </a>
-            )
-          }
-          {
-            discord && (
-              <a href={discord.href} target="_blank" rel="noopener noreferrer" class="sl-flex">
-                <Icon name={discord.icon} size="1em" />
-                {discordLink}
-              </a>
-            )
-          }
+          {editUrl && (
+            <a href={editUrl} target="_blank" rel="noopener noreferrer" class="sl-flex">
+              <Icon name="pencil" size="1em" />
+              {Astro.locals.t("page.editLink")}
+            </a>
+          )}
+          {github && (
+            <a href={`${github.href}/issues/new`} target="_blank" rel="noopener noreferrer" class="sl-flex">
+              <Icon name={github.icon} size="1em" />
+              {issueLink}
+            </a>
+          )}
+          {discord && (
+            <a href={discord.href} target="_blank" rel="noopener noreferrer" class="sl-flex">
+              <Icon name={discord.icon} size="1em" />
+              {discordLink}
+            </a>
+          )}
           <LanguageSelect />
         </div>
         <div>
-          <p>&copy; <a target="_blank" rel="noopener noreferrer" href="https://anoma.ly">Anomaly</a></p>
+          <p>
+            &copy;{" "}
+            <a target="_blank" rel="noopener noreferrer" href="https://anoma.ly">
+              Anomaly
+            </a>
+          </p>
           <p title={Astro.locals.t("page.lastUpdated")}>
-            {Astro.locals.t("page.lastUpdated")} {" "}
-            {
-              lastUpdated ? (
-                <time datetime={lastUpdated.toISOString()}>
-                  {lastUpdated.toLocaleDateString(lang, { dateStyle: "medium", timeZone: "UTC" })}
-                </time>
-              ) : (
-                "-"
-              )
-            }
+            {Astro.locals.t("page.lastUpdated")}{" "}
+            {lastUpdated ? (
+              <time datetime={lastUpdated.toISOString()}>
+                {lastUpdated.toLocaleDateString(lang, { dateStyle: "medium", timeZone: "UTC" })}
+              </time>
+            ) : (
+              "-"
+            )}
           </p>
         </div>
       </div>
@@ -110,7 +107,7 @@ const discord = config.social?.find((item) => item.icon === "discord")
   }
 
   .doc :global(starlight-lang-select select) {
-    min-width: 7em;
+    min-width: 15em;
   }
 
   @media (min-width: 30rem) {


### PR DESCRIPTION
### What does this PR do?

Please provide a description of the issue (if there is one), the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

- Closes #13103

The language selector was always truncating the label. This is unnecessary because there is a lot of available space.

**BEFORE**
<img width="399" height="187" alt="image" src="https://github.com/user-attachments/assets/c11d5aa7-adcc-4f7f-aa3e-ecc64edb6dea" />

I have changed it so it will no longer truncate.

**AFTER**
<img width="483" height="188" alt="image" src="https://github.com/user-attachments/assets/40621248-00aa-4ba8-9061-70953043b274" />
<img width="316" height="155" alt="image" src="https://github.com/user-attachments/assets/7d441875-7061-460c-a4ac-72860d2b15da" />

### How did you verify your code works?

I've verified it by running `bun --cwd packages/web dev` and looked at the footer.
New appearance is in the attached screenshot above.