### PR TITLE
feat: enable 1M context window for Anthropic Claude models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -96,7 +96,7 @@ export namespace Provider {
         options: {
           headers: {
             "anthropic-beta":
-              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14",
+              "claude-code-20250219,interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,context-1m-2025-08-07",
           },
         },
       }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -461,7 +461,7 @@ export namespace ProviderTransform {
 
         if (model.api.id.includes("opus-4-6") || model.api.id.includes("opus-4.6")) {
           const efforts = ["low", "medium", "high", "max"]
-          return Object.fromEntries(
+          const thinkingVariants = Object.fromEntries(
             efforts.map((effort) => [
               effort,
               {
@@ -472,6 +472,15 @@ export namespace ProviderTransform {
               },
             ]),
           )
+          return {
+            ...thinkingVariants,
+            "1m": {
+              headers: {
+                "anthropic-beta": "context-1m-2025-08-07",
+              },
+              contextLimit: 1_000_000,
+            },
+          }
         }
 
         return {
@@ -760,6 +769,13 @@ export namespace ProviderTransform {
 
   export function maxOutputTokens(model: Provider.Model): number {
     return Math.min(model.limit.output, OUTPUT_TOKEN_MAX) || OUTPUT_TOKEN_MAX
+  }
+
+  export function contextLimit(model: Provider.Model, variant?: string): number {
+    if (variant && model.variants?.[variant]?.contextLimit) {
+      return model.variants[variant].contextLimit
+    }
+    return model.limit.context
   }
 
   export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -29,10 +29,14 @@ export namespace SessionCompaction {
 
   const COMPACTION_BUFFER = 20_000
 
-  export async function isOverflow(input: { tokens: MessageV2.Assistant["tokens"]; model: Provider.Model }) {
+  export async function isOverflow(input: {
+    tokens: MessageV2.Assistant["tokens"]
+    model: Provider.Model
+    variant?: string
+  }) {
     const config = await Config.get()
     if (config.compaction?.auto === false) return false
-    const context = input.model.limit.context
+    const context = ProviderTransform.contextLimit(input.model, input.variant)
     if (context === 0) return false
 
     const count =

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -271,7 +271,13 @@ export namespace SessionProcessor {
                     sessionID: input.sessionID,
                     messageID: input.assistantMessage.parentID,
                   })
-                  if (await SessionCompaction.isOverflow({ tokens: usage.tokens, model: input.model })) {
+                  if (
+                    await SessionCompaction.isOverflow({
+                      tokens: usage.tokens,
+                      model: input.model,
+                      variant: streamInput.user.variant,
+                    })
+                  ) {
                     needsCompaction = true
                   }
                   break

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -538,7 +538,7 @@ export namespace SessionPrompt {
       if (
         lastFinished &&
         lastFinished.summary !== true &&
-        (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model }))
+        (await SessionCompaction.isOverflow({ tokens: lastFinished.tokens, model, variant: lastUser.variant }))
       ) {
         await SessionCompaction.create({
           sessionID,


### PR DESCRIPTION
## Summary

- Add optional `1m` variant for Claude Opus 4.6 that enables the 1M token context window
- Users can select this variant in the model selector (e.g., `claude-opus-4-6[1m]`) to opt-in to extended context
- Default context remains at 200K to avoid higher session costs

## Details

This PR makes the 1M context window **opt-in** rather than automatic. The `context-1m-2025-08-07` header is sent to enable the feature on Anthropic's side, but the actual context limit is only increased when the user explicitly selects the `[1m]` variant.

### Why optional?

The 1M context window uses higher token pricing (`context_over_200k` tier) and delays compaction. Making it opt-in lets users choose when they need the extended context vs. when they prefer lower costs with automatic compaction at 200K.

### Changes

- **transform.ts**: Add `1m` variant for Opus 4.6 with `contextLimit: 1_000_000`
- **transform.ts**: Add `contextLimit()` helper to resolve effective limit from variant
- **compaction.ts**: Update `isOverflow()` to use variant-aware context limit
- **processor.ts** / **prompt.ts**: Pass variant to overflow checks

### Usage

```bash
# Default (200K context, lower cost)
/model anthropic/claude-opus-4-6

# Extended context (1M, higher cost)  
/model anthropic/claude-opus-4-6[1m]
```

---

**Note to reviewers**: This supersedes the approach in #12342 which enabled 1M by default. The optional variant approach gives users control over the cost/context tradeoff.

Closes #13455