### PR TITLE
docs: corrected the wording of the `Agent Skills` zh-cn doc

### DIFF
--- a/packages/web/src/content/docs/zh-cn/skills.mdx
+++ b/packages/web/src/content/docs/zh-cn/skills.mdx
@@ -1,62 +1,65 @@
 ---
-title: 《代理技巧》
-description: “贯穿 SKILL.md 定义可重用行为”
+title: 智能体技能（Agent Skills）
+description: 通过 SKILL.md 定义来实现可复用行为
 ---
 
-代理让 opencode 技能从您的存储库或主目录中找到可重用的指令。
-技能贯穿本机 `skill` 工具输入导入 - 代理可以查看可用技能并可以在需要时加载完整内容。
-
----
-
-## 放置文件
-
-为每个技能名称建立一个资料夹，并在其中放入`SKILL.md`。
-opencode 搜索这些位置：
-
-- Project config: `.opencode/skills/<name>/SKILL.md`
-- Global config: `~/.config/opencode/skills/<name>/SKILL.md`
-- 专案Claude兼容：`.claude/skills/<name>/SKILL.md`
-- 全域性 Claude 兼容： `~/.claude/skills/<name>/SKILL.md`
-- 专案代理兼容：`.agents/skills/<name>/SKILL.md`
-- 全球代理兼容：`~/.agents/skills/<name>/SKILL.md`
+智能体技能（Agent Skills）可让 OpenCode 从你的代码仓库或主目录中发现可复用指令。
+工具型智能体（tool-agents）的原生技能会按需加载可识别的可用技能，并在需要时加载完整内容。
 
 ---
 
-## 了解发现
+## 部署文件
 
-对于专案本地路径， opencode 从当前工作目录向上走，直到到达 git 工作树。
-It loads any matching `skills/*/SKILL.md` in `.opencode/` and any matching `.claude/skills/*/SKILL.md` or `.agents/skills/*/SKILL.md` along the way.
+为每个技能名称创建一个独立文件夹，并在其中放入一个 `SKILL.md` 文件。
+OpenCode 会检索以下路径：
 
-Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, and `~/.agents/skills/*/SKILL.md`.
+- 项目级配置: `.opencode/skills/<name>/SKILL.md`
+- 全局配置: `~/.config/opencode/skills/<name>/SKILL.md`
+- 兼容Claude项目级配置：`.claude/skills/<name>/SKILL.md`
+- 兼容Claude全局配置： `~/.claude/skills/<name>/SKILL.md`
+- 兼容agent项目级配置：`.agents/skills/<name>/SKILL.md`
+- 兼容agent全局配置：`~/.agents/skills/<name>/SKILL.md`
 
 ---
 
-## 编写 Frontmatter
+## 发现机制
 
-每个 `SKILL.md` 必须以 YAML frontmatter 。
-仅識別这些欄位：
+对于本地项目路径，OpenCode 会从当前工作目录向上递归查找，直到抵达 Git 工作区根目录。
+沿途会任意匹配`.opencode/skills/*/SKILL.md`以及`.claude/skills/*/SKILL.md`或者`.agents/skills/*/SKILL.md`
+
+也会从以下全局路径下加载： 
+- `~/.config/opencode/skills/*/SKILL.md`
+- `~/.claude/skills/*/SKILL.md`
+- `~/.agents/skills/*/SKILL.md`.
+
+---
+
+## 编写前置元数据（Frontmatter）
+
+每个 SKILL.md 文件必须以 YAML 前置元数据（frontmatter）开头。
+仅以下字段会被识别：
 
 - `name`（必填）
 - `description`（必填）
-- `license`（任选）
-- `compatibility`（任选）
-- `metadata`（任选，字符串到字符串对映）
+- `license`（可选）
+- `compatibility`（可选）
+- `metadata`（可选）元数据（字符串键值对映射(string-to-string map))
 
 未知的 frontmatter 栏位将被忽略。
 
 ---
 
-## 验证名称
+## 名称校验规则
 
-`name` 必须：
+`name` 必须符合：
 
-- 長度为 1–64 个字元
-- 为小寫字母數字并带有單个連字元分隔符
-- 不以 `-` 開始或結束
-- 不包含連續的 `--`
-- 匹配包含 `SKILL.md` 的目录名
+- 长度为 1–64 个字符
+- 仅包含小写字母、数字，且仅允许使用单个连字符（-）作为分隔符
+- 不能以连字符（-）开头或结尾
+- 不能包含连续的两个连字符（--）
+- 需与包含`SKILL.md`文件的文件夹名称完全一致
 
