### PR TITLE
fix(win32): clean up TUI screen on Ctrl+C exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -111,6 +111,17 @@ export function tui(input: {
   // promise to prevent immediate exit
   return new Promise<void>(async (resolve) => {
     const mode = await getTerminalBackgroundColor()
+
+    // Catch SIGINT (Ctrl+C arriving as signal due to win32 guard race condition)
+    // to ensure terminal cleanup when the keyboard-event path isn't taken.
+    const { writeSync } = await import("fs")
+    process.on("SIGINT", () => {
+      try {
+        writeSync(1, "\x1b[?1049l\x1b[2J\x1b[H\x1b[?25h\x1b[0m")
+      } catch {}
+      process.exit(0)
+    })
+
     const onExit = async () => {
       await input.onExit?.()
       resolve()
@@ -168,6 +179,7 @@ export function tui(input: {
         targetFps: 60,
         gatherStats: false,
         exitOnCtrlC: false,
+        exitSignals: [],
         useKittyKeyboard: {},
         autoFocus: false,
         consoleOptions: {

--- a/packages/opencode/src/cli/cmd/tui/context/exit.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/exit.tsx
@@ -1,4 +1,5 @@
 import { useRenderer } from "@opentui/solid"
+import { writeSync } from "fs"
 import { createSimpleContext } from "./helper"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 type Exit = ((reason?: unknown) => Promise<void>) & {
@@ -40,6 +41,11 @@ export const { use: useExit, provider: ExitProvider } = createSimpleContext({
           }
         }
         const text = store.get()
+        // Give the zig render thread time to finish its final frame
+        // before writing terminal restore sequences
+        await new Promise((r) => setTimeout(r, 50))
+        // Restore terminal: exit alternate screen, clear screen, show cursor, reset attrs
+        writeSync(1, "\x1b[?1049l\x1b[2J\x1b[H\x1b[?25h\x1b[0m")
         if (text) process.stdout.write(text + "\n")
         process.exit(0)
       },


### PR DESCRIPTION
## Summary

Builds on @j-token's `exitSignals: []` fix from #13298. After Ctrl+C, the TUI screen content remained visible in the terminal instead of being cleaned up. Fixes #13301, #12939.

Three changes:

1. **`exitSignals: []`** (`app.tsx`) — prevent opentui from registering signal handlers that race with the win32 Ctrl+C guard (from #13298).
2. **Terminal restore on graceful exit** (`exit.tsx`) — after `renderer.destroy()`, wait 50ms for the zig render thread to finish its final frame, then write `\x1b[?1049l\x1b[2J\x1b[H\x1b[?25h\x1b[0m` via `writeSync` to exit alternate screen, clear the viewport, and restore cursor.
3. **SIGINT handler** (`app.tsx`) — catch Ctrl+C arriving as signal (win32 guard race condition) and write the same terminal restore sequences before `process.exit(0)`.