### PR TITLE
feat(cli): add max-turns flag to run command

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -291,6 +291,10 @@ export const RunCommand = cmd({
         describe: "show thinking blocks",
         default: false,
       })
+      .option("max-turns", {
+        type: "number",
+        describe: "maximum number of agentic turns",
+      })
   },
   handler: async (args) => {
     let message = [...args.message, ...(args["--"] || [])]
@@ -439,6 +443,7 @@ export const RunCommand = cmd({
 
       async function loop() {
         const toggles = new Map<string, boolean>()
+        let turnCount = 0;
 
         for await (const event of events.stream) {
           if (
@@ -479,8 +484,14 @@ export const RunCommand = cmd({
 
             if (part.type === "step-finish") {
               if (emit("step_finish", { part })) continue
+              if(args.maxTurns) {
+                turnCount++
+                if(turnCount >= args.maxTurns) {
+                  UI.println(UI.Style.TEXT_WARNING_BOLD + "!", UI.Style.TEXT_NORMAL, `maximum turns of ${args.maxTurns} reached, stopping session`)
+                  process.exit(1)
+                }
+              }
             }
-
             if (part.type === "text" && part.time?.end) {
               if (emit("text", { part })) continue
               const text = part.text.trim()

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -349,6 +349,7 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | `--title`    |       | Title for the session (uses truncated prompt if no value provided)      |
 | `--attach`   |       | Attach to a running opencode server (e.g., http://localhost:4096)       |
 | `--port`     |       | Port for the local server (defaults to random port)                     |
+| `--max-turns`|       | Maximum number of agentic turns                                         |
 
 ---
 


### PR DESCRIPTION
### What does this PR do?

Closes #9869
Adds a `--max-turns` argument to the run command. Does not count subagents turns.

### How did you verify your code works?

**Test without `--max-turns` argument**
```
➜  bun dev -- run  "Find the secret cheat code hidden in this repo. Read one file at a time"
$ bun run --cwd packages/opencode --conditions=browser src/index.ts run "Find the secret cheat code hidden in this repo. Read one file at a time"

> build · k2p5

I'll help you find the secret cheat code. Let me start by exploring the repository structure.

→ Read .
✱ Grep "cheat|secret|hidden|code" in . · 2027 matches
→ Read README.md

$ find /var/home/federico/Misc/opencode-maxturns/packages/opencode -type f -name "*.ts" -o -name "*.js" -o -name "*.json" -o -name "*.md" | head -50
(omissis)

→ Read AGENTS.md
✱ Grep "cheat" in . · 0 matches
✱ Grep "konami|upupdowndown|easter.egg|hidden.*code" in . · 0 matches

$ grep -r -i "secret\|password\|key\|hidden\|code" /var/home/federico/Misc/opencode-maxturns/packages/opencode/src --include="*.ts" --include="*.js" | grep -v "node_modules" | head -20
(omissis)

$ find /var/home/federico/Misc/opencode-maxturns/packages/opencode -name "*secret*" -o -name "*cheat*" -o -name "*hidden*" -o -name "*easter*" 2>/dev/null
→ Read test/tool/read.test.ts
[ ... and so on agent never stops ]
```

**Test with `--max-turns 1` argument**
```
➜  bun dev -- run --max-turns 1  "Find the secret cheat code hidden in this repo. Read one file at a time"
$ bun run --cwd packages/opencode --conditions=browser src/index.ts run --max-turns "1" "Find the secret cheat code hidden in this repo. Read one file at a time"

> build · k2p5

I'll help you find the secret cheat code! Let me start by exploring the repository structure.

→ Read .
!  maximum turns of 1 reached, stopping session
error: script "dev" exited with code 1
```

**Test with `--max-turns 3` argument**
```
➜  bun dev -- run --max-turns 3  "Find the secret cheat code hidden in this repo. Read one file at a time"
$ bun run --cwd packages/opencode --conditions=browser src/index.ts run --max-turns "3" "Find the secret cheat code hidden in this repo. Read one file at a time"

> build · k2p5

I'll help you find the secret cheat code. Let me start by exploring the repository structure.

→ Read .
→ Read README.md
→ Read package.json
!  maximum turns of 3 reached, stopping session
error: script "dev" exited with code 1
```