### PR TITLE
feat(app): sync server projects into web client list

### DIFF
--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -356,12 +356,18 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       }
     }
 
+    const normalizePath = (directory: string) => {
+      const normalized = directory.replaceAll("\\", "/").replace(/\/+$/, "")
+      if (/^[a-z]:\//i.test(normalized)) return normalized.toLowerCase()
+      return normalized
+    }
+
     const roots = createMemo(() => {
       const map = new Map<string, string>()
       for (const project of globalSync.data.project) {
         const sandboxes = project.sandboxes ?? []
         for (const sandbox of sandboxes) {
-          map.set(sandbox, project.worktree)
+          map.set(normalizePath(sandbox), normalizePath(project.worktree))
         }
       }
       return map
@@ -369,24 +375,25 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     const rootFor = (directory: string) => {
       const map = roots()
-      if (map.size === 0) return directory
+      const origin = normalizePath(directory)
+      if (map.size === 0) return origin
 
       const visited = new Set<string>()
-      const chain = [directory]
+      const chain = [origin]
 
       while (chain.length) {
         const current = chain[chain.length - 1]
-        if (!current) return directory
+        if (!current) return origin
 
         const next = map.get(current)
         if (!next) return current
 
-        if (visited.has(next)) return directory
+        if (visited.has(next)) return origin
         visited.add(next)
         chain.push(next)
       }
 
-      return directory
+      return origin
     }
 
     createEffect(() => {
@@ -394,30 +401,32 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         .filter((project) => project.id !== "global")
         .map((project) => project.worktree)
         .filter((worktree): worktree is string => !!worktree)
+      const raw = new Map(worktrees.map((worktree) => [normalizePath(worktree), worktree]))
       const known = new Set(worktrees.map(rootFor))
       if (known.size === 0) return
 
       const projects = untrack(() => server.projects.list())
-      const seen = new Set(projects.map((project) => project.worktree))
+      const seen = new Set(projects.map((project) => normalizePath(project.worktree)))
 
       batch(() => {
         for (const project of projects) {
+          const worktree = normalizePath(project.worktree)
           const root = rootFor(project.worktree)
-          if (root === project.worktree) continue
+          if (root === worktree) continue
 
           server.projects.close(project.worktree)
 
           if (!seen.has(root)) {
-            server.projects.open(root)
+            server.projects.open(raw.get(root) ?? root)
             seen.add(root)
           }
 
-          if (project.expanded) server.projects.expand(root)
+          if (project.expanded) server.projects.expand(raw.get(root) ?? root)
         }
 
         for (const worktree of known) {
           if (seen.has(worktree)) continue
-          server.projects.open(worktree)
+          server.projects.open(raw.get(worktree) ?? worktree)
           seen.add(worktree)
         }
       })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -8,6 +8,7 @@ import { usePlatform } from "./platform"
 import { Project } from "@opencode-ai/sdk/v2"
 import { Persist, persisted, removePersisted } from "@/utils/persist"
 import { same } from "@/utils/same"
+import { normalizeWorktreePath } from "@/utils/worktree-path"
 import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 
 const AVATAR_COLOR_KEYS = ["pink", "mint", "orange", "purple", "cyan", "lime"] as const
@@ -356,67 +357,65 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       }
     }
 
-    const normalizePath = (directory: string) => {
-      const normalized = directory.replaceAll("\\", "/").replace(/\/+$/, "")
-      if (/^[a-z]:\//i.test(normalized)) return normalized.toLowerCase()
-      return normalized
-    }
-
     const roots = createMemo(() => {
       const map = new Map<string, string>()
       for (const project of globalSync.data.project) {
         const sandboxes = project.sandboxes ?? []
         for (const sandbox of sandboxes) {
-          map.set(normalizePath(sandbox), normalizePath(project.worktree))
+          map.set(normalizeWorktreePath(sandbox), normalizeWorktreePath(project.worktree))
         }
       }
       return map
     })
 
     const [sync, setSync] = createStore({
-      hydrated: false,
+      hydrated: {} as Record<string, boolean>,
     })
 
-    const rootFor = (directory: string) => {
+    const syncKey = createMemo(() => server.url)
+
+    const rootFor = (_directory: string) => {
       const map = roots()
-      const origin = normalizePath(directory)
-      if (map.size === 0) return origin
+      const directory = normalizeWorktreePath(_directory)
+      if (map.size === 0) return directory
 
       const visited = new Set<string>()
-      const chain = [origin]
+      const chain = [directory]
 
       while (chain.length) {
         const current = chain[chain.length - 1]
-        if (!current) return origin
+        if (!current) return directory
 
         const next = map.get(current)
         if (!next) return current
 
-        if (visited.has(next)) return origin
+        if (visited.has(next)) return directory
         visited.add(next)
         chain.push(next)
       }
 
-      return origin
+      return directory
     }
 
     createEffect(() => {
-      if (sync.hydrated) return
+      const key = syncKey()
+      if (!key) return
+      if (sync.hydrated[key]) return
 
       const worktrees = globalSync.data.project
         .filter((project) => project.id !== "global")
         .map((project) => project.worktree)
         .filter((worktree): worktree is string => !!worktree)
-      const raw = new Map(worktrees.map((worktree) => [normalizePath(worktree), worktree]))
+      const raw = new Map(worktrees.map((worktree) => [normalizeWorktreePath(worktree), worktree]))
       const known = new Set(worktrees.map(rootFor))
       if (known.size === 0) return
 
       const projects = untrack(() => server.projects.list())
-      const seen = new Set(projects.map((project) => normalizePath(project.worktree)))
+      const seen = new Set(projects.map((project) => normalizeWorktreePath(project.worktree)))
 
       batch(() => {
         for (const project of projects) {
-          const worktree = normalizePath(project.worktree)
+          const worktree = normalizeWorktreePath(project.worktree)
           const root = rootFor(project.worktree)
           if (root === worktree) continue
 
@@ -436,7 +435,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           seen.add(worktree)
         }
 
-        setSync("hydrated", true)
+        setSync("hydrated", key, true)
       })
     })
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -373,6 +373,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return map
     })
 
+    const [sync, setSync] = createStore({
+      hydrated: false,
+    })
+
     const rootFor = (directory: string) => {
       const map = roots()
       const origin = normalizePath(directory)
@@ -397,6 +401,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     }
 
     createEffect(() => {
+      if (sync.hydrated) return
+
       const worktrees = globalSync.data.project
         .filter((project) => project.id !== "global")
         .map((project) => project.worktree)
@@ -429,6 +435,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           server.projects.open(raw.get(worktree) ?? worktree)
           seen.add(worktree)
         }
+
+        setSync("hydrated", true)
       })
     })
 

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -421,6 +421,8 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
           server.projects.close(project.worktree)
 
