### PR TITLE
fix(web): open external links in new tab

### DIFF
--- a/packages/web/src/components/Lander.astro
+++ b/packages/web/src/components/Lander.astro
@@ -87,7 +87,7 @@ if (image) {
         <li><b>{t('app.lander.features.shareable_links.title')}</b>: {t('app.lander.features.shareable_links.description')}</li>
         <li><b>GitHub Copilot</b>: {t('app.lander.features.github_copilot.description')}</li>
         <li><b>ChatGPT Plus/Pro</b>: {t('app.lander.features.chatgpt_plus_pro.description')}</li>
-        <li><b>{t('app.lander.features.use_any_model.title')}</b>: {t('app.lander.features.use_any_model.prefix')} <a href="https://models.dev">Models.dev</a>, {t('app.lander.features.use_any_model.suffix')}</li>
+        <li><b>{t('app.lander.features.use_any_model.title')}</b>: {t('app.lander.features.use_any_model.prefix')} <a href="https://models.dev" target="_blank" rel="noopener noreferrer">Models.dev</a>, {t('app.lander.features.use_any_model.suffix')}</li>
       </ul>
     </section>
 


### PR DESCRIPTION
Fixes the external link to models.dev on the landing page to open in a new tab with proper security attributes.

**Problem:**
The link to models.dev in the landing page features list doesn't open in a new tab and is missing "noopener noreferrer" rel attributes. This is inconsistent with other external links on the page (GitHub, Discord, Anomaly).

**Change:**
Added "target="_blank" rel="noopener noreferrer"" to the models.dev link in packages/web/src/components/Lander.astro.

**Verification:**
- [x] Link now opens in new tab
- [x] Security attributes match other external links on the page