### PR TITLE
fix(test): clean up pending Question promises to prevent unhandled rejections

### DIFF
--- a/packages/opencode/test/question/question.test.ts
+++ b/packages/opencode/test/question/question.test.ts
@@ -21,7 +21,9 @@ test("ask - returns pending promise", async () => {
           },
         ],
       })
+      promise.catch(() => {})
       expect(promise).toBeInstanceOf(Promise)
+      await Instance.dispose()
     },
   })
 })
@@ -45,11 +47,12 @@ test("ask - adds to pending list", async () => {
       Question.ask({
         sessionID: "ses_test",
         questions,
-      })
+      }).catch(() => {})
 
       const pending = await Question.list()
       expect(pending.length).toBe(1)
       expect(pending[0].questions).toEqual(questions)
+      await Instance.dispose()
     },
   })
 })
@@ -269,7 +272,7 @@ test("list - returns all pending requests", async () => {
             options: [{ label: "A", description: "A" }],
           },
         ],
-      })
+      }).catch(() => {})
 
       Question.ask({
         sessionID: "ses_test2",
@@ -280,10 +283,11 @@ test("list - returns all pending requests", async () => {
             options: [{ label: "B", description: "B" }],
           },
         ],
-      })
+      }).catch(() => {})
 
       const pending = await Question.list()
       expect(pending.length).toBe(2)
+      await Instance.dispose()
     },
   })
 })


### PR DESCRIPTION
## Summary
Fixes CI failure caused by unhandled promise rejections in question tests.

## Root cause
`question.test.ts` created pending `Question.ask()` promises without `.catch()` and without disposing the test `Instance`. Later `Instance.disposeAll()` rejected those orphaned promises, producing `Unhandled error between tests` (`The user dismissed this question`).

## Changes
- Add `.catch(() => {})` to pending `Question.ask()` promises in affected tests
- Add `await Instance.dispose()` cleanup in those tests

## Validation
- `bun test test/question/question.test.ts test/memory/dispose.test.ts` in `packages/opencode`: **17 pass / 0 fail**