+          if (server.projects.hidden(raw.get(root) ?? root)) continue
+
           if (!seen.has(root)) {
             server.projects.open(raw.get(root) ?? root)
             seen.add(root)
@@ -431,6 +433,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
         for (const worktree of known) {
           if (seen.has(worktree)) continue
+          if (server.projects.hidden(raw.get(worktree) ?? worktree)) continue
           server.projects.open(raw.get(worktree) ?? worktree)
           seen.add(worktree)
         }

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -1,5 +1,5 @@
 import { createStore, produce } from "solid-js/store"
-import { batch, createEffect, createMemo, onCleanup, onMount, type Accessor } from "solid-js"
+import { batch, createEffect, createMemo, onCleanup, onMount, untrack, type Accessor } from "solid-js"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useGlobalSync } from "./global-sync"
 import { useGlobalSDK } from "./global-sdk"
@@ -390,7 +390,14 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     }
 
     createEffect(() => {
-      const projects = server.projects.list()
+      const worktrees = globalSync.data.project
+        .filter((project) => project.id !== "global")
+        .map((project) => project.worktree)
+        .filter((worktree): worktree is string => !!worktree)
+      const known = new Set(worktrees.map(rootFor))
+      if (known.size === 0) return
+
+      const projects = untrack(() => server.projects.list())
       const seen = new Set(projects.map((project) => project.worktree))
 
       batch(() => {
@@ -406,6 +413,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
           }
 
           if (project.expanded) server.projects.expand(root)
+        }
+
+        for (const worktree of known) {
+          if (seen.has(worktree)) continue
+          server.projects.open(worktree)
+          seen.add(worktree)
         }
       })
     })

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -3,6 +3,7 @@ import { batch, createEffect, createMemo, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import { usePlatform } from "@/context/platform"
 import { Persist, persisted } from "@/utils/persist"
+import { normalizeWorktreePath } from "@/utils/worktree-path"
 import { checkServerHealth } from "@/utils/server-health"
 
 type StoredProject = { worktree: string; expanded: boolean }
@@ -181,38 +182,43 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          if (current.find((x) => x.worktree === directory)) return
-          setStore("projects", key, [{ worktree: directory, expanded: true }, ...current])
+          const normalized = normalizeWorktreePath(directory)
+          if (current.find((x) => normalizeWorktreePath(x.worktree) === normalized)) return
+          setStore("projects", key, [{ worktree: normalized, expanded: true }, ...current])
         },
         close(directory: string) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