-等效的正規表示式：
+等效正则表达式：
 
 ```text
 ^[a-z0-9]+(-[a-z0-9]+)*$
@@ -66,14 +69,14 @@ Global definitions are also loaded from `~/.config/opencode/skills/*/SKILL.md`, 
 
 ## 遵循长度规则
 
-`description` 必须是 1-1024 个字元。
-保持足夠具體，以便代理能夠正确选择。
+`description` 必须是 1-1024 个字符。
+请保持足够具体，以便智能体正确选择。
 
 ---
 
-## 使用一个例子
+## 举个例子
 
-Create `.opencode/skills/git-release/SKILL.md` like this:
+像这样创建 `.opencode/skills/git-release/SKILL.md` :
 
 ```markdown
 ---
@@ -100,9 +103,9 @@ Ask clarifying questions if the target versioning scheme is unclear.
 
 ---
 
-## 识别工具说明
+## 识别工具描述
 
-opencode 列出了 `skill` 工具描述中的可用技能。
+OpenCode 列出了 `skill` 工具描述中的可用技能。
 每个条目都包含技能名称和描述：
 
 ```xml
@@ -114,7 +117,7 @@ opencode 列出了 `skill` 工具描述中的可用技能。
 </available_skills>
 ```
 
-代理通过呼叫工具來載入技能：
+智能体通过调用工具来加载技能：
 
 ```
 skill({ name: "git-release" })
@@ -124,7 +127,7 @@ skill({ name: "git-release" })
 
 ## 配置权限
 
-Control which skills agents can access using pattern-based permissions in `opencode.json`:
+在 `opencode.json` 中使用基于模式的权限，控制智能体可以访问哪些技能：
 
 ```json
 {
@@ -139,21 +142,21 @@ Control which skills agents can access using pattern-based permissions in `openc
 }
 ```
 
-| 許可    | 行为                       |
+| 权限    | 行为                       |
 | ------- | -------------------------- |
 | `allow` | 技能立即加载               |
-| `deny`  | 对特工隐藏技能，访问被拒绝 |
-| `ask`   | 加载前提示用户批准         |
+| `deny`  | 对智能体隐藏技能，访问被拒绝 |
+| `ask`   | 加载前提示用户确认         |
 
-模式支持万用字元：`internal-*` 匹配 `internal-docs`、`internal-tools` 等。
+模式支持通配符：`internal-*` 匹配 `internal-docs`、`internal-tools` 等。
 
 ---
 
-## 覆盖每个代理
+## 覆盖每个智能体
 
-为特定代理授予与全域性默认权限不同的权限。
+为特定智能体赋予与全局默认值不同的权限。
 
-**对于自定義代理**（在代理前言中）：
+**对于自定义智能体（在智能体前置元数据(frontmatter)中）：**
 
 ```yaml
 ---
@@ -163,7 +166,7 @@ permission:
 ---
 ```
 
-**For built-in agents** (in `opencode.json`):
+对于内置智能体（在 opencode.json 中）：
 
 ```json
 {
@@ -183,9 +186,9 @@ permission:
 
 ## 禁用技能工具
 
-完全禁用不应该使用技能的特工：
+对不应使用技能的智能体完全禁用技能：
 
-**对于定製代理**：
+**对于自定义智能体**：
 
 ```yaml
 ---
@@ -194,7 +197,7 @@ tools:
 ---
 ```
 
-**对于內建代理**：
+**对于内置智能体**：
 
 ```json
 {
@@ -208,15 +211,16 @@ tools:
 }
 ```
 
-禁用後，`<available_skills>` 部分将被完全省略。
+禁用后，`<available_skills>` 部分将被完全省略。
 
 ---
 
-## 解决加载问题
+## 加载问题排查
 
-如果某項技能沒有显示：
+如果某项技能沒有显示：
 
 1. 验证 `SKILL.md` 拼写为全部大写
 2. 检查 frontmatter 是否包括 `name` 和 `description`
-3. 確保技能名称在所有位置都是唯一的
-4. 查询权限——具有`deny`的代理隐藏技能
+3. 确保技能名称在所有路径下都是唯一的
+4. 检查查询 —— 被设为 `deny` 的技能对智能体隐藏
+


### PR DESCRIPTION
Corrected the wording of the `Agent Skills` zh-cn documentation to conform to common Simplified Chinese usage conventions.