### PR TITLE
fix(provider): filter custom loaders by enabled/disabled providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -906,7 +906,7 @@ export namespace Provider {
     }
 
     for (const [providerID, fn] of Object.entries(CUSTOM_LOADERS)) {
-      if (disabled.has(providerID)) continue
+      if (!isProviderAllowed(providerID)) continue
       const data = database[providerID]
       if (!data) {
         log.error("Provider does not exist in model list " + providerID)


### PR DESCRIPTION
Fixes #12407

## Summary
- Apply `isProviderAllowed(providerID)` in the `CUSTOM_LOADERS` loop
- Prevent custom loaders from running for providers excluded by `enabled_providers`

## Why
`CUSTOM_LOADERS` previously skipped only `disabled_providers`, so excluded providers could still run loader side effects (including package install attempts) before final provider filtering.

## Scope
- `packages/opencode/src/provider/provider.ts` (single-line logic fix)
