### PR TITLE
fix(opencode): reduce memory allocations in read tool

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -176,6 +176,31 @@ export const ReadTool = Tool.define("read", {
 
     for await (const chunk of stream) {
       buf += chunk
+
+      const cap = MAX_BYTES + MAX_LINE_LENGTH
+      if (buf.length > cap && !buf.includes("\n")) {
+        if (line >= start) {
+          inRange = true
+          const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
+          const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
+          if (bytes + size > MAX_BYTES) {
+            truncatedByBytes = true
+            hasMoreLines = true
+            stopped = true
+            stream.destroy()
+            break
+          }
+          raw.push(clipped)
+          bytes += size
+          truncatedByBytes = true
+          hasMoreLines = true
+          stopped = true
+          stream.destroy()
+          break
+        }
+
+        buf = ""
+      }
       const parts = buf.split("\n")
       buf = parts.pop() ?? ""
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -144,117 +144,34 @@ export const ReadTool = Tool.define("read", {
     const limit = params.limit ?? DEFAULT_READ_LIMIT
     const offset = params.offset ?? 1
     const start = offset - 1
-    const reader = file.stream().pipeThrough(new TextDecoderStream()).getReader()
-    let buf = ""
+
+    const estimate = Math.max(MAX_BYTES + MAX_LINE_LENGTH, (start + limit + 1) * 256)
+    let readBytes = Math.min(stat.size, estimate)
+
+    let text = await file.slice(0, readBytes).text()
+    let lines = text.split("\n")
+
+    while (start >= lines.length && readBytes < stat.size) {
+      readBytes = Math.min(stat.size, readBytes * 2)
+      text = await file.slice(0, readBytes).text()
+      lines = text.split("\n")
+    }
+
+    if (start >= lines.length) throw new Error(`Offset ${offset} is out of range for this file (${lines.length} lines)`)
 
     const raw: string[] = []
     let bytes = 0
     let truncatedByBytes = false
-    let truncatedByCap = false
-    let hasMoreLines = false
-    let totalLines = 0
-    let line = 0
-    let inRange = false
-    let stopped = false
 
-    while (true) {
-      const chunk = await reader.read()
-      if (chunk.done) break
-      buf += chunk.value
-
-      const idx = buf.lastIndexOf("\n")
-      if (idx === -1) {
-        if (buf.length > MAX_BYTES + MAX_LINE_LENGTH && line >= start) {
-          inRange = true
-          const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
-          const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
-          if (bytes + size > MAX_BYTES) {
-            truncatedByBytes = true
-            hasMoreLines = true
-            stopped = true
-            break
-          }
-          raw.push(clipped)
-          bytes += size
-          truncatedByCap = true
-          hasMoreLines = true
-          stopped = true
-          break
-        }
-
-        if (buf.length > MAX_BYTES + MAX_LINE_LENGTH && line < start) {
-          buf = ""
-        }
-
-        if (stopped) break
-        continue
+    for (let i = start; i < Math.min(lines.length, start + limit); i++) {
+      const line = lines[i].length > MAX_LINE_LENGTH ? lines[i].substring(0, MAX_LINE_LENGTH) + "..." : lines[i]
+      const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
+      if (bytes + size > MAX_BYTES) {
+        truncatedByBytes = true
+        break
       }
-
-      const parts = buf.slice(0, idx).split("\n")
-      buf = buf.slice(idx + 1)
-
-      for (const value of parts) {
-        if (line >= start) inRange = true
-        if (line < start) {
-          line++
-          continue
-        }
-
-        if (raw.length >= limit) {
-          hasMoreLines = true
-          stopped = true
-          break
-        }
-
-        const clipped = value.length > MAX_LINE_LENGTH ? value.substring(0, MAX_LINE_LENGTH) + "..." : value
-        const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
-        if (bytes + size > MAX_BYTES) {
-          truncatedByBytes = true
-          hasMoreLines = true
-          stopped = true
-          break
-        }
-
-        raw.push(clipped)
-        bytes += size
-        line++
-      }
-
-      if (stopped) break
-    }
-
-    if (stopped) await reader.cancel()
-    reader.releaseLock()
-
-    if (!stopped) {
-      if (line >= start) inRange = true
-
-      if (!inRange) {
-        line++
-      }
-
-      if (inRange && raw.length >= limit) {
-        hasMoreLines = true
-        line++
-      }
-
-      if (inRange && raw.length < limit) {
-        const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
-        const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
-        if (bytes + size > MAX_BYTES) {
-          truncatedByBytes = true
-          hasMoreLines = true
-          line++
-        }
-        if (bytes + size <= MAX_BYTES) {
-          raw.push(clipped)
-          bytes += size
-          line++
-        }
-      }
-
-      totalLines = line
-      if (!inRange) throw new Error(`Offset ${offset} is out of range for this file (${totalLines} lines)`)
+      raw.push(line)
+      bytes += size
     }
 
     const content = raw.map((line, index) => {
@@ -265,19 +182,16 @@ export const ReadTool = Tool.define("read", {
     output += content.join("\n")
 
     const lastReadLine = offset + raw.length - 1
-    const truncated = hasMoreLines || truncatedByBytes || truncatedByCap
+    const reachedEOF = readBytes >= stat.size
+    const hasMoreLines = !reachedEOF || lines.length > lastReadLine
+    const truncated = hasMoreLines || truncatedByBytes
 
     if (truncatedByBytes) {
       output += `\n\n(Output truncated at ${MAX_BYTES} bytes. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    }
-    if (!truncatedByBytes && truncatedByCap) {
-      output += `\n\n(Output truncated. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    }
-    if (!truncatedByBytes && !truncatedByCap && hasMoreLines) {
+    } else if (hasMoreLines) {
       output += `\n\n(File has more lines. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    }
-    if (!truncatedByBytes && !truncatedByCap && !hasMoreLines) {
-      output += `\n\n(End of file - total ${totalLines} lines)`
+    } else {
+      output += `\n\n(End of file - total ${lines.length} lines)`
     }
     output += "\n</content>"
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -13,6 +13,8 @@ import { InstructionPrompt } from "../session/instruction"
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
 const MAX_BYTES = 50 * 1024
+const MAX_INLINE_BYTES = 20 * 1024 * 1024
+const MAX_DIR_ENTRIES = 10_000
 
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
@@ -50,7 +52,7 @@ export const ReadTool = Tool.define("read", {
       const dir = path.dirname(filepath)
       const base = path.basename(filepath)
 
-      const dirEntries = fs.readdirSync(dir)
+      const dirEntries = await fs.promises.readdir(dir)
       const suggestions = dirEntries
         .filter(
           (entry) =>
@@ -68,6 +70,19 @@ export const ReadTool = Tool.define("read", {
 
     if (stat.isDirectory()) {
       const dirents = await fs.promises.readdir(filepath, { withFileTypes: true })
+      if (dirents.length > MAX_DIR_ENTRIES) {
+        const msg = `Directory too large to list (${dirents.length} entries). Use a more specific path or glob pattern.`
+        const output = [`<path>${filepath}</path>`, `<type>directory</type>`, `<entries>`, msg, `</entries>`].join("\n")
+        return {
+          title,
+          output,
+          metadata: {
+            preview: msg,
+            truncated: true,
+            loaded: [] as string[],
+          },
+        }
+      }
       const entries = await Promise.all(
         dirents.map(async (dirent) => {
           if (dirent.isDirectory()) return dirent.name + "/"
@@ -115,6 +130,9 @@ export const ReadTool = Tool.define("read", {
       file.type.startsWith("image/") && file.type !== "image/svg+xml" && file.type !== "image/vnd.fastbidsheet"
     const isPdf = file.type === "application/pdf"
     if (isImage || isPdf) {
+      if (stat.size > MAX_INLINE_BYTES) {
+        throw new Error(`File too large for inline display (${stat.size} bytes). Maximum supported size is 20MB.`)
+      }
       const mime = file.type
       const msg = `${isImage ? "Image" : "PDF"} read successfully`
       return {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -52,7 +52,7 @@ export const ReadTool = Tool.define("read", {
       const dir = path.dirname(filepath)
       const base = path.basename(filepath)
 
-      const dirEntries = await fs.promises.readdir(dir).catch(() => [] as string[])
+      const dirEntries = await fs.promises.readdir(dir).catch((): string[] => [])
       const suggestions = dirEntries
         .filter(
           (entry) =>
@@ -72,10 +72,9 @@ export const ReadTool = Tool.define("read", {
       const dirents = await fs.promises.readdir(filepath, { withFileTypes: true })
       if (dirents.length > MAX_DIR_ENTRIES) {
         const msg = `Directory too large to list (${dirents.length} entries). Use a more specific path or glob pattern.`
-        const output = [`<path>${filepath}</path>`, `<type>directory</type>`, `<entries>`, msg, `</entries>`].join("\n")
         return {
           title,
-          output,
+          output: [`<path>${filepath}</path>`, `<type>directory</type>`, `<entries>`, msg, `</entries>`].join("\n"),
           metadata: {
             preview: msg,
             truncated: true,
@@ -174,7 +173,6 @@ export const ReadTool = Tool.define("read", {
     let line = 0
     let inRange = false
     let stopped = false
-    const cap = MAX_BYTES + MAX_LINE_LENGTH
 
     while (true) {
       const chunk = await reader.read()
@@ -183,23 +181,26 @@ export const ReadTool = Tool.define("read", {
 
       const idx = buf.lastIndexOf("\n")
       if (idx === -1) {
-        if (buf.length > cap) {
-          if (line >= start) {
-            inRange = true
-            const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
-            const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
-            if (bytes + size > MAX_BYTES) {
-              truncatedByBytes = true
-            } else {
-              raw.push(clipped)
-              bytes += size
-              truncatedByCap = true
-            }
+        if (buf.length > MAX_BYTES + MAX_LINE_LENGTH && line >= start) {
+          inRange = true
+          const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
+          const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
+          if (bytes + size > MAX_BYTES) {
+            truncatedByBytes = true
             hasMoreLines = true
             stopped = true
-          } else {
-            buf = ""
+            break
           }
+          raw.push(clipped)
+          bytes += size
+          truncatedByCap = true
+          hasMoreLines = true
+          stopped = true
+          break
+        }
+
+        if (buf.length > MAX_BYTES + MAX_LINE_LENGTH && line < start) {
+          buf = ""
         }
 
         if (stopped) break
@@ -245,22 +246,28 @@ export const ReadTool = Tool.define("read", {
     if (!stopped) {
       if (line >= start) inRange = true
 
-      if (line < start) {
+      if (!inRange) {
         line++
-      } else if (raw.length >= limit) {
+      }
+
+      if (inRange && raw.length >= limit) {
         hasMoreLines = true
         line++
-      } else {
+      }
+
+      if (inRange && raw.length < limit) {
         const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
         const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
         if (bytes + size > MAX_BYTES) {
           truncatedByBytes = true
           hasMoreLines = true
-        } else {
+          line++
+        }
+        if (bytes + size <= MAX_BYTES) {
           raw.push(clipped)
           bytes += size
+          line++
         }
-        line++
       }
 
       totalLines = line
@@ -270,7 +277,6 @@ export const ReadTool = Tool.define("read", {
     const content = raw.map((line, index) => {
       return `${index + offset}: ${line}`
     })
-    const preview = raw.slice(0, 20).join("\n")
 
     let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
     output += content.join("\n")
@@ -280,11 +286,14 @@ export const ReadTool = Tool.define("read", {
 
     if (truncatedByBytes) {
       output += `\n\n(Output truncated at ${MAX_BYTES} bytes. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    } else if (truncatedByCap) {
+    }
+    if (!truncatedByBytes && truncatedByCap) {
       output += `\n\n(Output truncated. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    } else if (hasMoreLines) {
+    }
+    if (!truncatedByBytes && !truncatedByCap && hasMoreLines) {
       output += `\n\n(File has more lines. Use 'offset' parameter to read beyond line ${lastReadLine})`
-    } else {
+    }
+    if (!truncatedByBytes && !truncatedByCap && !hasMoreLines) {
       output += `\n\n(End of file - total ${totalLines} lines)`
     }
     output += "\n</content>"
@@ -301,7 +310,7 @@ export const ReadTool = Tool.define("read", {
       title,
       output,
       metadata: {
-        preview,
+        preview: raw.slice(0, 20).join("\n"),
         truncated,
         loaded: instructions.map((i) => i.filepath),
       },

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -245,7 +245,7 @@ async function isBinaryFile(filepath: string, file: Bun.BunFile): Promise<boolea
   if (fileSize === 0) return false
 
   const bufferSize = Math.min(4096, fileSize)
-  const buffer = await file.arrayBuffer()
+  const buffer = await file.slice(0, bufferSize).arrayBuffer()
   if (buffer.byteLength === 0) return false
   const bytes = new Uint8Array(buffer.slice(0, bufferSize))
 

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -162,7 +162,7 @@ export const ReadTool = Tool.define("read", {
     const limit = params.limit ?? DEFAULT_READ_LIMIT
     const offset = params.offset ?? 1
     const start = offset - 1
-    const stream = fs.createReadStream(filepath, { encoding: "utf8" })
+    const reader = file.stream().pipeThrough(new TextDecoderStream()).getReader()
     let buf = ""
 
     const raw: string[] = []
@@ -176,8 +176,10 @@ export const ReadTool = Tool.define("read", {
     let stopped = false
     const cap = MAX_BYTES + MAX_LINE_LENGTH
 
-    for await (const chunk of stream) {
-      buf += chunk
+    while (true) {
+      const chunk = await reader.read()
+      if (chunk.done) break
+      buf += chunk.value
 
       const idx = buf.lastIndexOf("\n")
       if (idx === -1) {
@@ -237,7 +239,8 @@ export const ReadTool = Tool.define("read", {
       if (stopped) break
     }
 
-    if (stopped) stream.destroy()
+    if (stopped) await reader.cancel()
+    reader.releaseLock()
 
     if (!stopped) {
       if (line >= start) inRange = true

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -52,7 +52,7 @@ export const ReadTool = Tool.define("read", {
       const dir = path.dirname(filepath)
       const base = path.basename(filepath)
 
-      const dirEntries = await fs.promises.readdir(dir)
+      const dirEntries = await fs.promises.readdir(dir).catch(() => [] as string[])
       const suggestions = dirEntries
         .filter(
           (entry) =>
@@ -168,6 +168,7 @@ export const ReadTool = Tool.define("read", {
     const raw: string[] = []
     let bytes = 0
     let truncatedByBytes = false
+    let truncatedByCap = false
     let hasMoreLines = false
     let totalLines = 0
     let line = 0
@@ -178,31 +179,35 @@ export const ReadTool = Tool.define("read", {
       buf += chunk
 
       const cap = MAX_BYTES + MAX_LINE_LENGTH
-      if (buf.length > cap && !buf.includes("\n")) {
-        if (line >= start) {
-          inRange = true
-          const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
-          const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
-          if (bytes + size > MAX_BYTES) {
-            truncatedByBytes = true
-            hasMoreLines = true
-            stopped = true
-            stream.destroy()
-            break
+      const idx = buf.lastIndexOf("\n")
+      if (idx === -1) {
+        if (buf.length > cap) {
+          if (line >= start) {
+            inRange = true
+            const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
+            const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
+            if (bytes + size > MAX_BYTES) {
+              truncatedByBytes = true
+              hasMoreLines = true
+              stopped = true
+            } else {
+              raw.push(clipped)
+              bytes += size
+              truncatedByCap = true
+              hasMoreLines = true
+              stopped = true
+            }
+          } else {
+            buf = ""
           }
-          raw.push(clipped)
-          bytes += size
-          truncatedByBytes = true
-          hasMoreLines = true
-          stopped = true
-          stream.destroy()
-          break
         }
 
-        buf = ""
+        if (stopped) break
+        continue
       }
-      const parts = buf.split("\n")
-      buf = parts.pop() ?? ""
+
+      const parts = buf.slice(0, idx).split("\n")
+      buf = buf.slice(idx + 1)
 
       for (const value of parts) {
         if (line >= start) inRange = true
@@ -214,7 +219,6 @@ export const ReadTool = Tool.define("read", {
         if (raw.length >= limit) {
           hasMoreLines = true
           stopped = true
-          stream.destroy()
           break
         }
 
@@ -224,7 +228,6 @@ export const ReadTool = Tool.define("read", {
           truncatedByBytes = true
           hasMoreLines = true
           stopped = true
-          stream.destroy()
           break
         }
 
@@ -235,6 +238,8 @@ export const ReadTool = Tool.define("read", {
 
       if (stopped) break
     }
+
+    if (stopped) stream.destroy()
 
     if (!stopped) {
       if (line >= start) inRange = true
@@ -270,10 +275,12 @@ export const ReadTool = Tool.define("read", {
     output += content.join("\n")
 
     const lastReadLine = offset + raw.length - 1
-    const truncated = hasMoreLines || truncatedByBytes
+    const truncated = hasMoreLines || truncatedByBytes || truncatedByCap
 
     if (truncatedByBytes) {
       output += `\n\n(Output truncated at ${MAX_BYTES} bytes. Use 'offset' parameter to read beyond line ${lastReadLine})`
+    } else if (truncatedByCap) {
+      output += `\n\n(Output truncated. Use 'offset' parameter to read beyond line ${lastReadLine})`
     } else if (hasMoreLines) {
       output += `\n\n(File has more lines. Use 'offset' parameter to read beyond line ${lastReadLine})`
     } else {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -174,11 +174,11 @@ export const ReadTool = Tool.define("read", {
     let line = 0
     let inRange = false
     let stopped = false
+    const cap = MAX_BYTES + MAX_LINE_LENGTH
 
     for await (const chunk of stream) {
       buf += chunk
 
-      const cap = MAX_BYTES + MAX_LINE_LENGTH
       const idx = buf.lastIndexOf("\n")
       if (idx === -1) {
         if (buf.length > cap) {
@@ -188,15 +188,13 @@ export const ReadTool = Tool.define("read", {
             const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
             if (bytes + size > MAX_BYTES) {
               truncatedByBytes = true
-              hasMoreLines = true
-              stopped = true
             } else {
               raw.push(clipped)
               bytes += size
               truncatedByCap = true
-              hasMoreLines = true
-              stopped = true
             }
+            hasMoreLines = true
+            stopped = true
           } else {
             buf = ""
           }
@@ -352,7 +350,7 @@ async function isBinaryFile(filepath: string, file: Bun.BunFile): Promise<boolea
   const bufferSize = Math.min(4096, fileSize)
   const buffer = await file.slice(0, bufferSize).arrayBuffer()
   if (buffer.byteLength === 0) return false
-  const bytes = new Uint8Array(buffer.slice(0, bufferSize))
+  const bytes = new Uint8Array(buffer)
 
   let nonPrintableCount = 0
   for (let i = 0; i < bytes.length; i++) {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -13,8 +13,6 @@ import { InstructionPrompt } from "../session/instruction"
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
 const MAX_BYTES = 50 * 1024
-const MAX_INLINE_BYTES = 20 * 1024 * 1024
-const MAX_DIR_ENTRIES = 10_000
 
 export const ReadTool = Tool.define("read", {
   description: DESCRIPTION,
@@ -70,18 +68,6 @@ export const ReadTool = Tool.define("read", {
 
     if (stat.isDirectory()) {
       const dirents = await fs.promises.readdir(filepath, { withFileTypes: true })
-      if (dirents.length > MAX_DIR_ENTRIES) {
-        const msg = `Directory too large to list (${dirents.length} entries). Use a more specific path or glob pattern.`
-        return {
-          title,
-          output: [`<path>${filepath}</path>`, `<type>directory</type>`, `<entries>`, msg, `</entries>`].join("\n"),
-          metadata: {
-            preview: msg,
-            truncated: true,
-            loaded: [] as string[],
-          },
-        }
-      }
       const entries = await Promise.all(
         dirents.map(async (dirent) => {
           if (dirent.isDirectory()) return dirent.name + "/"
@@ -129,9 +115,6 @@ export const ReadTool = Tool.define("read", {
       file.type.startsWith("image/") && file.type !== "image/svg+xml" && file.type !== "image/vnd.fastbidsheet"
     const isPdf = file.type === "application/pdf"
     if (isImage || isPdf) {
-      if (stat.size > MAX_INLINE_BYTES) {
-        throw new Error(`File too large for inline display (${stat.size} bytes). Maximum supported size is 20MB.`)
-      }
       const mime = file.type
       const msg = `${isImage ? "Image" : "PDF"} read successfully`
       return {

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -162,21 +162,78 @@ export const ReadTool = Tool.define("read", {
     const limit = params.limit ?? DEFAULT_READ_LIMIT
     const offset = params.offset ?? 1
     const start = offset - 1
-    const lines = await file.text().then((text) => text.split("\n"))
-    if (start >= lines.length) throw new Error(`Offset ${offset} is out of range for this file (${lines.length} lines)`)
+    const stream = fs.createReadStream(filepath, { encoding: "utf8" })
+    let buf = ""
 
     const raw: string[] = []
     let bytes = 0
     let truncatedByBytes = false
-    for (let i = start; i < Math.min(lines.length, start + limit); i++) {
-      const line = lines[i].length > MAX_LINE_LENGTH ? lines[i].substring(0, MAX_LINE_LENGTH) + "..." : lines[i]
-      const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
-      if (bytes + size > MAX_BYTES) {
-        truncatedByBytes = true
-        break
+    let hasMoreLines = false
+    let totalLines = 0
+    let line = 0
+    let inRange = false
+    let stopped = false
+
+    for await (const chunk of stream) {
+      buf += chunk
+      const parts = buf.split("\n")
+      buf = parts.pop() ?? ""
+
+      for (const value of parts) {
+        if (line >= start) inRange = true
+        if (line < start) {
+          line++
+          continue
+        }
+
+        if (raw.length >= limit) {
+          hasMoreLines = true
+          stopped = true
+          stream.destroy()
+          break
+        }
+
+        const clipped = value.length > MAX_LINE_LENGTH ? value.substring(0, MAX_LINE_LENGTH) + "..." : value
+        const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
+        if (bytes + size > MAX_BYTES) {
+          truncatedByBytes = true
+          hasMoreLines = true
+          stopped = true
+          stream.destroy()
+          break
+        }
+
+        raw.push(clipped)
+        bytes += size
+        line++
       }
-      raw.push(line)
-      bytes += size
+
+      if (stopped) break
+    }
+
+    if (!stopped) {
+      if (line >= start) inRange = true
+
+      if (line < start) {
+        line++
+      } else if (raw.length >= limit) {
+        hasMoreLines = true
+        line++
+      } else {
+        const clipped = buf.length > MAX_LINE_LENGTH ? buf.substring(0, MAX_LINE_LENGTH) + "..." : buf
+        const size = Buffer.byteLength(clipped, "utf-8") + (raw.length > 0 ? 1 : 0)
+        if (bytes + size > MAX_BYTES) {
+          truncatedByBytes = true
+          hasMoreLines = true
+        } else {
+          raw.push(clipped)
+          bytes += size
+        }
+        line++
+      }
+
+      totalLines = line
+      if (!inRange) throw new Error(`Offset ${offset} is out of range for this file (${totalLines} lines)`)
     }
 
     const content = raw.map((line, index) => {
@@ -187,9 +244,7 @@ export const ReadTool = Tool.define("read", {
     let output = [`<path>${filepath}</path>`, `<type>file</type>`, "<content>"].join("\n")
     output += content.join("\n")
 
-    const totalLines = lines.length
     const lastReadLine = offset + raw.length - 1
-    const hasMoreLines = totalLines > lastReadLine
     const truncated = hasMoreLines || truncatedByBytes
 
     if (truncatedByBytes) {

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test"
-import * as fs from "fs"
 import path from "path"
 import { ReadTool } from "../../src/tool/read"
 import { Instance } from "../../src/project/instance"

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -416,24 +416,6 @@ describe("tool.read memory regression tests", () => {
     })
   })
 
-  test("truncates a huge single-line file without reading beyond cap", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        await Bun.write(path.join(dir, "one-line.txt"), "a".repeat(60 * 1024))
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "one-line.txt") }, ctx)
-        expect(result.metadata.truncated).toBe(true)
-        expect(result.output).toContain("Output truncated")
-        expect(result.output).not.toContain("Output truncated at")
-      },
-    })
-  })
-
   test("suggests similar filenames when file is missing", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {
@@ -447,24 +429,6 @@ describe("tool.read memory regression tests", () => {
         const missing = path.join(tmp.path, "example.tx")
         await expect(read.execute({ filePath: missing }, ctx)).rejects.toThrow("Did you mean one of these?")
         await expect(read.execute({ filePath: missing }, ctx)).rejects.toThrow(path.join(tmp.path, "example.txt"))
-      },
-    })
-  })
-
-  test("early stream destroy on line limit does not throw", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const lines = Array.from({ length: 3000 }, (_, i) => `line${i}`).join("\n")
-        await Bun.write(path.join(dir, "many-lines.txt"), lines)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "many-lines.txt"), limit: 100 }, ctx)
-        expect(result.metadata.truncated).toBe(true)
-        expect(result.output).toContain("File has more lines")
       },
     })
   })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import * as fs from "fs"
 import path from "path"
 import { ReadTool } from "../../src/tool/read"
 import { Instance } from "../../src/project/instance"
@@ -392,6 +393,123 @@ root_type Monster;`
         expect(result.attachments).toBeUndefined()
         expect(result.output).toContain("namespace MyGame")
         expect(result.output).toContain("table Monster")
+      },
+    })
+  })
+})
+
+describe("tool.read memory regression tests", () => {
+  test("rejects binary files using a 4KB slice check", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "binary.txt"), Buffer.from([97, 98, 99, 0, 100, 101, 102]))
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, "binary.txt") }, ctx)).rejects.toThrow(
+          "Cannot read binary file:",
+        )
+      },
+    })
+  })
+
+  test("rejects inline images larger than 20MB", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const filepath = path.join(dir, "too-large.png")
+        await Bun.write(filepath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+        await fs.promises.truncate(filepath, 20 * 1024 * 1024 + 1)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        await expect(read.execute({ filePath: path.join(tmp.path, "too-large.png") }, ctx)).rejects.toThrow(
+          "File too large for inline display",
+        )
+      },
+    })
+  })
+
+  test("caps directory listing at 10K entries", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const target = path.join(dir, "bigdir")
+        await fs.promises.mkdir(target, { recursive: true })
+        const batch = 200
+        for (let i = 0; i < 10001; i += batch) {
+          const end = Math.min(10001, i + batch)
+          await Promise.all(
+            Array.from({ length: end - i }, (_, j) => Bun.write(path.join(target, `f-${i + j}.txt`), "")),
+          )
+        }
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, "bigdir") }, ctx)
+        expect(result.metadata.truncated).toBe(true)
+        expect(result.output).toContain("Directory too large to list")
+        expect(result.output).toContain("10001")
+      },
+    })
+  })
+
+  test("truncates a huge single-line file without reading beyond cap", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "one-line.txt"), "a".repeat(60 * 1024))
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, "one-line.txt") }, ctx)
+        expect(result.metadata.truncated).toBe(true)
+        expect(result.output).toContain("Output truncated")
+        expect(result.output).not.toContain("Output truncated at")
+      },
+    })
+  })
+
+  test("suggests similar filenames when file is missing", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "example.txt"), "ok")
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const missing = path.join(tmp.path, "example.tx")
+        await expect(read.execute({ filePath: missing }, ctx)).rejects.toThrow("Did you mean one of these?")
+        await expect(read.execute({ filePath: missing }, ctx)).rejects.toThrow(path.join(tmp.path, "example.txt"))
+      },
+    })
+  })
+
+  test("early stream destroy on line limit does not throw", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        const lines = Array.from({ length: 3000 }, (_, i) => `line${i}`).join("\n")
+        await Bun.write(path.join(dir, "many-lines.txt"), lines)
+      },
+    })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const read = await ReadTool.init()
+        const result = await read.execute({ filePath: path.join(tmp.path, "many-lines.txt"), limit: 100 }, ctx)
+        expect(result.metadata.truncated).toBe(true)
+        expect(result.output).toContain("File has more lines")
       },
     })
   })

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -416,51 +416,6 @@ describe("tool.read memory regression tests", () => {
     })
   })
 
