### PR TITLE
fix: add Clear Modified command for session sidebar diff

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -12,13 +12,15 @@ import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean; hideDiff?: boolean }) {
+export function Sidebar(props: { sessionID: string; overlay?: boolean; hiddenDiff?: Record<string, true> }) {
   const sync = useSync()
   const { theme } = useTheme()
   const session = createMemo(() => sync.session.get(props.sessionID)!)
   const diff = createMemo(() => {
-    if (props.hideDiff) return []
-    return sync.data.session_diff[props.sessionID] ?? []
+    const hidden = props.hiddenDiff ?? {}
+    return (sync.data.session_diff[props.sessionID] ?? []).filter(
+      (item) => !hidden[`${item.file}:${item.additions}:${item.deletions}`],
+    )
   })
   const todo = createMemo(() => sync.data.todo[props.sessionID] ?? [])
   const messages = createMemo(() => sync.data.message[props.sessionID] ?? [])

--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -12,11 +12,14 @@ import { useDirectory } from "../../context/directory"
 import { useKV } from "../../context/kv"
 import { TodoItem } from "../../component/todo-item"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+export function Sidebar(props: { sessionID: string; overlay?: boolean; hideDiff?: boolean }) {
   const sync = useSync()
   const { theme } = useTheme()
   const session = createMemo(() => sync.session.get(props.sessionID)!)
-  const diff = createMemo(() => sync.data.session_diff[props.sessionID] ?? [])
+  const diff = createMemo(() => {
+    if (props.hideDiff) return []
+    return sync.data.session_diff[props.sessionID] ?? []
+  })
   const todo = createMemo(() => sync.data.todo[props.sessionID] ?? [])
   const messages = createMemo(() => sync.data.message[props.sessionID] ?? [])
 


### PR DESCRIPTION
tl;dr: made it so you can do `ctrl + p` and have the option to clear the "Modified Files" display

https://github.com/user-attachments/assets/c2ec7477-bd4d-45af-b074-b130d7bf8905

## Summary

- add a new session command palette action, `Clear Modified`, available via Ctrl+P to hide the sidebar Modified Files section without mutating persisted diff state

- keep clear behavior scoped to the current session and in-memory only, so it does not affect git data or backend `session_diff` storage

- automatically restore the Modified Files section when a new diff arrives by invalidating the hidden state when diff content changes

## Validation
- ran repo pre-push typecheck successfully during branch push