### PR TITLE
fix: robust subagent completion propagation

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -302,13 +302,18 @@ export namespace SessionPrompt {
       }
 
       if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
-      if (
-        lastAssistant?.finish &&
-        !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
-        lastUser.id < lastAssistant.id
-      ) {
-        log.info("exiting loop", { sessionID })
-        break
+      if (lastAssistant?.finish && !["tool-calls", "unknown"].includes(lastAssistant.finish)) {
+        if (lastUser.id < lastAssistant.id) {
+          log.info("exiting loop", { sessionID })
+          break
+        } else {
+          log.warn("assistant finished but user message is newer", {
+            sessionID,
+            lastUserId: lastUser.id,
+            lastAssistantId: lastAssistant.id,
+            finish: lastAssistant.finish,
+          })
+        }
       }
 
       step++
@@ -650,7 +655,7 @@ export namespace SessionPrompt {
       }
       continue
     }
-    SessionCompaction.prune({ sessionID })
+    await SessionCompaction.prune({ sessionID })
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user") continue
       const queued = state()[sessionID]?.callbacks ?? []

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,10 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { Bus } from "../bus"
+import { Log } from "../util/log"
+
+const log = Log.create({ service: "tool.task" })
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -125,22 +129,56 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
 
-      const result = await SessionPrompt.prompt({
-        messageID,
-        sessionID: session.id,
-        model: {
-          modelID: model.modelID,
-          providerID: model.providerID,
-        },
-        agent: agent.name,
-        tools: {
-          todowrite: false,
-          todoread: false,
-          ...(hasTaskPermission ? {} : { task: false }),
-          ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
-        },
-        parts: promptParts,
+      let promptResolved = false
+
+      // Listen for child completion signal — if the child's assistant message
+      // gets a final finish reason or error but the prompt doesn't resolve shortly
+      // after, force-cancel the child to unblock the parent.
+      const unsub = Bus.subscribe(MessageV2.Event.Updated, (event) => {
+        const msg = event.properties.info
+        if (msg.sessionID !== session.id) return
+        if (msg.role !== "assistant") return
+
+        // Detect terminal states: final finish reason OR error
+        const hasTerminalFinish =
+          "finish" in msg && msg.finish && !["tool-calls", "unknown"].includes(msg.finish)
+        const hasError = "error" in msg && msg.error
+        if (!hasTerminalFinish && !hasError) return
+
+        setTimeout(() => {
+          if (!promptResolved) {
+            log.warn("subagent completed but prompt did not resolve, forcing cancel", {
+              sessionID: session.id,
+              finish: "finish" in msg ? msg.finish : undefined,
+              error: hasError,
+            })
+            SessionPrompt.cancel(session.id)
+          }
+        }, 3000)
       })
+
+      let result: MessageV2.WithParts
+      try {
+        result = await SessionPrompt.prompt({
+          messageID,
+          sessionID: session.id,
+          model: {
+            modelID: model.modelID,
+            providerID: model.providerID,
+          },
+          agent: agent.name,
+          tools: {
+            todowrite: false,
+            todoread: false,
+            ...(hasTaskPermission ? {} : { task: false }),
+            ...Object.fromEntries((config.experimental?.primary_tools ?? []).map((t) => [t, false])),
+          },
+          parts: promptParts,
+        })
+        promptResolved = true
+      } finally {
+        unsub()
+      }
 
       const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
 


### PR DESCRIPTION
## Summary

Fixes parent session hanging indefinitely when a subagent (Task tool) completes but `SessionPrompt.prompt()` never resolves. Fixes #9003, #10802, #11865, #6792.

Three targeted changes:

1. **`await` the `prune()` call** (`prompt.ts:653`) — was fire-and-forget, racing with the immediately following `MessageV2.stream()` reads.
2. **Diagnostic logging** (`prompt.ts:305-312`) — the loop exit condition silently continued when assistant finished but user message ID was newer. Now logs a warning so this case is visible.
3. **Event-driven recovery** (`task.ts`) — subscribe to child `MessageV2.Event.Updated`; if the child reaches a terminal state (finish or error) but the prompt doesn't resolve within 3s, force-cancel to unblock the parent. Not a timeout — only fires with positive proof of completion.