### PR TITLE
fix: add WAL checkpoint on database open

### DIFF
--- a/packages/opencode/src/storage/db.ts
+++ b/packages/opencode/src/storage/db.ts
@@ -74,6 +74,7 @@ export namespace Database {
     sqlite.run("PRAGMA busy_timeout = 5000")
     sqlite.run("PRAGMA cache_size = -64000")
     sqlite.run("PRAGMA foreign_keys = ON")
+    sqlite.run("PRAGMA wal_checkpoint(PASSIVE)")
 
     const db = drizzle({ client: sqlite, schema })
 


### PR DESCRIPTION
## Summary
- Add `PRAGMA wal_checkpoint(PASSIVE)` on database open to clean up stale WAL data from interrupted writes
- This prevents SQLITE_MISUSE errors when the process is killed mid-write