### PR TITLE
feat(docs): add copy page markdown action to docs title

### DIFF
--- a/packages/console/app/src/config.ts
+++ b/packages/console/app/src/config.ts
@@ -9,8 +9,8 @@ export const config = {
   github: {
     repoUrl: "https://github.com/anomalyco/opencode",
     starsFormatted: {
-      compact: "95K",
-      full: "95,000",
+      compact: "100K",
+      full: "100,000",
     },
   },
 
@@ -22,8 +22,8 @@ export const config = {
 
   // Static stats (used on landing page)
   stats: {
-    contributors: "650",
-    commits: "8,500",
+    contributors: "700",
+    commits: "9,000",
     monthlyUsers: "2.5M",
   },
 } as const

--- a/packages/console/app/src/routes/zen/util/error.ts
+++ b/packages/console/app/src/routes/zen/util/error.ts
@@ -3,11 +3,13 @@ export class CreditsError extends Error {}
 export class MonthlyLimitError extends Error {}
 export class UserLimitError extends Error {}
 export class ModelError extends Error {}
-export class FreeUsageLimitError extends Error {}
-export class SubscriptionUsageLimitError extends Error {
+
+class LimitError extends Error {
   retryAfter?: number
   constructor(message: string, retryAfter?: number) {
     super(message)
     this.retryAfter = retryAfter
   }
 }
+export class FreeUsageLimitError extends LimitError {}
+export class SubscriptionUsageLimitError extends LimitError {}

--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -313,7 +313,7 @@ export async function handler(
 
     if (error instanceof FreeUsageLimitError || error instanceof SubscriptionUsageLimitError) {
       const headers = new Headers()
-      if (error instanceof SubscriptionUsageLimitError && error.retryAfter) {
+      if (error.retryAfter) {
         headers.set("retry-after", String(error.retryAfter))
       }
       return new Response(

--- a/packages/console/app/src/routes/zen/util/rateLimiter.ts
+++ b/packages/console/app/src/routes/zen/util/rateLimiter.ts
@@ -28,15 +28,44 @@ export function createRateLimiter(limit: ZenData.RateLimit | undefined, rawIp: s
     check: async () => {
       const rows = await Database.use((tx) =>
         tx
-          .select({ count: IpRateLimitTable.count })
+          .select({ interval: IpRateLimitTable.interval, count: IpRateLimitTable.count })
           .from(IpRateLimitTable)
           .where(and(eq(IpRateLimitTable.ip, ip), inArray(IpRateLimitTable.interval, intervals))),
       )
       const total = rows.reduce((sum, r) => sum + r.count, 0)
       logger.debug(`rate limit total: ${total}`)
-      if (total >= limitValue) throw new FreeUsageLimitError(`Rate limit exceeded. Please try again later.`)
+      if (total >= limitValue)
+        throw new FreeUsageLimitError(
+          `Rate limit exceeded. Please try again later.`,
+          limit.period === "day" ? getRetryAfterDay(now) : getRetryAfterHour(rows, intervals, limitValue, now),
+        )
     },
   }
+}
+
+export function getRetryAfterDay(now: number) {
+  return Math.ceil((86_400_000 - (now % 86_400_000)) / 1000)
+}
+
+export function getRetryAfterHour(
+  rows: { interval: string; count: number }[],
+  intervals: string[],
+  limit: number,
+  now: number,
+) {
+  const counts = new Map(rows.map((r) => [r.interval, r.count]))
+  // intervals are ordered newest to oldest: [current, -1h, -2h]
+  // simulate dropping oldest intervals one at a time
+  let running = intervals.reduce((sum, i) => sum + (counts.get(i) ?? 0), 0)
+  for (let i = intervals.length - 1; i >= 0; i--) {
+    running -= counts.get(intervals[i]) ?? 0
+    if (running < limit) {
+      // interval at index i rolls out of the window (intervals.length - i) hours from the current hour start
+      const hours = intervals.length - i
+      return Math.ceil((hours * 3_600_000 - (now % 3_600_000)) / 1000)
+    }
+  }
+  return Math.ceil((3_600_000 - (now % 3_600_000)) / 1000)
 }
 
 function buildYYYYMMDD(timestamp: number) {

--- a/packages/console/app/test/rateLimiter.test.ts
+++ b/packages/console/app/test/rateLimiter.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test"
+import { getRetryAfterDay, getRetryAfterHour } from "../src/routes/zen/util/rateLimiter"
+
+describe("getRetryAfterDay", () => {
+  test("returns full day at midnight UTC", () => {
+    const midnight = Date.UTC(2026, 0, 15, 0, 0, 0, 0)
+    expect(getRetryAfterDay(midnight)).toBe(86_400)
+  })
+
+  test("returns remaining seconds until next UTC day", () => {
+    const noon = Date.UTC(2026, 0, 15, 12, 0, 0, 0)
+    expect(getRetryAfterDay(noon)).toBe(43_200)
+  })
+
+  test("rounds up to nearest second", () => {
+    const almost = Date.UTC(2026, 0, 15, 23, 59, 59, 500)
+    expect(getRetryAfterDay(almost)).toBe(1)
+  })
+})
+
+describe("getRetryAfterHour", () => {
+  // 14:30:00 UTC — 30 minutes into the current hour
+  const now = Date.UTC(2026, 0, 15, 14, 30, 0, 0)
+  const intervals = ["2026011514", "2026011513", "2026011512"]
+
+  test("waits 3 hours when all usage is in current hour", () => {
+    const rows = [{ interval: "2026011514", count: 10 }]
+    // only current hour has usage — it won't leave the window for 3 hours from hour start
+    // 3 * 3600 - 1800 = 9000s
+    expect(getRetryAfterHour(rows, intervals, 10, now)).toBe(9000)
+  })
+
+  test("waits 1 hour when dropping oldest interval is sufficient", () => {
+    const rows = [
+      { interval: "2026011514", count: 2 },
+      { interval: "2026011512", count: 10 },
+    ]
+    // total=12, drop oldest (-2h, count=10) -> 2 < 10
+    // hours = 3 - 2 = 1 -> 1 * 3600 - 1800 = 1800s
+    expect(getRetryAfterHour(rows, intervals, 10, now)).toBe(1800)
+  })
+
+  test("waits 2 hours when usage spans oldest two intervals", () => {
+    const rows = [
+      { interval: "2026011513", count: 8 },
+      { interval: "2026011512", count: 5 },
+    ]
+    // total=13, drop -2h (5) -> 8, 8 >= 8, drop -1h (8) -> 0 < 8
+    // hours = 3 - 1 = 2 -> 2 * 3600 - 1800 = 5400s
+    expect(getRetryAfterHour(rows, intervals, 8, now)).toBe(5400)
+  })
+
+  test("waits 1 hour when oldest interval alone pushes over limit", () => {
+    const rows = [
+      { interval: "2026011514", count: 1 },
+      { interval: "2026011513", count: 1 },
+      { interval: "2026011512", count: 10 },
+    ]
+    // total=12, drop -2h (10) -> 2 < 10
+    // hours = 3 - 2 = 1 -> 1800s
+    expect(getRetryAfterHour(rows, intervals, 10, now)).toBe(1800)
+  })
+
+  test("waits 2 hours when middle interval keeps total over limit", () => {
+    const rows = [
+      { interval: "2026011514", count: 4 },
+      { interval: "2026011513", count: 4 },
+      { interval: "2026011512", count: 4 },
+    ]
+    // total=12, drop -2h (4) -> 8, 8 >= 5, drop -1h (4) -> 4 < 5
+    // hours = 3 - 1 = 2 -> 5400s
+    expect(getRetryAfterHour(rows, intervals, 5, now)).toBe(5400)
+  })
+
+  test("rounds up to nearest second", () => {
+    const offset = Date.UTC(2026, 0, 15, 14, 30, 0, 500)
+    const rows = [
+      { interval: "2026011514", count: 2 },
+      { interval: "2026011512", count: 10 },
+    ]
+    // hours=1 -> 3_600_000 - 1_800_500 = 1_799_500ms -> ceil(1799.5) = 1800
+    expect(getRetryAfterHour(rows, intervals, 10, offset)).toBe(1800)
+  })
+
+  test("fallback returns time until next hour when rows are empty", () => {
+    // edge case: rows empty but function called (shouldn't happen in practice)
+    // loop drops all zeros, running stays 0 which is < any positive limit on first iteration
+    const rows: { interval: string; count: number }[] = []
+    // drop -2h (0) -> 0 < 1 -> hours = 3 - 2 = 1 -> 1800s
+    expect(getRetryAfterHour(rows, intervals, 1, now)).toBe(1800)
+  })
+})

--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -276,6 +276,7 @@ export default defineConfig({
         Header: "./src/components/Header.astro",
         Footer: "./src/components/Footer.astro",
         SiteTitle: "./src/components/SiteTitle.astro",
+        PageTitle: "./src/components/PageTitle.astro",
       },
       plugins: [
         theme({

--- a/packages/web/src/components/PageTitle.astro
+++ b/packages/web/src/components/PageTitle.astro
@@ -1,0 +1,183 @@
+---
+import Default from "@astrojs/starlight/components/PageTitle.astro"
+
+const { slug } = Astro.locals.starlightRoute.entry
+const isHome = slug === ""
+const t = Astro.locals.t as (key: string, fallback?: string) => string
+
+const copyPage = t("docs.copy_page", "Copy page")
+const copying = t("docs.copying", "Copying…")
+const copied = t("share.copied", "Copied!")
+const failed = t("share.error", "Error")
+---
+
+<div class="page-title-row">
+  <Default {...Astro.props}><slot /></Default>
+  {!isHome && (
+    <button
+      type="button"
+      class="copy-page"
+      data-slug={slug}
+      data-label-idle={copyPage}
+      data-label-copying={copying}
+      data-label-copied={copied}
+      data-label-failed={failed}
+      aria-label={copyPage}
+      title={copyPage}
+    >
+      <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+      </svg>
+      <span class="label">{copyPage}</span>
+    </button>
+  )}
+</div>
+
+<script>
+  function init() {
+    const el = document.querySelector<HTMLButtonElement>(".copy-page")
+    if (!el) return
+
+    const slug = el.dataset.slug
+    if (!slug) return
+
+    const span = el.querySelector<HTMLSpanElement>(".label")
+    if (!span) return
+
+    const labels = {
+      idle: el.dataset.labelIdle || "Copy page",
+      copying: el.dataset.labelCopying || "Copying…",
+      copied: el.dataset.labelCopied || "Copied!",
+      failed: el.dataset.labelFailed || "Error",
+    }
+
+    const base = import.meta.env.BASE_URL.replace(/\/$/, "")
+    const url = `${base}/${slug}.md`
+
+    // Re-bind to satisfy TS closure narrowing
+    const btn: HTMLButtonElement = el
+    const label: HTMLSpanElement = span
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let active = true
+    let busy = false
+
+    function setState(state: "idle" | "copying" | "copied" | "failed") {
+      if (!active) return
+      if (timer) clearTimeout(timer)
+
+      const text = labels[state]
+      label.textContent = text
+      btn.setAttribute("aria-label", text)
+      btn.setAttribute("title", text)
+      btn.dataset.state = state
+
+      if (state === "copied" || state === "failed") {
+        timer = setTimeout(() => setState("idle"), 2000)
+      }
+    }
+
+    // Deprecated but kept as graceful fallback for contexts without Clipboard API
+    function fallback(text: string) {
+      const el = document.createElement("textarea")
+      el.value = text
+      el.style.position = "fixed"
+      el.style.opacity = "0"
+      document.body.appendChild(el)
+      el.select()
+      const ok = document.execCommand("copy")
+      document.body.removeChild(el)
+      setState(ok ? "copied" : "failed")
+    }
+
+    btn.addEventListener("click", () => {
+      if (busy) return
+      busy = true
+      setState("copying")
+
+      fetch(url)
+        .then((res) => {
+          if (!res.ok) return setState("failed")
+          return res.text().then((md) => {
+            if (!navigator.clipboard?.writeText) return fallback(md)
+            navigator.clipboard.writeText(md).then(
+              () => setState("copied"),
+              () => fallback(md),
+            )
+          })
+        })
+        .catch(() => setState("failed"))
+        .finally(() => { busy = false })
+    })
+
+    document.addEventListener("astro:before-swap", function cleanup() {
+      active = false
+      if (timer) clearTimeout(timer)
+      document.removeEventListener("astro:before-swap", cleanup)
+    })
+  }
+
+  // Module script runs once; listener is intentionally long-lived across navigations
+  init()
+  document.addEventListener("astro:after-swap", init)
+</script>
+
+<style>
+  .page-title-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+
+  .copy-page {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    cursor: pointer;
+    background: none;
+    border: 1px solid var(--color-border-weak);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    font-size: 12px;
+    font-family: inherit;
+    color: var(--color-text-weak);
+    transition: color 0.15s ease, border-color 0.15s ease;
+    white-space: nowrap;
+    align-self: center;
+  }
+
+  .copy-page:hover {
+    color: var(--color-text-strong);
+    border-color: var(--color-border);
+  }
+
+  .copy-page:focus-visible {
+    outline: 2px solid var(--color-background-interactive);
+    outline-offset: 2px;
+  }
+
+  .copy-page[data-state="copied"] {
+    color: var(--sl-color-green-high, #22c55e);
+    border-color: var(--sl-color-green-high, #22c55e);
+  }
+
+  .copy-page[data-state="failed"] {
+    color: var(--sl-color-red-high, #ef4444);
+    border-color: var(--sl-color-red-high, #ef4444);
+  }
+
+  .copy-page svg {
+    display: block;
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 480px) {
+    .copy-page .label {
+      display: none;
+    }
+  }
+</style>

--- a/packages/web/src/content/i18n/ar.json
+++ b/packages/web/src/content/i18n/ar.json
@@ -71,5 +71,7 @@
   "share.match_other": "مطابقات",
   "share.result_one": "نتيجة",
   "share.result_other": "نتائج",
-  "share.debug_key": "المفتاح"
+  "share.debug_key": "المفتاح",
+  "docs.copy_page": "نسخ الصفحة",
+  "docs.copying": "جارٍ النسخ…"
 }

--- a/packages/web/src/content/i18n/bs.json
+++ b/packages/web/src/content/i18n/bs.json
@@ -71,5 +71,7 @@
   "share.match_other": "podudaranja",
   "share.result_one": "rezultat",
   "share.result_other": "rezultati",
-  "share.debug_key": "Ključ"
+  "share.debug_key": "Ključ",
+  "docs.copy_page": "Kopiraj stranicu",
+  "docs.copying": "Kopiranje…"
 }

--- a/packages/web/src/content/i18n/da.json
+++ b/packages/web/src/content/i18n/da.json
@@ -71,5 +71,7 @@
   "share.match_other": "kampe",
   "share.result_one": "resultat",
   "share.result_other": "resultater",
-  "share.debug_key": "Nøgle"
+  "share.debug_key": "Nøgle",
+  "docs.copy_page": "Kopiér side",
+  "docs.copying": "Kopierer…"
 }

--- a/packages/web/src/content/i18n/de.json
+++ b/packages/web/src/content/i18n/de.json
@@ -71,5 +71,7 @@
   "share.match_other": "Treffer",
   "share.result_one": "Ergebnis",
   "share.result_other": "Ergebnisse",
-  "share.debug_key": "Schlüssel"
+  "share.debug_key": "Schlüssel",
+  "docs.copy_page": "Seite kopieren",
+  "docs.copying": "Kopieren…"
 }

--- a/packages/web/src/content/i18n/en.json
+++ b/packages/web/src/content/i18n/en.json
@@ -71,5 +71,7 @@
   "share.match_other": "matches",
   "share.result_one": "result",
   "share.result_other": "results",
-  "share.debug_key": "Key"
+  "share.debug_key": "Key",
+  "docs.copy_page": "Copy page",
+  "docs.copying": "Copying…"
 }

--- a/packages/web/src/content/i18n/es.json
+++ b/packages/web/src/content/i18n/es.json
@@ -71,5 +71,7 @@
   "share.match_other": "coincidencias",
   "share.result_one": "resultado",
   "share.result_other": "resultados",
-  "share.debug_key": "Clave"
+  "share.debug_key": "Clave",
+  "docs.copy_page": "Copiar página",
+  "docs.copying": "Copiando…"
 }

--- a/packages/web/src/content/i18n/fr.json
+++ b/packages/web/src/content/i18n/fr.json
@@ -71,5 +71,7 @@
   "share.match_other": "correspondances",
   "share.result_one": "résultat",
   "share.result_other": "résultats",
-  "share.debug_key": "Clé"
+  "share.debug_key": "Clé",
+  "docs.copy_page": "Copier la page",
+  "docs.copying": "Copie…"
 }

--- a/packages/web/src/content/i18n/it.json
+++ b/packages/web/src/content/i18n/it.json
@@ -71,5 +71,7 @@
   "share.match_other": "corrispondenze",
   "share.result_one": "risultato",
   "share.result_other": "risultati",
-  "share.debug_key": "Chiave"
+  "share.debug_key": "Chiave",
+  "docs.copy_page": "Copia pagina",
+  "docs.copying": "Copia in corso…"
 }

--- a/packages/web/src/content/i18n/ja.json
+++ b/packages/web/src/content/i18n/ja.json
@@ -71,5 +71,7 @@
   "share.match_other": "一致",
   "share.result_one": "結果",
   "share.result_other": "結果",
-  "share.debug_key": "キー"
+  "share.debug_key": "キー",
+  "docs.copy_page": "ページをコピー",
+  "docs.copying": "コピー中…"
 }

--- a/packages/web/src/content/i18n/ko.json
+++ b/packages/web/src/content/i18n/ko.json
@@ -71,5 +71,7 @@
   "share.match_other": "일치",
   "share.result_one": "결과",
   "share.result_other": "결과",
-  "share.debug_key": "키"
+  "share.debug_key": "키",
+  "docs.copy_page": "페이지 복사",
+  "docs.copying": "복사 중…"
 }

--- a/packages/web/src/content/i18n/nb.json
+++ b/packages/web/src/content/i18n/nb.json
@@ -71,5 +71,7 @@
   "share.match_other": "treff",
   "share.result_one": "resultat",
   "share.result_other": "resultater",
-  "share.debug_key": "Nøkkel"
+  "share.debug_key": "Nøkkel",
+  "docs.copy_page": "Kopier side",
+  "docs.copying": "Kopierer…"
 }

--- a/packages/web/src/content/i18n/pl.json
+++ b/packages/web/src/content/i18n/pl.json
@@ -71,5 +71,7 @@
   "share.match_other": "dopasowania",
   "share.result_one": "wynik",
   "share.result_other": "wyniki",
-  "share.debug_key": "Klawisz"
+  "share.debug_key": "Klawisz",
+  "docs.copy_page": "Kopiuj stronę",
+  "docs.copying": "Kopiowanie…"
 }

--- a/packages/web/src/content/i18n/pt-BR.json
+++ b/packages/web/src/content/i18n/pt-BR.json
@@ -71,5 +71,7 @@
   "share.match_other": "correspondências",
   "share.result_one": "resultado",
   "share.result_other": "resultados",
-  "share.debug_key": "Chave"
+  "share.debug_key": "Chave",
+  "docs.copy_page": "Copiar página",
+  "docs.copying": "Copiando…"
 }

--- a/packages/web/src/content/i18n/ru.json
+++ b/packages/web/src/content/i18n/ru.json
@@ -71,5 +71,7 @@
   "share.match_other": "совпадений",
   "share.result_one": "результат",
   "share.result_other": "результатов",
-  "share.debug_key": "Ключ"
+  "share.debug_key": "Ключ",
+  "docs.copy_page": "Копировать страницу",
+  "docs.copying": "Копирование…"
 }

