### PR TITLE
fix(opencode): increase LSP diagnostics timeout to 10s

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -228,7 +228,7 @@ export namespace LSPClient {
               }
             })
           }),
-          3000,
+          10000,
         )
           .catch(() => {})
           .finally(() => {


### PR DESCRIPTION
### What does this PR do?

Found out that the 3s timeout for LSP diagnostics is a bit too short for ESLint. It usually takes around 4-5s to spin up and send the first set of issues, so it was basically timing out and getting empty results for no reason. I bumped it to 10s which should be plenty.

### How did you verify your code works?

I mocked a slow server that takes 4s to respond... worked fine with the 10s limit whereas the old code just gave up.

Fixes #13272