### PR TITLE
docs(troubleshooting): add Linux TUI link-opening guidance

### DIFF
--- a/packages/web/src/content/docs/troubleshooting.mdx
+++ b/packages/web/src/content/docs/troubleshooting.mdx
@@ -298,3 +298,15 @@ export DISPLAY=:99.0
 ```
 
 opencode will detect if you're using Wayland and prefer `wl-clipboard`, otherwise it will try to find clipboard tools in order of: `xclip` and `xsel`.
+
+---
+
+### Links not opening from the TUI (Linux)
+
+If URLs shown in OpenCode are not opening in your browser:
+
+1. Try your terminal's link-open gesture (often `Ctrl+Click` or `Cmd+Click`, depending on terminal settings).
+2. Ensure mouse support and hyperlink handling are enabled in your terminal emulator.
+3. If your terminal does not support clickable links, copy the URL and open it manually.
+
+OpenCode currently does not provide a dedicated keybind to open arbitrary URLs from chat output.


### PR DESCRIPTION
### What does this PR do?

Fixes #9024.

Adds a troubleshooting section for Linux terminals where links shown in the TUI do not open.
It documents practical steps (`Ctrl/Cmd+Click`, terminal hyperlink settings, fallback copy/paste) and clarifies that there is no dedicated keybind for opening arbitrary chat URLs today.

### How did you verify your code works?

- Checked current TUI behavior and keybind docs to confirm there is no dedicated URL-open keybind for arbitrary chat links.
- Validation will run in GitHub Actions CI.