### PR TITLE
fix(test): move timeout config to CLI flag

### DIFF
--- a/packages/opencode/bunfig.toml
+++ b/packages/opencode/bunfig.toml
@@ -2,4 +2,6 @@ preload = ["@opentui/solid/preload"]
 
 [test]
 preload = ["./test/preload.ts"]
-timeout = 30000  # 30 seconds - allow time for package installation
+# timeout is not actually parsed from bunfig.toml (see src/bunfig.zig in oven-sh/bun)
+# using --timeout in package.json scripts instead
+# https://github.com/oven-sh/bun/issues/7789

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "typecheck": "tsgo --noEmit",
-    "test": "bun test",
+    "test": "bun test --timeout 30000",
     "build": "bun run script/build.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",
     "random": "echo 'Random script updated at $(date)' && echo 'Change queued successfully' && echo 'Another change made' && echo 'Yet another change' && echo 'One more change' && echo 'Final change' && echo 'Another final change' && echo 'Yet another final change'",


### PR DESCRIPTION
## Summary

- `[test] timeout` in `bunfig.toml` is **not actually parsed** by Bun's config loader (`src/bunfig.zig` in oven-sh/bun). The setting was silently ignored, falling back to the default 5000ms instead of the intended 30000ms.
- Move the timeout to `--timeout` CLI flag in the test script, which works correctly.

## Context

- Bun upstream issue: https://github.com/oven-sh/bun/issues/7789 (open since Dec 2023)
- Related issue: #13491

> [!NOTE]
> This PR was created by an AI agent (Claude Code). The analysis is based on reading Bun's source code and running a verification test. Please verify independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)