### PR TITLE
docs(models): explain thinking visibility vs model support

### DIFF
--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -199,6 +199,19 @@ You can override existing variants or add your own:
 
 Use the keybind `variant_cycle` to quickly switch between variants. [Learn more](/docs/keybinds).
 
+### Thinking toggle behavior
+
+`/thinking` controls whether thinking/reasoning blocks are shown in the UI.
+It does not force a model to reason.
+
+Actual reasoning behavior depends on:
+
+- provider/model support
+- selected variant configuration
+- account/plan capabilities (for providers that gate reasoning features)
+
+For GitHub Copilot specifically, thinking availability depends on the Copilot model you selected. If you do not see reasoning output, try another model/variant (`ctrl+t` cycles variants).
+
 ---
 
 ## Loading models


### PR DESCRIPTION
### What does this PR do?

Fixes #4803.

Adds a short "Thinking toggle behavior" section to model docs clarifying:
- `/thinking` controls visibility only
- actual reasoning depends on model/provider/variant support
- for Copilot, available reasoning behavior depends on selected model and plan
- `ctrl+t` can be used to cycle variants

### How did you verify your code works?

- Aligned wording with existing `/thinking` and variant behavior documented across TUI/models docs.
- Validation will run in GitHub Actions CI.