### PR TITLE
fix(app): sync chat when returning from background

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -1,7 +1,7 @@
 import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2/client"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
-import { batch, onCleanup } from "solid-js"
+import { batch, onCleanup, onMount } from "solid-js"
 import { usePlatform } from "./platform"
 import { useServer } from "./server"
 
@@ -94,6 +94,38 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
     let streamErrorLogged = false
     const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
+    let isStale = false
+    let defer: ReturnType<typeof setTimeout> | undefined
+
+    const sync = () => {
+      emitter.emit("global", { type: "resume", properties: {} } as unknown as Event)
+    }
+
+    const resume = () => {
+      if (defer) return
+      defer = setTimeout(() => {
+        defer = undefined
+        if (!isStale) return
+        isStale = false
+        sync()
+      }, 100)
+    }
+
+    const freeze = () => {
+      isStale = true
+      void flush()
+    }
+
+    const resumed = () => resume()
+
+    const visible = () => {
+      if (document.visibilityState !== "visible") {
+        isStale = true
+        return
+      }
+      resume()
+    }
+
     void (async () => {
       while (!abort.signal.aborted) {
         try {
@@ -108,6 +140,11 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
               })
             },
           })
+          streamErrorLogged = false
+          if (isStale) {
+            isStale = false
+            sync()
+          }
           let yielded = Date.now()
           for await (const event of events.stream) {
             streamErrorLogged = false
@@ -145,9 +182,18 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       }
     })().finally(flush)
 
-    onCleanup(() => {
-      abort.abort()
-      flush()
+    onMount(() => {
+      document.addEventListener("freeze", freeze)
+      document.addEventListener("resume", resumed)
+      document.addEventListener("visibilitychange", visible)
+
+      onCleanup(() => {
+        document.removeEventListener("freeze", freeze)
+        document.removeEventListener("resume", resumed)
+        document.removeEventListener("visibilitychange", visible)
+        abort.abort()
+        flush()
+      })
     })
 
     const sdk = createOpencodeClient({

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -20,7 +20,7 @@ export function applyGlobalEvent(input: {
   setGlobalProject: (next: Project[] | ((draft: Project[]) => void)) => void
   refresh: () => void
 }) {
-  if (input.event.type === "global.disposed") {
+  if (input.event.type === "global.disposed" || input.event.type === "resume") {
     input.refresh()
     return
   }


### PR DESCRIPTION
### What does this PR do?

When using `opencode web` and using it over a mobile phone, connectivity is not getting restored correctly if the phone locks or puts the browser into the background, forcing the user to full refresh the page. By tracking visibility state as well as using the page lifecycle API's `freeze` and `resume` allows us to correctly restore connection.

Fixes #7990 point "Maintaining connections while in the background (preventing disconnection)."

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Tests ran on my local environment using `bun run dev web` and my mobile phone on both mobile and wifi connections, attempting both tests on screen locking as well as browser going into the background.