--- a/packages/web/src/content/i18n/th.json
+++ b/packages/web/src/content/i18n/th.json
@@ -71,5 +71,7 @@
   "share.match_other": "รายการที่ตรงกัน",
   "share.result_one": "ผลลัพธ์",
   "share.result_other": "ผลลัพธ์",
-  "share.debug_key": "คีย์"
+  "share.debug_key": "คีย์",
+  "docs.copy_page": "คัดลอกหน้า",
+  "docs.copying": "กำลังคัดลอก…"
 }

--- a/packages/web/src/content/i18n/tr.json
+++ b/packages/web/src/content/i18n/tr.json
@@ -71,5 +71,7 @@
   "share.match_other": "eşleşme",
   "share.result_one": "sonuç",
   "share.result_other": "sonuç",
-  "share.debug_key": "Anahtar"
+  "share.debug_key": "Anahtar",
+  "docs.copy_page": "Sayfayı kopyala",
+  "docs.copying": "Kopyalanıyor…"
 }

--- a/packages/web/src/content/i18n/zh-CN.json
+++ b/packages/web/src/content/i18n/zh-CN.json
@@ -71,5 +71,7 @@
   "share.match_other": "匹配项",
   "share.result_one": "结果",
   "share.result_other": "结果",
-  "share.debug_key": "键"
+  "share.debug_key": "键",
+  "docs.copy_page": "复制页面",
+  "docs.copying": "复制中…"
 }

--- a/packages/web/src/content/i18n/zh-TW.json
+++ b/packages/web/src/content/i18n/zh-TW.json
@@ -71,5 +71,7 @@
   "share.match_other": "符合項目",
   "share.result_one": "結果",
   "share.result_other": "結果",
-  "share.debug_key": "金鑰"
+  "share.debug_key": "金鑰",
+  "docs.copy_page": "複製頁面",
+  "docs.copying": "複製中…"
 }


### PR DESCRIPTION
## Summary

- Add a "Copy page as markdown" action to the docs site title bar, allowing users to copy the full page content as markdown to their clipboard.

## Testing

- Verified with `astro build` — passes with no errors.