### PR TITLE
fix(docs): correct `format` attribute in `StructuredOutputs`

### DIFF
--- a/packages/web/src/content/docs/sdk.mdx
+++ b/packages/web/src/content/docs/sdk.mdx
@@ -128,7 +128,7 @@ const result = await client.session.prompt({
   path: { id: sessionId },
   body: {
     parts: [{ type: "text", text: "Research Anthropic and provide company info" }],
-    outputFormat: {
+    format: {
       type: "json_schema",
       schema: {
         type: "object",

--- a/packages/web/src/content/docs/sdk.mdx
+++ b/packages/web/src/content/docs/sdk.mdx
@@ -119,7 +119,7 @@ try {
 
 ## Structured Output
 
-You can request structured JSON output from the model by specifying an `outputFormat` with a JSON schema. The model will use a `StructuredOutput` tool to return validated JSON matching your schema.
+You can request structured JSON output from the model by specifying an `format` with a JSON schema. The model will use a `StructuredOutput` tool to return validated JSON matching your schema.
 
 ### Basic Usage
 


### PR DESCRIPTION
Corrects the docs to match the  `format` attribute introduced in https://github.com/anomalyco/opencode/pull/8161

Addresses #13342 

### What does this PR do?

Updates the docs to match the types added for StructuredOutputs

### How did you verify your code works?

If it doesn't then i'm in trouble.