-  test("rejects inline images larger than 20MB", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const filepath = path.join(dir, "too-large.png")
-        await Bun.write(filepath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
-        await fs.promises.truncate(filepath, 20 * 1024 * 1024 + 1)
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        await expect(read.execute({ filePath: path.join(tmp.path, "too-large.png") }, ctx)).rejects.toThrow(
-          "File too large for inline display",
-        )
-      },
-    })
-  })
-
-  test("caps directory listing at 10K entries", async () => {
-    await using tmp = await tmpdir({
-      init: async (dir) => {
-        const target = path.join(dir, "bigdir")
-        await fs.promises.mkdir(target, { recursive: true })
-        const batch = 200
-        for (let i = 0; i < 10001; i += batch) {
-          const end = Math.min(10001, i + batch)
-          await Promise.all(
-            Array.from({ length: end - i }, (_, j) => Bun.write(path.join(target, `f-${i + j}.txt`), "")),
-          )
-        }
-      },
-    })
-    await Instance.provide({
-      directory: tmp.path,
-      fn: async () => {
-        const read = await ReadTool.init()
-        const result = await read.execute({ filePath: path.join(tmp.path, "bigdir") }, ctx)
-        expect(result.metadata.truncated).toBe(true)
-        expect(result.output).toContain("Directory too large to list")
-        expect(result.output).toContain("10001")
-      },
-    })
-  })
-
   test("truncates a huge single-line file without reading beyond cap", async () => {
     await using tmp = await tmpdir({
       init: async (dir) => {


### PR DESCRIPTION
Fixes #13669

Reduce transient memory allocations in ReadTool:
- Bounded `file.slice(0, estimate).text()` instead of `file.text()` for text reads (issue item 1)
- Binary detection reads only first 4KB via `file.slice(0, 4096).arrayBuffer()` (issue item 2)
- Async `readdir` for missing-file suggestions

Item 3 from the issue (image/PDF base64 size guard) is not addressed here — capping inline images would be a feature regression since all sizes currently work. That can be revisited separately if needed.

### Tests

```
$ cd packages/opencode && bun test test/tool/read.test.ts --timeout 30000

bun test v1.2.20 (6ad208bc)

 33 pass
 0 fail
 59 expect() calls
Ran 33 tests across 1 file. [2.06s]
```

### Memory verification

100MB text file read, peak RSS measured by polling the child process VmRSS.
The opencode launcher spawns a native binary child, so `pgrep -P` finds the actual process to sample.

```bash
STOCK=$(npm root -g)/opencode-ai/node_modules/opencode-linux-x64/bin/opencode
PATCHED=packages/opencode/dist/opencode-linux-x64/bin/opencode

# Generate 100MB fixture
(yes "line lorem ipsum dolor sit amet" || true) 2>/dev/null \
  | head -c 104857600 > /tmp/large.txt

# Measure one run (repeat for each binary)
measure() {
  OPENCODE_BIN_PATH="$1" opencode run \
    "Use the read tool on /tmp/large.txt with offset 1 and limit 2000. Reply OK." \
    >/dev/null 2>/dev/null &
  local parent=$!
  local child="" peak=0

  # Wait for native binary child to spawn
  for i in $(seq 1 40); do
    child=$(pgrep -P $parent 2>/dev/null | head -1)
    [ -n "$child" ] && break
    sleep 0.25
  done

  # Poll VmRSS every 50ms
  while kill -0 $parent 2>/dev/null; do
    local rss=$(awk '/^VmRSS/{print $2}' /proc/${child}/status 2>/dev/null)
    [ "${rss:-0}" -gt "$peak" ] && peak=$rss
    sleep 0.05
  done
  wait $parent 2>/dev/null
  echo "$peak"
}

echo "stock:   $(measure $STOCK) KB"
echo "patched: $(measure $PATCHED) KB"
rm /tmp/large.txt
```

Results (3 runs each):

```
label      run  peak_rss_kb
stock        1       590580
stock        2       602804
stock        3       600364
patched      1       394936
patched      2       387172
patched      3       386440

stock   mean=584 MB  stddev=6.3 MB
patched mean=380 MB  stddev=4.6 MB
delta   -35% peak RSS
```

Small file control (100 lines) — no regression:

```
stock-small   peak_rss = 356 MB
patched-small peak_rss = 378 MB  (within noise)
```

### Edge cases verified

| Case | Result |
|------|--------|
| Empty file (0 bytes) | Reads successfully, reports 1 blank line |
| Single 5MB line (no newlines) | Returns truncated first line |
| Offset past EOF (offset=9999 on 2-line file) | `Error: Offset 9999 is out of range` |
| Binary file (random bytes) | `Error: Cannot read binary file` |
| Unicode/multibyte (CJK, emoji, accents) | All characters preserved correctly |