### PR TITLE
feat: include configured OpenAI models in Codex OAuth allowlist

### DIFF
--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -2,6 +2,7 @@ import type { Hooks, PluginInput } from "@opencode-ai/plugin"
 import { Log } from "../util/log"
 import { Installation } from "../installation"
 import { Auth, OAUTH_DUMMY_KEY } from "../auth"
+import { Config } from "../config/config"
 import os from "os"
 import { ProviderTransform } from "@/provider/transform"
 
@@ -12,6 +13,19 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+const OPENAI_OAUTH_ALLOWED_MODELS = [
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex-mini",
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5.3-codex",
+  "gpt-5.1-codex",
+]
+
+export function buildOpenAIOAuthAllowedModels(configModelIds: string[]) {
+  // OAuth 기본 허용 목록은 유지하고, 사용자가 설정한 모델 키를 추가 허용한다.
+  return new Set([...OPENAI_OAUTH_ALLOWED_MODELS, ...configModelIds])
+}
 
 interface PkceCodes {
   verifier: string
@@ -356,15 +370,9 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Filter models to only allowed Codex models for OAuth
-        const allowedModels = new Set([
-          "gpt-5.1-codex-max",
-          "gpt-5.1-codex-mini",
-          "gpt-5.2",
-          "gpt-5.2-codex",
-          "gpt-5.3-codex",
-          "gpt-5.1-codex",
-        ])
+        const cfg = await Config.get()
+        const configModelIds = Object.keys(cfg.provider?.openai?.models ?? {})
+        const allowedModels = buildOpenAIOAuthAllowedModels(configModelIds)
         for (const modelId of Object.keys(provider.models)) {
           if (!allowedModels.has(modelId)) {
             delete provider.models[modelId]

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -3,6 +3,7 @@ import {
   parseJwtClaims,
   extractAccountIdFromClaims,
   extractAccountId,
+  buildOpenAIOAuthAllowedModels,
   type IdTokenClaims,
 } from "../../src/plugin/codex"
 
@@ -118,6 +119,20 @@ describe("plugin.codex", () => {
           refresh_token: "rt",
         }),
       ).toBe("acc-123")
+    })
+  })
+
+  describe("buildOpenAIOAuthAllowedModels", () => {
+    test("keeps default OAuth allowlist", () => {
+      const models = buildOpenAIOAuthAllowedModels([])
+      expect(models.has("gpt-5.2")).toBe(true)
+      expect(models.has("gpt-5.1-codex-max")).toBe(true)
+    })
+
+    test("adds user configured model keys", () => {
+      const models = buildOpenAIOAuthAllowedModels(["gpt-5.3-codex-spark", "my-openai-alias"])
+      expect(models.has("gpt-5.3-codex-spark")).toBe(true)
+      expect(models.has("my-openai-alias")).toBe(true)
     })
   })
 })


### PR DESCRIPTION
## Summary
- add a helper to build the OpenAI OAuth allowlist from built-in defaults plus user-configured OpenAI model keys
- keep existing default Codex/OpenAI model IDs in place for backward compatibility
- add unit tests that verify both default retention and configured-model inclusion

## Why
OpenAI OAuth filtering currently allows only a hardcoded model set. As a result, user-configured OpenAI model aliases in `config.provider.openai.models` are filtered out and cannot be selected in OAuth sessions.

## Changes
- update OAuth filtering logic in `packages/opencode/src/plugin/codex.ts`
- add tests in `packages/opencode/test/plugin/codex.test.ts`

Closes #13401

## Test
- `bun test test/plugin/codex.test.ts`
- result: 15 passed, 0 failed
