### PR TITLE
fix(web): sync docs locale cookie on alias redirects

### DIFF
--- a/packages/app/src/context/language.tsx
+++ b/packages/app/src/context/language.tsx
@@ -57,6 +57,10 @@ export type Locale =
 type RawDictionary = typeof en & typeof uiEn
 type Dictionary = i18n.Flatten<RawDictionary>
 
+function cookie(locale: Locale) {
+  return `oc_locale=${encodeURIComponent(locale)}; Path=/; Max-Age=31536000; SameSite=Lax`
+}
+
 const LOCALES: readonly Locale[] = [
   "en",
   "zh",
@@ -210,6 +214,7 @@ export const { use: useLanguage, provider: LanguageProvider } = createSimpleCont
     createEffect(() => {
       if (typeof document !== "object") return
       document.documentElement.lang = locale()
+      document.cookie = cookie(locale())
     })
 
     return {


### PR DESCRIPTION
Closes #13108 #13078 #13057

### What does this PR do?

This fixes docs locale reversion when users explicitly navigate via locale aliases (especially /docs/en) while an existing non-English oc_locale cookie is set.
I updated docs middleware to set oc_locale on alias redirects, and normalize root English to oc_locale=en.  
I also synced locale changes to oc_locale in app language context so cookie/state stay aligned.
Why this works: docs routing reads oc_locale when deciding redirects from /docs. If cookie and user-selected locale drift, users can bounce back to a previous non-English locale. Keeping cookie synchronized removes that drift.
Note: production /docs/en returning 404 appears to be a front-door routing issue. This PR improves locale consistency once requests reach app/docs logic.


### How did you verify your code works?

- Reproduced and checked behavior locally with oc_locale set to non-English values (not only ko).
- Verified /docs/<locale> alias redirect behavior and cookie updates in local docs middleware flow.
- Confirmed changed files are:
  - packages/web/src/middleware.ts
  - packages/app/src/context/language.tsx
- Checked production headers for context:
  - /docs/en returns 404
  - /docs returns 200
