### PR TITLE
fix(copilot): enable gpt-5.3-codex and other models requiring /responses endpoint

### DIFF
--- a/packages/opencode/src/plugin/copilot.ts
+++ b/packages/opencode/src/plugin/copilot.ts
@@ -308,6 +308,11 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         output.headers["anthropic-beta"] = "interleaved-thinking-2025-05-14"
       }
 
+      // Skip x-initiator override when using @ai-sdk/github-copilot - it has its own
+      // fetch wrapper that sets x-initiator based on message content, and overriding
+      // it here causes "invalid initiator" validation errors from Copilot API
+      if (incoming.model.api.npm === "@ai-sdk/github-copilot") return
+
       const session = await sdk.session
         .get({
           path: {

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -53,7 +53,7 @@ export namespace Plugin {
 
     for (let plugin of plugins) {
       // ignore old codex plugin since it is supported first party now
-      if (plugin.includes("opencode-openai-codex-auth") || plugin.includes("opencode-copilot-auth")) continue
+      if (plugin.includes("opencode-openai-codex-auth")) continue
       log.info("loading plugin", { path: plugin })
       if (!plugin.startsWith("file://")) {
         const lastAtIndex = plugin.lastIndexOf("@")

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -837,6 +837,17 @@ export namespace Provider {
       database[providerID] = parsed
     }
 
+    // Force github-copilot models to use @ai-sdk/github-copilot instead of @ai-sdk/openai-compatible.
+    // Models like gpt-5.3-codex require the /responses endpoint, which only @ai-sdk/github-copilot supports.
+    // This must run after config processing to catch user-defined models not present in models.dev.
+    for (const providerID of ["github-copilot", "github-copilot-enterprise"]) {
+      if (database[providerID]) {
+        for (const model of Object.values(database[providerID].models)) {
+          model.api.npm = "@ai-sdk/github-copilot"
+        }
+      }
+    }
+
     // load env
     const env = Env.all()
     for (const [providerID, provider] of Object.entries(database)) {


### PR DESCRIPTION
## Summary
- Force all `github-copilot` models to use `@ai-sdk/github-copilot` SDK after config processing
- Allow external copilot auth plugins to load from config
- Skip x-initiator override when using bundled SDK to prevent validation errors

Fixes #13487

## Changes

### `provider.ts`
Added npm override loop **after** config processing to ensure config-defined github-copilot models use the bundled SDK with `responses()` support instead of falling back to `@ai-sdk/openai-compatible`.

### `plugin/index.ts`
Removed explicit skip for `opencode-copilot-auth` plugin, allowing external auth plugins to load when specified in user config.

### `copilot.ts`
Skip `x-initiator` header override when model uses `@ai-sdk/github-copilot` SDK. The bundled SDK has its own fetch wrapper that sets `x-initiator` based on message content - overriding it caused "invalid initiator" validation errors from Copilot API.