### PR TITLE
fix(app): improve initial bottom scroll on iOS/iPad Safari

### DIFF
--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -101,6 +101,27 @@ export const useSessionHashScroll = (input: {
       input.autoScroll.forceScrollToBottom()
       const el = input.scroller()
       if (el) input.scheduleScrollState(el)
+
+      // iOS Safari and iPad Safari (including iPadOS desktop-mode UA) often need
+      // a delayed retry for the initial scroll to bottom after layout settles.
+      const isAppleMobileSafari = (() => {
+        if (typeof navigator !== "object") return false
+        const ua = navigator.userAgent
+        const isSafari = /Safari/i.test(ua) && !/CriOS|FxiOS|EdgiOS|OPiOS|mercury/i.test(ua)
+        const isIOS = /iPhone|iPad|iPod/i.test(ua)
+        const isIPadOSDesktop = navigator.maxTouchPoints > 0 && /Macintosh/i.test(ua)
+        return isSafari && (isIOS || isIPadOSDesktop)
+      })()
+
+      if (isAppleMobileSafari) {
+        setTimeout(() => {
+          requestAnimationFrame(() => {
+            input.autoScroll.forceScrollToBottom()
+            const el = input.scroller()
+            if (el) input.scheduleScrollState(el)
+          })
+        }, 100)
+      }
       return
     }
 


### PR DESCRIPTION
Fixes #13156

## Problem
On initial session load without a hash, iOS/iPad Safari can land above the latest chat messages.

## Cause
Mobile Safari can apply late layout/viewport adjustments after first paint, so the initial bottom scroll is not always final.

## Fix
- In `packages/app/src/pages/session/use-session-hash-scroll.ts`, keep existing initial scroll behavior.
- Add a single delayed retry scroll-to-bottom for Apple mobile Safari only.
- Run this only when there is no hash.

## Safety
- Hash deep links (`#message-...`) remain unchanged and still take priority.
- No API or routing changes.
- Change is localized to one file.

## Manual verification
- iPhone Safari: open session with no hash -> lands at bottom.
- iPad Safari: open session with no hash -> lands at bottom.
- Open with `#message-...` -> jumps to target message (not overridden).