### PR TITLE
feat(opencode): Support background subagents

### DIFF
--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -11,6 +11,7 @@ import { Command } from "../command"
 import { Instance } from "./instance"
 import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
+import { SessionBackground } from "../session/background"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -22,6 +23,7 @@ export async function InstanceBootstrap() {
   FileWatcher.init()
   Vcs.init()
   Snapshot.init()
+  SessionBackground.init()
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/session/background.ts
+++ b/packages/opencode/src/session/background.ts
@@ -1,0 +1,99 @@
+import { Bus } from "@/bus"
+import { Session } from "./index"
+import { SessionStatus } from "./status"
+import { Instance } from "@/project/instance"
+import { Log } from "@/util/log"
+import { SessionID, MessageID, PartID } from "./schema"
+import { SessionPrompt } from "./prompt"
+
+export namespace SessionBackground {
+  const log = Log.create({ service: "session.background" })
+
+  const state = Instance.state(
+    () => {
+      const wakeable = new Set<SessionID>()
+      const unsubscribes = [
+        Bus.subscribe(Session.Event.BackgroundTaskCompleted, async (event) => {
+          const sessionID = event.properties.sessionID
+          const task = event.properties.task
+
+          await updateTaskMessage(sessionID, task).then(() => {
+            state().wakeable.add(sessionID)
+          }).catch((err) => {
+            log.error("failed to update background task session message", { sessionID, error: err })
+          })
+          await wake(sessionID).catch((err) => {
+            log.error("failed to wake for finished tasks", { sessionID, error: err })
+          })
+        }),
+        Bus.subscribe(SessionStatus.Event.Status, async (event) => {
+          const sessionID = event.properties.sessionID
+
+          await wake(sessionID).catch((err) => {
+            log.error("failed to wake for finished tasks", { sessionID, error: err })
+          })
+        }),
+      ]
+      return { wakeable, unsubscribes }
+    },
+    async (current) => {
+      for (const unsubscribe of current.unsubscribes) {
+        unsubscribe()
+      }
+    },
+  )
+
+  export function init() {
+    return state()
+  }
+
+  async function wake(sessionID: SessionID) {
+    const session = await Session.get(sessionID).catch(() => {
+      log.warn("session not found, skipping wake", { sessionID })
+      return
+    })
+    if (!session) {
+      return
+    }
+
+    const s = state()
+    if (!s.wakeable.has(sessionID)) {
+      return
+    }
+
+    const status = SessionStatus.get(sessionID)
+    if (status.type !== "idle") {
+      return
+    }
+
+    s.wakeable.delete(sessionID)
+    SessionStatus.set(sessionID, { type: "busy" })
+    await SessionPrompt.loop({ sessionID })
+  }
+
+  async function updateTaskMessage(sessionID: SessionID, task: Session.BackgroundTask) {
+    const msgID = MessageID.ascending()
+    const output = [`Session ID: ${task.sessionID}`, "", "<task_result>", task.result, "</task_result>"].join("\n")
+    const text =
+      task.status === "success"
+        ? `Background task '${task.description}' completed.\n${output}`
+        : `Background task '${task.description}' failed: ${task.result}`
+
+    await Session.updateMessage({
+      id: msgID,
+      sessionID,
+      role: "user",
+      time: { created: Date.now() },
+      agent: task.agent,
+      model: task.model,
+    })
+    await Session.updatePart({
+      id: PartID.ascending(),
+      messageID: msgID,
+      sessionID,
+      type: "text",
+      synthetic: true,
+      text,
+    })
+  }
+}

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -181,6 +181,19 @@ export namespace Session {
   })
   export type GlobalInfo = z.output<typeof GlobalInfo>
 
+  export const BackgroundTask = z.object({
+    sessionID: SessionID.zod,
+    result: z.string(),
+    status: z.enum(["success", "error"]),
+    description: z.string(),
+    agent: z.string(),
+    model: z.object({
+      providerID: ProviderID.zod,
+      modelID: ModelID.zod,
+    }),
+  })
+  export type BackgroundTask = z.output<typeof BackgroundTask>
+
   export const Event = {
     Created: BusEvent.define(
       "session.created",
@@ -212,6 +225,13 @@ export namespace Session {
       z.object({
         sessionID: SessionID.zod.optional(),
         error: MessageV2.Assistant.shape.error,
+      }),
+    ),
+    BackgroundTaskCompleted: BusEvent.define(
+      "session.background_task_completed",
+      z.object({
+        sessionID: SessionID.zod,
+        task: BackgroundTask,
       }),
     ),
   }
@@ -668,6 +688,7 @@ export namespace Session {
       for (const child of await children(sessionID)) {
         await remove(child.id)
       }
+      SessionPrompt.cancel(sessionID)
       await unshare(sessionID).catch(() => {})
       // CASCADE delete handles messages and parts automatically
       Database.use((db) => {

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -219,6 +219,7 @@ export namespace MessageV2 {
       })
       .optional(),
     command: z.string().optional(),
+    background: z.boolean().optional(),
   }).meta({
     ref: "SubtaskPart",
   })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -406,6 +406,7 @@ export namespace SessionPrompt {
           description: task.description,
           subagent_type: task.agent,
           command: task.command,
+          background: task.background,
         }
         await Plugin.trigger(
           "tool.execute.before",

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -60,6 +60,7 @@ export namespace SessionStatus {
   }
 
   export function set(sessionID: SessionID, status: Info) {
+    state()[sessionID] = status
     Bus.publish(Event.Status, {
       sessionID,
       status,
@@ -70,8 +71,6 @@ export namespace SessionStatus {
         sessionID,
       })
       delete state()[sessionID]
-      return
     }
-    state()[sessionID] = status
   }
 }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -11,6 +11,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { Permission } from "@/permission"
+import { Bus } from "@/bus"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -23,6 +24,13 @@ const parameters = z.object({
     )
     .optional(),
   command: z.string().describe("The command that triggered this task").optional(),
+  background: z
+    .boolean()
+    .default(false)
+    .describe(
+      "If true, the task runs in the background and the main agent can continue working. Results will be reported back when done.",
+    )
+    .optional(),
 })
 
 export const TaskTool = Tool.define("task", async (ctx) => {
@@ -119,21 +127,11 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       })
 
       const messageID = MessageID.ascending()
