### PR TITLE
docs: add Claxedo to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -65,6 +65,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Claxedo](https://github.com/kyashrathore/Claxedo)                                        | Multi-agent workspace — run any CLI coding agent in parallel with split panels, tabs, and streamlined code review |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [Claxedo](https://github.com/kyashrathore/Claxedo) to the ecosystem Projects table

Claxedo is a fork of the OpenCode app with some UX and workflow upgrades while staying aligned with upstream.


🤖 Generated with [Claude Code](https://claude.com/claude-code)