### PR TITLE
docs(cli): explain project-scoped session visibility

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -391,6 +391,13 @@ List all OpenCode sessions.
 opencode session list
 ```
 
+Session commands are project-scoped:
+
+- inside a Git repository, OpenCode shows sessions for that project
+- outside Git, OpenCode uses the global project scope
+
+If you are trying to access a session created in another project, run session commands from that project's directory.
+
 ##### Flags
 
 | Flag          | Short | Description                          |
@@ -428,6 +435,9 @@ opencode export [sessionID]
 ```
 
 If you don't provide a session ID, you'll be prompted to select from available sessions.
+
+Like `session list`, this command shows sessions for the current project scope.
+For where sessions are stored on disk, see [Troubleshooting: Storage](/docs/troubleshooting#storage).
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Fixes #5099.

Clarifies that session CLI commands are project-scoped (Git project vs global scope), and adds guidance for exporting/listing sessions from the correct directory.
Also links to storage docs for on-disk session location details.

### How did you verify your code works?

- Aligned wording with existing project/session scoping behavior discussed by maintainers and current docs.
- Validation will run in GitHub Actions CI.