### PR TITLE
fix: add hard enforcement for plan mode restrictions

### DIFF
--- a/packages/opencode/src/permission/plan-mode.test.ts
+++ b/packages/opencode/src/permission/plan-mode.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, expect } from "bun:test"
+import { PlanMode, validateCommandForPlanMode, isPlanMode } from "./plan-mode"
+
+describe("PlanMode", () => {
+  describe("isPlanMode", () => {
+    test("returns true for plan agent", () => {
+      expect(isPlanMode("plan")).toBe(true)
+    })
+
+    test("returns false for build agent", () => {
+      expect(isPlanMode("build")).toBe(false)
+    })
+
+    test("returns false for other agents", () => {
+      expect(isPlanMode("general")).toBe(false)
+      expect(isPlanMode("explore")).toBe(false)
+    })
+  })
+
+  describe("validateCommandForPlanMode", () => {
+    describe("non-plan mode", () => {
+      test("allows all commands in build mode", () => {
+        expect(validateCommandForPlanMode("rm -rf /", "build").allowed).toBe(true)
+        expect(validateCommandForPlanMode("git commit -m 'test'", "build").allowed).toBe(true)
+      })
+    })
+
+    describe("destructive commands", () => {
+      test("blocks rm command", () => {
+        const result = validateCommandForPlanMode("rm file.txt", "plan")
+        expect(result.allowed).toBe(false)
+        expect(result.command).toBe("rm")
+      })
+
+      test("blocks rm -rf", () => {
+        const result = validateCommandForPlanMode("rm -rf /", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks sed command", () => {
+        const result = validateCommandForPlanMode("sed -i 's/old/new/g' file.txt", "plan")
+        expect(result.allowed).toBe(false)
+        expect(result.command).toBe("sed")
+      })
+
+      test("blocks mv command", () => {
+        const result = validateCommandForPlanMode("mv old.txt new.txt", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks mkdir command", () => {
+        const result = validateCommandForPlanMode("mkdir newdir", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks chmod command", () => {
+        const result = validateCommandForPlanMode("chmod +x script.sh", "plan")
+        expect(result.allowed).toBe(false)
+      })
+    })
+
+    describe("package manager commands", () => {
+      test("blocks npm install", () => {
+        const result = validateCommandForPlanMode("npm install", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks npm i shorthand", () => {
+        const result = validateCommandForPlanMode("npm i lodash", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks yarn add", () => {
+        const result = validateCommandForPlanMode("yarn add react", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks pip install", () => {
+        const result = validateCommandForPlanMode("pip install requests", "plan")
+        expect(result.allowed).toBe(false)
+      })
+    })
+
+    describe("git commands", () => {
+      test("blocks git commit", () => {
+        const result = validateCommandForPlanMode("git commit -m 'test'", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks git push", () => {
+        const result = validateCommandForPlanMode("git push origin main", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("allows git status", () => {
+        const result = validateCommandForPlanMode("git status", "plan")
+        expect(result.allowed).toBe(true)
+      })
+
+      test("allows git diff", () => {
+        const result = validateCommandForPlanMode("git diff", "plan")
+        expect(result.allowed).toBe(true)
+      })
+
+      test("allows git log", () => {
+        const result = validateCommandForPlanMode("git log --oneline", "plan")
+        expect(result.allowed).toBe(true)
+      })
+
+      test("allows git branch", () => {
+        const result = validateCommandForPlanMode("git branch -a", "plan")
+        expect(result.allowed).toBe(true)
+      })
+    })
+
+    describe("read-only commands", () => {
+      test("allows ls", () => {
+        expect(validateCommandForPlanMode("ls -la", "plan").allowed).toBe(true)
+      })
+
+      test("allows cat", () => {
+        expect(validateCommandForPlanMode("cat file.txt", "plan").allowed).toBe(true)
+      })
+
+      test("allows grep", () => {
+        expect(validateCommandForPlanMode("grep -r 'pattern' src/", "plan").allowed).toBe(true)
+      })
+
+      test("allows find", () => {
+        expect(validateCommandForPlanMode("find . -name '*.ts'", "plan").allowed).toBe(true)
+      })
+
+      test("allows echo", () => {
+        expect(validateCommandForPlanMode("echo 'hello world'", "plan").allowed).toBe(true)
+      })
+
+      test("allows pwd", () => {
+        expect(validateCommandForPlanMode("pwd", "plan").allowed).toBe(true)
+      })
+
+      test("allows which", () => {
+        expect(validateCommandForPlanMode("which node", "plan").allowed).toBe(true)
+      })
+    })
+
+    describe("dangerous characters", () => {
+      test("blocks backtick command substitution", () => {
+        const result = validateCommandForPlanMode("echo `date`", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("blocks newline injection", () => {
+        const result = validateCommandForPlanMode("echo hello\nrm -rf /", "plan")
+        expect(result.allowed).toBe(false)
+      })
+    })
+
+    describe("edge cases", () => {
+      test("handles empty command", () => {
+        expect(validateCommandForPlanMode("", "plan").allowed).toBe(true)
+      })
+
+      test("handles whitespace-only command", () => {
+        expect(validateCommandForPlanMode("   ", "plan").allowed).toBe(true)
+      })
+
+      test("handles commands with leading whitespace", () => {
+        const result = validateCommandForPlanMode("   rm file.txt", "plan")
+        expect(result.allowed).toBe(false)
+      })
+
+      test("is case-insensitive for commands", () => {
+        const result = validateCommandForPlanMode("RM file.txt", "plan")
+        expect(result.allowed).toBe(false)
+      })
+    })
+  })
+})

--- a/packages/opencode/src/permission/plan-mode.ts
+++ b/packages/opencode/src/permission/plan-mode.ts
@@ -1,0 +1,249 @@
+import { Log } from "@/util/log"
+
+const log = Log.create({ service: "plan-mode" })
+
+const DESTRUCTIVE_COMMANDS = new Set([
+  "rm",
+  "rmdir",
+  "mv",
+  "cp",
+  "mkdir",
+  "touch",
+  "chmod",
+  "chown",
+  "ln",
+  "sed",
+  "awk",
+  "tee",
+  "truncate",
+  "dd",
+  "shred",
+  "wipe",
+  "install",
+])
+
+const DESTRUCTIVE_PATTERNS = [
+  /^git\s+(commit|push|reset|rebase|merge|cherry-pick|am|stash\s+pop|stash\s+apply)/i,
+  /^npm\s+(install|i|uninstall|remove|ci|publish)/i,
+  /^yarn\s+(add|remove|upgrade|publish)/i,
+  /^pnpm\s+(add|remove|install|publish)/i,
+  /^pip\s+(install|uninstall)/i,
+  /^cargo\s+(install|publish)/i,
+  /^go\s+(install|get|mod\s+(tidy|download))/i,
+  /^brew\s+(install|uninstall|upgrade)/i,
+  /^apt\s*(install|remove|purge|upgrade)/i,
+  /^apt-get\s*(install|remove|purge|upgrade)/i,
+  /^docker\s+(run|build|push|rmi|rm|stop|kill|exec)/i,
+  /^kubectl\s+(apply|delete|create|patch|exec)/i,
+  /^helm\s+(install|upgrade|uninstall|delete)/i,
+]
+
+const READONLY_COMMANDS = new Set([
+  "ls",
+  "dir",
+  "cat",
+  "head",
+  "tail",
+  "less",
+  "more",
+  "grep",
+  "egrep",
+  "fgrep",
+  "find",
+  "locate",
+  "which",
+  "whereis",
+  "type",
+  "whoami",
+  "id",
+  "pwd",
+  "echo",
+  "printf",
+  "wc",
+  "sort",
+  "uniq",
+  "cut",
+  "tr",
+  "stat",
+  "file",
+  "du",
+  "df",
+  "free",
+  "uptime",
+  "date",
+  "cal",
+  "env",
+  "printenv",
+  "uname",
+  "hostname",
+  "arch",
+  "nc",
+  "curl",
+  "wget",
+])
+
+const READONLY_GIT_PATTERNS = [
+  /^git\s+(status|diff|log|show|branch|tag|remote|stash\s+list|blame|shortlog|rev-parse|ls-files|ls-tree|describe)/i,
+]
+
+export interface PlanModeValidationResult {
+  allowed: boolean
+  reason?: string
+  command?: string
+}
+
+export function isPlanMode(agent: string): boolean {
+  return agent === "plan"
+}
+
+export function validateCommandForPlanMode(command: string, agent: string): PlanModeValidationResult {
+  if (!isPlanMode(agent)) {
+    return { allowed: true }
+  }
+
+  const trimmed = command.trim()
+  if (!trimmed) {
+    return { allowed: true }
+  }
+
+  const firstToken = extractFirstToken(trimmed)
+  if (!firstToken) {
+    return { allowed: true }
+  }
+
+  if (DESTRUCTIVE_COMMANDS.has(firstToken)) {
+    log.info("plan mode: blocking destructive command", { command: firstToken })
+    return {
+      allowed: false,
+      reason: `Command '${firstToken}' is not allowed in plan mode. Plan mode is read-only. Switch to 'build' mode to make changes.`,
+      command: firstToken,
+    }
+  }
+
+  for (const pattern of DESTRUCTIVE_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      const matched = pattern.source.match(/\w+\s+\w+/)?.[0] || firstToken
+      log.info("plan mode: blocking destructive pattern", { pattern: pattern.source })
+      return {
+        allowed: false,
+        reason: `Command '${matched}' is not allowed in plan mode. Plan mode is read-only. Switch to 'build' mode to make changes.`,
+        command: matched,
+      }
+    }
+  }
+
+  const dangerousChars = detectDangerousChars(trimmed)
+  if (dangerousChars) {
+    log.info("plan mode: blocking dangerous characters", { chars: dangerousChars })
+    return {
+      allowed: false,
+      reason: `Potentially unsafe command detected (${dangerousChars}). Plan mode restricts commands that could modify files. Switch to 'build' mode to execute this command.`,
+      command: dangerousChars,
+    }
+  }
+
+  if (READONLY_COMMANDS.has(firstToken)) {
+    return { allowed: true }
+  }
+
+  for (const pattern of READONLY_GIT_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      return { allowed: true }
+    }
+  }
+
+  return { allowed: true }
+}
+
+function extractFirstToken(command: string): string {
+  let i = 0
+  while (i < command.length && /\s/.test(command[i])) {
+    i++
+  }
+
+  let token = ""
+  let inQuote = false
+  let quoteChar = ""
+
+  while (i < command.length) {
+    const char = command[i]
+
+    if (inQuote) {
+      if (char === quoteChar && command[i - 1] !== "\\") {
+        inQuote = false
+      } else {
+        token += char
+      }
+    } else if (char === '"' || char === "'") {
+      inQuote = true
+      quoteChar = char
+    } else if (/\s/.test(char)) {
+      break
+    } else if (char === "|" || char === "&" || char === ";" || char === "<" || char === ">") {
+      break
+    } else {
+      token += char
+    }
+    i++
+  }
+
+  const parts = token.split(/\s+/)
+  return parts[0]?.toLowerCase() || ""
+}
+
+function detectDangerousChars(command: string): string | null {
+  let inSingleQuote = false
+  let inDoubleQuote = false
+  let isEscaped = false
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i]
+
+    if (isEscaped) {
+      isEscaped = false
+      continue
+    }
+
+    if (char === "\\" && !inSingleQuote) {
+      isEscaped = true
+      continue
+    }
+
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote
+      continue
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote
+      continue
+    }
+
+    const inAnyQuote = inSingleQuote || inDoubleQuote
+
+    if (!inAnyQuote) {
+      if (/[\n\r\u2028\u2029\u0085]/.test(char)) {
+        return "newline injection"
+      }
+    }
+
+    if (char === "`" && !inSingleQuote) {
+      return "command substitution (backtick)"
+    }
+
+    if (!inAnyQuote && char === ">" && i > 0 && command[i - 1] !== ">") {
+      if (i === 0 || command[i - 1] !== "2") {
+        return "file redirect"
+      }
+    }
+  }
+
+  return null
+}
+
+export const PlanMode = {
+  isPlanMode,
+  validateCommandForPlanMode,
+  DESTRUCTIVE_COMMANDS,
+  READONLY_COMMANDS,
+}

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -13,6 +13,7 @@ import { LSP } from "../lsp"
 import { Filesystem } from "../util/filesystem"
 import DESCRIPTION from "./apply_patch.txt"
 import { File } from "../file"
+import { PlanMode } from "@/permission/plan-mode"
 
 const PatchParams = z.object({
   patchText: z.string().describe("The full patch text that describes all changes to be made"),
@@ -22,6 +23,10 @@ export const ApplyPatchTool = Tool.define("apply_patch", {
   description: DESCRIPTION,
   parameters: PatchParams,
   async execute(params, ctx) {
+    if (PlanMode.isPlanMode(ctx.agent)) {
+      throw new Error("The 'apply_patch' tool is not allowed in plan mode. Plan mode is read-only. Switch to 'build' mode to make changes.")
+    }
+
     if (!params.patchText) {
       throw new Error("patchText is required")
     }

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -17,6 +17,7 @@ import { Shell } from "@/shell/shell"
 import { BashArity } from "@/permission/arity"
 import { Truncate } from "./truncation"
 import { Plugin } from "@/plugin"
+import { PlanMode } from "@/permission/plan-mode"
 
 const MAX_METADATA_LENGTH = 30_000
 const DEFAULT_TIMEOUT = Flag.OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS || 2 * 60 * 1000
@@ -81,6 +82,12 @@ export const BashTool = Tool.define("bash", async () => {
         throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
       }
       const timeout = params.timeout ?? DEFAULT_TIMEOUT
+
+      const planModeCheck = PlanMode.validateCommandForPlanMode(params.command, ctx.agent)
+      if (!planModeCheck.allowed) {
+        throw new Error(planModeCheck.reason || "Command not allowed in plan mode")
+      }
+
       const tree = await parser().then((p) => p.parse(params.command))
       if (!tree) {
         throw new Error("Failed to parse command")

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -17,6 +17,7 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { Snapshot } from "@/snapshot"
 import { assertExternalDirectory } from "./external-directory"
+import { PlanMode } from "@/permission/plan-mode"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
 
@@ -33,6 +34,10 @@ export const EditTool = Tool.define("edit", {
     replaceAll: z.boolean().optional().describe("Replace all occurrences of oldString (default false)"),
   }),
   async execute(params, ctx) {
+    if (PlanMode.isPlanMode(ctx.agent)) {
+      throw new Error("The 'edit' tool is not allowed in plan mode. Plan mode is read-only. Switch to 'build' mode to make changes.")
+    }
+
     if (!params.filePath) {
       throw new Error("filePath is required")
     }

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -12,6 +12,7 @@ import { Filesystem } from "../util/filesystem"
 import { Instance } from "../project/instance"
 import { trimDiff } from "./edit"
 import { assertExternalDirectory } from "./external-directory"
+import { PlanMode } from "@/permission/plan-mode"
 
 const MAX_DIAGNOSTICS_PER_FILE = 20
 const MAX_PROJECT_DIAGNOSTICS_FILES = 5
@@ -23,6 +24,10 @@ export const WriteTool = Tool.define("write", {
     filePath: z.string().describe("The absolute path to the file to write (must be absolute, not relative)"),
   }),
   async execute(params, ctx) {
+    if (PlanMode.isPlanMode(ctx.agent)) {
+      throw new Error("The 'write' tool is not allowed in plan mode. Plan mode is read-only. Switch to 'build' mode to make changes.")
+    }
+
     const filepath = path.isAbsolute(params.filePath) ? params.filePath : path.join(Instance.directory, params.filePath)
     await assertExternalDirectory(ctx, filepath)
 


### PR DESCRIPTION
Fixes #10314

## Problem

Plan mode was relying solely on text reminders in the system prompt, allowing models to bypass restrictions and make file changes via destructive bash commands (sed, rm, etc).

## Solution

Add runtime validation that blocks destructive operations in plan mode:

- Block destructive commands: `rm`, `mv`, `cp`, `sed`, `awk`, `tee`, `chmod`, `mkdir`, etc.
- Block package managers: `npm install`, `yarn add`, `pip install`
- Block git write operations: `git commit`, `git push`, `git reset`
- Block dangerous characters: backticks, newline injection
- Allow read-only commands: `ls`, `cat`, `grep`, `git status/diff/log`

## Files Changed

- `src/permission/plan-mode.ts` - Command validator
- `src/permission/plan-mode.test.ts` - 33 test cases
- `src/tool/bash.ts` - Plan mode check before execution
- `src/tool/edit.ts` - Block in plan mode
- `src/tool/write.ts` - Block in plan mode
- `src/tool/apply_patch.ts` - Block in plan mode

## Testing

```
bun test  # 969 pass, 5 skip, 0 fail
```