### PR TITLE
docs: add pacman installation option for Arch Linux alongside AUR

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS و Linux (موصى به، دائما محدث)
 brew install opencode              # macOS و Linux (صيغة brew الرسمية، تحديث اقل)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # اي نظام
 nix run nixpkgs#opencode           # او github:anomalyco/opencode لاحدث فرع dev
 ```

--- a/README.br.md
+++ b/README.br.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS e Linux (recomendado, sempre atualizado)
 brew install opencode              # macOS e Linux (fórmula oficial do brew, atualiza menos)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # qualquer sistema
 nix run nixpkgs#opencode           # ou github:anomalyco/opencode para a branch dev mais recente
 ```

--- a/README.bs.md
+++ b/README.bs.md
@@ -51,7 +51,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS i Linux (preporučeno, uvijek ažurno)
 brew install opencode              # macOS i Linux (zvanična brew formula, rjeđe se ažurira)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # Bilo koji OS
 nix run nixpkgs#opencode           # ili github:anomalyco/opencode za najnoviji dev branch
 ```

--- a/README.da.md
+++ b/README.da.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS og Linux (anbefalet, altid up to date)
 brew install opencode              # macOS og Linux (officiel brew formula, opdateres sjældnere)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # alle OS
 nix run nixpkgs#opencode           # eller github:anomalyco/opencode for nyeste dev-branch
 ```

--- a/README.de.md
+++ b/README.de.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS und Linux (empfohlen, immer aktuell)
 brew install opencode              # macOS und Linux (offizielle Brew-Formula, seltener aktualisiert)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # jedes Betriebssystem
 nix run nixpkgs#opencode           # oder github:anomalyco/opencode für den neuesten dev-Branch
 ```

--- a/README.es.md
+++ b/README.es.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS y Linux (recomendado, siempre al día)
 brew install opencode              # macOS y Linux (fórmula oficial de brew, se actualiza menos)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # cualquier sistema
 nix run nixpkgs#opencode           # o github:anomalyco/opencode para la rama dev más reciente
 ```

--- a/README.fr.md
+++ b/README.fr.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS et Linux (recommandé, toujours à jour)
 brew install opencode              # macOS et Linux (formule officielle brew, mise à jour moins fréquente)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # n'importe quel OS
 nix run nixpkgs#opencode           # ou github:anomalyco/opencode pour la branche dev la plus récente
 ```

--- a/README.it.md
+++ b/README.it.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS e Linux (consigliato, sempre aggiornato)
 brew install opencode              # macOS e Linux (formula brew ufficiale, aggiornata meno spesso)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # Qualsiasi OS
 nix run nixpkgs#opencode           # oppure github:anomalyco/opencode per l’ultima branch di sviluppo
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS と Linux（推奨。常に最新）
 brew install opencode              # macOS と Linux（公式 brew formula。更新頻度は低め）
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # どのOSでも
 nix run nixpkgs#opencode           # または github:anomalyco/opencode で最新 dev ブランチ
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS 및 Linux (권장, 항상 최신)
 brew install opencode              # macOS 및 Linux (공식 brew formula, 업데이트 빈도 낮음)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # 어떤 OS든
 nix run nixpkgs#opencode           # 또는 github:anomalyco/opencode 로 최신 dev 브랜치
 ```

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS and Linux (recommended, always up to date)
 brew install opencode              # macOS and Linux (official brew formula, updated less)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # Any OS
 nix run nixpkgs#opencode           # or github:anomalyco/opencode for latest dev branch
 ```

--- a/README.no.md
+++ b/README.no.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS og Linux (anbefalt, alltid oppdatert)
 brew install opencode              # macOS og Linux (offisiell brew-formel, oppdateres sjeldnere)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # alle OS
 nix run nixpkgs#opencode           # eller github:anomalyco/opencode for nyeste dev-branch
 ```

--- a/README.pl.md
+++ b/README.pl.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS i Linux (polecane, zawsze aktualne)
 brew install opencode              # macOS i Linux (oficjalna formuła brew, rzadziej aktualizowana)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # dowolny system
 nix run nixpkgs#opencode           # lub github:anomalyco/opencode dla najnowszej gałęzi dev
 ```

--- a/README.ru.md
+++ b/README.ru.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS и Linux (рекомендуем, всегда актуально)
 brew install opencode              # macOS и Linux (официальная формула brew, обновляется реже)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # любая ОС
 nix run nixpkgs#opencode           # или github:anomalyco/opencode для самой свежей ветки dev
 ```

--- a/README.th.md
+++ b/README.th.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS และ Linux (แนะนำ อัปเดตเสมอ)
 brew install opencode              # macOS และ Linux (brew formula อย่างเป็นทางการ อัปเดตน้อยกว่า)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # ระบบปฏิบัติการใดก็ได้
 nix run nixpkgs#opencode           # หรือ github:anomalyco/opencode สำหรับสาขาพัฒนาล่าสุด
 ```

--- a/README.tr.md
+++ b/README.tr.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS ve Linux (önerilir, her zaman güncel)
 brew install opencode              # macOS ve Linux (resmi brew formülü, daha az güncellenir)
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # Tüm işletim sistemleri
 nix run nixpkgs#opencode           # veya en güncel geliştirme dalı için github:anomalyco/opencode
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS 和 Linux（推荐，始终保持最新）
 brew install opencode              # macOS 和 Linux（官方 brew formula，更新频率较低）
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # 任意系统
 nix run nixpkgs#opencode           # 或用 github:anomalyco/opencode 获取最新 dev 分支
 ```

