### PR TITLE
fix: run JSON session migration for incremental upgrades

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -27,8 +27,6 @@ import { WebCommand } from "./cli/cmd/web"
 import { PrCommand } from "./cli/cmd/pr"
 import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
-import path from "path"
-import { Global } from "./global"
 import { JsonMigration } from "./storage/json-migration"
 import { Database } from "./storage/db"
 
@@ -80,8 +78,7 @@ const cli = yargs(hideBin(process.argv))
       args: process.argv.slice(2),
     })
 
-    const marker = path.join(Global.Path.data, "opencode.db")
-    if (!(await Bun.file(marker).exists())) {
+    if (await JsonMigration.shouldRun()) {
       const tty = process.stderr.isTTY
       process.stderr.write("Performing one time database migration, may take a few minutes..." + EOL)
       const width = 36
@@ -108,6 +105,7 @@ const cli = yargs(hideBin(process.argv))
             }
           },
         })
+        await JsonMigration.markComplete()
       } finally {
         if (tty) process.stderr.write("\x1b[?25h")
         else {

--- a/packages/opencode/src/storage/json-migration.ts
+++ b/packages/opencode/src/storage/json-migration.ts
@@ -10,6 +10,24 @@ import { existsSync } from "fs"
 
 export namespace JsonMigration {
   const log = Log.create({ service: "json-migration" })
+  const migrationMarkerPath = path.join(Global.Path.data, "json-sqlite-migration-complete")
+
+  export function markerPath() {
+    return migrationMarkerPath
+  }
+
+  export function storagePath() {
+    return path.join(Global.Path.data, "storage")
+  }
+
+  export async function shouldRun() {
+    if (!existsSync(storagePath())) return false
+    return !(await Bun.file(markerPath()).exists())
+  }
+
+  export async function markComplete() {
+    await Bun.write(markerPath(), "1")
+  }
 
   export type Progress = {
     current: number
@@ -22,7 +40,7 @@ export namespace JsonMigration {
   }
 
   export async function run(sqlite: Database, options?: Options) {
-    const storageDir = path.join(Global.Path.data, "storage")
+    const storageDir = storagePath()
 
     if (!existsSync(storageDir)) {
       log.info("storage directory does not exist, skipping migration")

--- a/packages/opencode/test/storage/json-migration.test.ts
+++ b/packages/opencode/test/storage/json-migration.test.ts
@@ -94,15 +94,36 @@ function createTestDb() {
 describe("JSON to SQLite migration", () => {
   let storageDir: string
   let sqlite: Database
+  const sqliteDbPath = path.join(Global.Path.data, "opencode.db")
+  const migrationMarkerPath = JsonMigration.markerPath()
 
   beforeEach(async () => {
     storageDir = await setupStorageDir()
+    await fs.rm(sqliteDbPath, { force: true })
+    await fs.rm(migrationMarkerPath, { force: true })
     sqlite = createTestDb()
   })
 
   afterEach(async () => {
     sqlite.close()
     await fs.rm(storageDir, { recursive: true, force: true })
+    await fs.rm(sqliteDbPath, { force: true })
+    await fs.rm(migrationMarkerPath, { force: true })
+  })
+
+  test("should run migration when storage exists and marker is missing", async () => {
+    await Bun.write(sqliteDbPath, "")
+    expect(await JsonMigration.shouldRun()).toBe(true)
+  })
+
+  test("should not run migration when completion marker exists", async () => {
+    await JsonMigration.markComplete()
+    expect(await JsonMigration.shouldRun()).toBe(false)
+  })
+
+  test("should not run migration when storage directory is missing", async () => {
+    await fs.rm(storageDir, { recursive: true, force: true })
+    expect(await JsonMigration.shouldRun()).toBe(false)
   })
 
   test("migrates project", async () => {


### PR DESCRIPTION
## Summary

Fixes #13654.

The JSON->SQLite migration gate currently checks for `opencode.db`. That fails for incremental upgrades because the DB can exist from earlier schema migrations, so legacy JSON sessions never get imported.

This PR switches the gate to a dedicated migration marker:
- run migration when `storage/` exists and `json-sqlite-migration-complete` is missing
- write the marker after migration completes
- keep migration logic unchanged otherwise

## Why this fixes it

Users who already have `opencode.db` but still have legacy JSON session files will now run the import once and recover old sessions.

## Testing

- `~/.bun/bin/bun test test/storage/json-migration.test.ts`
- `~/.bun/bin/bun test test/storage/json-migration.test.ts --coverage`
- Added tests for migration gating behavior:
  - storage exists + marker missing -> runs
  - marker exists -> skips
  - storage missing -> skips
