### PR TITLE
feat(app): add before/after review modes

### DIFF
--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout"
+import { createSessionKeyReader, ensureSessionKey, normalizeReviewDiffStyle, pruneSessionKeys } from "./layout"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {
@@ -65,5 +65,19 @@ describe("pruneSessionKeys", () => {
     })
 
     expect(drop).toEqual([])
+  })
+})
+
+describe("normalizeReviewDiffStyle", () => {
+  test("keeps supported styles", () => {
+    expect(normalizeReviewDiffStyle("unified")).toBe("unified")
+    expect(normalizeReviewDiffStyle("split")).toBe("split")
+    expect(normalizeReviewDiffStyle("before")).toBe("before")
+    expect(normalizeReviewDiffStyle("after")).toBe("after")
+  })
+
+  test("falls back for unknown styles", () => {
+    expect(normalizeReviewDiffStyle(undefined)).toBe("split")
+    expect(normalizeReviewDiffStyle("stacked")).toBe("split")
   })
 })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -49,7 +49,12 @@ type TabHandoff = {
 
 export type LocalProject = Partial<Project> & { worktree: string; expanded: boolean }
 
-export type ReviewDiffStyle = "unified" | "split"
+export type ReviewDiffStyle = "unified" | "split" | "before" | "after"
+
+export function normalizeReviewDiffStyle(style: string | undefined): ReviewDiffStyle {
+  if (style === "unified" || style === "split" || style === "before" || style === "after") return style
+  return "split"
+}
 
 export function ensureSessionKey(key: string, touch: (key: string) => void, seed: (key: string) => void) {
   touch(key)
@@ -549,13 +554,13 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
       },
       review: {
-        diffStyle: createMemo(() => store.review?.diffStyle ?? "split"),
+        diffStyle: createMemo(() => normalizeReviewDiffStyle(store.review?.diffStyle)),
         setDiffStyle(diffStyle: ReviewDiffStyle) {
           if (!store.review) {
-            setStore("review", { diffStyle, panelOpened: true })
+            setStore("review", { diffStyle: normalizeReviewDiffStyle(diffStyle), panelOpened: true })
             return
           }
-          setStore("review", "diffStyle", diffStyle)
+          setStore("review", "diffStyle", normalizeReviewDiffStyle(diffStyle))
         },
       },
       fileTree: {

--- a/packages/app/src/pages/session/review-tab.tsx
+++ b/packages/app/src/pages/session/review-tab.tsx
@@ -7,7 +7,7 @@ import { useSDK } from "@/context/sdk"
 import { useLayout } from "@/context/layout"
 import type { LineComment } from "@/context/comments"
 
-export type DiffStyle = "unified" | "split"
+export type DiffStyle = "unified" | "split" | "before" | "after"
 
 export interface SessionReviewTabProps {
   title?: JSX.Element

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -7,6 +7,7 @@ import { Icon } from "./icon"
 import { LineComment, LineCommentEditor } from "./line-comment"
 import { StickyAccordionHeader } from "./sticky-accordion-header"
 import { useDiffComponent } from "../context/diff"
+import { useCodeComponent } from "../context/code"
 import { useI18n } from "../context/i18n"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import { checksum } from "@opencode-ai/util/encode"
@@ -17,7 +18,7 @@ import { PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
 import { type SelectedLineRange } from "@pierre/diffs"
 import { Dynamic } from "solid-js/web"
 
-export type SessionReviewDiffStyle = "unified" | "split"
+export type SessionReviewDiffStyle = "unified" | "split" | "before" | "after"
 
 export type SessionReviewComment = {
   id: string
@@ -170,11 +171,23 @@ function markerTop(wrapper: HTMLElement, marker: HTMLElement) {
   return rect.top - wrapperRect.top + Math.max(0, (rect.height - 20) / 2)
 }
 
+function normalizeSelectionForStyle(style: SessionReviewDiffStyle, range: SelectedLineRange) {
+  if (style !== "before" && style !== "after") return range
+  const side = style === "before" ? "deletions" : "additions"
+  if (range.side === side && (range.endSide === undefined || range.endSide === side)) return range
+  return {
+    ...range,
+    side,
+    endSide: range.endSide !== undefined ? side : undefined,
+  }
+}
+
 export const SessionReview = (props: SessionReviewProps) => {
   let scroll: HTMLDivElement | undefined
   let focusToken = 0
   const i18n = useI18n()
   const diffComponent = useDiffComponent()
+  const codeComponent = useCodeComponent()
   const anchors = new Map<string, HTMLElement>()
   const [store, setStore] = createStore({
     open: props.diffs.length > 10 ? [] : props.diffs.map((d) => d.file),
@@ -186,6 +199,8 @@ export const SessionReview = (props: SessionReviewProps) => {
 
   const open = () => props.open ?? store.open
   const diffStyle = () => props.diffStyle ?? (props.split ? "split" : "unified")
+  const isDiffStyle = () => diffStyle() === "unified" || diffStyle() === "split"
+  const pierreDiffStyle = () => (diffStyle() === "split" ? "split" : "unified")
   const hasDiffs = () => props.diffs.length > 0
 
   const handleChange = (open: string[]) => {
@@ -206,7 +221,10 @@ export const SessionReview = (props: SessionReviewProps) => {
     return `lines ${start}-${end}`
   }
 
-  const selectionSide = (range: SelectedLineRange) => range.endSide ?? range.side ?? "additions"
+  const selectionSide = (range: SelectedLineRange) => {
+    const normalized = normalizeSelectionForStyle(diffStyle(), range)
+    return normalized.endSide ?? normalized.side ?? "additions"
+  }
 
   const selectionPreview = (diff: FileDiff, range: SelectedLineRange) => {
     const side = selectionSide(range)
@@ -294,12 +312,15 @@ export const SessionReview = (props: SessionReviewProps) => {
         <div data-slot="session-review-actions">
           <Show when={hasDiffs() && props.onDiffStyleChange}>
             <RadioGroup
-              options={["unified", "split"] as const}
+              options={["unified", "split", "before", "after"] as const}
               current={diffStyle()}
               value={(style) => style}
-              label={(style) =>
-                i18n.t(style === "unified" ? "ui.sessionReview.diffStyle.unified" : "ui.sessionReview.diffStyle.split")
-              }
+              label={(style) => {
+                if (style === "unified") return i18n.t("ui.sessionReview.diffStyle.unified")
+                if (style === "split") return i18n.t("ui.sessionReview.diffStyle.split")
+                if (style === "before") return i18n.t("ui.sessionReview.diffStyle.before")
+                return i18n.t("ui.sessionReview.diffStyle.after")
+              }}
               onSelect={(style) => style && props.onDiffStyleChange?.(style)}
             />
           </Show>
@@ -478,7 +499,8 @@ export const SessionReview = (props: SessionReviewProps) => {
                     return
                   }
 
-                  setSelection({ file: diff.file, range })
+                  const normalized = normalizeSelectionForStyle(diffStyle(), range)
+                  setSelection({ file: diff.file, range: normalized })
                 }
 
                 const handleLineSelectionEnd = (range: SelectedLineRange | null) => {
@@ -489,8 +511,9 @@ export const SessionReview = (props: SessionReviewProps) => {
                     return
                   }
 
-                  setSelection({ file: diff.file, range })
-                  setCommenting({ file: diff.file, range })
+                  const normalized = normalizeSelectionForStyle(diffStyle(), range)
+                  setSelection({ file: diff.file, range: normalized })
+                  setCommenting({ file: diff.file, range: normalized })
                 }
 
                 const openComment = (comment: SessionReviewComment) => {
@@ -592,28 +615,49 @@ export const SessionReview = (props: SessionReviewProps) => {
                             </div>
                           </Match>
                           <Match when={!isImage()}>
-                            <Dynamic
-                              component={diffComponent}
-                              preloadedDiff={diff.preloaded}
-                              diffStyle={diffStyle()}
-                              onRendered={() => {
-                                props.onDiffRendered?.()
-                                scheduleAnchors()
-                              }}
-                              enableLineSelection={props.onLineComment != null}
-                              onLineSelected={handleLineSelected}
-                              onLineSelectionEnd={handleLineSelectionEnd}
-                              selectedLines={selectedLines()}
-                              commentedLines={commentedLines()}
-                              before={{
-                                name: diff.file!,
-                                contents: typeof diff.before === "string" ? diff.before : "",
-                              }}
-                              after={{
-                                name: diff.file!,
-                                contents: typeof diff.after === "string" ? diff.after : "",
-                              }}
-                            />
+                            <Switch>
+                              <Match when={isDiffStyle()}>
+                                <Dynamic
+                                  component={diffComponent}
+                                  preloadedDiff={diff.preloaded}
+                                  diffStyle={pierreDiffStyle()}
+                                  onRendered={() => {
+                                    props.onDiffRendered?.()
+                                    scheduleAnchors()
+                                  }}
+                                  enableLineSelection={props.onLineComment != null}
+                                  onLineSelected={handleLineSelected}
+                                  onLineSelectionEnd={handleLineSelectionEnd}
+                                  selectedLines={selectedLines()}
+                                  commentedLines={commentedLines()}
+                                  before={{
+                                    name: diff.file!,
+                                    contents: typeof diff.before === "string" ? diff.before : "",
+                                  }}
+                                  after={{
+                                    name: diff.file!,
+                                    contents: typeof diff.after === "string" ? diff.after : "",
+                                  }}
+                                />
+                              </Match>
+                              <Match when={true}>
+                                <Dynamic
+                                  component={codeComponent}
+                                  file={{
+                                    name: diff.file!,
+                                    contents: diffStyle() === "before" ? beforeText() : afterText(),
+                                  }}
+                                  onRendered={() => {
+                                    props.onDiffRendered?.()
+                                    scheduleAnchors()
+                                  }}
+                                  enableLineSelection={props.onLineComment != null}
+                                  onLineSelectionEnd={handleLineSelectionEnd}
+                                  selectedLines={selectedLines()}
+                                  commentedLines={commentedLines()}
+                                />
+                              </Match>
+                            </Switch>
                           </Match>
                         </Switch>
 

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -171,9 +171,9 @@ function markerTop(wrapper: HTMLElement, marker: HTMLElement) {
   return rect.top - wrapperRect.top + Math.max(0, (rect.height - 20) / 2)
 }
 
-function normalizeSelectionForStyle(style: SessionReviewDiffStyle, range: SelectedLineRange) {
+function normalizeSelectionForStyle(style: SessionReviewDiffStyle, range: SelectedLineRange): SelectedLineRange {
   if (style !== "before" && style !== "after") return range
-  const side = style === "before" ? "deletions" : "additions"
+  const side: NonNullable<SelectedLineRange["side"]> = style === "before" ? "deletions" : "additions"
   if (range.side === side && (range.endSide === undefined || range.endSide === side)) return range
   return {
     ...range,

--- a/packages/ui/src/i18n/ar.ts
+++ b/packages/ui/src/i18n/ar.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "تغييرات آخر دور",
   "ui.sessionReview.diffStyle.unified": "موحد",
   "ui.sessionReview.diffStyle.split": "منقسم",
+  "ui.sessionReview.diffStyle.before": "قبل",
+  "ui.sessionReview.diffStyle.after": "بعد",
   "ui.sessionReview.expandAll": "توسيع الكل",
   "ui.sessionReview.collapseAll": "طي الكل",
   "ui.sessionReview.change.added": "مضاف",

--- a/packages/ui/src/i18n/br.ts
+++ b/packages/ui/src/i18n/br.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Alterações do último turno",
   "ui.sessionReview.diffStyle.unified": "Unificado",
   "ui.sessionReview.diffStyle.split": "Dividido",
+  "ui.sessionReview.diffStyle.before": "Antes",
+  "ui.sessionReview.diffStyle.after": "Depois",
   "ui.sessionReview.expandAll": "Expandir tudo",
   "ui.sessionReview.collapseAll": "Recolher tudo",
   "ui.sessionReview.change.added": "Adicionado",

--- a/packages/ui/src/i18n/bs.ts
+++ b/packages/ui/src/i18n/bs.ts
@@ -7,6 +7,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Promjene u posljednjem potezu",
   "ui.sessionReview.diffStyle.unified": "Ujedinjeno",
   "ui.sessionReview.diffStyle.split": "Podijeljeno",
+  "ui.sessionReview.diffStyle.before": "Prije",
+  "ui.sessionReview.diffStyle.after": "Poslije",
   "ui.sessionReview.expandAll": "Proširi sve",
   "ui.sessionReview.collapseAll": "Sažmi sve",
   "ui.sessionReview.change.added": "Dodano",

--- a/packages/ui/src/i18n/da.ts
+++ b/packages/ui/src/i18n/da.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Ændringer fra sidste tur",
   "ui.sessionReview.diffStyle.unified": "Samlet",
   "ui.sessionReview.diffStyle.split": "Opdelt",
+  "ui.sessionReview.diffStyle.before": "Før",
+  "ui.sessionReview.diffStyle.after": "Efter",
   "ui.sessionReview.expandAll": "Udvid alle",
   "ui.sessionReview.collapseAll": "Skjul alle",
 

--- a/packages/ui/src/i18n/de.ts
+++ b/packages/ui/src/i18n/de.ts
@@ -7,6 +7,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Änderungen der letzten Runde",
   "ui.sessionReview.diffStyle.unified": "Vereinheitlicht",
   "ui.sessionReview.diffStyle.split": "Geteilt",
+  "ui.sessionReview.diffStyle.before": "Vorher",
+  "ui.sessionReview.diffStyle.after": "Nachher",
   "ui.sessionReview.expandAll": "Alle erweitern",
   "ui.sessionReview.collapseAll": "Alle reduzieren",
 

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Last turn changes",
   "ui.sessionReview.diffStyle.unified": "Unified",
   "ui.sessionReview.diffStyle.split": "Split",
+  "ui.sessionReview.diffStyle.before": "Before",
+  "ui.sessionReview.diffStyle.after": "After",
   "ui.sessionReview.expandAll": "Expand all",
   "ui.sessionReview.collapseAll": "Collapse all",
   "ui.sessionReview.change.added": "Added",

--- a/packages/ui/src/i18n/es.ts
+++ b/packages/ui/src/i18n/es.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Cambios del último turno",
   "ui.sessionReview.diffStyle.unified": "Unificado",
   "ui.sessionReview.diffStyle.split": "Dividido",
+  "ui.sessionReview.diffStyle.before": "Antes",
+  "ui.sessionReview.diffStyle.after": "Después",
   "ui.sessionReview.expandAll": "Expandir todo",
   "ui.sessionReview.collapseAll": "Colapsar todo",
   "ui.sessionReview.change.added": "Añadido",

--- a/packages/ui/src/i18n/fr.ts
+++ b/packages/ui/src/i18n/fr.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Modifications du dernier tour",
   "ui.sessionReview.diffStyle.unified": "Unifié",
   "ui.sessionReview.diffStyle.split": "Divisé",
+  "ui.sessionReview.diffStyle.before": "Avant",
+  "ui.sessionReview.diffStyle.after": "Après",
   "ui.sessionReview.expandAll": "Tout développer",
   "ui.sessionReview.collapseAll": "Tout réduire",
   "ui.sessionReview.change.added": "Ajouté",

--- a/packages/ui/src/i18n/ja.ts
+++ b/packages/ui/src/i18n/ja.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "前回ターンの変更",
   "ui.sessionReview.diffStyle.unified": "Unified",
   "ui.sessionReview.diffStyle.split": "Split",
+  "ui.sessionReview.diffStyle.before": "Before",
+  "ui.sessionReview.diffStyle.after": "After",
   "ui.sessionReview.expandAll": "すべて展開",
   "ui.sessionReview.collapseAll": "すべて折りたたむ",
 

--- a/packages/ui/src/i18n/ko.ts
+++ b/packages/ui/src/i18n/ko.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "마지막 턴 변경 사항",
   "ui.sessionReview.diffStyle.unified": "통합 보기",
   "ui.sessionReview.diffStyle.split": "분할 보기",
+  "ui.sessionReview.diffStyle.before": "이전",
+  "ui.sessionReview.diffStyle.after": "이후",
   "ui.sessionReview.expandAll": "모두 펼치기",
   "ui.sessionReview.collapseAll": "모두 접기",
   "ui.sessionReview.change.added": "추가됨",

--- a/packages/ui/src/i18n/no.ts
+++ b/packages/ui/src/i18n/no.ts
@@ -6,6 +6,8 @@ export const dict: Record<Keys, string> = {
   "ui.sessionReview.title.lastTurn": "Endringer i siste tur",
   "ui.sessionReview.diffStyle.unified": "Samlet",
   "ui.sessionReview.diffStyle.split": "Delt",
+  "ui.sessionReview.diffStyle.before": "Før",
+  "ui.sessionReview.diffStyle.after": "Etter",
   "ui.sessionReview.expandAll": "Utvid alle",
   "ui.sessionReview.collapseAll": "Fold sammen alle",
   "ui.sessionReview.change.added": "Lagt til",

--- a/packages/ui/src/i18n/pl.ts
+++ b/packages/ui/src/i18n/pl.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Zmiany z ostatniej tury",
   "ui.sessionReview.diffStyle.unified": "Ujednolicony",
   "ui.sessionReview.diffStyle.split": "Podzielony",
+  "ui.sessionReview.diffStyle.before": "Przed",
+  "ui.sessionReview.diffStyle.after": "Po",
   "ui.sessionReview.expandAll": "Rozwiń wszystko",
   "ui.sessionReview.collapseAll": "Zwiń wszystko",
 

--- a/packages/ui/src/i18n/ru.ts
+++ b/packages/ui/src/i18n/ru.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "Изменения последнего хода",
   "ui.sessionReview.diffStyle.unified": "Объединённый",
   "ui.sessionReview.diffStyle.split": "Разделённый",
+  "ui.sessionReview.diffStyle.before": "До",
+  "ui.sessionReview.diffStyle.after": "После",
   "ui.sessionReview.expandAll": "Развернуть всё",
   "ui.sessionReview.collapseAll": "Свернуть всё",
 

--- a/packages/ui/src/i18n/th.ts
+++ b/packages/ui/src/i18n/th.ts
@@ -3,6 +3,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "การเปลี่ยนแปลงของเทิร์นล่าสุด",
   "ui.sessionReview.diffStyle.unified": "แบบรวม",
   "ui.sessionReview.diffStyle.split": "แบบแยก",
+  "ui.sessionReview.diffStyle.before": "ก่อน",
+  "ui.sessionReview.diffStyle.after": "หลัง",
   "ui.sessionReview.expandAll": "ขยายทั้งหมด",
   "ui.sessionReview.collapseAll": "ย่อทั้งหมด",
   "ui.sessionReview.change.added": "เพิ่ม",

--- a/packages/ui/src/i18n/zh.ts
+++ b/packages/ui/src/i18n/zh.ts
@@ -7,6 +7,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "上一轮变更",
   "ui.sessionReview.diffStyle.unified": "统一",
   "ui.sessionReview.diffStyle.split": "拆分",
+  "ui.sessionReview.diffStyle.before": "变更前",
+  "ui.sessionReview.diffStyle.after": "变更后",
   "ui.sessionReview.expandAll": "全部展开",
   "ui.sessionReview.collapseAll": "全部收起",
   "ui.sessionReview.change.added": "已添加",

--- a/packages/ui/src/i18n/zht.ts
+++ b/packages/ui/src/i18n/zht.ts
@@ -7,6 +7,8 @@ export const dict = {
   "ui.sessionReview.title.lastTurn": "上一輪變更",
   "ui.sessionReview.diffStyle.unified": "整合",
   "ui.sessionReview.diffStyle.split": "拆分",
+  "ui.sessionReview.diffStyle.before": "變更前",
+  "ui.sessionReview.diffStyle.after": "變更後",
   "ui.sessionReview.expandAll": "全部展開",
   "ui.sessionReview.collapseAll": "全部收合",
   "ui.sessionReview.change.added": "已新增",


### PR DESCRIPTION
### What does this PR do?

Closes #13466

This PR adds two new review modes in the Session Review diff tool: Before and After, alongside the existing Unified and Split modes.

With these modes, developers can switch from line-based diff visualization to full-file snapshots of the previous and updated versions. This makes it much easier to understand broader file logic, context, and intent when a diff alone is too fragmented.

*Why this is worth adding*

Diffs are great for local edits, but they can hide architectural/contextual changes across a file. Full-file Before/After views reduce cognitive overhead when reviewing larger refactors, movement of logic, or context-heavy modifications. This improves review quality and speeds up understanding without removing existing diff workflows.

### How did you verify your code works?
Added unit coverage for diff-style normalization, passed typecheck, and manually validated all four review modes plus line-comment behavior in before/after views.

### Screenshots
Entire View
<img width="2056" height="1290" alt="image" src="https://github.com/user-attachments/assets/983e3195-6ace-471b-b739-9c463591fe02" />

Close up
<img width="398" height="130" alt="image" src="https://github.com/user-attachments/assets/847aad28-2cab-4ef6-97ca-c72d8708c6e9" />

Before selected
<img width="1043" height="410" alt="image" src="https://github.com/user-attachments/assets/76a772e2-1bca-4e75-97a0-3ff073fc069f" />

After selected
<img width="1037" height="340" alt="image" src="https://github.com/user-attachments/assets/1a1f1803-95c6-4748-b626-8f9796469705" />
