### PR TITLE
fix: retry on timeout errors instead of failing

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -971,6 +971,14 @@ export function fromError(
           cause: e,
         },
       ).toObject()
+    case e instanceof DOMException && e.name === "TimeoutError":
+      return new APIError(
+        {
+          message: e.message || "Operation timed out",
+          isRetryable: true,
+        },
+        { cause: e },
+      ).toObject()
     case OutputLengthError.isInstance(e):
       return e
     case LoadAPIKeyError.isInstance(e):

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -950,6 +950,14 @@ describe("session.message-v2.toModelMessage", () => {
 })
 
 describe("session.message-v2.fromError", () => {
+  test("classifies timeout DOMException as retryable APIError", () => {
+    const result = MessageV2.fromError(new DOMException("operation timed out", "TimeoutError"), { providerID })
+
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    expect((result as MessageV2.APIError).data.message).toBe("operation timed out")
+    expect((result as MessageV2.APIError).data.isRetryable).toBe(true)
+  })
+
   test("serializes context_length_exceeded as ContextOverflowError", () => {
     const input = {
       type: "error",


### PR DESCRIPTION
Fixes #13138

## Problem
When provider requests timeout (default 5 min), `AbortSignal.timeout()` throws a `DOMException` with `name: 'TimeoutError'`. This error was not handled in `fromError()`, causing it to fall through to `Unknown` error type which is not retryable. Sessions stopped immediately instead of retrying.

## Solution
Handle `TimeoutError` DOMException in `fromError()` and convert it to `APIError` with `isRetryable: true`. This enables automatic retry with exponential backoff via the existing retry mechanism.

## Testing
Verified the fix handles timeout errors correctly. The session will now retry on provider timeouts instead of failing immediately.

---

**Related issues/PRs (not duplicates):**
- #7929 - `AbortSignal.timeout is not a function` (missing API on Windows/web)
- #12762 - Bash tool timeout config being ignored
- #8633 / #8630 - MCP timeout configuration
- #13189 - Model fallback with TTFT-based timeout