### PR TITLE
fix: skip JSON to SQLite migration on `opencode serve`

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -83,7 +83,8 @@ const cli = yargs(hideBin(process.argv))
     const cmd = opts._[0]
     // skip migration for commands that may be called programmatically
     // migration progress should only be shown to interactive users
-    if (cmd !== "serve" && cmd !== "upgrade" && !(await Bun.file(marker).exists())) {
+    const skip = cmd === "serve" || cmd === "upgrade" || cmd === "run"
+    if (!skip && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY
       const width = 36

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -83,8 +83,8 @@ const cli = yargs(hideBin(process.argv))
     const cmd = opts._[0]
     // skip migration for commands that may be called programmatically
     // migration progress should only be shown to interactive users
-    const skip = ["serve", "acp", "run", "mcp", "export", "import", "completion", "upgrade"].includes(cmd as string)
-    if (!skip && !(await Bun.file(marker).exists())) {
+    const skipMigration = ["serve", "acp", "run", "mcp", "export", "import", "completion", "upgrade"].includes(cmd as string)
+    if (!skipMigration && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY
       const width = 36

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -83,7 +83,15 @@ const cli = yargs(hideBin(process.argv))
     const cmd = opts._[0]
     // skip migration for commands that may be called programmatically
     // migration progress should only be shown to interactive users
-    const skip = cmd === "serve" || cmd === "acp" || cmd === "run" || cmd === "upgrade"
+    const skip =
+      cmd === "serve" ||
+      cmd === "acp" ||
+      cmd === "run" ||
+      cmd === "mcp" ||
+      cmd === "export" ||
+      cmd === "import" ||
+      cmd === "completion" ||
+      cmd === "upgrade"
     if (!skip && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -80,11 +80,8 @@ const cli = yargs(hideBin(process.argv))
     })
 
     const marker = path.join(Global.Path.data, "migration.json")
-    const cmd = opts._[0]
-    // skip migration for commands that may be called programmatically
-    // migration progress should only be shown to interactive users
-    const skipMigration = ["serve", "acp", "run", "mcp", "export", "import", "completion", "upgrade"].includes(cmd as string)
-    if (!skipMigration && !(await Bun.file(marker).exists())) {
+    // only run migration in interactive terminals where user can see progress
+    if (process.stdout.isTTY && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY
       const width = 36

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -80,7 +80,7 @@ const cli = yargs(hideBin(process.argv))
     })
 
     const marker = path.join(Global.Path.data, "opencode.db")
-    if (!(await Bun.file(marker).exists())) {
+    if (opts._[0] !== "serve" && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY
       const width = 36

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -81,6 +81,8 @@ const cli = yargs(hideBin(process.argv))
 
     const marker = path.join(Global.Path.data, "opencode.db")
     const cmd = opts._[0]
+    // skip migration for commands that may be called programmatically
+    // migration progress should only be shown to interactive users
     if (cmd !== "serve" && cmd !== "upgrade" && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -79,7 +79,7 @@ const cli = yargs(hideBin(process.argv))
       args: process.argv.slice(2),
     })
 
-    const marker = path.join(Global.Path.data, "opencode.db")
+    const marker = path.join(Global.Path.data, "migration.json")
     const cmd = opts._[0]
     // skip migration for commands that may be called programmatically
     // migration progress should only be shown to interactive users
@@ -111,6 +111,7 @@ const cli = yargs(hideBin(process.argv))
             }
           },
         })
+        await Bun.write(marker, JSON.stringify({ migratedAt: new Date().toISOString() }))
       } finally {
         if (tty) process.stdout.write("\x1b[?25h")
         else {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -80,7 +80,8 @@ const cli = yargs(hideBin(process.argv))
     })
 
     const marker = path.join(Global.Path.data, "opencode.db")
-    if (opts._[0] !== "serve" && !(await Bun.file(marker).exists())) {
+    const cmd = opts._[0]
+    if (cmd !== "serve" && cmd !== "upgrade" && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY
       const width = 36

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -83,7 +83,7 @@ const cli = yargs(hideBin(process.argv))
     const cmd = opts._[0]
     // skip migration for commands that may be called programmatically
     // migration progress should only be shown to interactive users
-    const skip = cmd === "serve" || cmd === "upgrade" || cmd === "run"
+    const skip = cmd === "serve" || cmd === "acp" || cmd === "run" || cmd === "upgrade"
     if (!skip && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -83,15 +83,7 @@ const cli = yargs(hideBin(process.argv))
     const cmd = opts._[0]
     // skip migration for commands that may be called programmatically
     // migration progress should only be shown to interactive users
-    const skip =
-      cmd === "serve" ||
-      cmd === "acp" ||
-      cmd === "run" ||
-      cmd === "mcp" ||
-      cmd === "export" ||
-      cmd === "import" ||
-      cmd === "completion" ||
-      cmd === "upgrade"
+    const skip = ["serve", "acp", "run", "mcp", "export", "import", "completion", "upgrade"].includes(cmd as string)
     if (!skip && !(await Bun.file(marker).exists())) {
       console.log("Performing one time database migration, may take a few minutes...")
       const tty = process.stdout.isTTY


### PR DESCRIPTION
Closes #13611

**Problem:** The JSON to SQLite migration can take several minutes for large databases. Commands like `serve` are designed for programmatic usage where the caller expects opencode to start quickly.

**Fix:** Only run migration when `process.stdout.isTTY` is true - if there's no TTY, the user can't see the progress anyway.

**Marker change:** Uses a dedicated `migration.json` marker file instead of checking for `opencode.db` existence. This prevents the issue where a non-TTY invocation creates the db via `Database.Client()`, which would permanently block migration from running on future interactive commands.