### PR TITLE
fix(tui): show filename first in search dropdown for long paths

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -261,7 +261,7 @@ export function Autocomplete(props: {
 
             const isDir = item.endsWith("/")
             return {
-              display: Locale.truncateMiddle(filename, width),
+              display: Locale.truncatePath(filename, width),
               value: filename,
               isDirectory: isDir,
               path: item,

--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -74,6 +74,18 @@ export namespace Locale {
     return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
   }
 
+  export function truncatePath(filepath: string, maxLength: number = 35): string {
+    if (filepath.length <= maxLength) return filepath
+    const slash = filepath.lastIndexOf("/")
+    if (slash === -1) return truncateMiddle(filepath, maxLength)
+    const name = filepath.slice(slash + 1)
+    const dir = filepath.slice(0, slash)
+    const sep = " — "
+    const available = maxLength - name.length - sep.length
+    if (available <= 0) return truncate(name, maxLength)
+    return name + sep + truncate(dir, available)
+  }
+
   export function pluralize(count: number, singular: string, plural: string): string {
     const template = count === 1 ? singular : plural
     return template.replace("{}", count.toString())


### PR DESCRIPTION
### What does this PR do?

Fixes #13054

Long file paths in the `@` autocomplete dropdown were getting middle-truncated (`src/comp…ponent.tsx`), which makes it hard to tell files apart in deep directory structures.

Now it shows the filename first, then the directory — like VS Code does: `MyComponent.tsx — src/components/deep/…`. The most useful bit (the filename) is always visible on the left.

Added a `truncatePath` helper to `Locale` that splits on the last `/`, puts the filename first with a ` — ` separator, and left-truncates the directory if it doesn't fit.

### How did you verify your code works?

Ran `bun typecheck` (passes) and `bun turbo test` (passes, one pre-existing Bedrock timeout unrelated to this change). Checked formatting with `bunx prettier --check` on both changed files.
