### PR TITLE
fix: enable token substitution in OPENCODE_CONFIG_CONTENT (take #)

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -175,8 +175,14 @@ export namespace Config {
     }
 
     // Inline config content overrides all non-managed config sources.
-    if (Flag.OPENCODE_CONFIG_CONTENT) {
-      result = mergeConfigConcatArrays(result, JSON.parse(Flag.OPENCODE_CONFIG_CONTENT))
+    // Route through load() to enable {env:} and {file:} token substitution.
+    // Use a path within Instance.directory so relative {file:} paths resolve correctly.
+    // The filename "OPENCODE_CONFIG_CONTENT" appears in error messages for clarity.
+    if (process.env.OPENCODE_CONFIG_CONTENT) {
+      result = mergeConfigConcatArrays(
+        result,
+        await load(process.env.OPENCODE_CONFIG_CONTENT, path.join(Instance.directory, "OPENCODE_CONFIG_CONTENT")),
+      )
       log.debug("loaded custom config from OPENCODE_CONFIG_CONTENT")
     }
 


### PR DESCRIPTION
### What does this PR do?

Route OPENCODE_CONFIG_CONTENT through load() to enable {env:} and {file:} token substitution. Uses the env var name as the path for clearer error messages instead of a generic <inline> placeholder.

Fixes anommalyco#13219

### How did you verify your code works?

Manual testing, `bun typecheck`, `bun test`.

You may manually test by running commands akin to the following (assuming bash):
```
echo "matrix" > /tmp/test-secret.txt 
export MODEL="opencode/big-pickle"
OPENCODE_CONFIG_CONTENT='{"$schema":"https://opencode.ai/config.json","theme":"{file:/tmp/test-secret.txt}", "model":"{env:MODEL}"}' bun dev```