### PR TITLE
feat(tui): add toggle to hide session header

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -149,6 +149,7 @@ export function Session() {
   const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
   const [showAssistantMetadata, setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
   const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
+  const [showHeader, setShowHeader] = kv.signal("header_visible", true)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [animationsEnabled, setAnimationsEnabled] = kv.signal("animations_enabled", true)
 
@@ -583,6 +584,15 @@ export function Session() {
       },
     },
     {
+      title: showHeader() ? "Hide header" : "Show header",
+      value: "session.toggle.header",
+      category: "Session",
+      onSelect: (dialog) => {
+        setShowHeader((prev) => !prev)
+        dialog.clear()
+      },
+    },
+    {
       title: "Page up",
       value: "session.page.up",
       keybind: "messages_page_up",
@@ -963,7 +973,7 @@ export function Session() {
       <box flexDirection="row">
         <box flexGrow={1} paddingBottom={1} paddingTop={1} paddingLeft={2} paddingRight={2} gap={1}>
           <Show when={session()}>
-            <Show when={!sidebarVisible() || !wide()}>
+            <Show when={showHeader() && (!sidebarVisible() || !wide())}>
               <Header />
             </Show>
             <scrollbox


### PR DESCRIPTION

<img width="720" height="367" alt="image" src="https://github.com/user-attachments/assets/02353517-5d13-4d5f-86a3-210e792fc8df" />


## Summary
- Adds a **Hide header** / **Show header** toggle to the command palette
- Preference persists across sessions via the KV store (`header_visible`)
- When hidden, reclaims the vertical space used by the session title + token/cost bar

Follows the same pattern as the existing scrollbar, timestamps, thinking, and tool details toggles.

## Test plan
- [ ] Open the TUI and verify the header is visible by default
- [ ] Open the command palette and run "Hide header" — header should disappear
- [ ] Run "Show header" — header should reappear
- [ ] Restart the TUI — preference should persist