### PR TITLE
fix: the Desktop “Open In” startup command in Windows/WSL

### DIFF
--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -132,7 +132,7 @@ const createPlatform = (password: Accessor<string | null>): Platform => {
               })
             if (linuxPath) {
               try {
-                const result = await Command.create("wsl", ["-e", app, linuxPath]).execute() // arguments are passed as separate array elements to avoid shell interpretation and injection attacks
+                const result = await Command.create("wsl", ["-e", app, "--", linuxPath]).execute() // arguments are passed as separate array elements to avoid shell interpretation and injection attacks; `--` prevents filenames starting with `-` from being treated as flags
                 if (result.code === 0) return // handled via WSL, skip Windows opener
                 console.warn("WSL open returned non-zero code", result.code, result.stderr)
               } catch (err) {

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -12,7 +12,7 @@ import {
 import { open, save } from "@tauri-apps/plugin-dialog"
 import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link"
 import { openPath as openerOpenPath } from "@tauri-apps/plugin-opener"
-import { open as shellOpen } from "@tauri-apps/plugin-shell"
+import { open as shellOpen, Command } from "@tauri-apps/plugin-shell"
 import { type as ostype } from "@tauri-apps/plugin-os"
 import { check, Update } from "@tauri-apps/plugin-updater"
 import { getCurrentWindow } from "@tauri-apps/api/window"
@@ -117,6 +117,11 @@ const createPlatform = (password: Accessor<string | null>): Platform => {
     async openPath(path: string, app?: string) {
       const os = ostype()
       if (os === "windows") {
+        if (window.__OPENCODE__?.wsl && app) {
+          const linuxPath = await commands.wslPath(path, "linux").catch(() => path)
+          await Command.create("wsl", ["-e", app, linuxPath]).execute()
+          return
+        }
         const resolvedApp = (app && (await commands.resolveAppPath(app))) || app
         const resolvedPath = await (async () => {
           if (window.__OPENCODE__?.wsl) {

--- a/packages/desktop/src/index.tsx
+++ b/packages/desktop/src/index.tsx
@@ -115,12 +115,31 @@ const createPlatform = (password: Accessor<string | null>): Platform => {
       void shellOpen(url).catch(() => undefined)
     },
     async openPath(path: string, app?: string) {
-      const os = ostype()
-      if (os === "windows") {
-        if (window.__OPENCODE__?.wsl && app) {
-          const linuxPath = await commands.wslPath(path, "linux").catch(() => path)
-          await Command.create("wsl", ["-e", app, linuxPath]).execute()
-          return
+        const os = ostype()
+        if (os === "windows") {
+          if (window.__OPENCODE__?.wsl && app) {
+            const allowed = new Set(["code", "cursor", "zed", "sublime-text"])
+          const validPattern = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
+          const isAppAllowed = allowed.has(app) && validPattern.test(app)
+          if (!isAppAllowed) {
+            console.warn("WSL open rejected app name", app) // fall back to Windows opener
+          } else {
+            const linuxPath = await commands
+              .wslPath(path, "linux")
+              .catch((err) => {
+                console.warn("Failed to convert path for WSL open", err)
+                return null
+              })
+            if (linuxPath) {
+              try {
+                const result = await Command.create("wsl", ["-e", app, linuxPath]).execute() // arguments are passed as separate array elements to avoid shell interpretation and injection attacks
+                if (result.code === 0) return // handled via WSL, skip Windows opener
+                console.warn("WSL open returned non-zero code", result.code, result.stderr)
+              } catch (err) {
+                console.warn("WSL open threw", err)
+              }
+            }
+          }
         }
         const resolvedApp = (app && (await commands.resolveAppPath(app))) || app
         const resolvedPath = await (async () => {


### PR DESCRIPTION
### What does this PR do?
Fixes #13089 
I encountered an error when using the `open in` `Vscode/Zed` command with a WSL environment integrated into Windows Desktop. Specifically, the WSL connection was being mistaken for the path.

Fix: On Windows with WSL enabled, `openPath` first attempts to call applications within the restricted whitelist (code/cursor/zed/sublime-text) via `wsl -e`. The path is first converted to Linux format, and failure/non-zero exit code logs are added.

If the WSL call is rejected or fails, the original Windows path conversion and the fallback logic of the opener plugin are maintained.

Tauri Command has been introduced to run WSL commands, and command injection risks are reduced through parameter arrays and stricter naming validation.

### How did you verify your code works?
I tested the effect after building locally using my fork, and now it can be opened directly.