### PR TITLE
fix(opencode): prioritize openai small models in getSmallModel

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1160,6 +1160,8 @@ export namespace Provider {
     const provider = await state().then((state) => state.providers[providerID])
     if (provider) {
       let priority = [
+        "gpt-4o-mini",
+        "gpt-3.5-turbo",
         "claude-haiku-4-5",
         "claude-haiku-4.5",
         "3-5-haiku",


### PR DESCRIPTION
### What does this PR do?

Fixed an issue where OpenAI users were seeing gpt-5-nano being used for background tasks (like summarization) instead of OpenAI's own small models... well the `getSmallModel` logic was missing gpt-4o-mini and gpt-3.5-turbo in its priority list, which caused it to fall back to the global opencode/gpt-5-nano default. 

### How did you verify your code works?

I wrote a targeted unit test that sets up a mock OpenAI provider. Verified that it now correctly selects gpt-4o-mini as the small model, and correctly falls back to gpt-3.5-turbo if the newer model isn't available.

Fixes #13263