### PR TITLE
fix: encode non-ASCII directory paths in v1 SDK HTTP headers

### DIFF
--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -19,9 +19,11 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   if (config?.directory) {
+    const isNonASCII = /[^\x00-\x7F]/.test(config.directory)
+    const encodedDirectory = isNonASCII ? encodeURIComponent(config.directory) : config.directory
     config.headers = {
       ...config.headers,
-      "x-opencode-directory": config.directory,
+      "x-opencode-directory": encodedDirectory,
     }
   }
 

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -19,11 +19,9 @@ export function createOpencodeClient(config?: Config & { directory?: string }) {
   }
 
   if (config?.directory) {
-    const isNonASCII = /[^\x00-\x7F]/.test(config.directory)
-    const encodedDirectory = isNonASCII ? encodeURIComponent(config.directory) : config.directory
     config.headers = {
       ...config.headers,
-      "x-opencode-directory": encodedDirectory,
+      "x-opencode-directory": encodeURIComponent(config.directory),
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes #13023

#11344 added `directory: Instance.directory` to the plugin client, but the v1 SDK (`packages/sdk/js/src/client.ts`) sends the raw path as the `x-opencode-directory` header. 

`Headers.set()` rejects non-ASCII characters per the Fetch standard, so any project path with Chinese/Japanese/Korean characters throws a TypeError, breaking all project functionality.

This applies the same `encodeURIComponent` fix already in the v2 SDK (#7145) to the v1 SDK.

### How did you verify your code works?

Reproduced the bug by running `opencode ~/path/测试中文路径` — got `TypeError: Header 'x-opencode-directory' has invalid value`. After the fix, `bun run dev ~/path/测试中文路径` starts normally with no errors.
