### PR TITLE
fix(docs): avoid footer language selector truncation

### DIFF
--- a/packages/web/src/components/Footer.astro
+++ b/packages/web/src/components/Footer.astro
@@ -110,7 +110,8 @@ const discord = config.social?.find((item) => item.icon === "discord")
   }
 
   .doc :global(starlight-lang-select select) {
-    min-width: 7em;
+    min-width: 18ch;
+    max-width: min(100%, 20rem);
   }
 
   @media (min-width: 30rem) {


### PR DESCRIPTION
﻿## Summary
- increase the footer docs language selector width from 7em to 18ch
- keep it responsive with max-width: min(100%, 20rem)
- prevent truncation of longer locale labels when there is available space

## Testing
- not run locally (visual/CSS change); GitHub preview and CI checks will validate

Fixes #13103
