### PR TITLE
desktop: use tracing for logging

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -535,8 +535,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -2492,6 +2494,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2700,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3065,6 +3085,7 @@ dependencies = [
 name = "opencode-desktop"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "comrak",
  "dirs",
  "futures",
@@ -3096,6 +3117,9 @@ dependencies = [
  "tauri-plugin-window-state",
  "tauri-specta",
  "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
  "webkit2gtk",
  "windows 0.61.3",
@@ -4413,6 +4437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5473,6 +5506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5745,9 +5787,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -5755,10 +5797,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.30"
+name = "tracing-appender"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5767,11 +5821,41 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5963,6 +6047,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -47,6 +47,10 @@ specta = "=2.0.0-rc.22"
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 dirs = "6.0.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
+chrono = "0.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"

--- a/packages/desktop/src-tauri/src/constants.rs
+++ b/packages/desktop/src-tauri/src/constants.rs
@@ -4,7 +4,6 @@ pub const SETTINGS_STORE: &str = "opencode.settings.dat";
 pub const DEFAULT_SERVER_URL_KEY: &str = "defaultServerUrl";
 pub const WSL_ENABLED_KEY: &str = "wslEnabled";
 pub const UPDATER_ENABLED: bool = option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some();
-pub const MAX_LOG_ENTRIES: usize = 200;
 
 pub fn window_state_flags() -> StateFlags {
     StateFlags::all() - StateFlags::DECORATIONS - StateFlags::VISIBLE

--- a/packages/desktop/src-tauri/src/job_object.rs
+++ b/packages/desktop/src-tauri/src/job_object.rs
@@ -15,9 +15,9 @@ use std::io::{Error, Result};
 use std::sync::Mutex;
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
 use windows::Win32::System::JobObjects::{
-    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
-    SetInformationJobObject,
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
 };
 use windows::Win32::System::Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE};
 
@@ -111,7 +111,7 @@ impl JobObjectState {
                 error: Mutex::new(None),
             },
             Err(e) => {
-                eprintln!("Failed to create job object: {e}");
+                tracing::error!("Failed to create job object: {e}");
                 Self {
                     job: Mutex::new(None),
                     error: Mutex::new(Some(format!("Failed to create job object: {e}"))),
@@ -123,11 +123,11 @@ impl JobObjectState {
     pub fn assign_pid(&self, pid: u32) {
         if let Some(job) = self.job.lock().unwrap().as_ref() {
             if let Err(e) = job.assign_pid(pid) {
-                eprintln!("Failed to assign process {pid} to job object: {e}");
+                tracing::error!(pid, "Failed to assign process to job object: {e}");
                 *self.error.lock().unwrap() =
                     Some(format!("Failed to assign process to job object: {e}"));
             } else {
-                println!("Assigned process {pid} to job object for automatic cleanup");
+                tracing::info!(pid, "Assigned process to job object for automatic cleanup");
             }
         }
     }

--- a/packages/desktop/src-tauri/src/linux_display.rs
+++ b/packages/desktop/src-tauri/src/linux_display.rs
@@ -14,7 +14,11 @@ struct DisplayConfig {
 }
 
 fn dir() -> Option<PathBuf> {
-  Some(dirs::data_dir()?.join(if cfg!(debug_assertions) { "ai.opencode.desktop.dev" } else { "ai.opencode.desktop" }))
+    Some(dirs::data_dir()?.join(if cfg!(debug_assertions) {
+        "ai.opencode.desktop.dev"
+    } else {
+        "ai.opencode.desktop"
+    }))
 }
 
 fn path() -> Option<PathBuf> {
@@ -22,13 +26,12 @@ fn path() -> Option<PathBuf> {
 }
 
 pub fn read_wayland() -> Option<bool> {
-    let raw = std::fs::read_to_string(dbg!(path()?)).ok()?;
+    let raw = std::fs::read_to_string(path()?).ok()?;
     let root = serde_json::from_str::<serde_json::Value>(&raw)
         .ok()?
-        .get(LINUX_DISPLAY_CONFIG_KEY).cloned()?;
-    serde_json::from_value::<DisplayConfig>(root)
-        .ok()?
-        .wayland
+        .get(LINUX_DISPLAY_CONFIG_KEY)
+        .cloned()?;
+    serde_json::from_value::<DisplayConfig>(root).ok()?.wayland
 }
 
 pub fn write_wayland(app: &AppHandle, value: bool) -> Result<(), String> {

--- a/packages/desktop/src-tauri/src/logging.rs
+++ b/packages/desktop/src-tauri/src/logging.rs
@@ -1,0 +1,83 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+const MAX_LOG_AGE_DAYS: u64 = 7;
+const TAIL_LINES: usize = 1000;
+
+static LOG_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
+pub fn init(log_dir: &Path) -> WorkerGuard {
+    std::fs::create_dir_all(log_dir).expect("failed to create log directory");
+
+    cleanup(log_dir);
+
+    let timestamp = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S");
+    let filename = format!("opencode-desktop_{timestamp}.log");
+    let log_path = log_dir.join(&filename);
+
+    LOG_PATH
+        .set(log_path.clone())
+        .expect("logging already initialized");
+
+    let file = File::create(&log_path).expect("failed to create log file");
+    let (non_blocking, guard) = tracing_appender::non_blocking(file);
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        if cfg!(debug_assertions) {
+            EnvFilter::new("opencode_lib=debug,opencode_desktop=debug,sidecar=debug")
+        } else {
+            EnvFilter::new("opencode_lib=info,opencode_desktop=info,sidecar=info")
+        }
+    });
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::layer().with_writer(std::io::stderr))
+        .with(
+            fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false),
+        )
+        .init();
+
+    guard
+}
+
+pub fn tail() -> String {
+    let Some(path) = LOG_PATH.get() else {
+        return String::new();
+    };
+
+    let Ok(file) = File::open(path) else {
+        return String::new();
+    };
+
+    let lines: Vec<String> = BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .collect();
+
+    let start = lines.len().saturating_sub(TAIL_LINES);
+    lines[start..].join("\n")
+}
+
+fn cleanup(log_dir: &Path) {
+    let cutoff = std::time::SystemTime::now()
+        - std::time::Duration::from_secs(MAX_LOG_AGE_DAYS * 24 * 60 * 60);
+
+    let Ok(entries) = std::fs::read_dir(log_dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        if let Ok(meta) = entry.metadata()
+            && let Ok(modified) = meta.modified()
+            && modified < cutoff
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}

--- a/packages/desktop/src-tauri/src/main.rs
+++ b/packages/desktop/src-tauri/src/main.rs
@@ -43,7 +43,7 @@ fn configure_display_backend() -> Option<String> {
         set_env_if_absent("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         return Some(
             "Wayland session detected; forcing X11 backend to avoid compositor protocol errors. \
-               Set OC_ALLOW_WAYLAND=1 to keep native Wayland."
+                Set OC_ALLOW_WAYLAND=1 to keep native Wayland."
                 .into(),
         );
     }
@@ -86,7 +86,7 @@ fn main() {
     #[cfg(target_os = "linux")]
     {
         if let Some(backend_note) = configure_display_backend() {
-            eprintln!("{backend_note:?}");
+            eprintln!("{backend_note}");
         }
     }
 

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -93,14 +93,14 @@ pub fn set_wsl_config(app: AppHandle, config: WslConfig) -> Result<(), String> {
 
 pub async fn get_saved_server_url(app: &tauri::AppHandle) -> Option<String> {
     if let Some(url) = get_default_server_url(app.clone()).ok().flatten() {
-        println!("Using desktop-specific custom URL: {url}");
+        tracing::info!(%url, "Using desktop-specific custom URL");
         return Some(url);
     }
 
     if let Some(cli_config) = cli::get_config(app).await
         && let Some(url) = get_server_url_from_config(&cli_config)
     {
-        println!("Using custom server URL from config: {url}");
+        tracing::info!(%url, "Using custom server URL from config");
         return Some(url);
     }
 
@@ -124,7 +124,7 @@ pub fn spawn_local_server(
                 tokio::time::sleep(Duration::from_millis(100)).await;
 
                 if check_health(&url, Some(&password)).await {
-                    println!("Server ready after {:?}", timestamp.elapsed());
+                    tracing::info!(elapsed = ?timestamp.elapsed(), "Server ready");
                     return Ok(());
                 }
             }
@@ -216,7 +216,7 @@ fn normalize_hostname_for_url(hostname: &str) -> String {
 fn get_server_url_from_config(config: &cli::Config) -> Option<String> {
     let server = config.server.as_ref()?;
     let port = server.port?;
-    println!("server.port found in OC config: {port}");
+    tracing::debug!(port, "server.port found in OC config");
     let hostname = server
         .hostname
         .as_ref()
@@ -227,7 +227,7 @@ fn get_server_url_from_config(config: &cli::Config) -> Option<String> {
 }
 
 pub async fn check_health_or_ask_retry(app: &AppHandle, url: &str) -> bool {
-    println!("Checking health for {url}");
+    tracing::debug!(%url, "Checking health");
     loop {
         if check_health(url, None).await {
             return true;


### PR DESCRIPTION
Converts all Rust logging to use the tracing-rs ecosystem. This allows us to write logs to the filesystem and more easily retrieve backend logs from the frontend