### PR TITLE
feat(desktop): mark as read

### DIFF
--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -493,6 +493,7 @@ export const dict = {
   "common.rename": "إعادة تسمية",
   "common.reset": "إعادة تعيين",
   "common.archive": "أرشفة",
+  "common.markAsRead": "وضع علامة كمقروء",
   "common.delete": "حذف",
   "common.close": "إغلاق",
   "common.edit": "تحرير",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -499,6 +499,7 @@ export const dict = {
   "common.rename": "Renomear",
   "common.reset": "Redefinir",
   "common.archive": "Arquivar",
+  "common.markAsRead": "Marcar como lida",
   "common.delete": "Excluir",
   "common.close": "Fechar",
   "common.edit": "Editar",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -559,6 +559,7 @@ export const dict = {
   "common.rename": "Preimenuj",
   "common.reset": "Resetuj",
   "common.archive": "Arhiviraj",
+  "common.markAsRead": "Označi kao pročitano",
   "common.delete": "Izbriši",
   "common.close": "Zatvori",
   "common.edit": "Uredi",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -555,6 +555,7 @@ export const dict = {
   "common.rename": "Omdøb",
   "common.reset": "Nulstil",
   "common.archive": "Arkivér",
+  "common.markAsRead": "Markér som læst",
   "common.delete": "Slet",
   "common.close": "Luk",
   "common.edit": "Rediger",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -507,6 +507,7 @@ export const dict = {
   "common.rename": "Umbenennen",
   "common.reset": "Zurücksetzen",
   "common.archive": "Archivieren",
+  "common.markAsRead": "Als gelesen markieren",
   "common.delete": "Löschen",
   "common.close": "Schließen",
   "common.edit": "Bearbeiten",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -560,6 +560,7 @@ export const dict = {
   "common.rename": "Rename",
   "common.reset": "Reset",
   "common.archive": "Archive",
+  "common.markAsRead": "Mark as read",
   "common.delete": "Delete",
   "common.close": "Close",
   "common.edit": "Edit",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -562,6 +562,7 @@ export const dict = {
   "common.rename": "Renombrar",
   "common.reset": "Restablecer",
   "common.archive": "Archivar",
+  "common.markAsRead": "Marcar como leído",
   "common.delete": "Eliminar",
   "common.close": "Cerrar",
   "common.edit": "Editar",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -505,6 +505,7 @@ export const dict = {
   "common.rename": "Renommer",
   "common.reset": "Réinitialiser",
   "common.archive": "Archiver",
+  "common.markAsRead": "Marquer comme lu",
   "common.delete": "Supprimer",
   "common.close": "Fermer",
   "common.edit": "Modifier",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -497,6 +497,7 @@ export const dict = {
   "common.rename": "名前変更",
   "common.reset": "リセット",
   "common.archive": "アーカイブ",
+  "common.markAsRead": "既読にする",
   "common.delete": "削除",
   "common.close": "閉じる",
   "common.edit": "編集",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -498,6 +498,7 @@ export const dict = {
   "common.rename": "이름 바꾸기",
   "common.reset": "초기화",
   "common.archive": "보관",
+  "common.markAsRead": "읽음으로 표시",
   "common.delete": "삭제",
   "common.close": "닫기",
   "common.edit": "편집",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -562,6 +562,7 @@ export const dict = {
   "common.rename": "Gi nytt navn",
   "common.reset": "Tilbakestill",
   "common.archive": "Arkiver",
+  "common.markAsRead": "Marker som lest",
   "common.delete": "Slett",
   "common.close": "Lukk",
   "common.edit": "Rediger",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -498,6 +498,7 @@ export const dict = {
   "common.rename": "Zmień nazwę",
   "common.reset": "Resetuj",
   "common.archive": "Archiwizuj",
+  "common.markAsRead": "Oznacz jako przeczytane",
   "common.delete": "Usuń",
   "common.close": "Zamknij",
   "common.edit": "Edytuj",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -560,6 +560,7 @@ export const dict = {
   "common.rename": "Переименовать",
   "common.reset": "Сбросить",
   "common.archive": "Архивировать",
+  "common.markAsRead": "Отметить как прочитанное",
   "common.delete": "Удалить",
   "common.close": "Закрыть",
   "common.edit": "Редактировать",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -554,6 +554,7 @@ export const dict = {
   "common.rename": "เปลี่ยนชื่อ",
   "common.reset": "รีเซ็ต",
   "common.archive": "จัดเก็บ",
+  "common.markAsRead": "ทำเครื่องหมายว่าอ่านแล้ว",
   "common.delete": "ลบ",
   "common.close": "ปิด",
   "common.edit": "แก้ไข",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -552,6 +552,7 @@ export const dict = {
   "common.rename": "重命名",
   "common.reset": "重置",
   "common.archive": "归档",
+  "common.markAsRead": "标记为已读",
   "common.delete": "删除",
   "common.close": "关闭",
   "common.edit": "编辑",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -550,6 +550,7 @@ export const dict = {
   "common.rename": "重新命名",
   "common.reset": "重設",
   "common.archive": "封存",
+  "common.markAsRead": "標記為已讀",
   "common.delete": "刪除",
   "common.close": "關閉",
   "common.edit": "編輯",

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -10,6 +10,7 @@ import { createSortable } from "@thisbeyond/solid-dnd"
 import { type LocalProject } from "@/context/layout"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
+import { useNotification } from "@/context/notification"
 import { ProjectIcon, SessionItem, type SessionItemProps } from "./sidebar-items"
 import { childMapByParent, displayName, sortedRootSessions } from "./helpers"
 import { projectSelected, projectTileActive } from "./sidebar-project-helpers"
@@ -59,6 +60,8 @@ const ProjectTile = (props: {
   selected: Accessor<boolean>
   active: Accessor<boolean>
   overlay: Accessor<boolean>
+  markAsReadDisabled: Accessor<boolean>
+  markAsRead: () => void
   onProjectMouseEnter: (worktree: string, event: MouseEvent) => void
   onProjectMouseLeave: (worktree: string) => void
   onProjectFocus: (worktree: string) => void
@@ -112,6 +115,14 @@ const ProjectTile = (props: {
       <ContextMenu.Content>
         <ContextMenu.Item onSelect={() => props.showEditProjectDialog(props.project)}>
           <ContextMenu.ItemLabel>{props.language.t("common.edit")}</ContextMenu.ItemLabel>
+        </ContextMenu.Item>
+        <ContextMenu.Item
+          data-action="project-mark-read"
+          data-project={base64Encode(props.project.worktree)}
+          disabled={props.markAsReadDisabled()}
+          onSelect={props.markAsRead}
+        >
+          <ContextMenu.ItemLabel>{props.language.t("common.markAsRead")}</ContextMenu.ItemLabel>
         </ContextMenu.Item>
         <ContextMenu.Item
           data-action="project-workspaces-toggle"
@@ -248,6 +259,7 @@ export const SortableProject = (props: {
 }): JSX.Element => {
   const globalSync = useGlobalSync()
   const language = useLanguage()
+  const notification = useNotification()
   const sortable = createSortable(props.project.worktree)
   const selected = createMemo(() =>
     projectSelected(props.ctx.currentDir(), props.project.worktree, props.project.sandboxes),
@@ -304,6 +316,14 @@ export const SortableProject = (props: {
       selected={selected}
       active={active}
       overlay={overlay}
+      markAsReadDisabled={() => {
+        const dirs = [props.project.worktree, ...(props.project.sandboxes ?? [])]
+        return dirs.reduce((total, directory) => total + notification.project.unseenCount(directory), 0) === 0
+      }}
+      markAsRead={() => {
+        const dirs = [props.project.worktree, ...(props.project.sandboxes ?? [])]
+        dirs.forEach((directory) => notification.project.markViewed(directory))
+      }}
       onProjectMouseEnter={props.ctx.onProjectMouseEnter}
       onProjectMouseLeave={props.ctx.onProjectMouseLeave}
       onProjectFocus={props.ctx.onProjectFocus}


### PR DESCRIPTION
### What does this PR do?

I do not know the cause but sometimes the localStorage cache seem to show unseen session which no matter what will mark the project as unread. Even though there are no sessions unread.

This adds a "Mark as read" that clears the notifications

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

1. Run a session
2. Change to other session before the first oen finishes
3. When session ends you can press "Mark as read" on the project tile


<img width="375" height="232" alt="image" src="https://github.com/user-attachments/assets/44a44d88-c758-457d-b3d4-305b44a95ec0" />

