### PR TITLE
desktop: remote OPENCODE_SQLITE env

### DIFF
--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -1,10 +1,3 @@
 fn main() {
-    if let Ok(git_ref) = std::env::var("GITHUB_REF") {
-        let branch = git_ref.strip_prefix("refs/heads/").unwrap_or(&git_ref);
-        if branch == "beta" {
-            println!("cargo:rustc-env=OPENCODE_SQLITE=1");
-        }
-    }
-
     tauri_build::build()
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -566,8 +566,7 @@ async fn initialize(app: AppHandle) {
     // come from any invocation of the sidecar CLI. The progress is captured by a stdout stream interceptor.
     // Then in the loading task, we wait for sqlite migration to complete before
     // starting our health check against the server, otherwise long migrations could result in a timeout.
-    let needs_sqlite_migration = option_env!("OPENCODE_SQLITE").is_some() && !sqlite_file_exists();
-    let sqlite_done = needs_sqlite_migration.then(|| {
+    let sqlite_done = !sqlite_file_exists().then(|| {
         tracing::info!(
             path = %opencode_db_path().expect("failed to get db path").display(),
             "Sqlite file not found, waiting for it to be generated"


### PR DESCRIPTION
Removes the OPENCODE_SQLITE env that is in place for gating the sqlite migration loadnig window to only show in beta builds.
We'll want to merge this ONLY after merging `sqlite2`.