### PR TITLE
desktop: sqlite migration progress bar

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -3117,6 +3117,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tauri-specta",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -5629,6 +5630,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -51,6 +51,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 chrono = "0.4"
+tokio-stream = { version = "0.1.18", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.2"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -560,9 +560,14 @@ async fn initialize(app: AppHandle) {
 
     tracing::info!("Main and loading windows created");
 
+    // SQLite migration handling:
+    // We only do this if the sqlite db doesn't exist, and we're expecting the sidecar to create it
+    // First, we spawn a task that listens for SqliteMigrationProgress events that can
+    // come from any invocation of the sidecar CLI. The progress is captured by a stdout stream interceptor.
+    // Then in the loading task, we wait for sqlite migration to complete before
+    // starting our health check against the server, otherwise long migrations could result in a timeout.
     let sqlite_enabled = option_env!("OPENCODE_SQLITE").is_some();
-    let sqlite_done_rx = (sqlite_enabled && !sqlite_file_exists()).then(|| {
-        let (sqlite_done_tx, sqlite_done_rx) = oneshot::channel::<()>();
+    let sqlite_done = (sqlite_enabled && !sqlite_file_exists()).then(|| {
         tracing::info!(
             path = %opencode_db_path().expect("failed to get db path").display(),
             "Sqlite file not found, waiting for it to be generated"
@@ -584,12 +589,8 @@ async fn initialize(app: AppHandle) {
 
         let app = app.clone();
         tokio::spawn(done_rx.map(async move |_| {
-            let _ = sqlite_done_tx.send(());
-
             app.unlisten(id);
-        }));
-
-        sqlite_done_rx
+        }))
     });
 
     let loading_task = tokio::spawn({
@@ -657,7 +658,7 @@ async fn initialize(app: AppHandle) {
             tracing::info!("server connection started");
 
             if let Some(cli_health_check) = cli_health_check {
-                if let Some(sqlite_done_rx) = sqlite_done_rx {
+                if let Some(sqlite_done_rx) = sqlite_done {
                     let _ = sqlite_done_rx.await;
                 }
                 tokio::spawn(cli_health_check);

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -24,16 +24,17 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
-use tauri::{AppHandle, Manager, RunEvent, State, ipc::Channel};
+use tauri::{AppHandle, Listener, Manager, RunEvent, State, ipc::Channel};
 #[cfg(any(target_os = "linux", all(debug_assertions, windows)))]
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_shell::process::CommandChild;
+use tauri_specta::Event;
 use tokio::{
     sync::{oneshot, watch},
     time::{sleep, timeout},
 };
 
-use crate::cli::sync_cli;
+use crate::cli::{sqlite_migration::SqliteMigrationProgress, sync_cli};
 use crate::constants::*;
 use crate::server::get_saved_server_url;
 use crate::windows::{LoadingWindow, MainWindow};
@@ -122,8 +123,8 @@ async fn await_initialization(
     let mut rx = init_state.current.clone();
 
     let events = async {
-        let e = (*rx.borrow()).clone();
-        let _ = events.send(e).unwrap();
+        let e = *rx.borrow();
+        let _ = events.send(e);
 
         while rx.changed().await.is_ok() {
             let step = *rx.borrow_and_update();
@@ -517,7 +518,10 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             wsl_path,
             resolve_app_path
         ])
-        .events(tauri_specta::collect_events![LoadingWindowComplete])
+        .events(tauri_specta::collect_events![
+            LoadingWindowComplete,
+            SqliteMigrationProgress
+        ])
         .error_handling(tauri_specta::ErrorHandlingMode::Throw)
 }
 
@@ -557,16 +561,44 @@ async fn initialize(app: AppHandle) {
     tracing::info!("Main and loading windows created");
 
     let sqlite_enabled = option_env!("OPENCODE_SQLITE").is_some();
+    let sqlite_done_rx = (sqlite_enabled && !sqlite_file_exists()).then(|| {
+        let (sqlite_done_tx, sqlite_done_rx) = oneshot::channel::<()>();
+        tracing::info!(
+            path = %opencode_db_path().expect("failed to get db path").display(),
+            "Sqlite file not found, waiting for it to be generated"
+        );
+
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+
+        let init_tx = init_tx.clone();
+        let id = SqliteMigrationProgress::listen(&app, move |e| {
+            let _ = init_tx.send(InitStep::SqliteWaiting);
+
+            if matches!(e.payload, SqliteMigrationProgress::Done)
+                && let Some(done_tx) = done_tx.lock().unwrap().take()
+            {
+                let _ = done_tx.send(());
+            }
+        });
+
+        let app = app.clone();
+        tokio::spawn(done_rx.map(async move |_| {
+            let _ = sqlite_done_tx.send(());
+
+            app.unlisten(id);
+        }));
+
+        sqlite_done_rx
+    });
 
     let loading_task = tokio::spawn({
-        let init_tx = init_tx.clone();
         let app = app.clone();
 
         async move {
-            let mut sqlite_exists = sqlite_file_exists();
-
             tracing::info!("Setting up server connection");
             let server_connection = setup_server_connection(app.clone()).await;
+            tracing::info!("Server connection setup");
 
             // we delay spawning this future so that the timeout is created lazily
             let cli_health_check = match server_connection {
@@ -622,23 +654,12 @@ async fn initialize(app: AppHandle) {
                 }
             };
 
+            tracing::info!("server connection started");
+
             if let Some(cli_health_check) = cli_health_check {
-                if sqlite_enabled {
-                    tracing::debug!(sqlite_exists, "Checking sqlite file existence");
-                    if !sqlite_exists {
-                        tracing::info!(
-                            path = %opencode_db_path().expect("failed to get db path").display(),
-                            "Sqlite file not found, waiting for it to be generated"
-                        );
-                        let _ = init_tx.send(InitStep::SqliteWaiting);
-
-                        while !sqlite_exists {
-                            sleep(Duration::from_secs(1)).await;
-                            sqlite_exists = sqlite_file_exists();
-                        }
-                    }
+                if let Some(sqlite_done_rx) = sqlite_done_rx {
+                    let _ = sqlite_done_rx.await;
                 }
-
                 tokio::spawn(cli_health_check);
             }
 
@@ -654,11 +675,11 @@ async fn initialize(app: AppHandle) {
             .is_err()
     {
         tracing::debug!("Loading task timed out, showing loading window");
-        let app = app.clone();
         let loading_window = LoadingWindow::create(&app).expect("Failed to create loading window");
         sleep(Duration::from_secs(1)).await;
         Some(loading_window)
     } else {
+        tracing::debug!("Showing main window without loading window");
         MainWindow::create(&app).expect("Failed to create main window");
 
         None
@@ -667,7 +688,6 @@ async fn initialize(app: AppHandle) {
     let _ = loading_task.await;
 
     tracing::info!("Loading done, completing initialisation");
-
     let _ = init_tx.send(InitStep::Done);
 
     if loading_window.is_some() {

--- a/packages/desktop/src-tauri/src/server.rs
+++ b/packages/desktop/src-tauri/src/server.rs
@@ -11,15 +11,9 @@ use crate::{
     constants::{DEFAULT_SERVER_URL_KEY, SETTINGS_STORE, WSL_ENABLED_KEY},
 };
 
-#[derive(Clone, serde::Serialize, serde::Deserialize, specta::Type, Debug)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, specta::Type, Debug, Default)]
 pub struct WslConfig {
     pub enabled: bool,
-}
-
-impl Default for WslConfig {
-    fn default() -> Self {
-        Self { enabled: false }
-    }
 }
 
 #[tauri::command]

--- a/packages/desktop/src/bindings.ts
+++ b/packages/desktop/src/bindings.ts
@@ -23,6 +23,7 @@ export const commands = {
 /** Events */
 export const events = {
 	loadingWindowComplete: makeEvent<LoadingWindowComplete>("loading-window-complete"),
+	sqliteMigrationProgress: makeEvent<SqliteMigrationProgress>("sqlite-migration-progress"),
 };
 
 /* Types */
@@ -36,6 +37,8 @@ export type ServerReadyData = {
 		url: string,
 		password: string | null,
 	};
+
+export type SqliteMigrationProgress = { type: "InProgress"; value: number } | { type: "Done" };
 
 export type WslConfig = {
 		enabled: boolean,


### PR DESCRIPTION
Adds logic for tracking sqlite migration progress in Desktop by reading stdout (works by intercepting the CommandEvent stream and emitting Tauri events)