### PR TITLE
fix(desktop): issue viewing new files opened from the file tree

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -272,6 +272,7 @@ export default function Page() {
     if (!path) return
     file.load(path)
     openReviewPanel()
+    tabs().setActive(next)
   }
 
   createEffect(() => {


### PR DESCRIPTION
### What does this PR do?

Fixes #13687. There is currently a bug where if a user opens a new file from the file tree, the side panel focuses whatever file was first opened (and is still open) in the file viewer. I think users would expect for new files to be immediately focused when opened.

The fix is a simple one-line addition to the `openTab` function. Now, whenever it is called, the opened tab is set as the active tab with `tabs().setActive(next)`.

## Before fix
https://github.com/user-attachments/assets/addcb5ff-edad-44db-a5ab-b0bc831cedf8

## After fix

https://github.com/user-attachments/assets/409e3fcc-a8a8-46e0-8bb9-212b6ce27c55

### How did you verify your code works?
Tested locally