### PR TITLE
fix(ui): allow target and rel attributes on links in markdown

### DIFF
--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -32,6 +32,7 @@ const config = {
   SANITIZE_NAMED_PROPS: true,
   FORBID_TAGS: ["style"],
   FORBID_CONTENTS: ["style", "script"],
+  ADD_ATTR: ["target", "rel"],
 }
 
 const iconPaths = {


### PR DESCRIPTION
Fixes links in chat messages to open in new tabs.

**Problem:**
Links returned by the agent in chat messages were not opening in new tabs because DOMPurify was stripping the "target" and "rel" attributes from anchor tags during sanitization.

**Root Cause:**
The DOMPurify configuration in packages/ui/src/components/markdown.tsx didn't include "target" and "rel" in the allowed attributes list, even though the marked renderer was correctly adding target="_blank" and rel="noopener noreferrer" to links.

**Fix:**
Added ADD_ATTR: ["target", "rel"] to the DOMPurify config to preserve these attributes on anchor elements.

**Testing:**
- Links in agent messages now open in new tabs
- Security attributes (noopener noreferrer) are preserved