### PR TITLE
ci(nix): add build check on pull requests

### DIFF
--- a/.github/workflows/nix-check.yml
+++ b/.github/workflows/nix-check.yml
@@ -1,0 +1,26 @@
+name: nix-check
+
+on:
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "nix/**"
+      - "package.json"
+      - "packages/*/package.json"
+      - "bun.lock"
+      - "patches/**"
+      - ".github/workflows/nix-check.yml"
+
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Nix
+        uses: nixbuild/nix-quick-install-action@v34
+
+      - name: Build opencode
+        run: nix build .#packages.x86_64-linux.default --no-link

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770073757,
-        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "lastModified": 1770843696,
+        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### What does this PR do?

This PR adds a `nix-check` workflow that runs `nix build` on pull requests that modify nix-related files (flake.nix, flake.lock, nix/**, package.json, bun.lock, patches/**).

**Problem:** Issue #13300 occurred because package.json was bumped to require Bun 1.3.9 but flake.lock still pinned nixpkgs with only Bun 1.3.8. The nix build broke but wasn't caught until after merge.

**Solution:** Instead of auto-updating flake.lock (which the nix overhaul in dac099a48 intentionally removed to avoid silently pulling in unrelated breakage), this PR fails the PR if the nix build breaks. This puts the responsibility on PR authors to keep flake.lock compatible with their changes.

The workflow runs on a single x86_64-linux runner to keep CI cost down. Cross-platform hash differences are already handled by the existing nix-hashes workflow post-merge.

**Relationship to #12175:** That PR proposes a `nix-eval` workflow using `nix eval` to catch evaluation-time errors (syntax, missing attributes). This is complementary but would not have caught #13300 — the Bun version mismatch is a build-time error. This PR uses `nix build` which catches both evaluation-time and build-time failures.

This PR also includes the flake.lock update to fix the immediate Bun version issue.

Fixes #13300

### How did you verify your code works?

Tested the workflow on my fork by triggering it with commits that touch the watched file paths. The workflow successfully runs `nix build .#packages.x86_64-linux.default --no-link` and catches build failures.