### PR TITLE
feat(opencode): Add Venice support in temperature, topP, topK and smallOption

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -318,7 +318,7 @@ export namespace ProviderTransform {
   export function topK(model: Provider.Model) {
     const id = model.id.toLowerCase()
     if (id.includes("minimax-m2")) {
-      if (id.includes("m2.") || id.includes("m25") || id.includes("m21")) return 40 // m2.1 and m2.5
+      if (["m2.", "m25", "m21"].some((s) => id.includes(s))) return 40
       return 20
     }
     if (id.includes("gemini")) return 64

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -298,8 +298,8 @@ export namespace ProviderTransform {
     if (id.includes("minimax-m2")) return 1.0
     if (id.includes("kimi-k2")) {
       // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
-      if (["thinking", "k2.", "k2p", "k2-"].some(s => id.includes(s))) {
-        return 1.0;
+      if (["thinking", "k2.", "k2p", "k2-5"].some((s) => id.includes(s))) {
+        return 1.0
       }
       return 0.6
     }
@@ -309,7 +309,7 @@ export namespace ProviderTransform {
   export function topP(model: Provider.Model) {
     const id = model.id.toLowerCase()
     if (id.includes("qwen")) return 1
-    if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some(s => id.includes(s))) {
+    if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some((s) => id.includes(s))) {
       return 0.95
     }
     return undefined

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -297,9 +297,9 @@ export namespace ProviderTransform {
     if (id.includes("glm-4.7")) return 1.0
     if (id.includes("minimax-m2")) return 1.0
     if (id.includes("kimi-k2")) {
-      // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5
-      if (id.includes("thinking") || id.includes("k2.") || id.includes("k2p")) {
-        return 1.0
+      // kimi-k2-thinking & kimi-k2.5 && kimi-k2p5 && kimi-k2-5
+      if (["thinking", "k2.", "k2p", "k2-"].some(s => id.includes(s))) {
+        return 1.0;
       }
       return 0.6
     }
@@ -309,7 +309,7 @@ export namespace ProviderTransform {
   export function topP(model: Provider.Model) {
     const id = model.id.toLowerCase()
     if (id.includes("qwen")) return 1
-    if (id.includes("minimax-m2") || id.includes("kimi-k2.5") || id.includes("kimi-k2p5") || id.includes("gemini")) {
+    if (["minimax-m2", "gemini", "kimi-k2.5", "kimi-k2p5", "kimi-k2-5"].some(s => id.includes(s))) {
       return 0.95
     }
     return undefined
@@ -318,7 +318,7 @@ export namespace ProviderTransform {
   export function topK(model: Provider.Model) {
     const id = model.id.toLowerCase()
     if (id.includes("minimax-m2")) {
-      if (id.includes("m2.1")) return 40
+      if (id.includes("m2.") || id.includes("m25") || id.includes("m21")) return 40 // m2.1 and m2.5
       return 20
     }
     if (id.includes("gemini")) return 64
@@ -750,6 +750,11 @@ export namespace ProviderTransform {
       }
       return { reasoningEffort: "minimal" }
     }
+
+    if (model.providerID === "venice") {
+      return { veniceParameters: { disableThinking: true } }
+    }
+
     return {}
   }
 


### PR DESCRIPTION
Closes #13552

- Add Venice to smallOptions() to disable thinking for small models
- Refactor kimi-k2 detection in temperature() to support Venice model naming
- Add kimi-k2-5 to topP() model list for Venice
- Refactor minimax-m2 detection in topK() to support Venice model naming variants
