### PR TITLE
feat(opencode): add import and export endpoints for session data

### DIFF
--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -124,15 +124,24 @@ export const SessionRoutes = lazy(() =>
       validator("json", SessionExport),
       async (c) => {
         const body = c.req.valid("json")
-        body.info.time.updated = Date.now() // Moved in now
-        await Storage.write(["session", Instance.project.id, body.info.id], body.info)
+        const info = {
+          ...body.info,
+          projectID: Instance.project.id,
+          directory: Instance.directory,
+          share: undefined,
+          time: {
+            ...body.info.time,
+            updated: Date.now(),
+          },
+        }
+        await Storage.write(["session", Instance.project.id, info.id], info)
         for (const msg of body.messages) {
-          await Storage.write(["message", body.info.id, msg.info.id], msg.info)
+          await Storage.write(["message", info.id, msg.info.id], msg.info)
           for (const part of msg.parts) {
             await Storage.write(["part", msg.info.id, part.id], part)
           }
         }
-        return c.json(body.info)
+        return c.json(info)
       },
     )
     .get(

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -16,8 +16,22 @@ import { Log } from "../../util/log"
 import { PermissionNext } from "@/permission/next"
 import { errors } from "../error"
 import { lazy } from "../../util/lazy"
+import { Storage } from "@/storage/storage"
+import { Instance } from "@/project/instance"
 
 const log = Log.create({ service: "server" })
+
+const SessionExport = z
+  .object({
+    info: Session.Info,
+    messages: z.array(
+      z.object({
+        info: MessageV2.Info,
+        parts: MessageV2.Part.array(),
+      }),
+    ),
+  })
+  .meta({ ref: "SessionExport" })
 
 export const SessionRoutes = lazy(() =>
   new Hono()
@@ -87,6 +101,75 @@ export const SessionRoutes = lazy(() =>
       async (c) => {
         const result = SessionStatus.list()
         return c.json(result)
+      },
+    )
+    .post(
+      "/import",
+      describeRoute({
+        summary: "Import session",
+        description: "Import session data from an export payload.",
+        operationId: "session.import",
+        responses: {
+          200: {
+            description: "Imported session",
+            content: {
+              "application/json": {
+                schema: resolver(Session.Info),
+              },
+            },
+          },
+          ...errors(400),
+        },
+      }),
+      validator("json", SessionExport),
+      async (c) => {
+        const body = c.req.valid("json")
+        body.info.time.updated = Date.now() // Moved in now
+        await Storage.write(["session", Instance.project.id, body.info.id], body.info)
+        for (const msg of body.messages) {
+          await Storage.write(["message", body.info.id, msg.info.id], msg.info)
+          for (const part of msg.parts) {
+            await Storage.write(["part", msg.info.id, part.id], part)
+          }
+        }
+        return c.json(body.info)
+      },
+    )
+    .get(
+      "/:sessionID/export",
+      describeRoute({
+        summary: "Export session",
+        description: "Export session data, including messages and parts, as JSON.",
+        operationId: "session.export",
+        responses: {
+          200: {
+            description: "Exported session data",
+            content: {
+              "application/json": {
+                schema: resolver(SessionExport),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: Session.get.schema,
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const session = await Session.get(sessionID)
+        const messages = await Session.messages({ sessionID })
+        return c.json({
+          info: session,
+          messages: messages.map((msg) => ({
+            info: msg.info,
+            parts: msg.parts,
+          })),
+        })
       },
     )
     .get(

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -108,9 +108,14 @@ import type {
   SessionDeleteErrors,
   SessionDeleteResponses,
   SessionDiffResponses,
+  SessionExport,
+  SessionExportErrors,
+  SessionExportResponses,
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
+  SessionImportErrors,
+  SessionImportResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListResponses,
@@ -1016,6 +1021,71 @@ export class Session extends HeyApiClient {
     const params = buildClientParams([parameters], [{ args: [{ in: "query", key: "directory" }] }])
     return (options?.client ?? this.client).get<SessionStatusResponses, SessionStatusErrors, ThrowOnError>({
       url: "/session/status",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Import session
+   *
+   * Import session data from an export payload.
+   */
+  public import<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      sessionExport?: SessionExport
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { key: "sessionExport", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionImportResponses, SessionImportErrors, ThrowOnError>({
+      url: "/session/import",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Export session
+   *
+   * Export session data, including messages and parts, as JSON.
+   */
+  public export<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<SessionExportResponses, SessionExportErrors, ThrowOnError>({
+      url: "/session/{sessionID}/export",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2045,6 +2045,14 @@ export type McpResource = {
   client: string
 }
 
+export type SessionExport = {
+  info: Session
+  messages: Array<{
+    info: Message
+    parts: Array<Part>
+  }>
+}
+
 export type TextPartInput = {
   id?: string
   type: "text"
@@ -2980,6 +2988,66 @@ export type SessionStatusResponses = {
 }
 
 export type SessionStatusResponse = SessionStatusResponses[keyof SessionStatusResponses]
+
+export type SessionImportData = {
+  body?: SessionExport
+  path?: never
+  query?: {
+    directory?: string
+  }
+  url: "/session/import"
+}
+
+export type SessionImportErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type SessionImportError = SessionImportErrors[keyof SessionImportErrors]
+
+export type SessionImportResponses = {
+  /**
+   * Imported session
+   */
+  200: Session
+}
+
+export type SessionImportResponse = SessionImportResponses[keyof SessionImportResponses]
+
+export type SessionExportData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/export"
+}
+
+export type SessionExportErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionExportError = SessionExportErrors[keyof SessionExportErrors]
+
+export type SessionExportResponses = {
+  /**
+   * Exported session data
+   */
+  200: SessionExport
+}
+
+export type SessionExportResponse = SessionExportResponses[keyof SessionExportResponses]
 
 export type SessionDeleteData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -1425,6 +1425,122 @@
         ]
       }
     },
+    "/session/import": {
+      "post": {
+        "operationId": "session.import",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "summary": "Import session",
+        "description": "Import session data from an export payload.",
+        "responses": {
+          "200": {
+            "description": "Imported session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionExport"
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.import({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/session/{sessionID}/export": {
+      "get": {
+        "operationId": "session.export",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "directory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "sessionID",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          }
+        ],
+        "summary": "Export session",
+        "description": "Export session data, including messages and parts, as JSON.",
+        "responses": {
+          "200": {
+            "description": "Exported session data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionExport"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.session.export({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/session/{sessionID}": {
       "get": {
         "operationId": "session.get",
@@ -10492,6 +10608,33 @@
           }
         },
         "required": ["name", "uri", "client"]
+      },
+      "SessionExport": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "$ref": "#/components/schemas/Session"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "info": {
+                  "$ref": "#/components/schemas/Message"
+                },
+                "parts": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Part"
+                  }
+                }
+              },
+              "required": ["info", "parts"]
+            }
+          }
+        },
+        "required": ["info", "messages"]
       },
       "TextPartInput": {
         "type": "object",


### PR DESCRIPTION
### What does this PR do?

Creates server endpoints for importing and exporting session data, follows the flow for the already existing cli commands `opencode import <file>` and `opencode export`

New endpoints are

`/session/import` and `/session/<session_id>/export`

### How did you verify your code works?

Tested it on my local machine