### PR TITLE
fix(opencode): preserve custom tool arg descriptions in LLM prompts

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -2,6 +2,8 @@ import path from "path"
 import os from "os"
 import fs from "fs/promises"
 import z from "zod"
+import { zodToJsonSchema } from "zod-to-json-schema"
+import type { JSONSchema7 } from "@ai-sdk/provider"
 import { Identifier } from "../id/id"
 import { MessageV2 } from "./message-v2"
 import { Log } from "../util/log"
@@ -781,7 +783,7 @@ export namespace SessionPrompt {
       { modelID: input.model.api.id, providerID: input.model.providerID },
       input.agent,
     )) {
-      const schema = ProviderTransform.schema(input.model, z.toJSONSchema(item.parameters))
+      const schema = ProviderTransform.schema(input.model, zodToJsonSchema(item.parameters) as JSONSchema7)
       tools[item.id] = tool({
         id: item.id as any,
         description: item.description,


### PR DESCRIPTION
### What does this PR do?

Fixes #4357

Custom tool `.describe()` metadata on args wasn't making it into the prompts sent to providers. `prompt.ts` was using `z.toJSONSchema()` to convert Zod schemas, but that method drops descriptions from dynamically imported schemas. `experimental.ts` already uses `zodToJsonSchema()` from `zod-to-json-schema` which handles this correctly — this just makes `prompt.ts` consistent.

### How did you verify your code works?

`bun typecheck` passes. Confirmed the `z.toJSONSchema` call is gone and replaced with `zodToJsonSchema` which already works correctly in `experimental.ts`.
