### PR TITLE
feat: add tui.no_terminal_padding_y config option

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -175,6 +175,11 @@ export function Session() {
     return new CustomSpeedScroll(3)
   })
 
+  const noTerminalPaddingX = createMemo(() => {
+    const tui = sync.data.config.tui
+    return tui?.no_terminal_padding_x ?? false
+  })
+
   createEffect(async () => {
     await sync.session
       .sync(route.sessionID)
@@ -971,7 +976,14 @@ export function Session() {
       }}
     >
       <box flexDirection="row">
-        <box flexGrow={1} paddingBottom={1} paddingTop={1} paddingLeft={2} paddingRight={2} gap={1}>
+        <box
+          flexGrow={1}
+          paddingBottom={1}
+          paddingTop={1}
+          paddingLeft={noTerminalPaddingX() ? 0 : 2}
+          paddingRight={noTerminalPaddingX() ? 0 : 2}
+          gap={1}
+        >
           <Show when={session()}>
             <Show when={showHeader() && (!sidebarVisible() || !wide())}>
               <Header />

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -175,9 +175,9 @@ export function Session() {
     return new CustomSpeedScroll(3)
   })
 
-  const noTerminalPaddingX = createMemo(() => {
+  const noTerminalPaddingY = createMemo(() => {
     const tui = sync.data.config.tui
-    return tui?.no_terminal_padding_x ?? false
+    return tui?.no_terminal_padding_y ?? false
   })
 
   createEffect(async () => {
@@ -978,10 +978,10 @@ export function Session() {
       <box flexDirection="row">
         <box
           flexGrow={1}
-          paddingBottom={1}
-          paddingTop={1}
-          paddingLeft={noTerminalPaddingX() ? 0 : 2}
-          paddingRight={noTerminalPaddingX() ? 0 : 2}
+          paddingBottom={noTerminalPaddingY() ? 0 : 1}
+          paddingTop={noTerminalPaddingY() ? 0 : 1}
+          paddingLeft={2}
+          paddingRight={2}
           gap={1}
         >
           <Show when={session()}>

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -928,7 +928,7 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
-    no_terminal_padding_x: z.boolean().optional().describe("Remove horizontal padding in the terminal interface"),
+    no_terminal_padding_y: z.boolean().optional().describe("Remove vertical padding in the terminal interface"),
   })
 
   export const Server = z

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -928,6 +928,7 @@ export namespace Config {
       .enum(["auto", "stacked"])
       .optional()
       .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+    no_terminal_padding_x: z.boolean().optional().describe("Remove horizontal padding in the terminal interface"),
   })
 
   export const Server = z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1692,6 +1692,10 @@ export type Config = {
      * Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column
      */
     diff_style?: "auto" | "stacked"
+    /**
+     * Remove horizontal padding in the terminal interface
+     */
+    no_terminal_padding_x?: boolean
   }
   server?: ServerConfig
   /**

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1693,9 +1693,9 @@ export type Config = {
      */
     diff_style?: "auto" | "stacked"
     /**
-     * Remove horizontal padding in the terminal interface
+     * Remove vertical padding in the terminal interface
      */
-    no_terminal_padding_x?: boolean
+    no_terminal_padding_y?: boolean
   }
   server?: ServerConfig
   /**


### PR DESCRIPTION
Adds a new configuration option `tui.no_terminal_padding_y` that removes vertical padding in the terminal interface.

## Changes
- Added `no_terminal_padding_y` boolean option to TUI config schema
- Implemented conditional vertical padding in session view (0 when enabled, 1 when disabled)
- Updated SDK types to include the new config field

## Problem Addressed
Users on smaller screens (laptops, phones) lose significant vertical space to padding. This option allows removal of top/bottom padding to maximize content visibility.

## Testing
- All CI checks should pass (typecheck, unit tests, check-standards)
- With config enabled: `paddingTop: 0, paddingBottom: 0`
- With config disabled (default): `paddingTop: 1, paddingBottom: 1`

Fixes #9955