### PR TITLE
fix(opencode): fix Clojure syntax highlighting

### DIFF
--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -214,7 +214,7 @@ export default {
     },
     {
       filetype: "clojure",
-      wasm: "https://github.com/sogaiu/tree-sitter-clojure/releases/download/v0.0.13/tree-sitter-clojure.wasm",
+      wasm: "https://github.com/anomalyco/tree-sitter-clojure/releases/download/v0.0.14/tree-sitter-clojure.wasm",
       queries: {
         highlights: [
           "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/clojure/highlights.scm",

--- a/packages/opencode/parsers-config.ts
+++ b/packages/opencode/parsers-config.ts
@@ -214,7 +214,8 @@ export default {
     },
     {
       filetype: "clojure",
-      wasm: "https://github.com/anomalyco/tree-sitter-clojure/releases/download/v0.0.14/tree-sitter-clojure.wasm",
+      // temporarily using fork to fix issues
+      wasm: "https://github.com/anomalyco/tree-sitter-clojure/releases/download/v0.0.1/tree-sitter-clojure.wasm",
       queries: {
         highlights: [
           "https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/refs/heads/master/queries/clojure/highlights.scm",


### PR DESCRIPTION
### What does this PR do?

Clojure syntax highlighting hasn't been working even though the feature was requested in #3926 and, later, added in #3912. This is due to the original feature PR referencing a nonexistent WASM artifact that was expected to be hosted and provided in [the repo](https://github.com/sogaiu/tree-sitter-clojure), that hosts the Clojure tree-sitter grammar and parser sources but doesn't provide such artifacts.

This PR fixes this by switching to using an auto-generated WASM artifact (using the official and shared tree-sitter GitHub Actions workflows) hosted and provided in [my own repo](https://github.com/finalfantasia/tree-sitter-clojure) forked from [the original](https://github.com/sogaiu/tree-sitter-clojure). 

Fixes #11279.

### How did you verify your code works?

#### BEFORE

<img width="1512" height="949" alt="Screenshot 2026-02-13 at 9 21 54 AM" src="https://github.com/user-attachments/assets/21ce9a90-8877-48f0-b3ed-880259bd1406" />

#### AFTER

<img width="1512" height="949" alt="Screenshot 2026-02-13 at 9 22 37 AM" src="https://github.com/user-attachments/assets/fb65fc6b-08ff-4561-b394-5d29cebf416c" />
