### PR TITLE
docs: add openkilo to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -33,6 +33,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | Clean up markdown tables produced by LLMs                                                         |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
+| [OpenKilo](https://github.com/AnganSamadder/openkilo)                                                    | Access frontier open-source AI models for free with zero configuration                           |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | AI-powered automatic Zellij session naming based on OpenCode context                              |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -33,7 +33,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)           | Clean up markdown tables produced by LLMs                                                         |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                        | 10x faster code editing with Morph Fast Apply API and lazy edit markers                           |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                          | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible            |
-| [OpenKilo](https://github.com/AnganSamadder/openkilo)                                                    | Access frontier open-source AI models for free with zero configuration                           |
+| [openkilo](https://github.com/AnganSamadder/openkilo)                                                    | Access frontier open-source AI models for free with zero configuration                           |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                                   | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                         | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                                   | AI-powered automatic Zellij session naming based on OpenCode context                              |


### PR DESCRIPTION
Adds OpenKilo to the ecosystem page.

## Plugin Details
- **Name**: OpenKilo
- **Repository**: https://github.com/AnganSamadder/openkilo
- **Description**: Access frontier open-source AI models for free with zero configuration

## Features
- 40+ free AI models (GLM 5, Kimi K2.5, DeepSeek v3.2, Llama, Qwen, etc.)
- No API key required for free models
- OpenRouter-compatible gateway
- Optional OAuth/API key for 350+ paid models