### PR TITLE
docs: add OpenCode Plan Manager to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [opencode-plan-manager](https://github.com/yurihbm/opencode-plan-manager)                                 | Folder-per-plan architecture for cross-session planning with Zod validation                       |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds [OpenCode Plan Manager](https://github.com/yurihbm/opencode-plan-manager) to the ecosystem plugins list.

## Links
- **Repo:** https://github.com/yurihbm/opencode-plan-manager
- **NPM:** https://www.npmjs.com/package/opencode-plan-manager

## Plugin Features
- Folder-per-plan architecture (`pending/`, `in_progress/`, `done/`)
- Cross-session planning with Zod validation
- Designed for Planner-Builder pattern

Fixes #13675