### PR TITLE
feat(tui): consolidate status indicators to increase scroll space and add status indicator style setting

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -8,6 +8,7 @@ import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGua
 import { Installation } from "@/installation"
 import { Flag } from "@/flag/flag"
 import { DialogProvider, useDialog } from "@tui/ui/dialog"
+import { DialogSelect } from "@tui/ui/dialog-select"
 import { DialogProvider as DialogProviderList } from "@tui/component/dialog-provider"
 import { SDKProvider, useSDK } from "@tui/context/sdk"
 import { SyncProvider, useSync } from "@tui/context/sync"
@@ -640,6 +641,44 @@ function App() {
       onSelect: (dialog) => {
         kv.set("animations_enabled", !kv.get("animations_enabled", true))
         dialog.clear()
+      },
+    },
+    {
+      title: "Status indicator style",
+      value: "app.indicator.style",
+      category: "System",
+      onSelect: (dialog) => {
+        const current = kv.get("indicator_style", "pulsatingCircle")
+        const options = [
+          {
+            value: "pulsatingCircle",
+            title: "●  Pulsating circle",
+            description: current === "pulsatingCircle" ? "current" : undefined,
+            onSelect: () => {
+              kv.set("indicator_style", "pulsatingCircle")
+              dialog.clear()
+            },
+          },
+          {
+            value: "blocks",
+            title: "■  Blocks scanner",
+            description: current === "blocks" ? "current" : undefined,
+            onSelect: () => {
+              kv.set("indicator_style", "blocks")
+              dialog.clear()
+            },
+          },
+          {
+            value: "diamonds",
+            title: "◆  Diamonds scanner",
+            description: current === "diamonds" ? "current" : undefined,
+            onSelect: () => {
+              kv.set("indicator_style", "diamonds")
+              dialog.clear()
+            },
+          },
+        ]
+        dialog.replace(() => <DialogSelect title="Status Indicator Style" options={options} />)
       },
     },
     {

--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -1,6 +1,5 @@
 import { BoxRenderable, TextareaRenderable, MouseEvent, PasteEvent, t, dim, fg } from "@opentui/core"
-import { createEffect, createMemo, type JSX, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
-import "opentui-spinner/solid"
+import { createEffect, createMemo, type JSX, on, Show, Switch, Match } from "solid-js"
 import { useLocal } from "@tui/context/local"
 import { useTheme } from "@tui/context/theme"
 import { EmptyBorder } from "@tui/component/border"
@@ -23,11 +22,8 @@ import type { FilePart } from "@opencode-ai/sdk/v2"
 import { TuiEvent } from "../../event"
 import { iife } from "@/util/iife"
 import { Locale } from "@/util/locale"
-import { formatDuration } from "@/util/format"
-import { createColors, createFrames } from "../../ui/spinner.ts"
 import { useDialog } from "@tui/ui/dialog"
 import { DialogProvider as DialogProviderConnect } from "../dialog-provider"
-import { DialogAlert } from "../../ui/dialog-alert"
 import { useToast } from "../../ui/toast"
 import { useKV } from "../../context/kv"
 import { useTextareaKeybindings } from "../textarea-keybindings"
@@ -756,26 +752,6 @@ export function Prompt(props: PromptProps) {
     return `Ask anything... "${PLACEHOLDERS[store.placeholder % PLACEHOLDERS.length]}"`
   })
 
-  const spinnerDef = createMemo(() => {
-    const color = local.agent.color(local.agent.current().name)
-    return {
-      frames: createFrames({
-        color,
-        style: "blocks",
-        inactiveFactor: 0.6,
-        // enableFading: false,
-        minAlpha: 0.3,
-      }),
-      color: createColors({
-        color,
-        style: "blocks",
-        inactiveFactor: 0.6,
-        // enableFading: false,
-        minAlpha: 0.3,
-      }),
-    }
-  })
-
   return (
     <>
       <Autocomplete
@@ -994,158 +970,50 @@ export function Prompt(props: PromptProps) {
               cursorColor={theme.text}
               syntaxStyle={syntax()}
             />
-            <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1}>
-              <text fg={highlight()}>
-                {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
-              </text>
-              <Show when={store.mode === "normal"}>
-                <box flexDirection="row" gap={1}>
-                  <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
-                    {local.model.parsed().model}
-                  </text>
-                  <text fg={theme.textMuted}>{local.model.parsed().provider}</text>
-                  <Show when={showVariant()}>
-                    <text fg={theme.textMuted}>·</text>
-                    <text>
-                      <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
+            <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between" flexWrap="wrap">
+              <box flexDirection="row" gap={1} flexShrink={0}>
+                <text fg={highlight()}>
+                  {store.mode === "shell" ? "Shell" : Locale.titlecase(local.agent.current().name)}{" "}
+                </text>
+                <Show when={store.mode === "normal"}>
+                  <box flexDirection="row" gap={1}>
+                    <text flexShrink={0} fg={keybind.leader ? theme.textMuted : theme.text}>
+                      {local.model.parsed().model}
                     </text>
-                  </Show>
-                </box>
-              </Show>
+                    <text flexShrink={0} fg={theme.textMuted}>{local.model.parsed().provider}</text>
+                    <Show when={showVariant()}>
+                      <text flexShrink={0} fg={theme.textMuted}>·</text>
+                      <text flexShrink={0}>
+                        <span style={{ fg: theme.warning, bold: true }}>{local.model.variant.current()}</span>
+                      </text>
+                    </Show>
+                  </box>
+                </Show>
+              </box>
+              <box flexDirection="row" gap={2} flexWrap="wrap">
+                <Switch>
+                  <Match when={store.mode === "normal"}>
+                    <Show when={local.model.variant.list().length > 0}>
+                      <text flexShrink={0} fg={theme.text}>
+                        {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>variants</span>
+                      </text>
+                    </Show>
+                    <text flexShrink={0} fg={theme.text}>
+                      {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>agents</span>
+                    </text>
+                    <text flexShrink={0} fg={theme.text}>
+                      {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
+                    </text>
+                  </Match>
+                  <Match when={store.mode === "shell"}>
+                    <text flexShrink={0} fg={theme.text}>
+                      esc <span style={{ fg: theme.textMuted }}>exit shell mode</span>
+                    </text>
+                  </Match>
+                </Switch>
+              </box>
             </box>
           </box>
-        </box>
-        <box
-          height={1}
-          border={["left"]}
-          borderColor={highlight()}
-          customBorderChars={{
-            ...EmptyBorder,
-            vertical: theme.backgroundElement.a !== 0 ? "╹" : " ",
-          }}
-        >
-          <box
-            height={1}
-            border={["bottom"]}
-            borderColor={theme.backgroundElement}
-            customBorderChars={
-              theme.backgroundElement.a !== 0
-                ? {
-                    ...EmptyBorder,
-                    horizontal: "▀",
-                  }
-                : {
-                    ...EmptyBorder,
-                    horizontal: " ",
-                  }
-            }
-          />
-        </box>
-        <box flexDirection="row" justifyContent="space-between">
-          <Show when={status().type !== "idle"} fallback={<text />}>
-            <box
-              flexDirection="row"
-              gap={1}
-              flexGrow={1}
-              justifyContent={status().type === "retry" ? "space-between" : "flex-start"}
-            >
-              <box flexShrink={0} flexDirection="row" gap={1}>
-                <box marginLeft={1}>
-                  <Show when={kv.get("animations_enabled", true)} fallback={<text fg={theme.textMuted}>[⋯]</text>}>
-                    <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
-                  </Show>
-                </box>
-                <box flexDirection="row" gap={1} flexShrink={0}>
-                  {(() => {
-                    const retry = createMemo(() => {
-                      const s = status()
-                      if (s.type !== "retry") return
-                      return s
-                    })
-                    const message = createMemo(() => {
-                      const r = retry()
-                      if (!r) return
-                      if (r.message.includes("exceeded your current quota") && r.message.includes("gemini"))
-                        return "gemini is way too hot right now"
-                      if (r.message.length > 80) return r.message.slice(0, 80) + "..."
-                      return r.message
-                    })
-                    const isTruncated = createMemo(() => {
-                      const r = retry()
-                      if (!r) return false
-                      return r.message.length > 120
-                    })
-                    const [seconds, setSeconds] = createSignal(0)
-                    onMount(() => {
-                      const timer = setInterval(() => {
-                        const next = retry()?.next
-                        if (next) setSeconds(Math.round((next - Date.now()) / 1000))
-                      }, 1000)
-
-                      onCleanup(() => {
-                        clearInterval(timer)
-                      })
-                    })
-                    const handleMessageClick = () => {
-                      const r = retry()
-                      if (!r) return
-                      if (isTruncated()) {
-                        DialogAlert.show(dialog, "Retry Error", r.message)
-                      }
-                    }
-
-                    const retryText = () => {
-                      const r = retry()
-                      if (!r) return ""
-                      const baseMessage = message()
-                      const truncatedHint = isTruncated() ? " (click to expand)" : ""
-                      const duration = formatDuration(seconds())
-                      const retryInfo = ` [retrying ${duration ? `in ${duration} ` : ""}attempt #${r.attempt}]`
-                      return baseMessage + truncatedHint + retryInfo
-                    }
-
-                    return (
-                      <Show when={retry()}>
-                        <box onMouseUp={handleMessageClick}>
-                          <text fg={theme.error}>{retryText()}</text>
-                        </box>
-                      </Show>
-                    )
-                  })()}
-                </box>
-              </box>
-              <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
-                esc{" "}
-                <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
-                  {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                </span>
-              </text>
-            </box>
-          </Show>
-          <Show when={status().type !== "retry"}>
-            <box gap={2} flexDirection="row">
-              <Switch>
-                <Match when={store.mode === "normal"}>
-                  <Show when={local.model.variant.list().length > 0}>
-                    <text fg={theme.text}>
-                      {keybind.print("variant_cycle")} <span style={{ fg: theme.textMuted }}>variants</span>
-                    </text>
-                  </Show>
-                  <text fg={theme.text}>
-                    {keybind.print("agent_cycle")} <span style={{ fg: theme.textMuted }}>agents</span>
-                  </text>
-                  <text fg={theme.text}>
-                    {keybind.print("command_list")} <span style={{ fg: theme.textMuted }}>commands</span>
-                  </text>
-                </Match>
-                <Match when={store.mode === "shell"}>
-                  <text fg={theme.text}>
-                    esc <span style={{ fg: theme.textMuted }}>exit shell mode</span>
-                  </text>
-                </Match>
-              </Switch>
-            </box>
-          </Show>
         </box>
       </box>
     </>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -7,6 +7,8 @@ import {
   For,
   Match,
   on,
+  onCleanup,
+  onMount,
   Show,
   Switch,
   useContext,
@@ -31,6 +33,7 @@ import { Prompt, type PromptRef } from "@tui/component/prompt"
 import type { AssistantMessage, Part, ToolPart, UserMessage, TextPart, ReasoningPart } from "@opencode-ai/sdk/v2"
 import { useLocal } from "@tui/context/local"
 import { Locale } from "@/util/locale"
+import { formatDuration } from "@/util/format"
 import type { Tool } from "@/tool/tool"
 import type { ReadTool } from "@/tool/read"
 import type { WriteTool } from "@/tool/write"
@@ -65,10 +68,13 @@ import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
 import parsers from "../../../../../../parsers-config.ts"
 import { Clipboard } from "../../util/clipboard"
 import { Toast, useToast } from "../../ui/toast"
+import { DialogAlert } from "../../ui/dialog-alert"
 import { useKV } from "../../context/kv.tsx"
 import { Editor } from "../../util/editor"
 import stripAnsi from "strip-ansi"
 import { Footer } from "./footer.tsx"
+import "opentui-spinner/solid"
+import { createColors, createFrames } from "../../ui/spinner"
 import { usePromptRef } from "../../context/prompt"
 import { useExit } from "../../context/exit"
 import { Filesystem } from "@/util/filesystem"
@@ -100,6 +106,12 @@ const context = createContext<{
   showDetails: () => boolean
   diffWrapMode: () => "word" | "none"
   sync: ReturnType<typeof useSync>
+  sessionStatus: () =>
+    | { type: "idle" }
+    | { type: "busy" }
+    | { type: "retry"; attempt: number; message: string; next: number }
+  statusIndicatorDef: () => { frames: string[]; color: any }
+  animationsEnabled: () => boolean
 }>()
 
 function use() {
@@ -139,6 +151,8 @@ export function Session() {
   const lastAssistant = createMemo(() => {
     return messages().findLast((x) => x.role === "assistant")
   })
+
+  const sessionStatus = createMemo(() => sync.data.session_status?.[route.sessionID] ?? { type: "idle" })
 
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
@@ -298,6 +312,43 @@ export function Session() {
   }
 
   const local = useLocal()
+
+  const statusIndicatorDef = createMemo(() => {
+    const color = local.agent.color(local.agent.current().name)
+    const style = kv.get("indicator_style", "pulsatingCircle") as "pulsatingCircle" | "blocks" | "diamonds"
+    if (style === "pulsatingCircle") {
+      return {
+        frames: createFrames({
+          color,
+          style: "pulsatingCircle",
+          pulseFrames: 24,
+          pulseMinAlpha: 0.25,
+          pulseMaxAlpha: 1.0,
+        }),
+        color: createColors({
+          color,
+          style: "pulsatingCircle",
+          pulseFrames: 24,
+          pulseMinAlpha: 0.25,
+          pulseMaxAlpha: 1.0,
+        }),
+      }
+    }
+    return {
+      frames: createFrames({
+        color,
+        style,
+        inactiveFactor: 0.6,
+        minAlpha: 0.3,
+      }),
+      color: createColors({
+        color,
+        style,
+        inactiveFactor: 0.6,
+        minAlpha: 0.3,
+      }),
+    }
+  })
 
   function moveChild(direction: number) {
     if (children().length === 1) return
@@ -968,6 +1019,9 @@ export function Session() {
         showDetails,
         diffWrapMode,
         sync,
+        sessionStatus,
+        statusIndicatorDef,
+        animationsEnabled,
       }}
     >
       <box flexDirection="row">
@@ -1253,10 +1307,16 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const local = useLocal()
   const { theme } = useTheme()
   const sync = useSync()
+  const ctx = use()
+  const dialog = useDialog()
   const messages = createMemo(() => sync.data.message[props.message.sessionID] ?? [])
 
   const final = createMemo(() => {
     return props.message.finish && !["tool-calls", "unknown"].includes(props.message.finish)
+  })
+
+  const inProgress = createMemo(() => {
+    return props.last && !final() && !props.message.error
   })
 
   const duration = createMemo(() => {
@@ -1300,25 +1360,98 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
       </Show>
       <Switch>
         <Match when={props.last || final() || props.message.error?.name === "MessageAbortedError"}>
-          <box paddingLeft={3}>
-            <text marginTop={1}>
-              <span
-                style={{
-                  fg:
-                    props.message.error?.name === "MessageAbortedError"
-                      ? theme.textMuted
-                      : local.agent.color(props.message.agent),
-                }}
-              >
-                ▣{" "}
-              </span>{" "}
-              <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
+          <box paddingLeft={3} flexDirection="row" gap={1} marginTop={1}>
+            <Show
+              when={inProgress()}
+              fallback={
+                <text>
+                  <span
+                    style={{
+                      fg:
+                        props.message.error?.name === "MessageAbortedError"
+                          ? theme.textMuted
+                          : local.agent.color(props.message.agent),
+                    }}
+                  >
+                    ▣
+                  </span>
+                </text>
+              }
+            >
+              <Show when={ctx.animationsEnabled()} fallback={<text fg={theme.textMuted}>[⋯]</text>}>
+                <spinner
+                  color={ctx.statusIndicatorDef().color}
+                  frames={ctx.statusIndicatorDef().frames}
+                  interval={40}
+                />
+              </Show>
+            </Show>
+            <text>
+              <span style={{ fg: theme.text }}> {Locale.titlecase(props.message.mode)}</span>
               <span style={{ fg: theme.textMuted }}> · {props.message.modelID}</span>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>
+              </Show>
+              <Show when={inProgress()}>
+                <Switch>
+                  <Match when={ctx.sessionStatus().type === "busy"}>
+                    <span style={{ fg: theme.textMuted }}> · </span>
+                    <span style={{ fg: theme.text }}>esc</span>
+                    <span style={{ fg: theme.textMuted }}> to interrupt</span>
+                  </Match>
+                  <Match when={ctx.sessionStatus().type === "retry"}>
+                    {(() => {
+                      const retry = () => {
+                        const s = ctx.sessionStatus()
+                        if (s.type !== "retry") return
+                        return s
+                      }
+                      const [seconds, setSeconds] = createSignal(0)
+                      onMount(() => {
+                        const timer = setInterval(() => {
+                          const next = retry()?.next
+                          if (next) setSeconds(Math.round((next - Date.now()) / 1000))
+                        }, 1000)
+                        onCleanup(() => clearInterval(timer))
+                      })
+                      const message = () => {
+                        const r = retry()
+                        if (!r) return ""
+                        if (r.message.includes("exceeded your current quota") && r.message.includes("gemini"))
+                          return "gemini is way too hot right now"
+                        if (r.message.length > 80) return r.message.slice(0, 80) + "..."
+                        return r.message
+                      }
+                      const isTruncated = () => {
+                        const r = retry()
+                        if (!r) return false
+                        return r.message.length > 120
+                      }
+                      const handleClick = () => {
+                        const r = retry()
+                        if (r && isTruncated()) {
+                          DialogAlert.show(dialog, "Retry Error", r.message)
+                        }
+                      }
+                      return (
+                        <>
+                          <span style={{ fg: theme.textMuted }}> · </span>
+                          <box onMouseUp={handleClick}>
+                            <text fg={theme.error}>
+                              {message()}
+                              {isTruncated() ? " (click to expand)" : ""} [retrying{" "}
+                              {formatDuration(seconds()) ? `in ${formatDuration(seconds())} ` : ""}attempt #
+                              {retry()?.attempt}]
+                            </text>
+                          </box>
+                        </>
+                      )
+                    })()}
+                  </Match>
+                </Switch>
               </Show>
             </text>
           </box>

--- a/packages/opencode/src/cli/cmd/tui/ui/spinner.ts
+++ b/packages/opencode/src/cli/cmd/tui/ui/spinner.ts
@@ -243,7 +243,7 @@ export function deriveInactiveColor(brightColor: ColorInput, factor: number = 0.
   return RGBA.fromValues(baseRgba.r, baseRgba.g, baseRgba.b, factor)
 }
 
-export type KnightRiderStyle = "blocks" | "diamonds"
+export type KnightRiderStyle = "blocks" | "diamonds" | "pulsatingCircle"
 
 export interface KnightRiderOptions {
   width?: number
@@ -262,6 +262,12 @@ export interface KnightRiderOptions {
   enableFading?: boolean
   /** Minimum alpha value when fading (default: 0, range: 0-1) */
   minAlpha?: number
+  /** Number of frames for pulse animation (default: 20) */
+  pulseFrames?: number
+  /** Minimum alpha for pulse animation (default: 0.2) */
+  pulseMinAlpha?: number
+  /** Maximum alpha for pulse animation (default: 1.0) */
+  pulseMaxAlpha?: number
 }
 
 /**
@@ -270,8 +276,15 @@ export interface KnightRiderOptions {
  * @returns Array of frame strings
  */
 export function createFrames(options: KnightRiderOptions = {}): string[] {
+  const style = options.style ?? "pulsatingCircle"
+
+  // PulseDot style: single character, opacity changes via color generator
+  if (style === "pulsatingCircle") {
+    const pulseFrames = options.pulseFrames ?? 20
+    return Array.from({ length: pulseFrames }, () => "●")
+  }
+
   const width = options.width ?? 8
-  const style = options.style ?? "diamonds"
   const holdStart = options.holdStart ?? 30
   const holdEnd = options.holdEnd ?? 9
 
@@ -334,6 +347,29 @@ export function createFrames(options: KnightRiderOptions = {}): string[] {
  * @returns ColorGenerator function
  */
 export function createColors(options: KnightRiderOptions = {}): ColorGenerator {
+  const style = options.style ?? "pulsatingCircle"
+
+  // PulseDot style: single character with pulsing opacity
+  if (style === "pulsatingCircle") {
+    const pulseFrames = options.pulseFrames ?? 20
+    const minAlpha = options.pulseMinAlpha ?? 0.2
+    const maxAlpha = options.pulseMaxAlpha ?? 1.0
+    const baseColor = options.color
+      ? options.color instanceof RGBA
+        ? options.color
+        : RGBA.fromHex(options.color as string)
+      : RGBA.fromHex("#ff0000")
+
+    return (frameIndex: number, _charIndex: number, totalFrames: number, _totalChars: number) => {
+      // Sine wave for smooth pulsing: 0 -> 1 -> 0
+      const progress = (frameIndex % totalFrames) / totalFrames
+      const sineValue = Math.sin(progress * Math.PI * 2)
+      // Map sine (-1 to 1) to alpha range (minAlpha to maxAlpha)
+      const alpha = minAlpha + ((sineValue + 1) / 2) * (maxAlpha - minAlpha)
+      return RGBA.fromValues(baseColor.r, baseColor.g, baseColor.b, alpha)
+    }
+  }
+
   const holdStart = options.holdStart ?? 30
   const holdEnd = options.holdEnd ?? 9
 


### PR DESCRIPTION
## Problem

Current TUI has several UX issues:

1. **Not too much vertical space for scroll** - status indicators and hints take extra lines
2. **Distracting status indicator** - the loading indicator is overly prominent and draws attention away from content
3. **Status indicator position** - status indicator is far from where the actual loading/thinking happens

## Changes

1. Move status indicator closer to dialog content - at the end of the last assistant message
2. Add a less intrusive status indicator style (pulsating circle)"
3. Inline status indicator with the status line - combine indicator with last request meta data element 
- When thinking is in progress: `●` (or 'scanner' spinner) replaces the square `▣` and user sees 
`● Mode · model · esc to interrupt`
- When complete (no changes): 
`▣ Mode · model · duration`
4. Move agent/variants/commands hints to the same line as current mode and model
5. Add switching of status indicator style into menu

## Result

- More organic and intuitive interface
- Less distracting and annoying
- Better use of vertical space (saves 1 line + offset, ~30-40 pixels of vertical space)

## Before
![Image](https://github.com/user-attachments/assets/575c5a51-db5c-4ab4-bead-208ac0369ba4)

## After  

![pulsating circle chat_fixed](https://github.com/user-attachments/assets/c1e1f232-441a-46fa-9400-28b69db6d2c0)

With current indicator style:

![block scanner chat_fixed](https://github.com/user-attachments/assets/966c861a-507a-40d3-a9c3-112d3b995f9f)

Switching indicator style in menu (diamonds scanner was found in exist code):

<img width="478" height="153" alt="menu" src="https://github.com/user-attachments/assets/0eaa0fa7-924b-496c-9ab5-89dea4b66091" />


Fixes #13622