### PR TITLE
fix(opencode): propagate subagent errors to parent session

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -142,6 +142,9 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         parts: promptParts,
       })
 
+      if (result.info.role === "assistant" && result.info.error)
+        throw new Error(`Subagent error: ${result.info.error.data.message}`)
+
       const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
 
       const output = [


### PR DESCRIPTION
### What does this PR do?

Fixes #13395

When a subagent's LLM call fails (e.g. bad model ID → `AI_APICallError`), the error gets logged but `SessionPrompt.prompt()` still returns normally with the error stashed on the assistant message. The task tool in `task.ts` only looks at text parts from the result, so it returns an empty `<task_result>` to the parent — which then hangs waiting for useful output that'll never come.

Added a check after `prompt()` returns: if the assistant message has an error, throw it so the parent gets a proper failed tool result and can report or recover.

### How did you verify your code works?

Traced the full call chain from `TaskTool.execute` → `SessionPrompt.prompt` → `loop` → `SessionProcessor.process` to confirm the error path. The processor catches LLM errors and sets `assistantMessage.error` but doesn't throw, so `prompt()` returns normally. `bun typecheck` and `bun turbo test` (936 tests) pass clean.
