### PR TITLE
feat: Add .agentignore to supported ignore files

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -368,7 +368,7 @@ Internally, tools like `grep`, `glob`, and `list` use [ripgrep](https://github.c
 
 ### Ignore patterns
 
-To include files that would normally be ignored, create a `.ignore` file in your project root. This file can explicitly allow certain paths.
+To include files that would normally be ignored, create a `.ignore or `.rgignore` file in your project root. This file can explicitly allow certain paths.
 
 ```text title=".ignore"
 !node_modules/


### PR DESCRIPTION
### What does this PR do?

The .ignore file is used by a number of other libraries like Tailwind. If we want to filter out certain folders for the agent to read, that means it's filtered out for Tailwind as well. This PR adds a new ignore file that is less likely to be used by other libraries outside of an agent context.

I'm also open to naming this anything else such as `.opencodeignore`


### How did you verify your code works?
Add a .agentignore file to your project and test if the agent can/can't read or write what is added there

Fixes https://github.com/anomalyco/opencode/issues/13235