### PR TITLE
fix(snapshot): respect info exclude in snapshot staging

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -66,7 +66,7 @@ export namespace Snapshot {
       await $`git --git-dir ${git} config core.autocrlf false`.quiet().nothrow()
       log.info("initialized")
     }
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+    await add(git)
     const hash = await $`git --git-dir ${git} --work-tree ${Instance.worktree} write-tree`
       .quiet()
       .cwd(Instance.directory)
@@ -84,7 +84,7 @@ export namespace Snapshot {
 
   export async function patch(hash: string): Promise<Patch> {
     const git = gitdir()
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+    await add(git)
     const result =
       await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff --name-only ${hash} -- .`
         .quiet()
@@ -162,7 +162,7 @@ export namespace Snapshot {
 
   export async function diff(hash: string) {
     const git = gitdir()
-    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+    await add(git)
     const result =
       await $`git -c core.autocrlf=false -c core.quotepath=false --git-dir ${git} --work-tree ${Instance.worktree} diff --no-ext-diff ${hash} -- .`
         .quiet()
@@ -252,5 +252,39 @@ export namespace Snapshot {
   function gitdir() {
     const project = Instance.project
     return path.join(Global.Path.data, "snapshot", project.id)
+  }
+
+  async function add(git: string) {
+    await syncExclude(git)
+    await $`git --git-dir ${git} --work-tree ${Instance.worktree} add .`.quiet().cwd(Instance.directory).nothrow()
+  }
+
+  async function syncExclude(git: string) {
+    const file = await excludes()
+    const target = path.join(git, "info", "exclude")
+    await fs.mkdir(path.join(git, "info"), { recursive: true })
+    if (!file) {
+      await Bun.write(target, "")
+      return
+    }
+    const text = await Bun.file(file)
+      .text()
+      .catch(() => "")
+    await Bun.write(target, text)
+  }
+
+  async function excludes() {
+    const file = await $`git rev-parse --path-format=absolute --git-path info/exclude`
+      .quiet()
+      .cwd(Instance.worktree)
+      .nothrow()
+      .text()
+    if (!file.trim()) return
+    const exists = await fs
+      .stat(file.trim())
+      .then(() => true)
+      .catch(() => false)
+    if (!exists) return
+    return file.trim()
   }
 }

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -466,6 +466,68 @@ test("gitignore changes", async () => {
   })
 })
 
+test("git info exclude changes", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const before = await Snapshot.track()
+      expect(before).toBeTruthy()
+
+      const file = `${tmp.path}/.git/info/exclude`
+      const text = await Bun.file(file).text()
+      await Bun.write(file, `${text.trimEnd()}\nignored.txt\n`)
+      await Bun.write(`${tmp.path}/ignored.txt`, "ignored content")
+      await Bun.write(`${tmp.path}/normal.txt`, "normal content")
+
+      const patch = await Snapshot.patch(before!)
+      expect(patch.files).toContain(`${tmp.path}/normal.txt`)
+      expect(patch.files).not.toContain(`${tmp.path}/ignored.txt`)
+
+      const after = await Snapshot.track()
+      const diffs = await Snapshot.diffFull(before!, after!)
+      expect(diffs.some((x) => x.file === "normal.txt")).toBe(true)
+      expect(diffs.some((x) => x.file === "ignored.txt")).toBe(false)
+    },
+  })
+})
+
+test("git info exclude keeps global excludes", async () => {
+  await using tmp = await bootstrap()
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const global = `${tmp.path}/global.ignore`
+      const config = `${tmp.path}/global.gitconfig`
+      await Bun.write(global, "global.tmp\n")
+      await Bun.write(config, `[core]\n\texcludesFile = ${global}\n`)
+
+      const prev = process.env.GIT_CONFIG_GLOBAL
+      process.env.GIT_CONFIG_GLOBAL = config
+      try {
+        const before = await Snapshot.track()
+        expect(before).toBeTruthy()
+
+        const file = `${tmp.path}/.git/info/exclude`
+        const text = await Bun.file(file).text()
+        await Bun.write(file, `${text.trimEnd()}\ninfo.tmp\n`)
+
+        await Bun.write(`${tmp.path}/global.tmp`, "global content")
+        await Bun.write(`${tmp.path}/info.tmp`, "info content")
+        await Bun.write(`${tmp.path}/normal.txt`, "normal content")
+
+        const patch = await Snapshot.patch(before!)
+        expect(patch.files).toContain(`${tmp.path}/normal.txt`)
+        expect(patch.files).not.toContain(`${tmp.path}/global.tmp`)
+        expect(patch.files).not.toContain(`${tmp.path}/info.tmp`)
+      } finally {
+        if (prev) process.env.GIT_CONFIG_GLOBAL = prev
+        else delete process.env.GIT_CONFIG_GLOBAL
+      }
+    },
+  })
+})
+
 test("concurrent file operations during patch", async () => {
   await using tmp = await bootstrap()
   await Instance.provide({


### PR DESCRIPTION
### What does this PR do?

fixes #13474

What I changed:
- In packages/opencode/src/snapshot/index.ts, I replaced direct git add . calls in track, patch, and diff with a shared add() helper.
- Before staging, add() now copies the project’s .git/info/exclude into the snapshot repo’s info/exclude (syncExclude()).
- If the project exclude file is missing/unresolvable, it writes an empty snapshot info/exclude so stale patterns are not retained.
Why this works:
- Snapshot git operations now run with the same per-repo exclude patterns as the real project repo.
- It preserves normal git behavior for global excludes (we are no longer overriding core.excludesFile per command), so both repo-local and global ignores are respected.
---
How did you verify your code works?
- Added regression tests in packages/opencode/test/snapshot/snapshot.test.ts:
  - git info exclude changes (ensures .git/info/exclude entries are ignored by snapshot patch/diff)
  - git info exclude keeps global excludes (ensures global excludes still apply alongside repo info/exclude)
- Ran:
  - bun test ./test/snapshot/snapshot.test.ts (from packages/opencode)
- Result:
  - 43 pass, 1 skip, 0 fail