### PR TITLE
docs(mcp): clarify per-project enabled override requirements

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -42,6 +42,10 @@ You can define MCP servers in your [OpenCode Config](https://opencode.ai/docs/co
 
 You can also disable a server by setting `enabled` to `false`. This is useful if you want to temporarily disable a server without removing it from your config.
 
+:::note
+Each config file must be valid on its own. If you override an MCP entry in a project config, include the required fields (`type` + `command` for local, or `type` + `url` for remote), not just `enabled`.
+:::
+
 ---
 
 ### Overriding remote defaults


### PR DESCRIPTION
### What does this PR do?

Fixes #5013.

Adds a note to MCP docs clarifying that each config file is validated independently, so project-level MCP overrides must include required server fields (not just `enabled`).

### How did you verify your code works?

- Checked config loading/validation flow to confirm files are parsed+validated independently before merge.
- Validation will run in GitHub Actions CI.