### PR TITLE
feat: add RLM (Recursive Language Model) engine

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -42,6 +42,17 @@ export namespace Agent {
       prompt: z.string().optional(),
       options: z.record(z.string(), z.any()),
       steps: z.number().int().positive().optional(),
+      rlm: z
+        .union([
+          z.boolean(),
+          z.object({
+            enabled: z.boolean().optional(),
+            max_iterations: z.number().int().positive().optional(),
+            max_depth: z.number().int().positive().optional(),
+            sub_model: z.string().optional(),
+          }),
+        ])
+        .optional(),
     })
     .meta({
       ref: "Agent",
@@ -228,6 +239,7 @@ export namespace Agent {
       item.steps = value.steps ?? item.steps
       item.options = mergeDeep(item.options, value.options ?? {})
       item.permission = PermissionNext.merge(item.permission, PermissionNext.fromConfig(value.permission ?? {}))
+      if (value.rlm !== undefined) item.rlm = value.rlm
     }
 
     // Ensure Truncate.GLOB is allowed unless explicitly configured

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -118,18 +118,19 @@ export function Session() {
   const session = createMemo(() => sync.session.get(route.sessionID))
   const children = createMemo(() => {
     const parentID = session()?.parentID ?? session()?.id
-    return sync.data.session
+    if (!parentID) return []
+    return (sync.data.session ?? [])
       .filter((x) => x.parentID === parentID || x.id === parentID)
       .toSorted((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
   })
-  const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+  const messages = createMemo(() => sync.data.message?.[route.sessionID] ?? [])
   const permissions = createMemo(() => {
     if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+    return children().flatMap((x) => sync.data.permission?.[x.id] ?? [])
   })
   const questions = createMemo(() => {
     if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.question[x.id] ?? [])
+    return children().flatMap((x) => sync.data.question?.[x.id] ?? [])
   })
 
   const pending = createMemo(() => {
@@ -164,7 +165,7 @@ export function Session() {
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
 
   const scrollAcceleration = createMemo(() => {
-    const tui = sync.data.config.tui
+    const tui = sync.data.config?.tui
     if (tui?.scroll_acceleration?.enabled) {
       return new MacOSScrollAccel()
     }
@@ -320,7 +321,7 @@ export function Session() {
       suggested: route.type === "session",
       keybind: "session_share",
       category: "Session",
-      enabled: sync.data.config.share !== "disabled",
+      enabled: sync.data.config?.share !== "disabled",
       slash: {
         name: "share",
       },
@@ -1115,6 +1116,7 @@ export function Session() {
               />
             </box>
           </Show>
+          <Footer />
           <Toast />
         </box>
         <Show when={sidebarVisible()}>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/overflow.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/overflow.tsx
@@ -1,0 +1,112 @@
+import { createMemo, For } from "solid-js"
+import { useKeyboard } from "@opentui/solid"
+import { selectedForeground, useTheme } from "../../context/theme"
+import { useSDK } from "../../context/sdk"
+import { SplitBorder } from "../../component/border"
+import { createStore } from "solid-js/store"
+import { useKeybind } from "../../context/keybind"
+import { useDialog } from "../../ui/dialog"
+import { useTerminalDimensions } from "@opentui/solid"
+
+export function OverflowPrompt(props: { request: { id: string; sessionID: string } }) {
+  const sdk = useSDK()
+  const { theme } = useTheme()
+  const keybind = useKeybind()
+  const dimensions = useTerminalDimensions()
+  const narrow = createMemo(() => dimensions().width < 80)
+  const dialog = useDialog()
+
+  const options = { compact: "Compact conversation", rlm: "Switch to RLM mode" } as const
+  const keys = Object.keys(options) as (keyof typeof options)[]
+  const [store, setStore] = createStore({ selected: keys[0] as keyof typeof options })
+
+  useKeyboard((evt) => {
+    if (dialog.stack.length > 0) return
+
+    if (evt.name === "left" || evt.name === "h") {
+      evt.preventDefault()
+      const idx = keys.indexOf(store.selected)
+      setStore("selected", keys[(idx - 1 + keys.length) % keys.length])
+    }
+    if (evt.name === "right" || evt.name === "l") {
+      evt.preventDefault()
+      const idx = keys.indexOf(store.selected)
+      setStore("selected", keys[(idx + 1) % keys.length])
+    }
+    if (evt.name === "return") {
+      evt.preventDefault()
+      sdk.client.session.rlmOverflowReply({
+        sessionID: props.request.sessionID,
+        requestID: props.request.id,
+        choice: store.selected,
+      })
+    }
+  })
+
+  return (
+    <box
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.accent}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <box flexDirection="row" gap={1} paddingLeft={1} flexShrink={0}>
+          <text fg={theme.accent}>{"◈"}</text>
+          <text fg={theme.text}>Context window overflow</text>
+        </box>
+        <box paddingLeft={1}>
+          <text fg={theme.textMuted}>
+            The conversation has exceeded the model's context window. You can compact (summarize) the conversation or
+            switch to RLM mode which handles large contexts natively.
+          </text>
+        </box>
+      </box>
+      <box
+        flexDirection={narrow() ? "column" : "row"}
+        flexShrink={0}
+        gap={1}
+        paddingTop={1}
+        paddingLeft={2}
+        paddingRight={3}
+        paddingBottom={1}
+        backgroundColor={theme.backgroundElement}
+        justifyContent={narrow() ? "flex-start" : "space-between"}
+        alignItems={narrow() ? "flex-start" : "center"}
+      >
+        <box flexDirection="row" gap={1} flexShrink={0}>
+          <For each={keys}>
+            {(option) => (
+              <box
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={option === store.selected ? theme.accent : theme.backgroundMenu}
+                onMouseOver={() => setStore("selected", option)}
+                onMouseUp={() => {
+                  setStore("selected", option)
+                  sdk.client.session.rlmOverflowReply({
+                    sessionID: props.request.sessionID,
+                    requestID: props.request.id,
+                    choice: option,
+                  })
+                }}
+              >
+                <text fg={option === store.selected ? selectedForeground(theme, theme.accent) : theme.textMuted}>
+                  {options[option]}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+        <box flexDirection="row" gap={2} flexShrink={0}>
+          <text fg={theme.text}>
+            {"⇆"} <span style={{ fg: theme.textMuted }}>select</span>
+          </text>
+          <text fg={theme.text}>
+            enter <span style={{ fg: theme.textMuted }}>confirm</span>
+          </text>
+        </box>
+      </box>
+    </box>
+  )
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -703,6 +703,18 @@ export namespace Config {
         .describe("Maximum number of agentic iterations before forcing text-only response"),
       maxSteps: z.number().int().positive().optional().describe("@deprecated Use 'steps' field instead."),
       permission: Permission.optional(),
+      rlm: z
+        .union([
+          z.boolean(),
+          z.object({
+            enabled: z.boolean().optional(),
+            max_iterations: z.number().int().positive().optional(),
+            max_depth: z.number().int().positive().optional(),
+            sub_model: ModelId.optional(),
+          }),
+        ])
+        .optional()
+        .describe("Enable RLM mode for this agent. Set to true or provide config overrides."),
     })
     .catchall(z.any())
     .transform((agent, ctx) => {
@@ -723,6 +735,7 @@ export namespace Config {
         "permission",
         "disable",
         "tools",
+        "rlm",
       ])
 
       // Extract unknown properties into options
@@ -782,6 +795,7 @@ export namespace Config {
       session_unshare: z.string().optional().default("none").describe("Unshare current session"),
       session_interrupt: z.string().optional().default("escape").describe("Interrupt current session"),
       session_compact: z.string().optional().default("<leader>c").describe("Compact the session"),
+      rlm_toggle: z.string().optional().default("none").describe("Toggle RLM mode for current session"),
       messages_page_up: z.string().optional().default("pageup,ctrl+alt+b").describe("Scroll messages up by one page"),
       messages_page_down: z
         .string()
@@ -1169,6 +1183,28 @@ export namespace Config {
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
         })
         .optional(),
+      rlm: z
+        .object({
+          enabled: z.boolean().optional().describe("Enable RLM (Recursive Language Model) mode globally (default: false)"),
+          max_iterations: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum number of RLM iterations before forcing a final answer (default: 30)"),
+          max_depth: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("Maximum recursion depth for nested RLM calls (default: 1)"),
+          sub_model: ModelId.optional().describe(
+            "Model to use for sub-LLM queries inside the REPL environment, in provider/model format. Defaults to the main model.",
+          ),
+          verbose: z.boolean().optional().describe("Enable verbose RLM logging (default: false)"),
+        })
+        .optional()
+        .describe("RLM (Recursive Language Model) configuration for iterative REPL-based reasoning"),
       experimental: z
         .object({
           disable_paste_summary: z.boolean().optional(),

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -11,6 +11,7 @@ export namespace Identifier {
     part: "prt",
     pty: "pty",
     tool: "tool",
+    rlmoverflow: "rov",
   } as const
 
   export function schema(prefix: keyof typeof prefixes) {

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -13,6 +13,7 @@ import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
 import { Snapshot } from "../snapshot"
 import { Truncate } from "../tool/truncation"
+import { RLMContext } from "@/rlm"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -26,6 +27,7 @@ export async function InstanceBootstrap() {
   Vcs.init()
   Snapshot.init()
   Truncate.init()
+  RLMContext.initGlobal()
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/rlm/README.md
+++ b/packages/opencode/src/rlm/README.md
@@ -1,0 +1,635 @@
+# RLM - Recursive Language Model
+
+Native TypeScript port of the [RLM](https://github.com/alexzhang13/rlm) system for OpenCode.
+Provides iterative REPL-based reasoning where an LLM can execute JavaScript code,
+query sub-LLMs recursively, and build up answers incrementally.
+
+## Architecture Overview
+
+```
+                        User sends message
+                               |
+                               v
+                    +---------------------+
+                    |    session/llm.ts    |
+                    |  resolveRLMConfig()  |
+                    +---------------------+
+                               |
+                     rlm enabled?  small model?
+                     /                        \
+                   yes                        no (or small)
+                   /                            \
+                  v                              v
+      +---------------------+          Normal Vercel AI SDK
+      | createRLMProvider() |          streamText() / generateText()
+      |    provider.ts      |
+      +---------------------+
+                  |
+                  | returns LanguageModelV2
+                  v
+      +---------------------------+
+      |   OpenCode calls          |
+      |   streamText({ model })   |
+      |   with RLM as the model   |
+      +---------------------------+
+                  |
+                  | triggers doStream()
+                  v
+  +-----------------------------------------+
+  |         provider.ts doStream()          |
+  |                                         |
+  |  1. Extract user content from prompt    |
+  |  2. Call rlmCompletion() with hooks     |
+  |  3. Emit stream parts:                 |
+  |     - reasoning-start/delta/end         |
+  |       (one per iteration)               |
+  |     - text-start/delta/end              |
+  |       (final answer)                    |
+  |     - finish                            |
+  +-----------------------------------------+
+                  |
+                  v
+  +-----------------------------------------+
+  |                                         |
+  |          rlm.ts rlmCompletion()         |
+  |           (Main Engine Loop)            |
+  |                                         |
+  |  See detailed diagram below             |
+  |                                         |
+  +-----------------------------------------+
+```
+
+## Detailed Engine Flow
+
+```
+  rlmCompletion(input)
+         |
+         v
+  +------------------+
+  | depth >= maxDepth |--yes--> fallbackAnswer(): simple LLM call, return
+  +------------------+
+         | no
+         v
+  +-------------------------------+
+  | Initialize:                   |
+  |  - Get language model         |
+  |  - Get sub-model (or same)    |
+  |  - Create LocalREPL           |
+  |  - repl.start()               |
+  |  - Build system prompt        |
+  |    (metadata + instructions)  |
+  +-------------------------------+
+         |
+         v
+  +-------------------------------+
+  | messageHistory = [            |
+  |   { system: RLM_SYSTEM_PROMPT |
+  |     + JS REPL instructions }, |
+  |   { assistant: context        |
+  |     metadata string }         |
+  | ]                             |
+  +-------------------------------+
+         |
+         v
+  ===================================
+  ||  ITERATION LOOP (i = 0..max)  ||
+  ===================================
+         |
+         v
+  +-------------------------------+
+  | Build current prompt:         |
+  |   messageHistory              |
+  |   + buildUserPrompt(          |
+  |       rootPrompt, i,          |
+  |       contextCount)           |
+  |                               |
+  | (iteration 0 includes         |
+  |  safeguard: "you haven't      |
+  |  seen the context yet")       |
+  +-------------------------------+
+         |
+         v
+  +-------------------------------+         +---------------------+
+  | completionTurn()              |         |                     |
+  |                               |         |  Vercel AI SDK      |
+  | 1. generateText({             |-------->|  generateText()     |
+  |      model: language,         |         |  to the root LLM    |
+  |      messages: prompt })      |<--------|                     |
+  |                               |         +---------------------+
+  | 2. Track usage tokens         |
+  |                               |
+  | 3. hooks.onLLMResponse()      |
+  |    (emits reasoning-delta     |
+  |     with the raw response)    |
+  +-------------------------------+
+         |
+         | raw LLM response text
+         v
+  +-------------------------------+
+  | findCodeBlocks(response)      |
+  | (parsing.ts)                  |
+  |                               |
+  | Regex: ```repl\n...\n```      |
+  | Returns string[] of code      |
+  +-------------------------------+
+         |
+         | code blocks found?
+         |
+    no --+---------- yes
+    |                  |
+    |                  v
+    |    +-----------------------------------+
+    |    | FOR EACH code block:              |
+    |    |                                   |
+    |    |   repl.executeCode(code)          |
+    |    |   (environment.ts)                |
+    |    |                                   |
+    |    |   hooks.onCodeExecuted()          |
+    |    |   (emits reasoning-delta with     |
+    |    |    truncated code + REPL output)  |
+    |    +-----------------------------------+
+    |                  |
+    |<-----------------+
+    |
+    v
+  +-------------------------------+
+  | findFinalAnswerAsync(         |
+  |   response, repl.executeCode) |
+  | (parsing.ts)                  |
+  |                               |
+  | Checks for:                   |
+  |  - FINAL_VAR(name)            |
+  |    -> executes console.log(   |
+  |       FINAL_VAR("name"))      |
+  |    -> returns stdout           |
+  |  - FINAL(answer text)         |
+  |    -> returns captured text   |
+  +-------------------------------+
+         |
+    found final answer?
+         |
+    yes--+--------no
+    |              |
+    v              v
+  +----------+  +---------------------------+
+  | Return   |  | Format iteration for      |
+  | {        |  | message history:           |
+  |  response|  |                            |
+  |  usage   |  | formatIteration()          |
+  |  time    |  | (parsing.ts)               |
+  |  iters   |  |                            |
+  | }        |  | -> assistant msg: response |
+  +----------+  | -> user msg per code block:|
+                |    "Code executed:          |
+                |     ```javascript           |
+                |     ...code...              |
+                |     ```                     |
+                |     REPL output: ..."       |
+                +---------------------------+
+                         |
+                         v
+                  Append to messageHistory
+                         |
+                         v
+                  +---------------+
+                  | Next iteration|
+                  | (back to top  |
+                  |  of loop)     |
+                  +---------------+
+
+  ===================================
+  || END ITERATION LOOP            ||
+  ===================================
+         |
+         | (max iterations reached)
+         v
+  +-------------------------------+
+  | getDefaultAnswer()            |
+  |                               |
+  | Appends "Please provide a     |
+  | final answer..." to history   |
+  | and calls generateText()      |
+  | one more time                 |
+  +-------------------------------+
+         |
+         v
+     Return result
+```
+
+## JavaScript REPL Execution Model
+
+The REPL uses Node's `vm` module (`vm.createContext` / `vm.runInContext`) for
+sandboxed execution. Code runs in an isolated context with only whitelisted
+globals — no access to `process`, `require`, `Bun`, `module`, or any Node/Bun
+builtins.
+
+```
+  executeCode(code)
+         |
+         v
+  +---------------------------------+
+  | Build fake console object:      |
+  |   .log()   -> stdoutParts[]     |
+  |   .info()  -> stdoutParts[]     |
+  |   .error() -> stderrParts[]     |
+  |   .warn()  -> stderrParts[]     |
+  |   .dir()   -> stdoutParts[]     |
+  +---------------------------------+
+         |
+         v
+  +---------------------------------+
+  | Inject fake console into        |
+  | this.ctx.console                |
+  +---------------------------------+
+         |
+         v
+  +---------------------------------+
+  | hoistDeclarations(code)         |
+  |                                 |
+  | Transforms top-level const/let  |
+  | into bare assignments so they   |
+  | appear on the vm context object |
+  | (visible in serializeLocals     |
+  | and SHOW_VARS).                 |
+  |                                 |
+  | e.g. "const x = 42" → "x = 42" |
+  +---------------------------------+
+         |
+         v
+  +---------------------------------+
+  | Wrap in async IIFE:             |
+  |   (async () => {                |
+  |     <processed code>            |
+  |   })()                          |
+  +---------------------------------+
+         |
+         v
+   +---------------------------------+
+  | vm.runInContext(                 |
+  |   wrappedCode,                  |
+  |   this.ctx,                     |
+  |   { timeout: timeoutMs }        |
+  | )                               |
+  |                                 |
+  | Sync timeout: vm.runInContext   |
+  | terminates synchronous infinite |
+  | loops (e.g. while(true){})      |
+  +---------------------------------+
+         |
+         v
+  +---------------------------------+
+  | Await the returned promise      |
+  | with Promise.race timeout       |
+  |                                 |
+  | Async timeout: catches hanging  |
+  | awaits (e.g. infinite Promise)  |
+  | Default: 30 seconds             |
+  +---------------------------------+
+         |
+    success?
+    /       \
+  yes       no
+  |          |
+  |          v
+  |    +---------------------+
+  |    | Catch error         |
+  |    | Push to stderrParts |
+  |    +---------------------+
+  |          |
+  |<---------+
+  |
+  v
+  +---------------------------------+
+  | Return REPLResult:              |
+  |   stdout: stdoutParts.join("")  |
+  |   stderr: stderrParts.join("")  |
+  |   locals: serializeLocals()     |
+  |   executionTime                 |
+  +---------------------------------+
+```
+
+### Sandboxed Globals (SANDBOX_GLOBALS)
+
+Only these globals are available to code running in the vm context:
+
+```
+  Constructors:   Array, ArrayBuffer, BigInt, Boolean, DataView, Date,
+                  Error, EvalError, Float32/64Array, Int8/16/32Array,
+                  Map, Number, Object, Promise, Proxy, RangeError,
+                  ReferenceError, RegExp, Set, String, Symbol,
+                  SyntaxError, TypeError, URIError, Uint8/16/32Array,
+                  Uint8ClampedArray, WeakMap, WeakSet, WeakRef
+
+  Utilities:      JSON, Math, decodeURI, decodeURIComponent,
+                  encodeURI, encodeURIComponent, isFinite, isNaN,
+                  parseFloat, parseInt, structuredClone
+
+  Async:          setTimeout, clearTimeout, setInterval,
+                  clearInterval, queueMicrotask
+
+  Constants:      Infinity, NaN, undefined
+
+  BLOCKED:        process, require, Bun, module, __dirname,
+                  __filename, import(), globalThis builtins
+```
+
+### Declaration Hoisting (hoistDeclarations)
+
+Top-level `const`/`let`/`var` declarations are transformed into bare
+assignments before execution. This ensures the variables are set as
+properties on the vm context object, making them visible in
+`serializeLocals()` and `SHOW_VARS()`.
+
+```
+  Input code                      →  Processed code
+  ─────────────────────────────────────────────────────
+  const x = 42                    →  x = 42
+  let a = 1, b = 2               →  a = 1; b = 2
+  let x                           →  x = undefined
+  const [a, b] = [1, 2]          →  [a, b] = [1, 2]
+  const { a, b } = obj           →  ;({ a, b } = obj)
+  function f() { const y = 1 }   →  (unchanged — depth > 0)
+```
+
+The transformation:
+- Only operates at brace depth 0 (top-level)
+- Tracks brace depth across lines, skipping braces in strings/comments
+- Handles simple, multiple declarators, array/object destructuring
+- Preserves nested declarations inside functions/blocks unchanged
+
+### Variable Persistence
+
+```
+  this.ctx (vm.Context — persistent across all executeCode() calls)
+  +-----------------------------------------------+
+  |  SANDBOX GLOBALS (at creation):                |
+  |    Math, JSON, Array, Object, Promise,         |
+  |    Map, Set, RegExp, Date, setTimeout, ...     |
+  |    (see SANDBOX_GLOBALS constant)              |
+  |                                                |
+  |  INJECTED HELPERS (at start()):                |
+  |    llm_query      -> async handler (LLM call)  |
+  |    llm_query_batched -> async handler (batch)  |
+  |    FINAL_VAR      -> retrieves var from ctx    |
+  |    SHOW_VARS      -> lists user variables      |
+  |                                                |
+  |  INJECTED (at each executeCode()):             |
+  |    console        -> fake console (captures    |
+  |                      stdout/stderr)            |
+  |                                                |
+  |  CONTEXT (at start() / loadContext()):         |
+  |    context_0      -> initial context payload   |
+  |    context        -> alias for context_0       |
+  |    context_1..N   -> additional contexts       |
+  |                                                |
+  |  USER VARIABLES (from executed code):          |
+  |    x, y, result, fibonacci, chunks, ...        |
+  |    (bare assignments become properties on      |
+  |     the context; hoistDeclarations converts    |
+  |     const/let to bare assignments)             |
+  +-----------------------------------------------+
+  |                                                |
+  |  INTERNAL_NAMES set (excluded from             |
+  |  serializeLocals and SHOW_VARS):               |
+  |    llm_query, llm_query_batched,               |
+  |    FINAL_VAR, SHOW_VARS, console               |
+  +-----------------------------------------------+
+```
+
+## Sub-LLM Query Flow (llm_query from REPL)
+
+```
+  LLM writes: answer = await llm_query("What is X?")
+                          |
+                          v
+                +-----------------------+
+                | scope.llm_query()     |
+                | (environment.ts)      |
+                +-----------------------+
+                          |
+                          v
+                +-----------------------+
+                | llmQueryHandler()     |
+                | (defined in rlm.ts)   |
+                +-----------------------+
+                          |
+                          v
+                +-----------------------+
+                | generateText({        |
+                |   model: subLanguage, |
+                |   messages: [         |
+                |     { role: "user",   |
+                |       content: prompt |
+                |     }                 |
+                |   ]                   |
+                | })                    |
+                +-----------------------+
+                          |
+                          v
+                +-----------------------+
+                | Vercel AI SDK         |
+                | calls the sub-model   |
+                | (may be same as root  |
+                |  or a different model)|
+                +-----------------------+
+                          |
+                          v
+                +-----------------------+
+                | Track usage tokens    |
+                | in totalUsage         |
+                +-----------------------+
+                          |
+                          v
+                Return result.text
+                (back to user code
+                 as the resolved
+                 await value)
+```
+
+## OpenCode Integration Points
+
+```
+  +------------------------------------------------------+
+  |                    opencode.json                      |
+  |                                                      |
+  |  {                                                   |
+  |    "rlm": {                      // global config    |
+  |      "enabled": true,                                |
+  |      "max_iterations": 5,                            |
+  |      "max_depth": 1,                                 |
+  |      "verbose": false,                               |
+  |      "sub_model": "provider/model-id"                |
+  |    }                                                 |
+  |  }                                                   |
+  +------------------------------------------------------+
+         |
+         v
+  +------------------------------------------------------+
+  |                config/config.ts                      |
+  |                                                      |
+  |  Config.Info schema includes:                        |
+  |    rlm: {                                            |
+  |      enabled, max_iterations, max_depth,             |
+  |      verbose, sub_model                              |
+  |    }                                                 |
+  +------------------------------------------------------+
+         |
+         v
+  +------------------------------------------------------+
+  |                agent/agent.ts                        |
+  |                                                      |
+  |  Agent.Info schema includes:                         |
+  |    rlm: {                                            |
+  |      enabled, max_iterations, max_depth, sub_model   |
+  |    }                                                 |
+  |                                                      |
+  |  (per-agent overrides, merged with global config)    |
+  +------------------------------------------------------+
+         |
+         v
+  +------------------------------------------------------+
+  |               session/llm.ts                         |
+  |                                                      |
+  |  resolveRLMConfig(agent, globalConfig)               |
+  |    -> checks agent.rlm first (per-agent override)    |
+  |    -> falls back to globalConfig.rlm                 |
+  |    -> returns undefined if disabled                  |
+  |    -> skips if input.small (title generation etc.)   |
+  |                                                      |
+  |  If enabled:                                         |
+  |    language = createRLMProvider({                     |
+  |      model, subModel, config                         |
+  |    })                                                |
+  |    // replaces the normal LanguageModelV2            |
+  |    // all subsequent streamText() calls go           |
+  |    // through the RLM engine                         |
+  +------------------------------------------------------+
+```
+
+## Stream Part Emission (what the UI sees)
+
+```
+  Iteration 1:
+    stream-start
+    reasoning-start  (id: rlm-reasoning-1)
+    reasoning-delta  "--- Iteration 1 ---\n<LLM response>\n"
+    reasoning-delta  "\n[REPL] x = 6 * 7...\n42\n"
+    reasoning-end    (id: rlm-reasoning-1)
+
+  Iteration 2:
+    reasoning-start  (id: rlm-reasoning-2)
+    reasoning-delta  "--- Iteration 2 ---\n<LLM response with FINAL()>\n"
+    reasoning-end    (id: rlm-reasoning-2)
+
+  Final answer:
+    text-start       (id: rlm-text-3)
+    text-delta       "The result of 6*7 is "
+    text-delta       "42"
+    text-end         (id: rlm-text-3)
+    finish           { finishReason: "stop", usage: {...} }
+```
+
+In the OpenCode UI:
+- **Reasoning pane**: shows all iteration content (LLM thinking + REPL execution results)
+- **Text output**: shows only the final answer
+
+## File Map
+
+```
+  src/rlm/
+  ├── index.ts          Barrel exports
+  ├── types.ts          Type definitions, usage tracking, config defaults
+  ├── prompts.ts        System prompt, user prompt builders
+  ├── parsing.ts        Code block extraction, FINAL/FINAL_VAR detection
+  ├── environment.ts    JavaScript REPL (vm.createContext sandbox + hoistDeclarations)
+  ├── rlm.ts            Main engine loop (rlmCompletion)
+  ├── provider.ts       LanguageModelV2 wrapper (createRLMProvider)
+  └── README.md         This file
+
+  Integration points:
+  ├── src/config/config.ts     Global RLM config schema
+  ├── src/agent/agent.ts       Per-agent RLM config schema
+  └── src/session/llm.ts       RLM activation + provider wrapping
+```
+
+## Example Session Trace
+
+```
+  User: "What is the 15th Fibonacci number? Use code to compute it."
+
+  ┌─────────────────────────────────────────────────────┐
+  │ Iteration 1                                         │
+  │                                                     │
+  │ LLM response:                                       │
+  │   "Let me check the context and compute this."      │
+  │   ```repl                                           │
+  │   console.log("Context:", context)                  │
+  │   ```                                               │
+  │                                                     │
+  │ REPL executes -> stdout: "Context: What is the..."  │
+  │ No FINAL() found -> continue                        │
+  └─────────────────────────────────────────────────────┘
+                         |
+                         v
+  ┌─────────────────────────────────────────────────────┐
+  │ Iteration 2                                         │
+  │                                                     │
+  │ LLM response:                                       │
+  │   "I see the question. Let me compute Fibonacci."   │
+  │   ```repl                                           │
+  │   fib = function(n) {                               │
+  │       if (n <= 1) return n                          │
+  │       return fib(n-1) + fib(n-2)                   │
+  │   }                                                 │
+  │   result = fib(15)                                  │
+  │   console.log("Fibonacci(15) =", result)            │
+  │   ```                                               │
+  │                                                     │
+  │ REPL executes -> stdout: "Fibonacci(15) = 610"      │
+  │ No FINAL() found -> continue                        │
+  └─────────────────────────────────────────────────────┘
+                         |
+                         v
+  ┌─────────────────────────────────────────────────────┐
+  │ Iteration 3                                         │
+  │                                                     │
+  │ LLM response:                                       │
+  │   "The 15th Fibonacci number is 610."               │
+  │   FINAL(The 15th Fibonacci number is 610)           │
+  │                                                     │
+  │ FINAL() detected -> return answer                   │
+  └─────────────────────────────────────────────────────┘
+                         |
+                         v
+              Output: "The 15th Fibonacci number is 610"
+```
+
+## Key Design Decisions
+
+1. **Pure TypeScript / JavaScript** - No Python subprocess, no external dependencies.
+   The REPL runs in-process using Node's `vm` module (`vm.createContext` /
+   `vm.runInContext`) for sandboxed, isolated execution.
+
+2. **vm Context persistence** - Variables assigned in one `executeCode()` call
+   persist in subsequent calls through the shared `vm.Context` object. Bare
+   assignments become properties on the context. Top-level `const`/`let`/`var`
+   are preprocessed by `hoistDeclarations()` which strips the keyword, turning
+   them into bare assignments that appear on the context object.
+
+3. **Security via SANDBOX_GLOBALS whitelist** - The vm context only exposes
+   explicitly whitelisted globals (`Math`, `JSON`, `Array`, `Promise`, etc.).
+   `process`, `require`, `Bun`, `module`, `import()`, and all Node/Bun builtins
+   are blocked. Code cannot escape the sandbox.
+
+4. **Fake console injection** - `console` is placed directly on the vm context
+   before each execution. `console.log()` captures output into `stdoutParts[]` /
+   `stderrParts[]` for structured result reporting.
+
+5. **LanguageModelV2 wrapping** - RLM appears as a standard Vercel AI SDK model.
+   OpenCode's existing `streamText()` / `generateText()` calls work unchanged.
+   The `doStream()` method runs `rlmCompletion()` internally and emits stream
+   parts (reasoning for iterations, text for final answer).
+
+6. **Config cascade** - RLM can be enabled globally (`opencode.json` -> `rlm.enabled`)
+   or per-agent (`agent.rlm.enabled`). Agent config overrides global. Small model
+   calls (title generation) always skip RLM.

--- a/packages/opencode/src/rlm/context.ts
+++ b/packages/opencode/src/rlm/context.ts
@@ -1,0 +1,365 @@
+/**
+ * RLM Context Manager — persistent, always-on context memory.
+ *
+ * Stores every message (user, assistant, tool calls, tool results, sub-agents)
+ * as structured JSON in the REPL sandbox AND on disk via Storage.
+ *
+ * The agent can query this context programmatically via the context_query tool,
+ * running JS code in the REPL sandbox against the full `context` array.
+ *
+ * On session load, context is restored from disk and re-injected into the REPL.
+ * On compaction, the full context history is included in the summary so nothing
+ * is lost.
+ *
+ * Lifecycle:
+ * - init(sessionID) — called when a session starts or loads
+ * - append(sessionID, entries) — called after each LLM step / message
+ * - snapshot(sessionID) — returns the full context array (for compaction)
+ * - execute(sessionID, code) — runs JS against the context REPL
+ * - persist(sessionID) — saves to disk
+ * - restore(sessionID) — loads from disk, re-injects into REPL
+ * - cleanup(sessionID) — frees memory
+ */
+
+import { Storage } from "@/storage/storage"
+import { Log } from "@/util/log"
+import { LocalREPL } from "./environment"
+import type { LLMQueryHandler, LLMQueryBatchedHandler } from "./environment"
+import type { REPLResult } from "./types"
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import z from "zod"
+
+const log = Log.create({ service: "rlm-context" })
+
+// ============================================================
+// Context Entry — the structured messages stored in the REPL
+// ============================================================
+
+export interface ContextEntry {
+  role: "system" | "user" | "assistant" | "tool-call" | "tool-result" | "sub-agent"
+  content: string
+  /** For tool-call and tool-result entries */
+  toolName?: string
+  toolCallId?: string
+  /** Timestamp when this entry was recorded */
+  time: number
+  /** Session ID of the sub-agent (for sub-agent entries) */
+  sourceSessionID?: string
+}
+
+// ============================================================
+// Per-session state
+// ============================================================
+
+interface SessionContext {
+  repl: LocalREPL
+  entries: ContextEntry[]
+  dirty: boolean
+}
+
+const sessions = new Map<string, SessionContext>()
+/** Maps child sessionID -> parent sessionID for shared context */
+const aliases = new Map<string, string>()
+
+function resolve(sessionID: string): string {
+  return aliases.get(sessionID) ?? sessionID
+}
+
+// ============================================================
+// Storage key
+// ============================================================
+
+function storageKey(sessionID: string): string[] {
+  return ["rlm_context", sessionID]
+}
+
+// ============================================================
+// LLM Query handlers (no-op defaults — the tool doesn't need sub-LLM)
+// ============================================================
+
+const noopQuery: LLMQueryHandler = async () => "Error: llm_query not available in context_query mode"
+const noopBatchedQuery: LLMQueryBatchedHandler = async (prompts) =>
+  prompts.map(() => "Error: llm_query_batched not available in context_query mode")
+
+// ============================================================
+// Public API
+// ============================================================
+
+/**
+ * Initialize context for a session. Creates REPL, restores from disk if exists.
+ */
+export async function init(sessionID: string): Promise<void> {
+  const id = resolve(sessionID)
+  if (sessions.has(id)) return
+
+  log.info("init", { sessionID: id })
+
+  const repl = new LocalREPL({
+    llmQueryHandler: noopQuery,
+    llmQueryBatchedHandler: noopBatchedQuery,
+    executionTimeoutMs: 10_000,
+  })
+  await repl.start()
+
+  const ctx: SessionContext = {
+    repl,
+    entries: [],
+    dirty: false,
+  }
+  sessions.set(id, ctx)
+
+  // Try restoring from disk
+  await restore(id)
+
+  // Sync entries into REPL
+  await syncToRepl(ctx)
+}
+
+/**
+ * Ensure context is initialized for a session, lazy init if needed.
+ */
+export async function ensure(sessionID: string): Promise<SessionContext> {
+  const id = resolve(sessionID)
+  if (!sessions.has(id)) await init(id)
+  return sessions.get(id)!
+}
+
+/**
+ * Append context entries for a session. Auto-persists.
+ */
+export async function append(sessionID: string, entries: ContextEntry[]): Promise<void> {
+  const id = resolve(sessionID)
+  const ctx = await ensure(id)
+  ctx.entries.push(...entries)
+  ctx.dirty = true
+  await syncToRepl(ctx)
+  await persist(id)
+}
+
+/**
+ * Get the full context snapshot (for compaction summaries).
+ */
+export async function snapshot(sessionID: string): Promise<ContextEntry[]> {
+  const id = resolve(sessionID)
+  const ctx = await ensure(id)
+  return [...ctx.entries]
+}
+
+/**
+ * Execute JavaScript code against the context REPL.
+ * The `context` variable contains the full ContextEntry[] array.
+ */
+export async function execute(sessionID: string, code: string): Promise<REPLResult> {
+  const id = resolve(sessionID)
+  const ctx = await ensure(id)
+  return ctx.repl.executeCode(code)
+}
+
+/**
+ * Alias a child session to share the parent's context.
+ * Used for sub-agent tasks.
+ */
+export function alias(childID: string, parentID: string): void {
+  log.info("alias", { childID, parentID })
+  aliases.set(childID, resolve(parentID))
+}
+
+/**
+ * Persist context to disk via Storage.
+ */
+export async function persist(sessionID: string): Promise<void> {
+  const id = resolve(sessionID)
+  const ctx = sessions.get(id)
+  if (!ctx || !ctx.dirty) return
+
+  log.info("persist", { sessionID: id, entries: ctx.entries.length })
+  await Storage.write(storageKey(id), ctx.entries)
+  ctx.dirty = false
+}
+
+/**
+ * Restore context from disk. Merges into existing entries if any.
+ */
+async function restore(sessionID: string): Promise<void> {
+  const ctx = sessions.get(sessionID)
+  if (!ctx) return
+
+  try {
+    const stored = await Storage.read<ContextEntry[]>(storageKey(sessionID))
+    if (Array.isArray(stored) && stored.length > 0) {
+      log.info("restore", { sessionID, entries: stored.length })
+      ctx.entries = stored
+    }
+  } catch {
+    // No stored context — fresh session
+  }
+}
+
+/**
+ * Sync the entries array into the REPL as the `context` variable.
+ */
+async function syncToRepl(ctx: SessionContext): Promise<void> {
+  await ctx.repl.executeCode(`context = ${JSON.stringify(ctx.entries)}`)
+}
+
+/**
+ * Get the number of context entries for a session.
+ */
+export async function count(sessionID: string): Promise<number> {
+  const id = resolve(sessionID)
+  const ctx = sessions.get(id)
+  return ctx?.entries.length ?? 0
+}
+
+/**
+ * Clean up a session's context. Persists before cleanup.
+ */
+export async function cleanup(sessionID: string): Promise<void> {
+  // Handle alias cleanup
+  if (aliases.has(sessionID)) {
+    aliases.delete(sessionID)
+    return
+  }
+
+  const ctx = sessions.get(sessionID)
+  if (!ctx) return
+
+  log.info("cleanup", { sessionID })
+  await persist(sessionID)
+  await ctx.repl.cleanup()
+  sessions.delete(sessionID)
+}
+
+/**
+ * Clean up all sessions. Called on process exit.
+ */
+export async function cleanupAll(): Promise<void> {
+  aliases.clear()
+  for (const [id, ctx] of sessions) {
+    try {
+      await persist(id)
+      await ctx.repl.cleanup()
+    } catch {
+      // best effort
+    }
+  }
+  sessions.clear()
+}
+
+// ============================================================
+// Helper: extract context entries from messages
+// ============================================================
+
+/**
+ * Convert a MessageV2.WithParts into ContextEntry[] for appending.
+ * Handles user messages, assistant text, tool calls, tool results.
+ */
+export function fromMessage(msg: {
+  info: { role: string; id: string; sessionID: string; time: { created: number } }
+  parts: Array<{
+    type: string
+    text?: string
+    tool?: string
+    callID?: string
+    state?: { status: string; input?: unknown; output?: unknown }
+    prompt?: string
+    description?: string
+  }>
+}): ContextEntry[] {
+  const entries: ContextEntry[] = []
+  const time = msg.info.time.created
+
+  if (msg.info.role === "user") {
+    for (const part of msg.parts) {
+      if (part.type === "text" && part.text) {
+        entries.push({ role: "user", content: part.text, time })
+      }
+      if (part.type === "subtask" && part.prompt) {
+        entries.push({
+          role: "sub-agent",
+          content: `Sub-task: ${part.description ?? part.prompt}`,
+          time,
+          sourceSessionID: msg.info.sessionID,
+        })
+      }
+    }
+  }
+
+  if (msg.info.role === "assistant") {
+    for (const part of msg.parts) {
+      if (part.type === "text" && part.text) {
+        entries.push({ role: "assistant", content: part.text, time })
+      }
+      if (part.type === "tool") {
+        if (part.state?.status === "completed" || part.state?.status === "error") {
+          entries.push({
+            role: "tool-call",
+            content: typeof part.state.input === "string"
+              ? part.state.input
+              : JSON.stringify(part.state.input ?? {}),
+            toolName: part.tool,
+            toolCallId: part.callID,
+            time,
+          })
+          entries.push({
+            role: "tool-result",
+            content: typeof part.state.output === "string"
+              ? part.state.output?.slice(0, 5000) ?? ""
+              : JSON.stringify(part.state.output ?? {}).slice(0, 5000),
+            toolName: part.tool,
+            toolCallId: part.callID,
+            time,
+          })
+        }
+      }
+    }
+  }
+
+  return entries
+}
+
+// ============================================================
+// Events
+// ============================================================
+
+export const Event = {
+  Updated: BusEvent.define(
+    "rlm.context.updated",
+    z.object({
+      sessionID: z.string(),
+      count: z.number(),
+    }),
+  ),
+}
+
+// ============================================================
+// Init hook for session deletion cleanup
+// ============================================================
+
+let initialized = false
+
+export function initGlobal(): void {
+  if (initialized) return
+  initialized = true
+
+  Bus.subscribe(
+    BusEvent.define("session.deleted", z.object({ info: z.object({ id: z.string() }).passthrough() })),
+    async (event) => {
+      await cleanup(event.properties.info.id)
+    },
+  )
+
+  process.on("exit", () => {
+    // Synchronous best-effort cleanup
+    for (const [, ctx] of sessions) {
+      try {
+        ctx.repl.cleanup()
+      } catch {
+        // best effort
+      }
+    }
+    sessions.clear()
+    aliases.clear()
+  })
+}

--- a/packages/opencode/src/rlm/environment.ts
+++ b/packages/opencode/src/rlm/environment.ts
@@ -1,0 +1,699 @@
+/**
+ * RLM Environment - Sandboxed JavaScript REPL
+ *
+ * Provides a sandboxed JavaScript execution environment for RLM code execution.
+ * Uses Node's `vm` module with `createContext`/`runInContext` for isolation.
+ *
+ * Security properties:
+ * - Code runs in an isolated vm context — no access to `process`, `require`,
+ *   `Bun`, `module`, `__dirname`, `__filename`, or any Node/Bun builtins
+ * - Only explicitly whitelisted globals are available (Math, JSON, Array, etc.)
+ * - console.log/console.error are intercepted for stdout/stderr capture
+ *
+ * Key features:
+ * - Variables persist across executeCode() calls (vm context is reused)
+ * - `const`, `let`, `var`, and bare assignments all persist across calls
+ * - Top-level `const`/`let` are also hoisted to bare assignments so they
+ *   appear in the context object (visible in serializeLocals/SHOW_VARS)
+ * - Injected functions: llm_query(), llm_query_batched(), FINAL_VAR(), SHOW_VARS()
+ * - All code runs in an async wrapper so top-level `await` works
+ * - Errors are caught gracefully — the REPL continues working after errors
+ */
+
+import * as vm from "node:vm"
+import type { REPLResult } from "./types"
+
+/** Function that handles llm_query() calls from inside the REPL */
+export type LLMQueryHandler = (prompt: string, model?: string) => Promise<string>
+
+/** Function that handles batched llm_query() calls */
+export type LLMQueryBatchedHandler = (prompts: string[], model?: string) => Promise<string[]>
+
+/** Default execution timeout in milliseconds (30 seconds) */
+const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000
+
+export interface LocalREPLOptions {
+  /** Handler for llm_query() calls from inside the REPL */
+  llmQueryHandler: LLMQueryHandler
+  /** Handler for llm_query_batched() calls from inside the REPL */
+  llmQueryBatchedHandler?: LLMQueryBatchedHandler
+  /** Initial context to load into the REPL */
+  contextPayload?: string | Record<string, unknown> | unknown[]
+  /**
+   * Maximum execution time per executeCode() call in milliseconds.
+   * - Synchronous infinite loops (e.g. `while(true){}`) are terminated by
+   *   vm.runInContext's built-in `timeout` option.
+   * - Async operations (e.g. hanging awaits) are terminated by a Promise.race
+   *   with a timer.
+   * - Set to 0 or Infinity to disable.
+   * - Default: 30000 (30 seconds)
+   */
+  executionTimeoutMs?: number
+}
+
+// Names injected into every execution scope — excluded from user-visible variables
+const INTERNAL_NAMES = new Set([
+  "llm_query",
+  "llm_query_batched",
+  "FINAL",
+  "FINAL_VAR",
+  "SHOW_VARS",
+  "console",
+  "__rlm_final__",
+])
+
+/**
+ * Whitelisted globals exposed to the vm sandbox.
+ * These are safe, side-effect-free constructors and utilities.
+ */
+const SANDBOX_GLOBALS: Record<string, unknown> = {
+  // Primitives & constructors
+  Array,
+  ArrayBuffer,
+  BigInt,
+  Boolean,
+  DataView,
+  Date,
+  Error,
+  EvalError,
+  Float32Array,
+  Float64Array,
+  Int8Array,
+  Int16Array,
+  Int32Array,
+  Infinity,
+  JSON,
+  Map,
+  Math,
+  NaN,
+  Number,
+  Object,
+  Promise,
+  Proxy,
+  RangeError,
+  ReferenceError,
+  RegExp,
+  Set,
+  String,
+  Symbol,
+  SyntaxError,
+  TypeError,
+  URIError,
+  Uint8Array,
+  Uint8ClampedArray,
+  Uint16Array,
+  Uint32Array,
+  WeakMap,
+  WeakSet,
+  WeakRef,
+
+  // Global functions
+  decodeURI,
+  decodeURIComponent,
+  encodeURI,
+  encodeURIComponent,
+  isFinite,
+  isNaN,
+  parseFloat,
+  parseInt,
+  structuredClone,
+
+  // Async utilities
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  queueMicrotask,
+
+  // Constants
+  undefined,
+}
+
+export class LocalREPL {
+  /** The vm context — acts as the global scope for executed code */
+  private ctx: vm.Context | null = null
+  private llmQueryHandler: LLMQueryHandler
+  private llmQueryBatchedHandler: LLMQueryBatchedHandler
+  private contextPayload?: string | Record<string, unknown> | unknown[]
+  private contextCount = 0
+  private ready = false
+  private executionTimeoutMs: number
+  /** Stores the value passed to FINAL() when called from code */
+  private finalValue: string | undefined = undefined
+  /** Whether FINAL() was called from within a code block */
+  private finalCalled = false
+
+  constructor(options: LocalREPLOptions) {
+    this.llmQueryHandler = options.llmQueryHandler
+    this.llmQueryBatchedHandler =
+      options.llmQueryBatchedHandler ??
+      (async (prompts, model) => {
+        return Promise.all(prompts.map((p) => this.llmQueryHandler(p, model)))
+      })
+    this.contextPayload = options.contextPayload
+    this.executionTimeoutMs = options.executionTimeoutMs ?? DEFAULT_EXECUTION_TIMEOUT_MS
+  }
+
+  /**
+   * Initialize the REPL execution context.
+   * Creates a sandboxed vm context with whitelisted globals and injected helpers.
+   */
+  async start(): Promise<void> {
+    // Create the sandbox with whitelisted globals
+    const sandbox: Record<string, unknown> = { ...SANDBOX_GLOBALS }
+
+    // Inject helper functions
+    sandbox.llm_query = (prompt: string, model?: string) => this.llmQueryHandler(prompt, model)
+    sandbox.llm_query_batched = (prompts: string[], model?: string) =>
+      this.llmQueryBatchedHandler(prompts, model)
+
+    sandbox.FINAL_VAR = (variableName: string): string => {
+      const name = String(variableName).trim().replace(/^["']|["']$/g, "")
+      if (this.ctx && name in this.ctx && !INTERNAL_NAMES.has(name)) {
+        const value = String(this.ctx[name])
+        this.finalCalled = true
+        this.finalValue = value
+        return value
+      }
+      const available = this.ctx
+        ? Object.keys(this.ctx).filter((k) => !k.startsWith("_") && !INTERNAL_NAMES.has(k) && !(k in SANDBOX_GLOBALS))
+        : []
+      if (available.length > 0) {
+        return `Error: Variable '${name}' not found. Available variables: [${available.map((v) => `"${v}"`).join(", ")}].`
+      }
+      return `Error: Variable '${name}' not found. No variables created yet.`
+    }
+
+    sandbox.FINAL = (answer: unknown): string => {
+      const value = typeof answer === "string" ? answer : inspectValue(answer)
+      this.finalCalled = true
+      this.finalValue = value
+      return value
+    }
+
+    sandbox.SHOW_VARS = (): string => {
+      if (!this.ctx) return "REPL not initialized."
+      const available: Record<string, string> = {}
+      for (const [k, v] of Object.entries(this.ctx)) {
+        if (k.startsWith("_") || INTERNAL_NAMES.has(k) || k in SANDBOX_GLOBALS) continue
+        available[k] = typeof v === "function" ? "function" : typeof v
+      }
+      if (Object.keys(available).length === 0) {
+        return "No variables created yet. Use ```repl``` blocks to create variables."
+      }
+      return `Available variables: ${JSON.stringify(available)}`
+    }
+
+    // Create the isolated vm context
+    this.ctx = vm.createContext(sandbox)
+    this.ready = true
+
+    // Load initial context if provided
+    if (this.contextPayload !== undefined) {
+      await this.loadContext(this.contextPayload)
+    }
+  }
+
+  /**
+   * Load context into the REPL environment.
+   */
+  async loadContext(context: string | Record<string, unknown> | unknown[], index?: number): Promise<void> {
+    if (!this.ctx) throw new Error("REPL not started. Call start() first.")
+
+    const contextIndex = index ?? this.contextCount
+    const varName = `context_${contextIndex}`
+
+    this.ctx[varName] = context
+    // When it's the first context (ends with _0), also alias as "context"
+    if (varName.endsWith("_0")) {
+      this.ctx["context"] = context
+    }
+
+    this.contextCount = Math.max(this.contextCount, contextIndex + 1)
+  }
+
+  /**
+   * Execute JavaScript code in the sandboxed REPL and return the result.
+   * Code runs in an async wrapper so top-level `await` works.
+   * Variables assigned in the code persist in the vm context.
+   */
+  async executeCode(code: string): Promise<REPLResult> {
+    if (!this.ready || !this.ctx) {
+      throw new Error("REPL not started. Call start() first.")
+    }
+
+    const startTime = performance.now()
+    const stdoutParts: string[] = []
+    const stderrParts: string[] = []
+
+    // Build a fake console that captures output
+    const fakeConsole = {
+      log: (...args: unknown[]) => {
+        stdoutParts.push(args.map((a) => (typeof a === "string" ? a : inspectValue(a))).join(" ") + "\n")
+      },
+      error: (...args: unknown[]) => {
+        stderrParts.push(args.map((a) => (typeof a === "string" ? a : inspectValue(a))).join(" ") + "\n")
+      },
+      warn: (...args: unknown[]) => {
+        stderrParts.push(args.map((a) => (typeof a === "string" ? a : inspectValue(a))).join(" ") + "\n")
+      },
+      info: (...args: unknown[]) => {
+        stdoutParts.push(args.map((a) => (typeof a === "string" ? a : inspectValue(a))).join(" ") + "\n")
+      },
+      dir: (...args: unknown[]) => {
+        stdoutParts.push(args.map((a) => inspectValue(a)).join(" ") + "\n")
+      },
+    }
+
+    // Inject the fake console into the vm context
+    this.ctx.console = fakeConsole
+
+    const timeoutMs = this.executionTimeoutMs
+
+    try {
+      // Pre-process: transform top-level const/let/var declarations into bare
+      // assignments so they appear on the context object (visible in serializeLocals
+      // and SHOW_VARS). In the vm, const/let persist across calls regardless, but
+      // only bare assignments and var are enumerable on the context object.
+      const processedCode = hoistDeclarations(code)
+
+      // Wrap in an async IIFE so top-level `await` works
+      const wrappedCode = `(async () => {\n${processedCode}\n})()`
+
+      // vm.runInContext's `timeout` option catches synchronous infinite loops
+      // (e.g. `while(true){}`). For async operations, we use Promise.race.
+      const vmOptions: vm.RunningCodeOptions = {}
+      if (timeoutMs > 0 && isFinite(timeoutMs)) {
+        vmOptions.timeout = timeoutMs
+      }
+
+      const result = vm.runInContext(wrappedCode, this.ctx, vmOptions)
+
+      // Await the async IIFE's promise, with a timeout guard for async hangs
+      if (timeoutMs > 0 && isFinite(timeoutMs)) {
+        await withTimeout(result, timeoutMs)
+      } else {
+        await result
+      }
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? `${err.constructor.name}: ${err.message}` : String(err)
+      stderrParts.push(errMsg)
+    }
+
+    return {
+      stdout: stdoutParts.join(""),
+      stderr: stderrParts.join(""),
+      locals: this.serializeLocals(),
+      executionTime: (performance.now() - startTime) / 1000,
+      rlmCalls: [],
+    }
+  }
+
+  /**
+   * Get the number of contexts loaded.
+   */
+  getContextCount(): number {
+    return this.contextCount
+  }
+
+  /**
+   * Check if FINAL() or FINAL_VAR() was called from within a code block.
+   */
+  hasFinalAnswer(): boolean {
+    return this.finalCalled
+  }
+
+  /**
+   * Get the final answer value set by FINAL() or FINAL_VAR() from code.
+   * Returns undefined if not called.
+   */
+  getFinalAnswer(): string | undefined {
+    return this.finalValue
+  }
+
+  /**
+   * Reset the final answer state (called between iterations if needed).
+   */
+  resetFinalAnswer(): void {
+    this.finalCalled = false
+    this.finalValue = undefined
+  }
+
+  /**
+   * Clean up the REPL — releases the vm context.
+   */
+  async cleanup(): Promise<void> {
+    this.ctx = null
+    this.ready = false
+    this.contextCount = 0
+  }
+
+  /**
+   * Serialize the current scope variables for reporting.
+   * Excludes internal/injected names, underscore-prefixed variables, and sandbox globals.
+   */
+  private serializeLocals(): Record<string, unknown> {
+    if (!this.ctx) return {}
+    const result: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(this.ctx)) {
+      if (k.startsWith("_") || INTERNAL_NAMES.has(k) || k in SANDBOX_GLOBALS) continue
+      try {
+        if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+          result[k] = v
+        } else if (Array.isArray(v)) {
+          result[k] = `<Array length=${v.length}>`
+        } else if (v && typeof v === "object") {
+          const keys = Object.keys(v)
+          result[k] = `<Object keys=${keys.length}>`
+        } else if (typeof v === "function") {
+          result[k] = `<function>`
+        } else if (v === null) {
+          result[k] = null
+        } else if (v === undefined) {
+          result[k] = undefined
+        } else {
+          result[k] = `<${typeof v}>`
+        }
+      } catch {
+        result[k] = `<${typeof v}>`
+      }
+    }
+    return result
+  }
+}
+
+// ============================================================
+// Declaration Hoisting
+// ============================================================
+
+/**
+ * Transform top-level `const`, `let`, and `var` declarations into bare
+ * assignments so they are captured by the Proxy's `set()` trap and persist
+ * across executeCode() calls.
+ *
+ * Only transforms declarations at the top level (brace depth 0). Declarations
+ * inside functions, loops, if-blocks, etc. are left untouched.
+ *
+ * Handles:
+ * - Simple:         `const x = 42`        → `x = 42`
+ * - Multiple:       `let a = 1, b = 2`    → `a = 1; b = 2`
+ * - No initializer: `let x`               → `x = undefined`
+ * - Array destructure: `const [a, b] = [1, 2]` → `[a, b] = [1, 2]` (kept, assignment target works)
+ * - Object destructure: `const { a, b } = obj` → `void function() { const { a, b } = obj; ... }` (uses wrapper)
+ * - For-loop heads: `for (let i = 0; ...)` → left untouched (part of a block construct)
+ * - Nested:         `function f() { const x = 1 }` → left untouched
+ *
+ * The transformation is intentionally conservative — it only matches lines that
+ * clearly start with const/let/var at brace depth 0. If the regex doesn't match
+ * a complex pattern, the code passes through unchanged (the model's code still
+ * runs, variables just won't persist).
+ */
+export function hoistDeclarations(code: string): string {
+  const lines = code.split("\n")
+  const result: string[] = []
+  let braceDepth = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Count net brace changes on lines BEFORE this one to determine current depth.
+    // We need to know the depth at the START of this line.
+    if (braceDepth === 0) {
+      const transformed = transformDeclarationLine(line)
+      if (transformed !== null) {
+        result.push(transformed)
+        braceDepth += netBraces(line)
+        continue
+      }
+    }
+
+    result.push(line)
+    braceDepth += netBraces(line)
+    // Clamp to 0 in case of unbalanced braces (shouldn't happen in valid code)
+    if (braceDepth < 0) braceDepth = 0
+  }
+
+  return result.join("\n")
+}
+
+/**
+ * Count the net change in brace depth for a line.
+ * Skips braces inside string literals and comments.
+ */
+function netBraces(line: string): number {
+  let depth = 0
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  let escaped = false
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+
+    if (ch === "\\") {
+      escaped = true
+      continue
+    }
+
+    // Handle string literals
+    if (ch === "'" && !inDouble && !inTemplate) {
+      inSingle = !inSingle
+      continue
+    }
+    if (ch === '"' && !inSingle && !inTemplate) {
+      inDouble = !inDouble
+      continue
+    }
+    if (ch === "`" && !inSingle && !inDouble) {
+      inTemplate = !inTemplate
+      continue
+    }
+
+    if (inSingle || inDouble || inTemplate) continue
+
+    // Skip line comments
+    if (ch === "/" && i + 1 < line.length && line[i + 1] === "/") break
+
+    if (ch === "{") depth++
+    else if (ch === "}") depth--
+  }
+
+  return depth
+}
+
+/**
+ * Attempt to transform a single line that starts with const/let/var into
+ * bare assignments. Returns the transformed line, or null if the line
+ * doesn't match the pattern.
+ */
+function transformDeclarationLine(line: string): string | null {
+  // Match lines starting with const/let/var (with optional whitespace)
+  const match = line.match(/^(\s*)(const|let|var)\s+(.+)$/)
+  if (!match) return null
+
+  const indent = match[1]
+  const declBody = match[3]
+
+  // Skip for-loop declarations: `for (let i = 0; ...`
+  // These are detected by the presence of `for` before the declaration on the same
+  // logical line. Since we split by newlines, for-loop heads where `for (` is on a
+  // previous line won't match this function anyway. But check for inline for-loops.
+  // Actually, `for (let ...` would be inside parentheses which means the `let` is
+  // not at column 0. But since we're looking at full lines, a for-loop head like
+  // `for (let i = 0; i < 10; i++) {` has `for` before `let`. We only match lines
+  // where const/let/var is the first keyword, so for-loops are naturally excluded.
+
+  // Handle destructuring patterns
+  if (declBody.startsWith("[")) {
+    // Array destructuring: `const [a, b] = [1, 2]` → `[a, b] = [1, 2]`
+    // This works because `[a, b] = expr` is a valid assignment expression
+    // when a and b are captured by the Proxy
+    return indent + declBody
+  }
+
+  if (declBody.startsWith("{")) {
+    // Object destructuring: `const { a, b } = obj` → needs special handling
+    // Bare `{ a, b } = obj` is a syntax error (leading `{` is parsed as block).
+    // Wrap in parens: `({ a, b } = obj)` — this is valid and the Proxy captures assignments.
+    // Find the `= expr` part
+    const eqIndex = findTopLevelEquals(declBody)
+    if (eqIndex === -1) return null
+    const pattern = declBody.slice(0, eqIndex).trim()
+    const value = declBody.slice(eqIndex + 1).trim()
+    return `${indent};(${pattern} = ${value})`
+  }
+
+  // Simple declarations, possibly with multiple declarators: `let a = 1, b = 2`
+  // Split by commas at the top level (not inside parens/brackets/braces)
+  const declarators = splitDeclarators(declBody)
+  const assignments: string[] = []
+
+  for (const decl of declarators) {
+    const trimmed = decl.trim()
+    const eqIdx = trimmed.indexOf("=")
+    if (eqIdx === -1) {
+      // No initializer: `let x` → `x = undefined`
+      if (/^[a-zA-Z_$][a-zA-Z0-9_$]*\s*;?\s*$/.test(trimmed)) {
+        const varName = trimmed.replace(/\s*;?\s*$/, "")
+        assignments.push(`${varName} = undefined`)
+      } else {
+        // Complex pattern without initializer — can't transform
+        return null
+      }
+    } else {
+      const name = trimmed.slice(0, eqIdx).trim()
+      const value = trimmed.slice(eqIdx + 1).trim()
+      // Validate it's a simple identifier
+      if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(name)) {
+        assignments.push(`${name} = ${value}`)
+      } else {
+        // Complex pattern (destructuring mixed into comma list) — can't transform
+        return null
+      }
+    }
+  }
+
+  if (assignments.length === 0) return null
+  return indent + assignments.join("; ")
+}
+
+/**
+ * Find the index of the top-level `=` in a destructuring declaration.
+ * Skips `=` inside nested brackets/braces.
+ */
+function findTopLevelEquals(s: string): number {
+  let depth = 0
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (ch === "{" || ch === "[" || ch === "(") depth++
+    else if (ch === "}" || ch === "]" || ch === ")") depth--
+    else if (ch === "=" && depth === 0 && s[i + 1] !== "=") return i
+  }
+  return -1
+}
+
+/**
+ * Split declarators by top-level commas (not inside parens/brackets/braces/strings).
+ */
+function splitDeclarators(s: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let current = ""
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  let escaped = false
+
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+
+    if (escaped) {
+      current += ch
+      escaped = false
+      continue
+    }
+
+    if (ch === "\\") {
+      current += ch
+      escaped = true
+      continue
+    }
+
+    if (ch === "'" && !inDouble && !inTemplate) {
+      inSingle = !inSingle
+      current += ch
+      continue
+    }
+    if (ch === '"' && !inSingle && !inTemplate) {
+      inDouble = !inDouble
+      current += ch
+      continue
+    }
+    if (ch === "`" && !inSingle && !inDouble) {
+      inTemplate = !inTemplate
+      current += ch
+      continue
+    }
+
+    if (inSingle || inDouble || inTemplate) {
+      current += ch
+      continue
+    }
+
+    if (ch === "(" || ch === "[" || ch === "{") {
+      depth++
+      current += ch
+    } else if (ch === ")" || ch === "]" || ch === "}") {
+      depth--
+      current += ch
+    } else if (ch === "," && depth === 0) {
+      parts.push(current)
+      current = ""
+    } else {
+      current += ch
+    }
+  }
+
+  if (current.trim()) parts.push(current)
+  return parts
+}
+
+/**
+ * Simple value inspector for console output (similar to util.inspect).
+ */
+function inspectValue(value: unknown): string {
+  if (value === null) return "null"
+  if (value === undefined) return "undefined"
+  if (typeof value === "string") return value
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  if (typeof value === "function") return `[Function: ${value.name || "anonymous"}]`
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+// ============================================================
+// Timeout Utilities
+// ============================================================
+
+/** Error thrown when code execution exceeds the configured timeout */
+export class ExecutionTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Code execution timed out after ${timeoutMs}ms`)
+    this.name = "ExecutionTimeoutError"
+  }
+}
+
+/**
+ * Race a promise against a timeout. Rejects with ExecutionTimeoutError
+ * if the promise doesn't resolve within the given time.
+ *
+ * This handles async timeouts (e.g. hanging `await` calls).
+ * Synchronous infinite loops are handled by vm.runInContext's
+ * built-in `timeout` option.
+ */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new ExecutionTimeoutError(timeoutMs))
+    }, timeoutMs)
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}

--- a/packages/opencode/src/rlm/index.ts
+++ b/packages/opencode/src/rlm/index.ts
@@ -1,0 +1,15 @@
+/**
+ * RLM - Recursive Language Model
+ *
+ * Native TypeScript port of the RLM system for OpenCode.
+ * Provides iterative REPL-based reasoning with recursive sub-LLM queries.
+ *
+ * @module rlm
+ */
+
+export * as RLMContext from "./context"
+export { LocalREPL, type LocalREPLOptions, type LLMQueryHandler, type LLMQueryBatchedHandler } from "./environment"
+export type {
+  REPLResult,
+} from "./types"
+export { emptyREPLResult } from "./types"

--- a/packages/opencode/src/rlm/overflow.ts
+++ b/packages/opencode/src/rlm/overflow.ts
@@ -1,0 +1,96 @@
+/**
+ * RLM Overflow — ask/reply dialog for context overflow.
+ *
+ * When the conversation context exceeds the model's window, instead of
+ * auto-compacting we block and ask the user: "Compact" or "Switch to RLM".
+ * Follows the same blocking-promise pattern as the Question system.
+ */
+
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { Identifier } from "@/id/id"
+import { Instance } from "@/project/instance"
+import { Log } from "@/util/log"
+import z from "zod"
+
+const log = Log.create({ service: "rlm-overflow" })
+
+export type OverflowChoice = "compact" | "rlm"
+
+export const Request = z
+  .object({
+    id: z.string(),
+    sessionID: z.string(),
+  })
+  .meta({ ref: "RLMOverflowRequest" })
+export type Request = z.infer<typeof Request>
+
+export const Event = {
+  Asked: BusEvent.define("rlm.overflow.asked", Request),
+  Replied: BusEvent.define(
+    "rlm.overflow.replied",
+    z.object({
+      sessionID: z.string(),
+      requestID: z.string(),
+      choice: z.enum(["compact", "rlm"]),
+    }),
+  ),
+}
+
+const state = Instance.state(async () => {
+  const pending: Record<
+    string,
+    {
+      info: Request
+      resolve: (choice: OverflowChoice) => void
+    }
+  > = {}
+  return { pending }
+})
+
+/**
+ * Ask the user to choose between compaction and RLM mode.
+ * Blocks until the user replies via the TUI.
+ */
+export async function ask(sessionID: string): Promise<OverflowChoice> {
+  const s = await state()
+  const id = Identifier.ascending("rlmoverflow")
+
+  log.info("asking", { id, sessionID })
+
+  return new Promise<OverflowChoice>((resolve) => {
+    const info: Request = { id, sessionID }
+    s.pending[id] = { info, resolve }
+    Bus.publish(Event.Asked, info)
+  })
+}
+
+/**
+ * Reply to an overflow request. Resolves the blocking promise from ask().
+ */
+export async function reply(input: {
+  requestID: string
+  choice: OverflowChoice
+}): Promise<void> {
+  const s = await state()
+  const existing = s.pending[input.requestID]
+  if (!existing) {
+    log.warn("reply for unknown request", { requestID: input.requestID })
+    return
+  }
+  delete s.pending[input.requestID]
+
+  log.info("replied", { requestID: input.requestID, choice: input.choice })
+
+  Bus.publish(Event.Replied, {
+    sessionID: existing.info.sessionID,
+    requestID: existing.info.id,
+    choice: input.choice,
+  })
+
+  existing.resolve(input.choice)
+}
+
+export async function list() {
+  return state().then((x) => Object.values(x.pending).map((x) => x.info))
+}

--- a/packages/opencode/src/rlm/parsing.ts
+++ b/packages/opencode/src/rlm/parsing.ts
@@ -1,0 +1,153 @@
+/**
+ * RLM Parsing - TypeScript port of rlm/utils/parsing.py
+ *
+ * Utilities for extracting code blocks and detecting final answers
+ * from LLM responses in the RLM loop.
+ */
+
+import type { REPLResult, RLMIteration } from "./types"
+
+/**
+ * Find REPL code blocks in text wrapped in triple backticks.
+ * Matches ```repl\n...\n``` blocks.
+ */
+export function findCodeBlocks(text: string): string[] {
+  const pattern = /```repl\s*\n([\s\S]*?)\n```/g
+  const results: string[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    results.push(match[1].trim())
+  }
+
+  return results
+}
+
+/**
+ * Find FINAL(...) or FINAL_VAR(...) statement in response.
+ *
+ * @param text - The response text to parse
+ * @param executeCode - Optional function to execute code for FINAL_VAR retrieval
+ * @returns The final answer string, or undefined if no pattern found
+ */
+export function findFinalAnswer(
+  text: string,
+  executeCode?: (code: string) => REPLResult | Promise<REPLResult>,
+): string | undefined {
+  // Check for FINAL_VAR pattern first - must be at start of line
+  const finalVarPattern = /^\s*FINAL_VAR\((.*?)\)/m
+  const varMatch = finalVarPattern.exec(text)
+  if (varMatch) {
+    const variableName = varMatch[1].trim().replace(/^["']|["']$/g, "")
+    if (executeCode) {
+      const result = executeCode(`console.log(FINAL_VAR("${variableName}"))`)
+      if (result instanceof Promise) {
+        // For sync contexts, we can't await — caller must handle
+        return undefined
+      }
+      const answer = result.stdout.trim()
+      return answer || result.stderr.trim() || ""
+    }
+    return undefined
+  }
+
+  // Check for FINAL pattern - must be at start of line
+  // Use greedy matching to capture content with nested parentheses
+  const finalPattern = /^\s*FINAL\(([\s\S]*)\)\s*$/m
+  const finalMatch = finalPattern.exec(text)
+  if (finalMatch) {
+    return finalMatch[1].trim()
+  }
+
+  return undefined
+}
+
+/**
+ * Async version of findFinalAnswer for environments with async executeCode.
+ */
+export async function findFinalAnswerAsync(
+  text: string,
+  executeCode?: (code: string) => Promise<REPLResult>,
+): Promise<string | undefined> {
+  // Check for FINAL_VAR pattern first
+  const finalVarPattern = /^\s*FINAL_VAR\((.*?)\)/m
+  const varMatch = finalVarPattern.exec(text)
+  if (varMatch) {
+    const variableName = varMatch[1].trim().replace(/^["']|["']$/g, "")
+    if (executeCode) {
+      const result = await executeCode(`console.log(FINAL_VAR("${variableName}"))`)
+      const answer = result.stdout.trim()
+      return answer || result.stderr.trim() || ""
+    }
+    return undefined
+  }
+
+  // Check for FINAL pattern
+  const finalPattern = /^\s*FINAL\(([\s\S]*)\)\s*$/m
+  const finalMatch = finalPattern.exec(text)
+  if (finalMatch) {
+    return finalMatch[1].trim()
+  }
+
+  return undefined
+}
+
+// ============================================================
+// Iteration Formatting
+// ============================================================
+
+/**
+ * Format an RLM iteration (including all code blocks) for the message history.
+ * Truncates large execution results.
+ */
+export function formatIteration(
+  iteration: RLMIteration,
+  maxCharLength = 20000,
+): Array<{ role: string; content: string }> {
+  const messages: Array<{ role: string; content: string }> = [{ role: "assistant", content: iteration.response }]
+
+  for (const block of iteration.codeBlocks) {
+    let result = formatExecutionResult(block.result)
+    if (result.length > maxCharLength) {
+      result = result.slice(0, maxCharLength) + `... + [${result.length - maxCharLength} chars...]`
+    }
+
+    messages.push({
+      role: "user",
+      content: `Code executed:\n\`\`\`javascript\n${block.code}\n\`\`\`\n\nREPL output:\n${result}`,
+    })
+  }
+
+  return messages
+}
+
+/**
+ * Format a REPLResult as a human-readable string.
+ */
+export function formatExecutionResult(result: REPLResult): string {
+  const parts: string[] = []
+
+  if (result.stdout) {
+    parts.push(`\n${result.stdout}`)
+  }
+
+  if (result.stderr) {
+    parts.push(`\n${result.stderr}`)
+  }
+
+  // Show key variables (excluding internal ones)
+  const importantVars: string[] = []
+  for (const [key, value] of Object.entries(result.locals)) {
+    if (!key.startsWith("_") && !["__builtins__", "__name__", "__doc__"].includes(key)) {
+      if (["string", "number", "boolean"].includes(typeof value) || Array.isArray(value) || (value && typeof value === "object")) {
+        importantVars.push(key)
+      }
+    }
+  }
+
+  if (importantVars.length > 0) {
+    parts.push(`REPL variables: [${importantVars.map((v) => `"${v}"`).join(", ")}]\n`)
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : "No output"
+}

--- a/packages/opencode/src/rlm/prompts.ts
+++ b/packages/opencode/src/rlm/prompts.ts
@@ -1,0 +1,147 @@
+/**
+ * RLM Prompts - TypeScript port of rlm/utils/prompts.py
+ *
+ * System prompts and prompt construction for the RLM loop.
+ */
+
+import type { QueryMetadata } from "./types"
+
+/**
+ * The core RLM system prompt that instructs the LLM how to use the REPL environment,
+ * llm_query(), llm_query_batched(), and the FINAL()/FINAL_VAR() termination protocol.
+ */
+export const RLM_SYSTEM_PROMPT = `You are a computational reasoning agent. You solve problems by writing and executing JavaScript code in a REPL environment.
+
+## REPL Environment
+
+Built-in variables and functions:
+- \`context\` — the input data for your task. May be a string, an object, or an array of structured messages (see below).
+- \`await llm_query(prompt)\` — query a sub-LLM. Returns a string. **Only use for processing large data (>1000 chars) that requires language understanding.** Never use llm_query to answer questions you already know the answer to.
+- \`await llm_query_batched(prompts)\` — query multiple prompts concurrently. Returns string[]. Much faster than sequential calls.
+- \`SHOW_VARS()\` — list all variables in scope
+- \`console.log()\` — print output
+
+## Structured Context Format
+
+When context is an array of messages (from a conversation), each element has:
+\`\`\`
+{ role: "system"|"user"|"assistant"|"tool-call"|"tool-result", content: string, toolName?: string, toolCallId?: string }
+\`\`\`
+
+You can query it programmatically:
+\`\`\`repl
+// Filter to just user messages
+userMsgs = context.filter(m => m.role === "user")
+// Get all tool results
+toolResults = context.filter(m => m.role === "tool-result")
+// Search for specific content
+matches = context.filter(m => m.content.includes("some keyword"))
+console.log(\`Found \${matches.length} matches\`)
+\`\`\`
+
+## Rules
+
+1. **Be efficient.** Minimize the number of iterations. If you can answer in 1-2 steps, do so. Every extra iteration wastes time.
+2. **Write code immediately.** No narration — just write the \`\`\`repl\`\`\` block.
+3. **Terminate immediately when you have the answer.** As soon as you know the answer, call FINAL() or set a variable and call FINAL_VAR(). Do NOT use additional console.log() calls to repeat or rephrase your answer.
+4. **Do NOT use llm_query() for simple questions.** If the question is conversational, factual, or something you can answer from your training data, answer directly with FINAL(). Only use llm_query() when you need to process large context data that exceeds what you can reason about directly.
+5. **Variables persist across REPL blocks.** Use bare assignments (\`x = 42\`). \`const\`/\`let\`/\`var\` also work.
+6. **JavaScript only** — \`console.log()\` not \`print()\`, template literals not f-strings.
+
+## Code Blocks
+
+\`\`\`repl
+console.log(typeof context, Array.isArray(context) ? context.length + " messages" : typeof context === "string" ? context.length + " chars" : JSON.stringify(context).length + " chars")
+\`\`\`
+
+## Workflow by Task Type
+
+**Simple/conversational question (short context):**
+Inspect context briefly, then immediately FINAL() your answer. 1-2 iterations max.
+
+**Data processing (large context):**
+1. Inspect context (type, length, structure)
+2. Process with llm_query_batched() over chunks
+3. Aggregate and FINAL_VAR()
+
+**Computation:**
+1. Compute the result in code
+2. FINAL_VAR() the result variable
+
+## Termination
+
+When done, provide your answer using ONE of these methods:
+1. \`FINAL(your answer)\` — call from inside a \`\`\`repl\`\`\` block or write as text outside code blocks
+2. \`FINAL_VAR(variable_name)\` — call from inside a \`\`\`repl\`\`\` block or write as text outside code blocks
+
+Both work as real functions inside \`\`\`repl\`\`\` blocks and as text-level commands outside them.
+
+**CRITICAL:** Call FINAL()/FINAL_VAR() as soon as you have the answer. Do not delay with extra console.log() calls, SHOW_VARS(), or unnecessary iterations.`
+
+/**
+ * Build the initial system prompt message history.
+ */
+export function buildRLMSystemPrompt(
+  systemPrompt: string,
+  queryMetadata: QueryMetadata,
+): Array<{ role: string; content: string }> {
+  let contextLengthsStr: string
+  if (queryMetadata.contextLengths.length > 100) {
+    const others = queryMetadata.contextLengths.length - 100
+    contextLengthsStr = JSON.stringify(queryMetadata.contextLengths.slice(0, 100)) + `... [${others} others]`
+  } else {
+    contextLengthsStr = JSON.stringify(queryMetadata.contextLengths)
+  }
+
+  const metadataPrompt = `Your context is a ${queryMetadata.contextType} with ${queryMetadata.contextTotalLength} total characters, and is broken up into chunks of char lengths: ${contextLengthsStr}.`
+
+  return [
+    { role: "system", content: systemPrompt },
+    { role: "assistant", content: metadataPrompt },
+  ]
+}
+
+// ============================================================
+// User Prompt Builders
+// ============================================================
+
+const USER_PROMPT = `Write a \`\`\`repl\`\`\` block now. Use the REPL to answer the prompt. Be efficient — if the answer is obvious, set it and call FINAL() or FINAL_VAR() immediately.`
+
+const USER_PROMPT_WITH_ROOT = `Write a \`\`\`repl\`\`\` block now to answer: "{root_prompt}"
+
+Be efficient — if you can answer directly, do so with FINAL(). Only use the REPL for computation or processing large context data.`
+
+/**
+ * Build the user prompt for each iteration of the RLM loop.
+ */
+export function buildUserPrompt(
+  rootPrompt?: string,
+  iteration = 0,
+  contextCount = 1,
+  historyCount = 0,
+): { role: string; content: string } {
+  let prompt: string
+
+  if (iteration === 0) {
+    prompt =
+      rootPrompt ? USER_PROMPT_WITH_ROOT.replace("{root_prompt}", rootPrompt) : USER_PROMPT
+  } else {
+    prompt =
+      "Continue from your previous REPL interactions above. " +
+      (rootPrompt ? USER_PROMPT_WITH_ROOT.replace("{root_prompt}", rootPrompt) : USER_PROMPT)
+  }
+
+  if (contextCount > 1) {
+    prompt += `\n\nNote: You have ${contextCount} contexts available (context_0 through context_${contextCount - 1}).`
+  }
+
+  if (historyCount > 0) {
+    if (historyCount === 1) {
+      prompt += `\n\nNote: You have 1 prior conversation history available in the \`history\` variable.`
+    } else {
+      prompt += `\n\nNote: You have ${historyCount} prior conversation histories available (history_0 through history_${historyCount - 1}).`
+    }
+  }
+
+  return { role: "user", content: prompt }
+}

--- a/packages/opencode/src/rlm/provider.ts
+++ b/packages/opencode/src/rlm/provider.ts
@@ -1,0 +1,348 @@
+/**
+ * RLM Provider - LanguageModelV2 implementation that wraps the RLM engine.
+ *
+ * This provider makes RLM appear as a standard Vercel AI SDK language model.
+ * When streamText() or generateText() calls this model:
+ *
+ * 1. doStream() runs the full RLM iterative loop internally via rlmCompletion()
+ * 2. Each iteration's reasoning/code execution is emitted as reasoning deltas
+ * 3. The final answer is emitted as text deltas
+ * 4. The model appears to "think" (reasoning) then produce output (text)
+ *
+ * This enables seamless integration with OpenCode's existing UI:
+ * - The reasoning pane shows RLM iterations (LLM responses + REPL output)
+ * - The text output shows the final answer
+ *
+ * The actual RLM loop logic lives in rlm.ts (rlmCompletion). This file
+ * only handles the LanguageModelV2 interface and stream part emission.
+ */
+
+import type {
+  LanguageModelV2,
+  LanguageModelV2CallOptions,
+  LanguageModelV2StreamPart,
+} from "@ai-sdk/provider"
+import { Provider } from "@/provider/provider"
+import { formatExecutionResult } from "./parsing"
+import { rlmCompletion } from "./rlm"
+import type { RLMConfig } from "./types"
+import { Log } from "@/util/log"
+import * as REPLManager from "./repl-manager"
+
+const log = Log.create({ service: "rlm-provider" })
+
+/** Counter for generating unique stream part IDs */
+let streamIdCounter = 0
+function nextId(prefix: string): string {
+  return `${prefix}-${++streamIdCounter}`
+}
+
+export interface RLMProviderOptions {
+  /** The underlying model to use for the RLM loop */
+  model: Provider.Model
+  /** Optional different model for sub-LLM queries from REPL */
+  subModel?: Provider.Model
+  /** RLM configuration */
+  config?: Partial<RLMConfig>
+  /** Optional session ID for shared REPL across sub-agents.
+   *  When set, the provider will look up or create a REPL via REPLManager. */
+  sessionID?: string
+}
+
+/**
+ * Create an RLM LanguageModelV2 provider.
+ *
+ * Usage:
+ *   const rlmModel = createRLMProvider({ model: myModel })
+ *   const result = await streamText({ model: rlmModel, messages: [...] })
+ */
+export function createRLMProvider(options: RLMProviderOptions): LanguageModelV2 {
+  return {
+    specificationVersion: "v2" as const,
+    provider: "rlm",
+    modelId: `rlm:${options.model.id}`,
+    supportedUrls: {},
+
+    async doGenerate(callOptions: LanguageModelV2CallOptions) {
+      const { messages: ctxMessages, userQuery } = extractStructuredContext(callOptions)
+      const repl = options.sessionID ? REPLManager.get(options.sessionID) : undefined
+
+      const result = await rlmCompletion({
+        prompt: ctxMessages,
+        rootPrompt: userQuery,
+        model: options.model,
+        subModel: options.subModel,
+        config: options.config,
+        abort: callOptions.abortSignal,
+        repl,
+      })
+
+      const inputTokens = computeInputTokens(result.usageSummary)
+      const outputTokens = computeOutputTokens(result.usageSummary)
+
+      return {
+        content: [{ type: "text" as const, text: result.response }],
+        finishReason: "stop" as const,
+        usage: {
+          inputTokens,
+          outputTokens,
+          totalTokens: inputTokens + outputTokens,
+        },
+        warnings: [],
+      }
+    },
+
+    async doStream(callOptions: LanguageModelV2CallOptions) {
+      const { messages: ctxMessages, userQuery } = extractStructuredContext(callOptions)
+      const repl = options.sessionID ? REPLManager.get(options.sessionID) : undefined
+
+      // Create a TransformStream to produce stream parts
+      const { readable, writable } = new TransformStream<LanguageModelV2StreamPart, LanguageModelV2StreamPart>()
+      const writer = writable.getWriter()
+
+      // Track the current reasoning ID so hooks can reference it
+      let currentReasoningId: string | undefined
+
+      // Run rlmCompletion in the background with hooks that emit stream parts
+      const streamPromise = (async () => {
+        try {
+          await writer.write({ type: "stream-start" as const, warnings: [] })
+
+          const result = await rlmCompletion({
+            prompt: ctxMessages,
+            rootPrompt: userQuery,
+            model: options.model,
+            subModel: options.subModel,
+            config: options.config,
+            abort: callOptions.abortSignal,
+            repl,
+            hooks: {
+              async onIterationStart(iterationIndex) {
+                currentReasoningId = nextId("rlm-reasoning")
+                await writer.write({
+                  type: "reasoning-start" as const,
+                  id: currentReasoningId,
+                })
+              },
+
+              async onLLMResponse(iterationIndex, response) {
+                if (!currentReasoningId) return
+                await writer.write({
+                  type: "reasoning-delta" as const,
+                  id: currentReasoningId,
+                  delta: `--- Iteration ${iterationIndex + 1} ---\n${response}\n`,
+                })
+              },
+
+              async onCodeExecuted(iterationIndex, code, codeResult) {
+                if (!currentReasoningId) return
+                const resultStr = formatExecutionResult(codeResult)
+                await writer.write({
+                  type: "reasoning-delta" as const,
+                  id: currentReasoningId,
+                  delta: `\n[REPL] ${code.slice(0, 50)}...\n${resultStr}\n`,
+                })
+              },
+
+              async onIterationEnd(_iteration, _iterationIndex) {
+                if (!currentReasoningId) return
+                await writer.write({
+                  type: "reasoning-end" as const,
+                  id: currentReasoningId,
+                })
+                currentReasoningId = undefined
+              },
+
+              async onMaxIterationsReached(maxIterations) {
+                const maxReasoningId = nextId("rlm-max-reasoning")
+                await writer.write({ type: "reasoning-start" as const, id: maxReasoningId })
+                await writer.write({
+                  type: "reasoning-delta" as const,
+                  id: maxReasoningId,
+                  delta: `\n--- Max iterations (${maxIterations}) reached, generating final answer ---\n`,
+                })
+                await writer.write({ type: "reasoning-end" as const, id: maxReasoningId })
+              },
+            },
+          })
+
+          // Stream the final answer as text deltas
+          const textId = nextId("rlm-text")
+          await writer.write({ type: "text-start" as const, id: textId })
+
+          const chunkSize = 50
+          for (let j = 0; j < result.response.length; j += chunkSize) {
+            await writer.write({
+              type: "text-delta" as const,
+              id: textId,
+              delta: result.response.slice(j, j + chunkSize),
+            })
+          }
+
+          await writer.write({ type: "text-end" as const, id: textId })
+
+          const inputTokens = computeInputTokens(result.usageSummary)
+          const outputTokens = computeOutputTokens(result.usageSummary)
+
+          await writer.write({
+            type: "finish" as const,
+            finishReason: "stop" as const,
+            usage: {
+              inputTokens,
+              outputTokens,
+              totalTokens: inputTokens + outputTokens,
+            },
+            providerMetadata: {
+              rlm: {
+                iterations: result.iterations,
+                executionTime: result.executionTime,
+              },
+            },
+          })
+        } catch (error) {
+          try {
+            await writer.write({
+              type: "error",
+              error: error instanceof Error ? error : new Error(String(error)),
+            })
+          } catch {
+            // Writer may be closed
+          }
+        } finally {
+          try {
+            await writer.close()
+          } catch {
+            // Already closed
+          }
+        }
+      })()
+
+      return {
+        stream: readable,
+        request: undefined,
+        response: undefined,
+      }
+    },
+  }
+}
+
+// ============================================================
+// Internal helpers
+// ============================================================
+
+/**
+ * Structured message for RLM context.
+ * All message types are preserved so the LLM can query them
+ * programmatically via the REPL (e.g. context.messages.filter(...)).
+ */
+interface ContextMessage {
+  role: string
+  content: string
+  toolName?: string
+  toolCallId?: string
+}
+
+/**
+ * Extract ALL messages from the call options prompt into a structured
+ * JSON object. This preserves system prompts, assistant responses,
+ * tool calls, and tool results — enabling the LLM to programmatically
+ * query the full conversation history via the REPL sandbox.
+ *
+ * Returns an object like:
+ * { messages: [...], userQuery: "the latest user message" }
+ */
+function extractStructuredContext(callOptions: LanguageModelV2CallOptions): {
+  messages: ContextMessage[]
+  userQuery: string
+} {
+  const prompt = callOptions.prompt ?? []
+  const messages: ContextMessage[] = []
+  let lastUserText = ""
+
+  for (const msg of prompt) {
+    if (msg.role === "system") {
+      messages.push({ role: "system", content: msg.content })
+    }
+
+    if (msg.role === "user") {
+      const parts: string[] = []
+      for (const part of msg.content) {
+        if (part.type === "text") parts.push(part.text)
+      }
+      const text = parts.join("\n")
+      messages.push({ role: "user", content: text })
+      lastUserText = text
+    }
+
+    if (msg.role === "assistant") {
+      const parts: string[] = []
+      for (const part of msg.content) {
+        if (part.type === "text") parts.push(part.text)
+        if (part.type === "tool-call") {
+          messages.push({
+            role: "tool-call",
+            content: JSON.stringify(part.input),
+            toolName: part.toolName,
+            toolCallId: part.toolCallId,
+          })
+        }
+      }
+      const text = parts.join("\n")
+      if (text) messages.push({ role: "assistant", content: text })
+    }
+
+    if (msg.role === "tool") {
+      for (const part of msg.content) {
+        if (part.type === "tool-result") {
+          const content = serializeToolOutput(part.output)
+          messages.push({
+            role: "tool-result",
+            content,
+            toolName: part.toolName,
+            toolCallId: part.toolCallId,
+          })
+        }
+      }
+    }
+  }
+
+  return { messages, userQuery: lastUserText }
+}
+
+/**
+ * Serialize a LanguageModelV2ToolResultOutput to a string.
+ */
+function serializeToolOutput(output: unknown): string {
+  if (!output || typeof output !== "object") return String(output ?? "")
+  const o = output as { type?: string; value?: unknown }
+  if (o.type === "text" || o.type === "error-text") return String(o.value ?? "")
+  if (o.type === "json" || o.type === "error-json") return JSON.stringify(o.value)
+  if (o.type === "content" && Array.isArray(o.value)) {
+    return o.value
+      .map((item: { type?: string; text?: string }) => (item.type === "text" ? item.text ?? "" : ""))
+      .join("\n")
+  }
+  return JSON.stringify(output)
+}
+
+/**
+ * Compute total input tokens from usage summary.
+ */
+function computeInputTokens(usage: import("./types").UsageSummary): number {
+  let total = 0
+  for (const model of Object.values(usage.modelUsageSummaries)) {
+    total += model.totalInputTokens
+  }
+  return total
+}
+
+/**
+ * Compute total output tokens from usage summary.
+ */
+function computeOutputTokens(usage: import("./types").UsageSummary): number {
+  let total = 0
+  for (const model of Object.values(usage.modelUsageSummaries)) {
+    total += model.totalOutputTokens
+  }
+  return total
+}

--- a/packages/opencode/src/rlm/repl-manager.ts
+++ b/packages/opencode/src/rlm/repl-manager.ts
@@ -1,0 +1,202 @@
+/**
+ * RLM REPL Manager - Session-scoped REPL lifecycle management.
+ *
+ * Manages shared LocalREPL instances tied to sessions. Sub-agents spawned
+ * from a parent session share the same REPL — each sub-agent's findings
+ * are stored as variables, so later sub-agents can reference earlier results.
+ *
+ * Also manages session-level RLM activation state (rlmActive toggle).
+ *
+ * Lifecycle:
+ * - REPL created lazily on first sub-agent spawn (via getOrCreate)
+ * - Cleaned up on session deletion (Session.Event.Deleted)
+ * - Safety cleanup on process exit
+ */
+
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { Log } from "@/util/log"
+import { LocalREPL } from "./environment"
+import type { LocalREPLOptions } from "./environment"
+import z from "zod"
+
+const log = Log.create({ service: "rlm-repl-manager" })
+
+// ============================================================
+// Shared REPL instances — one per session
+// ============================================================
+
+const repls = new Map<string, LocalREPL>()
+/** Maps child sessionID → parent sessionID for aliased REPLs */
+const aliases = new Map<string, string>()
+
+/**
+ * Get or create a shared REPL for a session.
+ * If the session already has a REPL, returns it.
+ * Otherwise creates a new one with the provided options and starts it.
+ */
+export async function getOrCreate(
+  sessionID: string,
+  options: LocalREPLOptions,
+): Promise<LocalREPL> {
+  const existing = repls.get(sessionID)
+  if (existing) return existing
+
+  log.info("repl.create", { sessionID })
+  const repl = new LocalREPL(options)
+  await repl.start()
+  repls.set(sessionID, repl)
+  return repl
+}
+
+/**
+ * Get a shared REPL for a session, if one exists.
+ */
+export function get(sessionID: string): LocalREPL | undefined {
+  return repls.get(sessionID)
+}
+
+/**
+ * Alias a child session to a parent's REPL.
+ * Both sessionIDs will resolve to the same REPL instance.
+ * Cleanup of the alias does NOT destroy the underlying REPL —
+ * only cleanup of the original (parent) sessionID does.
+ */
+export function alias(childID: string, parentID: string): void {
+  const repl = repls.get(parentID)
+  if (!repl) return
+  log.info("repl.alias", { childID, parentID })
+  aliases.set(childID, parentID)
+  repls.set(childID, repl)
+}
+
+/**
+ * Clean up and remove a session's shared REPL.
+ * If this sessionID is an alias, only removes the alias (not the REPL).
+ */
+export async function cleanup(sessionID: string): Promise<void> {
+  if (aliases.has(sessionID)) {
+    log.info("repl.cleanup.alias", { sessionID })
+    aliases.delete(sessionID)
+    repls.delete(sessionID)
+    return
+  }
+  const repl = repls.get(sessionID)
+  if (!repl) return
+  log.info("repl.cleanup", { sessionID })
+  await repl.cleanup()
+  repls.delete(sessionID)
+}
+
+/**
+ * Clean up all REPLs. Called on process exit as safety net.
+ */
+async function cleanupAll(): Promise<void> {
+  aliases.clear()
+  // Deduplicate — aliased entries share the same instance
+  const seen = new Set<LocalREPL>()
+  for (const [sessionID, repl] of repls) {
+    if (seen.has(repl)) {
+      repls.delete(sessionID)
+      continue
+    }
+    seen.add(repl)
+    try {
+      await repl.cleanup()
+    } catch {
+      // best effort
+    }
+    repls.delete(sessionID)
+  }
+}
+
+// ============================================================
+// Session-level RLM activation state
+// ============================================================
+
+const active = new Map<string, boolean>()
+
+/** Check if RLM is active for a session */
+export function isActive(sessionID: string): boolean {
+  return active.get(sessionID) ?? false
+}
+
+/** Toggle RLM active state for a session. Returns the new state. */
+export function toggle(sessionID: string): boolean {
+  const next = !isActive(sessionID)
+  active.set(sessionID, next)
+  log.info("rlm.toggle", { sessionID, active: next })
+  Bus.publish(Event.Toggled, { sessionID, active: next })
+  return next
+}
+
+/** Activate RLM for a session */
+export function activate(sessionID: string): void {
+  active.set(sessionID, true)
+  log.info("rlm.activate", { sessionID })
+  Bus.publish(Event.Toggled, { sessionID, active: true })
+}
+
+/** Deactivate RLM for a session */
+export function deactivate(sessionID: string): void {
+  active.set(sessionID, false)
+  log.info("rlm.deactivate", { sessionID })
+  Bus.publish(Event.Toggled, { sessionID, active: false })
+}
+
+// ============================================================
+// Events
+// ============================================================
+
+export const Event = {
+  Toggled: BusEvent.define(
+    "rlm.toggled",
+    z.object({
+      sessionID: z.string(),
+      active: z.boolean(),
+    }),
+  ),
+}
+
+// ============================================================
+// Cleanup on session deletion + process exit
+// ============================================================
+
+let initialized = false
+
+export function init(): void {
+  if (initialized) return
+  initialized = true
+
+  // Clean up REPL when session is deleted
+  Bus.subscribe(
+    // Using the event type string directly to avoid circular imports
+    // with Session module
+    BusEvent.define("session.deleted", z.object({ info: z.object({ id: z.string() }).passthrough() })),
+    async (event) => {
+      const sessionID = event.properties.info.id
+      await cleanup(sessionID)
+      active.delete(sessionID)
+      aliases.delete(sessionID)
+    },
+  )
+
+  // Safety net — cleanup all on process exit
+  process.on("exit", () => {
+    // Can't await in exit handler, but cleanup() nulls out the vm context
+    // which is synchronous enough for GC
+    const seen = new Set<LocalREPL>()
+    for (const [, repl] of repls) {
+      if (seen.has(repl)) continue
+      seen.add(repl)
+      try {
+        repl.cleanup()
+      } catch {
+        // best effort
+      }
+    }
+    repls.clear()
+    aliases.clear()
+    active.clear()
+  })
+}

--- a/packages/opencode/src/rlm/rlm.ts
+++ b/packages/opencode/src/rlm/rlm.ts
@@ -1,0 +1,463 @@
+/**
+ * RLM Core Engine - TypeScript port of rlm/core/rlm.py
+ *
+ * This is the main Recursive Language Model implementation.
+ * It orchestrates the iterative loop:
+ *   1. Send message history to the LLM
+ *   2. Parse response for ```repl``` code blocks
+ *   3. Execute code blocks in the Python REPL
+ *   4. Check for FINAL()/FINAL_VAR() termination
+ *   5. Format iteration results and append to history
+ *   6. Repeat until final answer or max iterations
+ *
+ * Integration with OpenCode:
+ * - Uses OpenCode's Provider system to get LanguageModelV2 instances
+ * - Uses Vercel AI SDK's generateText() for LLM completions
+ * - The REPL's llm_query() calls are routed through the same provider system
+ */
+
+import { generateText } from "ai"
+import { Provider } from "@/provider/provider"
+import { Log } from "@/util/log"
+import { LocalREPL } from "./environment"
+import { findCodeBlocks, findFinalAnswerAsync, formatIteration } from "./parsing"
+import { RLM_SYSTEM_PROMPT, buildRLMSystemPrompt, buildUserPrompt } from "./prompts"
+import type {
+  CodeBlock,
+  RLMChatCompletion,
+  RLMConfig,
+  RLMIteration,
+  REPLResult,
+  UsageSummary,
+} from "./types"
+import { buildQueryMetadata, DEFAULT_RLM_CONFIG, emptyUsageSummary, mergeUsageSummaries } from "./types"
+
+const log = Log.create({ service: "rlm" })
+
+// ============================================================
+// RLM Engine
+// ============================================================
+
+/**
+ * Lifecycle hooks for observing the RLM loop.
+ * Used by provider.ts to emit stream parts during iteration.
+ */
+export interface RLMLoopHooks {
+  /** Called at the start of each iteration (before the LLM call). */
+  onIterationStart?: (iterationIndex: number) => void | Promise<void>
+  /** Called after the LLM responds, with the raw response text. */
+  onLLMResponse?: (iterationIndex: number, response: string) => void | Promise<void>
+  /** Called after each code block is executed. */
+  onCodeExecuted?: (iterationIndex: number, code: string, result: REPLResult) => void | Promise<void>
+  /** Called when an iteration completes (after final answer check). */
+  onIterationEnd?: (iteration: RLMIteration, iterationIndex: number) => void | Promise<void>
+  /** Called when max iterations is reached (before the default-answer LLM call). */
+  onMaxIterationsReached?: (maxIterations: number) => void | Promise<void>
+}
+
+export interface RLMCompletionInput {
+  /** The prompt/context to process */
+  prompt: string | Record<string, unknown> | unknown[]
+  /** Optional root prompt visible to the LLM (e.g., the user's question) */
+  rootPrompt?: string
+  /** The model to use for the main RLM loop */
+  model: Provider.Model
+  /** Optional different model for sub-LLM queries from inside the REPL */
+  subModel?: Provider.Model
+  /** RLM configuration overrides */
+  config?: Partial<RLMConfig>
+  /** Abort signal */
+  abort?: AbortSignal
+  /** Callback for streaming iteration updates (legacy, prefer hooks) */
+  onIteration?: (iteration: RLMIteration, index: number) => void
+  /** Lifecycle hooks for fine-grained observation of the RLM loop */
+  hooks?: RLMLoopHooks
+  /** Optional pre-existing REPL instance (for shared REPL across sub-agents).
+   *  When provided, the REPL is NOT cleaned up on completion — the caller owns its lifecycle. */
+  repl?: LocalREPL
+}
+
+export interface RLMCompletionOutput {
+  response: string
+  usageSummary: UsageSummary
+  executionTime: number
+  iterations: number
+}
+
+/**
+ * Main RLM completion function.
+ *
+ * This replaces the Python RLM.completion() method with a native TypeScript
+ * implementation that integrates with OpenCode's provider system.
+ */
+export async function rlmCompletion(input: RLMCompletionInput): Promise<RLMCompletionOutput> {
+  const config = { ...DEFAULT_RLM_CONFIG, ...input.config }
+  const startTime = performance.now()
+
+  log.info("rlm.completion.start", {
+    modelID: input.model.id,
+    providerID: input.model.providerID,
+    maxIterations: config.maxIterations,
+    maxDepth: config.maxDepth,
+  })
+
+  // If at max depth, fall back to a simple LLM call
+  if (config.depth >= config.maxDepth) {
+    return fallbackAnswer(input)
+  }
+
+  // Get the language model for the main loop
+  const language = await Provider.getLanguage(input.model)
+
+  // Get the sub-model language (for llm_query() inside REPL)
+  const subLanguage = input.subModel ? await Provider.getLanguage(input.subModel) : language
+  const subModel = input.subModel ?? input.model
+
+  // Track total usage
+  let totalUsage = emptyUsageSummary()
+
+  // Create the LLM query handler for the REPL
+  const llmQueryHandler = async (prompt: string, _model?: string): Promise<string> => {
+    try {
+      const result = await generateText({
+        model: subLanguage,
+        messages: [{ role: "user", content: prompt }],
+        abortSignal: input.abort,
+      })
+
+      // Track usage
+      if (result.usage) {
+        const modelName = subModel.id
+        totalUsage = mergeUsageSummaries(totalUsage, {
+          modelUsageSummaries: {
+            [modelName]: {
+              totalCalls: 1,
+              totalInputTokens: result.usage.inputTokens ?? 0,
+              totalOutputTokens: result.usage.outputTokens ?? 0,
+            },
+          },
+        })
+      }
+
+      return result.text
+    } catch (error) {
+      log.error("rlm.llm_query.error", { error })
+      return `Error: LLM query failed - ${error}`
+    }
+  }
+
+  // Create batched handler
+  const llmQueryBatchedHandler = async (prompts: string[], _model?: string): Promise<string[]> => {
+    try {
+      const results = await Promise.all(
+        prompts.map((prompt) =>
+          generateText({
+            model: subLanguage,
+            messages: [{ role: "user", content: prompt }],
+            abortSignal: input.abort,
+          }),
+        ),
+      )
+
+      // Track usage for all calls
+      for (const result of results) {
+        if (result.usage) {
+          totalUsage = mergeUsageSummaries(totalUsage, {
+            modelUsageSummaries: {
+              [subModel.id]: {
+                totalCalls: 1,
+                totalInputTokens: result.usage.inputTokens ?? 0,
+                totalOutputTokens: result.usage.outputTokens ?? 0,
+              },
+            },
+          })
+        }
+      }
+
+      return results.map((r) => r.text)
+    } catch (error) {
+      log.error("rlm.llm_query_batched.error", { error })
+      return prompts.map(() => `Error: LLM query failed - ${error}`)
+    }
+  }
+
+  // Create and start the REPL environment, or use the provided one
+  const externalRepl = !!input.repl
+  const repl = input.repl ?? new LocalREPL({
+    llmQueryHandler,
+    llmQueryBatchedHandler,
+    contextPayload: input.prompt as string | Record<string, unknown> | unknown[],
+  })
+
+  try {
+    if (!externalRepl) {
+      await repl.start()
+    } else {
+      // For shared REPLs, load the prompt as additional context
+      await repl.loadContext(input.prompt as string | Record<string, unknown> | unknown[])
+    }
+
+    // Build initial message history
+    const queryMetadata = buildQueryMetadata(input.prompt)
+    let messageHistory = buildRLMSystemPrompt(
+      config.customSystemPrompt ?? RLM_SYSTEM_PROMPT,
+      queryMetadata,
+    )
+
+    const hooks = input.hooks
+
+    // Main iteration loop
+    for (let i = 0; i < config.maxIterations; i++) {
+      if (input.abort?.aborted) {
+        throw new Error("RLM completion aborted")
+      }
+
+      await hooks?.onIterationStart?.(i)
+
+      // Build current prompt
+      const currentPrompt = [
+        ...messageHistory,
+        buildUserPrompt(input.rootPrompt, i, repl.getContextCount()),
+      ]
+
+      // Single completion turn (with hooks for fine-grained observation)
+      const iteration = await completionTurn({
+        prompt: currentPrompt,
+        language,
+        model: input.model,
+        repl,
+        abort: input.abort,
+        totalUsage,
+        onUsageUpdate: (u) => {
+          totalUsage = u
+        },
+        hooks: {
+          onLLMResponse: hooks?.onLLMResponse
+            ? (response) => hooks.onLLMResponse!(i, response)
+            : undefined,
+          onCodeExecuted: hooks?.onCodeExecuted
+            ? (code, result) => hooks.onCodeExecuted!(i, code, result)
+            : undefined,
+        },
+      })
+
+      // Check for final answer — first from in-code FINAL()/FINAL_VAR() calls,
+      // then from text-level FINAL()/FINAL_VAR() patterns
+      let finalAnswer: string | undefined
+      if (repl.hasFinalAnswer()) {
+        finalAnswer = repl.getFinalAnswer()
+        repl.resetFinalAnswer()
+      } else {
+        finalAnswer = await findFinalAnswerAsync(
+          iteration.response,
+          (code) => repl.executeCode(code),
+        )
+      }
+      iteration.finalAnswer = finalAnswer
+
+      // Notify callbacks
+      await hooks?.onIterationEnd?.(iteration, i)
+      input.onIteration?.(iteration, i + 1)
+
+      log.info("rlm.iteration", {
+        iteration: i + 1,
+        hasFinalAnswer: finalAnswer !== undefined,
+        codeBlocks: iteration.codeBlocks.length,
+      })
+
+      if (finalAnswer !== undefined) {
+        const executionTime = (performance.now() - startTime) / 1000
+        log.info("rlm.completion.done", {
+          iterations: i + 1,
+          executionTime,
+        })
+
+        return {
+          response: finalAnswer,
+          usageSummary: totalUsage,
+          executionTime,
+          iterations: i + 1,
+        }
+      }
+
+      // Format iteration for next prompt
+      const newMessages = formatIteration(iteration)
+      messageHistory = [...messageHistory, ...newMessages]
+    }
+
+    // Ran out of iterations — ask for a final answer
+    await hooks?.onMaxIterationsReached?.(config.maxIterations)
+    log.warn("rlm.max_iterations_reached", { maxIterations: config.maxIterations })
+    const defaultAnswer = await getDefaultAnswer({
+      messageHistory,
+      language,
+      model: input.model,
+      abort: input.abort,
+      totalUsage,
+      onUsageUpdate: (u) => {
+        totalUsage = u
+      },
+    })
+
+    const executionTime = (performance.now() - startTime) / 1000
+    return {
+      response: defaultAnswer,
+      usageSummary: totalUsage,
+      executionTime,
+      iterations: config.maxIterations,
+    }
+  } finally {
+    if (!externalRepl) {
+      await repl.cleanup()
+    }
+  }
+}
+
+// ============================================================
+// Internal helpers
+// ============================================================
+
+interface CompletionTurnInput {
+  prompt: Array<{ role: string; content: string }>
+  language: Awaited<ReturnType<typeof Provider.getLanguage>>
+  model: Provider.Model
+  repl: LocalREPL
+  abort?: AbortSignal
+  totalUsage: UsageSummary
+  onUsageUpdate: (usage: UsageSummary) => void
+  hooks?: {
+    onLLMResponse?: (response: string) => void | Promise<void>
+    onCodeExecuted?: (code: string, result: REPLResult) => void | Promise<void>
+  }
+}
+
+/**
+ * Perform a single iteration: LLM call + code execution.
+ */
+async function completionTurn(input: CompletionTurnInput): Promise<RLMIteration> {
+  const iterStart = performance.now()
+
+  // Call the LLM
+  const result = await generateText({
+    model: input.language,
+    messages: input.prompt.map((m) => ({
+      role: m.role as "system" | "user" | "assistant",
+      content: m.content,
+    })),
+    abortSignal: input.abort,
+  })
+
+  // Track usage
+  if (result.usage) {
+    input.onUsageUpdate(
+      mergeUsageSummaries(input.totalUsage, {
+        modelUsageSummaries: {
+          [input.model.id]: {
+            totalCalls: 1,
+            totalInputTokens: result.usage.inputTokens ?? 0,
+            totalOutputTokens: result.usage.outputTokens ?? 0,
+          },
+        },
+      }),
+    )
+  }
+
+  const response = result.text
+
+  // Notify hook of LLM response
+  await input.hooks?.onLLMResponse?.(response)
+
+  // Find and execute code blocks
+  const codeBlockStrs = findCodeBlocks(response)
+  const codeBlocks: CodeBlock[] = []
+
+  for (const codeStr of codeBlockStrs) {
+    const codeResult = await input.repl.executeCode(codeStr)
+    codeBlocks.push({ code: codeStr, result: codeResult })
+    await input.hooks?.onCodeExecuted?.(codeStr, codeResult)
+  }
+
+  return {
+    prompt: input.prompt,
+    response,
+    codeBlocks,
+    iterationTime: (performance.now() - iterStart) / 1000,
+  }
+}
+
+/**
+ * Fallback when at max depth — just do a simple LLM call.
+ */
+async function fallbackAnswer(input: RLMCompletionInput): Promise<RLMCompletionOutput> {
+  const startTime = performance.now()
+  const language = await Provider.getLanguage(input.model)
+
+  const promptStr = typeof input.prompt === "string" ? input.prompt : JSON.stringify(input.prompt)
+  const result = await generateText({
+    model: language,
+    messages: [{ role: "user", content: promptStr }],
+    abortSignal: input.abort,
+  })
+
+  return {
+    response: result.text,
+    usageSummary: {
+      modelUsageSummaries: {
+        [input.model.id]: {
+          totalCalls: 1,
+          totalInputTokens: result.usage?.inputTokens ?? 0,
+          totalOutputTokens: result.usage?.outputTokens ?? 0,
+        },
+      },
+    },
+    executionTime: (performance.now() - startTime) / 1000,
+    iterations: 0,
+  }
+}
+
+interface DefaultAnswerInput {
+  messageHistory: Array<{ role: string; content: string }>
+  language: Awaited<ReturnType<typeof Provider.getLanguage>>
+  model: Provider.Model
+  abort?: AbortSignal
+  totalUsage: UsageSummary
+  onUsageUpdate: (usage: UsageSummary) => void
+}
+
+/**
+ * Get a default answer when max iterations are reached.
+ */
+async function getDefaultAnswer(input: DefaultAnswerInput): Promise<string> {
+  const messages = [
+    ...input.messageHistory,
+    {
+      role: "assistant" as const,
+      content: "Please provide a final answer to the user's question based on the information provided.",
+    },
+  ]
+
+  const result = await generateText({
+    model: input.language,
+    messages: messages.map((m) => ({
+      role: m.role as "system" | "user" | "assistant",
+      content: m.content,
+    })),
+    abortSignal: input.abort,
+  })
+
+  if (result.usage) {
+    input.onUsageUpdate(
+      mergeUsageSummaries(input.totalUsage, {
+        modelUsageSummaries: {
+          [input.model.id]: {
+            totalCalls: 1,
+            totalInputTokens: result.usage.inputTokens ?? 0,
+            totalOutputTokens: result.usage.outputTokens ?? 0,
+          },
+        },
+      }),
+    )
+  }
+
+  return result.text
+}

--- a/packages/opencode/src/rlm/types.ts
+++ b/packages/opencode/src/rlm/types.ts
@@ -1,0 +1,197 @@
+/**
+ * RLM Types - TypeScript port of rlm/core/types.py
+ *
+ * Core type definitions for the Recursive Language Model system.
+ */
+
+// ============================================================
+// Backend & Environment Types
+// ============================================================
+
+/** Supported LLM client backends */
+export type ClientBackend =
+  | "openai"
+  | "portkey"
+  | "openrouter"
+  | "vercel"
+  | "vllm"
+  | "litellm"
+  | "anthropic"
+  | "azure_openai"
+  | "gemini"
+
+/** Supported execution environments */
+export type EnvironmentType = "local"
+
+// ============================================================
+// Usage Tracking
+// ============================================================
+
+export interface ModelUsageSummary {
+  totalCalls: number
+  totalInputTokens: number
+  totalOutputTokens: number
+}
+
+export interface UsageSummary {
+  modelUsageSummaries: Record<string, ModelUsageSummary>
+}
+
+export function emptyUsageSummary(): UsageSummary {
+  return { modelUsageSummaries: {} }
+}
+
+export function mergeUsageSummaries(a: UsageSummary, b: UsageSummary): UsageSummary {
+  const merged = { ...a.modelUsageSummaries }
+  for (const [model, usage] of Object.entries(b.modelUsageSummaries)) {
+    if (merged[model]) {
+      merged[model] = {
+        totalCalls: merged[model].totalCalls + usage.totalCalls,
+        totalInputTokens: merged[model].totalInputTokens + usage.totalInputTokens,
+        totalOutputTokens: merged[model].totalOutputTokens + usage.totalOutputTokens,
+      }
+    } else {
+      merged[model] = { ...usage }
+    }
+  }
+  return { modelUsageSummaries: merged }
+}
+
+// ============================================================
+// REPL & Iteration Types
+// ============================================================
+
+export interface RLMChatCompletion {
+  rootModel: string
+  prompt: string | Record<string, unknown>
+  response: string
+  usageSummary: UsageSummary
+  executionTime: number
+}
+
+export interface REPLResult {
+  stdout: string
+  stderr: string
+  locals: Record<string, unknown>
+  executionTime: number
+  rlmCalls: RLMChatCompletion[]
+}
+
+export function emptyREPLResult(): REPLResult {
+  return {
+    stdout: "",
+    stderr: "",
+    locals: {},
+    executionTime: 0,
+    rlmCalls: [],
+  }
+}
+
+export interface CodeBlock {
+  code: string
+  result: REPLResult
+}
+
+export interface RLMIteration {
+  prompt: unknown
+  response: string
+  codeBlocks: CodeBlock[]
+  finalAnswer?: string
+  iterationTime?: number
+}
+
+// ============================================================
+// Metadata
+// ============================================================
+
+export interface RLMMetadata {
+  rootModel: string
+  maxDepth: number
+  maxIterations: number
+  backend: string
+  backendKwargs: Record<string, unknown>
+  environmentType: string
+  environmentKwargs: Record<string, unknown>
+  otherBackends?: string[]
+}
+
+// ============================================================
+// Configuration
+// ============================================================
+
+export interface RLMConfig {
+  /** Maximum iterations per completion (default 30) */
+  maxIterations: number
+  /** Maximum recursion depth (default 1) */
+  maxDepth: number
+  /** Current depth (default 0) */
+  depth: number
+  /** Custom system prompt override */
+  customSystemPrompt?: string
+  /** Enable verbose logging */
+  verbose: boolean
+
+}
+
+export const DEFAULT_RLM_CONFIG: RLMConfig = {
+  maxIterations: 30,
+  maxDepth: 1,
+  depth: 0,
+  verbose: false,
+}
+
+// ============================================================
+// Query Metadata (for system prompt construction)
+// ============================================================
+
+export interface QueryMetadata {
+  contextLengths: number[]
+  contextTotalLength: number
+  contextType: "str" | "dict" | "list"
+}
+
+export function buildQueryMetadata(prompt: string | Record<string, unknown> | unknown[]): QueryMetadata {
+  if (typeof prompt === "string") {
+    return {
+      contextLengths: [prompt.length],
+      contextTotalLength: prompt.length,
+      contextType: "str",
+    }
+  }
+  if (Array.isArray(prompt)) {
+    const lengths = prompt.map((item) => {
+      if (typeof item === "string") return item.length
+      if (typeof item === "object" && item !== null && "content" in item) {
+        return String((item as Record<string, unknown>).content ?? "").length
+      }
+      try {
+        return JSON.stringify(item).length
+      } catch {
+        return String(item).length
+      }
+    })
+    return {
+      contextLengths: lengths,
+      contextTotalLength: lengths.reduce((a, b) => a + b, 0),
+      contextType: "list",
+    }
+  }
+  // dict/object
+  const lengths: number[] = []
+  for (const value of Object.values(prompt)) {
+    if (typeof value === "string") {
+      lengths.push(value.length)
+    } else {
+      try {
+        lengths.push(JSON.stringify(value).length)
+      } catch {
+        lengths.push(String(value).length)
+      }
+    }
+  }
+  return {
+    contextLengths: lengths,
+    contextTotalLength: lengths.reduce((a, b) => a + b, 0),
+    contextType: "dict",
+  }
+}

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -15,6 +15,7 @@ import { Plugin } from "@/plugin"
 import { Config } from "@/config/config"
 import { ProviderTransform } from "@/provider/transform"
 
+
 export namespace SessionCompaction {
   const log = Log.create({ service: "session.compaction" })
 
@@ -148,6 +149,19 @@ export namespace SessionCompaction {
       { sessionID: input.sessionID },
       { context: [], prompt: undefined },
     )
+
+    // Find the last compaction summary from the full message history
+    let lastSummary: string | undefined
+    for await (const m of MessageV2.stream(input.sessionID)) {
+      if (m.info.role !== "assistant") continue
+      if (!(m.info as MessageV2.Assistant).summary) continue
+      if (m.info.id === msg.id) continue
+      const text = m.parts.find((p) => p.type === "text")?.text
+      if (text) {
+        lastSummary = text
+        break // stream yields newest first, so first match is the latest
+      }
+    }
     const defaultPrompt = `Provide a detailed prompt for continuing our conversation above.
 Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
 The summary that you construct will be used so that another agent can read it and continue the work.
@@ -176,7 +190,12 @@ When constructing the summary, try to stick to this template:
 [Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
 ---`
 
-    const promptText = compacting.prompt ?? [defaultPrompt, ...compacting.context].join("\n\n")
+    // Include the last compaction summary so accumulated knowledge carries forward
+    const summarySection = lastSummary
+      ? `\n\n## Previous Compaction Summary\n\nThe following is the most recent compaction summary. You MUST incorporate ALL important information from this summary into your new summary so nothing is lost across compactions:\n\n${lastSummary}`
+      : ""
+
+    const promptText = compacting.prompt ?? [defaultPrompt + summarySection, ...compacting.context].join("\n\n")
     const result = await processor.process({
       user: userMessage,
       agent,

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -23,6 +23,7 @@ import { Flag } from "@/flag/flag"
 import { PermissionNext } from "@/permission/next"
 import { Auth } from "@/auth"
 
+
 export namespace LLM {
   const log = Log.create({ service: "llm" })
   export const OUTPUT_TOKEN_MAX = ProviderTransform.OUTPUT_TOKEN_MAX
@@ -56,12 +57,15 @@ export namespace LLM {
       modelID: input.model.id,
       providerID: input.model.providerID,
     })
-    const [language, cfg, provider, auth] = await Promise.all([
+    const [baseLanguage, cfg, provider, auth] = await Promise.all([
       Provider.getLanguage(input.model),
       Config.get(),
       Provider.getProvider(input.model.providerID),
       Auth.get(input.model.providerID),
     ])
+
+    const language = baseLanguage
+
     const isCodex = provider.id === "openai" && auth?.type === "oauth"
 
     const system = []
@@ -280,4 +284,5 @@ export namespace LLM {
     }
     return false
   }
+
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -42,6 +42,7 @@ import { Tool } from "@/tool/tool"
 import { PermissionNext } from "@/permission/next"
 import { SessionStatus } from "./status"
 import { LLM } from "./llm"
+import { RLMContext } from "@/rlm"
 import { iife } from "@/util/iife"
 import { Shell } from "@/shell/shell"
 import { Truncate } from "@/tool/truncation"
@@ -293,11 +294,21 @@ export namespace SessionPrompt {
 
     let step = 0
     const session = await Session.get(sessionID)
+    await RLMContext.init(sessionID)
     while (true) {
       SessionStatus.set(sessionID, { type: "busy" })
       log.info("loop", { step, sessionID })
       if (abort.aborted) break
       let msgs = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+
+      // On first iteration, feed all existing messages into RLM context
+      // (handles session restore / resume)
+      if (step === 0) {
+        for (const msg of msgs) {
+          const entries = RLMContext.fromMessage(msg)
+          if (entries.length > 0) await RLMContext.append(sessionID, entries)
+        }
+      }
 
       let lastUser: MessageV2.User | undefined
       let lastAssistant: MessageV2.Assistant | undefined
@@ -673,6 +684,16 @@ export namespace SessionPrompt {
         model,
         toolChoice: format.type === "json_schema" ? "required" : undefined,
       })
+
+      // Feed the new assistant message into RLM context
+      {
+        const latest = await MessageV2.filterCompacted(MessageV2.stream(sessionID))
+        const newest = latest.findLast((m) => m.info.role === "assistant")
+        if (newest) {
+          const entries = RLMContext.fromMessage(newest)
+          if (entries.length > 0) await RLMContext.append(sessionID, entries)
+        }
+      }
 
       // If structured output was captured, save it and exit immediately
       // This takes priority because the StructuredOutput tool was called successfully

--- a/packages/opencode/src/session/prompt/copilot-gpt-5.txt
+++ b/packages/opencode/src/session/prompt/copilot-gpt-5.txt
@@ -34,12 +34,6 @@ incremental steps - use the todo tool to track your progress.
 
 ## 1. Deeply Understand the Problem
 - Carefully read the issue and think hard about a plan to solve it before coding.
-- Break down the problem into manageable parts. Consider the following:
-- What is the expected behavior?
-- What are the edge cases?
-- What are the potential pitfalls?
-- How does this fit into the larger context of the codebase?
-- What are the dependencies and interactions with other parts of the code
 
 ## 2. Codebase Investigation
 - Explore relevant files and directories.

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -48,6 +48,8 @@ export namespace SystemPrompt {
             : ""
         }`,
         `</directories>`,
+        ``,
+        `You have access to a \`context_query\` tool that lets you query the full conversation history using JavaScript — including messages that were compacted away from your visible context. Use it to verify facts when you are uncertain: re-check what the user asked for, what files were changed, what decisions were made, or what constraints were given. Do not guess — confirm.`,
       ].join("\n"),
     ]
   }

--- a/packages/opencode/src/tool/context_query.ts
+++ b/packages/opencode/src/tool/context_query.ts
@@ -1,0 +1,40 @@
+import z from "zod"
+import { Tool } from "./tool"
+import DESCRIPTION from "./context_query.txt"
+import * as RLMContext from "@/rlm/context"
+
+export const ContextQueryTool = Tool.define("context_query", {
+  description: DESCRIPTION,
+  parameters: z.object({
+    code: z
+      .string()
+      .describe(
+        "JavaScript code to execute against the context memory. The `context` variable is an array of all conversation entries. Use console.log() to output results.",
+      ),
+  }),
+  async execute(params, ctx) {
+    const result = await RLMContext.execute(ctx.sessionID, params.code)
+
+    const output = [
+      result.stdout ? result.stdout.trim() : "",
+      result.stderr ? `[stderr] ${result.stderr.trim()}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n")
+
+    const locals = Object.entries(result.locals)
+      .filter(([k]) => k !== "context")
+      .map(([k, v]) => `${k} = ${v}`)
+      .join(", ")
+
+    const footer = locals ? `\n[variables: ${locals}]` : ""
+
+    return {
+      title: "context_query",
+      metadata: {
+        executionTime: result.executionTime,
+      },
+      output: (output || "(no output)") + footer,
+    }
+  },
+})

--- a/packages/opencode/src/tool/context_query.txt
+++ b/packages/opencode/src/tool/context_query.txt
@@ -1,0 +1,25 @@
+Query the conversation's persistent context memory using JavaScript code.
+
+The `context` variable contains an array of ALL messages from this conversation (including sub-agent tasks), persisted across compactions and session reloads. Each entry has:
+```
+{ role: "user"|"assistant"|"tool-call"|"tool-result"|"sub-agent", content: string, toolName?: string, toolCallId?: string, time: number, sourceSessionID?: string }
+```
+
+Use this tool to VERIFY facts before acting on them. When you are uncertain about:
+- What the user previously asked for or specified as requirements
+- Which files were modified, created, or read earlier in the conversation
+- What decisions were made and why
+- What instructions or constraints the user gave
+- What was already accomplished vs what remains
+
+...query the context to confirm rather than guessing or assuming. This reduces hallucination and ensures you act on what actually happened, not what you think happened.
+
+Example queries:
+- Verify requirements: `console.log(context.filter(m => m.role === "user").map(m => m.content).join("\n---\n"))`
+- Check what files were written: `console.log(context.filter(m => m.role === "tool-call" && m.toolName === "write").map(m => m.content))`
+- Find a specific discussion: `console.log(context.filter(m => m.content.includes("keyword")).map(m => m.role + ": " + m.content.slice(0, 200)))`
+- Count compactions: `console.log(context.filter(m => m.content.includes("compaction")).length)`
+
+Write JavaScript code that will run in a sandboxed REPL. Use `console.log()` to output results. Variables persist across calls. The code has access to: Array, Map, Set, JSON, Math, RegExp, String, Date, Promise, setTimeout.
+
+IMPORTANT: The context memory contains the COMPLETE conversation history from the very start, even across compactions. Use this tool when you need to verify something from earlier in the conversation that may have been compacted away from your visible message history.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -27,6 +27,7 @@ import { LspTool } from "./lsp"
 import { Truncate } from "./truncation"
 import { PlanExitTool, PlanEnterTool } from "./plan"
 import { ApplyPatchTool } from "./apply_patch"
+import { ContextQueryTool } from "./context_query"
 
 export namespace ToolRegistry {
   const log = Log.create({ service: "tool.registry" })
@@ -112,6 +113,7 @@ export namespace ToolRegistry {
       CodeSearchTool,
       SkillTool,
       ApplyPatchTool,
+      ContextQueryTool,
       ...(Flag.OPENCODE_EXPERIMENTAL_LSP_TOOL ? [LspTool] : []),
       ...(config.experimental?.batch_tool === true ? [BatchTool] : []),
       ...(Flag.OPENCODE_EXPERIMENTAL_PLAN_MODE && Flag.OPENCODE_CLIENT === "cli" ? [PlanExitTool, PlanEnterTool] : []),

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { RLMContext } from "@/rlm"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -102,6 +103,9 @@ export const TaskTool = Tool.define("task", async (ctx) => {
       })
       const msg = await MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID })
       if (msg.info.role !== "assistant") throw new Error("Not an assistant message")
+
+      // Alias child session to share parent's RLM context
+      RLMContext.alias(session.id, ctx.sessionID)
 
       const model = agent.model ?? {
         modelID: msg.info.modelID,

--- a/packages/opencode/test/rlm/environment.test.ts
+++ b/packages/opencode/test/rlm/environment.test.ts
@@ -1,0 +1,943 @@
+import { describe, expect, test, afterEach } from "bun:test"
+import { LocalREPL, hoistDeclarations } from "../../src/rlm/environment"
+
+/**
+ * Tests for the native JavaScript REPL (LocalREPL class).
+ *
+ * These tests verify the in-process JavaScript execution engine:
+ *
+ * 1. Startup & initialization
+ * 2. Basic code execution (console.log, variables, expressions)
+ * 3. Variable persistence across executions
+ * 4. Error handling (syntax errors, runtime errors)
+ * 5. Context loading
+ * 6. llm_query() round-trips (async)
+ * 7. llm_query_batched() round-trips
+ * 8. FINAL_VAR() and SHOW_VARS() functions
+ * 9. Graceful cleanup
+ * 10. Stdout capture isolation
+ */
+
+let repl: LocalREPL | null = null
+
+afterEach(async () => {
+  if (repl) {
+    await repl.cleanup()
+    repl = null
+  }
+})
+
+function createREPL(overrides?: {
+  llmQueryHandler?: (prompt: string, model?: string) => Promise<string>
+  llmQueryBatchedHandler?: (prompts: string[], model?: string) => Promise<string[]>
+  contextPayload?: string | Record<string, unknown> | unknown[]
+  executionTimeoutMs?: number
+}) {
+  repl = new LocalREPL({
+    llmQueryHandler:
+      overrides?.llmQueryHandler ?? (async (prompt) => `echo: ${prompt}`),
+    llmQueryBatchedHandler: overrides?.llmQueryBatchedHandler,
+    contextPayload: overrides?.contextPayload,
+    executionTimeoutMs: overrides?.executionTimeoutMs,
+  })
+  return repl
+}
+
+// ============================================================
+// 1. Startup & Initialization
+// ============================================================
+
+describe("REPL startup", () => {
+  test("starts successfully", async () => {
+    const r = createREPL()
+    await r.start()
+    // If start() returns without error, the REPL is ready
+    expect(true).toBe(true)
+  })
+
+  test("executeCode throws if not started", async () => {
+    const r = createREPL()
+    expect(r.executeCode('console.log("hi")')).rejects.toThrow("not started")
+  })
+})
+
+// ============================================================
+// 2. Basic Code Execution
+// ============================================================
+
+describe("basic execution", () => {
+  test("console.log captures stdout", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode('console.log("hello world")')
+    expect(result.stdout).toBe("hello world\n")
+    expect(result.stderr).toBe("")
+  })
+
+  test("variable assignment and access", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("x = 42; console.log(x)")
+    expect(result.stdout).toBe("42\n")
+    expect(result.locals).toHaveProperty("x", 42)
+  })
+
+  test("arithmetic expression", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("result = 2 + 3 * 4; console.log(result)")
+    expect(result.stdout).toBe("14\n")
+    expect(result.locals).toHaveProperty("result", 14)
+  })
+
+  test("multi-line code execution", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const code = `
+items = [1, 2, 3, 4, 5]
+total = items.reduce((a, b) => a + b, 0)
+avg = total / items.length
+console.log(\`sum=\${total}, avg=\${avg}\`)
+`
+    const result = await r.executeCode(code)
+    expect(result.stdout).toContain("sum=15, avg=3")
+    expect(result.locals).toHaveProperty("total", 15)
+    expect(result.locals).toHaveProperty("avg", 3)
+  })
+
+  test("Math module works", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("pi_val = Math.PI; console.log(Math.round(pi_val * 10000) / 10000)")
+    expect(result.stdout).toBe("3.1416\n")
+  })
+})
+
+// ============================================================
+// 3. Variable Persistence Across Executions
+// ============================================================
+
+describe("variable persistence", () => {
+  test("variables persist across multiple executeCode calls", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("a = 10")
+    await r.executeCode("b = 20")
+    const result = await r.executeCode("c = a + b; console.log(c)")
+
+    expect(result.stdout).toBe("30\n")
+    expect(result.locals).toHaveProperty("a", 10)
+    expect(result.locals).toHaveProperty("b", 20)
+    expect(result.locals).toHaveProperty("c", 30)
+  })
+
+  test("functions persist across executions", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("double = function(x) { return x * 2 }")
+    const result = await r.executeCode("val = double(21); console.log(val)")
+    expect(result.stdout).toBe("42\n")
+  })
+})
+
+// ============================================================
+// 4. Error Handling
+// ============================================================
+
+describe("error handling", () => {
+  test("syntax error returns stderr", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("if (true console.log('bad')")
+    expect(result.stderr).toContain("SyntaxError")
+  })
+
+  test("runtime error returns stderr", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("null.property")
+    expect(result.stderr).toContain("TypeError")
+  })
+
+  test("ReferenceError for undefined variable", async () => {
+    const r = createREPL()
+    await r.start()
+
+    // In the vm sandbox, accessing an undefined variable throws ReferenceError
+    const result = await r.executeCode("undefined_var.toString()")
+    expect(result.stderr).toContain("ReferenceError")
+  })
+
+  test("REPL continues working after an error", async () => {
+    const r = createREPL()
+    await r.start()
+
+    // Cause an error
+    await r.executeCode("null.property")
+
+    // Should still work
+    const result = await r.executeCode("y = 99; console.log(y)")
+    expect(result.stdout).toBe("99\n")
+    expect(result.stderr).toBe("")
+  })
+
+  test("partial output captured before error", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode('console.log("before"); null.property; console.log("after")')
+    expect(result.stdout).toContain("before")
+    expect(result.stderr).toContain("TypeError")
+    // "after" should NOT appear since the exception interrupted execution
+    expect(result.stdout).not.toContain("after")
+  })
+})
+
+// ============================================================
+// 5. Context Loading
+// ============================================================
+
+describe("context loading", () => {
+  test("string context is loaded as context_0", async () => {
+    const r = createREPL({ contextPayload: "hello context" })
+    await r.start()
+
+    // context_0 should be accessible, and since it ends in _0, also "context"
+    const result = await r.executeCode("console.log(context_0); console.log(context)")
+    expect(result.stdout).toContain("hello context")
+    expect(r.getContextCount()).toBe(1)
+  })
+
+  test("dict context is loaded", async () => {
+    const r = createREPL({ contextPayload: { key: "value", num: 42 } })
+    await r.start()
+
+    const result = await r.executeCode("console.log(context_0.key)")
+    expect(result.stdout).toContain("value")
+  })
+
+  test("list context is loaded", async () => {
+    const r = createREPL({ contextPayload: [1, 2, 3] })
+    await r.start()
+
+    const result = await r.executeCode("console.log(context_0.length)")
+    expect(result.stdout).toContain("3")
+  })
+
+  test("additional context can be loaded after start", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.loadContext("first", 0)
+    await r.loadContext("second", 1)
+
+    const result = await r.executeCode("console.log(context_0, context_1)")
+    expect(result.stdout).toContain("first")
+    expect(result.stdout).toContain("second")
+    expect(r.getContextCount()).toBe(2)
+  })
+})
+
+// ============================================================
+// 6. llm_query() Round-Trips
+// ============================================================
+
+describe("llm_query round-trips", () => {
+  test("llm_query() routes through handler and returns result", async () => {
+    const queries: string[] = []
+    const r = createREPL({
+      llmQueryHandler: async (prompt) => {
+        queries.push(prompt)
+        return `The answer is 42`
+      },
+    })
+    await r.start()
+
+    const result = await r.executeCode(
+      'response = await llm_query("What is the meaning of life?"); console.log(response)',
+    )
+    expect(result.stdout).toContain("The answer is 42")
+    expect(queries).toEqual(["What is the meaning of life?"])
+  })
+
+  test("multiple llm_query() calls in one execution", async () => {
+    let callCount = 0
+    const r = createREPL({
+      llmQueryHandler: async (prompt) => {
+        callCount++
+        return `response-${callCount}`
+      },
+    })
+    await r.start()
+
+    const result = await r.executeCode(
+      'r1 = await llm_query("q1"); r2 = await llm_query("q2"); console.log(r1, r2)',
+    )
+    expect(result.stdout).toContain("response-1")
+    expect(result.stdout).toContain("response-2")
+    expect(callCount).toBe(2)
+  })
+
+  test("llm_query() with no model passes undefined", async () => {
+    let receivedModel: string | undefined = "not-called"
+    const r = createREPL({
+      llmQueryHandler: async (prompt, model) => {
+        receivedModel = model
+        return "ok"
+      },
+    })
+    await r.start()
+
+    await r.executeCode('await llm_query("test")')
+    expect(receivedModel).toBeUndefined()
+  })
+})
+
+// ============================================================
+// 7. llm_query_batched() Round-Trips
+// ============================================================
+
+describe("llm_query_batched round-trips", () => {
+  test("batched queries route through handler", async () => {
+    const r = createREPL({
+      llmQueryBatchedHandler: async (prompts) => {
+        return prompts.map((p, i) => `answer-${i}: ${p}`)
+      },
+    })
+    await r.start()
+
+    const result = await r.executeCode(
+      'results = await llm_query_batched(["q1", "q2", "q3"]); results.forEach(r => console.log(r))',
+    )
+    expect(result.stdout).toContain("answer-0: q1")
+    expect(result.stdout).toContain("answer-1: q2")
+    expect(result.stdout).toContain("answer-2: q3")
+  })
+
+  test("batched falls back to sequential when no batched handler", async () => {
+    let callCount = 0
+    const r = createREPL({
+      llmQueryHandler: async (prompt) => {
+        callCount++
+        return `seq-${callCount}`
+      },
+      // No llmQueryBatchedHandler — should fall back to sequential
+    })
+    await r.start()
+
+    const result = await r.executeCode(
+      'results = await llm_query_batched(["a", "b"]); results.forEach(r => console.log(r))',
+    )
+    expect(result.stdout).toContain("seq-1")
+    expect(result.stdout).toContain("seq-2")
+    expect(callCount).toBe(2)
+  })
+})
+
+// ============================================================
+// 8. FINAL_VAR() and SHOW_VARS()
+// ============================================================
+
+describe("FINAL_VAR and SHOW_VARS", () => {
+  test("FINAL_VAR returns variable value", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("answer = 'the final answer'")
+    const result = await r.executeCode('console.log(FINAL_VAR("answer"))')
+    expect(result.stdout).toContain("the final answer")
+  })
+
+  test("FINAL_VAR sets hasFinalAnswer flag", async () => {
+    const r = createREPL()
+    await r.start()
+
+    expect(r.hasFinalAnswer()).toBe(false)
+    await r.executeCode("answer = 'done'")
+    await r.executeCode('FINAL_VAR("answer")')
+    expect(r.hasFinalAnswer()).toBe(true)
+    expect(r.getFinalAnswer()).toBe("done")
+  })
+
+  test("FINAL_VAR does not set flag for non-existent variable", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode('FINAL_VAR("nonexistent")')
+    expect(r.hasFinalAnswer()).toBe(false)
+  })
+
+  test("FINAL_VAR returns error for non-existent variable", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode('console.log(FINAL_VAR("nonexistent"))')
+    expect(result.stdout).toContain("Error")
+    expect(result.stdout).toContain("not found")
+  })
+
+  test("SHOW_VARS lists available variables", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("x = 1; y = 'hello'; z = [1,2,3]")
+    const result = await r.executeCode("console.log(SHOW_VARS())")
+    expect(result.stdout).toContain("x")
+    expect(result.stdout).toContain("y")
+    expect(result.stdout).toContain("z")
+  })
+
+  test("SHOW_VARS returns message when no variables exist", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("console.log(SHOW_VARS())")
+    expect(result.stdout).toContain("No variables")
+  })
+})
+
+// ============================================================
+// 8b. FINAL() function
+// ============================================================
+
+describe("FINAL function", () => {
+  test("FINAL sets hasFinalAnswer and stores value", async () => {
+    const r = createREPL()
+    await r.start()
+
+    expect(r.hasFinalAnswer()).toBe(false)
+    await r.executeCode('FINAL("hello world")')
+    expect(r.hasFinalAnswer()).toBe(true)
+    expect(r.getFinalAnswer()).toBe("hello world")
+  })
+
+  test("FINAL works with string concatenation", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("x = 'answer is ' + 42")
+    await r.executeCode("FINAL(x)")
+    expect(r.hasFinalAnswer()).toBe(true)
+    expect(r.getFinalAnswer()).toBe("answer is 42")
+  })
+
+  test("FINAL works with numbers", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("FINAL(42)")
+    expect(r.getFinalAnswer()).toBe("42")
+  })
+
+  test("FINAL works with objects (serialized)", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode('FINAL({a: 1, b: "two"})')
+    expect(r.hasFinalAnswer()).toBe(true)
+    const answer = r.getFinalAnswer()!
+    expect(answer).toContain("a")
+    expect(answer).toContain("1")
+    expect(answer).toContain("two")
+  })
+
+  test("resetFinalAnswer clears the state", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode('FINAL("first")')
+    expect(r.hasFinalAnswer()).toBe(true)
+    r.resetFinalAnswer()
+    expect(r.hasFinalAnswer()).toBe(false)
+    expect(r.getFinalAnswer()).toBeUndefined()
+  })
+
+  test("last FINAL call wins", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode('FINAL("first")')
+    await r.executeCode('FINAL("second")')
+    expect(r.getFinalAnswer()).toBe("second")
+  })
+
+  test("FINAL does not appear in SHOW_VARS", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode('FINAL("test")')
+    const result = await r.executeCode("console.log(SHOW_VARS())")
+    expect(result.stdout).not.toContain("FINAL")
+    expect(result.stdout).not.toContain("__rlm_final__")
+  })
+})
+
+// ============================================================
+// 9. Graceful Cleanup
+// ============================================================
+
+describe("cleanup", () => {
+  test("cleanup completes without error", async () => {
+    const r = createREPL()
+    await r.start()
+    await r.executeCode("x = 1")
+
+    // Should not throw
+    await r.cleanup()
+    repl = null // Prevent afterEach from double-cleaning
+  })
+
+  test("double cleanup does not throw", async () => {
+    const r = createREPL()
+    await r.start()
+    await r.cleanup()
+    await r.cleanup() // Should be safe
+    repl = null
+  })
+})
+
+// ============================================================
+// 10. Stdout Capture Isolation
+// ============================================================
+
+describe("stdout isolation", () => {
+  test("lots of console.log output does not break execution", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+for (let i = 0; i < 100; i++) {
+    console.log(\`line \${i}: {"type": "result", "data": \${i}}\`)
+}
+`)
+    expect(result.stdout).toContain("line 0:")
+    expect(result.stdout).toContain("line 99:")
+    expect(result.stderr).toBe("")
+
+    // REPL should still work after
+    const result2 = await r.executeCode("console.log('still working')")
+    expect(result2.stdout).toBe("still working\n")
+  })
+
+  test("console.error during exec is captured in stderr", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+console.log("stdout line")
+console.error("stderr line")
+`)
+    expect(result.stdout).toContain("stdout line")
+    expect(result.stderr).toContain("stderr line")
+  })
+})
+
+// ============================================================
+// 11. Execution timing
+// ============================================================
+
+describe("execution timing", () => {
+  test("executionTime is populated", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("x = 1 + 1")
+    expect(result.executionTime).toBeGreaterThanOrEqual(0)
+    expect(typeof result.executionTime).toBe("number")
+  })
+})
+
+// ============================================================
+// 12. Locals serialization
+// ============================================================
+
+describe("locals serialization", () => {
+  test("scalar types are serialized directly", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+s = "hello"
+n = 42
+f = 3.14
+b = true
+`)
+    expect(result.locals).toHaveProperty("s", "hello")
+    expect(result.locals).toHaveProperty("n", 42)
+    expect(result.locals).toHaveProperty("f", 3.14)
+    expect(result.locals).toHaveProperty("b", true)
+  })
+
+  test("collections show type and length", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+my_list = [1, 2, 3]
+my_obj = {a: 1}
+`)
+    expect(result.locals).toHaveProperty("my_list", "<Array length=3>")
+    expect(result.locals).toHaveProperty("my_obj", "<Object keys=1>")
+  })
+
+  test("internal variables (starting with _) are excluded from locals", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("_internal = 'hidden'; visible = 'shown'")
+    expect(result.locals).not.toHaveProperty("_internal")
+    expect(result.locals).toHaveProperty("visible", "shown")
+  })
+})
+
+// ============================================================
+// 13. hoistDeclarations() unit tests
+// ============================================================
+
+describe("hoistDeclarations", () => {
+  test("transforms const to bare assignment", () => {
+    expect(hoistDeclarations("const x = 42")).toBe("x = 42")
+  })
+
+  test("transforms let to bare assignment", () => {
+    expect(hoistDeclarations("let y = 'hello'")).toBe("y = 'hello'")
+  })
+
+  test("transforms var to bare assignment", () => {
+    expect(hoistDeclarations("var z = true")).toBe("z = true")
+  })
+
+  test("transforms let without initializer", () => {
+    expect(hoistDeclarations("let x")).toBe("x = undefined")
+  })
+
+  test("transforms multiple declarators", () => {
+    expect(hoistDeclarations("let a = 1, b = 2")).toBe("a = 1; b = 2")
+  })
+
+  test("preserves indentation", () => {
+    expect(hoistDeclarations("  const x = 42")).toBe("  x = 42")
+  })
+
+  test("transforms array destructuring", () => {
+    expect(hoistDeclarations("const [a, b] = [1, 2]")).toBe("[a, b] = [1, 2]")
+  })
+
+  test("transforms object destructuring with parens", () => {
+    const result = hoistDeclarations("const { a, b } = obj")
+    expect(result).toBe(";({ a, b } = obj)")
+  })
+
+  test("does NOT transform inside blocks (braceDepth > 0)", () => {
+    const code = `if (true) {
+  const inner = 1
+}`
+    expect(hoistDeclarations(code)).toBe(code)
+  })
+
+  test("does NOT transform inside functions", () => {
+    const code = `function f() {
+  const local = 42
+  return local
+}`
+    expect(hoistDeclarations(code)).toBe(code)
+  })
+
+  test("transforms top-level but not nested", () => {
+    const code = `const top = 1
+function f() {
+  const inner = 2
+}
+const bottom = 3`
+    const expected = `top = 1
+function f() {
+  const inner = 2
+}
+bottom = 3`
+    expect(hoistDeclarations(code)).toBe(expected)
+  })
+
+  test("handles arrow functions with object literal values", () => {
+    const result = hoistDeclarations("const fn = () => ({ x: 1 })")
+    expect(result).toBe("fn = () => ({ x: 1 })")
+  })
+
+  test("handles complex expressions on the right side", () => {
+    const result = hoistDeclarations("const items = [1, 2, 3].map(x => x * 2)")
+    expect(result).toBe("items = [1, 2, 3].map(x => x * 2)")
+  })
+
+  test("passes through non-declaration lines unchanged", () => {
+    const code = "x = 42\nconsole.log(x)"
+    expect(hoistDeclarations(code)).toBe(code)
+  })
+
+  test("handles for-loop: const inside braces not transformed", () => {
+    const code = `for (let i = 0; i < 10; i++) {
+  const x = i * 2
+  console.log(x)
+}`
+    // The for-line itself starts with `for`, not `const/let/var`, so it's untouched.
+    // The inner `const x` is at braceDepth 1, so it's also untouched.
+    expect(hoistDeclarations(code)).toBe(code)
+  })
+
+  test("handles trailing semicolons", () => {
+    expect(hoistDeclarations("const x = 42;")).toBe("x = 42;")
+  })
+})
+
+// ============================================================
+// 14. const/let persistence in REPL
+// ============================================================
+
+describe("const/let persistence", () => {
+  test("const variable persists across executeCode calls", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("const x = 42")
+    const result = await r.executeCode("console.log(x)")
+    expect(result.stdout).toBe("42\n")
+    expect(result.locals).toHaveProperty("x", 42)
+  })
+
+  test("let variable persists across executeCode calls", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("let y = 'hello'")
+    const result = await r.executeCode("console.log(y)")
+    expect(result.stdout).toBe("hello\n")
+  })
+
+  test("const array destructuring persists", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("const [a, b, c] = [10, 20, 30]")
+    const result = await r.executeCode("console.log(a + b + c)")
+    expect(result.stdout).toBe("60\n")
+  })
+
+  test("const object destructuring persists", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode('const { name, age } = { name: "Alice", age: 30 }')
+    const result = await r.executeCode("console.log(name, age)")
+    expect(result.stdout).toBe("Alice 30\n")
+  })
+
+  test("multiple const declarators persist", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("const a = 1, b = 2, c = 3")
+    const result = await r.executeCode("console.log(a + b + c)")
+    expect(result.stdout).toBe("6\n")
+  })
+
+  test("let without initializer persists as undefined", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("let x")
+    const result = await r.executeCode("console.log(x)")
+    expect(result.stdout).toBe("undefined\n")
+  })
+
+  test("const inside nested block does NOT leak to scope", async () => {
+    const r = createREPL()
+    await r.start()
+
+    // const inside a block should stay block-scoped (NOT hoisted)
+    await r.executeCode("if (true) { const inner = 99 }")
+    // inner should not be in scope — accessing it returns undefined from Proxy
+    const result = await r.executeCode("console.log(typeof inner)")
+    expect(result.stdout).toBe("undefined\n")
+  })
+
+  test("const function persists and is callable", async () => {
+    const r = createREPL()
+    await r.start()
+
+    await r.executeCode("const double = (n) => n * 2")
+    const result = await r.executeCode("console.log(double(21))")
+    expect(result.stdout).toBe("42\n")
+  })
+})
+
+// ============================================================
+// 15. Sandbox security
+// ============================================================
+
+describe("sandbox security", () => {
+  test("process is not accessible", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("console.log(typeof process)")
+    expect(result.stdout).toBe("undefined\n")
+  })
+
+  test("require is not accessible", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("console.log(typeof require)")
+    expect(result.stdout).toBe("undefined\n")
+  })
+
+  test("Bun is not accessible", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("console.log(typeof Bun)")
+    expect(result.stdout).toBe("undefined\n")
+  })
+
+  test("module/exports are not accessible", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode("console.log(typeof module, typeof exports)")
+    expect(result.stdout).toBe("undefined undefined\n")
+  })
+
+  test("import() is not available for dynamic imports", async () => {
+    const r = createREPL()
+    await r.start()
+
+    // Dynamic import should fail in the sandbox
+    const result = await r.executeCode('const m = await import("node:fs")')
+    expect(result.stderr.length).toBeGreaterThan(0)
+  })
+
+  test("whitelisted globals ARE accessible", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+console.log(typeof Math)
+console.log(typeof JSON)
+console.log(typeof Array)
+console.log(typeof Promise)
+console.log(typeof Map)
+console.log(typeof Set)
+console.log(typeof RegExp)
+console.log(typeof Date)
+`)
+    expect(result.stdout).toBe("object\nobject\nfunction\nfunction\nfunction\nfunction\nfunction\nfunction\n")
+    expect(result.stderr).toBe("")
+  })
+
+  test("setTimeout works in sandbox", async () => {
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+result = await new Promise(resolve => setTimeout(() => resolve("done"), 10))
+console.log(result)
+`)
+    expect(result.stdout).toBe("done\n")
+  })
+})
+
+// ============================================================
+// 16. Execution Timeout
+// ============================================================
+
+describe("Execution timeout", () => {
+  test("async operation that exceeds timeout reports error in stderr", async () => {
+    const r = createREPL({ executionTimeoutMs: 100 })
+    await r.start()
+
+    const result = await r.executeCode(`
+await new Promise(resolve => setTimeout(resolve, 5000))
+console.log("should not reach here")
+`)
+    expect(result.stderr).toContain("timed out")
+    expect(result.stderr).toContain("100ms")
+    expect(result.stdout).toBe("")
+  })
+
+  test("fast code executes within timeout", async () => {
+    const r = createREPL({ executionTimeoutMs: 5000 })
+    await r.start()
+
+    const result = await r.executeCode(`
+x = 42
+console.log(x)
+`)
+    expect(result.stdout).toBe("42\n")
+    expect(result.stderr).toBe("")
+  })
+
+  test("REPL remains usable after a timeout", async () => {
+    const r = createREPL({ executionTimeoutMs: 100 })
+    await r.start()
+
+    // First: trigger a timeout
+    const result1 = await r.executeCode(`
+await new Promise(resolve => setTimeout(resolve, 5000))
+`)
+    expect(result1.stderr).toContain("timed out")
+
+    // Second: normal execution should still work
+    const result2 = await r.executeCode(`
+y = 99
+console.log(y)
+`)
+    expect(result2.stdout).toBe("99\n")
+    expect(result2.stderr).toBe("")
+  })
+
+  test("timeout disabled with 0", async () => {
+    const r = createREPL({ executionTimeoutMs: 0 })
+    await r.start()
+
+    // Should not timeout — executes a small delay successfully
+    const result = await r.executeCode(`
+await new Promise(resolve => setTimeout(resolve, 50))
+console.log("ok")
+`)
+    expect(result.stdout).toBe("ok\n")
+    expect(result.stderr).toBe("")
+  })
+
+  test("timeout disabled with Infinity", async () => {
+    const r = createREPL({ executionTimeoutMs: Infinity })
+    await r.start()
+
+    const result = await r.executeCode(`
+await new Promise(resolve => setTimeout(resolve, 50))
+console.log("ok")
+`)
+    expect(result.stdout).toBe("ok\n")
+    expect(result.stderr).toBe("")
+  })
+
+  test("default timeout is applied (30s) — fast code works", async () => {
+    // Uses default timeout (30s). Fast code should complete easily.
+    const r = createREPL()
+    await r.start()
+
+    const result = await r.executeCode(`
+total = 0
+for (let i = 0; i < 1000000; i++) total += i
+console.log(total)
+`)
+    expect(result.stdout).toBe("499999500000\n")
+    expect(result.stderr).toBe("")
+  })
+})

--- a/packages/opencode/test/rlm/parsing.test.ts
+++ b/packages/opencode/test/rlm/parsing.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, test } from "bun:test"
+import {
+  findCodeBlocks,
+  findFinalAnswer,
+  findFinalAnswerAsync,
+  formatIteration,
+  formatExecutionResult,
+} from "../../src/rlm/parsing"
+import type { REPLResult, RLMIteration } from "../../src/rlm/types"
+
+// ============================================================
+// findCodeBlocks
+// ============================================================
+
+describe("findCodeBlocks", () => {
+  test("extracts a single repl code block", () => {
+    const text = 'Some text\n```repl\nprint("hello")\n```\nMore text'
+    const blocks = findCodeBlocks(text)
+    expect(blocks).toEqual(['print("hello")'])
+  })
+
+  test("extracts multiple repl code blocks", () => {
+    const text = `
+Here is step 1:
+\`\`\`repl
+x = 1
+print(x)
+\`\`\`
+
+And step 2:
+\`\`\`repl
+y = x + 1
+print(y)
+\`\`\`
+`
+    const blocks = findCodeBlocks(text)
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toBe("x = 1\nprint(x)")
+    expect(blocks[1]).toBe("y = x + 1\nprint(y)")
+  })
+
+  test("ignores non-repl code blocks", () => {
+    const text = '```python\nprint("not repl")\n```\n```repl\nprint("yes repl")\n```'
+    const blocks = findCodeBlocks(text)
+    expect(blocks).toEqual(['print("yes repl")'])
+  })
+
+  test("returns empty array when no blocks found", () => {
+    const text = "Just plain text with no code blocks"
+    expect(findCodeBlocks(text)).toEqual([])
+  })
+
+  test("handles empty repl block", () => {
+    const text = "```repl\n\n```"
+    const blocks = findCodeBlocks(text)
+    expect(blocks).toEqual([""])
+  })
+
+  test("handles multi-line code with indentation", () => {
+    const text = `
+\`\`\`repl
+def foo(x):
+    return x * 2
+
+result = foo(21)
+print(result)
+\`\`\`
+`
+    const blocks = findCodeBlocks(text)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toContain("def foo(x):")
+    expect(blocks[0]).toContain("    return x * 2")
+  })
+})
+
+// ============================================================
+// findFinalAnswer (sync)
+// ============================================================
+
+describe("findFinalAnswer", () => {
+  test("detects FINAL() with simple string", () => {
+    const text = "After analysis:\nFINAL(The answer is 42)"
+    const answer = findFinalAnswer(text)
+    expect(answer).toBe("The answer is 42")
+  })
+
+  test("detects FINAL() with multi-line content", () => {
+    const text = `
+Some reasoning here.
+FINAL(Line one
+Line two
+Line three)
+`
+    const answer = findFinalAnswer(text)
+    expect(answer).toBe("Line one\nLine two\nLine three")
+  })
+
+  test("detects FINAL() with nested parentheses", () => {
+    const text = "FINAL(f(x) = (x+1)*(x-1))"
+    const answer = findFinalAnswer(text)
+    // Greedy matching should capture everything
+    expect(answer).toBe("f(x) = (x+1)*(x-1)")
+  })
+
+  test("detects FINAL_VAR() with executeCode callback", () => {
+    const mockResult: REPLResult = {
+      stdout: "the stored answer\n",
+      stderr: "",
+      locals: {},
+      executionTime: 0,
+      rlmCalls: [],
+    }
+    const text = 'FINAL_VAR("my_answer")'
+    const answer = findFinalAnswer(text, () => mockResult)
+    expect(answer).toBe("the stored answer")
+  })
+
+  test("FINAL_VAR without executeCode returns undefined", () => {
+    const text = 'FINAL_VAR("my_answer")'
+    const answer = findFinalAnswer(text)
+    expect(answer).toBeUndefined()
+  })
+
+  test("returns undefined when no FINAL pattern found", () => {
+    const text = "Just some regular text without any final answer"
+    const answer = findFinalAnswer(text)
+    expect(answer).toBeUndefined()
+  })
+
+  test("FINAL() at start of line matches", () => {
+    const text = "prefix text\nFINAL(answer here)"
+    const answer = findFinalAnswer(text)
+    expect(answer).toBe("answer here")
+  })
+
+  test("FINAL() with leading whitespace matches", () => {
+    const text = "  FINAL(indented answer)"
+    const answer = findFinalAnswer(text)
+    expect(answer).toBe("indented answer")
+  })
+
+  test("FINAL_VAR takes priority over FINAL", () => {
+    const mockResult: REPLResult = {
+      stdout: "var value\n",
+      stderr: "",
+      locals: {},
+      executionTime: 0,
+      rlmCalls: [],
+    }
+    const text = 'FINAL_VAR("x")\nFINAL(some text)'
+    const answer = findFinalAnswer(text, () => mockResult)
+    expect(answer).toBe("var value")
+  })
+
+  test("FINAL_VAR strips quotes from variable name", () => {
+    const mockResult: REPLResult = {
+      stdout: "42\n",
+      stderr: "",
+      locals: {},
+      executionTime: 0,
+      rlmCalls: [],
+    }
+    // Test with double quotes
+    expect(findFinalAnswer('FINAL_VAR("answer")', () => mockResult)).toBe("42")
+    // Test with single quotes
+    expect(findFinalAnswer("FINAL_VAR('answer')", () => mockResult)).toBe("42")
+  })
+})
+
+// ============================================================
+// findFinalAnswerAsync
+// ============================================================
+
+describe("findFinalAnswerAsync", () => {
+  test("async FINAL_VAR executes code and returns result", async () => {
+    const text = 'FINAL_VAR("result")'
+    const answer = await findFinalAnswerAsync(text, async (code) => ({
+      stdout: "async answer\n",
+      stderr: "",
+      locals: {},
+      executionTime: 0,
+      rlmCalls: [],
+    }))
+    expect(answer).toBe("async answer")
+  })
+
+  test("async FINAL() returns directly without executing", async () => {
+    let executed = false
+    const text = "FINAL(direct answer)"
+    const answer = await findFinalAnswerAsync(text, async () => {
+      executed = true
+      return { stdout: "", stderr: "", locals: {}, executionTime: 0, rlmCalls: [] }
+    })
+    expect(answer).toBe("direct answer")
+    expect(executed).toBe(false)
+  })
+
+  test("async returns undefined when no pattern", async () => {
+    const answer = await findFinalAnswerAsync("no patterns here")
+    expect(answer).toBeUndefined()
+  })
+})
+
+// ============================================================
+// formatExecutionResult
+// ============================================================
+
+describe("formatExecutionResult", () => {
+  test("formats stdout", () => {
+    const result: REPLResult = {
+      stdout: "hello world",
+      stderr: "",
+      locals: {},
+      executionTime: 0.1,
+      rlmCalls: [],
+    }
+    const formatted = formatExecutionResult(result)
+    expect(formatted).toContain("hello world")
+  })
+
+  test("formats stderr", () => {
+    const result: REPLResult = {
+      stdout: "",
+      stderr: "NameError: name 'x' is not defined",
+      locals: {},
+      executionTime: 0.1,
+      rlmCalls: [],
+    }
+    const formatted = formatExecutionResult(result)
+    expect(formatted).toContain("NameError")
+  })
+
+  test("shows REPL variables", () => {
+    const result: REPLResult = {
+      stdout: "",
+      stderr: "",
+      locals: { x: 42, name: "test", items: [1, 2, 3] },
+      executionTime: 0.1,
+      rlmCalls: [],
+    }
+    const formatted = formatExecutionResult(result)
+    expect(formatted).toContain("x")
+    expect(formatted).toContain("name")
+    expect(formatted).toContain("items")
+  })
+
+  test("returns 'No output' for empty result", () => {
+    const result: REPLResult = {
+      stdout: "",
+      stderr: "",
+      locals: {},
+      executionTime: 0.1,
+      rlmCalls: [],
+    }
+    const formatted = formatExecutionResult(result)
+    expect(formatted).toBe("No output")
+  })
+
+  test("excludes internal variables", () => {
+    const result: REPLResult = {
+      stdout: "",
+      stderr: "",
+      locals: { __builtins__: {}, __name__: "__main__", visible: 1 },
+      executionTime: 0.1,
+      rlmCalls: [],
+    }
+    const formatted = formatExecutionResult(result)
+    expect(formatted).toContain("visible")
+    expect(formatted).not.toContain("__builtins__")
+    expect(formatted).not.toContain("__name__")
+  })
+})
+
+// ============================================================
+// formatIteration
+// ============================================================
+
+describe("formatIteration", () => {
+  test("formats iteration with response and code blocks", () => {
+    const iteration: RLMIteration = {
+      prompt: [],
+      response: "Let me compute this.",
+      codeBlocks: [
+        {
+          code: "x = 2 + 2\nprint(x)",
+          result: {
+            stdout: "4\n",
+            stderr: "",
+            locals: { x: 4 },
+            executionTime: 0.01,
+            rlmCalls: [],
+          },
+        },
+      ],
+    }
+
+    const messages = formatIteration(iteration)
+    expect(messages).toHaveLength(2)
+    expect(messages[0].role).toBe("assistant")
+    expect(messages[0].content).toBe("Let me compute this.")
+    expect(messages[1].role).toBe("user")
+    expect(messages[1].content).toContain("x = 2 + 2")
+    expect(messages[1].content).toContain("4")
+  })
+
+  test("formats iteration with no code blocks", () => {
+    const iteration: RLMIteration = {
+      prompt: [],
+      response: "Just thinking out loud.",
+      codeBlocks: [],
+    }
+
+    const messages = formatIteration(iteration)
+    expect(messages).toHaveLength(1)
+    expect(messages[0].role).toBe("assistant")
+    expect(messages[0].content).toBe("Just thinking out loud.")
+  })
+
+  test("truncates long execution results", () => {
+    const longOutput = "x".repeat(30000)
+    const iteration: RLMIteration = {
+      prompt: [],
+      response: "Running big computation.",
+      codeBlocks: [
+        {
+          code: "print('x' * 30000)",
+          result: {
+            stdout: longOutput,
+            stderr: "",
+            locals: {},
+            executionTime: 0.5,
+            rlmCalls: [],
+          },
+        },
+      ],
+    }
+
+    const messages = formatIteration(iteration, 20000)
+    expect(messages).toHaveLength(2)
+    expect(messages[1].content.length).toBeLessThan(longOutput.length + 500)
+    expect(messages[1].content).toContain("chars...")
+  })
+
+  test("formats multiple code blocks in order", () => {
+    const iteration: RLMIteration = {
+      prompt: [],
+      response: "Two steps.",
+      codeBlocks: [
+        {
+          code: "a = 1",
+          result: { stdout: "", stderr: "", locals: { a: 1 }, executionTime: 0, rlmCalls: [] },
+        },
+        {
+          code: "b = 2",
+          result: { stdout: "", stderr: "", locals: { a: 1, b: 2 }, executionTime: 0, rlmCalls: [] },
+        },
+      ],
+    }
+
+    const messages = formatIteration(iteration)
+    expect(messages).toHaveLength(3)
+    expect(messages[1].content).toContain("a = 1")
+    expect(messages[2].content).toContain("b = 2")
+  })
+})

