### PR TITLE
fix(app): ensure SSE stream works for remote and local servers

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -25,6 +25,7 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       baseUrl: server.url,
       signal: abort.signal,
       headers: auth,
+      fetch: server.isLocal() ? undefined : platform.fetch,
     })
     const emitter = createGlobalEmitter<{
       [key: string]: Event

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -22,7 +22,7 @@ export function serverDisplayName(url: string) {
 function projectsKey(url: string) {
   if (!url) return ""
   const host = url.replace(/^https?:\/\//, "").split(":")[0]
-  if (host === "localhost" || host === "127.0.0.1") return "local"
+  if (host === "localhost" || host === "127.0.0.1" || host === "::1") return "local"
   return url
 }
 


### PR DESCRIPTION
### What does this PR do?

Remote servers (e.g., behind Twingate/VPN) need platform.fetch (Tauri) to access OS-level networking routes. I updated the event stream to use the native platform fetch for remote connections while keeping browser fetch for localhost to ensure reliable local streaming.
 

### How did you verify your code works?

Tested with a headless server on a local IP. Confirmed that streaming works for both remote/IP and localhost connections in the desktop app. UI now updates in real-time as expected (see screenshot).

<img width="1512" height="982" alt="Screenshot 2026-02-12 at 09 25 21" src="https://github.com/user-attachments/assets/14adee52-4965-433e-818d-c6ae23798c76" />

Fixes #13211