### PR TITLE
feat: add model fallback support with TTFT-based timeout

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -38,6 +38,15 @@ export namespace Agent {
           providerID: z.string(),
         })
         .optional(),
+      fallbackModels: z
+        .array(
+          z.object({
+            modelID: z.string(),
+            providerID: z.string(),
+          }),
+        )
+        .optional(),
+      firstTokenTimeout: z.number().int().positive().optional(),
       variant: z.string().optional(),
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
@@ -216,6 +225,12 @@ export namespace Agent {
           native: false,
         }
       if (value.model) item.model = Provider.parseModel(value.model)
+      if (value.fallback_models) {
+        item.fallbackModels = value.fallback_models.map((m: string) => Provider.parseModel(m))
+      }
+      if (value.first_token_timeout !== undefined) {
+        item.firstTokenTimeout = value.first_token_timeout
+      }
       item.variant = value.variant ?? item.variant
       item.prompt = value.prompt ?? item.prompt
       item.description = value.description ?? item.description

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -672,6 +672,18 @@ export namespace Config {
   export const Agent = z
     .object({
       model: ModelId.optional(),
+      fallback_models: z
+        .array(ModelId)
+        .optional()
+        .describe("Fallback models to try when the primary model fails, in priority order"),
+      first_token_timeout: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "First token timeout base in ms. Actual timeout = base + inputChars * 0.5. Only effective when fallback_models is also configured.",
+        ),
       variant: z
         .string()
         .optional()
@@ -709,6 +721,8 @@ export namespace Config {
       const knownKeys = new Set([
         "name",
         "model",
+        "fallback_models",
+        "first_token_timeout",
         "variant",
         "prompt",
         "description",

--- a/packages/opencode/src/session/fallback.ts
+++ b/packages/opencode/src/session/fallback.ts
@@ -1,0 +1,49 @@
+import { Instance } from "@/project/instance"
+
+export namespace SessionFallback {
+  export interface ModelRef {
+    providerID: string
+    modelID: string
+  }
+
+  const state = Instance.state(() => {
+    const data: Record<string, number> = {}
+    return data
+  })
+
+  function key(sessionID: string, agentName: string) {
+    return `${sessionID}:${agentName}`
+  }
+
+  export function buildModelList(primary: ModelRef, fallbacks?: ModelRef[]): ModelRef[] {
+    if (!fallbacks || fallbacks.length === 0) return [primary]
+    const seen = new Set<string>()
+    const result: ModelRef[] = []
+    for (const ref of [primary, ...fallbacks]) {
+      const key = `${ref.providerID}:${ref.modelID}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      result.push(ref)
+    }
+    return result
+  }
+
+  export function getStartIndex(sessionID: string, agentName: string): number {
+    return state()[key(sessionID, agentName)] ?? 0
+  }
+
+  export function recordSuccess(sessionID: string, agentName: string, index: number) {
+    state()[key(sessionID, agentName)] = index
+  }
+
+  /**
+   * Returns the next model index to try, cycling through all models starting
+   * from startIndex. Returns undefined when all models have been tried.
+   */
+  export function nextIndex(current: number, total: number, startIndex: number): number | undefined {
+    const safe = startIndex >= total ? 0 : startIndex
+    const next = (current + 1) % total
+    if (next === safe) return undefined
+    return next
+  }
+}

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -775,6 +775,8 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      case e instanceof Error && e.name === "FirstTokenTimeoutError":
+        return new NamedError.Unknown({ message: e.message }, { cause: e }).toObject()
       case e instanceof Error:
         return new NamedError.Unknown({ message: e.toString() }, { cause: e }).toObject()
       default:

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -9,16 +9,47 @@ import { Bus } from "@/bus"
 import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { Plugin } from "@/plugin"
-import type { Provider } from "@/provider/provider"
+import { SessionFallback } from "./fallback"
+import { Provider } from "@/provider/provider"
 import { LLM } from "./llm"
 import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
+import { TuiEvent } from "@/cli/cmd/tui/event"
+import type { ModelMessage } from "ai"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
+  const FALLBACK_RETRY_LIMIT = 1
   const log = Log.create({ service: "session.processor" })
+
+  class FirstTokenTimeoutError extends Error {
+    constructor(timeoutMs: number, modelID: string) {
+      super(`First token timeout after ${timeoutMs}ms for model ${modelID}`)
+      this.name = "FirstTokenTimeoutError"
+    }
+  }
+
+  export function estimateInputChars(messages: ModelMessage[]): number {
+    let chars = 0
+    for (const msg of messages) {
+      if (typeof msg.content === "string") {
+        chars += msg.content.length
+      } else if (Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          if ("text" in part && typeof part.text === "string") {
+            chars += part.text.length
+          }
+        }
+      }
+    }
+    return chars
+  }
+
+  export function computeTtftTimeout(baseMs: number, messages: ModelMessage[]): number {
+    return baseMs + estimateInputChars(messages) * 0.5
+  }
 
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
@@ -28,12 +59,36 @@ export namespace SessionProcessor {
     sessionID: string
     model: Provider.Model
     abort: AbortSignal
+    fallbackModels?: Array<{ providerID: string; modelID: string }>
+    firstTokenTimeout?: number
+    agentName?: string
   }) {
     const toolcalls: Record<string, MessageV2.ToolPart> = {}
     let snapshot: string | undefined
     let blocked = false
     let attempt = 0
     let needsCompaction = false
+
+    const modelList = input.fallbackModels?.length
+      ? SessionFallback.buildModelList(
+          { providerID: input.model.providerID, modelID: input.model.id },
+          input.fallbackModels,
+        )
+      : undefined
+    let fallbackStartIndex =
+      modelList && input.agentName ? SessionFallback.getStartIndex(input.sessionID, input.agentName) : 0
+    if (modelList && fallbackStartIndex >= modelList.length) {
+      fallbackStartIndex = 0
+    }
+    let currentModelIndex = fallbackStartIndex
+    if (modelList) {
+      log.info("fallback.init", {
+        modelList: modelList.map((m) => `${m.providerID}/${m.modelID}`).join(", "),
+        fallbackStartIndex,
+        agentName: input.agentName,
+        sessionID: input.sessionID,
+      })
+    }
 
     const result = {
       get message() {
@@ -46,11 +101,61 @@ export namespace SessionProcessor {
         log.info("process")
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
+
+        // If fallback state remembers a previously successful model, switch to it
+        if (modelList && fallbackStartIndex > 0 && fallbackStartIndex < modelList.length) {
+          const ref = modelList[fallbackStartIndex]
+          try {
+            const nextModel = await Provider.getModel(ref.providerID, ref.modelID)
+            input.model = nextModel
+            streamInput.model = nextModel
+            input.assistantMessage.modelID = nextModel.id
+            input.assistantMessage.providerID = nextModel.providerID
+            await Session.updateMessage(input.assistantMessage)
+          } catch {
+            // If resolving the remembered model fails, reset to primary
+            // so the fallback cycle covers all models
+            currentModelIndex = 0
+            fallbackStartIndex = 0
+          }
+        }
+
         while (true) {
+          let ttftTimer: ReturnType<typeof setTimeout> | undefined
+          let ttftAbortController: AbortController | undefined
+
           try {
             let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
-            const stream = await LLM.stream(streamInput)
+
+            // Set up TTFT timer when fallback is configured and firstTokenTimeout is set
+            const ttftBase =
+              modelList && modelList.length > 1 && input.firstTokenTimeout ? input.firstTokenTimeout : undefined
+            let effectiveAbort = input.abort
+            let ttftAbortController: AbortController | undefined
+            if (ttftBase !== undefined) {
+              ttftAbortController = new AbortController()
+              effectiveAbort = AbortSignal.any([input.abort, ttftAbortController.signal])
+            }
+
+            const stream = await LLM.stream({ ...streamInput, abort: effectiveAbort })
+
+            // Start TTFT timer after LLM.stream() returns to measure only HTTP/network overhead
+            // This excludes framework initialization time (provider init, config loading, etc.)
+            let ttftTimer: ReturnType<typeof setTimeout> | undefined
+            if (ttftBase !== undefined) {
+              const timeoutMs = computeTtftTimeout(ttftBase, streamInput.messages)
+              ttftTimer = setTimeout(() => {
+                ttftAbortController!.abort(
+                  new FirstTokenTimeoutError(timeoutMs, `${input.model.providerID}/${input.model.id}`),
+                )
+              }, timeoutMs)
+              log.info("ttft.timer.start", {
+                timeoutMs,
+                baseMs: ttftBase,
+                model: `${input.model.providerID}/${input.model.id}`,
+              })
+            }
 
             for await (const value of stream.fullStream) {
               input.abort.throwIfAborted()
@@ -60,6 +165,10 @@ export namespace SessionProcessor {
                   break
 
                 case "reasoning-start":
+                  if (ttftTimer) {
+                    clearTimeout(ttftTimer)
+                    ttftTimer = undefined
+                  }
                   if (value.id in reasoningMap) {
                     continue
                   }
@@ -101,6 +210,10 @@ export namespace SessionProcessor {
                   break
 
                 case "tool-input-start":
+                  if (ttftTimer) {
+                    clearTimeout(ttftTimer)
+                    ttftTimer = undefined
+                  }
                   const part = await Session.updatePart({
                     id: toolcalls[value.id]?.id ?? Identifier.ascending("part"),
                     messageID: input.assistantMessage.id,
@@ -277,6 +390,10 @@ export namespace SessionProcessor {
                   break
 
                 case "text-start":
+                  if (ttftTimer) {
+                    clearTimeout(ttftTimer)
+                    ttftTimer = undefined
+                  }
                   currentText = {
                     id: Identifier.ascending("part"),
                     messageID: input.assistantMessage.id,
@@ -329,6 +446,15 @@ export namespace SessionProcessor {
                   break
 
                 default:
+                  // AI SDK yields "abort" event when the abort signal fires,
+                  // rather than throwing. Detect TTFT-triggered abort and throw
+                  // to enter the catch block and trigger fallback.
+                  if ((value as any).type === "abort" && ttftAbortController?.signal.aborted && !input.abort.aborted) {
+                    const reason = ttftAbortController.signal.reason
+                    if (reason instanceof FirstTokenTimeoutError) {
+                      throw reason
+                    }
+                  }
                   log.info("unhandled", {
                     ...value,
                   })
@@ -337,33 +463,118 @@ export namespace SessionProcessor {
               if (needsCompaction) break
             }
           } catch (e: any) {
+            // If the TTFT abort controller triggered (not user abort), replace the
+            // DOMException("AbortError") with FirstTokenTimeoutError so it doesn't
+            // get classified as AbortedError (which skips fallback).
+            let err = e
+            if (ttftAbortController?.signal.aborted && !input.abort.aborted) {
+              const reason = ttftAbortController.signal.reason
+              if (reason instanceof FirstTokenTimeoutError) {
+                err = reason
+              }
+            }
+
             log.error("process", {
-              error: e,
-              stack: JSON.stringify(e.stack),
+              error: err,
+              stack: JSON.stringify(err.stack),
             })
-            const error = MessageV2.fromError(e, { providerID: input.model.providerID })
-            if (MessageV2.ContextOverflowError.isInstance(error)) {
-              // TODO: Handle context overflow error
-            }
-            const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
-              attempt++
-              const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
-              SessionStatus.set(input.sessionID, {
-                type: "retry",
-                attempt,
-                message: retry,
-                next: Date.now() + delay,
+            const error = MessageV2.fromError(err, { providerID: input.model.providerID })
+
+            // No fallback configured → preserve existing retry/fail logic
+            if (!modelList || modelList.length <= 1) {
+              const retry = SessionRetry.retryable(error)
+              if (retry !== undefined) {
+                attempt++
+                const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
+                SessionStatus.set(input.sessionID, {
+                  type: "retry",
+                  attempt,
+                  message: retry,
+                  next: Date.now() + delay,
+                })
+                await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                continue
+              }
+              input.assistantMessage.error = error
+              Bus.publish(Session.Event.Error, {
+                sessionID: input.assistantMessage.sessionID,
+                error: input.assistantMessage.error,
               })
-              await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              SessionStatus.set(input.sessionID, { type: "idle" })
+            } else {
+              // Fallback configured: context overflow and abort should not trigger fallback
+              if (MessageV2.ContextOverflowError.isInstance(error) || MessageV2.AbortedError.isInstance(error)) {
+                input.assistantMessage.error = error
+                Bus.publish(Session.Event.Error, {
+                  sessionID: input.assistantMessage.sessionID,
+                  error: input.assistantMessage.error,
+                })
+                SessionStatus.set(input.sessionID, { type: "idle" })
+              } else {
+                // For retryable API errors, try a short retry before switching models
+                const retry = SessionRetry.retryable(error)
+                if (retry !== undefined && MessageV2.APIError.isInstance(error) && attempt < FALLBACK_RETRY_LIMIT) {
+                  attempt++
+                  const delay = SessionRetry.delay(attempt, error)
+                  SessionStatus.set(input.sessionID, {
+                    type: "retry",
+                    attempt,
+                    message: retry,
+                    next: Date.now() + delay,
+                  })
+                  await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                  continue
+                }
+
+                // Not retryable, or retry exhausted — switch to next model
+                let switched = false
+                let tryIdx: number | undefined = SessionFallback.nextIndex(
+                  currentModelIndex,
+                  modelList.length,
+                  fallbackStartIndex,
+                )
+                while (tryIdx !== undefined) {
+                  const ref = modelList[tryIdx]
+                  try {
+                    const nextModel = await Provider.getModel(ref.providerID, ref.modelID)
+                    input.model = nextModel
+                    streamInput.model = nextModel
+                    input.assistantMessage.modelID = nextModel.id
+                    input.assistantMessage.providerID = nextModel.providerID
+                    await Session.updateMessage(input.assistantMessage)
+                    log.info("fallback", {
+                      from: currentModelIndex,
+                      to: tryIdx,
+                      providerID: ref.providerID,
+                      modelID: ref.modelID,
+                    })
+                    currentModelIndex = tryIdx
+                    attempt = 0
+                    switched = true
+                    break
+                  } catch {
+                    // This model can't be resolved, skip to the next one
+                    currentModelIndex = tryIdx
+                    tryIdx = SessionFallback.nextIndex(currentModelIndex, modelList.length, fallbackStartIndex)
+                  }
+                }
+
+                if (switched) continue
+
+                // All models tried → final failure
+                input.assistantMessage.error = error
+                Bus.publish(Session.Event.Error, {
+                  sessionID: input.assistantMessage.sessionID,
+                  error: input.assistantMessage.error,
+                })
+                SessionStatus.set(input.sessionID, { type: "idle" })
+              }
             }
-            input.assistantMessage.error = error
-            Bus.publish(Session.Event.Error, {
-              sessionID: input.assistantMessage.sessionID,
-              error: input.assistantMessage.error,
-            })
-            SessionStatus.set(input.sessionID, { type: "idle" })
+          } finally {
+            if (ttftTimer) {
+              clearTimeout(ttftTimer)
+              ttftTimer = undefined
+            }
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)
@@ -398,6 +609,29 @@ export namespace SessionProcessor {
           }
           input.assistantMessage.time.completed = Date.now()
           await Session.updateMessage(input.assistantMessage)
+          // Record which model was last used for next request.
+          // Only record on actual success — when all models fail, preserve the
+          // previous success record so the next call starts from a known-good model.
+          if (modelList && input.agentName) {
+            if (!input.assistantMessage.error) {
+              log.info("fallback.record", {
+                sessionID: input.sessionID,
+                agentName: input.agentName,
+                currentModelIndex,
+                model: `${input.model.providerID}/${input.model.id}`,
+              })
+              SessionFallback.recordSuccess(input.sessionID, input.agentName, currentModelIndex)
+              if (currentModelIndex !== fallbackStartIndex) {
+                const from = modelList[fallbackStartIndex]
+                const to = modelList[currentModelIndex]
+                Bus.publish(TuiEvent.ToastShow, {
+                  message: `${input.agentName}: ${from.providerID}/${from.modelID} → ${to.providerID}/${to.modelID}`,
+                  variant: "info" as const,
+                  duration: 3000,
+                })
+              }
+            }
+          }
           if (needsCompaction) return "compact"
           if (blocked) return "stop"
           if (input.assistantMessage.error) return "stop"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -572,6 +572,9 @@ export namespace SessionPrompt {
         sessionID: sessionID,
         model,
         abort,
+        fallbackModels: agent.fallbackModels,
+        firstTokenTimeout: agent.firstTokenTimeout,
+        agentName: agent.name,
       })
       using _ = defer(() => InstructionPrompt.clear(processor.message.id))
 

--- a/packages/opencode/test/session/fallback.test.ts
+++ b/packages/opencode/test/session/fallback.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { SessionFallback } from "../../src/session/fallback"
+import { Instance } from "../../src/project/instance"
+
+const projectRoot = path.join(__dirname, "../..")
+
+describe("SessionFallback.buildModelList", () => {
+  const primary = { providerID: "p1", modelID: "m1" }
+
+  test("returns array with only primary when no fallbacks", () => {
+    expect(SessionFallback.buildModelList(primary)).toEqual([primary])
+    expect(SessionFallback.buildModelList(primary, [])).toEqual([primary])
+    expect(SessionFallback.buildModelList(primary, undefined)).toEqual([primary])
+  })
+
+  test("returns primary followed by fallbacks", () => {
+    const fb1 = { providerID: "p2", modelID: "m2" }
+    const fb2 = { providerID: "p3", modelID: "m3" }
+    expect(SessionFallback.buildModelList(primary, [fb1, fb2])).toEqual([primary, fb1, fb2])
+  })
+
+  test("deduplicates when primary appears in fallbacks", () => {
+    const fb1 = { providerID: "p2", modelID: "m2" }
+    expect(SessionFallback.buildModelList(primary, [fb1, primary])).toEqual([primary, fb1])
+  })
+
+  test("deduplicates within fallbacks", () => {
+    const fb1 = { providerID: "p2", modelID: "m2" }
+    expect(SessionFallback.buildModelList(primary, [fb1, fb1, fb1])).toEqual([primary, fb1])
+  })
+
+  test("preserves first-occurrence order after deduplication", () => {
+    const fb1 = { providerID: "p2", modelID: "m2" }
+    const fb2 = { providerID: "p3", modelID: "m3" }
+    expect(SessionFallback.buildModelList(primary, [fb1, fb2, fb1, primary])).toEqual([primary, fb1, fb2])
+  })
+
+  test("all duplicates collapse to single model", () => {
+    expect(SessionFallback.buildModelList(primary, [primary, primary])).toEqual([primary])
+  })
+})
+
+describe("SessionFallback.nextIndex", () => {
+  test("cycles to next index", () => {
+    expect(SessionFallback.nextIndex(0, 4, 0)).toBe(1)
+  })
+
+  test("wraps around at end of list", () => {
+    expect(SessionFallback.nextIndex(3, 4, 0)).toBeUndefined()
+  })
+
+  test("returns undefined when all models tried (full cycle)", () => {
+    expect(SessionFallback.nextIndex(0, 3, 1)).toBeUndefined()
+  })
+
+  test("cycles correctly with non-zero start", () => {
+    expect(SessionFallback.nextIndex(2, 4, 2)).toBe(3)
+    expect(SessionFallback.nextIndex(3, 4, 2)).toBe(0)
+    expect(SessionFallback.nextIndex(0, 4, 2)).toBe(1)
+    expect(SessionFallback.nextIndex(1, 4, 2)).toBeUndefined()
+  })
+
+  test("returns undefined for single model list", () => {
+    expect(SessionFallback.nextIndex(0, 1, 0)).toBeUndefined()
+  })
+
+  test("cycles all models with two-model list", () => {
+    expect(SessionFallback.nextIndex(0, 2, 0)).toBe(1)
+    expect(SessionFallback.nextIndex(1, 2, 0)).toBeUndefined()
+  })
+
+  test("treats out-of-bounds startIndex as 0", () => {
+    // startIndex === total
+    expect(SessionFallback.nextIndex(0, 3, 3)).toBe(1)
+    expect(SessionFallback.nextIndex(1, 3, 3)).toBe(2)
+    expect(SessionFallback.nextIndex(2, 3, 3)).toBeUndefined()
+
+    // startIndex > total
+    expect(SessionFallback.nextIndex(0, 3, 10)).toBe(1)
+    expect(SessionFallback.nextIndex(2, 3, 10)).toBeUndefined()
+  })
+})
+
+describe("SessionFallback.recordSuccess / getStartIndex", () => {
+  test("defaults to 0 when no record exists", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        expect(SessionFallback.getStartIndex("unknown-session", "unknown-agent")).toBe(0)
+      },
+    })
+  })
+
+  test("remembers the last successful model index", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        SessionFallback.recordSuccess("s1", "agent1", 2)
+        expect(SessionFallback.getStartIndex("s1", "agent1")).toBe(2)
+      },
+    })
+  })
+
+  test("updates on subsequent successes", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        SessionFallback.recordSuccess("s2", "agent2", 1)
+        expect(SessionFallback.getStartIndex("s2", "agent2")).toBe(1)
+
+        SessionFallback.recordSuccess("s2", "agent2", 3)
+        expect(SessionFallback.getStartIndex("s2", "agent2")).toBe(3)
+      },
+    })
+  })
+
+  test("tracks different session/agent combinations independently", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        SessionFallback.recordSuccess("s3", "agentA", 1)
+        SessionFallback.recordSuccess("s3", "agentB", 2)
+        SessionFallback.recordSuccess("s4", "agentA", 3)
+
+        expect(SessionFallback.getStartIndex("s3", "agentA")).toBe(1)
+        expect(SessionFallback.getStartIndex("s3", "agentB")).toBe(2)
+        expect(SessionFallback.getStartIndex("s4", "agentA")).toBe(3)
+      },
+    })
+  })
+})
+
+describe("SessionFallback full cycle simulation", () => {
+  test("request 1: primary fails, fb1 fails, fb2 succeeds → remembers 2", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const models = [
+          { providerID: "p0", modelID: "m0" },
+          { providerID: "p1", modelID: "m1" },
+          { providerID: "p2", modelID: "m2" },
+          { providerID: "p3", modelID: "m3" },
+        ]
+        const list = SessionFallback.buildModelList(models[0], models.slice(1))
+        expect(list).toHaveLength(4)
+
+        const startIndex = 0
+        let current = startIndex
+
+        // model 0 fails → try next
+        const next1 = SessionFallback.nextIndex(current, list.length, startIndex)
+        expect(next1).toBe(1)
+        current = next1!
+
+        // model 1 fails → try next
+        const next2 = SessionFallback.nextIndex(current, list.length, startIndex)
+        expect(next2).toBe(2)
+        current = next2!
+
+        // model 2 succeeds
+        SessionFallback.recordSuccess("sim", "test", current)
+        expect(SessionFallback.getStartIndex("sim", "test")).toBe(2)
+      },
+    })
+  })
+
+  test("all models fail → nextIndex returns undefined after full cycle", () => {
+    const startIndex = 0
+    let current = startIndex
+
+    current = SessionFallback.nextIndex(current, 3, startIndex)!
+    expect(current).toBe(1)
+
+    current = SessionFallback.nextIndex(current, 3, startIndex)!
+    expect(current).toBe(2)
+
+    const result = SessionFallback.nextIndex(current, 3, startIndex)
+    expect(result).toBeUndefined()
+  })
+
+  test("request 2: starts from remembered model, cycles remaining then wraps", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        // Previous request remembered model 2
+        SessionFallback.recordSuccess("r2", "agent", 2)
+        const startIndex = SessionFallback.getStartIndex("r2", "agent")
+        expect(startIndex).toBe(2)
+
+        let current = startIndex
+
+        // model 2 (remembered) fails → try 3
+        const next1 = SessionFallback.nextIndex(current, 4, startIndex)
+        expect(next1).toBe(3)
+        current = next1!
+
+        // model 3 fails → wrap to 0
+        const next2 = SessionFallback.nextIndex(current, 4, startIndex)
+        expect(next2).toBe(0)
+        current = next2!
+
+        // model 0 fails → try 1
+        const next3 = SessionFallback.nextIndex(current, 4, startIndex)
+        expect(next3).toBe(1)
+        current = next3!
+
+        // model 1 succeeds
+        SessionFallback.recordSuccess("r2", "agent", current)
+        expect(SessionFallback.getStartIndex("r2", "agent")).toBe(1)
+
+        // all tried → undefined
+        const next4 = SessionFallback.nextIndex(current, 4, startIndex)
+        expect(next4).toBeUndefined()
+      },
+    })
+  })
+
+  test("remembered model unresolvable: caller resets startIndex to 0, full cycle available", () => {
+    // Simulates processor.ts behavior: remembered model (index 2) fails to resolve,
+    // caller resets both currentModelIndex and fallbackStartIndex to 0.
+    // All 4 models should be reachable in the cycle.
+    const startIndex = 0
+    let current = startIndex
+
+    // model 0 (primary) fails → try 1
+    current = SessionFallback.nextIndex(current, 4, startIndex)!
+    expect(current).toBe(1)
+
+    // model 1 fails → try 2
+    current = SessionFallback.nextIndex(current, 4, startIndex)!
+    expect(current).toBe(2)
+
+    // model 2 fails → try 3
+    current = SessionFallback.nextIndex(current, 4, startIndex)!
+    expect(current).toBe(3)
+
+    // all tried → undefined
+    const result = SessionFallback.nextIndex(current, 4, startIndex)
+    expect(result).toBeUndefined()
+  })
+
+  test("recordSuccess can reset back to primary (index 0)", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        SessionFallback.recordSuccess("reset", "agent", 2)
+        expect(SessionFallback.getStartIndex("reset", "agent")).toBe(2)
+
+        // Primary recovered, record success at 0
+        SessionFallback.recordSuccess("reset", "agent", 0)
+        expect(SessionFallback.getStartIndex("reset", "agent")).toBe(0)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/processor-ttft.test.ts
+++ b/packages/opencode/test/session/processor-ttft.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+import { MessageV2 } from "../../src/session/message-v2"
+import type { ModelMessage } from "ai"
+
+describe("SessionProcessor.estimateInputChars", () => {
+  test("returns 0 for empty messages", () => {
+    expect(SessionProcessor.estimateInputChars([])).toBe(0)
+  })
+
+  test("counts chars from string content", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "world!" },
+    ]
+    expect(SessionProcessor.estimateInputChars(messages)).toBe(11)
+  })
+
+  test("counts chars from array content with text parts", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "text", text: " world" },
+        ],
+      },
+    ]
+    expect(SessionProcessor.estimateInputChars(messages)).toBe(11)
+  })
+
+  test("ignores non-text parts in array content", () => {
+    const messages: ModelMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "image", image: new Uint8Array(), mimeType: "image/png" } as any,
+        ],
+      },
+    ]
+    expect(SessionProcessor.estimateInputChars(messages)).toBe(5)
+  })
+
+  test("handles mixed string and array content messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "system prompt" },
+      {
+        role: "user",
+        content: [{ type: "text", text: "user msg" }],
+      },
+      { role: "assistant", content: "reply" },
+    ]
+    // "system prompt" = 13, "user msg" = 8, "reply" = 5
+    expect(SessionProcessor.estimateInputChars(messages)).toBe(26)
+  })
+
+  test("handles large input correctly", () => {
+    const longText = "x".repeat(100_000)
+    const messages: ModelMessage[] = [{ role: "user", content: longText }]
+    expect(SessionProcessor.estimateInputChars(messages)).toBe(100_000)
+  })
+})
+
+describe("SessionProcessor.computeTtftTimeout", () => {
+  test("returns base when no messages", () => {
+    expect(SessionProcessor.computeTtftTimeout(5000, [])).toBe(5000)
+  })
+
+  test("adds 0.5ms per char", () => {
+    const messages: ModelMessage[] = [{ role: "user", content: "x".repeat(2000) }]
+    // 5000 + 2000 * 0.5 = 6000
+    expect(SessionProcessor.computeTtftTimeout(5000, messages)).toBe(6000)
+  })
+
+  test("matches expected timeout table values", () => {
+    const base = 5000
+
+    // ~2K chars → 6s
+    const msg2k: ModelMessage[] = [{ role: "user", content: "x".repeat(2000) }]
+    expect(SessionProcessor.computeTtftTimeout(base, msg2k)).toBe(6000)
+
+    // ~10K chars → 10s
+    const msg10k: ModelMessage[] = [{ role: "user", content: "x".repeat(10_000) }]
+    expect(SessionProcessor.computeTtftTimeout(base, msg10k)).toBe(10_000)
+
+    // ~50K chars → 30s
+    const msg50k: ModelMessage[] = [{ role: "user", content: "x".repeat(50_000) }]
+    expect(SessionProcessor.computeTtftTimeout(base, msg50k)).toBe(30_000)
+
+    // ~100K chars → 55s
+    const msg100k: ModelMessage[] = [{ role: "user", content: "x".repeat(100_000) }]
+    expect(SessionProcessor.computeTtftTimeout(base, msg100k)).toBe(55_000)
+
+    // ~400K chars → 205s
+    const msg400k: ModelMessage[] = [{ role: "user", content: "x".repeat(400_000) }]
+    expect(SessionProcessor.computeTtftTimeout(base, msg400k)).toBe(205_000)
+  })
+
+  test("works with different base values", () => {
+    const messages: ModelMessage[] = [{ role: "user", content: "x".repeat(10_000) }]
+    expect(SessionProcessor.computeTtftTimeout(3000, messages)).toBe(8000)
+    expect(SessionProcessor.computeTtftTimeout(10_000, messages)).toBe(15_000)
+  })
+
+  test("accumulates chars across multiple messages", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "x".repeat(1000) },
+      { role: "user", content: "x".repeat(3000) },
+      { role: "assistant", content: "x".repeat(2000) },
+    ]
+    // 5000 + 6000 * 0.5 = 8000
+    expect(SessionProcessor.computeTtftTimeout(5000, messages)).toBe(8000)
+  })
+})
+
+describe("MessageV2.fromError with FirstTokenTimeoutError", () => {
+  test("serializes FirstTokenTimeoutError as UnknownError", () => {
+    const error = new Error("First token timeout after 6000ms for model test/model")
+    error.name = "FirstTokenTimeoutError"
+    const result = MessageV2.fromError(error, { providerID: "test" })
+
+    expect(result.name).toBe("UnknownError")
+    expect(result.data.message).toContain("First token timeout")
+    expect(result.data.message).toContain("6000ms")
+  })
+
+  test("FirstTokenTimeoutError is not classified as AbortedError", () => {
+    const error = new Error("First token timeout after 5000ms for model p/m")
+    error.name = "FirstTokenTimeoutError"
+    const result = MessageV2.fromError(error, { providerID: "test" })
+
+    expect(MessageV2.AbortedError.isInstance(result)).toBe(false)
+  })
+
+  test("DOMException AbortError is classified as AbortedError", () => {
+    const error = new DOMException("The operation was aborted", "AbortError")
+    const result = MessageV2.fromError(error, { providerID: "test" })
+
+    expect(MessageV2.AbortedError.isInstance(result)).toBe(true)
+  })
+})


### PR DESCRIPTION
### What does this PR do?

This PR adds model fallback support for agents. When a primary model fails or is too slow to respond, the system automatically cycles through configured fallback models.
feat #7602 #9575

**Key changes:**

- **New config options**: `fallback_models` (list of fallback models in priority order) and `first_token_timeout` (base timeout in ms for first-token detection, scaled by input size: `base + inputChars * 0.5`)
- **Fallback cycling logic** (`SessionFallback`): builds a deduplicated model list, cycles through all models starting from the last successful one, and remembers which model worked per session/agent pair
- **TTFT timeout**: measures time-to-first-token from after `LLM.stream()` returns (excluding framework init overhead), so the timeout reflects actual network/model latency
- **Short retry before switching**: for retryable API errors, one retry attempt is made on the same model before falling back to the next
- **Error handling**: context overflow and user abort errors skip fallback (not model-specific); `FirstTokenTimeoutError` is properly unwrapped from `AbortError` so it triggers fallback instead of
being treated as user cancellation
- **Toast notification**: when a fallback switch occurs, a toast is shown indicating the model change
- **Edge case fixes**: clamps out-of-bounds `fallbackStartIndex` to prevent infinite loops when models are removed from config; resets both indices when the remembered model fails to resolve

**Files changed:**
- `src/session/fallback.ts` — new module for fallback state management and model cycling
- `src/session/processor.ts` — main integration: TTFT timer, fallback loop, error classification
- `src/agent/agent.ts` / `src/config/config.ts` — schema additions for `fallback_models` and `first_token_timeout`
- `src/session/prompt.ts` / `src/session/message-v2.ts` — pass fallback config to processor; handle `FirstTokenTimeoutError`

### How did you verify your code works?

- Added unit tests for `SessionFallback` (buildModelList, nextIndex cycling, recordSuccess/getStartIndex, full cycle simulations including remembered-model and out-of-bounds edge cases) — see `test/session/fallback.test.ts`
- Added unit tests for TTFT computation (estimateInputChars, computeTtftTimeout with various input sizes) and `FirstTokenTimeoutError` serialization — see `test/session/processor-ttft.test.ts`
- Manual testing with multiple model configurations to verify fallback cycling, TTFT timeout triggering, and toast notifications