### PR TITLE
fix(edit): unescape newString replacements to avoid literal \\n

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -24,6 +24,33 @@ function normalizeLineEndings(text: string): string {
   return text.replaceAll("\r\n", "\n")
 }
 
+export function unescapeString(text: string): string {
+  return text.replace(/\\(n|t|r|'|"|`|\\|\n|\$)/g, (match, captured) => {
+    switch (captured) {
+      case "n":
+        return "\n"
+      case "t":
+        return "\t"
+      case "r":
+        return "\r"
+      case "'":
+        return "'"
+      case '"':
+        return '"'
+      case "`":
+        return "`"
+      case "\\":
+        return "\\"
+      case "\n":
+        return "\n"
+      case "$":
+        return "$"
+      default:
+        return match
+    }
+  })
+}
+
 export const EditTool = Tool.define("edit", {
   description: DESCRIPTION,
   parameters: z.object({
@@ -50,7 +77,7 @@ export const EditTool = Tool.define("edit", {
     await FileTime.withLock(filePath, async () => {
       if (params.oldString === "") {
         const existed = await Bun.file(filePath).exists()
-        contentNew = params.newString
+        contentNew = unescapeString(params.newString)
         diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
         await ctx.ask({
           permission: "edit",
@@ -61,7 +88,7 @@ export const EditTool = Tool.define("edit", {
             diff,
           },
         })
-        await Bun.write(filePath, params.newString)
+        await Bun.write(filePath, contentNew)
         await Bus.publish(File.Event.Edited, {
           file: filePath,
         })
@@ -433,33 +460,6 @@ export const IndentationFlexibleReplacer: Replacer = function* (content, find) {
 }
 
 export const EscapeNormalizedReplacer: Replacer = function* (content, find) {
-  const unescapeString = (str: string): string => {
-    return str.replace(/\\(n|t|r|'|"|`|\\|\n|\$)/g, (match, capturedChar) => {
-      switch (capturedChar) {
-        case "n":
-          return "\n"
-        case "t":
-          return "\t"
-        case "r":
-          return "\r"
-        case "'":
-          return "'"
-        case '"':
-          return '"'
-        case "`":
-          return "`"
-        case "\\":
-          return "\\"
-        case "\n":
-          return "\n"
-        case "$":
-          return "$"
-        default:
-          return match
-      }
-    })
-  }
-
   const unescapedFind = unescapeString(find)
 
   // Try direct match with unescaped find string
@@ -616,7 +616,9 @@ export function trimDiff(diff: string): string {
 }
 
 export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
-  if (oldString === newString) {
+  const replacement = unescapeString(newString)
+
+  if (oldString === replacement) {
     throw new Error("oldString and newString must be different")
   }
 
@@ -638,11 +640,11 @@ export function replace(content: string, oldString: string, newString: string, r
       if (index === -1) continue
       notFound = false
       if (replaceAll) {
-        return content.replaceAll(search, newString)
+        return content.replaceAll(search, replacement)
       }
       const lastIndex = content.lastIndexOf(search)
       if (index !== lastIndex) continue
-      return content.substring(0, index) + newString + content.substring(index + search.length)
+      return content.substring(0, index) + replacement + content.substring(index + search.length)
     }
   }
 

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { replace, unescapeString } from "../../src/tool/edit"
+
+describe("tool.edit escaping", () => {
+  test("unescapes escaped newline sequences", () => {
+    expect(unescapeString('print("hello\\nworld")')).toBe('print("hello\nworld")')
+  })
+
+  test("uses unescaped replacement text for edits", () => {
+    const content = "start\nold\nend\n"
+    const output = replace(content, "old", 'print("hello\\nworld")')
+    expect(output).toBe('start\nprint("hello\nworld")\nend\n')
+  })
+
+  test("preserves literal backslash-n when double escaped", () => {
+    const output = replace("old", "old", "line1\\\\nline2")
+    expect(output).toBe("line1\\nline2")
+  })
+
+  test("unescapes replacement text for replaceAll", () => {
+    const output = replace("old\nold\n", "old", "a\\nb", true)
+    expect(output).toBe("a\nb\na\nb\n")
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Fixes #3545.

`edit` currently unescapes matching for `oldString` but writes `newString` directly. Some providers send `newString` with escaped `\\n`, which can cause literal `\n` to be written to files.

Changes:
- move `unescapeString` to a shared helper in `packages/opencode/src/tool/edit.ts`
- apply unescape to replacement text in `replace(...)`
- apply unescape in the `oldString === ""` write path
- add regression tests in `packages/opencode/test/tool/edit.test.ts`

### How did you verify your code works?

- Added regression tests for:
  - escaped newline replacement
  - `replaceAll` path
  - double-escaped `\\\\n` remaining literal when intended
- GitHub Actions passed on this PR:
  - `typecheck`
  - `unit (linux)`
  - `e2e (linux)`
  - `e2e (windows)`
  - `test (linux)`