### PR TITLE
ci: Add timeout to build-cli step in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Build
         id: build
+        timeout-minutes: 15
         run: |
           ./packages/opencode/script/build.ts
         env:


### PR DESCRIPTION
### What does this PR do?

Added timeout of 15 minute to the `build-cli` step in `publish.yml`

since I saw this happen more then once:

<img width="1206" height="827" alt="image" src="https://github.com/user-attachments/assets/4ba40eb5-12e9-4f21-8376-97fb691baad0" />
