### PR TITLE
fix(desktop): focus window after update/relaunch

### DIFF
--- a/packages/desktop/src-tauri/src/windows.rs
+++ b/packages/desktop/src-tauri/src/windows.rs
@@ -22,6 +22,8 @@ impl MainWindow {
 
     pub fn create(app: &AppHandle) -> Result<Self, tauri::Error> {
         if let Some(window) = app.get_webview_window(Self::LABEL) {
+            let _ = window.set_focus();
+            let _ = window.unminimize();
             return Ok(Self(window));
         }
 
@@ -49,6 +51,9 @@ impl MainWindow {
         ));
 
         let window = window_builder.build()?;
+
+        // Ensure window is focused after creation (e.g., after update/relaunch)
+        let _ = window.set_focus();
 
         setup_window_state_listener(app, &window);
 


### PR DESCRIPTION
## Summary
When the app relaunches after an update, the window would remain hidden in the Dock instead of being focused and brought to the foreground.

## Changes
Ensures `set_focus()` is called in `MainWindow::create`:
1. After building a new window
2. When returning an existing window (early return path), also calls `unminimize()`

## Testing
- Updated the app via the built-in updater
- Confirmed the window now comes to the foreground automatically

Fixes #13700