### PR TITLE
docs(tui): clarify SSH behavior for bash tool commands

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -53,6 +53,12 @@ Start a message with `!` to run a shell command.
 
 The output of the command is added to the conversation as a tool result.
 
+If a command works in your shell (for example `ssh my-host`), OpenCode can run it through the `bash` tool as well, subject to your permission settings.
+
+:::note
+OpenCode does not add a special SSH transport layer. It executes shell commands in your current environment, so SSH behavior depends on your local shell setup, keys, agent forwarding, and network access.
+:::
+
 ---
 
 ## Commands


### PR DESCRIPTION
### What does this PR do?

Fixes #4780.

Adds a clarification in TUI docs that OpenCode can run SSH commands via the `bash` tool when those commands already work in the user shell, and that behavior depends on local shell/SSH environment and permissions.

### How did you verify your code works?

- Confirmed this aligns with current tool model: shell commands run in current environment via `bash` tool.
- Validation will run in GitHub Actions CI.