### PR TITLE
fix(tui): pass directory to tui() to fix session loading

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -161,6 +161,7 @@ export const TuiThreadCommand = cmd({
 
       const tuiPromise = tui({
         url,
+        directory: cwd,
         fetch: customFetch,
         events,
         args: {


### PR DESCRIPTION
Fixes #13600

Pass the `cwd` variable to `tui()` in `thread.ts` to fix session loading.

The issue occurred when running a locally built OpenCode from within the local repository clone.

**Verified by:** Running TUI and confirming sessions load correctly.