### PR TITLE
feat(tui): add toolOutputText theme color for bash output

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/theme.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/theme.tsx
@@ -52,6 +52,7 @@ type ThemeColors = {
   info: RGBA
   text: RGBA
   textMuted: RGBA
+  toolOutputText: RGBA
   selectedListItemText: RGBA
   background: RGBA
   backgroundPanel: RGBA
@@ -130,9 +131,10 @@ type ColorValue = HexColor | RefName | Variant | RGBA
 type ThemeJson = {
   $schema?: string
   defs?: Record<string, HexColor | RefName>
-  theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
+  theme: Omit<Record<keyof ThemeColors, ColorValue>, "selectedListItemText" | "backgroundMenu" | "toolOutputText"> & {
     selectedListItemText?: ColorValue
     backgroundMenu?: ColorValue
+    toolOutputText?: ColorValue
     thinkingOpacity?: number
   }
 }
@@ -198,7 +200,7 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
 
   const resolved = Object.fromEntries(
     Object.entries(theme.theme)
-      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
+      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "toolOutputText" && key !== "thinkingOpacity")
       .map(([key, value]) => {
         return [key, resolveColor(value as ColorValue)]
       }),
@@ -219,6 +221,13 @@ function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
     resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu)
   } else {
     resolved.backgroundMenu = resolved.backgroundElement
+  }
+
+  // Handle toolOutputText - optional with fallback to text
+  if (theme.theme.toolOutputText !== undefined) {
+    resolved.toolOutputText = resolveColor(theme.theme.toolOutputText)
+  } else {
+    resolved.toolOutputText = resolved.text
   }
 
   // Handle thinkingOpacity - optional with default of 0.6

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1688,7 +1688,7 @@ function Bash(props: ToolProps<typeof BashTool>) {
           <box gap={1}>
             <text fg={theme.text}>$ {props.input.command}</text>
             <Show when={output()}>
-              <text fg={theme.text}>{limited()}</text>
+              <text fg={theme.toolOutputText}>{limited()}</text>
             </Show>
             <Show when={overflow()}>
               <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>


### PR DESCRIPTION
Fixes #13601

Adds `toolOutputText` as an optional theme color for bash command output. Falls back to `text` if not specified.

**Motivation:** Having a separate color for tool output allows themes to highlight important content while making intermediate tool responses less visually prominent.

**Changes:**
- Add `toolOutputText` to ThemeColors type
- Handle it in resolveTheme() with fallback
- Use it in Bash component for output text

**Verified by:** Running TUI with custom theme that sets `toolOutputText` to a different color.