### PR TITLE
docs(commands): clarify preferred commands/ directory name

### DIFF
--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -17,6 +17,10 @@ Custom commands are in addition to the built-in commands like `/init`, `/undo`, 
 
 Create markdown files in the `commands/` directory to define custom commands.
 
+:::note
+`commands/` is the preferred directory name. Legacy singular `command/` is still supported for backwards compatibility.
+:::
+
 Create `.opencode/commands/test.md`:
 
 ```md title=".opencode/commands/test.md"


### PR DESCRIPTION
### What does this PR do?

Fixes #10622.

Adds an explicit note in `docs/commands` that:
- `commands/` is the recommended directory name
- legacy `command/` is still supported for backward compatibility

This removes ambiguity for users asking which directory name is correct.

### How did you verify your code works?

- Cross-checked with existing config docs that already mention plural-first naming with singular compatibility.
- Validation will run in GitHub Actions CI.