### PR TITLE
docs(ko): polish Korean phrasing in acp, agents, config, and custom-tools docs

### DIFF
--- a/packages/web/src/content/docs/ko/acp.mdx
+++ b/packages/web/src/content/docs/ko/acp.mdx
@@ -1,12 +1,12 @@
 ---
 title: ACP Support
-description: Use opencode in any ACP-compatible editor.
+description: Use OpenCode in any ACP-compatible editor.
 ---
 
-opencode는 [Agent Client Protocol](https://agentclientprotocol.com) 또는 (ACP)을 지원하며, 호환 편집기 및 IDE에서 직접 사용할 수 있습니다.
+OpenCode는 [Agent Client Protocol](https://agentclientprotocol.com)(ACP)을 지원하므로, ACP 호환 편집기와 IDE에서 OpenCode를 직접 사용할 수 있습니다.
 
 :::tip
-ACP를 지원하는 편집기 및 도구 목록의 경우 [ACP 진행 보고서](https://zed.dev/blog/acp-progress-report#available-now)를 확인하십시오.
+ACP를 지원하는 편집기와 tool 목록은 [ACP progress report](https://zed.dev/blog/acp-progress-report#available-now)에서 확인하세요.
 :::
 
 ACP는 코드 편집기와 AI 코딩 에이전트 간의 통신을 표준화하는 개방형 프로토콜입니다.
@@ -15,17 +15,17 @@ ACP는 코드 편집기와 AI 코딩 에이전트 간의 통신을 표준화하�
 
 ## 구성
 
-ACP를 통해 opencode를 사용하려면 `opencode acp` 명령을 실행하려면 편집기를 구성하십시오.
+ACP로 OpenCode를 사용하려면, 편집기에서 `opencode acp` 명령을 실행하도록 config를 설정하세요.
 
-명령은 opencode를 실행하여 JSON-RPC를 통해 편집기와 통신하는 ACP 호환 하위 프로세스로 시작합니다.
+이 명령은 OpenCode를 ACP 호환 subprocess로 시작하며, stdio 기반 JSON-RPC를 통해 편집기와 통신합니다.
 
-아래는 ACP를 지원하는 인기있는 편집기의 예입니다.
+아래는 ACP를 지원하는 주요 편집기 예시입니다.
 
 ---
 
-##### Zed를
+### Zed
 
-[Zed](https://zed.dev) 구성 (`~/.config/zed/settings.json`)에 추가 :
+[Zed](https://zed.dev) config(`~/.config/zed/settings.json`)에 다음을 추가하세요.
 
 ```json title="~/.config/zed/settings.json"
 {
@@ -38,9 +38,9 @@ ACP를 통해 opencode를 사용하려면 `opencode acp` 명령을 실행하려�
 }
 ```
 
-그것을 열려면 **Command Palette **에서 `agent: new thread` 동작을 사용하십시오.
+열려면 **Command Palette**에서 `agent: new thread` action을 사용하세요.
 
-`keymap.json`를 편집하여 키보드 단축키도 결합할 수 있습니다.
+`keymap.json`을 수정해 키보드 단축키를 바인딩할 수도 있습니다.
 
 ```json title="keymap.json"
 [
@@ -67,9 +67,9 @@ ACP를 통해 opencode를 사용하려면 `opencode acp` 명령을 실행하려�
 
 ---
 
-#### JetBrains IDEs의 특징
+### JetBrains IDEs
 
-[JetBrains IDE]에 추가하십시오 (https://www.jetbrains.com/) [documentation]에 따라 acp.json (https://www.jetbrains.com/help/ai-assistant/acp.html):
+[JetBrains IDE](https://www.jetbrains.com/)에서는 [documentation](https://www.jetbrains.com/help/ai-assistant/acp.html)에 따라 `acp.json`에 다음을 추가하세요.
 
 ```json title="acp.json"
 {
@@ -82,13 +82,13 @@ ACP를 통해 opencode를 사용하려면 `opencode acp` 명령을 실행하려�
 }
 ```
 
-그것을 열려면 AI Chat Agent selector의 새로운 'opencode' 에이전트를 사용하십시오.
+열려면 AI Chat agent selector에서 새 `OpenCode` agent를 선택하세요.
 
 ---
 
-#### Avante.nvim의
+### Avante.nvim
 
-[Avante.nvim](https://github.com/yetone/avante.nvim) 구성에 추가하십시오:
+[Avante.nvim](https://github.com/yetone/avante.nvim) config에 다음을 추가하세요.
 
 ```lua
 {
@@ -101,7 +101,7 @@ ACP를 통해 opencode를 사용하려면 `opencode acp` 명령을 실행하려�
 }
 ```
 
-환경 변수를 전달해야 하는 경우:
+환경 변수를 전달해야 한다면 다음과 같이 설정하세요.
 
 ```lua {6-8}
 {
@@ -119,9 +119,9 @@ ACP를 통해 opencode를 사용하려면 `opencode acp` 명령을 실행하려�
 
 ---
 
-#### CodeCompanion.nvim
+### CodeCompanion.nvim
 
-opencode를 [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)에서 ACP 에이전트로 사용하려면 Neovim config에 다음을 추가하십시오.
+[CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim)에서 OpenCode를 ACP agent로 사용하려면 Neovim config에 다음을 추가하세요.
 
 ```lua
 require("codecompanion").setup({
@@ -136,21 +136,21 @@ require("codecompanion").setup({
 })
 ```
 
-이 구성은 CodeCompanion을 설정하여 채팅을 위한 ACP 에이전트로 opencode를 사용합니다.
+이 config는 chat에서 OpenCode를 ACP agent로 사용하도록 CodeCompanion을 설정합니다.
 
-환경 변수 (`OPENCODE_API_KEY`와 같은)를 전달해야하는 경우, CodeCompanion.nvim 문서에서 [Configuring Adapters: Environment variables](https://codecompanion.olimorris.dev/getting-started#setting-an-api-key)를 참조하십시오.
+환경 변수(`OPENCODE_API_KEY` 등)를 전달해야 한다면 CodeCompanion.nvim documentation의 [Configuring Adapters: Environment Variables](https://codecompanion.olimorris.dev/getting-started#setting-an-api-key)를 참고하세요.
 
 ## 지원
 
-opencode는 terminal에서 같은 ACP를 통해 작동합니다. 모든 기능은 지원됩니다:
+OpenCode는 ACP를 통해서도 터미널과 동일하게 동작합니다. 다음 기능을 모두 지원합니다.
 
 :::note
 `/undo` 및 `/redo`와 같은 일부 내장 슬래시 명령은 현재 지원되지 않습니다.
 :::
 
-- 내장 도구 (파일 작업, terminal 명령 등)
-- 사용자 정의 도구 및 슬래시 명령
-- opencode config에서 설정된 MCP 서버
-- `AGENTS.md`의 프로젝트 별 규칙
-- 사용자 정의 포맷 및 라이터
-- 에이전트 및 권한 시스템
+- 내장 tool(파일 작업, terminal 명령 등)
+- 사용자 정의 tool과 slash command
+- OpenCode config에 설정한 MCP 서버
+- `AGENTS.md`의 프로젝트별 규칙
+- 사용자 정의 formatter와 linter
+- agent 및 권한 시스템

--- a/packages/web/src/content/docs/ko/agents.mdx
+++ b/packages/web/src/content/docs/ko/agents.mdx
@@ -3,140 +3,139 @@ title: Agents
 description: Configure and use specialized agents.
 ---
 
-에이전트는 특정 작업과 워크플로우를 구성할 수 있는 AI 보조를 전문으로 합니다. 사용자 정의 프롬프트, 모델 및 도구 액세스와 초점을 맞춘 도구를 만들 수 있습니다.
+agent는 특정 작업과 워크플로에 맞게 설정할 수 있는 전문 AI assistant입니다. custom prompt, model, tool 접근 권한을 조합해 목적에 맞는 agent를 만들 수 있습니다.
 
 :::tip
-코드를 분석하고 코드 변경없이 제안을 검토 할 계획 에이전트를 사용합니다.
+코드를 수정하지 않고 분석과 제안 검토만 하고 싶다면 plan agent를 사용하세요.
 :::
 
-세션 중에 에이전트를 전환하거나 `@` 언급으로 호출 할 수 있습니다.
+세션 중에 agent를 전환하거나 `@` mention으로 호출할 수 있습니다.
 
 ---
 
 ## 유형
 
-OpenCode의 두 가지 유형이 있습니다; 기본 에이전트와 subagents.
+OpenCode의 agent는 primary agent와 subagent, 두 가지 유형으로 나뉩니다.
 
 ---
 
-### 주요 에이전트
+### Primary agents
 
-주요 에이전트은 당신이 직접 상호 작용하는 주요 조수입니다. **Tab** 키 또는 설정된 `switch_agent` keybind를 사용하여 주기 할 수 있습니다. 이 에이전트은 당신의 주요 대화를 취급합니다. 도구 액세스는 권한을 통해 구성된다 — 예를 들어, Build는 Plan이 제한되는 동안 모든 도구를 사용할 수 있습니다.
+primary agent는 사용자가 직접 상호작용하는 메인 assistant입니다. **Tab** 키 또는 설정한 `switch_agent` keybind로 순환 전환할 수 있습니다. primary agent는 메인 대화를 처리하며, tool 접근은 permission으로 제어합니다. 예를 들어 Build는 모든 tool이 활성화되어 있고 Plan은 제한되어 있습니다.
 
 :::tip
-세션 중에 기본 에이전트를 전환하는 **Tab** 키를 사용할 수 있습니다.
+세션 중 **Tab** 키로 primary agent를 빠르게 전환할 수 있습니다.
 :::
 
-OpenCode는 두 개의 내장 기본 에이전트, **Build** 및 **Plan**와 함께 제공됩니다. 우리는
-아래에서 보기.
+OpenCode에는 기본 제공 primary agent인 **Build**와 **Plan**이 포함되어 있습니다. 아래에서 각각 살펴보겠습니다.
 
 ---
 
 ### Subagents
 
-Subagents는 기본 에이전트가 특정 작업을 위해 호출 할 수있는 전문 보조입니다. 또한 수동으로 그들을 호출 할 수 있습니다 ** @ 언급 ** 메시지에서 그들.
+subagent는 primary agent가 특정 작업을 위해 호출하는 전문 assistant입니다. 메시지에서 **@ mention**으로 직접 호출할 수도 있습니다.
 
-OpenCode는 두 개의 내장 subagents, **General** 및 **Explore**. 아래에서 볼 수 있습니다.
-
----
-
-## 내장
-
-OpenCode는 기본 에이전트와 두 개의 내장 subagents로 제공됩니다.
+OpenCode에는 기본 제공 subagent인 **General**과 **Explore**가 포함되어 있습니다. 아래에서 살펴보겠습니다.
 
 ---
 
-### 사용 Build
+## 기본 제공
 
-_모드_: `primary`
-
-Build는 **default** 모든 도구가 활성화된 기본 에이전트입니다. 이것은 당신이 파일 가동 및 체계 명령에 가득 차있는 접근을 필요로 하는 발달 일을 위한 표준 에이전트입니다.
+OpenCode는 기본적으로 primary agent 2개와 subagent 2개를 제공합니다.
 
 ---
 
-### 사용 Plan
+### Use build
 
-_모드_: `primary`
+_Mode_: `primary`
 
-계획 및 분석을 위해 설계된 제한된 에이전트. 우리는 더 많은 통제를 주고 무인화한 변화를 방지하기 위하여 허가 체계를 이용합니다.
-기본적으로, 뒤에 오는 전부는 `ask`로 놓입니다:
+Build는 모든 tool이 활성화된 **default** primary agent입니다. 파일 작업과 시스템 명령에 대한 전체 접근이 필요한 일반적인 개발 작업에 사용하는 표준 agent입니다.
 
-- `file edits`: 모든 쓰기, 패치 및 편집
+---
+
+### Use plan
+
+_Mode_: `primary`
+
+Plan은 계획과 분석에 특화된 제한형 agent입니다. 더 높은 제어력과 의도치 않은 변경 방지를 위해 permission 시스템을 사용합니다.
+기본값으로 아래 항목은 모두 `ask`로 설정됩니다.
+
+- `file edits`: 모든 write, patch, edit
 - `bash`: 모든 bash 명령
 
-이 에이전트는 코드를 분석 할 LLM을 원할 때 유용합니다, 변경을 제안하거나 코드베이스에 실제 수정없이 계획을 만들 수 있습니다.
+코드베이스를 실제로 수정하지 않고 LLM 분석, 변경 제안, 계획 수립만 진행하고 싶을 때 유용합니다.
 
 ---
 
-### 사용 General
+### Use general
 
-_모드_: `subagent`
+_Mode_: `subagent`
 
-복잡한 질문을 연구하고 다중 단계 작업을 실행하기위한 범용 에이전트. 전체 도구 액세스 (todo 제외), 그래서 필요할 때 파일 변경을 만들 수 있습니다. 평행한에 있는 일의 다수 단위를 달리기 위하여 이것을 사용하십시오.
-
----
-
-### 사용 Explore
-
-_모드_: `subagent`
-
-Codebases를 탐구하는 빠르고, 읽기 전용 에이전트. 파일을 수정할 수 없습니다. 이 작업을 사용하면 패턴, 키워드 검색 코드, 또는 codebase에 대한 질문에 신속하게 파일을 찾을 수 있습니다.
+복잡한 질문을 조사하고 다단계 작업을 수행하기 위한 범용 agent입니다. todo를 제외한 모든 tool 접근이 가능하므로 필요하면 파일 수정도 할 수 있습니다. 여러 작업 단위를 병렬로 처리할 때 사용하세요.
 
 ---
 
-### 사용 Compaction
+### Use explore
 
-_모드_: `primary`
+_Mode_: `subagent`
 
-더 작은 요약으로 긴 맥락을 압축하는 숨겨진 시스템 에이전트. 필요한 경우 자동으로 실행되며 UI에서 선택할 수 없습니다.
-
----
-
-### 사용 Title
-
-_모드_: `primary`
-
-짧은 세션 타이틀을 생성하는 숨겨진 시스템 에이전트. 그것은 자동으로 실행하고 UI에서 선택할 수 없습니다.
+코드베이스 탐색에 최적화된 빠른 읽기 전용 agent입니다. 파일을 수정할 수 없습니다. 패턴 기반 파일 탐색, 키워드 검색, 코드베이스 관련 질의 응답을 빠르게 처리할 때 사용하세요.
 
 ---
 
-### 사용 Summary
+### Use compaction
 
-_모드_: `primary`
+_Mode_: `primary`
 
-세션 summaries를 만드는 숨겨진 시스템 에이전트. 그것은 자동으로 실행하고 UI에서 선택할 수 없습니다.
+긴 context를 더 짧은 요약으로 압축하는 숨겨진 시스템 agent입니다. 필요할 때 자동으로 실행되며 UI에서 직접 선택할 수 없습니다.
+
+---
+
+### Use title
+
+_Mode_: `primary`
+
+짧은 세션 제목을 생성하는 숨겨진 시스템 agent입니다. 자동으로 실행되며 UI에서 직접 선택할 수 없습니다.
+
+---
+
+### Use summary
+
+_Mode_: `primary`
+
+세션 요약을 생성하는 숨겨진 시스템 agent입니다. 자동으로 실행되며 UI에서 직접 선택할 수 없습니다.
 
 ---
 
 ## 사용법
 
-1. 주요 에이전트을 위해, **Tab ** 열쇠를 사용하여 세션 도중 주기. 구성 된 `switch_agent` keybind도 사용할 수 있습니다.
+1. primary agent는 세션 중 **Tab** 키로 순환 전환할 수 있습니다. 설정한 `switch_agent` keybind를 사용할 수도 있습니다.
 
-2. Subagents은 invoked 일 수 있습니다:
-   - **Automatically** 그들의 설명에 근거를 둔 특화된 업무를 위한 주요 에이전트에 의하여.
-   - 메시지에 대한 subagents\*\*. 예를 들어.
+2. subagent 호출 방법:
+   - **Automatically**: primary agent가 설명(description)을 바탕으로 특화 작업에 자동 호출합니다.
+   - 수동 호출: 메시지에서 subagent를 **@ mention**하여 호출합니다. 예:
 
      ```txt frame="none"
      @general help me search for this function
      ```
 
-3. ** 세션 간의 편차 **: subagents는 자신의 자녀 세션을 만들 때, 부모 세션과 모든 어린이 세션을 사용하여 탐색 할 수 있습니다.
-   - **\<Leader>+Right** (또는 부모 → Child1 → Child2 →를 통해 전달하기 위해 설정된 `session_child_cycle` keybind)
-   - **\<Leader>+Left** (또는 `session_child_cycle_reverse` keybind) 부모를 통해 돌아 가기 위해 ← child1 ← child2 ← ... ← 부모
+3. **세션 간 이동**: subagent가 child session을 만들면 아래 키로 parent session과 child session 사이를 이동할 수 있습니다.
+   - **\<Leader>+Right** (또는 설정한 `session_child_cycle` keybind): parent → child1 → child2 → ... → parent 순방향 순환
+   - **\<Leader>+Left** (또는 설정한 `session_child_cycle_reverse` keybind): parent ← child1 ← child2 ← ... ← parent 역방향 순환
 
-   이로 인해 주요 대화와 특이한 subagent 작업을 원활하게 전환할 수 있습니다.
+   이를 통해 메인 대화와 특화 subagent 작업 사이를 자연스럽게 오갈 수 있습니다.
 
 ---
 
 ## 구성
 
-내장 에이전트를 사용자 정의하거나 구성을 통해 자신의 만들 수 있습니다. 에이전트는 두 가지 방법으로 구성 될 수 있습니다:
+기본 제공 agent를 커스터마이즈하거나 config를 통해 직접 agent를 만들 수 있습니다. agent는 두 가지 방식으로 설정합니다.
 
 ---
 
 ### JSON
 
-`opencode.json` config 파일에 에이전트 구성:
+`opencode.json` config 파일에서 agent를 설정합니다.
 
 ```json title="opencode.json"
 {
@@ -179,10 +178,10 @@ _모드_: `primary`
 
 ### Markdown
 
-Markdown 파일을 사용하여 에이전트를 정의 할 수 있습니다. 그들에 게:
+Markdown 파일로도 agent를 정의할 수 있습니다. 다음 위치에 두세요.
 
-- 글로벌: `~/.config/opencode/agents/`
-- 프로젝트: `.opencode/agents/`
+- Global: `~/.config/opencode/agents/`
+- Per-project: `.opencode/agents/`
 
 ```markdown title="~/.config/opencode/agents/review.md"
 ---
@@ -206,19 +205,19 @@ You are in code review mode. Focus on:
 Provide constructive feedback without making direct changes.
 ```
 
-markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.md`는 `review` 에이전트을 만듭니다.
+Markdown 파일명은 agent 이름이 됩니다. 예를 들어 `review.md`는 `review` agent를 만듭니다.
 
 ---
 
 ## 옵션
 
-이 구성 옵션을 자세히 살펴봅시다.
+각 config 옵션을 자세히 살펴보겠습니다.
 
 ---
 
-### 묘사
+### Description
 
-`description` 옵션을 사용하여 에이전트가 작동하고 사용할 때의 간단한 설명을 제공합니다.
+`description` 옵션으로 agent의 역할과 사용 시점을 간단히 설명하세요.
 
 ```json title="opencode.json"
 {
@@ -230,15 +229,15 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 }
 ```
 
-\*\* config 옵션이 필요합니다.
+이 옵션은 **필수** config 항목입니다.
 
 ---
 
-### 온도
+### Temperature
 
-`temperature` config와 LLM의 응답의 임의성과 창의성을 제어합니다.
+`temperature` config로 LLM 응답의 무작위성과 창의성을 제어합니다.
 
-더 낮은 값은 더 집중하고 세심한 응답을 만듭니다. 더 높은 값은 창의력과 가변성을 증가하면서.
+값이 낮을수록 응답이 더 집중되고 결정적이며, 값이 높을수록 창의성과 다양성이 커집니다.
 
 ```json title="opencode.json"
 {
@@ -253,10 +252,11 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 }
 ```
 
-온도 값은 일반적으로 0.0에서 1.0에 배열합니다:
+Temperature 값은 일반적으로 0.0~1.0 범위를 사용합니다.
 
-- **0.0-0.2**: 매우 집중하고 신중한 응답, 코드 분석 및 계획에 이상 -**0.3-0.5**: 일부 창의력과 균형 잡힌 응답, 일반 개발 작업에 좋은
-- **0.6-1.0**: 더 창조적이고 다양한 응답, 뇌하수 및 탐험에 유용한
+- **0.0-0.2**: 매우 집중되고 결정적인 응답, 코드 분석/계획에 적합
+- **0.3-0.5**: 적당한 창의성이 섞인 균형형 응답, 일반 개발 작업에 적합
+- **0.6-1.0**: 더 창의적이고 다양한 응답, 브레인스토밍/탐색에 유용
 
 ```json title="opencode.json"
 {
@@ -276,15 +276,15 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 }
 ```
 
-온도가 지정되지 않은 경우, opencode는 모델 별 기본을 사용합니다. 일반적으로 대부분의 모델의 경우 0, Qwen 모델의 경우 0.55.
+temperature를 지정하지 않으면 OpenCode는 model별 기본값을 사용합니다. 일반적으로 대부분의 model은 0, Qwen model은 0.55를 사용합니다.
 
 ---
 
-## 최대 단계
+### Max steps
 
-에이전트의 최대 수를 통제하는 에이전트은 원본과 반응하기 전에 실행할 수 있습니다. 이 사용자는 에이전트 행동에 제한을 설정하는 비용을 제어 할 수 있습니다.
+agent가 텍스트 응답만 하도록 강제되기 전까지 수행할 수 있는 agentic iteration의 최대 횟수를 제어합니다. 비용을 관리하려는 사용자에게 agentic action 제한을 제공하기 위한 옵션입니다.
 
-이 설정되지 않은 경우, 에이전트는 모델이 중지하거나 사용자가 세션을 중단하도록 선택할 때까지 계속됩니다.
+이 값을 설정하지 않으면 model이 중단을 선택하거나 사용자가 세션을 중단할 때까지 agent는 계속 반복합니다.
 
 ```json title="opencode.json"
 {
@@ -298,17 +298,17 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 }
 ```
 
-제한이 도달되면, 에이전트는 특별한 시스템을 신속하게 작업의 요약과 권장되는 나머지 작업에 응답하도록 지시합니다.
+제한에 도달하면 agent는 작업 요약과 남은 권장 작업을 응답하도록 지시하는 특수 시스템 prompt를 받습니다.
 
 :::caution
-레거시 `maxSteps` 필드는 deprecated. 대신 `steps`를 사용하십시오.
+레거시 `maxSteps` 필드는 deprecated입니다. 대신 `steps`를 사용하세요.
 :::
 
 ---
 
-#### 비활성화
+### Disable
 
-`true`로 에이전트를 비활성화합니다.
+`true`로 설정하면 agent를 비활성화합니다.
 
 ```json title="opencode.json"
 {
@@ -322,9 +322,9 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 
 ---
 
-#### 프롬프트
+### Prompt
 
-`prompt` config를 가진 이 에이전트을 위한 주문 체계 prompt 파일을 지정하십시오. prompt 파일은 에이전트의 목적에 따라 지시를 포함해야합니다.
+`prompt` config로 해당 agent의 custom 시스템 prompt 파일을 지정합니다. prompt 파일에는 agent 목적에 맞는 지시사항을 작성하세요.
 
 ```json title="opencode.json"
 {
@@ -336,16 +336,16 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 }
 ```
 
-이 경로는 config 파일이 있는 곳에 관계됩니다. 그래서 이것은 글로벌 opencode 구성과 프로젝트 특정 구성 모두를 위해 작동합니다.
+이 경로는 config 파일 위치 기준의 상대 경로입니다. 따라서 전역 OpenCode config와 프로젝트별 config 모두에서 동일하게 동작합니다.
 
 ---
 
-### 모형
+### Model
 
-`model` config를 사용하여이 에이전트에 대한 모델을 삭제합니다. 다른 작업에 최적화 된 다른 모델을 사용하는 데 유용합니다. 예를 들어, 계획을위한 빠른 모델, 구현을위한 더 많은 모델.
+`model` config로 해당 agent의 model을 override할 수 있습니다. 작업 특성에 맞춰 model을 달리 쓸 때 유용합니다. 예를 들어 계획에는 더 빠른 model, 구현에는 더 강력한 model을 사용할 수 있습니다.
 
 :::tip
-모델을 지정하지 않는 경우, 기본 에이전트는 [model globallyconfig](/docs/config#models)를 사용하며, subagents는 subagent를 호출하는 1차 에이전트의 모델을 사용합니다.
+model을 지정하지 않으면 primary agent는 [전역으로 설정한 model](/docs/config#models)을 사용하고, subagent는 해당 subagent를 호출한 primary agent의 model을 사용합니다.
 :::
 
 ```json title="opencode.json"
@@ -358,13 +358,13 @@ markdown 파일 이름은 에이전트 이름입니다. 예를 들어, `review.m
 }
 ```
 
-opencode config의 모델 ID는 `provider/model-id` 형식을 사용합니다. 예를 들어, [OpenCode Zen](/docs/zen)을 사용한다면, GPT 5.1 Codex에 `opencode/gpt-5.1-codex`를 사용할 수 있습니다.
+OpenCode config의 model ID는 `provider/model-id` 형식을 사용합니다. 예를 들어 [OpenCode Zen](/docs/zen)을 사용한다면 GPT 5.1 Codex에 `opencode/gpt-5.1-codex`를 사용합니다.
 
 ---
 
-## 도구
+### Tools
 
-`tools` config로 이 에이전트에서 사용할 수있는 제어. `true` 또는 `false`로 설정하여 특정 도구를 활성화하거나 비활성화 할 수 있습니다.
+`tools` config로 agent에서 사용할 tool을 제어합니다. 각 tool을 `true` 또는 `false`로 설정해 활성화/비활성화할 수 있습니다.
 
 ```json title="opencode.json" {3-6,9-12}
 {
@@ -385,10 +385,10 @@ opencode config의 모델 ID는 `provider/model-id` 형식을 사용합니다. �
 ```
 
 :::note
-에이전트 별 구성 overrides 글로벌 구성.
+agent별 config는 전역 config를 override합니다.
 :::
 
-한 번에 여러 도구를 제어 할 와일드 카드를 사용할 수 있습니다. 예를 들어, MCP 서버에서 모든 도구를 비활성화하려면:
+와일드카드를 사용하면 여러 tool을 한 번에 제어할 수 있습니다. 예를 들어 MCP 서버의 모든 tool을 비활성화하려면 다음과 같이 설정합니다.
 
 ```json title="opencode.json"
 {
@@ -405,17 +405,17 @@ opencode config의 모델 ID는 `provider/model-id` 형식을 사용합니다. �
 }
 ```
 
-[공구에 대해 더 알아보기](/docs/tools).
+[tool에 대해 더 알아보기](/docs/tools).
 
 ---
 
-## # 권한
+### Permissions
 
-에이전트가 수행 할 수있는 작업을 관리 할 수있는 권한을 구성 할 수 있습니다. 현재 `edit`, `bash` 및 `webfetch` 도구에 대한 권한은 다음과 같습니다.
+permission을 설정해 agent가 수행할 수 있는 action을 제어할 수 있습니다. 현재 `edit`, `bash`, `webfetch` tool의 permission은 다음 값으로 설정할 수 있습니다.
 
-- `"ask"` - 도구 실행하기 전에 승인을위한 Prompt
-- `"allow"` - 승인없이 모든 작업을 허용
-- `"deny"` - 도구 비활성화
+- `"ask"` — tool 실행 전에 승인 요청
+- `"allow"` — 승인 없이 모든 작업 허용
+- `"deny"` — tool 비활성화
 
 ```json title="opencode.json"
 {
@@ -426,7 +426,7 @@ opencode config의 모델 ID는 `provider/model-id` 형식을 사용합니다. �
 }
 ```
 
-당신은 에이전트 당이 허가를 override 할 수 있습니다.
+이 permission은 agent별로 override할 수 있습니다.
 
 ```json title="opencode.json" {3-5,8-10}
 {
@@ -444,7 +444,7 @@ opencode config의 모델 ID는 `provider/model-id` 형식을 사용합니다. �
 }
 ```
 
-Markdown 에이전트에서 권한을 설정할 수 있습니다.
+Markdown agent에서도 permission을 설정할 수 있습니다.
 
 ```markdown title="~/.config/opencode/agents/review.md"
 ---
@@ -463,7 +463,7 @@ permission:
 Only analyze code and suggest changes.
 ```
 
-특정 bash 명령에 대한 권한을 설정할 수 있습니다.
+특정 bash 명령에 대해서도 permission을 설정할 수 있습니다.
 
 ```json title="opencode.json" {7}
 {
@@ -481,7 +481,7 @@ Only analyze code and suggest changes.
 }
 ```
 
-이것은 glob 본을 가지고 갈 수 있습니다.
+여기에는 glob 패턴을 사용할 수 있습니다.
 
 ```json title="opencode.json" {7}
 {
@@ -498,8 +498,8 @@ Only analyze code and suggest changes.
 }
 ```
 
-또한 `*` 와일드 카드를 사용하여 모든 명령에 대한 권한을 관리 할 수 있습니다.
-마지막 일치 규칙이 우선적으로 걸리기 때문에, `*` 와일드카드를 첫번째로 두고 특정 규칙을 후에 두십시오.
+또한 `*` 와일드카드로 모든 명령의 permission을 제어할 수 있습니다.
+마지막으로 일치한 규칙이 우선하므로 `*` 와일드카드를 먼저 두고, 구체적인 규칙을 뒤에 두세요.
 
 ```json title="opencode.json" {8}
 {
@@ -517,13 +517,13 @@ Only analyze code and suggest changes.
 }
 ```
 
-[허가에 대해 더 알아보기](/docs/permissions).
+[permission에 대해 더 알아보기](/docs/permissions).
 
 ---
 
-### 형태
+### Mode
 
-`mode` config로 에이전트 모드를 제어합니다. `mode` 선택권은 에이전트이 사용될 수 있는 방법을 결정하기 위하여 이용됩니다.
+`mode` config로 agent 모드를 제어합니다. `mode` 옵션은 agent를 어떤 방식으로 사용할지 결정합니다.
 
 ```json title="opencode.json"
 {
@@ -535,13 +535,13 @@ Only analyze code and suggest changes.
 }
 ```
 
-`mode` 선택권은 `primary`, `subagent`, 또는 `all`에 놓일 수 있습니다. `mode`가 지정되지 않은 경우 `all`로 기본값입니다.
+`mode`는 `primary`, `subagent`, `all` 중 하나로 설정할 수 있습니다. 설정하지 않으면 기본값은 `all`입니다.
 
 ---
 
-## #숨겨진
+### Hidden
 
-`@`를 사용해 `hidden: true` 자동 완성 메뉴에서 시약을 숨깁니다. 작업 도구를 통해 다른 에이전트에 의해 invoked programmatically 있어야하는 내부 시약에 유용합니다.
+`hidden: true`를 설정하면 `@` 자동완성 메뉴에서 subagent를 숨길 수 있습니다. 다른 agent가 Task tool을 통해 programmatic으로만 호출해야 하는 내부 subagent에 유용합니다.
 
 ```json title="opencode.json"
 {
@@ -554,17 +554,17 @@ Only analyze code and suggest changes.
 }
 ```
 
-자동 완성 메뉴의 사용자 가시에만 영향을 미칩니다. 숨겨진 에이전트는 여전히 작업 도구를 통해 모델에 의해 호출 될 수 있습니다 권한 허용.
+이 설정은 자동완성 메뉴에서의 사용자 가시성에만 영향을 줍니다. permission이 허용되면 hidden agent도 모델이 Task tool을 통해 호출할 수 있습니다.
 
 :::note
-`mode: subagent` 에이전트에서만 적용합니다.
+`mode: subagent` agent에만 적용됩니다.
 :::
 
 ---
 
-## 작업 권한
+### Task permissions
 
-에이전트가 `permission.task`와 작업 도구를 통해 호출 할 수있는 제어. 유연한 일치를 위한 glob 본을 사용합니다.
+`permission.task`로 Task tool을 통해 해당 agent가 호출할 수 있는 subagent 범위를 제어합니다. 유연한 매칭을 위해 glob 패턴을 사용합니다.
 
 ```json title="opencode.json"
 {
@@ -583,23 +583,23 @@ Only analyze code and suggest changes.
 }
 ```
 
-`deny`로 설정할 때, Subagent는 작업 도구 설명에서 완전히 제거됩니다. 그래서 모델은 그것을 호출하려고하지 않습니다.
+`deny`로 설정되면 해당 subagent는 Task tool 설명에서 완전히 제거되므로 모델이 호출을 시도하지 않습니다.
 
 :::tip
-규칙은 순서로 평가되고, **마지막 일치 규칙은**를 이깁니다. 위의 예에서 `orchestrator-planner`는 `*` (deny)와 `orchestrator-*` (allow) 모두 일치하지만 `orchestrator-*`가 `*` 후 제공되므로 결과는 `allow`입니다.
+규칙은 선언 순서대로 평가되며, **마지막으로 일치한 규칙이 승리합니다**. 위 예시에서 `orchestrator-planner`는 `*`(deny)와 `orchestrator-*`(allow) 모두에 일치하지만, `orchestrator-*`가 뒤에 있으므로 결과는 `allow`입니다.
 :::
 
 :::tip
-사용자는 `@` 자동 완성 메뉴를 통해 직접 어떤 subagent를 호출 할 수 있습니다. 에이전트의 작업 허가가 거부 할 경우에도.
+사용자는 agent의 task permission이 deny여도 `@` 자동완성 메뉴를 통해 어떤 subagent든 직접 호출할 수 있습니다.
 :::
 
 ---
 
-### 색깔
+### Color
 
-`color` 옵션과 UI에서 에이전트의 시각적 외관을 사용자 정의합니다. 이것은 어떻게 에이전트가 인터페이스에 나타납니다.
+`color` 옵션으로 UI에서 agent의 시각 스타일을 지정할 수 있습니다. 인터페이스에서 agent가 표시되는 방식에 영향을 줍니다.
 
-유효한 hex 색깔을 사용하십시오 (예를들면, `#FF5733`) 또는 주제 색깔: `primary`, `secondary`, `accent`, `success`, `warning`, `error`, `info`.
+유효한 hex 색상(예: `#FF5733`) 또는 theme 색상(`primary`, `secondary`, `accent`, `success`, `warning`, `error`, `info`)을 사용하세요.
 
 ```json title="opencode.json"
 {
@@ -616,9 +616,9 @@ Only analyze code and suggest changes.
 
 ---
 
-### 정상 P
+### Top P
 
-`top_p` 선택권을 가진 응답 다양성을 통제하십시오. 무작위 통제를 위한 온도에 대안.
+`top_p` 옵션으로 응답 다양성을 제어합니다. 무작위성을 제어하는 Temperature의 대안입니다.
 
 ```json title="opencode.json"
 {
@@ -630,15 +630,15 @@ Only analyze code and suggest changes.
 }
 ```
 
-가치는 0.0에서 1.0에 배열합니다. 더 낮은 가치는 더 집중되고, 더 높은 가치는 더 다양합니다.
+값 범위는 0.0~1.0입니다. 값이 낮을수록 집중되고, 높을수록 다양해집니다.
 
 ---
 
-### 추가
+### Additional
 
-에이전트 구성에 지정하는 다른 옵션은 ** 직접 통과 ** 모델 옵션으로 공급자. 이 공급자 별 기능 및 매개 변수를 사용할 수 있습니다.
+agent config에 지정한 나머지 옵션은 모델 옵션으로 provider에 **그대로 전달(pass through)** 됩니다. 이를 통해 provider별 기능과 파라미터를 활용할 수 있습니다.
 
-예를 들어, OpenAI의 이유 모델과 함께, 당신은 이유를 제어 할 수 있습니다 노력:
+예를 들어 OpenAI reasoning model에서는 reasoning effort를 제어할 수 있습니다.
 
 ```json title="opencode.json" {6,7}
 {
@@ -653,55 +653,55 @@ Only analyze code and suggest changes.
 }
 ```
 
-이 추가 옵션은 모델과 공급자 별입니다. 공급자의 문서 확인 가능 매개 변수.
+이 추가 옵션은 model 및 provider마다 다릅니다. 사용 가능한 파라미터는 provider 문서를 확인하세요.
 
 :::tip
-`opencode models`를 실행하여 사용 가능한 모델 목록을 볼 수 있습니다.
+사용 가능한 model 목록은 `opencode models` 명령으로 확인할 수 있습니다.
 :::
 
 ---
 
-## 에이전트 만들기
+## 에이전트 생성
 
-다음 명령을 사용하여 새로운 에이전트를 만들 수 있습니다:
+아래 명령으로 새 agent를 만들 수 있습니다.
 
 ```bash
 opencode agent create
 ```
 
-이 대화 형 명령은:
+이 인터랙티브 명령은 다음을 수행합니다.
 
-1. 에이전트을 저장하는 곳에게; 세계적인 프로젝트 별.
-2. 에이전트이 해야 하는 무슨의 묘사.
-3. 적절한 시스템 프롬프트 및 식별자를 생성한다.
-4. 당신은 에이전트이 접근할 수 있는 어떤 공구를 선정하자.
-5. 마지막으로, 에이전트 구성을 가진 markdown 파일을 창조하십시오.
+1. agent 저장 위치를 묻습니다(전역/프로젝트).
+2. agent가 수행할 작업의 설명을 받습니다.
+3. 적절한 시스템 prompt와 식별자를 생성합니다.
+4. agent가 접근할 tool을 선택하게 합니다.
+5. 마지막으로 agent config가 담긴 Markdown 파일을 생성합니다.
 
 ---
 
 ## 사용 사례
 
-다른 에이전트을 위한 몇몇 일반적인 사용 사례는 여기 있습니다.
+서로 다른 agent의 대표적인 사용 사례는 다음과 같습니다.
 
-- **빌딩 에이전트**: 모든 도구와 함께 전체 개발 작업
-- ** 플랜 에이전트**: 변화없이 분석 및 계획
-- **리뷰 에이전트**: Code review with read-only access plus 문서 도구
-- ** 디버그 에이전트**: bash 및 읽기 도구와 함께 조사에 집중
-- **Docs 에이전트 **: 파일 작업과 문서 작성하지만 시스템 명령 없음
+- **Build agent**: 모든 tool을 활성화한 전체 개발 작업
+- **Plan agent**: 코드 변경 없이 분석과 계획 수행
+- **Review agent**: 읽기 전용 접근 + 문서화 tool 기반 코드 리뷰
+- **Debug agent**: bash/read tool 중심의 조사 작업
+- **Docs agent**: 파일 작업은 가능하지만 시스템 명령은 없는 문서 작성 작업
 
 ---
 
-## 예제
+## 예시
 
-여기에 유용 할 수있는 몇 가지 예 에이전트가 있습니다.
+실제로 유용하게 쓸 수 있는 예시 agent를 소개합니다.
 
 :::tip
-당신은 공유하고 싶은 에이전트이 있습니까? [PR](https://github.com/anomalyco/opencode).
+공유하고 싶은 agent가 있나요? [PR 제출하기](https://github.com/anomalyco/opencode).
 :::
 
 ---
 
-### 문서 에이전트
+### Documentation agent
 
 ```markdown title="~/.config/opencode/agents/docs-writer.md"
 ---
@@ -723,7 +723,7 @@ Focus on:
 
 ---
 
-## 보안 감사
+### Security auditor
 
 ```markdown title="~/.config/opencode/agents/security-auditor.md"
 ---

--- a/packages/web/src/content/docs/ko/cli.mdx
+++ b/packages/web/src/content/docs/ko/cli.mdx
@@ -1,17 +1,17 @@
 ---
 title: CLI
-description: opencode CLI options and commands.
+description: opencode CLI 옵션과 명령어.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components"
 
-기본적으로 opencode CLI는 어떤 인수 없이 실행할 때 [TUI](/docs/tui)를 시작합니다.
+opencode CLI는 인수 없이 실행하면 기본적으로 [TUI](/docs/tui)를 시작합니다.
 
 ```bash
 opencode
 ```
 
-그러나이 페이지에서 문서로 명령을받습니다. opencode programmatically와 상호 작용할 수 있습니다.
+이 페이지에 나온 것처럼 명령을 함께 전달할 수도 있습니다. 이를 통해 opencode를 프로그래밍 방식으로 사용할 수 있습니다.
 
 ```bash
 opencode run "Explain how closures work in JavaScript"
@@ -19,38 +19,38 @@ opencode run "Explain how closures work in JavaScript"
 
 ---
 
-### 튜이
+### tui
 
-opencode terminal 사용자 인터페이스를 시작합니다.
+OpenCode 터미널 사용자 인터페이스를 시작합니다.
 
 ```bash
 opencode [project]
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그       | 짧은 이름 | 설명                                                              |
-| ------------ | --------- | ----------------------------------------------------------------- |
-| `--continue` | `-c`      | 마지막 세션 계속하기                                              |
-| `--session`  | `-s`      | 계속할 세션 ID                                                    |
-| `--fork`     |           | 계속 시 세션 포크하기 (`--continue` 또는 `--session`과 함께 사용) |
-| `--prompt`   |           | 사용할 프롬프트                                                   |
-| `--model`    | `-m`      | `provider/model` 형식의 모델                                      |
-| `--agent`    |           | 사용할 에이전트                                                   |
-| `--port`     |           | 수신 대기할 포트                                                  |
-| `--hostname` |           | 수신 대기할 호스트명                                              |
-
----
-
-## 명령
-
-opencode CLI에는 다음과 같은 명령이 있습니다.
+| 플래그       | 축약 | 설명                                                                   |
+| ------------ | ---- | ---------------------------------------------------------------------- |
+| `--continue` | `-c` | 마지막 세션 이어서 실행                                                |
+| `--session`  | `-s` | 이어서 실행할 세션 ID                                                  |
+| `--fork`     |      | 세션을 이어갈 때 포크 생성 (`--continue` 또는 `--session`과 함께 사용) |
+| `--prompt`   |      | 사용할 프롬프트                                                        |
+| `--model`    | `-m` | 사용할 모델 (`provider/model` 형식)                                    |
+| `--agent`    |      | 사용할 에이전트                                                        |
+| `--port`     |      | 수신 포트                                                              |
+| `--hostname` |      | 수신 호스트명                                                          |
 
 ---
 
-## 에이전트
+## Commands
 
-opencode에 대한 에이전트 관리.
+opencode CLI는 아래 명령들도 제공합니다.
+
+---
+
+### agent
+
+opencode용 에이전트를 관리합니다.
 
 ```bash
 opencode agent [command]
@@ -58,15 +58,15 @@ opencode agent [command]
 
 ---
 
-### 첨부
+### attach
 
-`serve` 또는 `web` 명령을 통해 이미 실행되는 opencode 백엔드 서버에 terminal을 첨부합니다.
+`serve` 또는 `web` 명령으로 이미 실행 중인 opencode 백엔드 서버에 터미널을 연결합니다.
 
 ```bash
 opencode attach [url]
 ```
 
-리모트 opencode 백엔드를 사용하여 TUI를 사용할 수 있습니다. 예를 들면:
+원격 opencode 백엔드와 TUI를 연결해 사용할 수 있습니다. 예:
 
 ```bash
 # Start the backend server for web/mobile access
@@ -76,30 +76,30 @@ opencode web --port 4096 --hostname 0.0.0.0
 opencode attach http://10.20.30.40:4096
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그      | 플래그 | Description                  |
-| ----------- | ------ | ---------------------------- |
-| `--dir`     |        | TUI를 시작하는 작업 디렉토리 |
-| `--session` | `-s`   | 세션 ID                      |
+| 플래그      | 축약 | 설명                       |
+| ----------- | ---- | -------------------------- |
+| `--dir`     |      | TUI를 시작할 작업 디렉터리 |
+| `--session` | `-s` | 이어서 실행할 세션 ID      |
 
 ---
 
-#### 생성
+#### create
 
-사용자 정의 구성으로 새로운 에이전트를 만듭니다.
+커스텀 설정으로 새 에이전트를 만듭니다.
 
 ```bash
 opencode agent create
 ```
 
-이 명령은 사용자 정의 시스템 프롬프트 및 도구 구성으로 새로운 에이전트를 만들기 위해 안내합니다.
+이 명령은 커스텀 시스템 프롬프트와 도구 설정을 사용해 새 에이전트를 만드는 과정을 안내합니다.
 
 ---
 
-#### 리스트
+#### list
 
-모든 사용 가능한 에이전트 목록.
+사용 가능한 모든 에이전트를 표시합니다.
 
 ```bash
 opencode agent list
@@ -109,7 +109,7 @@ opencode agent list
 
 ### auth
 
-credentials 및 로그인을 관리하는 명령.
+provider 인증 정보와 로그인을 관리합니다.
 
 ```bash
 opencode auth [command]
@@ -117,27 +117,27 @@ opencode auth [command]
 
 ---
 
-#### 로그인
+#### login
 
-opencode는 [Models.dev](https://models.dev)의 공급자 목록에 의해 구동되므로 `opencode auth login`를 사용하여 사용하려는 모든 공급자의 API 키를 구성할 수 있습니다. 이것은 `~/.local/share/opencode/auth.json`에서 저장됩니다.
+OpenCode는 [Models.dev](https://models.dev)의 provider 목록을 기반으로 동작하므로, `opencode auth login`으로 원하는 provider의 API 키를 설정할 수 있습니다. 인증 정보는 `~/.local/share/opencode/auth.json`에 저장됩니다.
 
 ```bash
 opencode auth login
 ```
 
-opencode가 시작하면 credentials 파일에서 공급자를로드합니다. 그리고 프로젝트에 있는 환경 또는 `.env` 파일에서 정의된 키가 있다면.
+OpenCode 시작 시 인증 파일에서 provider 정보를 불러오며, 시스템 환경 변수나 프로젝트의 `.env`에 정의된 키도 함께 로드합니다.
 
 ---
 
-#### 리스트
+#### list
 
-credentials 파일에 저장 한 모든 인증 된 제공 업체를 나열합니다.
+인증 파일에 저장된 provider 목록을 표시합니다.
 
 ```bash
 opencode auth list
 ```
 
-또는 짧은 버전.
+축약형도 사용할 수 있습니다.
 
 ```bash
 opencode auth ls
@@ -145,9 +145,9 @@ opencode auth ls
 
 ---
 
-### 로그아웃
+#### logout
 
-credentials 파일에서 삭제하여 공급자에서 로그.
+인증 파일에서 provider 정보를 제거해 로그아웃합니다.
 
 ```bash
 opencode auth logout
@@ -155,9 +155,9 @@ opencode auth logout
 
 ---
 
-#### github에
+### github
 
-저장소 자동화를 위한 GitHub 에이전트 관리.
+저장소 자동화를 위한 GitHub 에이전트를 관리합니다.
 
 ```bash
 opencode github [command]
@@ -165,7 +165,7 @@ opencode github [command]
 
 ---
 
-### 설치
+#### install
 
 저장소에 GitHub 에이전트를 설치합니다.
 
@@ -173,30 +173,30 @@ opencode github [command]
 opencode github install
 ```
 
-필요한 GitHub Actions 워크플로우를 설정하고 구성 프로세스를 통해 안내합니다. [더 알아보기](/docs/github).
+필요한 GitHub Actions 워크플로를 설정하고 구성 과정을 안내합니다. [더 알아보기](/docs/github).
 
 ---
 
-#### 실행
+#### run
 
-GitHub 에이전트를 실행합니다. 이것은 일반적으로 GitHub Actions에서 사용됩니다.
+GitHub 에이전트를 실행합니다. 보통 GitHub Actions에서 사용합니다.
 
 ```bash
 opencode github run
 ```
 
-##### 플래그
+##### Flags
 
-| 플래그    | 설명                    |
-| --------- | ----------------------- |
-| `--event` | GitHub 모의 이벤트      |
-| `--token` | GitHub 개인 액세스 토큰 |
+| 플래그    | 설명                      |
+| --------- | ------------------------- |
+| `--event` | 실행할 GitHub 모의 이벤트 |
+| `--token` | GitHub 개인 액세스 토큰   |
 
 ---
 
-#### mcp를
+### mcp
 
-Model Context Protocol 서버 관리
+Model Context Protocol 서버를 관리합니다.
 
 ```bash
 opencode mcp [command]
@@ -204,27 +204,27 @@ opencode mcp [command]
 
 ---
 
-#### 추가
+#### add
 
-MCP 서버를 구성에 추가합니다.
+구성에 MCP 서버를 추가합니다.
 
 ```bash
 opencode mcp add
 ```
 
-이 명령은 로컬 또는 원격 MCP 서버를 추가하여 안내합니다.
+이 명령은 로컬 또는 원격 MCP 서버를 추가하는 과정을 안내합니다.
 
 ---
 
-#### 리스트
+#### list
 
-모든 구성 MCP 서버와 연결 상태를 나열합니다.
+구성된 MCP 서버와 연결 상태를 표시합니다.
 
 ```bash
 opencode mcp list
 ```
 
-또는 짧은 버전을 사용합니다.
+축약형도 사용할 수 있습니다.
 
 ```bash
 opencode mcp ls
@@ -234,21 +234,21 @@ opencode mcp ls
 
 #### auth
 
-OAuth-enabled MCP 서버 인증
+OAuth를 지원하는 MCP 서버를 인증합니다.
 
 ```bash
 opencode mcp auth [name]
 ```
 
-서버 이름을 제공하지 않으면 OAuth-capable 서버에서 선택할 수 있습니다.
+서버 이름을 입력하지 않으면 OAuth 지원 서버 목록에서 선택하라는 안내가 표시됩니다.
 
-OAuth-capable 서버와 인증 상태를 나열할 수 있습니다.
+OAuth 지원 서버와 인증 상태를 목록으로 볼 수도 있습니다.
 
 ```bash
 opencode mcp auth list
 ```
 
-또는 짧은 버전을 사용합니다.
+축약형도 사용할 수 있습니다.
 
 ```bash
 opencode mcp auth ls
@@ -256,9 +256,9 @@ opencode mcp auth ls
 
 ---
 
-### 로그아웃
+#### logout
 
-MCP 서버의 OAuth 자격 제거.
+MCP 서버의 OAuth 인증 정보를 제거합니다.
 
 ```bash
 opencode mcp logout [name]
@@ -266,9 +266,9 @@ opencode mcp logout [name]
 
 ---
 
-### 디버그
+#### debug
 
-MCP 서버의 OAuth 연결 문제.
+MCP 서버의 OAuth 연결 문제를 디버그합니다.
 
 ```bash
 opencode mcp debug <name>
@@ -276,32 +276,32 @@ opencode mcp debug <name>
 
 ---
 
-## 모델
+### models
 
-구성 공급자에서 모든 가능한 모델을 나열합니다.
+구성된 provider에서 사용 가능한 모델 목록을 표시합니다.
 
 ```bash
 opencode models [provider]
 ```
 
-이 명령은 `provider/model` 형식으로 구성된 제공 업체에서 사용할 수있는 모든 모델을 표시합니다.
+이 명령은 구성된 provider 전체에서 사용 가능한 모델을 `provider/model` 형식으로 출력합니다.
 
-이것은 [your config](/docs/config/)에서 사용하는 정확한 모델 이름을 파악하는 데 유용합니다.
+[config](/docs/config/)에 지정할 정확한 모델명을 확인할 때 유용합니다.
 
-선택적으로 공급자 ID를 필터 모델로 전달할 수 있습니다.
+특정 provider ID를 넘겨 해당 provider의 모델만 필터링할 수도 있습니다.
 
 ```bash
 opencode models anthropic
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그      | 설명                                                        |
-| ----------- | ----------------------------------------------------------- |
-| `--refresh` | 모델 캐시를 모델에서 새로 고침                              |
-| `--verbose` | 더 많은 verbose 모델 출력 사용(비용과 같은 메타데이터 포함) |
+| 플래그      | 설명                                              |
+| ----------- | ------------------------------------------------- |
+| `--refresh` | models.dev에서 모델 캐시 새로고침                 |
+| `--verbose` | 더 자세한 모델 출력 사용(비용 등 메타데이터 포함) |
 
-`--refresh` 플래그를 사용하여 캐시 모델 목록을 업데이트합니다. 이것은 새로운 모델이 공급자에 추가되었을 때 유용합니다. opencode에서 그들을보고 싶습니다.
+`--refresh` 플래그를 사용하면 캐시된 모델 목록을 갱신할 수 있습니다. provider에 새 모델이 추가된 뒤 OpenCode에서 바로 확인하고 싶을 때 유용합니다.
 
 ```bash
 opencode models --refresh
@@ -309,21 +309,21 @@ opencode models --refresh
 
 ---
 
-### 실행
+### run
 
-직접 프롬프트를 통과하여 비동기 모드에서 opencode를 실행합니다.
+프롬프트를 직접 전달해 비대화형 모드로 opencode를 실행합니다.
 
 ```bash
 opencode run [message..]
 ```
 
-이것은 스크립트, 자동화 또는 전체 TUI를 실행하지 않고 빠른 응답을 원할 때 유용합니다. 예를 들어.
+스크립트, 자동화, 또는 전체 TUI를 띄우지 않고 빠른 응답이 필요할 때 유용합니다. 예:
 
 ```bash "opencode run"
 opencode run Explain the use of context in Go
 ```
 
-`opencode serve` 인스턴스를 실행하여 MCP 서버 콜드 부팅 시간을 각 실행할 수 있습니다.
+매번 MCP 서버 콜드 부트가 발생하지 않도록, 실행 중인 `opencode serve` 인스턴스에 붙어서 실행할 수도 있습니다.
 
 ```bash
 # Start a headless server in one terminal
@@ -333,48 +333,49 @@ opencode serve
 opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그       | 짧은 이름 | 설명                                                  |
-| ------------ | --------- | ----------------------------------------------------- |
-| `--command`  |           | 실행 중인 명령 사용(미지정 시 args의 메시지 사용)     |
-| `--continue` | `-c`      | 마지막 세션                                           |
-| `--session`  | `-s`      | 세션 ID                                               |
-| `--share`    |           | 세션 공유                                             |
-| `--model`    | `-m`      | `-m`의 형태로 사용 가능                               |
-| `--agent`    |           | 에이전트                                              |
-| `--file`     | `-f`      | 메시지 첨부 파일                                      |
-| `--format`   |           | 출력 형식: formatted 또는 json(raw JSON 이벤트)       |
-| `--title`    |           | 세션의 제목(제공되지 않은 경우 truncated prompt 사용) |
-| `--attach`   |           | 운영 개시 서버(예: http://localhost:4096)             |
-| `--port`     |           | 현지 서버 포트                                        |
+| 플래그       | 축약 | 설명                                                                   |
+| ------------ | ---- | ---------------------------------------------------------------------- |
+| `--command`  |      | 실행할 명령(인수는 message로 전달)                                     |
+| `--continue` | `-c` | 마지막 세션 이어서 실행                                                |
+| `--session`  | `-s` | 이어서 실행할 세션 ID                                                  |
+| `--fork`     |      | 세션을 이어갈 때 포크 생성 (`--continue` 또는 `--session`과 함께 사용) |
+| `--share`    |      | 세션 공유                                                              |
+| `--model`    | `-m` | 사용할 모델 (`provider/model` 형식)                                    |
+| `--agent`    |      | 사용할 에이전트                                                        |
+| `--file`     | `-f` | 메시지에 첨부할 파일                                                   |
+| `--format`   |      | 출력 형식: default(포맷됨) 또는 json(원시 JSON 이벤트)                 |
+| `--title`    |      | 세션 제목(값이 없으면 프롬프트를 잘라 자동 생성)                       |
+| `--attach`   |      | 실행 중인 opencode 서버에 연결(예: http://localhost:4096)              |
+| `--port`     |      | 로컬 서버 포트(기본값: 랜덤 포트)                                      |
 
 ---
 
-## 서비스
+### serve
 
-API 액세스를 위한 headless opencode 서버를 시작합니다. 완전한 HTTP 인터페이스를 위해 [server docs](/docs/server)를 체크하십시오.
+API 접근용 headless OpenCode 서버를 시작합니다. 전체 HTTP 인터페이스는 [server docs](/docs/server)를 참고하세요.
 
 ```bash
 opencode serve
 ```
 
-TUI 인터페이스없이 API 액세스를 제공하는 HTTP 서버를 시작합니다. `OPENCODE_SERVER_PASSWORD`를 설정하여 HTTP 기본 auth (`opencode`에 기본적으로 이름을 지정합니다).
+이 명령은 TUI 없이 opencode 기능에 접근할 수 있는 HTTP 서버를 시작합니다. `OPENCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
 
-#### 플래그
+#### Flags
 
-| 플래그       | 설명                               |
-| ------------ | ---------------------------------- |
-| `--port`     | 포트                               |
-| `--hostname` | 듣고 싶은 이름                     |
-| `--mdns`     | 엔터블 mDNS 검색                   |
-| `--cors`     | CORS를 허용하는 추가 브라우저 기원 |
+| 플래그       | 설명                              |
+| ------------ | --------------------------------- |
+| `--port`     | 수신 포트                         |
+| `--hostname` | 수신 호스트명                     |
+| `--mdns`     | mDNS 검색 활성화                  |
+| `--cors`     | 허용할 추가 브라우저 origin(CORS) |
 
 ---
 
-### 세션
+### session
 
-opencode 세션 관리.
+OpenCode 세션을 관리합니다.
 
 ```bash
 opencode session [command]
@@ -382,63 +383,63 @@ opencode session [command]
 
 ---
 
-#### 리스트
+#### list
 
-모든 opencode 세션 목록.
+OpenCode 세션 목록을 표시합니다.
 
 ```bash
 opencode session list
 ```
 
-##### 플래그
+##### Flags
 
-| 플래그        | 짧은 이름 | 설명                       |
-| ------------- | --------- | -------------------------- |
-| `--max-count` | `-n`      | 최근 세션에 제한           |
-| `--format`    |           | 출력 형식: table 또는 json |
+| 플래그        | 축약 | 설명                                   |
+| ------------- | ---- | -------------------------------------- |
+| `--max-count` | `-n` | 최근 N개 세션만 표시                   |
+| `--format`    |      | 출력 형식: table 또는 json(기본 table) |
 
 ---
 
-### 통계
+### stats
 
-opencode 세션에 대한 토큰 사용 및 비용 통계를 표시합니다.
+OpenCode 세션의 토큰 사용량과 비용 통계를 표시합니다.
 
 ```bash
 opencode stats
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그      | 설명                                                                |
-| ----------- | ------------------------------------------------------------------- |
-| `--days`    | 지난 N일간의 통계를 보여 주세요(모든 시간)                          |
-| `--tools`   | 쇼의 도구 수                                                        |
-| `--models`  | 모델 사용 내역(기본적으로 숨겨져 있음) 상단 N을 표시할 수 있는 번호 |
-| `--project` | 프로젝트별 필터링(모든 프로젝트, 빈 문자열: 현재 프로젝트)          |
+| 플래그      | 설명                                                         |
+| ----------- | ------------------------------------------------------------ |
+| `--days`    | 최근 N일 통계 표시(기본값: 전체 기간)                        |
+| `--tools`   | 표시할 도구 개수(기본값: 전체)                               |
+| `--models`  | 모델 사용량 상세 표시(기본 숨김). 숫자를 주면 상위 N개 표시  |
+| `--project` | 프로젝트 필터(기본: 전체 프로젝트, 빈 문자열: 현재 프로젝트) |
 
 ---
 
-### 수출
+### export
 
-JSON으로 세션 데이터를 내보내기.
+세션 데이터를 JSON으로 내보냅니다.
 
 ```bash
 opencode export [sessionID]
 ```
 
-세션 ID를 제공하지 않는 경우 사용 가능한 세션에서 선택할 수 있습니다.
+세션 ID를 지정하지 않으면 사용 가능한 세션에서 선택하라는 안내가 표시됩니다.
 
 ---
 
-### 가져오기
+### import
 
-JSON 파일 또는 opencode 공유 URL에서 세션 데이터를 가져옵니다.
+JSON 파일 또는 OpenCode 공유 URL에서 세션 데이터를 가져옵니다.
 
 ```bash
 opencode import <file>
 ```
 
-로컬 파일 또는 opencode 공유 URL에서 가져올 수 있습니다.
+로컬 파일이나 OpenCode 공유 URL에서 가져올 수 있습니다.
 
 ```bash
 opencode import session.json
@@ -447,24 +448,24 @@ opencode import https://opncd.ai/s/abc123
 
 ---
 
-#### 웹
+### web
 
-웹 인터페이스로 headless opencode 서버를 시작합니다.
+웹 인터페이스를 포함한 headless OpenCode 서버를 시작합니다.
 
 ```bash
 opencode web
 ```
 
-HTTP 서버를 시작하고 웹 인터페이스를 통해 opencode에 액세스하는 웹 브라우저를 엽니 다. `OPENCODE_SERVER_PASSWORD`를 설정하여 HTTP 기본 auth (`opencode`에 기본적으로 이름을 지정합니다).
+이 명령은 HTTP 서버를 시작하고 웹 브라우저를 열어 웹 인터페이스로 OpenCode에 접속합니다. `OPENCODE_SERVER_PASSWORD`를 설정하면 HTTP basic auth가 활성화됩니다(기본 사용자명: `opencode`).
 
-#### 플래그
+#### Flags
 
-| 플래그       | 설명                               |
-| ------------ | ---------------------------------- |
-| `--port`     | 포트                               |
-| `--hostname` | 듣고 싶은 이름                     |
-| `--mdns`     | 엔터블 mDNS 검색                   |
-| `--cors`     | CORS를 허용하는 추가 브라우저 기원 |
+| 플래그       | 설명                              |
+| ------------ | --------------------------------- |
+| `--port`     | 수신 포트                         |
+| `--hostname` | 수신 호스트명                     |
+| `--mdns`     | mDNS 검색 활성화                  |
+| `--cors`     | 허용할 추가 브라우저 origin(CORS) |
 
 ---
 
@@ -476,127 +477,127 @@ ACP(Agent Client Protocol) 서버를 시작합니다.
 opencode acp
 ```
 
-이 명령은 nd-JSON을 사용하여 stdin/stdout을 통해 통신하는 ACP 서버를 시작합니다.
+이 명령은 nd-JSON 형식으로 stdin/stdout을 통해 통신하는 ACP 서버를 시작합니다.
 
-#### 플래그
+#### Flags
 
-| 플래그       | 설명           |
-| ------------ | -------------- |
-| `--cwd`      | 작업 디렉토리  |
-| `--port`     | 포트           |
-| `--hostname` | 듣고 싶은 이름 |
+| 플래그       | 설명          |
+| ------------ | ------------- |
+| `--cwd`      | 작업 디렉터리 |
+| `--port`     | 수신 포트     |
+| `--hostname` | 수신 호스트명 |
 
 ---
 
-## 제거
+### uninstall
 
-opencode 제거하고 관련 파일을 제거합니다.
+OpenCode를 제거하고 관련 파일을 삭제합니다.
 
 ```bash
 opencode uninstall
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그          | 플래그 | Description                |
-| --------------- | ------ | -------------------------- |
-| `--keep-config` | `-c`   | 구성 파일 유지             |
-| `--keep-data`   | `-d`   | 세션 데이터 및 스냅샷 유지 |
-| `--dry-run`     |        | 제거하지 않고 제거하는 것  |
-| `--force`       | `-f`   | 확인 프롬프트              |
+| 플래그          | 축약 | 설명                            |
+| --------------- | ---- | ------------------------------- |
+| `--keep-config` | `-c` | 설정 파일 유지                  |
+| `--keep-data`   | `-d` | 세션 데이터와 스냅샷 유지       |
+| `--dry-run`     |      | 실제 삭제 없이 삭제 대상만 표시 |
+| `--force`       | `-f` | 확인 프롬프트 건너뛰기          |
 
 ---
 
-### 업그레이드
+### upgrade
 
-업데이트 opencode 최신 버전 또는 특정 버전.
+opencode를 최신 버전 또는 특정 버전으로 업데이트합니다.
 
 ```bash
 opencode upgrade [target]
 ```
 
-최신 버전으로 업그레이드하십시오.
+최신 버전으로 업그레이드:
 
 ```bash
 opencode upgrade
 ```
 
-특정 버전으로 업그레이드하십시오.
+특정 버전으로 업그레이드:
 
 ```bash
 opencode upgrade v0.1.48
 ```
 
-#### 플래그
+#### Flags
 
-| 플래그     | 플래그 | Description                                  |
-| ---------- | ------ | -------------------------------------------- |
-| `--method` | `-m`   | 사용중인 설치 방법; 컬, npm, pnpm, bun, brew |
-
----
-
-## 글로벌 플래그
-
-opencode CLI는 다음의 글로벌 플래그를 사용합니다.
-
-| 플래그         | 짧은 이름 | 설명                                |
-| -------------- | --------- | ----------------------------------- |
-| `--help`       | `-h`      | 디스플레이 도움말                   |
-| `--version`    | `-v`      | 인쇄판 번호                         |
-| `--print-logs` |           | 스터디로 로그인                     |
-| `--log-level`  |           | 로그 레벨(DEBUG, INFO, WARN, ERROR) |
+| 플래그     | 축약 | 설명                                       |
+| ---------- | ---- | ------------------------------------------ |
+| `--method` | `-m` | 설치 방식 지정: curl, npm, pnpm, bun, brew |
 
 ---
 
-## 환경 변수
+## Global Flags
 
-opencode는 환경 변수를 사용하여 구성할 수 있습니다.
+opencode CLI는 아래 전역 플래그를 지원합니다.
 
-| 변하기 쉬운                           | 유형    | 묘사                                      |
-| ------------------------------------- | ------- | ----------------------------------------- |
-| `OPENCODE_AUTO_SHARE`                 | 불린    | 자동 공유 세션                            |
-| `OPENCODE_GIT_BASH_PATH`              | string  | Windows에서 실행되는 Git Bash 경로        |
-| `OPENCODE_CONFIG`                     | string  | 설정파일 경로                             |
-| `OPENCODE_CONFIG_DIR`                 | string  | 구성 디렉토리 경로                        |
-| `OPENCODE_CONFIG_CONTENT`             | 문자열  | 인라인 json 구성 내용                     |
-| `OPENCODE_DISABLE_AUTOUPDATE`         | 불린    | 자동 업데이트 체크 아웃                   |
-| `OPENCODE_DISABLE_PRUNE`              | boolean | 오래된 자료의 무능                        |
-| `OPENCODE_DISABLE_TERMINAL_TITLE`     | 불린    | 자동 단말 제목 업데이트                   |
-| `OPENCODE_PERMISSION`                 | 문자열  | 인라인 json 권한 설정                     |
-| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | 불린    | 기본 플러그인 비활성화                    |
-| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | 불린    | 자동 LSP 서버 다운로드                    |
-| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | 불린    | 실험 모델                                 |
-| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 자동 컨텍스트 컴팩트                      |
-| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`(prompt + Skill)의 읽을 수 있음  |
-| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | 불린    | `~/.claude/CLAUDE.md`를 읽을 수 있습니다  |
-| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | 불린    | `.claude/skills` 적재 가능                |
-| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 리모트 소스에서 모델에 익숙하지 않은 모델 |
-| `OPENCODE_FAKE_VCS`                   | string  | 시험용 VCS 제공업체                       |
-| `OPENCODE_DISABLE_FILETIME_CHECK`     | boolean | 최적화를 위한 파일 시간 검사              |
-| `OPENCODE_CLIENT`                     | string  | 클라이언트 식별자(`cli`와 동일)           |
-| `OPENCODE_ENABLE_EXA`                 | 불린    | 엑다 웹 검색 도구                         |
-| `OPENCODE_SERVER_PASSWORD`            | string  | `serve`/`web`에 대한 기본 요점            |
-| `OPENCODE_SERVER_USERNAME`            | string  | 기본 사용자 이름(기본 `opencode`)         |
-| `OPENCODE_MODELS_URL`                 | string  | 모델 구성의 맞춤 URL                      |
+| 플래그         | 축약 | 설명                                |
+| -------------- | ---- | ----------------------------------- |
+| `--help`       | `-h` | 도움말 표시                         |
+| `--version`    | `-v` | 버전 출력                           |
+| `--print-logs` |      | 로그를 stderr로 출력                |
+| `--log-level`  |      | 로그 레벨(DEBUG, INFO, WARN, ERROR) |
 
 ---
 
-### 실험
+## Environment variables
 
-이 환경변수는 변화하거나 제거될 수 있는 실험적인 특징을 가능하게 합니다.
+OpenCode는 환경 변수로도 구성할 수 있습니다.
 
-| 변하기 쉬운                                     | 유형    | 묘사                               |
-| ----------------------------------------------- | ------- | ---------------------------------- |
-| `OPENCODE_EXPERIMENTAL`                         | 불린    | 모든 실험적인 특징                 |
-| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 아이콘 검색                        |
-| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | 불린    | TUI의 선택 해제                    |
-| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | 번호    | ms에서 bash 명령의 기본 시간       |
-| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | 번호    | LLM 응답을 위한 최대 Output Tokens |
-| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 전체 디디터용 파일워커             |
-| `OPENCODE_EXPERIMENTAL_OXFMT`                   | 불린    | 엔블 oxfmt 형식                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | 불린    | 실험적인 LSP 도구                  |
-| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 사용 가능한 파일워커               |
-| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 실험용 Exa 기능                    |
-| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | 불린    | 실험적인 LSP형 검사                |
-| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 실험용 마운팅 기능                 |
-| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | 불린    | 플랜 모드                          |
+| 변수                                  | 타입    | 설명                                           |
+| ------------------------------------- | ------- | ---------------------------------------------- |
+| `OPENCODE_AUTO_SHARE`                 | boolean | 세션 자동 공유                                 |
+| `OPENCODE_GIT_BASH_PATH`              | string  | Windows에서 Git Bash 실행 파일 경로            |
+| `OPENCODE_CONFIG`                     | string  | 설정 파일 경로                                 |
+| `OPENCODE_CONFIG_DIR`                 | string  | 설정 디렉터리 경로                             |
+| `OPENCODE_CONFIG_CONTENT`             | string  | 인라인 JSON 설정 내용                          |
+| `OPENCODE_DISABLE_AUTOUPDATE`         | boolean | 자동 업데이트 확인 비활성화                    |
+| `OPENCODE_DISABLE_PRUNE`              | boolean | 오래된 데이터 정리(prune) 비활성화             |
+| `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | 터미널 제목 자동 업데이트 비활성화             |
+| `OPENCODE_PERMISSION`                 | string  | 인라인 JSON 권한 설정                          |
+| `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | 기본 플러그인 비활성화                         |
+| `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | LSP 서버 자동 다운로드 비활성화                |
+| `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | 실험적 모델 활성화                             |
+| `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | 자동 컨텍스트 컴팩션 비활성화                  |
+| `OPENCODE_DISABLE_CLAUDE_CODE`        | boolean | `.claude`(프롬프트 + 스킬) 읽기 비활성화       |
+| `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT` | boolean | `~/.claude/CLAUDE.md` 읽기 비활성화            |
+| `OPENCODE_DISABLE_CLAUDE_CODE_SKILLS` | boolean | `.claude/skills` 로드 비활성화                 |
+| `OPENCODE_DISABLE_MODELS_FETCH`       | boolean | 원격 소스에서 모델 목록 가져오기 비활성화      |
+| `OPENCODE_FAKE_VCS`                   | string  | 테스트용 가짜 VCS provider                     |
+| `OPENCODE_DISABLE_FILETIME_CHECK`     | boolean | 최적화를 위한 파일 시간 검사 비활성화          |
+| `OPENCODE_CLIENT`                     | string  | 클라이언트 식별자(기본값: `cli`)               |
+| `OPENCODE_ENABLE_EXA`                 | boolean | Exa 웹 검색 도구 활성화                        |
+| `OPENCODE_SERVER_PASSWORD`            | string  | `serve`/`web` 기본 인증 활성화                 |
+| `OPENCODE_SERVER_USERNAME`            | string  | 기본 인증 사용자명 오버라이드(기본 `opencode`) |
+| `OPENCODE_MODELS_URL`                 | string  | 모델 설정을 가져올 사용자 지정 URL             |
+
+---
+
+### Experimental
+
+아래 환경 변수는 변경되거나 제거될 수 있는 실험 기능을 활성화합니다.
+
+| 변수                                            | 타입    | 설명                           |
+| ----------------------------------------------- | ------- | ------------------------------ |
+| `OPENCODE_EXPERIMENTAL`                         | boolean | 모든 실험 기능 활성화          |
+| `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY`          | boolean | 아이콘 탐색 활성화             |
+| `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`  | boolean | TUI에서 선택 시 복사 비활성화  |
+| `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS` | number  | bash 명령 기본 타임아웃(ms)    |
+| `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX`        | number  | LLM 응답 최대 출력 토큰 수     |
+| `OPENCODE_EXPERIMENTAL_FILEWATCHER`             | boolean | 전체 디렉터리 파일 감시 활성화 |
+| `OPENCODE_EXPERIMENTAL_OXFMT`                   | boolean | oxfmt 포매터 활성화            |
+| `OPENCODE_EXPERIMENTAL_LSP_TOOL`                | boolean | 실험적 LSP 도구 활성화         |
+| `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER`     | boolean | 파일 감시 비활성화             |
+| `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | 실험적 Exa 기능 활성화         |
+| `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | 실험적 LSP 타입 검사 활성화    |
+| `OPENCODE_EXPERIMENTAL_MARKDOWN`                | boolean | 실험적 Markdown 기능 활성화    |
+| `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Plan mode 활성화               |

--- a/packages/web/src/content/docs/ko/commands.mdx
+++ b/packages/web/src/content/docs/ko/commands.mdx
@@ -3,21 +3,23 @@ title: Commands
 description: Create custom commands for repetitive tasks.
 ---
 
-사용자 지정 명령은 TUI에서 실행될 때 실행할 때 실행해야 합니다.
+커스텀 명령을 사용하면 TUI에서 해당 명령이 실행될 때 사용할 프롬프트를 미리 정의할 수 있습니다.
 
 ```bash frame="none"
 /my-command
 ```
 
-사용자 정의 명령은 `/init`, `/undo`, `/redo`, `/share`, `/share`, `/help`와 같은 내장된 명령 이외에 있습니다. [더 알아보기](/docs/tui#commands).
+---
+
+커스텀 명령은 `/init`, `/undo`, `/redo`, `/share`, `/help` 같은 내장 명령과 별도로 추가됩니다. [더 알아보기](/docs/tui#commands).
 
 ---
 
-## 명령 파일 생성
+## 명령 파일 만들기
 
-사용자 지정 명령을 정의하려면 `commands/` 디렉토리의 Markdown 파일을 만듭니다.
+커스텀 명령은 `commands/` 디렉터리에 Markdown 파일을 만들어 정의합니다.
 
-`.opencode/commands/test.md` 만들기:
+예: `.opencode/commands/test.md`
 
 ```md title=".opencode/commands/test.md"
 ---
@@ -30,9 +32,9 @@ Run the full test suite with coverage report and show any failures.
 Focus on the failing tests and suggest fixes.
 ```
 
-frontmatter 명령 속성을 정의합니다. 콘텐츠는 템플릿이 됩니다.
+프런트매터(frontmatter)에는 명령 속성을 정의하고, 본문은 템플릿 프롬프트가 됩니다.
 
-명령명에 따라 `/`를 입력하여 명령을 사용하십시오.
+명령 이름 앞에 `/`를 붙여 실행합니다.
 
 ```bash frame="none"
 "/test"
@@ -42,13 +44,13 @@ frontmatter 명령 속성을 정의합니다. 콘텐츠는 템플릿이 됩니�
 
 ## 구성
 
-opencode config를 통해 사용자 지정 명령을 추가하거나 `commands/` 디렉토리에 있는 Markdown 파일을 만들 수 있습니다.
+커스텀 명령은 OpenCode 설정으로 추가하거나, `commands/` 디렉터리에 Markdown 파일을 만들어 추가할 수 있습니다.
 
 ---
 
-### JSON 태그
+### JSON
 
-opencode [config](/docs/config)에서 `command` 옵션을 사용하십시오:
+OpenCode [config](/docs/config)의 `command` 옵션을 사용합니다.
 
 ```json title="opencode.jsonc" {4-12}
 {
@@ -67,7 +69,7 @@ opencode [config](/docs/config)에서 `command` 옵션을 사용하십시오:
 }
 ```
 
-이제 TUI에서이 명령을 실행할 수 있습니다.
+이제 TUI에서 다음처럼 실행할 수 있습니다.
 
 ```bash frame="none"
 /test
@@ -77,10 +79,10 @@ opencode [config](/docs/config)에서 `command` 옵션을 사용하십시오:
 
 ### Markdown
 
-Markdown 파일을 사용하여 명령을 정의할 수 있습니다. 그들에 게:
+Markdown 파일로도 명령을 정의할 수 있습니다. 아래 경로 중 하나에 두면 됩니다.
 
-- 글로벌: `~/.config/opencode/commands/`
-- 프로젝트: `.opencode/commands/`
+- 전역: `~/.config/opencode/commands/`
+- 프로젝트별: `.opencode/commands/`
 
 ```markdown title="~/.config/opencode/commands/test.md"
 ---
@@ -93,8 +95,7 @@ Run the full test suite with coverage report and show any failures.
 Focus on the failing tests and suggest fixes.
 ```
 
-markdown 파일 이름은 명령 이름입니다. 예를 들어, `test.md` lets
-당신은 실행:
+Markdown 파일명이 명령 이름이 됩니다. 예를 들어 `test.md`라면 아래처럼 실행합니다.
 
 ```bash frame="none"
 /test
@@ -102,15 +103,15 @@ markdown 파일 이름은 명령 이름입니다. 예를 들어, `test.md` lets
 
 ---
 
-## Prompt 구성
+## 프롬프트 구성
 
-사용자 정의 명령에 대한 프롬프트는 몇 가지 특별한 placeholders 및 구문을 지원합니다.
+커스텀 명령 프롬프트는 몇 가지 특수 플레이스홀더(placeholder)와 문법을 지원합니다.
 
 ---
 
-#### 가격
+### 인수(Arguments)
 
-`$ARGUMENTS` placeholder를 사용하여 명령을 전달합니다.
+`$ARGUMENTS` 플레이스홀더로 명령 인수를 전달할 수 있습니다.
 
 ```md title=".opencode/commands/component.md"
 ---
@@ -121,22 +122,22 @@ Create a new React component named $ARGUMENTS with TypeScript support.
 Include proper typing and basic structure.
 ```
 
-인수로 명령을 실행:
+인수를 넣어 실행하면:
 
 ```bash frame="none"
 /component Button
 ```
 
-그리고 `$ARGUMENTS`는 `Button`로 대체될 것입니다.
+`$ARGUMENTS`가 `Button`으로 치환됩니다.
 
-위치 매개 변수를 사용하여 개별 인수에 액세스 할 수 있습니다.
+위치 인수도 사용할 수 있습니다.
 
 - `$1` - 첫 번째 인수
 - `$2` - 두 번째 인수
 - `$3` - 세 번째 인수
-- 그래서 ...
+- 이후 동일
 
-예를 들면:
+예시:
 
 ```md title=".opencode/commands/create-file.md"
 ---
@@ -147,25 +148,25 @@ Create a file named $1 in the directory $2
 with the following content: $3
 ```
 
-명령을 실행:
+실행:
 
 ```bash frame="none"
 /create-file config.json src "{ \"key\": \"value\" }"
 ```
 
-이렇게 대체됩니다:
+치환 결과:
 
-- `$1`는 `config.json`
-- `$2`는 `src`
-- `$3`는 `{ "key": "value" }`
+- `$1` -> `config.json`
+- `$2` -> `src`
+- `$3` -> `{ "key": "value" }`
 
 ---
 
-### 포탄 산출
+### 셸 출력
 
-사용 !`command` 는 [bash command](/docs/tui#bash-commands)를 프롬프트로 출력합니다.
+_!`command`_ 문법으로 [bash 명령](/docs/tui#bash-commands)의 출력 결과를 프롬프트에 주입할 수 있습니다.
 
-예를 들어, 테스트 범위를 분석하는 사용자 정의 명령을 만들려면:
+예를 들어 테스트 커버리지 분석 명령을 만들면:
 
 ```md title=".opencode/commands/analyze-coverage.md"
 ---
@@ -178,7 +179,7 @@ Here are the current test results:
 Based on these results, suggest improvements to increase coverage.
 ```
 
-또는 최근 변경 사항 :
+최근 변경 리뷰용으로는:
 
 ```md title=".opencode/commands/review-changes.md"
 ---
@@ -191,13 +192,13 @@ Recent git commits:
 Review these changes and suggest any improvements.
 ```
 
-명령은 프로젝트의 루트 디렉토리에서 실행하고 출력은 프롬프트의 일부가됩니다.
+명령은 프로젝트 루트 디렉터리에서 실행되며, 출력 결과는 프롬프트 본문에 포함됩니다.
 
 ---
 
-## 파일 참조
+### 파일 참조
 
-파일명에 따라 `@`를 사용하여 명령에 파일이 포함되어 있습니다.
+`@` 뒤에 파일명을 붙여 명령에 파일을 포함할 수 있습니다.
 
 ```md title=".opencode/commands/review-component.md"
 ---
@@ -208,19 +209,19 @@ Review the component in @src/components/Button.tsx.
 Check for performance issues and suggest improvements.
 ```
 
-파일 콘텐츠는 자동으로 프롬프트에 포함되어 있습니다.
+파일 내용은 자동으로 프롬프트에 포함됩니다.
 
 ---
 
 ## 옵션
 
-구성 옵션을 자세히 살펴봅시다.
+구성 옵션을 자세히 살펴봅니다.
 
 ---
 
-### 템플릿
+### Template
 
-`template` 옵션은 명령이 실행될 때 LLM에 전송될 프롬프트를 정의합니다.
+`template` 옵션은 명령 실행 시 LLM에 전달할 프롬프트를 정의합니다.
 
 ```json title="opencode.json"
 {
@@ -232,13 +233,13 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-\*\* config 옵션이 필요합니다.
+이 옵션은 **필수**입니다.
 
 ---
 
-### 묘사
+### Description
 
-`description` 옵션을 사용하여 명령의 간단한 설명을 제공합니다.
+`description` 옵션으로 명령의 짧은 설명을 추가할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -250,15 +251,15 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-명령에 입력할 때 TUI의 설명으로 표시됩니다.
+이 설명은 TUI에서 명령을 입력할 때 표시됩니다.
 
 ---
 
-## 에이전트
+### Agent
 
-`agent` config를 선택적으로 지정합니다. [agent](/docs/agents)는 이 명령을 실행해야 합니다.
-이 경우 [subagent](/docs/agents/#subagents) 명령은 기본으로 시약을 트리거합니다.
-이 행동을 비활성화하려면 `subtask`를 `false`로 설정하십시오.
+`agent` 설정으로 이 명령을 실행할 [agent](/docs/agents)를 지정할 수 있습니다.
+지정한 값이 [subagent](/docs/agents/#subagents)면 기본적으로 subagent 호출이 실행됩니다.
+이 동작을 끄려면 `subtask`를 `false`로 설정하세요.
 
 ```json title="opencode.json"
 {
@@ -270,15 +271,14 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-** 옵션** 설정 옵션입니다. 지정된 경우, 현재 에이전트에 기본값.
+이 옵션은 **선택**입니다. 지정하지 않으면 현재 에이전트가 기본값으로 사용됩니다.
 
 ---
 
-### 서브스크랩
+### Subtask
 
-`subtask` boolean을 사용하여 명령을 강제로 [subagent](/docs/agents/#subagents) 호출합니다.
-이것은 당신이 명령을 원하지 않는 경우 유용합니다 당신의 기본 컨텍스트를 pollute하고 \*\* 에이전트는 시약으로 행동하는,
-`mode`가 [시약](/docs/시약) 구성에 `primary`로 설정되는 경우에도.
+`subtask` 불리언(boolean)을 사용하면 명령이 [subagent](/docs/agents/#subagents) 호출을 강제로 트리거합니다.
+주 컨텍스트를 오염시키고 싶지 않을 때 유용하며, [agent](/docs/agents) 설정의 `mode`가 `primary`여도 subagent로 실행합니다.
 
 ```json title="opencode.json"
 {
@@ -290,13 +290,13 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-** 옵션** 설정 옵션입니다.
+이 옵션은 **선택**입니다.
 
 ---
 
-### 모형
+### Model
 
-`model` config를 사용하여 이 명령의 기본 모델을 무시합니다.
+`model` 설정으로 이 명령의 기본 모델을 오버라이드할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -308,16 +308,16 @@ Check for performance issues and suggest improvements.
 }
 ```
 
-** 옵션** 설정 옵션입니다.
+이 옵션은 **선택**입니다.
 
 ---
 
-## 내장
+## Built-in
 
-opencode는 `/init`, `/undo`, `/redo`, `/share`, `/help`, `/help`와 같은 몇몇 붙박이 명령을 포함합니다; [learn more](./tui#commands).
+OpenCode는 `/init`, `/undo`, `/redo`, `/share`, `/help` 등 여러 내장 명령을 제공합니다. [더 알아보기](/docs/tui#commands).
 
 :::note
-사용자 지정 명령은 내장 명령을 무시할 수 있습니다.
+커스텀 명령은 내장 명령을 덮어쓸 수 있습니다.
 :::
 
-같은 이름으로 사용자 정의 명령을 정의하면 내장 명령을 무시합니다.
+같은 이름으로 커스텀 명령을 정의하면 내장 명령보다 커스텀 명령이 우선합니다.

--- a/packages/web/src/content/docs/ko/config.mdx
+++ b/packages/web/src/content/docs/ko/config.mdx
@@ -1,15 +1,15 @@
 ---
 title: Config
-description: Using the opencode JSON config.
+description: Using the OpenCode JSON config.
 ---
 
-JSON config 파일을 사용하여 opencode를 구성할 수 있습니다.
+JSON config 파일로 OpenCode를 설정할 수 있습니다.
 
 ---
 
 ## 형식
 
-opencode는 **JSON** 및 **JSONC** (JSON with Comments) 형식을 지원합니다.
+OpenCode는 **JSON**과 **JSONC**(주석이 포함된 JSON) 형식을 모두 지원합니다.
 
 ```jsonc title="opencode.jsonc"
 {
@@ -25,44 +25,44 @@ opencode는 **JSON** 및 **JSONC** (JSON with Comments) 형식을 지원합니�
 
 ## 위치
 
-다른 위치의 몇 개에 구성을 배치 할 수 있으며 그들은
-precedence의 다른 순서.
+config 파일은 여러 위치에 둘 수 있으며, 각 위치에는 우선순위가 있습니다.
 
 :::note
-구성 파일은 \*\* 함께, 대체되지 않습니다.
+config 파일은 **교체되지 않고 병합**됩니다.
 :::
 
-구성 파일은 함께 결합되어 대체되지 않습니다. 다음 구성 위치에서 설정이 결합됩니다. 나중에 configs override 이전 하나만 충돌 키. 모든 구성에서 설정이 보존됩니다.
+config 파일은 서로 대체되는 방식이 아니라 병합됩니다. 아래 config 위치의 설정이 결합되며, 충돌하는 key에 대해서만 나중에 로드된 config가 앞선 값을 override합니다. 충돌하지 않는 설정은 모두 유지됩니다.
 
-예를 들어, 글로벌 구성 세트 `theme: "opencode"` 및 `autoupdate: true` 및 프로젝트 구성 세트 `model: "anthropic/claude-sonnet-4-5"`를 설정하면 최종 구성은 모든 세 가지 설정을 포함합니다.
+예를 들어, 전역 config에 `theme: "opencode"`와 `autoupdate: true`가 있고 프로젝트 config에 `model: "anthropic/claude-sonnet-4-5"`가 있으면 최종 config에는 이 세 설정이 모두 포함됩니다.
 
 ---
 
-### 임신 순서
+### 우선순위
 
-Config 소스는 이 순서에서 적재됩니다 (더 많은 소스는 더 이른 것 삭제합니다):
+config source는 다음 순서로 로드됩니다(나중 source가 앞선 source를 override).
 
-1. ** 원격 설정** (`.well-known/opencode`에서) - 조직 기본 2.**Global config** (`~/.config/opencode/opencode.json`) - 사용자 선호도
-2. ** 사용자 정의 설정** (`OPENCODE_CONFIG` env var) - 사용자 정의 overrides
-3. ** 프로젝트 별 설정** (`opencode.json`) - 프로젝트 별 설정
-4. **`.opencode` 디렉토리 ** - 에이전트, 명령, 플러그인
-5. ** 인라인 설정** (`OPENCODE_CONFIG_CONTENT` env var) - 런타임 오버라이드
+1. **Remote config**(`.well-known/opencode`) - 조직 기본값
+2. **Global config**(`~/.config/opencode/opencode.json`) - 사용자 기본 설정
+3. **Custom config**(`OPENCODE_CONFIG` env var) - custom override
+4. **Project config**(프로젝트의 `opencode.json`) - 프로젝트별 설정
+5. **`.opencode` directories** - agents, commands, plugins
+6. **Inline config**(`OPENCODE_CONFIG_CONTENT` env var) - 런타임 override
 
-이것은 프로젝트 구성은 글로벌 디폴트를 override 할 수 있으며, 글로벌 구성은 원격 조직 디폴트를 override 할 수 있습니다.
+즉, 프로젝트 config는 전역 기본값을 override할 수 있고, 전역 config는 조직의 Remote 기본값을 override할 수 있습니다.
 
 :::note
-`.opencode`와 `~/.config/opencode` 감독 사용 **plural 이름** 하위 디렉토리에 대 한: `agents/`, `commands/`, `modes/`, `plugins/`, `skills/`, `tools/`, 그리고 `themes/`. Singular 이름 (예를들면, `agent/`)는 또한 뒤쪽 겸용성을 위해 지원됩니다.
+`.opencode` 및 `~/.config/opencode` 디렉토리는 하위 디렉토리에 **복수형 이름**을 사용합니다: `agents/`, `commands/`, `modes/`, `plugins/`, `skills/`, `tools/`, `themes/`. 단수형 이름(예: `agent/`)도 하위 호환성을 위해 지원합니다.
 :::
 
 ---
 
-### 리모트
+### Remote
 
-조직은 `.well-known/opencode` 엔드포인트를 통해 기본 구성을 제공 할 수 있습니다. 이것은 당신이 그것을 지원하는 공급자로 정통할 때 자동적으로 fetched.
+조직은 `.well-known/opencode` endpoint로 기본 config를 제공할 수 있습니다. 이를 지원하는 provider로 인증하면 자동으로 가져옵니다.
 
-원격 설정은 기본 레이어로 제공된 첫 번째입니다. 다른 구성 소스 (글로벌, 프로젝트)는 이러한 기본값을 무시할 수 있습니다.
+Remote config는 가장 먼저 로드되어 기본 레이어 역할을 합니다. 이후의 모든 config source(전역, 프로젝트)는 이 기본값을 override할 수 있습니다.
 
-예를 들어, 조직이 기본으로 비활성화 된 MCP 서버를 제공한다면:
+예를 들어, 조직에서 기본 비활성화된 MCP 서버를 제공하는 경우:
 
 ```json title="Remote config from .well-known/opencode"
 {
@@ -76,7 +76,7 @@ Config 소스는 이 순서에서 적재됩니다 (더 많은 소스는 더 이�
 }
 ```
 
-로컬 설정에서 특정 서버를 사용할 수 있습니다:
+로컬 config에서 특정 서버를 활성화할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -92,68 +92,65 @@ Config 소스는 이 순서에서 적재됩니다 (더 많은 소스는 더 이�
 
 ---
 
-## 글로벌
+### Global
 
-`~/.config/opencode/opencode.json`에서 글로벌 opencode 구성을 배치합니다. 테마, 공급자, keybinds와 같은 사용자 전체 선호도에 대한 글로벌 구성을 사용합니다.
+전역 OpenCode config는 `~/.config/opencode/opencode.json`에 두세요. theme, provider, keybind 같은 사용자 전체 기본 설정은 전역 config로 관리하세요.
 
-글로벌 구성 overrides 원격 조직 기본.
+전역 config는 조직의 Remote 기본값을 override합니다.
 
 ---
 
-## 프로젝트 당
+### Per project
 
-프로젝트 루트에 `opencode.json`를 추가합니다. Project config는 표준 구성 파일 중 가장 높은 우선순위가 있습니다. 이는 글로벌 및 원격 구성 모두 overrides합니다.
+프로젝트 루트에 `opencode.json`을 추가하세요. 프로젝트 config는 표준 config 파일 중 우선순위가 가장 높아 전역 및 Remote config를 모두 override합니다.
 
 :::tip
-프로젝트의 루트에 특정 설정.
+프로젝트별 config는 프로젝트 루트에 두세요.
 :::
 
-opencode가 시작될 때, 현재 디렉토리의 설정 파일이나 가장 가까운 Git 디렉토리로 이동합니다.
+OpenCode 시작 시 현재 디렉토리에서 config 파일을 찾고, 없으면 가장 가까운 Git 디렉토리까지 상위로 탐색합니다.
 
-이것은 Git로 검사되고 글로벌 하나로 동일한 schema를 사용합니다.
+이 파일은 Git에 커밋해도 안전하며 전역 config와 동일한 schema를 사용합니다.
 
 ---
 
-### 사용자 정의 경로
+### Custom path
 
-`OPENCODE_CONFIG` 환경 변수를 사용하여 사용자 정의 구성 파일 경로 지정.
+`OPENCODE_CONFIG` 환경 변수로 custom config 파일 경로를 지정하세요.
 
 ```bash
 export OPENCODE_CONFIG=/path/to/my/custom-config.json
 opencode run "Hello world"
 ```
 
-Custom config는 precedence 순서에 있는 세계적인 프로젝트 구성 사이에서 적재됩니다.
+Custom config는 우선순위상 전역 config와 프로젝트 config 사이에서 로드됩니다.
 
 ---
 
-## 사용자 정의 디렉토리
+### Custom directory
 
-`OPENCODE_CONFIG_DIR`를 사용하여 사용자 정의 구성 디렉토리 지정
-환경 변수. 이 디렉토리는 에이전트, 명령을 검색합니다,
-모드 및 플러그인은 표준 `.opencode` 디렉토리와 같은, 그리고 해야
-동일한 구조를 따르십시오.
+`OPENCODE_CONFIG_DIR` 환경 변수로 custom config 디렉토리를 지정할 수 있습니다. 이 디렉토리는 표준 `.opencode` 디렉토리와 동일하게 agents, commands, modes, plugins를 검색하며, 동일한 구조를 따라야 합니다.
 
 ```bash
 export OPENCODE_CONFIG_DIR=/path/to/my/config-directory
 opencode run "Hello world"
 ```
 
-사용자 정의 디렉토리는 글로벌 구성 및 `.opencode` 디렉토리 후로드됩니다. \*\* 설정할 수 있습니다.
+custom 디렉토리는 전역 config와 `.opencode` 디렉토리 뒤에 로드되므로 해당 설정을 **override할 수 있습니다**.
 
 ---
 
-## 여성
+## Schema
 
-구성 파일에는 [**`opencode.ai/config.json`**](https://opencode.ai/config.json)에서 정의된 스키마가 있습니다.
+config 파일의 schema는 [**`opencode.ai/config.json`**](https://opencode.ai/config.json)에 정의되어 있습니다.
 
-당신의 편집자는 schema에 근거를 둔 검증하고 자동 완성될 수 있어야 합니다.
+편집기에서 이 schema를 기반으로 validation과 autocomplete를 사용할 수 있습니다.
 
 ---
 
-#### TUI
+### TUI
 
-`tui` 옵션을 통해 TUI-specific 설정을 구성할 수 있습니다.
+`tui` 옵션으로 TUI 관련 설정을 구성할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -168,19 +165,19 @@ opencode run "Hello world"
 }
 ```
 
-유효한 선택권:
+사용 가능한 옵션:
 
-- `scroll_acceleration.enabled` - macOS 스타일 스크롤 가속을 가능하게합니다. ** `scroll_speed`에 대한 준비. **
-- `scroll_speed` - 사용자 정의 스크롤 속도 승수 (기본: `3`, 최소: `1`). `scroll_acceleration.enabled`가 `true`인 경우에 Ignored.
-- `diff_style` - 제어 디프 렌더링. `"auto"`는 terminal 폭에, `"stacked"` 항상 단 하나 란을 보여줍니다 적응시킵니다.
+- `scroll_acceleration.enabled` - macOS 스타일 스크롤 가속을 활성화합니다. **`scroll_speed`보다 우선합니다.**
+- `scroll_speed` - 사용자 정의 스크롤 속도 배수(기본: `3`, 최소: `1`). `scroll_acceleration.enabled`가 `true`이면 무시됩니다.
+- `diff_style` - diff 렌더링 방식을 제어합니다. `"auto"`는 터미널 너비에 맞춰 조정되고, `"stacked"`는 항상 단일 컬럼으로 표시합니다.
 
-[TUI를 사용하여 더 자세히 알아보기](/docs/tui).
+[TUI에 대해 더 알아보기](/docs/tui).
 
 ---
 
-## 서버
+### Server
 
-`opencode serve` 및 `opencode web` 명령에 대한 서버 설정을 구성할 수 있습니다.
+`server` 옵션으로 `opencode serve`와 `opencode web` 명령의 server 설정을 구성할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -195,21 +192,21 @@ opencode run "Hello world"
 }
 ```
 
-유효한 선택권:
+사용 가능한 옵션:
 
-- `port` - 듣는 항구.
-- `hostname` - 듣는 호스트 이름. `mdns`가 활성화되고 hostname이 설정되지 않으면 `0.0.0.0`로 기본값이 됩니다.
-- `mdns` - 사용 가능한 mDNS 서비스 발견. 이 네트워크에서 다른 장치가 opencode 서버를 발견 할 수 있습니다.
-- `mdnsDomain` - mDNS 서비스에 대한 사용자 정의 도메인 이름. 기본 `opencode.local`. 동일한 네트워크에서 여러 인스턴스를 실행하는 데 유용합니다.
-- `cors` - 브라우저 기반 클라이언트에서 HTTP 서버를 사용할 때 CORS를 허용하는 추가 기원. 가치는 가득 차있는 근원이어야 합니다 (scheme + 주인 + 선택적인 항구), 예를들면 `https://app.example.com`.
+- `port` - 수신할 포트입니다.
+- `hostname` - 수신할 호스트명입니다. `mdns`가 활성화되어 있고 hostname이 없으면 기본값은 `0.0.0.0`입니다.
+- `mdns` - mDNS service discovery를 활성화합니다. 네트워크 내 다른 기기에서 OpenCode server를 찾을 수 있습니다.
+- `mdnsDomain` - mDNS service의 custom 도메인 이름입니다. 기본값은 `opencode.local`입니다. 같은 네트워크에서 여러 인스턴스를 실행할 때 유용합니다.
+- `cors` - 브라우저 기반 client에서 HTTP server를 사용할 때 허용할 추가 CORS origin입니다. 값은 전체 origin(scheme + host + optional port) 형식이어야 하며, 예: `https://app.example.com`.
 
-[서버에 대해 자세히 알아보기](/docs/server).
+[server에 대해 더 알아보기](/docs/server).
 
 ---
 
-## 도구
+### Tools
 
-LLM은 `tools` 옵션을 통해 사용할 수 있습니다.
+`tools` 옵션으로 LLM이 사용할 수 있는 tool을 관리할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -221,13 +218,13 @@ LLM은 `tools` 옵션을 통해 사용할 수 있습니다.
 }
 ```
 
-[이 도구에 대해 자세히 알아보기](/docs/tools).
+[tool에 대해 더 알아보기](/docs/tools).
 
 ---
 
-## 모델
+### Models
 
-`provider`, `model` 및 `small_model` 옵션을 통해 opencode config에서 사용하려는 공급자와 모델을 구성할 수 있습니다.
+OpenCode config의 `provider`, `model`, `small_model` 옵션으로 사용할 provider와 model을 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -238,9 +235,9 @@ LLM은 `tools` 옵션을 통해 사용할 수 있습니다.
 }
 ```
 
-`small_model` 옵션은 제목 생성과 같은 경량 작업을 위한 별도의 모델을 구성합니다. 기본적으로, opencode는 당신의 공급자에게서 1개가 유효하다면 더 싼 모형을 이용하는 것을 시도합니다, 그렇지 않으면 당신의 주요 모형에 돌려보냅니다.
+`small_model`은 제목 생성 같은 경량 작업에 사용할 별도 model을 설정합니다. 기본적으로 OpenCode는 provider에서 더 저렴한 model을 사용할 수 있으면 우선 사용하고, 없으면 메인 model로 fallback합니다.
 
-공급자 선택권은 `timeout`와 `setCacheKey`를 포함할 수 있습니다:
+provider 옵션에는 `timeout`, `setCacheKey`를 포함할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -256,20 +253,20 @@ LLM은 `tools` 옵션을 통해 사용할 수 있습니다.
 }
 ```
 
-- `timeout` - 밀리 초 (기본: 300000)에서 타임 아웃 요청. `false`로 분리할 수 있습니다.
-- `setCacheKey` - 캐시 키가 항상 지정된 공급자를 위해 설정됩니다.
+- `timeout` - 요청 timeout(밀리초, 기본값: 300000). `false`로 비활성화할 수 있습니다.
+- `setCacheKey` - 지정된 provider에 대해 cache key가 항상 설정되도록 보장합니다.
 
-[local model](/docs/models#local)을 구성할 수 있습니다. [더 알아보기](/docs/models).
+[local model](/docs/models#local)도 설정할 수 있습니다. [더 알아보기](/docs/models).
 
 ---
 
-### 공급자 특정 선택권
+#### Provider-Specific Options
 
-몇몇 공급자는 일반적인 `timeout` 및 `apiKey` 조정을 넘어서 추가 구성 선택권을 지원합니다.
+일부 provider는 공통 옵션인 `timeout`, `apiKey` 외에 추가 config 옵션을 지원합니다.
 
-##### 아마존 베드록
+##### Amazon Bedrock
 
-Amazon Bedrock는 AWS 별 구성을 지원합니다:
+Amazon Bedrock은 AWS 전용 config를 지원합니다.
 
 ```json title="opencode.json"
 {
@@ -286,21 +283,21 @@ Amazon Bedrock는 AWS 별 구성을 지원합니다:
 }
 ```
 
-- `region` - Bedrock를 위한 AWS 지역 (`AWS_REGION` env var 또는 `us-east-1`에 기본)
-- `profile` - AWS는 `~/.aws/credentials` (`AWS_PROFILE` env var에 기본)에서 단면도 지명했습니다
-- `endpoint` - VPC 엔드 포인트에 대한 사용자 정의 엔드 포인트 URL. 이것은 AWS 별 용어를 사용하여 일반적인 `baseURL` 옵션에 대한 별명입니다. 둘 다 지정되는 경우에, `endpoint`는 전진합니다.
+- `region` - Bedrock용 AWS 리전(`AWS_REGION` env var 또는 기본값 `us-east-1`)
+- `profile` - `~/.aws/credentials`의 AWS named profile(기본값: `AWS_PROFILE` env var)
+- `endpoint` - VPC endpoint용 custom endpoint URL입니다. AWS 용어를 사용한 일반 `baseURL` 옵션의 별칭(alias)입니다. 둘 다 지정하면 `endpoint`가 우선합니다.
 
 :::note
-Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기반 인증을 통해 우선 순위를 부여합니다. 자세한 내용은 [authentication precedence](/docs/providers#authentication-precedence)를 참조하십시오.
+Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인증보다 우선합니다. 자세한 내용은 [authentication precedence](/docs/providers#authentication-precedence)를 참고하세요.
 :::
 
-[Amazon-bedrock에 대해 자세히 알아보기](/docs/providers#amazon-bedrock).
+[Amazon Bedrock config 더 알아보기](/docs/providers#amazon-bedrock).
 
 ---
 
-## 테마
+### Themes
 
-`theme` 옵션을 통해 opencode config에서 사용하려는 테마를 구성할 수 있습니다.
+`theme` 옵션으로 OpenCode config에서 사용할 theme를 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -313,9 +310,9 @@ Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기
 
 ---
 
-## 에이전트
+### Agents
 
-`agent` 옵션을 통해 특정 작업을 전문 에이전트를 구성할 수 있습니다.
+`agent` 옵션으로 특정 작업용 전문 agent를 구성할 수 있습니다.
 
 ```jsonc title="opencode.jsonc"
 {
@@ -335,13 +332,13 @@ Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기
 }
 ```
 
-`~/.config/opencode/agents/` 또는 `.opencode/agents/`에서 Markdown 파일을 사용하여 에이전트를 정의 할 수 있습니다. [더 알아보기](/docs/시약).
+`~/.config/opencode/agents/` 또는 `.opencode/agents/`의 Markdown 파일로 agent를 정의할 수도 있습니다. [더 알아보기](/docs/agents).
 
 ---
 
-### 기본 에이전트
+### Default agent
 
-`default_agent` 옵션을 사용하여 기본 에이전트를 설정할 수 있습니다. 아무도 명시적으로 지정되지 않을 때 에이전트가 사용되는 결정.
+`default_agent` 옵션으로 기본 agent를 설정할 수 있습니다. 별도 지정이 없을 때 어떤 agent를 사용할지 결정합니다.
 
 ```json title="opencode.json"
 {
@@ -350,15 +347,15 @@ Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기
 }
 ```
 
-기본 에이전트은 주요 에이전트이어야 합니다 (미약 아닙니다). 이것은 `"build"` 또는 `"plan"`, 또는 정의된 [custom 에이전트](./agents) 같이 붙박이 에이전트일 수 있습니다. 지정된 에이전트가 존재하지 않는 경우, opencode는 경고로 `"build"`로 돌아갑니다.
+기본 agent는 primary agent여야 합니다(subagent 불가). `"build"`, `"plan"` 같은 내장 agent나 직접 정의한 [custom agent](/docs/agents)를 지정할 수 있습니다. 지정한 agent가 없거나 subagent이면 OpenCode는 경고와 함께 `"build"`로 fallback합니다.
 
-이 설정은 모든 인터페이스에서 적용됩니다: TUI, CLI (`opencode run`), 데스크탑 앱 및 GitHub Action.
+이 설정은 TUI, CLI(`opencode run`), 데스크톱 앱, GitHub Action 등 모든 인터페이스에 적용됩니다.
 
 ---
 
-## 공유
+### Sharing
 
-`share` 옵션을 통해 [share](/docs/share) 기능을 구성할 수 있습니다.
+`share` 옵션으로 [share](/docs/share) 기능을 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -367,19 +364,19 @@ Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기
 }
 ```
 
-이 소요:
+허용 값:
 
-- `"manual"` - 명령을 통해 수동 공유 허용 (기본값)
-- `"auto"` - 자동 공유 새로운 대화
-- `"disabled"` - 완전하게 공유할 수 있는
+- `"manual"` - 명령으로 수동 공유 허용(기본값)
+- `"auto"` - 새 대화를 자동 공유
+- `"disabled"` - 공유 기능 완전 비활성화
 
-기본적으로 `/share` 명령을 사용하여 대화를 명시적으로 공유해야 할 수동 모드로 설정됩니다.
+기본값은 manual 모드이며, `/share` 명령으로 명시적으로 공유해야 합니다.
 
 ---
 
-## 명령
+### Commands
 
-`command` 옵션을 통해 반복 작업을 위한 사용자 지정 명령을 구성할 수 있습니다.
+`command` 옵션으로 반복 작업용 custom command를 구성할 수 있습니다.
 
 ```jsonc title="opencode.jsonc"
 {
@@ -399,13 +396,13 @@ Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기
 }
 ```
 
-`~/.config/opencode/commands/` 또는 `.opencode/commands/`에서 Markdown 파일을 사용하여 명령을 정의 할 수 있습니다. [더 이상](/docs/commands).
+`~/.config/opencode/commands/` 또는 `.opencode/commands/`의 Markdown 파일로 command를 정의할 수도 있습니다. [더 알아보기](/docs/commands).
 
 ---
 
-## 키빈드
+### Keybinds
 
-`keybinds` 옵션을 통해 keybinds를 사용자 정의 할 수 있습니다.
+`keybinds` 옵션으로 keybind를 커스터마이즈할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -418,9 +415,9 @@ Bearer 토큰 (`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 프로파일 기
 
 ---
 
-## 자동 업데이트
+### Autoupdate
 
-opencode는 자동으로 시작될 때 새로운 업데이트를 다운로드합니다. `autoupdate` 옵션으로 이것을 비활성화 할 수 있습니다.
+OpenCode는 시작 시 새 업데이트를 자동으로 다운로드합니다. `autoupdate` 옵션으로 비활성화할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -429,14 +426,14 @@ opencode는 자동으로 시작될 때 새로운 업데이트를 다운로드합
 }
 ```
 
-업데이트를 원하지 않으면 새로운 버전이 사용할 수있을 때 알림을하고 `autoupdate`를 `"notify"`로 설정하십시오.
-Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경우에만 작동합니다.
+업데이트를 자동 적용하지 않고 새 버전 알림만 받고 싶다면 `autoupdate`를 `"notify"`로 설정하세요.
+이 옵션은 Homebrew 같은 패키지 매니저로 설치하지 않은 경우에만 동작합니다.
 
 ---
 
-## 형식
+### Formatters
 
-`formatter` 옵션을 통해 코드 형식기를 구성할 수 있습니다.
+`formatter` 옵션으로 코드 formatter를 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -456,15 +453,15 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-[출판자에 대해 자세히 알아보기](/docs/formatters).
+[formatter에 대해 더 알아보기](/docs/formatters).
 
 ---
 
-## # 권한
+### Permissions
 
-기본적으로, opencode ** 명시된 승인 없이 모든 작업**을 허용한다. `permission` 옵션을 사용하여 이것을 변경할 수 있습니다.
+기본적으로 OpenCode는 **명시적 승인 없이 모든 작업을 허용**합니다. `permission` 옵션으로 이 동작을 바꿀 수 있습니다.
 
-예를 들어, `edit` 및 `bash` 도구가 사용자 승인을 요구합니다.
+예를 들어 `edit`, `bash` tool이 사용자 승인을 요구하게 하려면:
 
 ```json title="opencode.json"
 {
@@ -476,32 +473,34 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-[이 권한에 대해 더 알아보기](/docs/permissions).
+[permission에 대해 더 알아보기](/docs/permissions).
 
 ---
 
-### 압축
+### Compaction
 
-`compaction` 옵션을 통해 컨텍스트 압축 동작을 제어할 수 있습니다.
+`compaction` 옵션으로 context compaction 동작을 제어할 수 있습니다.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
   "compaction": {
     "auto": true,
-    "prune": true
+    "prune": true,
+    "reserved": 10000
   }
 }
 ```
 
-- `auto` - 컨텍스트가 풀 때 자동으로 세션을 압축합니다 (기본: `true`).
-- `prune` - 토큰을 저장하기 위해 오래된 도구 출력을 제거 (기본: `true`).
+- `auto` - context가 가득 찼을 때 세션을 자동 compact합니다(기본값: `true`).
+- `prune` - token 절약을 위해 오래된 tool 출력을 제거합니다(기본값: `true`).
+- `reserved` - compaction용 token buffer입니다. compaction 중 overflow가 나지 않도록 충분한 window를 남깁니다.
 
 ---
 
-### 시계
+### Watcher
 
-`watcher` 옵션을 통해 파일워커가 패턴을 무시할 수 있습니다.
+`watcher` 옵션으로 파일 watcher ignore 패턴을 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -512,13 +511,13 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-패턴은 glob 구문을 따릅니다. 이 파일을 보시려면 noisy 디렉토리를 제외하십시오.
+패턴은 glob 문법을 따릅니다. 파일 감시에서 노이즈가 많은 디렉토리를 제외할 때 유용합니다.
 
 ---
 
-### MCP 서버
+### MCP servers
 
-`mcp` 옵션을 통해 사용하려는 MCP 서버를 구성할 수 있습니다.
+`mcp` 옵션으로 사용할 MCP server를 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -527,15 +526,15 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-[더 이상](/docs/mcp-servers).
+[더 알아보기](/docs/mcp-servers).
 
 ---
 
-### 플러그인
+### Plugins
 
-[Plugins](/docs/plugins)는 사용자 정의 도구, 후크 및 통합으로 opencode를 확장합니다.
+[Plugins](/docs/plugins)는 custom tool, hook, integration으로 OpenCode를 확장합니다.
 
-`.opencode/plugins/` 또는 `~/.config/opencode/plugins/`에서 플러그인 파일을 배치하십시오. `plugin` 옵션을 통해 npm에서 플러그인을로드 할 수 있습니다.
+plugin 파일은 `.opencode/plugins/` 또는 `~/.config/opencode/plugins/`에 두세요. `plugin` 옵션으로 npm plugin을 로드할 수도 있습니다.
 
 ```json title="opencode.json"
 {
@@ -544,13 +543,13 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-[더 이상](/docs/plugins).
+[더 알아보기](/docs/plugins).
 
 ---
 
-### 지시
+### Instructions
 
-`instructions` 옵션을 통해 사용할 모델에 대한 지침을 구성할 수 있습니다.
+`instructions` 옵션으로 사용 중인 model에 제공할 지침 파일을 설정할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -559,14 +558,13 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-이 경로와 glob 패턴의 배열을 사용하여 명령 파일. [더 알아보기
-여기 규칙에 관하여](./rules).
+이 옵션은 지침 파일 경로 및 glob 패턴 배열을 받습니다. [rules에 대해 더 알아보기](/docs/rules).
 
 ---
 
-## Disabled 공급자
+### Disabled providers
 
-`disabled_providers` 옵션을 통해 자동으로 로드된 공급자를 비활성화할 수 있습니다. 이것은 당신이 그들의 credentials가 유효하다하더라도 적재되는에서 특정 공급자를 방지할 때 유용합니다.
+`disabled_providers` 옵션으로 자동 로드되는 provider를 비활성화할 수 있습니다. credential이 있어도 특정 provider를 로드하지 않게 하고 싶을 때 유용합니다.
 
 ```json title="opencode.json"
 {
@@ -576,20 +574,20 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 ```
 
 :::note
-`disabled_providers`는 `enabled_providers`에 우선권을 가지고 있습니다.
+`disabled_providers`는 `enabled_providers`보다 우선합니다.
 :::
 
-`disabled_providers` 옵션은 공급자 ID의 배열을 허용합니다. 공급자가 비활성화되면:
+`disabled_providers`는 provider ID 배열을 받습니다. provider가 비활성화되면:
 
-- 환경 변수가 설정된 경우에도 로드되지 않습니다.
-- API 키가 `/connect` 명령을 통해 구성되는 경우에도로드되지 않습니다.
-- 공급자의 모델은 모델 선택 목록에 표시되지 않습니다.
+- 환경 변수가 설정되어 있어도 로드되지 않습니다.
+- `/connect` 명령으로 API key를 설정해도 로드되지 않습니다.
+- 해당 provider의 model은 model 선택 목록에 표시되지 않습니다.
 
 ---
 
-### Enabled 공급자
+### Enabled providers
 
-`enabled_providers` 옵션을 통해 공급자의 수당을 지정할 수 있습니다. 설정할 때 지정된 공급자만이 활성화되고 다른 모든 사람들이 무시됩니다.
+`enabled_providers` 옵션으로 provider allowlist를 지정할 수 있습니다. 이 값을 설정하면 지정한 provider만 활성화되고 나머지는 무시됩니다.
 
 ```json title="opencode.json"
 {
@@ -598,19 +596,19 @@ Homebrew와 같은 패키지 관리자를 사용하여 설치되지 않은 경�
 }
 ```
 
-opencode를 제한 할 때 유용합니다. 특정 공급자를 사용하지 않도록하십시오.
+provider를 하나씩 비활성화하는 대신, OpenCode가 특정 provider만 사용하도록 제한하고 싶을 때 유용합니다.
 
 :::note
-`disabled_providers`는 `enabled_providers`에 우선권을 가지고 있습니다.
+`disabled_providers`는 `enabled_providers`보다 우선합니다.
 :::
 
-공급자가 `enabled_providers`와 `disabled_providers` 둘 다에서 나타나면, `disabled_providers`는 뒤에 오는 겸용성을 위한 우선권을 가지고 갑니다.
+동일 provider가 `enabled_providers`와 `disabled_providers`에 모두 있으면 하위 호환성을 위해 `disabled_providers`가 우선합니다.
 
 ---
 
-### 실험
+### Experimental
 
-`experimental` 열쇠는 활동적인 발달의 밑에 있는 선택권을 포함합니다.
+`experimental` key에는 현재 활발히 개발 중인 옵션이 포함됩니다.
 
 ```json title="opencode.json"
 {
@@ -620,20 +618,20 @@ opencode를 제한 할 때 유용합니다. 특정 공급자를 사용하지 않
 ```
 
 :::caution
-실험 옵션은 안정되지 않습니다. 그들은 예고없이 변경하거나 제거 할 수 있습니다.
+experimental 옵션은 안정적이지 않습니다. 예고 없이 변경되거나 제거될 수 있습니다.
 :::
 
 ---
 
-## 변수
+## Variables
 
-config 파일에서 참조 환경 변수 및 파일 내용에 대한 변수 대변을 사용할 수 있습니다.
+config 파일에서 환경 변수와 파일 내용을 참조할 수 있도록 변수 치환을 사용할 수 있습니다.
 
 ---
 
-##### Env 바
+### Env vars
 
-`{env:VARIABLE_NAME}`를 사용하여 환경 변수를 대체합니다.
+`{env:VARIABLE_NAME}` 형식으로 환경 변수를 치환할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -650,13 +648,13 @@ config 파일에서 참조 환경 변수 및 파일 내용에 대한 변수 대�
 }
 ```
 
-환경 변수가 설정되지 않으면 빈 문자열로 대체됩니다.
+환경 변수가 설정되지 않았으면 빈 문자열로 치환됩니다.
 
 ---
 
-## 파일
+### Files
 
-`{file:path/to/file}`를 사용하여 파일의 내용을 대체합니다.
+`{file:path/to/file}` 형식으로 파일 내용을 치환할 수 있습니다.
 
 ```json title="opencode.json"
 {
@@ -672,13 +670,13 @@ config 파일에서 참조 환경 변수 및 파일 내용에 대한 변수 대�
 }
 ```
 
-파일 경로는:
+파일 경로는 다음을 지원합니다.
 
-- config 파일 디렉토리에 관계
-- 또는 `/` 또는 `~`로 시작하는 절대 경로
+- config 파일 디렉토리 기준 상대 경로
+- `/` 또는 `~`로 시작하는 절대 경로
 
-이것들은 유용하다:
+이 기능은 다음 상황에 유용합니다.
 
-- 별도의 파일에서 API 키와 같은 민감한 데이터를 유지.
-- config를 cluttering하지 않고 큰 명령어 파일을 포함합니다.
-- 여러 구성 파일에서 공통 구성 스니펫 공유.
+- API key 같은 민감 정보를 별도 파일로 분리
+- 큰 지침 파일을 config를 복잡하게 만들지 않고 포함
+- 여러 config 파일에서 공통 설정 스니펫 재사용

--- a/packages/web/src/content/docs/ko/custom-tools.mdx
+++ b/packages/web/src/content/docs/ko/custom-tools.mdx
@@ -1,30 +1,30 @@
 ---
 title: Custom Tools
-description: Create tools the LLM can call in opencode.
+description: Create tools the LLM can call in OpenCode.
 ---
 
-사용자 정의 도구는 LLM이 대화 중에 호출 할 수있는 기능을 만듭니다. 그들은 `read`, `write` 및 `bash`와 같은 opencode의 [붙박이 도구](./tools)와 함께 작동합니다.
+custom tool은 대화 중 LLM이 호출할 수 있도록 사용자가 직접 만든 함수입니다. `read`, `write`, `bash` 같은 OpenCode의 [built-in tools](/docs/tools)와 함께 동작합니다.
 
 ---
 
 ## 도구 만들기
 
-도구는 **TypeScript** 또는 **JavaScript** 파일로 정의됩니다. 그러나 도구 정의는 ** 어떤 언어로 작성된 스크립트를 호출 할 수 있습니다 ** - TypeScript 또는 JavaScript는 도구 정의 자체에서만 사용됩니다.
+tool은 **TypeScript** 또는 **JavaScript** 파일로 정의합니다. 다만 tool 정의에서 호출하는 스크립트는 **어떤 언어든** 사용할 수 있습니다. 즉, TypeScript/JavaScript는 tool 정의 자체에만 필요합니다.
 
 ---
 
-## 위치
+### 위치
 
-그들은 정의 할 수 있습니다:
+tool은 다음 위치에 둘 수 있습니다.
 
-- 프로젝트의 `.opencode/tools/` 디렉토리에 배치하여 로컬.
-- 또는 전 세계적으로 `~/.config/opencode/tools/`에 배치하여.
+- 프로젝트의 `.opencode/tools/` 디렉토리(로컬)
+- `~/.config/opencode/tools/` 디렉토리(전역)
 
 ---
 
-## 구조
+### 구조
 
-도구를 만드는 가장 쉬운 방법은 `tool()` helper를 사용하여 유형 안전 및 검증을 제공합니다.
+tool을 가장 쉽게 만드는 방법은 타입 안정성과 validation을 제공하는 `tool()` helper를 사용하는 것입니다.
 
 ```ts title=".opencode/tools/database.ts" {1}
 import { tool } from "@opencode-ai/plugin"
@@ -41,13 +41,13 @@ export default tool({
 })
 ```
 
-**파일 이름**는 **tool name**가 됩니다. 위는 `database` 공구를 만듭니다.
+**파일 이름**이 **tool 이름**이 됩니다. 위 예시는 `database` tool을 생성합니다.
 
 ---
 
-### 파일 당 다수 공구
+#### 파일 하나에 여러 tool 정의
 
-단일 파일에서 여러 도구를 수출할 수 있습니다. 각 수출은 ** 별도의 도구 ** 이름 ** `<filename>_<exportname>`**:
+하나의 파일에서 여러 tool을 export할 수도 있습니다. 각 export는 **별도의 tool**이 되며 이름은 **`<filename>_<exportname>`** 형식을 사용합니다.
 
 ```ts title=".opencode/tools/math.ts"
 import { tool } from "@opencode-ai/plugin"
@@ -75,13 +75,13 @@ export const multiply = tool({
 })
 ```
 
-이것은 2개의 공구를 만듭니다: `math_add`와 `math_multiply`.
+이 경우 `math_add`, `math_multiply` 두 tool이 생성됩니다.
 
 ---
 
-#### 가격
+### 인자
 
-`tool.schema`를 사용할 수 있습니다, 그냥 [Zod](https://zod.dev), 인수 유형을 정의합니다.
+인자 타입은 `tool.schema`로 정의할 수 있습니다. `tool.schema`는 [Zod](https://zod.dev) 기반입니다.
 
 ```ts "tool.schema"
 args: {
@@ -89,7 +89,7 @@ args: {
 }
 ```
 
-[Zod](https://zod.dev)를 직접 가져오고 일반 객체를 반환할 수 있습니다.
+[Zod](https://zod.dev)를 직접 import해서 일반 객체를 반환하는 방식도 사용할 수 있습니다.
 
 ```ts {6}
 import { z } from "zod"
@@ -108,9 +108,9 @@ export default {
 
 ---
 
-### 텍스트
+### Context
 
-도구는 현재 세션에 대한 컨텍스트를받습니다.
+tool은 현재 세션의 context 정보를 전달받습니다.
 
 ```ts title=".opencode/tools/project.ts" {8}
 import { tool } from "@opencode-ai/plugin"
@@ -126,18 +126,18 @@ export default tool({
 })
 ```
 
-세션 작업 디렉토리에 `context.directory`를 사용합니다.
-git worktree 루트에 `context.worktree`를 사용합니다.
+세션 작업 디렉토리는 `context.directory`를 사용하세요.
+git worktree 루트는 `context.worktree`를 사용하세요.
 
 ---
 
-## 예제
+## 예시
 
-### Python 도구 작성
+### Python으로 tool 작성
 
-원하는 모든 언어로 도구를 쓸 수 있습니다. 여기에 Python을 사용하여 두 개의 숫자를 추가하는 예입니다.
+tool은 원하는 언어로 작성할 수 있습니다. 아래는 Python으로 두 숫자를 더하는 예시입니다.
 
-먼저 Python 스크립트로 도구를 만듭니다.
+먼저 Python 스크립트로 tool을 만듭니다.
 
 ```python title=".opencode/tools/add.py"
 import sys
@@ -147,7 +147,7 @@ b = int(sys.argv[2])
 print(a + b)
 ```
 
-그런 다음 도구 정의를 만듭니다.
+그다음 이 스크립트를 호출하는 tool 정의를 만듭니다.
 
 ```ts title=".opencode/tools/python-add.ts" {10}
 import { tool } from "@opencode-ai/plugin"
@@ -167,4 +167,4 @@ export default tool({
 })
 ```
 
-여기에 우리는 [`Bun.$`](https://bun.com/docs/runtime/shell) 유틸리티를 사용하여 Python 스크립트를 실행합니다.
+여기서는 Python 스크립트를 실행하기 위해 [`Bun.$`](https://bun.com/docs/runtime/shell) 유틸리티를 사용합니다.

--- a/packages/web/src/content/docs/ko/index.mdx
+++ b/packages/web/src/content/docs/ko/index.mdx
@@ -7,40 +7,39 @@ import { Tabs, TabItem } from "@astrojs/starlight/components"
 import config from "../../../../config.mjs"
 export const console = config.console
 
-[**OpenCode**](/)는 오픈 소스 AI 코딩 에이전트입니다. terminal 기반 인터페이스, 데스크탑 앱 또는 IDE 확장으로 사용할 수 있습니다.
+[**OpenCode**](/)는 터미널 기반 인터페이스, 데스크톱 앱, IDE 확장 형태로 사용할 수 있는 오픈 소스 AI 코딩 에이전트입니다.
 
 ![opencode TUI with the opencode theme](../../../assets/lander/screenshot.png)
 
-시작합시다.
+바로 시작해 봅시다.
 
 ---
 
-### 필수품
+#### 사전 준비
 
-당신의 terminal에 있는 OpenCode를 사용하려면, 당신은 필요로 할 것입니다:
+터미널에서 OpenCode를 사용하려면 다음이 필요합니다.
 
-1. 현대 terminal 에뮬레이터는 좋아합니다:
+1. 최신 터미널 에뮬레이터(예:)
+   - [WezTerm](https://wezterm.org), 크로스 플랫폼
+   - [Alacritty](https://alacritty.org), 크로스 플랫폼
+   - [Ghostty](https://ghostty.org), Linux 및 macOS
+   - [Kitty](https://sw.kovidgoyal.net/kitty/), Linux 및 macOS
 
-- [WezTerm](https://wezterm.org), 크로스 플랫폼
-- [Alacritty](https://alacritty.org), 크로스 플랫폼
-- [Ghostty](https://ghostty.org), 리눅스 및 macOS
-- [Kitty](https://sw.kovidgoyal.net/kitty/), 리눅스 및 macOS
-
-2. 사용하려는 LLM 공급자를 위한 API 키.
+2. 사용할 LLM 제공자의 API 키
 
 ---
 
 ## 설치
 
-OpenCode를 설치하는 가장 쉬운 방법은 설치 스크립트를 통해 입니다.
+가장 쉬운 설치 방법은 설치 스크립트를 사용하는 것입니다.
 
 ```bash
 curl -fsSL https://opencode.ai/install | bash
 ```
 
-다음 명령으로 설치할 수도 있습니다:
+아래 명령으로도 설치할 수 있습니다.
 
-- ** Node.js** 사용
+- **Node.js 사용**
 
         <Tabs>
 
@@ -74,79 +73,78 @@ curl -fsSL https://opencode.ai/install | bash
 
   </Tabs>
 
-- ** macOS 및 Linux에서 Homebrew 사용 **
+- **macOS/Linux에서 Homebrew 사용**
 
   ```bash
   brew install anomalyco/tap/opencode
   ```
 
-> 최신 릴리스를 위해 OpenCode 탭을 사용하는 것이 좋습니다. 공식 `brew install opencode` 공식은 Homebrew 팀에 의해 유지되고 더 자주 업데이트됩니다.
+  > 최신 릴리스는 OpenCode tap 사용을 권장합니다. 공식 `brew install opencode` 포뮬러는 Homebrew 팀이 관리하므로 업데이트 주기가 더 긴 편입니다.
 
-- **Arch Linux에서 Paru를 사용 **
+- **Arch Linux에서 Paru 사용**
 
   ```bash
   paru -S opencode-bin
   ```
 
-#### 윈도우
+#### Windows
 
-:::tip[추천: WSL 사용]
-Windows에서 최고의 경험을 위해 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl)를 사용하는 것이 좋습니다. OpenCode의 기능으로 더 나은 성능과 전체 호환성을 제공합니다.
+:::tip[권장: WSL 사용]
+Windows에서는 [Windows Subsystem for Linux (WSL)](/docs/windows-wsl)을 사용하는 것이 가장 좋습니다. OpenCode 기능과의 호환성이 높고 성능도 더 좋습니다.
 :::
 
-- ** Chocolatey **
+- **Chocolatey 사용**
 
   ```bash
   choco install opencode
   ```
 
-- ** Scoop를 사용 **
+- **Scoop 사용**
 
   ```bash
   scoop install opencode
   ```
 
-- ** npm **
+- **NPM 사용**
 
   ```bash
   npm install -g opencode-ai
   ```
 
-- **Mise**
+- **Mise 사용**
 
   ```bash
   mise use -g github:anomalyco/opencode
   ```
 
-- ** Docker 사용**
+- **Docker 사용**
 
   ```bash
   docker run -it --rm ghcr.io/anomalyco/opencode
   ```
 
-Bun을 사용하여 Windows에서 OpenCode 설치 지원은 현재 진행 중입니다.
+Windows에서 Bun을 통한 OpenCode 설치는 아직 지원되지 않으며, 현재 지원을 준비 중입니다.
 
-[Releases](https://github.com/anomalyco/opencode/releases)에서 이진을 할 수도 있습니다.
+[Releases](https://github.com/anomalyco/opencode/releases)에서 바이너리를 직접 받아 설치할 수도 있습니다.
 
 ---
 
 ## 구성
 
-OpenCode를 사용하면 API 키를 구성하여 LLM 공급자를 사용할 수 있습니다.
+OpenCode는 API 키를 설정하면 원하는 LLM 제공자를 사용할 수 있습니다.
 
-LLM 공급자를 사용하는 새로운 경우, [OpenCode Zen](/docs/zen)를 사용하는 것이 좋습니다.
-OpenCode에 의해 테스트 및 확인 된 모델의 큐레이터 목록입니다.
-팀.
+LLM 제공자(LLM Provider)를 처음 사용한다면 [OpenCode Zen](/docs/zen)을 추천합니다.
+OpenCode 팀이 테스트하고 검증한 모델 목록입니다.
 
-1. TUI에서 `/connect` 명령을 실행하고, opencode를 선택하고, [opencode.ai/auth](https://opencode.ai/auth)에 머리를 선택합니다.
+1. TUI에서 `/connect` 명령을 실행한 뒤 `opencode`를 선택하고 [opencode.ai/auth](https://opencode.ai/auth)로 이동합니다.
 
    ```txt
    /connect
    ```
 
-2. 로그인, 청구 세부 정보를 추가하고 API 키를 복사하십시오.
+2. 로그인 후 결제 정보를 입력하고 API 키를 복사합니다.
 
-3. API 키를 붙여.
+3. API 키를 붙여 넣습니다.
 
    ```txt
    ┌ API key
@@ -155,85 +153,79 @@ OpenCode에 의해 테스트 및 확인 된 모델의 큐레이터 목록입니�
    └ enter
    ```
 
-158| 또는 다른 공급자 중 하나를 선택할 수 있습니다. [더 알아보기](/docs/providers#directory).
+다른 제공자를 선택해도 됩니다. [더 알아보기](/docs/providers#directory).
 
 ---
 
 ## 초기화
 
-이제 공급자를 구성했습니다. 프로젝트로 이동할 수 있습니다.
-일하고 싶습니다.
+이제 제공자 구성이 끝났으니, 작업할 프로젝트 디렉터리로 이동합니다.
 
 ```bash
 cd /path/to/project
 ```
 
-OpenCode를 실행합니다.
+그리고 OpenCode를 실행합니다.
 
 ```bash
 opencode
 ```
 
-다음, 다음 명령을 실행하여 프로젝트의 OpenCode를 초기화합니다.
+다음 명령으로 프로젝트용 OpenCode 초기화를 진행합니다.
 
 ```bash frame="none"
 /init
 ```
 
-OpenCode를 사용하여 프로젝트를 분석하고 `AGENTS.md` 파일을 만들 수 있습니다.
-프로젝트 루트.
+이 명령은 프로젝트를 분석하고 루트에 `AGENTS.md` 파일을 생성합니다.
 
 :::tip
-프로젝트의 `AGENTS.md` 파일을 Git에 투입해야 합니다.
+프로젝트의 `AGENTS.md`는 Git에 커밋해 두는 것을 권장합니다.
 :::
 
-이 도움말 OpenCode는 프로젝트 구조와 코딩 패턴을 이해
-사용.
+그러면 OpenCode가 프로젝트 구조와 코딩 패턴을 더 잘 이해할 수 있습니다.
 
 ---
 
 ## 사용법
 
-OpenCode를 사용하여 프로젝트에 작업할 준비가 되어 있습니다. 자주 묻는 질문
-모두!
+이제 OpenCode로 프로젝트 작업을 시작할 준비가 되었습니다. 무엇이든 물어보세요.
 
-AI 코딩 에이전트를 사용하는 새로운 경우, 여기에 할 수있는 몇 가지 예입니다
-도움.
+AI 코딩 에이전트를 처음 쓰는 경우 도움이 되는 예시를 소개합니다.
 
 ---
 
-## 질문
+### 질문하기
 
-Codebase를 설명하기 위해 OpenCode를 요청할 수 있습니다.
+OpenCode에 코드베이스 설명을 요청할 수 있습니다.
 
 :::tip
-`@` 키를 사용하여 프로젝트에서 파일을 검색합니다.
+프로젝트 파일은 `@` 키로 퍼지 검색할 수 있습니다.
 :::
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 How is authentication handled in @packages/functions/src/api/index.ts
 ```
 
-이것은 당신이 작동하지 않은 코드베이스의 일부가 있다면 도움이된다.
+직접 작업하지 않은 코드 영역을 이해할 때 특히 유용합니다.
 
 ---
 
-### 추가 기능
+### 기능 추가
 
-프로젝트에 새로운 기능을 추가하려면 OpenCode를 요청할 수 있습니다. 우리는 먼저 계획을 만들 것을 묻는 것이 좋습니다.
+프로젝트에 새 기능을 추가해 달라고 요청할 수 있습니다. 다만 먼저 계획을 만들게 하는 것을 권장합니다.
 
-1. **플랜을 선택 **
+1. **계획 만들기**
 
-   OpenCode는 Plan mode 로 변경할 수 있는 능력을 비활성화하고
-   대신 제안 how 그것은 기능을 구현할 것입니다.
+   OpenCode에는 변경 작업을 비활성화하고 구현 방법을 제안만 하는 _Plan mode_가 있습니다.
 
-   **Tab** 키를 사용하여 전환합니다. 오른쪽 하단에 있는 이 지표를 볼 수 있습니다.
+   **Tab** 키로 전환하면 오른쪽 아래에 모드 표시가 나타납니다.
 
    ```bash frame="none" title="Switch to Plan mode"
    <TAB>
    ```
 
-   이제 우리가해야 할 일을 설명합니다.
+   이제 원하는 작업을 구체적으로 설명합니다.
 
    ```txt frame="none"
    When a user deletes a note, we'd like to flag it as deleted in the database.
@@ -241,17 +233,15 @@ How is authentication handled in @packages/functions/src/api/index.ts
    From this screen, the user can undelete a note or permanently delete it.
    ```
 
-   당신이 원하는 것을 이해하기 위해 OpenCode를 충분히 세부 정보를 제공하려는. 그것은 도움
-   팀의 주니어 개발자에게 이야기하고 싶습니다.
+   OpenCode가 정확히 이해할 만큼 충분한 맥락을 주는 것이 중요합니다. 팀의 주니어 개발자에게 설명하듯 요청하면 도움이 됩니다.
 
    :::tip
-   OpenCode를 많은 컨텍스트와 예제를 제공하여 당신이 무엇을 이해하는 데 도움이
-   이름 \*
+   맥락과 예시를 충분히 제공하면 원하는 결과를 얻기 쉽습니다.
    :::
 
-2. **플랜에 대해서 **
+2. **계획 다듬기**
 
-   플랜을 제공하면 피드백을 제공하거나 자세한 내용을 추가 할 수 있습니다.
+   계획이 나오면 피드백을 주거나 추가 요구사항을 붙일 수 있습니다.
 
    ```txt frame="none"
    We'd like to design this new screen using a design I've used before.
@@ -259,22 +249,20 @@ How is authentication handled in @packages/functions/src/api/index.ts
    ```
 
    :::tip
-   단말에 이미지를 드래그하고 드롭하여 프롬프트에 추가합니다.
+   이미지를 터미널에 드래그 앤 드롭하면 프롬프트에 첨부할 수 있습니다.
    :::
 
-   OpenCode는 어떤 이미지를 스캔할 수 있습니다. 당신은 할 수
-   이 작업을 수행하고 끝으로 이미지를 삭제합니다.
+   OpenCode는 첨부한 이미지를 분석해 프롬프트에 포함합니다.
 
-3. ** 기능 구축 **
+3. **기능 구현**
 
-   플랜으로 편안하게 느끼면 Build mode by
-   **Tab** 키를 다시 입력합니다.
+   계획이 충분히 만족스러우면 **Tab** 키를 다시 눌러 _Build mode_로 돌아갑니다.
 
    ```bash frame="none"
    <TAB>
    ```
 
-   그리고 변경을 요청합니다.
+   그리고 실제 변경을 요청합니다.
 
    ```bash frame="none"
    Sounds good! Go ahead and make the changes.
@@ -282,10 +270,9 @@ How is authentication handled in @packages/functions/src/api/index.ts
 
 ---
 
-### 변경
+### 바로 변경하기
 
-더 똑바른 변화를 위해, 당신은 OpenCode를 직접 그것을 건설할 수 있습니다
-첫 플랜을 검토하지 않고.
+비교적 단순한 변경은 계획 검토 없이 바로 구현하도록 요청해도 됩니다.
 
 ```txt frame="none" "@packages/functions/src/settings.ts" "@packages/functions/src/notes.ts"
 We need to add authentication to the /settings route. Take a look at how this is
@@ -293,40 +280,37 @@ handled in the /notes route in @packages/functions/src/notes.ts and implement
 the same logic in @packages/functions/src/settings.ts
 ```
 
-좋은 양의 세부 사항을 제공 하려면 OpenCode가 올바른
-이름 \*
+원하는 변경이 정확히 반영되도록, 필요한 맥락을 충분히 제공하세요.
 
 ---
 
-### Undo 변경
+### 변경 되돌리기
 
-OpenCode를 호출하면 변경 사항을 만들 수 있습니다.
+예를 들어 OpenCode에 변경을 요청했다고 가정해 보겠습니다.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-그러나 당신이 원하는 것은 아닙니다. ** 변경할 수 없습니다 **
-`/undo` 명령을 사용하여.
+결과가 기대와 다르면 `/undo` 명령으로 **되돌릴 수** 있습니다.
 
 ```bash frame="none"
 /undo
 ```
 
-OpenCode는 이제 당신이 만든 변경을 반전하고 원래 메시지를 표시
-다시.
+OpenCode는 방금 적용한 변경을 되돌리고 원래 메시지를 다시 보여줍니다.
 
 ```txt frame="none" "@packages/functions/src/api/index.ts"
 Can you refactor the function in @packages/functions/src/api/index.ts?
 ```
 
-여기에서 당신은 신속하고 다시 시도 OpenCode를 요청할 수 있습니다.
+이 상태에서 프롬프트를 다듬어 다시 시도하면 됩니다.
 
 :::tip
-`/undo`를 여러 번 실행할 수 있습니다.
+`/undo`는 여러 번 연속으로 실행할 수 있습니다.
 :::
 
-또는 \*\* `/redo` 명령을 사용하여 변경할 수 있습니다.
+반대로 `/redo` 명령으로 **다시 적용**할 수도 있습니다.
 
 ```bash frame="none"
 /redo
@@ -336,24 +320,24 @@ Can you refactor the function in @packages/functions/src/api/index.ts?
 
 ## 공유
 
-opencode와 나눈 대화는 [팀과 공유](/docs/share)할 수 있습니다.
+OpenCode와의 대화는 [팀과 공유](/docs/share)할 수 있습니다.
 
 ```bash frame="none"
 /share
 ```
 
-현재 대화에 대한 링크를 만들고 클립보드에 복사합니다.
+현재 대화 링크를 생성하고 클립보드에 복사합니다.
 
 :::note
-대화는 기본적으로 공유되지 않습니다.
+대화는 기본값으로 공유되지 않습니다.
 :::
 
-여기 [example 대화](https://opencode.ai/s/4XP1fce5) 는 opencode 입니다.
+아래는 OpenCode [대화 예시](https://opencode.ai/s/4XP1fce5)입니다.
 
 ---
 
-## 사용자 정의
+## 커스터마이즈
 
-그리고 그게 다야! 이제 opencode를 사용하여 프로입니다.
+이제 OpenCode 사용의 기본은 끝났습니다.
 
-자신의 것을 만들기 위해, 우리는 [themes](/docs/themes), [keybinds](/docs/keybinds), [configuring code formatters](/docs/formatters), [creating custom commands](/docs/commands), 또는 [opencode config](/docs/config)와 함께 연주하는 것을 추천합니다.
+자신의 워크플로우에 맞추려면 [테마 선택](/docs/themes), [키바인드 커스터마이즈](/docs/keybinds), [코드 포매터 설정](/docs/formatters), [커스텀 명령 작성](/docs/commands), [OpenCode config 조정](/docs/config)을 추천합니다.


### PR DESCRIPTION
Fixes #13440

### What does this PR do?
This PR improves wording quality in four Korean docs pages:
- ko/acp.mdx
- ko/agents.mdx
- ko/config.mdx
- ko/custom-tools.mdx

These pages had several literal translations that made parts of the docs awkward to read.
I rewrote phrasing to sound natural in Korean while preserving technical meaning and structure.
I only changed documentation wording and consistency (tone/terminology), and kept commands, links, code blocks, and headings intact.

### How did you verify your code works?
- Reviewed each file diff against the English source docs.
- Checked MDX structure integrity (frontmatter, headings, code blocks, links).
- Confirmed this PR is docs-only and does not change runtime behavior.