### PR TITLE
feat: add chat_template_kwargs for nvidia nim provider

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -663,6 +663,7 @@ export namespace ProviderTransform {
     providerOptions?: Record<string, any>
   }): Record<string, any> {
     const result: Record<string, any> = {}
+    const modelId = input.model.api.id.toLowerCase()
 
     // openai and providers using openai package should set store to false by default.
     if (
@@ -696,6 +697,17 @@ export namespace ProviderTransform {
       }
     }
 
+    if (
+      input.model.providerID === "nvidia" &&
+      input.model.api.npm === "@ai-sdk/openai-compatible" &&
+      modelId.startsWith("z-ai/glm")
+    ) {
+      result["chat_template_kwargs"] = {
+        enable_thinking: true,
+        clear_thinking: false,
+      }
+    }
+
     if (input.model.providerID === "openai" || input.providerOptions?.setCacheKey) {
       result["promptCacheKey"] = input.sessionID
     }
@@ -710,7 +722,6 @@ export namespace ProviderTransform {
     }
 
     // Enable thinking by default for kimi-k2.5/k2p5 models using anthropic SDK
-    const modelId = input.model.api.id.toLowerCase()
     if (
       (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
       (modelId.includes("k2p5") || modelId.includes("kimi-k2.5") || modelId.includes("kimi-k2p5"))

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { Provider } from "../../src/provider/provider"
 import { ProviderTransform } from "../../src/provider/transform"
 
 const OUTPUT_TOKEN_MAX = 32000
@@ -370,6 +371,54 @@ describe("ProviderTransform.providerOptions", () => {
     expect(ProviderTransform.providerOptions(model, { reasoningFormat: "parsed" })).toEqual({
       groq: { reasoningFormat: "parsed" },
     })
+  })
+})
+
+describe("ProviderTransform.options - nvidia glm thinking", () => {
+  const sessionID = "test-session-123"
+
+  const createModel = (apiID: string) =>
+    ({
+      id: `nvidia/${apiID}`,
+      providerID: "nvidia",
+      api: {
+        id: apiID,
+        url: "https://integrate.api.nvidia.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: apiID,
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 204800, output: 131072 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2025-01-01",
+    }) satisfies Provider.Model
+
+  test("adds chat_template_kwargs for z-ai/glm models", () => {
+    const model = createModel("z-ai/glm5")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+
+    expect(result.chat_template_kwargs).toEqual({
+      enable_thinking: true,
+      clear_thinking: false,
+    })
+  })
+
+  test("does not add chat_template_kwargs for non glm models", () => {
+    const model = createModel("nvidia/nemotron-3-nano-30b-a3b")
+    const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })
+
+    expect(result.chat_template_kwargs).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -323,6 +323,94 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("sends chat_template_kwargs for nvidia glm models", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const providerID = "nvidia"
+    const modelID = "z-ai/glm4.7"
+    const source = await loadFixture(providerID, modelID)
+    const model = source.model
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: [providerID],
+            provider: {
+              [providerID]: {
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(providerID, model.id)
+        const sessionID = "session-test-nvidia-glm"
+        const agent = {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 0.4,
+        } satisfies Agent.Info
+
+        const user = {
+          id: "user-nvidia-glm",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID, modelID: resolved.id },
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+
+        expect(capture.url.pathname.endsWith("/chat/completions")).toBe(true)
+        expect(body.model).toBe(resolved.api.id)
+        expect(body.chat_template_kwargs).toEqual({
+          enable_thinking: true,
+          clear_thinking: false,
+        })
+      },
+    })
+  })
+
   test("sends responses API payload for OpenAI models", async () => {
     const server = state.server
     if (!server) {


### PR DESCRIPTION
From the official documentation for nvidia nim it is possible to set `"enable_thinking":true,"clear_thinking":false ` inside the request, this PR adds support of that
Resolves https://github.com/anomalyco/opencode/issues/13584.

https://build.nvidia.com/z-ai/glm5/modelcard

Example of code:

```
import OpenAI from 'openai';

const openai = new OpenAI({
  apiKey: '$NVIDIA_API_KEY',
  baseURL: 'https://integrate.api.nvidia.com/v1',
})
 
async function main() {
  const completion = await openai.chat.completions.create({
    model: "z-ai/glm5",
    messages: [{"role":"user","content":""}],
    temperature: 1,
    top_p: 1,
    max_tokens: 16384,
    chat_template_kwargs: {"enable_thinking":true,"clear_thinking":false},
    stream: true
  })
   
  for await (const chunk of completion) {
        const reasoning = chunk.choices[0]?.delta?.reasoning_content;
    if (reasoning) process.stdout.write(reasoning);
        process.stdout.write(chunk.choices[0]?.delta?.content || '')
    
  }
  
}

main();
