### PR TITLE
fix(tui): stop truncating last table row after streaming completes

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   close-stale-prs:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/compliance-close.yml
+++ b/.github/workflows/compliance-close.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   close-non-compliant:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     steps:
       - name: Close non-compliant issues and PRs after 2 hours

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       REGISTRY: ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/daily-issues-recap.yml
+++ b/.github/workflows/daily-issues-recap.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   daily-recap:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/daily-pr-recap.yml
+++ b/.github/workflows/daily-pr-recap.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   pr-recap:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   deploy:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs-locale-sync.yml
+++ b/.github/workflows/docs-locale-sync.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sync-locales:
-    if: github.actor != 'opencode-agent[bot]'
+    if: github.repository == 'anomalyco/opencode' && (github.actor != 'opencode-agent[bot]')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write

--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   check-duplicates:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -21,6 +21,7 @@ jobs:
   # Native runners required: bun install cross-compilation flags (--os/--cpu)
   # do not produce byte-identical node_modules as native installs.
   compute-hash:
+    if: github.repository == 'anomalyco/opencode'
     strategy:
       fail-fast: false
       matrix:
@@ -75,8 +76,8 @@ jobs:
           retention-days: 1
 
   update-hashes:
+    if: github.repository == 'anomalyco/opencode' && github.event_name != 'pull_request'
     needs: compute-hash
-    if: github.event_name != 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   notify:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Send nicely-formatted embed to Discord

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   opencode:
     if: |
+      github.repository == 'anomalyco/opencode' &&
       contains(github.event.comment.body, ' /oc') ||
       startsWith(github.event.comment.body, '/oc') ||
       contains(github.event.comment.body, ' /opencode') ||

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-duplicates:
     if: |
+      github.repository == 'anomalyco/opencode' &&
       github.event.pull_request.user.login != 'actions-user' &&
       github.event.pull_request.user.login != 'opencode' &&
       github.event.pull_request.user.login != 'rekram1-node' &&
@@ -67,6 +68,7 @@ jobs:
           fi
 
   add-contributor-label:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-standards:
     if: |
+      github.repository == 'anomalyco/opencode' &&
       github.event.pull_request.user.login != 'actions-user' &&
       github.event.pull_request.user.login != 'opencode' &&
       github.event.pull_request.user.login != 'rekram1-node' &&

--- a/.github/workflows/publish-github-action.yml
+++ b/.github/workflows/publish-github-action.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,8 @@ permissions:
 
 jobs:
   version:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.repository == 'anomalyco/opencode'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,9 +59,9 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
 
   build-cli:
+    if: github.repository == 'anomalyco/opencode'
     needs: version
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    if: github.repository == 'anomalyco/opencode'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -87,6 +87,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
 
   build-tauri:
+    if: github.repository == 'anomalyco/opencode'
     needs:
       - build-cli
       - version
@@ -203,6 +204,7 @@ jobs:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api-key.p8
 
   publish:
+    if: github.repository == 'anomalyco/opencode'
     needs:
       - version
       - build-cli

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   release:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-guidelines:
     if: |
+      github.repository == 'anomalyco/opencode' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/review') &&
       contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)

--- a/.github/workflows/sign-cli.yml
+++ b/.github/workflows/sign-cli.yml
@@ -12,8 +12,8 @@ permissions:
 
 jobs:
   sign-cli:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.repository == 'anomalyco/opencode'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   stale:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/sync-zed-extension.yml
+++ b/.github/workflows/sync-zed-extension.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   zed:
+    if: github.repository == 'anomalyco/opencode'
     name: Release Zed Extension
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   unit:
+    if: github.repository == 'anomalyco/opencode'
     name: unit (linux)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     defaults:
@@ -31,6 +32,7 @@ jobs:
         run: bun turbo test
 
   e2e:
+    if: github.repository == 'anomalyco/opencode'
     name: e2e (${{ matrix.settings.name }})
     needs: unit
     strategy:
@@ -80,12 +82,12 @@ jobs:
             packages/app/e2e/playwright-report
 
   required:
+    if: github.repository == 'anomalyco/opencode' && always()
     name: test (linux)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - unit
       - e2e
-    if: always()
     steps:
       - name: Verify upstream test jobs passed
         run: |

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   typecheck:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository

--- a/.github/workflows/vouch-check-issue.yml
+++ b/.github/workflows/vouch-check-issue.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   check:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     steps:
       - name: Check if issue author is denounced

--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   check:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR author is denounced

--- a/.github/workflows/vouch-manage-by-issue.yml
+++ b/.github/workflows/vouch-manage-by-issue.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   manage:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1377,7 +1377,7 @@ function TextPart(props: { last: boolean; part: TextPart; message: AssistantMess
           <Match when={Flag.OPENCODE_EXPERIMENTAL_MARKDOWN}>
             <markdown
               syntaxStyle={syntax()}
-              streaming={true}
+              streaming={!props.message.time.completed}
               content={props.part.text.trim()}
               conceal={ctx.conceal()}
             />


### PR DESCRIPTION
## Summary

Fixes the experimental markdown renderer cutting off the last row of tables (#13539).

## Problem

When `OPENCODE_EXPERIMENTAL_MARKDOWN=true`, tables always have their last row truncated. The opentui `<markdown>` component's streaming mode intentionally drops the last table row (which may be incomplete during generation):

```ts
const rowsToRender = this._streaming && table.rows.length > 0
  ? table.rows.slice(0, -1)  // drops last row during streaming
  : table.rows
```

However, in the `TextPart` component, `streaming` was hardcoded to `true`:

```tsx
<markdown
  streaming={true}  // ← always true, even after message completes
  ...
/>
```

So the last row stayed hidden permanently, even after the response finished generating.

## Fix

Pass the actual streaming state based on whether the message has completed:

```tsx
<markdown
  streaming={!props.message.time.completed}
  ...
/>
```

- While the message is being generated: `streaming=true` (last row hidden, as intended)
- After the message completes: `streaming=false` (all rows visible)

## Testing

Single prop change. `message.time.completed` is already used in the same component for duration calculation. Verified locally — all table rows render after message completes, streaming protection still active during generation.

Fixes #13539
Related: #12164, #11223