### PR TITLE
fix(session): add ORDER BY time_updated DESC to Session.list() and children()

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -10,7 +10,7 @@ import { Flag } from "../flag/flag"
 import { Identifier } from "../id/id"
 import { Installation } from "../installation"
 
-import { Database, NotFoundError, eq, and, or, like } from "../storage/db"
+import { Database, NotFoundError, eq, and, or, like, desc } from "../storage/db"
 import { SessionTable, MessageTable, PartTable } from "./session.sql"
 import { Storage } from "@/storage/storage"
 import { Log } from "../util/log"
@@ -519,6 +519,7 @@ export namespace Session {
             // or(eq(SessionTable.directory, Instance.directory), like(SessionTable.directory, `%${suffix}`)),
           ),
         )
+        .orderBy(desc(SessionTable.time_updated))
         .all(),
     )
     for (const row of rows) {
@@ -533,6 +534,7 @@ export namespace Session {
         .select()
         .from(SessionTable)
         .where(and(eq(SessionTable.project_id, project.id), eq(SessionTable.parent_id, parentID)))
+        .orderBy(desc(SessionTable.time_updated))
         .all(),
     )
     return rows.map(fromRow)


### PR DESCRIPTION
## Summary
Fixes #13569

Adds `ORDER BY time_updated DESC` to `Session.list()` and `Session.children()` for deterministic ordering.

## Problem
The current implementation returns sessions in SQLite's internal storage order, which is not guaranteed to be stable. This makes the `limit` parameter unreliable (returns arbitrary subset instead of most recent).

## Changes
- Add `desc` import from `storage/db`
- Add `.orderBy(desc(SessionTable.time_updated))` to `list()`
- Add `.orderBy(desc(SessionTable.time_updated))` to `children()`

## Testing
This is a minimal change that adds database-level ordering. The TUI already sorts client-side with `.toSorted((a, b) => b.time.updated - a.time.updated)`, so this change aligns the API behavior with existing client expectations.

---
🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>