+          const normalized = normalizeWorktreePath(directory)
           setStore(
             "projects",
             key,
-            current.filter((x) => x.worktree !== directory),
+            current.filter((x) => normalizeWorktreePath(x.worktree) !== normalized),
           )
         },
         expand(directory: string) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          const index = current.findIndex((x) => x.worktree === directory)
+          const normalized = normalizeWorktreePath(directory)
+          const index = current.findIndex((x) => normalizeWorktreePath(x.worktree) === normalized)
           if (index !== -1) setStore("projects", key, index, "expanded", true)
         },
         collapse(directory: string) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          const index = current.findIndex((x) => x.worktree === directory)
+          const normalized = normalizeWorktreePath(directory)
+          const index = current.findIndex((x) => normalizeWorktreePath(x.worktree) === normalized)
           if (index !== -1) setStore("projects", key, index, "expanded", false)
         },
         move(directory: string, toIndex: number) {
           const key = origin()
           if (!key) return
           const current = store.projects[key] ?? []
-          const fromIndex = current.findIndex((x) => x.worktree === directory)
+          const normalized = normalizeWorktreePath(directory)
+          const fromIndex = current.findIndex((x) => normalizeWorktreePath(x.worktree) === normalized)
           if (fromIndex === -1 || fromIndex === toIndex) return
           const result = [...current]
           const [item] = result.splice(fromIndex, 1)
@@ -227,7 +233,10 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
         touch(directory: string) {
           const key = origin()
           if (!key) return
-          setStore("lastProject", key, directory)
+          const normalized = normalizeWorktreePath(directory)
+          const current = store.projects[key] ?? []
+          const match = current.find((x) => normalizeWorktreePath(x.worktree) === normalized)
+          setStore("lastProject", key, match?.worktree ?? normalized)
         },
       },
     }

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -39,6 +39,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
         list: [] as string[],
         currentSidecarUrl: "",
         projects: {} as Record<string, StoredProject[]>,
+        hiddenProjects: {} as Record<string, string[]>,
         lastProject: {} as Record<string, string>,
       }),
     )
@@ -158,6 +159,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
 
     const origin = createMemo(() => projectsKey(state.active))
     const projectsList = createMemo(() => store.projects[origin()] ?? [])
