### PR TITLE
fix(app): preserve undo history for plain-text paste

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -89,6 +89,9 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     }
 
     if (!plainText) return
+    const inserted = typeof document.execCommand === "function" && document.execCommand("insertText", false, plainText)
+    if (inserted) return
+
     input.addPart({ type: "text", content: plainText, start: 0, end: 0 })
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes #13350

In the desktop prompt input, plain-text paste was inserted via manual DOM mutation, which bypassed Chromium's native undo transaction. This updates only the plain-text paste branch to use native text insertion (`execCommand("insertText")`) with the existing fallback path.

### How did you verify your code works?
After change, Ctrl+Z undoes pasted plain text as one atomic edit and image paste still creates attachments