-
-      function cancel() {
-        SessionPrompt.cancel(session.id)
-      }
-      ctx.abort.addEventListener("abort", cancel)
-      using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
-
-      const result = await SessionPrompt.prompt({
+      const promptInput = {
         messageID,
         sessionID: session.id,
-        model: {
-          modelID: model.modelID,
-          providerID: model.providerID,
-        },
+        model,
         agent: agent.name,
         tools: {
           todowrite: false,
@@ -142,7 +140,55 @@ export const TaskTool = Tool.define("task", async (ctx) => {
           ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
         },
         parts: promptParts,
-      })
+      }
+
+      if (params.background) {
+        iife(async () => {
+          const result = await SessionPrompt.prompt(promptInput)
+          const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
+
+          Bus.publish(Session.Event.BackgroundTaskCompleted, {
+            sessionID: ctx.sessionID,
+            task: {
+              sessionID: session.id,
+              result: text,
+              status: "success",
+              description: params.description,
+              agent: agent.name,
+              model,
+            },
+          })
+        }).catch((err) => {
+          Bus.publish(Session.Event.BackgroundTaskCompleted, {
+            sessionID: ctx.sessionID,
+            task: {
+              sessionID: session.id,
+              result: String(err),
+              status: "error",
+              description: params.description,
+              agent: agent.name,
+              model,
+            },
+          })
+        })
+
+        return {
+          title: params.description,
+          metadata: {
+            sessionId: session.id,
+            model,
+          },
+          output: `Background task started.\nSession ID: ${session.id}\n\nYou will be notified when it completes.`,
+        }
+      }
+
+      function cancel() {
+        SessionPrompt.cancel(session.id)
+      }
+      ctx.abort.addEventListener("abort", cancel)
+      using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
+
+      const result = await SessionPrompt.prompt(promptInput)
 
       const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
 

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -23,6 +23,11 @@ Usage notes:
 5. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).
 6. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
 
+Background tasks:
+- You can set background=true to run a task asynchronously if it will take a long time, or if you are requested to do so.
+- Background tasks wake you upon completion, so you should wait passively and idly for output of background tasks.
+- It is forbidden to track completion of tasks yourself via sleeping, or to delegate that tracking to other subagents.
+
 Example usage (NOTE: The agents below are fictional examples for illustration only - use the actual agents listed above):
 
 <example_agent_descriptions>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -290,6 +290,7 @@ export type SubtaskPart = {
     modelID: string
   }
   command?: string
+  background?: boolean
 }
 
 export type ReasoningPart = {
@@ -882,6 +883,24 @@ export type EventSessionError = {
   }
 }
 
+export type EventSessionBackgroundTaskCompleted = {
+  type: "session.background_task_completed"
+  properties: {
+    sessionID: string
+    task: {
+      sessionID: string
+      result: string
+      status: "success" | "error"
+      description: string
+      agent: string
+      model: {
+        providerID: string
+        modelID: string
+      }
+    }
+  }
+}
+
 export type EventVcsBranchUpdated = {
   type: "vcs.branch.updated"
   properties: {
@@ -994,6 +1013,7 @@ export type Event =
   | EventSessionDeleted
   | EventSessionDiff
   | EventSessionError
+  | EventSessionBackgroundTaskCompleted
   | EventVcsBranchUpdated
   | EventWorkspaceReady
   | EventWorkspaceFailed
@@ -1764,6 +1784,7 @@ export type SubtaskPartInput = {
     modelID: string
   }
   command?: string
+  background?: boolean
 }
 
 export type ProviderAuthMethod = {


### PR DESCRIPTION
### Issue for this PR

Closes #5887

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The goal of this PR is to support fire-and-forget/async/background tasks in my best approximation of how Claude Code handles it.

This is done by calling `SessionPrompt.prompt` async and emitting a new `BackgroundTaskCompleted` event when the promise resolves. The new `SessionBackground` component listens for these events (and the idle status event) and takes care of flushing the queue of finished task information to the parent session and forcing it to take it a turn with the results of the completed task(s).

This attempts to be a bit more minimal than https://github.com/anomalyco/opencode/pull/7206 to increase the chances of acceptance. I am a first-time contributor to opencode and I almost certainly overlooked something here. I'm happy to receive any suggestions or review.

### How did you verify your code works?
I opened opencode and entered the following prompt:
```
Run 4 general background subagents in parallel. Each one should use bash to
sleep for an amount of time and then print out a random number. Have them sleep
for 10, 18, 18.2, and 18.2 seconds, respectively. Then print out a chart to be
updated as each task notifies you of its completion.
```
And verified that the agent (tested with Kimi K2.5 Free):
- Could handle additional user interaction before the first subagent completed.
- Woke after the first subagent completed to update the chart.
- Woke a second time after the second subagent completed to update the chart.
- Woke a third and final time after the third and fourth subagents completed (to test that we buffer the results of two completions but still only give the primary agent a single turn once idled again)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._