### PR TITLE
fix(ui): add spacing between multiple toasts

### DIFF
--- a/packages/ui/src/components/toast.css
+++ b/packages/ui/src/components/toast.css
@@ -40,6 +40,8 @@
   background: var(--surface-float-base);
   color: var(--text-invert-base);
   box-shadow: var(--shadow-md);
+  margin-bottom: 5px;
+  margin-top: 5px;
 
   [data-slot="toast-inner"] {
     display: flex;


### PR DESCRIPTION
### What does this PR do?

Fixes #13259

When multiple toasts are shown, they stack with no gap and look stuck together. This PR adds vertical spacing between toasts in `packages/ui` so they are visually separated.

### How did you verify your code works?

Triggered multiple toasts in the web app and confirmed spacing between them.