### PR TITLE
fix(bash): make description optional for tool calls

### DIFF
--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -73,9 +73,11 @@ export const BashTool = Tool.define("bash", async () => {
         .string()
         .describe(
           "Clear, concise description of what this command does in 5-10 words. Examples:\nInput: ls\nOutput: Lists files in current directory\n\nInput: git status\nOutput: Shows working tree status\n\nInput: npm install\nOutput: Installs package dependencies\n\nInput: mkdir foo\nOutput: Creates directory 'foo'",
-        ),
+        )
+        .optional(),
     }),
     async execute(params, ctx) {
+      const description = params.description ?? "Run shell command"
       const cwd = params.workdir || Instance.directory
       if (params.timeout !== undefined && params.timeout < 0) {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
@@ -181,7 +183,7 @@ export const BashTool = Tool.define("bash", async () => {
       ctx.metadata({
         metadata: {
           output: "",
-          description: params.description,
+          description,
         },
       })
 
@@ -191,7 +193,7 @@ export const BashTool = Tool.define("bash", async () => {
           metadata: {
             // truncate the metadata to avoid GIANT blobs of data (has nothing to do w/ what agent can access)
             output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
-            description: params.description,
+            description,
           },
         })
       }
@@ -256,11 +258,11 @@ export const BashTool = Tool.define("bash", async () => {
       }
 
       return {
-        title: params.description,
+        title: description,
         metadata: {
           output: output.length > MAX_METADATA_LENGTH ? output.slice(0, MAX_METADATA_LENGTH) + "\n\n..." : output,
           exit: proc.exitCode,
-          description: params.description,
+          description,
         },
         output,
       }

--- a/packages/opencode/test/tool/bash.test.ts
+++ b/packages/opencode/test/tool/bash.test.ts
@@ -37,6 +37,23 @@ describe("tool.bash", () => {
       },
     })
   })
+
+  test("basic without description", async () => {
+    await Instance.provide({
+      directory: projectRoot,
+      fn: async () => {
+        const bash = await BashTool.init()
+        const result = await bash.execute(
+          {
+            command: "echo 'test'",
+          },
+          ctx,
+        )
+        expect(result.metadata.exit).toBe(0)
+        expect(result.metadata.description).toBe("Run shell command")
+      },
+    })
+  })
 })
 
 describe("tool.bash permissions", () => {


### PR DESCRIPTION
Fixes #13146

## Summary
- Make `description` optional in `BashTool` input schema
- Add a fallback description (`Run shell command`) when callers omit it
- Add regression test to verify `bash.execute({ command })` works without `description`

## Why
Some clients/tool-call paths invoke bash with only `command`. Requiring `description` causes schema validation errors and makes bash effectively unusable in those flows.

## Scope
- `packages/opencode/src/tool/bash.ts`
- `packages/opencode/test/tool/bash.test.ts`
