### PR TITLE
refactor: extract shared Provider.filter and resolveNetworkOptions explicit flags

### DIFF
--- a/packages/opencode/src/cli/cmd/auth.ts
+++ b/packages/opencode/src/cli/cmd/auth.ts
@@ -3,6 +3,7 @@ import { cmd } from "./cmd"
 import * as prompts from "@clack/prompts"
 import { UI } from "../ui"
 import { ModelsDev } from "../../provider/models"
+import { Provider } from "../../provider/provider"
 import { map, pipe, sortBy, values } from "remeda"
 import path from "path"
 import os from "os"
@@ -254,14 +255,12 @@ export const AuthLoginCommand = cmd({
         await ModelsDev.refresh().catch(() => {})
 
         const config = await Config.get()
-
-        const disabled = new Set(config.disabled_providers ?? [])
-        const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
+        const pf = Provider.filter(config)
 
         const providers = await ModelsDev.get().then((x) => {
           const filtered: Record<string, (typeof x)[string]> = {}
           for (const [key, value] of Object.entries(x)) {
-            if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
+            if (pf.allowed(key)) {
               filtered[key] = value
             }
           }

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -137,9 +137,9 @@ export const TuiThreadCommand = cmd({
       // Check if server should be started (port or hostname explicitly set in CLI or config)
       const networkOpts = await resolveNetworkOptions(args)
       const shouldStartServer =
-        process.argv.includes("--port") ||
-        process.argv.includes("--hostname") ||
-        process.argv.includes("--mdns") ||
+        networkOpts.explicit.port ||
+        networkOpts.explicit.hostname ||
+        networkOpts.explicit.mdns ||
         networkOpts.mdns ||
         networkOpts.port !== 0 ||
         networkOpts.hostname !== "127.0.0.1"

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -1,5 +1,4 @@
 import type { Argv, InferredOptionTypes } from "yargs"
-import { Config } from "../config/config"
 
 const options = {
   port: {
@@ -36,18 +35,25 @@ export function withNetworkOptions<T>(yargs: Argv<T>) {
   return yargs.options(options)
 }
 
-export async function resolveNetworkOptions(args: NetworkOptions) {
-  const config = await Config.global()
-  const portExplicitlySet = process.argv.includes("--port")
-  const hostnameExplicitlySet = process.argv.includes("--hostname")
-  const mdnsExplicitlySet = process.argv.includes("--mdns")
-  const mdnsDomainExplicitlySet = process.argv.includes("--mdns-domain")
-  const corsExplicitlySet = process.argv.includes("--cors")
+export function resolveFrom(
+  args: NetworkOptions,
+  config: {
+    server?: { port?: number; hostname?: string; mdns?: boolean; mdnsDomain?: string; cors?: string[] }
+  } | null,
+  argv: string[],
+) {
+  const explicit = {
+    port: argv.includes("--port"),
+    hostname: argv.includes("--hostname"),
+    mdns: argv.includes("--mdns"),
+    mdnsDomain: argv.includes("--mdns-domain"),
+    cors: argv.includes("--cors"),
+  }
 
-  const mdns = mdnsExplicitlySet ? args.mdns : (config?.server?.mdns ?? args.mdns)
-  const mdnsDomain = mdnsDomainExplicitlySet ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
-  const port = portExplicitlySet ? args.port : (config?.server?.port ?? args.port)
-  const hostname = hostnameExplicitlySet
+  const mdns = explicit.mdns ? args.mdns : (config?.server?.mdns ?? args.mdns)
+  const mdnsDomain = explicit.mdnsDomain ? args["mdns-domain"] : (config?.server?.mdnsDomain ?? args["mdns-domain"])
+  const port = explicit.port ? args.port : (config?.server?.port ?? args.port)
+  const hostname = explicit.hostname
     ? args.hostname
     : mdns && !config?.server?.hostname
       ? "0.0.0.0"
@@ -56,5 +62,11 @@ export async function resolveNetworkOptions(args: NetworkOptions) {
   const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
   const cors = [...configCors, ...argsCors]
 
-  return { hostname, port, mdns, mdnsDomain, cors }
+  return { hostname, port, mdns, mdnsDomain, cors, explicit }
+}
+
+export async function resolveNetworkOptions(args: NetworkOptions) {
+  const { Config } = await import("../config/config")
+  const config = await Config.global()
+  return resolveFrom(args, config, process.argv)
 }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -690,6 +690,22 @@ export namespace Provider {
     return m
   }
 
+  export function filter(config: Config.Info): {
+    disabled: Set<string>
+    allowed(providerID: string): boolean
+  } {
+    const disabled = new Set(config.disabled_providers ?? [])
+    const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
+    return {
+      disabled,
+      allowed(providerID: string) {
+        if (enabled && !enabled.has(providerID)) return false
+        if (disabled.has(providerID)) return false
+        return true
+      },
+    }
+  }
+
   export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
     return {
       id: provider.id,
@@ -707,14 +723,7 @@ export namespace Provider {
     const modelsDev = await ModelsDev.get()
     const database = mapValues(modelsDev, fromModelsDevProvider)
 
-    const disabled = new Set(config.disabled_providers ?? [])
-    const enabled = config.enabled_providers ? new Set(config.enabled_providers) : null
-
-    function isProviderAllowed(providerID: string): boolean {
-      if (enabled && !enabled.has(providerID)) return false
-      if (disabled.has(providerID)) return false
-      return true
-    }
+    const pf = filter(config)
 
     const providers: { [providerID: string]: Info } = {}
     const languages = new Map<string, LanguageModelV2>()
@@ -840,7 +849,7 @@ export namespace Provider {
     // load env
     const env = Env.all()
     for (const [providerID, provider] of Object.entries(database)) {
-      if (disabled.has(providerID)) continue
+      if (pf.disabled.has(providerID)) continue
       const apiKey = provider.env.map((item) => env[item]).find(Boolean)
       if (!apiKey) continue
       mergeProvider(providerID, {
@@ -851,7 +860,7 @@ export namespace Provider {
 
     // load apikeys
     for (const [providerID, provider] of Object.entries(await Auth.all())) {
-      if (disabled.has(providerID)) continue
+      if (pf.disabled.has(providerID)) continue
       if (provider.type === "api") {
         mergeProvider(providerID, {
           source: "api",
@@ -863,7 +872,7 @@ export namespace Provider {
     for (const plugin of await Plugin.list()) {
       if (!plugin.auth) continue
       const providerID = plugin.auth.provider
-      if (disabled.has(providerID)) continue
+      if (pf.disabled.has(providerID)) continue
 
       // For github-copilot plugin, check if auth exists for either github-copilot or github-copilot-enterprise
       let hasAuth = false
@@ -890,7 +899,7 @@ export namespace Provider {
       // If this is github-copilot plugin, also register for github-copilot-enterprise if auth exists
       if (providerID === "github-copilot") {
         const enterpriseProviderID = "github-copilot-enterprise"
-        if (!disabled.has(enterpriseProviderID)) {
+        if (!pf.disabled.has(enterpriseProviderID)) {
           const enterpriseAuth = await Auth.get(enterpriseProviderID)
           if (enterpriseAuth) {
             const enterpriseOptions = await plugin.auth.loader(
@@ -908,7 +917,7 @@ export namespace Provider {
     }
 
     for (const [providerID, fn] of Object.entries(CUSTOM_LOADERS)) {
-      if (disabled.has(providerID)) continue
+      if (pf.disabled.has(providerID)) continue
       const data = database[providerID]
       if (!data) {
         log.error("Provider does not exist in model list " + providerID)
@@ -933,7 +942,7 @@ export namespace Provider {
     }
 
     for (const [providerID, provider] of Object.entries(providers)) {
-      if (!isProviderAllowed(providerID)) {
+      if (!pf.allowed(providerID)) {
         delete providers[providerID]
         continue
       }

--- a/packages/opencode/src/server/routes/provider.ts
+++ b/packages/opencode/src/server/routes/provider.ts
@@ -36,13 +36,12 @@ export const ProviderRoutes = lazy(() =>
       }),
       async (c) => {
         const config = await Config.get()
-        const disabled = new Set(config.disabled_providers ?? [])
-        const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
+        const pf = Provider.filter(config)
 
         const allProviders = await ModelsDev.get()
         const filteredProviders: Record<string, (typeof allProviders)[string]> = {}
         for (const [key, value] of Object.entries(allProviders)) {
-          if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) {
+          if (pf.allowed(key)) {
             filteredProviders[key] = value
           }
         }

--- a/packages/opencode/test/cli/network.test.ts
+++ b/packages/opencode/test/cli/network.test.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "bun:test"
+import { resolveFrom } from "../../src/cli/network"
+
+test("explicit flags: CLI override takes precedence", () => {
+  const opts = resolveFrom(
+    {
+      port: 8080,
+      hostname: "localhost",
+      mdns: false,
+      "mdns-domain": "opencode.local",
+      cors: [],
+    },
+    { server: { port: 3000, hostname: "0.0.0.0" } },
+    ["node", "script.ts", "--port", "8080", "--hostname", "localhost"],
+  )
+
+  expect(opts.explicit.port).toBe(true)
+  expect(opts.explicit.hostname).toBe(true)
+  expect(opts.port).toBe(8080)
+  expect(opts.hostname).toBe("localhost")
+})
+
+test("explicit flags: config fallback when CLI not set", () => {
+  const opts = resolveFrom(
+    {
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: false,
+      "mdns-domain": "opencode.local",
+      cors: [],
+    },
+    { server: { port: 3000, hostname: "0.0.0.0" } },
+    ["node", "script.ts"],
+  )
+
+  expect(opts.explicit.port).toBe(false)
+  expect(opts.explicit.hostname).toBe(false)
+  expect(opts.port).toBe(3000)
+  expect(opts.hostname).toBe("0.0.0.0")
+})
+
+test("explicit flags: defaults when no CLI or config", () => {
+  const opts = resolveFrom(
+    {
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: false,
+      "mdns-domain": "opencode.local",
+      cors: [],
+    },
+    null,
+    ["node", "script.ts"],
+  )
+
+  expect(opts.explicit.port).toBe(false)
+  expect(opts.explicit.hostname).toBe(false)
+  expect(opts.explicit.mdns).toBe(false)
+  expect(opts.explicit.mdnsDomain).toBe(false)
+  expect(opts.explicit.cors).toBe(false)
+  expect(opts.port).toBe(0)
+  expect(opts.hostname).toBe("127.0.0.1")
+  expect(opts.mdns).toBe(false)
+})
+
+test("explicit flags: mdns with hostname interaction", () => {
+  const opts = resolveFrom(
+    {
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: true,
+      "mdns-domain": "opencode.local",
+      cors: [],
+    },
+    null,
+    ["node", "script.ts", "--mdns"],
+  )
+
+  expect(opts.explicit.mdns).toBe(true)
+  expect(opts.mdns).toBe(true)
+  expect(opts.hostname).toBe("0.0.0.0")
+})
+
+test("explicit flags: cors merge from config and CLI", () => {
+  const opts = resolveFrom(
+    {
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: false,
+      "mdns-domain": "opencode.local",
+      cors: ["https://test.com"],
+    },
+    { server: { cors: ["https://example.com"] } },
+    ["node", "script.ts", "--cors", "https://test.com"],
+  )
+
+  expect(opts.explicit.cors).toBe(true)
+  expect(opts.cors).toContain("https://example.com")
+  expect(opts.cors).toContain("https://test.com")
+})
+
+test("explicit flags: mdns-domain explicit flag", () => {
+  const opts = resolveFrom(
+    {
+      port: 0,
+      hostname: "127.0.0.1",
+      mdns: false,
+      "mdns-domain": "custom.local",
+      cors: [],
+    },
+    null,
+    ["node", "script.ts", "--mdns-domain", "custom.local"],
+  )
+
+  expect(opts.explicit.mdnsDomain).toBe(true)
+  expect(opts.mdnsDomain).toBe("custom.local")
+})

--- a/packages/opencode/test/provider/filter.test.ts
+++ b/packages/opencode/test/provider/filter.test.ts
@@ -1,0 +1,74 @@
+import { test, expect } from "bun:test"
+import { Provider } from "../../src/provider/provider"
+import type { Config } from "../../src/config/config"
+
+test("Provider.filter with disabled_providers only", () => {
+  const config: Config.Info = {
+    disabled_providers: ["anthropic", "openai"],
+    enabled_providers: null,
+  } as any
+  const pf = Provider.filter(config)
+  expect(pf.disabled.has("anthropic")).toBe(true)
+  expect(pf.disabled.has("openai")).toBe(true)
+  expect(pf.disabled.has("google")).toBe(false)
+  expect(pf.allowed("anthropic")).toBe(false)
+  expect(pf.allowed("openai")).toBe(false)
+  expect(pf.allowed("google")).toBe(true)
+})
+
+test("Provider.filter with enabled_providers only", () => {
+  const config: Config.Info = {
+    disabled_providers: null,
+    enabled_providers: ["anthropic", "openai"],
+  } as any
+  const pf = Provider.filter(config)
+  expect(pf.disabled.has("anthropic")).toBe(false)
+  expect(pf.allowed("anthropic")).toBe(true)
+  expect(pf.allowed("openai")).toBe(true)
+  expect(pf.allowed("google")).toBe(false)
+})
+
+test("Provider.filter with both disabled and enabled_providers", () => {
+  const config: Config.Info = {
+    disabled_providers: ["openai"],
+    enabled_providers: ["anthropic", "openai", "google"],
+  } as any
+  const pf = Provider.filter(config)
+  expect(pf.allowed("anthropic")).toBe(true)
+  expect(pf.allowed("openai")).toBe(false)
+  expect(pf.allowed("google")).toBe(true)
+})
+
+test("Provider.filter with neither disabled nor enabled_providers", () => {
+  const config: Config.Info = {
+    disabled_providers: null,
+    enabled_providers: null,
+  } as any
+  const pf = Provider.filter(config)
+  expect(pf.disabled.size).toBe(0)
+  expect(pf.allowed("anthropic")).toBe(true)
+  expect(pf.allowed("openai")).toBe(true)
+  expect(pf.allowed("google")).toBe(true)
+})
+
+test("Provider.filter with empty enabled_providers array", () => {
+  const config: Config.Info = {
+    disabled_providers: null,
+    enabled_providers: [],
+  } as any
+  const pf = Provider.filter(config)
+  expect(pf.allowed("anthropic")).toBe(false)
+  expect(pf.allowed("openai")).toBe(false)
+  expect(pf.allowed("google")).toBe(false)
+})
+
+test("Provider.filter with overlapping disabled and enabled_providers", () => {
+  const config: Config.Info = {
+    disabled_providers: ["anthropic", "google"],
+    enabled_providers: ["anthropic", "openai", "google"],
+  } as any
+  const pf = Provider.filter(config)
+  expect(pf.allowed("anthropic")).toBe(false)
+  expect(pf.allowed("openai")).toBe(true)
+  expect(pf.allowed("google")).toBe(false)
+})


### PR DESCRIPTION
## Summary

- Extract `Provider.filter(config)` function to eliminate repeated disabled/enabled provider filtering across 3 files
- Add `explicit` flag tracking to `resolveNetworkOptions` return value, removing `process.argv.includes` duplication in `thread.ts`

## Motivation

Provider filtering logic (Set creation from `disabled_providers`/`enabled_providers` + predicate check) was duplicated in:
- `provider.ts` state() closure
- `server/routes/provider.ts` route handler
- `cli/cmd/auth.ts` auth flow

Similarly, `thread.ts` re-checked `process.argv.includes("--port")` etc. after calling `resolveNetworkOptions` because the function didn't expose which flags were explicitly set.

## Changes

### Provider.filter extraction
- Added `Provider.filter(config)` returning `{ disabled: Set, allowed(id): boolean }`
- Updated `provider.ts` state() to use `pf.allowed()` for final filter and `pf.disabled.has()` for assembly guards
- Replaced inline Set creation + filtering in `routes/provider.ts` and `auth.ts`
- Standardized `null` (was inconsistent `null` vs `undefined`) for missing `enabled_providers`

### resolveNetworkOptions explicit flags
- Extracted pure `resolveFrom(args, config, argv)` function for testability
- Added `explicit` field to return value tracking 5 CLI flags
- Updated `thread.ts` to read `networkOpts.explicit.*` instead of re-checking `process.argv`

## Tests

- `test/provider/filter.test.ts` — 6 unit tests: disabled-only, enabled-only, both, neither, empty enabled, overlap
- `test/cli/network.test.ts` — 6 unit tests: CLI override, config fallback, defaults, mdns+hostname interaction, cors merge, explicit flags

All existing tests pass (987/995; 3 pre-existing failures in session-select.test.ts unrelated to these changes).