--- a/packages/opencode/test/rlm/rlm-flow.test.ts
+++ b/packages/opencode/test/rlm/rlm-flow.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, test, mock } from "bun:test"
+import type { LanguageModelV2, LanguageModelV2CallOptions } from "@ai-sdk/provider"
+import { generateText } from "ai"
+import { LocalREPL } from "../../src/rlm/environment"
+import { findCodeBlocks, findFinalAnswerAsync, formatIteration } from "../../src/rlm/parsing"
+import { RLM_SYSTEM_PROMPT, buildRLMSystemPrompt, buildUserPrompt } from "../../src/rlm/prompts"
+import { buildQueryMetadata, DEFAULT_RLM_CONFIG } from "../../src/rlm/types"
+import type { CodeBlock, RLMIteration } from "../../src/rlm/types"
+
+/**
+ * Full RLM flow integration tests.
+ *
+ * These tests exercise the complete RLM loop:
+ *   LLM call -> parse code blocks -> execute in JS REPL -> check for FINAL -> repeat
+ *
+ * We use a mock LanguageModelV2 that returns scripted responses to simulate
+ * a real LLM without needing API keys or network access.
+ */
+
+// ============================================================
+// Mock LanguageModelV2 factory
+// ============================================================
+
+function createMockLanguageModel(responses: string[]): LanguageModelV2 {
+  let callIndex = 0
+
+  return {
+    specificationVersion: "v2",
+    provider: "mock",
+    modelId: "mock-model",
+    supportedUrls: {},
+
+    async doGenerate(options: LanguageModelV2CallOptions) {
+      const response = responses[callIndex] ?? "FINAL(No more responses)"
+      callIndex++
+      return {
+        content: [{ type: "text" as const, text: response }],
+        finishReason: "stop" as const,
+        usage: {
+          inputTokens: 10,
+          outputTokens: response.length,
+          totalTokens: 10 + response.length,
+        },
+        warnings: [],
+      }
+    },
+
+    async doStream(options: LanguageModelV2CallOptions) {
+      const response = responses[callIndex] ?? "FINAL(No more responses)"
+      callIndex++
+
+      const parts = [
+        { type: "text-start" as const, id: "t-1" },
+        { type: "text-delta" as const, id: "t-1", delta: response },
+        { type: "text-end" as const, id: "t-1" },
+        {
+          type: "finish" as const,
+          finishReason: "stop" as const,
+          usage: { inputTokens: 10, outputTokens: response.length, totalTokens: 10 + response.length },
+        },
+      ]
+
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const part of parts) {
+            controller.enqueue(part)
+          }
+          controller.close()
+        },
+      })
+
+      return { stream, request: undefined, response: undefined }
+    },
+  }
+}
+
+// ============================================================
+// Simulated RLM loop (mirrors runRLMLoop without Provider deps)
+// ============================================================
+
+async function simulateRLMLoop(opts: {
+  prompt: string
+  model: LanguageModelV2
+  subModel?: LanguageModelV2
+  maxIterations?: number
+}): Promise<{ finalAnswer: string; iterations: number; allIterations: RLMIteration[] }> {
+  const maxIterations = opts.maxIterations ?? 10
+  const subModel = opts.subModel ?? opts.model
+
+  const llmQueryHandler = async (p: string): Promise<string> => {
+    const result = await generateText({
+      model: subModel,
+      messages: [{ role: "user", content: p }],
+    })
+    return result.text
+  }
+
+  const repl = new LocalREPL({
+    llmQueryHandler,
+    contextPayload: opts.prompt,
+  })
+
+  try {
+    await repl.start()
+
+    const queryMetadata = buildQueryMetadata(opts.prompt)
+    let messageHistory = buildRLMSystemPrompt(RLM_SYSTEM_PROMPT, queryMetadata)
+    const allIterations: RLMIteration[] = []
+
+    for (let i = 0; i < maxIterations; i++) {
+      const currentPrompt = [...messageHistory, buildUserPrompt(undefined, i, repl.getContextCount())]
+
+      const result = await generateText({
+        model: opts.model,
+        messages: currentPrompt.map((m) => ({
+          role: m.role as "system" | "user" | "assistant",
+          content: m.content,
+        })),
+      })
+
+      const response = result.text
+      const codeBlockStrs = findCodeBlocks(response)
+      const codeBlocks: CodeBlock[] = []
+
+      for (const codeStr of codeBlockStrs) {
+        const codeResult = await repl.executeCode(codeStr)
+        codeBlocks.push({ code: codeStr, result: codeResult })
+      }
+
+      const iteration: RLMIteration = { prompt: currentPrompt, response, codeBlocks }
+      const finalAnswer = await findFinalAnswerAsync(response, (code) => repl.executeCode(code))
+      iteration.finalAnswer = finalAnswer
+      allIterations.push(iteration)
+
+      if (finalAnswer !== undefined) {
+        return { finalAnswer, iterations: i + 1, allIterations }
+      }
+
+      messageHistory = [...messageHistory, ...formatIteration(iteration)]
+    }
+
+    return { finalAnswer: "(max iterations reached)", iterations: maxIterations, allIterations }
+  } finally {
+    await repl.cleanup()
+  }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe("full RLM loop", () => {
+  test("single iteration: FINAL() without code execution", async () => {
+    const model = createMockLanguageModel([
+      "After thinking about it, the answer is clear.\nFINAL(42)",
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "What is 6*7?", model })
+    expect(result.finalAnswer).toBe("42")
+    expect(result.iterations).toBe(1)
+    expect(result.allIterations[0].codeBlocks).toHaveLength(0)
+  })
+
+  test("two iterations: code execution then FINAL()", async () => {
+    const model = createMockLanguageModel([
+      // Iteration 1: execute some code
+      'Let me compute this.\n```repl\nx = 6 * 7\nconsole.log(`Result: ${x}`)\n```',
+      // Iteration 2: use the result and give final answer
+      "Based on the computation, the answer is:\nFINAL(The result of 6*7 is 42)",
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "What is 6*7?", model })
+    expect(result.finalAnswer).toBe("The result of 6*7 is 42")
+    expect(result.iterations).toBe(2)
+    expect(result.allIterations[0].codeBlocks).toHaveLength(1)
+    expect(result.allIterations[0].codeBlocks[0].result.stdout).toContain("Result: 42")
+  })
+
+  test("three iterations: multiple code blocks with variable persistence", async () => {
+    const model = createMockLanguageModel([
+      // Iteration 1: define a function
+      "Let me define a helper function.\n```repl\nfibonacci = function(n) {\n    if (n <= 1) return n\n    return fibonacci(n - 1) + fibonacci(n - 2)\n}\n```",
+      // Iteration 2: use the function
+      "Now let me compute some Fibonacci numbers.\n```repl\nresults = []\nfor (let i = 0; i < 10; i++) results.push(fibonacci(i))\nconsole.log(JSON.stringify(results))\n```",
+      // Iteration 3: give the final answer
+      'FINAL_VAR("results")',
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "Compute first 10 Fibonacci numbers", model })
+    // FINAL_VAR("results") should retrieve the array from the REPL
+    expect(result.finalAnswer).toContain("0,1,1,2,3,5,8,13,21,34")
+    expect(result.iterations).toBe(3)
+  })
+
+  test("code execution error is handled gracefully", async () => {
+    const model = createMockLanguageModel([
+      // Iteration 1: code with a runtime error
+      "Let me try this:\n```repl\nresult = null.property\n```",
+      // Iteration 2: LLM "sees" the error and gives a corrected answer
+      "I see there was an error. Let me fix that.\nFINAL(Accessing property on null throws TypeError)",
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "What happens with null.property?", model })
+    expect(result.finalAnswer).toBe("Accessing property on null throws TypeError")
+    expect(result.iterations).toBe(2)
+    // The first iteration should have captured the error
+    expect(result.allIterations[0].codeBlocks[0].result.stderr).toContain("TypeError")
+  })
+
+  test("max iterations reached without FINAL", async () => {
+    const model = createMockLanguageModel([
+      "Step 1:\n```repl\nx = 1\n```",
+      "Step 2:\n```repl\nx = x + 1\n```",
+      "Step 3:\n```repl\nx = x + 1\n```",
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "Count to infinity", model, maxIterations: 3 })
+    expect(result.finalAnswer).toBe("(max iterations reached)")
+    expect(result.iterations).toBe(3)
+  })
+
+  test("multiple code blocks in a single iteration", async () => {
+    const model = createMockLanguageModel([
+      'Let me do two things.\n```repl\na = 10\nconsole.log(`a = ${a}`)\n```\n\nAnd also:\n```repl\nb = 20\nconsole.log(`b = ${b}`)\n```',
+      "Now I know both values.\nFINAL(a=10, b=20)",
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "Set a=10 and b=20", model })
+    expect(result.finalAnswer).toBe("a=10, b=20")
+    expect(result.iterations).toBe(2)
+    expect(result.allIterations[0].codeBlocks).toHaveLength(2)
+    expect(result.allIterations[0].codeBlocks[0].result.stdout).toContain("a = 10")
+    expect(result.allIterations[0].codeBlocks[1].result.stdout).toContain("b = 20")
+  })
+
+  test("llm_query() from inside REPL uses sub-model", async () => {
+    // Main model orchestrates the loop
+    const mainModel = createMockLanguageModel([
+      // Iteration 1: ask the sub-model from inside REPL
+      '```repl\nanswer = await llm_query("What is the capital of France?")\nconsole.log(answer)\n```',
+      // Iteration 2: use the answer
+      "FINAL(Paris is the capital)",
+    ])
+
+    // Sub-model responds to llm_query()
+    const subModel = createMockLanguageModel([
+      "Paris",
+    ])
+
+    const result = await simulateRLMLoop({
+      prompt: "Use llm_query to find the capital of France",
+      model: mainModel,
+      subModel,
+    })
+
+    expect(result.finalAnswer).toBe("Paris is the capital")
+    expect(result.iterations).toBe(2)
+    // The first iteration should show the sub-model's response in stdout
+    expect(result.allIterations[0].codeBlocks[0].result.stdout).toContain("Paris")
+  })
+
+  test("context is accessible in REPL via context_0", async () => {
+    const model = createMockLanguageModel([
+      '```repl\nconsole.log(`Context: ${context_0}`)\nconsole.log(`Also: ${context}`)\n```',
+      "FINAL(Context was accessible)",
+    ])
+
+    const result = await simulateRLMLoop({
+      prompt: "Important data here",
+      model,
+    })
+
+    expect(result.finalAnswer).toBe("Context was accessible")
+    expect(result.allIterations[0].codeBlocks[0].result.stdout).toContain("Important data here")
+  })
+
+  test("SHOW_VARS() works in RLM loop", async () => {
+    const model = createMockLanguageModel([
+      // First block: define variables
+      '```repl\nx = 42\ny = "hello"\n```',
+      // Second block: SHOW_VARS() can now see them
+      '```repl\nconsole.log(SHOW_VARS())\n```',
+      "FINAL(Variables shown)",
+    ])
+
+    const result = await simulateRLMLoop({ prompt: "Test SHOW_VARS", model })
+    expect(result.finalAnswer).toBe("Variables shown")
+    // SHOW_VARS is in iteration 2 (index 1), first code block
+    expect(result.allIterations[1].codeBlocks[0].result.stdout).toContain("x")
+    expect(result.allIterations[1].codeBlocks[0].result.stdout).toContain("y")
+  })
+})
+
+// ============================================================
+// System prompt construction
+// ============================================================
+
+describe("system prompt construction", () => {
+  test("buildRLMSystemPrompt produces valid message array", () => {
+    const metadata = buildQueryMetadata("test prompt")
+    const messages = buildRLMSystemPrompt(RLM_SYSTEM_PROMPT, metadata)
+
+    expect(messages.length).toBeGreaterThanOrEqual(1)
+    expect(messages[0].role).toBe("system")
+    expect(messages[0].content).toContain("REPL")
+    expect(messages[0].content).toContain("JavaScript")
+  })
+
+  test("buildUserPrompt includes iteration info", () => {
+    const msg = buildUserPrompt("What is 2+2?", 0, 1)
+    expect(msg.role).toBe("user")
+    expect(msg.content.length).toBeGreaterThan(0)
+  })
+
+  test("buildQueryMetadata handles string prompt", () => {
+    const metadata = buildQueryMetadata("hello world")
+    expect(metadata.contextType).toBe("str")
+    expect(metadata.contextTotalLength).toBe(11)
+    expect(metadata.contextLengths).toEqual([11])
+  })
+
+  test("buildQueryMetadata handles array prompt", () => {
+    const metadata = buildQueryMetadata(["a", "bb", "ccc"])
+    expect(metadata.contextType).toBe("list")
+    expect(metadata.contextLengths).toEqual([1, 2, 3])
+    expect(metadata.contextTotalLength).toBe(6)
+  })
+
+  test("buildQueryMetadata handles object prompt", () => {
+    const metadata = buildQueryMetadata({ key: "value" })
+    expect(metadata.contextType).toBe("dict")
+    expect(metadata.contextTotalLength).toBe(5) // "value".length
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -124,6 +124,10 @@ import type {
   SessionPromptResponses,
   SessionRevertErrors,
   SessionRevertResponses,
+  SessionRlmOverflowReplyErrors,
+  SessionRlmOverflowReplyResponses,
+  SessionRlmToggleErrors,
+  SessionRlmToggleResponses,
   SessionShareErrors,
   SessionShareResponses,
   SessionShellErrors,
@@ -1413,6 +1417,79 @@ export class Session extends HeyApiClient {
     )
     return (options?.client ?? this.client).post<SessionSummarizeResponses, SessionSummarizeErrors, ThrowOnError>({
       url: "/session/{sessionID}/summarize",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Toggle RLM mode
+   *
+   * Toggle Recursive Language Model mode for a session.
+   */
+  public rlmToggle<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionRlmToggleResponses, SessionRlmToggleErrors, ThrowOnError>({
+      url: "/session/{sessionID}/rlm/toggle",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Reply to RLM overflow prompt
+   *
+   * Reply to a context overflow prompt with a choice of compact or RLM mode.
+   */
+  public rlmOverflowReply<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      requestID: string
+      directory?: string
+      choice?: "compact" | "rlm"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "body", key: "choice" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      SessionRlmOverflowReplyResponses,
+      SessionRlmOverflowReplyErrors,
+      ThrowOnError
+    >({
+      url: "/session/{sessionID}/rlm/overflow/{requestID}",
       ...options,
       ...params,
       headers: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -567,6 +567,33 @@ export type EventPermissionReplied = {
   }
 }
 
+export type EventRlmToggled = {
+  type: "rlm.toggled"
+  properties: {
+    sessionID: string
+    active: boolean
+  }
+}
+
+export type RlmOverflowRequest = {
+  id: string
+  sessionID: string
+}
+
+export type EventRlmOverflowAsked = {
+  type: "rlm.overflow.asked"
+  properties: RlmOverflowRequest
+}
+
+export type EventRlmOverflowReplied = {
+  type: "rlm.overflow.replied"
+  properties: {
+    sessionID: string
+    requestID: string
+    choice: "compact" | "rlm"
+  }
+}
+
 export type SessionStatus =
   | {
       type: "idle"
@@ -951,6 +978,9 @@ export type Event =
   | EventMessagePartRemoved
   | EventPermissionAsked
   | EventPermissionReplied
+  | EventRlmToggled
+  | EventRlmOverflowAsked
+  | EventRlmOverflowReplied
   | EventSessionStatus
   | EventSessionIdle
   | EventQuestionAsked
@@ -1076,6 +1106,10 @@ export type KeybindsConfig = {
    * Compact the session
    */
   session_compact?: string
+  /**
+   * Toggle RLM mode for current session
+   */
+  rlm_toggle?: string
   /**
    * Scroll messages up by one page
    */
@@ -1470,6 +1504,17 @@ export type AgentConfig = {
    */
   maxSteps?: number
   permission?: PermissionConfig
+  /**
+   * Enable RLM mode for this agent. Set to true or provide config overrides.
+   */
+  rlm?:
+    | boolean
+    | {
+        enabled?: boolean
+        max_iterations?: number
+        max_depth?: number
+        sub_model?: string
+      }
   [key: string]:
     | unknown
     | string
@@ -1494,6 +1539,13 @@ export type AgentConfig = {
     | "info"
     | number
     | PermissionConfig
+    | boolean
+    | {
+        enabled?: boolean
+        max_iterations?: number
+        max_depth?: number
+        sub_model?: string
+      }
     | undefined
 }
 
@@ -1857,6 +1909,31 @@ export type Config = {
      * Token buffer for compaction. Leaves enough window to avoid overflow during compaction.
      */
     reserved?: number
+  }
+  /**
+   * RLM (Recursive Language Model) configuration for iterative REPL-based reasoning
+   */
+  rlm?: {
+    /**
+     * Enable RLM (Recursive Language Model) mode globally (default: false)
+     */
+    enabled?: boolean
+    /**
+     * Maximum number of RLM iterations before forcing a final answer (default: 30)
+     */
+    max_iterations?: number
+    /**
+     * Maximum recursion depth for nested RLM calls (default: 1)
+     */
+    max_depth?: number
+    /**
+     * Model to use for sub-LLM queries inside the REPL environment, in provider/model format. Defaults to the main model.
+     */
+    sub_model?: string
+    /**
+     * Enable verbose RLM logging (default: false)
+     */
+    verbose?: boolean
   }
   experimental?: {
     disable_paste_summary?: boolean
@@ -2222,6 +2299,14 @@ export type Agent = {
     [key: string]: unknown
   }
   steps?: number
+  rlm?:
+    | boolean
+    | {
+        enabled?: boolean
+        max_iterations?: number
+        max_depth?: number
+        sub_model?: string
+      }
 }
 
 export type LspStatus = {
@@ -3375,6 +3460,86 @@ export type SessionSummarizeResponses = {
 }
 
 export type SessionSummarizeResponse = SessionSummarizeResponses[keyof SessionSummarizeResponses]
+
+export type SessionRlmToggleData = {
+  body?: never
+  path: {
+    /**
+     * Session ID
+     */
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/rlm/toggle"
+}
+
+export type SessionRlmToggleErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionRlmToggleError = SessionRlmToggleErrors[keyof SessionRlmToggleErrors]
+
+export type SessionRlmToggleResponses = {
+  /**
+   * RLM mode toggled
+   */
+  200: {
+    active: boolean
+  }
+}
+
+export type SessionRlmToggleResponse = SessionRlmToggleResponses[keyof SessionRlmToggleResponses]
+
+export type SessionRlmOverflowReplyData = {
+  body?: {
+    choice: "compact" | "rlm"
+  }
+  path: {
+    /**
+     * Session ID
+     */
+    sessionID: string
+    /**
+     * Overflow request ID
+     */
+    requestID: string
+  }
+  query?: {
+    directory?: string
+  }
+  url: "/session/{sessionID}/rlm/overflow/{requestID}"
+}
+
+export type SessionRlmOverflowReplyErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type SessionRlmOverflowReplyError = SessionRlmOverflowReplyErrors[keyof SessionRlmOverflowReplyErrors]
+
+export type SessionRlmOverflowReplyResponses = {
+  /**
+   * Overflow reply accepted
+   */
+  200: boolean
+}
+
+export type SessionRlmOverflowReplyResponse = SessionRlmOverflowReplyResponses[keyof SessionRlmOverflowReplyResponses]
 
 export type SessionMessagesData = {
   body?: never


### PR DESCRIPTION
This PR adds a JavaScript REPL-based recursive reasoning system that enables LLMs to execute code iteratively in a sandboxed VM environment.
> Disclaimer: This code was entirely AI-generated using OpenCode. I haven't had time to review it thoroughly, but I've tested it via nix package install and it works great. Context rebuilding is surprisingly fast.
What's included:
- Sandboxed vm-based REPL with execution timeout and variable persistence
- context_query tool for verification during RLM execution
- Session-level toggle via TUI and rlm_toggle keybind
- Enabled by default
- Last summary is always sent along with compacted context, which helps preserve long context and drastically reduces hallucination
What this enables:
With RLM, the model can now handle session context questions that were previously impossible — things like:
- "What was the first error we fixed in this session?"
- "Which files did we modify 10000 messages ago?"
- "Summarize all the changes we've made so far using context_query"
- "What was my original request before we went down this rabbit hole?"
If you have long sessions where the model starts forgetting earlier context, RLM can help. Let me know how it goes!

ported from: https://github.com/alexzhang13/rlm