### PR TITLE
feat(acp): stream bash tool output during execution

### DIFF
--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -318,6 +318,10 @@ export namespace ACP {
                       title: part.tool,
                       locations: toLocations(part.tool, part.state.input),
                       rawInput: part.state.input,
+                      // Stream partial output during execution (e.g., bash stdout)
+                      rawOutput: part.state.metadata?.output
+                        ? { output: part.state.metadata.output }
+                        : undefined,
                     },
                   })
                   .catch((error) => {
@@ -831,6 +835,10 @@ export namespace ACP {
                     title: part.tool,
                     locations: toLocations(part.tool, part.state.input),
                     rawInput: part.state.input,
+                    // Stream partial output during execution (e.g., bash stdout)
+                    rawOutput: part.state.metadata?.output
+                      ? { output: part.state.metadata.output }
+                      : undefined,
                   },
                 })
                 .catch((err) => {


### PR DESCRIPTION
## Summary

Streams partial bash output through ACP during tool execution, enabling real-time feedback for ACP clients.

Fixes #5024

## Changes

In `packages/opencode/src/acp/agent.ts`, added `rawOutput` to the "running" status update (8 lines total, 4 per case):

```typescript
case "running":
  await this.connection.sessionUpdate({
    sessionId,
    update: {
      // ... existing fields ...
      rawInput: part.state.input,
      // NEW: Stream partial output during execution
      rawOutput: part.state.metadata?.output
        ? { output: part.state.metadata.output }
        : undefined,
    },
  })
```

## Background

The bash tool already updates `ctx.metadata()` with stdout on each chunk (line 179 in `bash.ts`), but this metadata was not being forwarded through ACP during the "running" state. Only "completed" and "error" states included `rawOutput`.

## Use Case

Any ACP client that wants to show users what is happening during long-running bash commands:
- Chat interfaces (Slack, Discord, Matrix bots)
- Web UIs with live terminal output
- IDE integrations showing command progress

Without this change, users see nothing until the command finishes. With this change, they see output line-by-line as it is produced.

## Testing

Tested with [opencode-chat-bridge](https://github.com/ominiverdi/opencode-chat-bridge), an ACP client that bridges OpenCode to Matrix chat rooms.

```
use bash to: echo "Starting..."; sleep 2; echo "Still working..."; sleep 2; echo "Done!"
```

Before: All output appears after 4 seconds.
After: Each line appears at 0s, 2s, and 4s respectively.


<img width="587" height="338" alt="image" src="https://github.com/user-attachments/assets/d4cba7ca-eb40-415d-9709-b98269d73c8f" />