--- a/README.zht.md
+++ b/README.zht.md
@@ -50,7 +50,8 @@ scoop install opencode             # Windows
 choco install opencode             # Windows
 brew install anomalyco/tap/opencode # macOS 與 Linux（推薦，始終保持最新）
 brew install opencode              # macOS 與 Linux（官方 brew formula，更新頻率較低）
-paru -S opencode-bin               # Arch Linux
+sudo pacman -S opencode            # Arch Linux (Stable)
+paru -S opencode-bin               # Arch Linux (Latest from AUR)
 mise use -g opencode               # 任何作業系統
 nix run nixpkgs#opencode           # 或使用 github:anomalyco/opencode 以取得最新開發分支
 ```

--- a/packages/web/src/content/docs/ar/index.mdx
+++ b/packages/web/src/content/docs/ar/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **باستخدام Paru على Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/da/index.mdx
+++ b/packages/web/src/content/docs/da/index.mdx
@@ -84,7 +84,8 @@ Du kan også installere det med følgende kommandoer:
 - **Brug af Paru på Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/de/index.mdx
+++ b/packages/web/src/content/docs/de/index.mdx
@@ -84,7 +84,8 @@ Sie können es auch mit den folgenden Befehlen installieren:
 - **Verwendung von Paru unter Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/es/index.mdx
+++ b/packages/web/src/content/docs/es/index.mdx
@@ -84,7 +84,8 @@ También puedes instalarlo con los siguientes comandos:
 - **Usando Paru en Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/fr/index.mdx
+++ b/packages/web/src/content/docs/fr/index.mdx
@@ -84,7 +84,8 @@ Vous pouvez également l'installer avec les commandes suivantes :
 - **Via Paru sur Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/index.mdx
+++ b/packages/web/src/content/docs/index.mdx
@@ -81,10 +81,11 @@ You can also install it with the following commands:
 
   > We recommend using the OpenCode tap for the most up to date releases. The official `brew install opencode` formula is maintained by the Homebrew team and is updated less frequently.
 
-- **Using Paru on Arch Linux**
+- **Installing on Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/it/index.mdx
+++ b/packages/web/src/content/docs/it/index.mdx
@@ -84,7 +84,8 @@ Puoi anche installarlo con i seguenti comandi:
 - **Con Paru su Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/ja/index.mdx
+++ b/packages/web/src/content/docs/ja/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **Arch Linux での Paru の使用**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/ko/index.mdx
+++ b/packages/web/src/content/docs/ko/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **Arch Linux에서 Paru 사용**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/nb/index.mdx
+++ b/packages/web/src/content/docs/nb/index.mdx
@@ -84,7 +84,8 @@ Du kan også installere den med følgende kommandoer:
 - **Bruke Paru på Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/pl/index.mdx
+++ b/packages/web/src/content/docs/pl/index.mdx
@@ -84,7 +84,8 @@ Możesz też użyć poniższych metod instalacji:
 - **Korzystanie z Paru na Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/pt-br/index.mdx
+++ b/packages/web/src/content/docs/pt-br/index.mdx
@@ -84,7 +84,8 @@ Você também pode instalá-lo com os seguintes comandos:
 - **Usando Paru no Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/ru/index.mdx
+++ b/packages/web/src/content/docs/ru/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **Использование Paru в Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/th/index.mdx
+++ b/packages/web/src/content/docs/th/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **ใช้ Paru บน Arch Linux**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/tr/index.mdx
+++ b/packages/web/src/content/docs/tr/index.mdx
@@ -84,7 +84,8 @@ Ayrıca aşağıdaki komutlarla da yükleyebilirsiniz:
 - **Paru'yu Arch Linux'ta kullanma**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/zh-cn/index.mdx
+++ b/packages/web/src/content/docs/zh-cn/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **在 Arch Linux 上使用 Paru**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows

--- a/packages/web/src/content/docs/zh-tw/index.mdx
+++ b/packages/web/src/content/docs/zh-tw/index.mdx
@@ -84,7 +84,8 @@ curl -fsSL https://opencode.ai/install | bash
 - **在 Arch Linux 上使用 Paru**
 
   ```bash
-  paru -S opencode-bin
+  sudo pacman -S opencode           # Arch Linux (Stable)
+  paru -S opencode-bin              # Arch Linux (Latest from AUR)
   ```
 
 #### Windows


### PR DESCRIPTION
Since opencode is now in Arch Linux [extra] repository, users can install via pacman for stable releases. Updated all 35 documentation files to show both options:
- pacman -S opencode (Stable from official repo, v1.1.53)
- paru -S opencode-bin (Latest from AUR, v1.1.60)

This gives users flexibility to choose between stable tested builds or bleeding edge releases based on their needs.

### What does this PR do?

update installation option for Arch Linux alongside AUR

### How did you verify your code works?
