### PR TITLE
feat(acp): stream bash tool output during execution

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -188,6 +188,10 @@ export namespace ACP {
                             title: part.tool,
                             locations: toLocations(part.tool, part.state.input),
                             rawInput: part.state.input,
+                            // Stream partial output during execution (e.g., bash stdout)
+                            rawOutput: part.state.metadata?.output
+                              ? { output: part.state.metadata.output }
+                              : undefined,
                           },
                         })
                         .catch((err) => {
@@ -518,6 +522,10 @@ export namespace ACP {
                     title: part.tool,
                     locations: toLocations(part.tool, part.state.input),
                     rawInput: part.state.input,
+                    // Stream partial output during execution (e.g., bash stdout)
+                    rawOutput: part.state.metadata?.output
+                      ? { output: part.state.metadata.output }
+                      : undefined,
                   },
                 })
                 .catch((err) => {


### PR DESCRIPTION
## Summary

Streams partial bash output through ACP during tool execution, enabling real-time feedback in chat bridges and other ACP clients.

Fixes #5024

## Changes

In `packages/opencode/src/acp/agent.ts`, added `rawOutput` to the "running" status update:

```typescript
case "running":
  await this.connection.sessionUpdate({
    sessionId,
    update: {
      sessionUpdate: "tool_call_update",
      toolCallId: part.callID,
      status: "in_progress",
      kind: toToolKind(part.tool),
      title: part.state.title || part.tool,
      locations: toLocations(part.tool, part.state.input),
      rawInput: part.state.input,
      // NEW: Stream partial output during execution
      rawOutput: part.state.metadata?.output
        ? { output: part.state.metadata.output }
        : undefined,
    },
  })
```

## Background

The bash tool already updates `ctx.metadata()` with stdout on each chunk (line 179 in `bash.ts`), but this metadata was not being forwarded through ACP during the "running" state. Only "completed" and "error" states included `rawOutput`.

This small change (5 lines) enables ACP clients to receive incremental bash output as it happens, rather than waiting for command completion.

## Testing

 Tested with [opencode-chat-bridge](https://github.com/ominiverdi/opencode-chat-bridge), an ACP client that bridges OpenCode to Matrix chat rooms.
 
 Before this change, running:
```
echo "Starting..."; sleep 2; echo "Still working..."; sleep 2; echo "Done!"
```
Would only show output after 4 seconds. After this change, each line appears as it's produced.

<img width="563" height="337" alt="image" src="https://github.com/user-attachments/assets/1fb91ac3-95a3-4571-9d18-b522a3428b56" />

