### PR TITLE
docs(providers): add billing and usage overview

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -15,6 +15,21 @@ To add a provider you need to:
 
 ---
 
+### Pricing and usage
+
+OpenCode routes requests to the provider/model you select. Billing depends on that provider:
+
+- If you use your own provider API key (OpenAI, Anthropic, OpenRouter, etc.), usage is billed by that provider.
+- If you use OpenCode-hosted models (OpenCode Zen), usage is billed in your OpenCode account.
+
+To inspect token and cost usage from the CLI, run:
+
+```bash
+opencode stats
+```
+
+---
+
 ### Credentials
 
 When you add a provider's API keys with the `/connect` command, they are stored


### PR DESCRIPTION
### What does this PR do?

Fixes #7580.

Adds a short "Pricing and usage" section to provider docs that explains billing ownership:
- own API keys => billed by that provider
- OpenCode-hosted models (Zen) => billed through OpenCode account

Also points users to `opencode stats` for usage/cost inspection from CLI.

### How did you verify your code works?

- Confirmed this matches existing CLI stats docs and provider setup flow.
- Validation will run in GitHub Actions CI.