### PR TITLE
fix(dev): add postinstall script to configure git symlinks on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:web": "bun --cwd packages/app dev",
     "typecheck": "bun turbo typecheck",
     "prepare": "husky",
+    "postinstall": "bun script/windows-symlinks.ts",
     "random": "echo 'Random script'",
     "hello": "echo 'Hello World!'",
     "test": "echo 'do not run tests from root' && exit 1"

--- a/script/windows-symlinks.ts
+++ b/script/windows-symlinks.ts
@@ -1,0 +1,16 @@
+import { $ } from "bun"
+
+if (process.platform !== "win32") {
+  process.exit(0)
+}
+
+console.log("Configuring git symlinks for Windows...")
+await $`git config core.symlinks true`.quiet()
+
+const symlinks = ["packages/app/src/custom-elements.d.ts", "packages/enterprise/src/custom-elements.d.ts"]
+
+for (const file of symlinks) {
+  await $`git restore ${file}`.quiet()
+}
+
+console.log("Done!")


### PR DESCRIPTION
## Summary
- Add `script/windows-symlinks.ts` that configures git symlinks on Windows
- Add `postinstall` script to automatically run after `bun install`
- Fixes TypeScript errors in symlinked `.d.ts` files on Windows

## Problem
On Windows, `git config core.symlinks` defaults to `false`, causing git to write symlinks as plain text files. TypeScript then reads the symlink path string as code, resulting in errors like:
```
src/custom-elements.d.ts(1,1): error TS1128: Declaration or statement expected.
```

## Solution
The postinstall script:
1. Detects if running on Windows (exits early on other platforms)
2. Enables `core.symlinks` in git config
3. Restores the affected symlinked files from git index

## Requirements
- Windows 10+ with Developer Mode enabled, OR
- Run terminal as Administrator

Closes #13397