### PR TITLE
docs(tools): document automatic tool output truncation

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -39,6 +39,22 @@ You can also use wildcards to control multiple tools at once. For example, to re
 
 ---
 
+## Tool output truncation
+
+OpenCode automatically truncates very large tool outputs before sending them back into model context.
+
+- Output is truncated when it is too large (line/byte limits).
+- The full output is saved to disk under `~/.local/share/opencode/tool-output/`.
+- Truncated results include a hint telling the agent to use `grep` or `read` with `offset/limit` on the saved output file.
+
+This helps avoid context blowups from tools like `bash`, `glob`, or broad searches.
+
+:::note
+There is currently no stable user-facing config to tune truncation thresholds directly.
+:::
+
+---
+
 ## Built-in
 
 Here are all the built-in tools available in OpenCode.


### PR DESCRIPTION
### What does this PR do?

Fixes #4826.

Adds a dedicated section to tools docs explaining automatic tool-output truncation:
- large outputs are truncated before being fed back into context
- full output is persisted under `~/.local/share/opencode/tool-output/`
- agents are guided to use `grep`/`read` with offset/limit on the saved file

Also clarifies there is no stable user-facing threshold tuning config today.

### How did you verify your code works?

- Cross-checked behavior against current truncation implementation and tool output handling in the codebase.
- Validation will run in GitHub Actions CI.