### PR TITLE
feat(opencode): add click to rename session in TUI sidebar

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1105,7 +1105,7 @@ export function Session() {
         <Show when={sidebarVisible()}>
           <Switch>
             <Match when={wide()}>
-              <Sidebar sessionID={route.sessionID} />
+              <Sidebar sessionID={route.sessionID} dialog={dialog} />
             </Match>
             <Match when={!wide()}>
               <box
@@ -1117,7 +1117,7 @@ export function Session() {
                 alignItems="flex-end"
                 backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
               >
-                <Sidebar sessionID={route.sessionID} />
+                <Sidebar sessionID={route.sessionID} dialog={dialog} />
               </box>
             </Match>
           </Switch>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -1,5 +1,5 @@
 import { useSync } from "@tui/context/sync"
-import { createMemo, For, Show, Switch, Match } from "solid-js"
+import { createMemo, createSignal, For, Show, Switch, Match } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "../../context/theme"
 import { Locale } from "@/util/locale"
@@ -11,8 +11,10 @@ import { useKeybind } from "../../context/keybind"
 import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
+import type { DialogContext } from "../../ui/dialog"
+import { DialogSessionRename } from "../../component/dialog-session-rename"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+export function Sidebar(props: { sessionID: string; overlay?: boolean; dialog?: DialogContext }) {
   const sync = useSync()
   const { theme } = useTheme()
   const session = createMemo(() => sync.session.get(props.sessionID)!)
@@ -63,6 +65,8 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
   const directory = useDirectory()
   const kv = useKV()
 
+  const [titleHovered, setTitleHovered] = createSignal(false)
+
   const hasProviders = createMemo(() =>
     sync.data.provider.some((x) => x.id !== "opencode" || Object.values(x.models).some((y) => y.cost?.input !== 0)),
   )
@@ -83,9 +87,22 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         <scrollbox flexGrow={1}>
           <box flexShrink={0} gap={1} paddingRight={1}>
             <box paddingRight={1}>
-              <text fg={theme.text}>
-                <b>{session().title}</b>
-              </text>
+              <box
+                backgroundColor={titleHovered() ? theme.borderSubtle : undefined}
+                paddingLeft={titleHovered() ? 1 : 0}
+                paddingRight={titleHovered() ? 1 : 0}
+                onMouseOver={() => setTitleHovered(true)}
+                onMouseOut={() => setTitleHovered(false)}
+                onMouseUp={() => {
+                  if (props.dialog) {
+                    props.dialog.replace(() => <DialogSessionRename session={props.sessionID} />)
+                  }
+                }}
+              >
+                <text fg={theme.text}>
+                  <b>{session().title}</b>
+                </text>
+              </box>
               <Show when={session().share?.url}>
                 <text fg={theme.textMuted}>{session().share!.url}</text>
               </Show>


### PR DESCRIPTION
Added click-to-rename functionality to the session title in the TUI sidebar.

How to Test:
1. Run bun dev to start the TUI
2. Trigger a chat. I used "Sleep for 10s"
3. Hover over the session title in the sidebar - should see grey background
4. Click the session title - rename dialog opens with current name pre-filled
5. Rename and confirm - title updates in sidebar

Fixes #13242