### PR TITLE
fix: tweak websearch tool description date info to avoid cache busts

### DIFF
--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -40,7 +40,7 @@ interface McpSearchResponse {
 export const WebSearchTool = Tool.define("websearch", async () => {
   return {
     get description() {
-      return DESCRIPTION.replace("{{date}}", new Date().toISOString().slice(0, 10))
+      return DESCRIPTION.replace("{{year}}", new Date().getFullYear().toString())
     },
     parameters: z.object({
       query: z.string().describe("Websearch query"),

--- a/packages/opencode/src/tool/websearch.txt
+++ b/packages/opencode/src/tool/websearch.txt
@@ -10,5 +10,5 @@ Usage notes:
   - Configurable context length for optimal LLM integration
   - Domain filtering and advanced search options available
 
-Today's date is {{date}}. You MUST use this year when searching for recent information or current events
-- Example: If today is 2025-07-15 and the user asks for "latest AI news", search for "AI news 2025", NOT "AI news 2024"
+The current year is {{year}}. You MUST use this year when searching for recent information or current events
+- Example: If the current year is 2026 and the user asks for "latest AI news", search for "AI news 2026", NOT "AI news 2025"


### PR DESCRIPTION
there are better solutions but I figure if the cache busts once a year that's fine lol