### PR TITLE
fix(patch): handle Windows drive-letter colons in patch header path parsing

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -79,23 +79,23 @@ export namespace Patch {
     const line = lines[startIdx]
 
     if (line.startsWith("*** Add File:")) {
-      const filePath = line.split(":", 2)[1]?.trim()
+      const filePath = line.slice("*** Add File:".length).trim()
       return filePath ? { filePath, nextIdx: startIdx + 1 } : null
     }
 
     if (line.startsWith("*** Delete File:")) {
-      const filePath = line.split(":", 2)[1]?.trim()
+      const filePath = line.slice("*** Delete File:".length).trim()
       return filePath ? { filePath, nextIdx: startIdx + 1 } : null
     }
 
     if (line.startsWith("*** Update File:")) {
-      const filePath = line.split(":", 2)[1]?.trim()
+      const filePath = line.slice("*** Update File:".length).trim()
       let movePath: string | undefined
       let nextIdx = startIdx + 1
 
       // Check for move directive
       if (nextIdx < lines.length && lines[nextIdx].startsWith("*** Move to:")) {
-        movePath = lines[nextIdx].split(":", 2)[1]?.trim()
+        movePath = lines[nextIdx].slice("*** Move to:".length).trim()
         nextIdx++
       }
 

--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -72,30 +72,35 @@ export namespace Patch {
   }
 
   // Parser implementation
+  const ADD_PREFIX = "*** Add File:"
+  const DELETE_PREFIX = "*** Delete File:"
+  const UPDATE_PREFIX = "*** Update File:"
+  const MOVE_PREFIX = "*** Move to:"
+
   function parsePatchHeader(
     lines: string[],
     startIdx: number,
   ): { filePath: string; movePath?: string; nextIdx: number } | null {
     const line = lines[startIdx]
 
-    if (line.startsWith("*** Add File:")) {
-      const filePath = line.slice("*** Add File:".length).trim()
+    if (line.startsWith(ADD_PREFIX)) {
+      const filePath = line.slice(ADD_PREFIX.length).trim()
       return filePath ? { filePath, nextIdx: startIdx + 1 } : null
     }
 
-    if (line.startsWith("*** Delete File:")) {
-      const filePath = line.slice("*** Delete File:".length).trim()
+    if (line.startsWith(DELETE_PREFIX)) {
+      const filePath = line.slice(DELETE_PREFIX.length).trim()
       return filePath ? { filePath, nextIdx: startIdx + 1 } : null
     }
 
-    if (line.startsWith("*** Update File:")) {
-      const filePath = line.slice("*** Update File:".length).trim()
+    if (line.startsWith(UPDATE_PREFIX)) {
+      const filePath = line.slice(UPDATE_PREFIX.length).trim()
       let movePath: string | undefined
       let nextIdx = startIdx + 1
 
       // Check for move directive
-      if (nextIdx < lines.length && lines[nextIdx].startsWith("*** Move to:")) {
-        movePath = lines[nextIdx].slice("*** Move to:".length).trim()
+      if (nextIdx < lines.length && lines[nextIdx].startsWith(MOVE_PREFIX)) {
+        movePath = lines[nextIdx].slice(MOVE_PREFIX.length).trim()
         nextIdx++
       }
 

--- a/packages/opencode/test/patch/patch.test.ts
+++ b/packages/opencode/test/patch/patch.test.ts
@@ -80,6 +80,37 @@ describe("Patch namespace", () => {
       }
     })
 
+    test("should parse paths containing colons (Windows drive letters)", () => {
+      const patchText = `*** Begin Patch
+*** Add File: C:\\Users\\user\\project\\new.txt
++content
+*** Delete File: D:\\repos\\project\\old.txt
+*** Update File: E:\\work\\src\\main.ts
+*** Move to: E:\\work\\src\\renamed.ts
+@@
+-old
++new
+*** End Patch`
+
+      const result = Patch.parsePatch(patchText)
+      expect(result.hunks).toHaveLength(3)
+
+      const add = result.hunks[0]
+      expect(add.type).toBe("add")
+      expect(add.path).toBe("C:\\Users\\user\\project\\new.txt")
+
+      const del = result.hunks[1]
+      expect(del.type).toBe("delete")
+      expect(del.path).toBe("D:\\repos\\project\\old.txt")
+
+      const update = result.hunks[2]
+      expect(update.type).toBe("update")
+      expect(update.path).toBe("E:\\work\\src\\main.ts")
+      if (update.type === "update") {
+        expect(update.move_path).toBe("E:\\work\\src\\renamed.ts")
+      }
+    })
+
     test("should throw error for invalid patch format", () => {
       const invalidPatch = `This is not a valid patch`
 


### PR DESCRIPTION
## Summary

- `parsePatchHeader` used `line.split(':', 2)` to extract file paths from headers like `*** Update File: D:\path\file.ts`. On Windows, the colon in the drive letter (e.g. `D:`) caused `split` to truncate the path to just the drive letter, producing invalid resolved paths like `<project_dir>\D`.
- Replaced `split(':')` with `slice()` after the known prefix length so the full path including drive letter is preserved.
- Added regression test covering all 4 header types (`Add File`, `Delete File`, `Update File`, `Move to`) with Windows drive-letter paths.

## Reproduction

When a model generates a patch with an absolute Windows path:
```
*** Update File: D:\repos\project\src\file.ts
```
The parser splits on `:` and gets `["*** Update File", " D"]`, truncating the path to `D`. This is then resolved as `path.resolve(projectDir, "D")` producing e.g. `D:\repos\project\D`, which fails with:
```
Error: apply_patch verification failed: Failed to read file to update: D:\repos\project\D
```

Fixes #10360. Related to #11687.

> **Note:** Similar fix to #10808 — arrived at independently. This PR uses a simpler inline approach while #10808 extracts a helper function. Either approach resolves the issue.