### PR TITLE
fix: prevent undeletable nul file on Windows

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1574,12 +1574,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
       process.platform === "win32" ? path.win32.basename(shell, ".exe") : path.basename(shell)
     ).toLowerCase()
 
+    const sanitizedCommand = Shell.sanitizeNullRedirect(input.command, shell)
+
     const invocations: Record<string, { args: string[] }> = {
       nu: {
-        args: ["-c", input.command],
+        args: ["-c", sanitizedCommand],
       },
       fish: {
-        args: ["-c", input.command],
+        args: ["-c", sanitizedCommand],
       },
       zsh: {
         args: [
@@ -1588,7 +1590,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           `
             [[ -f ~/.zshenv ]] && source ~/.zshenv >/dev/null 2>&1 || true
             [[ -f "\${ZDOTDIR:-$HOME}/.zshrc" ]] && source "\${ZDOTDIR:-$HOME}/.zshrc" >/dev/null 2>&1 || true
-            eval ${JSON.stringify(input.command)}
+            eval ${JSON.stringify(sanitizedCommand)}
           `,
         ],
       },
@@ -1599,25 +1601,25 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           `
             shopt -s expand_aliases
             [[ -f ~/.bashrc ]] && source ~/.bashrc >/dev/null 2>&1 || true
-            eval ${JSON.stringify(input.command)}
+            eval ${JSON.stringify(sanitizedCommand)}
           `,
         ],
       },
       // Windows cmd
       cmd: {
-        args: ["/c", input.command],
+        args: ["/c", sanitizedCommand],
       },
       // Windows PowerShell
       powershell: {
-        args: ["-NoProfile", "-Command", input.command],
+        args: ["-NoProfile", "-Command", sanitizedCommand],
       },
       pwsh: {
-        args: ["-NoProfile", "-Command", input.command],
+        args: ["-NoProfile", "-Command", sanitizedCommand],
       },
       // Fallback: any shell that doesn't match those above
       //  - No -l, for max compatibility
       "": {
-        args: ["-c", `${input.command}`],
+        args: ["-c", `${sanitizedCommand}`],
       },
     }
 

--- a/packages/opencode/src/shell/shell.ts
+++ b/packages/opencode/src/shell/shell.ts
@@ -64,4 +64,29 @@ export namespace Shell {
     if (s && !BLACKLIST.has(process.platform === "win32" ? path.win32.basename(s) : path.basename(s))) return s
     return fallback()
   })
