### PR TITLE
fix(opencode): stop overwriting manual model selection on agent data refresh

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/context/local.tsx
+++ b/packages/opencode/src/cli/cmd/tui/context/local.tsx
@@ -1,5 +1,5 @@
 import { createStore } from "solid-js/store"
-import { batch, createEffect, createMemo } from "solid-js"
+import { batch, createMemo } from "solid-js"
 import { useSync } from "@tui/context/sync"
 import { useTheme } from "@tui/context/theme"
 import { uniqueBy } from "remeda"
@@ -380,24 +380,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         }
       },
     }
-
-    // Automatically update model when agent changes
-    createEffect(() => {
-      const value = agent.current()
-      if (value.model) {
-        if (isModelValid(value.model))
-          model.set({
-            providerID: value.model.providerID,
-            modelID: value.model.modelID,
-          })
-        else
-          toast.show({
-            variant: "warning",
-            message: `Agent ${value.name}'s configured model ${value.model.providerID}/${value.model.modelID} is not valid`,
-            duration: 3000,
-          })
-      }
-    })
 
     const result = {
       model,


### PR DESCRIPTION
## Summary

Fixes #13456

Remove the `createEffect` in `local.tsx` that enforced the agent's default model whenever agent state was refreshed by the server. This effect was redundant and caused user-selected models to silently revert to the agent's default on every server sync.

## Problem

When a user manually selects a different model in the TUI model switcher, a `createEffect` (L384-400) tracks `agent.current()` and overwrites the selection with the agent's configured default. This fires not only on agent switches but on **any** server sync that updates agent data — silently replacing the user's choice.

## Root Cause

The `createEffect` at `local.tsx:384-400` tracks the full `agent.current()` reactive object. When `sync.data.agent` is reconciled during server bootstrap or instance disposal events, the effect re-runs and calls `model.set()` with the agent's default model, overwriting whatever the user had manually selected.

## Why Removing the Effect is Safe

The `currentModel` memo (L196-205) already handles all fallback cases through its priority chain:

1. **`modelStore.model[agentName]`** — user's manual per-agent selection (set by `model.set()`)
2. **`agent.model`** — agent's configured default
3. **`fallbackModel`** — CLI `--model` arg / config file / recent list / first available provider

| Scenario | Without Effect | With Effect (current bug) |
|----------|---------------|--------------------------|
| Startup, no manual selection | Falls to agent default ✅ | Sets agent default ✅ |
| User selects Model X | Uses Model X ✅ | Uses Model X ✅ |
| **Server sync fires** | **Keeps Model X** ✅ | **Reverts to default** 🐛 |
| Switch to different agent | Falls to that agent's default ✅ | Sets that agent's default ✅ |
| Switch back to original agent | **Restores Model X** ✅ | **Loses Model X** 🐛 |

## Changes

- Remove `createEffect` that overwrote model selection on agent data refresh
- Remove unused `createEffect` import

## How to Verify

1. Launch TUI, select a non-default model via the model switcher
2. Send a message (triggers server sync)
3. Verify the selected model persists and is not reverted to the agent's default