### PR TITLE
fix: sanitize tool JSON schemas for Claude API compatibility

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -763,6 +763,21 @@ export namespace ProviderTransform {
   }
 
   export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {
+    // Strip $schema meta field from Zod 4 toJSONSchema() output.
+    // Claude API's input_schema rejects this field.
+    if ("$schema" in schema) {
+      const { $schema: _, ...rest } = schema as any
+      schema = rest as JSONSchema.BaseSchema
+    }
+
+    // Claude API (especially thinking models) requires the "required" field
+    // to be present when "properties" exists, even if it's an empty array.
+    // Without this, the API returns "JSON schema is invalid" errors.
+    const s = schema as any
+    if (s.type === "object" && s.properties && !s.required) {
+      s.required = []
+    }
+
     /*
     if (["openai", "azure"].includes(providerID)) {
       if (schema.type === "object" && schema.properties) {


### PR DESCRIPTION
## Summary

Fixes #13618

Claude API (especially thinking models like `claude-opus-4-6-thinking`) rejects tool schemas that have `properties` without a `required` field, returning:

```
***.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12
```

This affects users who use plugins like oh-my-opencode that generate tool schemas without explicit `required` arrays (e.g., the `session_list` tool).

## Changes

Added two sanitization steps at the top of `ProviderTransform.schema()` in `packages/opencode/src/provider/transform.ts`:

1. **Strip `$schema` meta field** — Zod 4's `toJSONSchema()` adds `"$schema": "https://json-schema.org/draft/2020-12/schema"` to every output. The codebase already handles this for `createStructuredOutputTool` but not in the general schema transform.

2. **Add `required: []` when missing** — When a schema has `properties` but no `required` field, automatically add an empty `required` array. This is the primary fix.

## Verification

Tested by intercepting OpenCode's API requests with a proxy, isolating all 33 tools, and testing each individually against Claude API:

| Test | Result |
|------|--------|
| `session_list` original schema (no `required`) | ❌ 400 error |
| `session_list` with `"required": []` added | ✅ 200 OK |
| All 33 tools together after fix | ✅ 200 OK |

Tested with both `claude-opus-4-6` and `claude-opus-4-6-thinking` models through new-api (OpenAI-compatible proxy).

## Related

- Similar issue in Claude Code: https://github.com/anthropics/claude-code/issues/586