### PR TITLE
feat(9989): Subagent session pagination

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -66,6 +66,17 @@ export function Header() {
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
 
+  const siblings = createMemo(() => {
+    const parentID = session()?.parentID
+    if (!parentID) return []
+    return sync.data.session
+      .filter((x) => x.parentID === parentID)
+      .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+  })
+
+  const currentIndex = createMemo(() => siblings().findIndex((x) => x.id === session()?.id))
+  const total = createMemo(() => siblings().length)
+
   return (
     <box flexShrink={0}>
       <box
@@ -84,7 +95,10 @@ export function Header() {
             <box flexDirection="column" gap={1}>
               <box flexDirection={narrow() ? "column" : "row"} justifyContent="space-between" gap={narrow() ? 1 : 0}>
                 <text fg={theme.text}>
-                  <b>Subagent session</b>
+                  <b>Subagent session</b>{" "}
+                  <span style={{ fg: theme.textMuted }}>
+                    {currentIndex() + 1} / {total()}
+                  </span>
                 </text>
                 <ContextInfo context={context} cost={cost} />
               </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -75,7 +75,6 @@ export function Header() {
   })
 
   const currentIndex = createMemo(() => siblings().findIndex((x) => x.id === session()?.id))
-  const total = createMemo(() => siblings().length)
 
   return (
     <box flexShrink={0}>
@@ -95,10 +94,13 @@ export function Header() {
             <box flexDirection="column" gap={1}>
               <box flexDirection={narrow() ? "column" : "row"} justifyContent="space-between" gap={narrow() ? 1 : 0}>
                 <text fg={theme.text}>
-                  <b>Subagent session</b>{" "}
-                  <span style={{ fg: theme.textMuted }}>
-                    {currentIndex() + 1} / {total()}
-                  </span>
+                  <b>Subagent session</b>
+                  <Show when={currentIndex() >= 0}>
+                    {" "}
+                    <span style={{ fg: theme.textMuted }}>
+                      {currentIndex() + 1} / {siblings().length}
+                    </span>
+                  </Show>
                 </text>
                 <ContextInfo context={context} cost={cost} />
               </box>


### PR DESCRIPTION
### What does this PR do?

It's not clear how many subagent sessions exist when browsing then in the TUI. This PR adds a paginated count next to "Subagent session" in the header. i.e. "1 / 2". The reported issue's suggestion is pretty simple and improved usability a lot.

<img width="656" height="199" alt="image" src="https://github.com/user-attachments/assets/ddd24637-c054-49f5-ab83-4a5bf6ee46f3" />

My solution ignore the parent session from the count, only listing sessions with a parent refrence.

The reported issue suggested adding labels/context to the prev/next buttons as well, but I think that's a different feature considering some session names can be very long. That requires more design consideration. 

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Verified by `bun dev` with visual inspection followed by `bun run typecheck` and `bun test`

Closes #9989 