### PR TITLE
fix: skip non-function exports when loading external plugins

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -85,6 +85,7 @@ export namespace Plugin {
       // Object.entries(mod) would return both entries pointing to the same function reference.
       const seen = new Set<PluginInstance>()
       for (const [_name, fn] of Object.entries<PluginInstance>(mod)) {
+        if (typeof fn !== "function") continue
         if (seen.has(fn)) continue
         seen.add(fn)
         const init = await fn(input)


### PR DESCRIPTION
## Summary

External plugins fail to load with `TypeError: fn is not a function` because the plugin loading code iterates over ALL exports from a module and tries to call each as a Plugin function. External plugins typically export many things besides the Plugin function (helpers, constants, types), causing the error when non-function exports are encountered.

## Root Cause

In `packages/opencode/src/plugin/index.ts`, the plugin loading loop iterates over all exports using `Object.entries(mod)` and attempts to call each as a Plugin function without checking if the export is actually a function.

## Fix

Add a `typeof fn !== "function"` check before attempting to call the export as a Plugin function.

## Changes

- **packages/opencode/src/plugin/index.ts**: Added type check to skip non-function exports

## Testing

Created a test plugin that exports additional non-function values (`SOME_CONSTANT`, `someObject`) alongside the Plugin function. Verified the plugin now loads successfully.

## Related Issue

Fixes #13543