### PR TITLE
feat(plugin): pass sessionID and callID to shell.env hook input

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1622,7 +1622,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
     const args = matchingInvocation?.args
 
     const cwd = Instance.directory
-    const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
+    const shellEnv = await Plugin.trigger("shell.env", { cwd, sessionID: input.sessionID, callID: part.callID }, { env: {} })
     const proc = spawn(shell, args, {
       cwd,
       detached: process.platform !== "win32",

--- a/packages/opencode/src/tool/bash.ts
+++ b/packages/opencode/src/tool/bash.ts
@@ -163,7 +163,7 @@ export const BashTool = Tool.define("bash", async () => {
         })
       }
 
-      const shellEnv = await Plugin.trigger("shell.env", { cwd }, { env: {} })
+      const shellEnv = await Plugin.trigger("shell.env", { cwd, sessionID: ctx.sessionID, callID: ctx.callID }, { env: {} })
       const proc = spawn(params.command, {
         shell,
         cwd,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -185,7 +185,10 @@ export interface Hooks {
     input: { tool: string; sessionID: string; callID: string },
     output: { args: any },
   ) => Promise<void>
-  "shell.env"?: (input: { cwd: string }, output: { env: Record<string, string> }) => Promise<void>
+  "shell.env"?: (
+    input: { cwd: string; sessionID?: string; callID?: string },
+    output: { env: Record<string, string> },
+  ) => Promise<void>
   "tool.execute.after"?: (
     input: { tool: string; sessionID: string; callID: string; args: any },
     output: {


### PR DESCRIPTION
Fixes #13661

### What does this PR do?

Adds optional `sessionID` and `callID` fields to the `shell.env` hook input, for symmetry with other events + state correlation when using concurrent subagents.

The fields are optional because `pty/index.ts` has no session context. `bash.ts` and `prompt.ts` already have both values in scope -- just passing them through.

### How did you verify your code works?

- Confirmed `ctx.sessionID` and `ctx.callID` are in scope at `bash.ts:166`
- Confirmed `input.sessionID` and `part.callID` are in scope at `prompt.ts:1625`
- `pty/index.ts` unchanged -- fields are optional, undefined is correct there
- Existing plugins unaffected -- new fields are additive on the input object
- Logged from plugin
      ```{"type":"debug","timestamp":"2026-02-15T00:03:14.492Z","level":"debug","message":"[shell.env] cwd=opencode sessionID=ses_3a1643f0dffeF2LkERFvZ6xOMw callID=toolu_vrtx_012mf7oncgJQaP6qf13pEGGg"}```