### PR TITLE
feat: add tui.no_terminal_padding_x config option

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -175,6 +175,11 @@ export function Session() {
     return new CustomSpeedScroll(3)
   })
 
+  const noTerminalPaddingX = createMemo(() => {
+    const tui = sync.data.config.tui
+    return tui?.no_terminal_padding_x ?? false
+  })
+
   createEffect(async () => {
     await sync.session
       .sync(route.sessionID)
@@ -971,7 +976,14 @@ export function Session() {
       }}
     >
       <box flexDirection="row">
-        <box flexGrow={1} paddingBottom={1} paddingTop={1} paddingLeft={2} paddingRight={2} gap={1}>
+        <box
+          flexGrow={1}
+          paddingBottom={1}
+          paddingTop={1}
+          paddingLeft={noTerminalPaddingX() ? 0 : 2}
+          paddingRight={noTerminalPaddingX() ? 0 : 2}
+          gap={1}
+        >
           <Show when={session()}>
             <Show when={showHeader() && (!sidebarVisible() || !wide())}>
               <Header />

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -928,6 +928,7 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    no_terminal_padding_x: z.boolean().optional().describe("Remove horizontal padding in the terminal interface"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1692,6 +1692,10 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Remove horizontal padding in the terminal interface
+     */
+    no_terminal_padding_x?: boolean
   }
   server?: ServerConfig
   /**


### PR DESCRIPTION
Adds a new configuration option `tui.no_terminal_padding_x` that removes horizontal padding in the terminal interface.

## Changes
- Added `no_terminal_padding_x` boolean option to TUI config schema
- Implemented conditional padding in session view (0 when enabled, 2 when disabled)
- Updated SDK types to include the new config field

## Testing
- All CI checks passing (typecheck, unit tests, check-standards)
- Manual testing shows padding is properly removed when option is enabled

Fixes #9955