+    const hiddenProjectsList = createMemo(() => store.hiddenProjects[origin()] ?? [])
     const isLocal = createMemo(() => origin() === "local")
 
     return {
@@ -183,6 +185,14 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           if (!key) return
           const current = store.projects[key] ?? []
           const normalized = normalizeWorktreePath(directory)
+          const hidden = store.hiddenProjects[key] ?? []
+          const hiddenIndex = hidden.findIndex((x) => normalizeWorktreePath(x) === normalized)
+          if (hiddenIndex !== -1)
+            setStore(
+              "hiddenProjects",
+              key,
+              hidden.filter((_, i) => i !== hiddenIndex),
+            )
           if (current.find((x) => normalizeWorktreePath(x.worktree) === normalized)) return
           setStore("projects", key, [{ worktree: normalized, expanded: true }, ...current])
         },
@@ -191,6 +201,10 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           if (!key) return
           const current = store.projects[key] ?? []
           const normalized = normalizeWorktreePath(directory)
+          const hidden = store.hiddenProjects[key] ?? []
+          if (!hidden.find((x) => normalizeWorktreePath(x) === normalized)) {
+            setStore("hiddenProjects", key, [...hidden, normalized])
+          }
           setStore(
             "projects",
             key,
@@ -237,6 +251,10 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           const current = store.projects[key] ?? []
           const match = current.find((x) => normalizeWorktreePath(x.worktree) === normalized)
           setStore("lastProject", key, match?.worktree ?? normalized)
+        },
+        hidden(directory: string) {
+          const normalized = normalizeWorktreePath(directory)
+          return hiddenProjectsList().some((worktree) => normalizeWorktreePath(worktree) === normalized)
         },
       },
     }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -507,20 +507,28 @@ export default function Layout(props: ParentProps) {
         if (value.dir) return
 
         const last = server.projects.last()
+        if (!last) {
+          setState("autoselect", false)
+          return
+        }
 
         if (value.list.length === 0) {
-          if (!last) return
           setState("autoselect", false)
           openProject(last, false)
           navigateToProject(last)
           return
         }
 
-        const next = value.list.find((project) => project.worktree === last) ?? value.list[0]
-        if (!next) return
+        const next = value.list.find((project) => project.worktree === last)
         setState("autoselect", false)
-        openProject(next.worktree, false)
-        navigateToProject(next.worktree)
+        if (next) {
+          openProject(next.worktree, false)
+          navigateToProject(next.worktree)
+          return
+        }
+
+        openProject(last, false)
+        navigateToProject(last)
       },
     ),
   )

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -18,6 +18,7 @@ import { useGlobalSync } from "@/context/global-sync"
 import { Persist, persisted } from "@/utils/persist"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
+import { sameWorktreePath } from "@/utils/worktree-path"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -519,7 +520,7 @@ export default function Layout(props: ParentProps) {
           return
         }
 
-        const next = value.list.find((project) => project.worktree === last)
+        const next = value.list.find((project) => sameWorktreePath(project.worktree, last))
         setState("autoselect", false)
         if (next) {
           openProject(next.worktree, false)

--- a/packages/app/src/utils/worktree-path.ts
+++ b/packages/app/src/utils/worktree-path.ts
@@ -1,0 +1,9 @@
+export function normalizeWorktreePath(directory: string) {
+  const normalized = directory.replaceAll("\\", "/").replace(/\/+$/, "")
+  if (!/^[a-z]:\//i.test(normalized)) return normalized
+  return normalized[0]!.toLowerCase() + normalized.slice(1)
+}
+
+export function sameWorktreePath(a: string, b: string) {
+  return normalizeWorktreePath(a) === normalizeWorktreePath(b)
+}


### PR DESCRIPTION
### What does this PR do?

Hydrate the projects list from the server so newly opened clients show existing projects without manual adds, each client stores its own hidden projects array as there is no way to delete projects on api. basically its now opt out of projects instead of opt in by adding path.

Also had to add worktree path normalisation, because windows paths are weird and projects kept duplicating as we check worktree paths in the seen set

### How did you verify your code works?

Tested locally by opening a new client and verifying that the projects show up.

fixes #13626