+
+  const UNIX_SHELLS = new Set(["bash", "sh", "zsh", "fish", "nu"])
+
+  export function isUnixLike(shell: string): boolean {
+    const base = path.basename(shell).toLowerCase().replace(/\.exe$/, "")
+    return UNIX_SHELLS.has(base)
+  }
+
+  /**
+   * On Windows, when using Git Bash the AI model may generate Windows-style
+   * `> nul` / `2>nul` redirections.  Git Bash interprets these literally and
+   * creates a file called "nul" instead of discarding output.
+   *
+   * This helper rewrites null-device redirections so they match the shell
+   * that will actually execute the command.
+   */
+  export function sanitizeNullRedirect(command: string, shell: string): string {
+    if (process.platform !== "win32") return command
+    if (isUnixLike(shell)) {
+      // Git Bash / Unix shell: replace Windows NUL with /dev/null
+      return command.replace(/(\d?>)\s*(?:nul|NUL)\b/g, "$1/dev/null")
+    }
+    // cmd.exe / PowerShell: replace /dev/null with NUL
+    return command.replace(/(\d?>)\s*\/dev\/null\b/g, "$1NUL")
+  }
 }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -164,7 +164,8 @@ export const BashTool = Tool.define("bash", async () => {
       }
 
       const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
-      const proc = spawn(params.command, {
+      const command = Shell.sanitizeNullRedirect(params.command, shell)
+      const proc = spawn(command, {
         shell,
         cwd,
         env: {

--- a/packages/opencode/src/tool/bash.txt
+++ b/packages/opencode/src/tool/bash.txt
@@ -38,6 +38,7 @@ Usage notes:
     - If the commands depend on each other and must run sequentially, use a single Bash call with '&&' to chain them together (e.g., `git add . && git commit -m "message" && git push`). For instance, if one operation must complete before another starts (like mkdir before cp, Write before Bash for git operations, or git add before git commit), run these operations sequentially instead.
     - Use ';' only when you need to run commands sequentially but don't care if earlier commands fail
     - DO NOT use newlines to separate commands (newlines are ok in quoted strings)
+  - IMPORTANT: On Windows, the bash tool uses Git Bash. Always use /dev/null for output redirection (e.g., `command 2>/dev/null`), NOT the Windows `nul` device. Using `> nul` or `2>nul` will create a literal file named "nul" instead of discarding output.
   - AVOID using `cd <directory> && <command>`. Use the `workdir` parameter to change directories instead.
     <good-example>
     Use workdir="/foo/bar" with command: pytest tests


### PR DESCRIPTION
## Problem

On Windows, OpenCode uses Git Bash as the shell for executing commands. When the AI model generates commands with Windows-style `> nul` or `2>nul` redirection, Git Bash interprets this literally (creating a file named `nul`) instead of routing to the null device. Since `nul` is a reserved Windows device name, the file cannot be deleted through normal Windows file operations.

### Before (v1.1.63) — `nul` file created, shows in Modified Files
<img width="1348" height="951" alt="before (1 1 63)" src="https://github.com/user-attachments/assets/be691ff9-7388-40d7-8f23-70432893f1d5" />

### The undeletable `nul` file in Windows Explorer
<img width="706" height="118" alt="nul" src="https://github.com/user-attachments/assets/080f1ffc-2e3c-4d6b-8680-f39f72e509ea" />

### After (this fix) — no `nul` file created
<img width="1348" height="951" alt="after" src="https://github.com/user-attachments/assets/477ce1c0-7f65-491f-9078-119a9f911e83" />

## Root cause

`spawn('echo test 2>nul', { shell: 'C:/Program Files/Git/bin/bash.exe' })` creates a literal `nul` file because Git Bash doesn't recognize `nul` as a Windows null device — it treats it as a regular filename.

## Fix

Two-pronged approach:

1. **Command sanitization** (`Shell.sanitizeNullRedirect()`): Before spawning any command, rewrites null-device redirections to match the actual shell:
   - Git Bash: `>nul` / `2>nul` → `>/dev/null` / `2>/dev/null`
   - cmd.exe/PowerShell: `>/dev/null` → `>NUL` (reverse direction)

   Applied in both `bash.ts` (tool execution) and `prompt.ts` (shell execution path).

2. **Model guidance**: Added a note to the bash tool description instructing models to use `/dev/null` instead of `nul` on Windows.

## Changes

- **`packages/opencode/src/shell/shell.ts`**: Added `isUnixLike()` and `sanitizeNullRedirect()` utilities to the `Shell` namespace
- **`packages/opencode/src/tool/bash.ts`**: Call `Shell.sanitizeNullRedirect()` before spawning
- **`packages/opencode/src/tool/bash.txt`**: Added Windows `/dev/null` guidance for models
- **`packages/opencode/src/session/prompt.ts`**: Call `Shell.sanitizeNullRedirect()` before spawning in shell execution path

## Tested

On Windows 11 with Git Bash. Before: `echo test 2>nul` creates an undeletable `nul` file. After: no `nul` file is created, output is correctly suppressed.

Fixes https://github.com/anomalyco/opencode/issues/13369
Fixes https://github.com/anomalyco/opencode/issues/11586
Fixes https://github.com/anomalyco/opencode/issues/11403
Fixes https://github.com/anomalyco/opencode/issues/8108