### PR TITLE
feat: replace Google Java Formatter with Spotless formatters

### DIFF
--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -372,11 +372,7 @@ export const googleJavaFormat: Info = {
   async enabled() {
     if (Bun.which("google-java-format")) return true
 
-    const jarNames = ["google-java-format-all-deps.jar", "google-java-format.jar"]
-    for (const jar of jarNames) {
-      const found = await Filesystem.findUp(jar, Instance.directory, Instance.worktree)
-      if (found.length > 0) return true
-    }
-    return false
+    const found = await Filesystem.findUp("google-java-format-all-deps.jar", Instance.directory, Instance.worktree)
+    return found.length > 0
   },
 }

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -364,3 +364,19 @@ export const ormolu: Info = {
     return Bun.which("ormolu") !== null
   },
 }
+
+export const googleJavaFormat: Info = {
+  name: "google-java-format",
+  command: ["google-java-format", "$FILE"],
+  extensions: [".java"],
+  async enabled() {
+    if (Bun.which("google-java-format")) return true
+
+    const jarNames = ["google-java-format.jar", "google-java-format-all-deps.jar"]
+    for (const jar of jarNames) {
+      const found = await Filesystem.findUp(jar, Instance.directory, Instance.worktree)
+      if (found.length > 0) return true
+    }
+    return false
+  },
+}

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -365,36 +365,57 @@ export const ormolu: Info = {
   },
 }
 
