### PR TITLE
fix(grep): ignore RIPGREP_CONFIG_PATH in internal rg calls

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -5,7 +5,6 @@ import fs from "fs/promises"
 import z from "zod"
 import { NamedError } from "@opencode-ai/util/error"
 import { lazy } from "../util/lazy"
-import { $ } from "bun"
 
 import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 import { Log } from "@/util/log"
@@ -88,6 +87,14 @@ export namespace Ripgrep {
   export type Begin = z.infer<typeof Begin>
   export type End = z.infer<typeof End>
   export type Summary = z.infer<typeof Summary>
+
+  function commandEnv() {
+    return {
+      ...process.env,
+      RIPGREP_CONFIG_PATH: "",
+    }
+  }
+
   const PLATFORM = {
     "arm64-darwin": { platform: "aarch64-apple-darwin", extension: "tar.gz" },
     "arm64-linux": {
@@ -243,6 +250,7 @@ export namespace Ripgrep {
       stderr: "ignore",
       maxBuffer: 1024 * 1024 * 20,
       signal: input.signal,
+      env: commandEnv(),
     })
 
     const reader = proc.stdout.getReader()
@@ -340,7 +348,7 @@ export namespace Ripgrep {
     limit?: number
     follow?: boolean
   }) {
-    const args = [`${await filepath()}`, "--no-config", "--json", "--hidden", "--glob='!.git/*'"]
+    const args = [await filepath(), "--no-config", "--json", "--hidden", "--glob=!.git/*"]
     if (input.follow) args.push("--follow")
 
     if (input.glob) {
@@ -356,14 +364,22 @@ export namespace Ripgrep {
     args.push("--")
     args.push(input.pattern)
 
-    const command = args.join(" ")
-    const result = await $`${{ raw: command }}`.cwd(input.cwd).quiet().nothrow()
-    if (result.exitCode !== 0) {
+    const proc = Bun.spawn(args, {
+      cwd: input.cwd,
+      stdout: "pipe",
+      stderr: "ignore",
+      maxBuffer: 1024 * 1024 * 20,
+      env: commandEnv(),
+    })
+
+    await proc.exited
+    if (proc.exitCode !== 0) {
       return []
     }
 
+    const output = await Bun.readableStreamToText(proc.stdout)
     // Handle both Unix (\n) and Windows (\r\n) line endings
-    const lines = result.text().trim().split(/\r?\n/).filter(Boolean)
+    const lines = output.trim().split(/\r?\n/).filter(Boolean)
     // Parse JSON lines from ripgrep output
 
     return lines

--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -217,7 +217,7 @@ export namespace Ripgrep {
   }) {
     input.signal?.throwIfAborted()
 
-    const args = [await filepath(), "--files", "--glob=!.git/*"]
+    const args = [await filepath(), "--no-config", "--files", "--glob=!.git/*"]
     if (input.follow) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
@@ -340,7 +340,7 @@ export namespace Ripgrep {
     limit?: number
     follow?: boolean
   }) {
-    const args = [`${await filepath()}`, "--json", "--hidden", "--glob='!.git/*'"]
+    const args = [`${await filepath()}`, "--no-config", "--json", "--hidden", "--glob='!.git/*'"]
     if (input.follow) args.push("--follow")
 
     if (input.glob) {

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -36,4 +36,28 @@ describe("file.ripgrep", () => {
     expect(hasVisible).toBe(true)
     expect(hasHidden).toBe(false)
   })
+
+  test("ignores RIPGREP_CONFIG_PATH when searching", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "testfile.txt"), "AAAAAAAAAA_FINDME_this_text_is_after_column_10")
+        await Bun.write(path.join(dir, "ripgreprc"), "--max-columns=10")
+      },
+    })
+
+    const previous = process.env.RIPGREP_CONFIG_PATH
+    process.env.RIPGREP_CONFIG_PATH = path.join(tmp.path, "ripgreprc")
+
+    try {
+      const matches = await Ripgrep.search({
+        cwd: tmp.path,
+        pattern: "FINDME",
+      })
+      expect(matches.length).toBe(1)
+      expect(matches[0]?.lines.text).toContain("FINDME")
+    } finally {
+      if (previous === undefined) delete process.env.RIPGREP_CONFIG_PATH
+      else process.env.RIPGREP_CONFIG_PATH = previous
+    }
+  })
 })


### PR DESCRIPTION
﻿## Summary
- add --no-config to internal g invocations in Ripgrep.files() and Ripgrep.search()
- prevent user RIPGREP_CONFIG_PATH / .ripgreprc from mutating OpenCode grep behavior
- add a regression test that sets RIPGREP_CONFIG_PATH and verifies search output still contains the real matching line

## Testing
- unable to run locally on this Windows host because un is not installed
- GitHub CI will validate

Fixes #12925
