### PR TITLE
docs: add opencode-hashline to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ar/ecosystem.mdx
+++ b/packages/web/src/content/docs/ar/ecosystem.mdx
@@ -47,6 +47,7 @@ description: مشاريع وتكاملات مبنية باستخدام OpenCode.
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | إشعارات نظام تشغيل أصلية لـ OpenCode - اعرف متى تكتمل المهام                              |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | حزمة تنسيق متعددة الوكلاء - 16 مكوّنا، تثبيت واحد                                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | git worktrees بلا تعقيد لـ OpenCode                                                       |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | تجزئة أسطر قابلة للعنونة بالمحتوى لتحرير الكود بدقة مع أداة تحرير بمرجع التجزئة          |
 
 ---
 

--- a/packages/web/src/content/docs/bs/ecosystem.mdx
+++ b/packages/web/src/content/docs/bs/ecosystem.mdx
@@ -43,6 +43,7 @@ Također možete pogledati [awesome-opencode](https://github.com/awesome-opencod
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Notifikacije izvornog OS-a za OpenCode – znajte kada se zadaci dovrše                                         |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Uvezeni višeagentni orkestracijski pojas – 16 komponenti, jedna instalacija                                   |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Git radna stabla bez trenja za OpenCode                                                                       |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Sadržajno adresabilno hashiranje linija za precizno AI uređivanje koda s alatom za uređivanje hash-referencom |
 
 ---
 

--- a/packages/web/src/content/docs/da/ecosystem.mdx
+++ b/packages/web/src/content/docs/da/ecosystem.mdx
@@ -47,6 +47,7 @@ Du kan også tjekke [awesome-opencode](https://github.com/awesome-opencode/aweso
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS-meddelelser for OpenCode – ved, hvornår opgaver er fuldført                                             |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orkestreringssele – 16 komponenter, én installation                                           |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Nulfriktions git-arbejdstræer for OpenCode                                                                        |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Indholdsadresserbar linjehashing til præcis AI-koderedigering med hash-reference redigeringsværktøj               |
 
 ---
 

--- a/packages/web/src/content/docs/de/ecosystem.mdx
+++ b/packages/web/src/content/docs/de/ecosystem.mdx
@@ -47,6 +47,7 @@ Sie können sich auch [awesome-opencode](https://github.com/awesome-opencode/awe
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS-Benachrichtigungen für OpenCode – wissen, wann Aufgaben erledigt sind                                               |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Gebündelter Multi-Agent-Orchestrierungs-Harness – 16 Komponenten, eine Installation                                           |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Reibungslose Git-Arbeitsbäume für OpenCode                                                                                    |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Inhaltsadressierbares Zeilen-Hashing für präzise KI-Codebearbeitung mit Hash-Referenz-Bearbeitungswerkzeug                    |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Content-addressable line hashing for precise AI code editing with hash-reference edit tool         |
 
 ---
 

--- a/packages/web/src/content/docs/es/ecosystem.mdx
+++ b/packages/web/src/content/docs/es/ecosystem.mdx
@@ -47,6 +47,7 @@ También puedes consultar [awesome-opencode](https://github.com/awesome-opencode
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Notificaciones nativas del sistema operativo para OpenCode: sepa cuándo se completan las tareas                             |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Arnés de orquestación multiagente incluido: 16 componentes, una instalación                                                 |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Árboles de trabajo de Git de fricción cero para OpenCode                                                                    |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Hash de líneas direccionable por contenido para edición precisa de código con IA y herramienta de edición por referencia hash |
 
 ---
 

--- a/packages/web/src/content/docs/fr/ecosystem.mdx
+++ b/packages/web/src/content/docs/fr/ecosystem.mdx
@@ -47,6 +47,7 @@ Vous pouvez également consulter [awesome-opencode](https://github.com/awesome-o
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Notifications natives du système d'exploitation pour OpenCode – savoir quand les tâches sont terminées                                               |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Harness d'orchestration multi-agent prêt à l'emploi - 16 composants, une installation                                                                |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Arbres de travail Git sans friction pour OpenCode                                                                                                    |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Hachage de lignes adressable par contenu pour l'édition précise de code par IA avec outil d'édition par référence hash                               |
 
 ---
 

--- a/packages/web/src/content/docs/it/ecosystem.mdx
+++ b/packages/web/src/content/docs/it/ecosystem.mdx
@@ -47,6 +47,7 @@ Puoi anche dare un'occhiata a [awesome-opencode](https://github.com/awesome-open
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Notifiche native del sistema per OpenCode: sai quando i task finiscono                            |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Harness di orchestrazione multi-agente bundle: 16 componenti, una installazione                   |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Git worktree senza attriti per OpenCode                                                           |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Hashing di riga indirizzabile per contenuto per editing preciso del codice AI con strumento di modifica per riferimento hash |
 
 ---
 

--- a/packages/web/src/content/docs/ja/ecosystem.mdx
+++ b/packages/web/src/content/docs/ja/ecosystem.mdx
@@ -46,6 +46,7 @@ OpenCode 関連プロジェクトをこのリストに追加したいですか? 
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | OpenCode のネイティブ OS 通知 – タスクがいつ完了したかを知る                                                         |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | バンドルされたマルチエージェントオーケストレーションハーネス – 16 コンポーネント、1 回のインストール                 |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | OpenCode 用のゼロフリクション Git ワークツリー                                                                       |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | コンテンツアドレス可能な行ハッシュによる正確な AI コード編集とハッシュ参照編集ツール                                  |
 
 ---
 

--- a/packages/web/src/content/docs/ko/ecosystem.mdx
+++ b/packages/web/src/content/docs/ko/ecosystem.mdx
@@ -47,6 +47,7 @@ opencode에 내장 된 커뮤니티 프로젝트의 컬렉션.
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | opencode의 Native OS 알림 – 작업이 완료되면 알 수 있습니다                             |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | 멀티 시약 오케스트라 묶음 하네스 – 16개 부품, 하나 설치                                |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | opencode를 위한 Zero-friction git worktree                                             |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | 정확한 AI 코드 편집을 위한 콘텐츠 주소 지정 라인 해싱 및 해시 참조 편집 도구           |
 
 ---
 

--- a/packages/web/src/content/docs/nb/ecosystem.mdx
+++ b/packages/web/src/content/docs/nb/ecosystem.mdx
@@ -47,6 +47,7 @@ Du kan også sjekke ut [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Innfødte OS-varsler for OpenCode – vet når oppgaver fullføres                                                 |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Medfølgende multi-agent orkestreringsrammeverk – 16 komponenter, én installasjon                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Nullfriksjon git-arbeidstre for OpenCode                                                                      |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Innholdsadresserbar linjehashing for presis AI-koderedigering med hash-referanse redigeringsverktøy            |
 
 ---
 

--- a/packages/web/src/content/docs/pl/ecosystem.mdx
+++ b/packages/web/src/content/docs/pl/ecosystem.mdx
@@ -47,6 +47,7 @@ Możesz także sprawdzić [awesome-opencode](https://github.com/awesome-opencode
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Natywne uruchomienie systemu dla opencode – wiesz, kiedy zadania zostaną zakończone                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Lista wiązek orkiestracji wieloagentowej – 16 dostępna, jedna instalacja                                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Drzewa robocze Git o zerowym tarciu dla opencode                                                                      |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Hashowanie wierszy adresowalne treścią do precyzyjnej edycji kodu AI z narzędziem edycji przez referencję hash        |
 
 ---
 

--- a/packages/web/src/content/docs/pt-br/ecosystem.mdx
+++ b/packages/web/src/content/docs/pt-br/ecosystem.mdx
@@ -47,6 +47,7 @@ Você também pode conferir [awesome-opencode](https://github.com/awesome-openco
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Notificações nativas do OS para opencode – saiba quando as tarefas são concluídas                                              |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Conjunto de orquestração multi-agente – 16 componentes, uma instalação                                                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Worktrees git sem atrito para opencode                                                                                         |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Hash de linhas endereçável por conteúdo para edição precisa de código com IA e ferramenta de edição por referência hash         |
 
 ---
 

--- a/packages/web/src/content/docs/ru/ecosystem.mdx
+++ b/packages/web/src/content/docs/ru/ecosystem.mdx
@@ -47,6 +47,7 @@ description: Проекты и интеграции, созданные с по�
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Встроенные уведомления ОС для opencode — узнайте, когда задачи завершены                                                                          |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Комплексный пакет многоагентной оркестровки — 16 компонентов, одна установка                                                                      |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Рабочие деревья git с нулевым трением для opencode                                                                                                |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Контентно-адресуемое хеширование строк для точного редактирования кода ИИ с инструментом правок по хеш-ссылкам |
 
 ---
 

--- a/packages/web/src/content/docs/th/ecosystem.mdx
+++ b/packages/web/src/content/docs/th/ecosystem.mdx
@@ -47,6 +47,7 @@ description: โปรเจ็กต์และการผสานรวม�
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | การแจ้งเตือนระบบปฏิบัติการดั้งเดิมสำหรับ OpenCode – ทราบเมื่องานเสร็จสมบูรณ์                                          |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | ชุดสายรัดประสานหลายเอเจนต์ที่ให้มา – ส่วนประกอบ 16 ชิ้น ติดตั้งเพียงครั้งเดียว                                        |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | เวิร์กทรีคอมไพล์ไร้แรงเสียดทานสำหรับ OpenCode                                                                         |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | การแฮชบรรทัดแบบอ้างอิงเนื้อหาสำหรับการแก้ไขโค้ด AI อย่างแม่นยำพร้อมเครื่องมือแก้ไขด้วยอ้างอิงแฮช                    |
 
 ---
 

--- a/packages/web/src/content/docs/tr/ecosystem.mdx
+++ b/packages/web/src/content/docs/tr/ecosystem.mdx
@@ -47,6 +47,7 @@ Ayrıca ekosistemi ve topluluğu bir araya getiren bir topluluk olan [awesome-op
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | opencode için yerel işletim sistemi bildirimleri – görevlerin ne zaman tamamlandığını bilin                                    |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Birlikte verilen çok aracılı orkestrasyon donanımı – 16 bileşen, tek kurulum                                                   |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | opencode için sıfır sürtünmeli git çalışma ağaçları                                                                            |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | Kesin AI kod düzenleme için içerik adreslenebilir satır hashleme ve hash referanslı düzenleme aracı                            |
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -47,6 +47,7 @@ description: 使用 opencode 构建的项目和集成。
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | opencode 的本机操作系统通知 – 了解任务何时完成                           |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | 一堆多代理编排工具 – 16个，组件一次安装                                  |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | opencode 的零难度 git 工作树                                             |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | 内容寻址行哈希，用于精确的 AI 代码编辑，配备哈希引用编辑工具             |
 
 ---
 

--- a/packages/web/src/content/docs/zh-tw/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-tw/ecosystem.mdx
@@ -47,6 +47,7 @@ description: 使用 opencode 構建的專案和整合。
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | opencode 的原生作業系統通知 – 了解任務何時完成                           |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | 捆綁的多代理編排工具 – 16 個組件，一次安裝                               |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | opencode 的零摩擦 git 工作樹                                             |
+| [opencode-hashline](https://github.com/izzzzzi/opencode-hashline)                                         | 內容尋址行雜湊，用於精確的 AI 程式碼編輯，配備雜湊參考編輯工具           |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add [opencode-hashline](https://github.com/izzzzzi/opencode-hashline) to the Plugins section of the ecosystem page
- Updated all 18 language versions (en, ar, bs, da, de, es, fr, it, ja, ko, nb, pl, pt-br, ru, th, tr, zh-cn, zh-tw) with localized descriptions

**opencode-hashline** is a plugin that annotates every line with a deterministic hash tag (`#HL 5:a3f|code`), enabling the AI to reference and edit code with surgical precision via hash references instead of fragile `old_string` matching.

- **npm**: https://www.npmjs.com/package/opencode-hashline
- **repo**: https://github.com/izzzzzi/opencode-hashline
- **benchmark**: 100% correctness on [react-edit-benchmark](https://github.com/can1357/oh-my-pi/tree/main/packages/react-edit-benchmark) (60/60) vs str_replace 96.7%

🤖 Generated with [Claude Code](https://claude.com/claude-code)