### PR TITLE
fix: pass directory to tui() in thread.ts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -161,6 +161,7 @@ export const TuiThreadCommand = cmd({
 
       const tuiPromise = tui({
         url,
+        directory: cwd,
         fetch: customFetch,
         events,
         args: {


### PR DESCRIPTION
## The Riddle of the Lost Path

**I am known to the one who resolves me, yet never spoken to the one who needs me most. What am I?**
*The `cwd` variable — computed on line 97, used to `chdir` on line 106, but never whispered to `tui()` on line 162.*

---

**Two siblings share a parent, yet only one remembers home. Who forgets?**
*`attach.ts` passes `directory` faithfully (line 53). `thread.ts` does not. They both call `tui()`, but only one tells it where it lives.*

---

**I travel through a header, across a wire, to tell a server where to look. Without me, the server guesses — and guesses wrong. What am I?**
*The `x-opencode-directory` header — set by the SDK when `directory` is provided, read by `server.ts:197` to resolve the correct project instance.*

---

**What has a key but opens no lock, a path but leads nowhere, and a session that cannot find itself?**
*A TUI started without `directory`: the SDK never sets the header, the server falls back to `process.cwd()`, and sessions from other projects vanish into the void.*

---

**The cure is one line. The disease is one omission. The proof is in the sibling who already got it right.**

```diff
  const tuiPromise = tui({
    url,
+   directory: cwd,
    fetch: customFetch,
    events,
```

Closes #13600