-export const googleJavaFormat: Info = {
-  name: "google-java-format",
-  command: ["java", "-jar", "google-java-format-all-deps.jar", "$FILE"],
+export const spotlessMaven: Info = {
+  name: "spotless-maven",
+  command: ["mvn", "spotless:apply", "-DspotlessFiles=$FILE"],
   extensions: [".java"],
   async enabled() {
-    if (Bun.which("google-java-format")) return true
-
-    const jarFound = await Filesystem.findUp("google-java-format-all-deps.jar", Instance.directory, Instance.worktree)
-    if (jarFound.length > 0) return true
-
     const pomFiles = await Filesystem.findUp("pom.xml", Instance.directory, Instance.worktree)
     for (const pom of pomFiles) {
       const content = await Bun.file(pom).text()
-      if (content.includes("spotless") && content.includes("google-java-format")) {
+      if (/\<artifactId\>spotless-maven-plugin\<\/artifactId\>/i.test(content)) {
+        const mvnw = await Filesystem.findUp("mvnw", Instance.directory, Instance.worktree)
+        if (mvnw.length > 0) {
+          this.command = ["./mvnw", "spotless:apply", "-DspotlessFiles=$FILE"]
+          return true
+        }
+
+        const mvnwCmd = await Filesystem.findUp("mvnw.cmd", Instance.directory, Instance.worktree)
+        if (mvnwCmd.length > 0) {
+          this.command = ["./mvnw.cmd", "spotless:apply", "-DspotlessFiles=$FILE"]
+          return true
+        }
+
+        this.command = ["mvn", "spotless:apply", "-DspotlessFiles=$FILE"]
         return true
       }
     }
+    return false
+  },
+}
 
+export const spotlessGradle: Info = {
+  name: "spotless-gradle",
+  command: ["gradle", "spotlessApply", "-PspotlessIdeHook=$FILE"],
+  extensions: [".java"],
+  async enabled() {
     const gradleFiles = await Filesystem.findUp("build.gradle", Instance.directory, Instance.worktree)
     for (const gradle of gradleFiles) {
       const content = await Bun.file(gradle).text()
-      if (content.includes("spotless") && content.includes("google-java-format")) {
-        return true
-      }
-    }
+      if (/['"]com\.diffplug\.spotless['"]/.test(content)) {
+        const gradlewUnix = await Filesystem.findUp("gradlew", Instance.directory, Instance.worktree)
+        if (gradlewUnix.length > 0) {
+          this.command = ["./gradlew", "spotlessApply", "-PspotlessIdeHook=$FILE"]
+          return true
+        }
 
-    const gradleKtsFiles = await Filesystem.findUp("build.gradle.kts", Instance.directory, Instance.worktree)
-    for (const gradle of gradleKtsFiles) {
-      const content = await Bun.file(gradle).text()
-      if (content.includes("spotless") && content.includes("google-java-format")) {
+        const gradlewWin = await Filesystem.findUp("gradlew.bat", Instance.directory, Instance.worktree)
+        if (gradlewWin.length > 0) {
+          this.command = ["./gradlew.bat", "spotlessApply", "-PspotlessIdeHook=$FILE"]
+          return true
+        }
+
+        this.command = ["gradle", "spotlessApply", "-PspotlessIdeHook=$FILE"]
         return true
       }
     }

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -372,7 +372,33 @@ export const googleJavaFormat: Info = {
   async enabled() {
     if (Bun.which("google-java-format")) return true
 
-    const found = await Filesystem.findUp("google-java-format-all-deps.jar", Instance.directory, Instance.worktree)
-    return found.length > 0
+    const jarFound = await Filesystem.findUp("google-java-format-all-deps.jar", Instance.directory, Instance.worktree)
+    if (jarFound.length > 0) return true
+
+    const pomFiles = await Filesystem.findUp("pom.xml", Instance.directory, Instance.worktree)
+    for (const pom of pomFiles) {
+      const content = await Bun.file(pom).text()
+      if (content.includes("spotless") && content.includes("google-java-format")) {
+        return true
+      }
+    }
+
+    const gradleFiles = await Filesystem.findUp("build.gradle", Instance.directory, Instance.worktree)
+    for (const gradle of gradleFiles) {
+      const content = await Bun.file(gradle).text()
+      if (content.includes("spotless") && content.includes("google-java-format")) {
+        return true
+      }
+    }
+
+    const gradleKtsFiles = await Filesystem.findUp("build.gradle.kts", Instance.directory, Instance.worktree)
+    for (const gradle of gradleKtsFiles) {
+      const content = await Bun.file(gradle).text()
+      if (content.includes("spotless") && content.includes("google-java-format")) {
+        return true
+      }
+    }
+
+    return false
   },
 }

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -374,19 +374,6 @@ export const spotlessMaven: Info = {
     for (const pom of pomFiles) {
       const content = await Bun.file(pom).text()
       if (/\<artifactId\>spotless-maven-plugin\<\/artifactId\>/i.test(content)) {
-        const mvnw = await Filesystem.findUp("mvnw", Instance.directory, Instance.worktree)
-        if (mvnw.length > 0) {
-          this.command = ["./mvnw", "spotless:apply", "-DspotlessFiles=$FILE"]
-          return true
-        }
-
-        const mvnwCmd = await Filesystem.findUp("mvnw.cmd", Instance.directory, Instance.worktree)
-        if (mvnwCmd.length > 0) {
-          this.command = ["./mvnw.cmd", "spotless:apply", "-DspotlessFiles=$FILE"]
-          return true
-        }
-
-        this.command = ["mvn", "spotless:apply", "-DspotlessFiles=$FILE"]
         return true
       }
     }
@@ -403,23 +390,9 @@ export const spotlessGradle: Info = {
     for (const gradle of gradleFiles) {
       const content = await Bun.file(gradle).text()
       if (/['"]com\.diffplug\.spotless['"]/.test(content)) {
-        const gradlewUnix = await Filesystem.findUp("gradlew", Instance.directory, Instance.worktree)
-        if (gradlewUnix.length > 0) {
-          this.command = ["./gradlew", "spotlessApply", "-PspotlessIdeHook=$FILE"]
-          return true
-        }
-
-        const gradlewWin = await Filesystem.findUp("gradlew.bat", Instance.directory, Instance.worktree)
-        if (gradlewWin.length > 0) {
-          this.command = ["./gradlew.bat", "spotlessApply", "-PspotlessIdeHook=$FILE"]
-          return true
-        }
-
-        this.command = ["gradle", "spotlessApply", "-PspotlessIdeHook=$FILE"]
         return true
       }
     }
-
     return false
   },
 }

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -367,12 +367,12 @@ export const ormolu: Info = {
 
 export const googleJavaFormat: Info = {
   name: "google-java-format",
-  command: ["google-java-format", "$FILE"],
+  command: ["java", "-jar", "google-java-format-all-deps.jar", "$FILE"],
   extensions: [".java"],
   async enabled() {
     if (Bun.which("google-java-format")) return true
 
-    const jarNames = ["google-java-format.jar", "google-java-format-all-deps.jar"]
+    const jarNames = ["google-java-format-all-deps.jar", "google-java-format.jar"]
     for (const jar of jarNames) {
       const found = await Filesystem.findUp(jar, Instance.directory, Instance.worktree)
       if (found.length > 0) return true

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -20,6 +20,7 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | zig                  | .zig, .zon                                                                                               | `zig` command available                                                                               |
 | clang-format         | .c, .cpp, .h, .hpp, .ino, and [more](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config file                                                                           |
 | ktlint               | .kt, .kts                                                                                                | `ktlint` command available                                                                            |
+| google-java-format   | .java                                                                                                    | `google-java-format` command available or `google-java-format-all-deps.jar` in project root           |
 | ruff                 | .py, .pyi                                                                                                | `ruff` command available with config                                                                  |
 | rustfmt              | .rs                                                                                                      | `rustfmt` command available                                                                           |
 | cargofmt             | .rs                                                                                                      | `cargo fmt` command available                                                                         |
@@ -39,6 +40,30 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | ormolu               | .hs                                                                                                      | `ormolu` command available                                                                            |
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
+
+### Google Java Format
+
+Google Java Format requires either:
+
+1. **`google-java-format` command in PATH** - Install via [releases](https://github.com/google/google-java-format/releases)
+2. **`google-java-format-all-deps.jar` in project root** - Download from [releases](https://github.com/google/google-java-format/releases)
+
+Example project structure:
+
+```
+my-java-project/
+├── src/
+│   └── Main.java
+└── google-java-format-all-deps.jar
+```
+
+When the JAR is in your project root, OpenCode will automatically run:
+
+```bash
+java -jar google-java-format-all-deps.jar $FILE
+```
+
+If you prefer a different location, you can configure it:
 
 ---
 
@@ -128,3 +153,16 @@ You can override the built-in formatters or add new ones by specifying the comma
 ```
 
 The **`$FILE` placeholder** in the command will be replaced with the path to the file being formatted.
+
+For example, to use a custom JAR location:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "formatter": {
+    "google-java-format": {
+      "command": ["java", "-jar", "C:\\tools\\google-java-format-all-deps.jar", "$FILE"]
+    }
+  }
+}
+```

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -42,46 +42,6 @@ OpenCode comes with several built-in formatters for popular languages and framew
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 
-### Spotless (Java Formatter)
-
-Spotless is a code formatter for Java that supports multiple formatters (Google Java Format, Eclipse, Palantir, etc.). OpenCode detects Spotless configuration in your project and formats files automatically.
-
-**Maven Projects**: Requires `spotless-maven-plugin` in `pom.xml`
-
-```xml
-<plugin>
-  <groupId>com.diffplug.spotless</groupId>
-  <artifactId>spotless-maven-plugin</artifactId>
-  <configuration>
-    <java>
-      <googleJavaFormat/>  <!-- or <eclipse/>, <palantir/>, etc. -->
-    </java>
-  </configuration>
-</plugin>
-```
-
-**Gradle Projects**: Requires `com.diffplug.spotless` plugin in `build.gradle`
-
-```gradle
-plugins {
-  id 'com.diffplug.spotless' version '6.15.0'
-}
-
-spotless {
-  java {
-    googleJavaFormat()  // or eclipse(), palantir(), etc.
-  }
-}
-```
-
-When a Java file is saved, OpenCode will run:
-- **Maven**: `mvn spotless:apply -DspotlessFiles=$FILE` (or `./mvnw` if Maven wrapper exists)
-- **Gradle**: `./gradlew spotlessApply -PspotlessIdeHook=$FILE` (or `gradle` if no wrapper)
-
-This ensures only the saved file is formatted, not the entire project.
-
----
-
 ## How it works
 
 When OpenCode writes or edits a file, it:

--- a/packages/web/src/content/docs/formatters.mdx
+++ b/packages/web/src/content/docs/formatters.mdx
@@ -20,7 +20,8 @@ OpenCode comes with several built-in formatters for popular languages and framew
 | zig                  | .zig, .zon                                                                                               | `zig` command available                                                                               |
 | clang-format         | .c, .cpp, .h, .hpp, .ino, and [more](https://clang.llvm.org/docs/ClangFormat.html)                       | `.clang-format` config file                                                                           |
 | ktlint               | .kt, .kts                                                                                                | `ktlint` command available                                                                            |
-| google-java-format   | .java                                                                                                    | `google-java-format` command available or `google-java-format-all-deps.jar` in project root           |
+| spotless-maven       | .java                                                                                                    | `spotless-maven-plugin` in `pom.xml`                                                                  |
+| spotless-gradle      | .java                                                                                                    | `com.diffplug.spotless` plugin in `build.gradle`                                                      |
 | ruff                 | .py, .pyi                                                                                                | `ruff` command available with config                                                                  |
 | rustfmt              | .rs                                                                                                      | `rustfmt` command available                                                                           |
 | cargofmt             | .rs                                                                                                      | `cargo fmt` command available                                                                         |
@@ -41,29 +42,43 @@ OpenCode comes with several built-in formatters for popular languages and framew
 
 So if your project has `prettier` in your `package.json`, OpenCode will automatically use it.
 
-### Google Java Format
+### Spotless (Java Formatter)
 
-Google Java Format requires either:
+Spotless is a code formatter for Java that supports multiple formatters (Google Java Format, Eclipse, Palantir, etc.). OpenCode detects Spotless configuration in your project and formats files automatically.
 
-1. **`google-java-format` command in PATH** - Install via [releases](https://github.com/google/google-java-format/releases)
-2. **`google-java-format-all-deps.jar` in project root** - Download from [releases](https://github.com/google/google-java-format/releases)
+**Maven Projects**: Requires `spotless-maven-plugin` in `pom.xml`
 
-Example project structure:
-
-```
-my-java-project/
-├── src/
-│   └── Main.java
-└── google-java-format-all-deps.jar
-```
-
-When the JAR is in your project root, OpenCode will automatically run:
-
-```bash
-java -jar google-java-format-all-deps.jar $FILE
+```xml
+<plugin>
+  <groupId>com.diffplug.spotless</groupId>
+  <artifactId>spotless-maven-plugin</artifactId>
+  <configuration>
+    <java>
+      <googleJavaFormat/>  <!-- or <eclipse/>, <palantir/>, etc. -->
+    </java>
+  </configuration>
+</plugin>
 ```
 
-If you prefer a different location, you can configure it:
+**Gradle Projects**: Requires `com.diffplug.spotless` plugin in `build.gradle`
+
+```gradle
+plugins {
+  id 'com.diffplug.spotless' version '6.15.0'
+}
+
+spotless {
+  java {
+    googleJavaFormat()  // or eclipse(), palantir(), etc.
+  }
+}
+```
+
+When a Java file is saved, OpenCode will run:
+- **Maven**: `mvn spotless:apply -DspotlessFiles=$FILE` (or `./mvnw` if Maven wrapper exists)
+- **Gradle**: `./gradlew spotlessApply -PspotlessIdeHook=$FILE` (or `gradle` if no wrapper)
+
+This ensures only the saved file is formatted, not the entire project.
 
 ---
 
@@ -154,14 +169,17 @@ You can override the built-in formatters or add new ones by specifying the comma
 
 The **`$FILE` placeholder** in the command will be replaced with the path to the file being formatted.
 
-For example, to use a custom JAR location:
+For example, to disable Spotless formatters or customize the command:
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
   "formatter": {
-    "google-java-format": {
-      "command": ["java", "-jar", "C:\\tools\\google-java-format-all-deps.jar", "$FILE"]
+    "spotless-maven": {
+      "disabled": true
+    },
+    "spotless-gradle": {
+      "command": ["./gradlew", "spotlessApply", "-PspotlessIdeHook=$FILE"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaces the Google Java Formatter implementation with generic Spotless formatters that support multiple Java formatters (Google, Eclipse, Palantir, etc.).

## Changes

- **Removed**: `googleJavaFormat` formatter entirely (PATH/JAR detection was problematic)
- **Added**: `spotlessMaven` formatter - runs `mvn spotless:apply -DspotlessFiles=$FILE`
- **Added**: `spotlessGradle` formatter - runs `gradle spotlessApply -PspotlessIdeHook=$FILE`
- File-specific formatting: Only formats the saved file, not entire project
- Simple implementation matching other formatters in the codebase
- Users can override command in `opencode.json` if they prefer wrapper
- Updated documentation

## Why Spotless?

- **Generic**: Works with all Spotless-supported formatters (Google, Eclipse, IntelliJ, Palantir)
- **Project-aware**: Uses project's build tool configuration
- **Safer**: Only formats projects explicitly configured with Spotless
- **No PATH/JAR issues**: Detects plugin in build files instead

## Verification

- Tested pom.xml detection with `spotless-maven-plugin`
- Tested build.gradle detection with `com.diffplug.spotless`
- Documentation updated with examples

Resolves #13585