### PR TITLE
feat(worktree): allow custom branch on create

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -777,6 +777,11 @@ export const dict = {
   "session.delete.button": "Delete session",
 
   "workspace.new": "New workspace",
+  "workspace.create.title": "Create workspace",
+  "workspace.create.branch.label": "Branch name",
+  "workspace.create.branch.placeholder": "my-feature-branch",
+  "workspace.create.branch.help": "Optional. Leave empty to use a generated name.",
+  "workspace.create.button": "Create workspace",
   "workspace.type.local": "local",
   "workspace.type.sandbox": "sandbox",
   "workspace.create.failed.title": "Failed to create workspace",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -768,6 +768,11 @@ export const dict = {
   "session.delete.button": "删除会话",
 
   "workspace.new": "新建工作区",
+  "workspace.create.title": "创建工作区",
+  "workspace.create.branch.label": "分支名称",
+  "workspace.create.branch.placeholder": "my-feature-branch",
+  "workspace.create.branch.help": "可选。留空以使用自动生成的名称。",
+  "workspace.create.button": "创建工作区",
   "workspace.type.local": "本地",
   "workspace.type.sandbox": "沙盒",
   "workspace.create.failed.title": "创建工作区失败",

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -19,6 +19,7 @@ import { Persist, persisted } from "@/utils/persist"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { decode64 } from "@/utils/base64"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
+import { TextField } from "@opencode-ai/ui/text-field"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
@@ -993,7 +994,7 @@ export default function Layout(props: ParentProps) {
         onSelect: () => {
           const project = currentProject()
           if (!project) return
-          return createWorkspace(project)
+          dialog.show(() => <DialogCreateWorkspace project={project} />)
         },
       },
       {
@@ -1311,6 +1312,50 @@ export default function Layout(props: ParentProps) {
     })
   }
 
+  function DialogCreateWorkspace(props: { project: LocalProject }) {
+    const [state, setState] = createStore({
+      branch: "",
+      loading: false,
+    })
+
+    const handleSubmit = async (e: Event) => {
+      e.preventDefault()
+      const branch = state.branch.trim() || undefined
+
+      setState("loading", true)
+      const created = await createWorkspace(props.project, branch)
+      if (!created) {
+        setState("loading", false)
+        return
+      }
+
+      dialog.close()
+    }
+
+    return (
+      <Dialog title={language.t("workspace.create.title")} fit>
+        <form onSubmit={handleSubmit} class="flex flex-col gap-4 pl-6 pr-2.5 pb-3 w-[400px]">
+          <TextField
+            autofocus
+            label={language.t("workspace.create.branch.label")}
+            placeholder={language.t("workspace.create.branch.placeholder")}
+            value={state.branch}
+            onChange={(branch) => setState("branch", branch)}
+            description={language.t("workspace.create.branch.help")}
+          />
+          <div class="flex justify-end gap-2">
+            <Button variant="ghost" size="large" onClick={() => dialog.close()} type="button">
+              {language.t("common.cancel")}
+            </Button>
+            <Button variant="primary" size="large" type="submit" disabled={state.loading}>
+              {language.t("workspace.create.button")}
+            </Button>
+          </div>
+        </form>
+      </Dialog>
+    )
+  }
+
   function DialogDeleteWorkspace(props: { root: string; directory: string }) {
     const name = createMemo(() => getFilename(props.directory))
     const [data, setData] = createStore({
@@ -1584,10 +1629,13 @@ export default function Layout(props: ParentProps) {
     setStore("activeWorkspace", undefined)
   }
 
-  const createWorkspace = async (project: LocalProject) => {
+  const createWorkspace = async (project: LocalProject, branch?: string) => {
     clearSidebarHoverState()
     const created = await globalSDK.client.worktree
-      .create({ directory: project.worktree })
+      .create({
+        directory: project.worktree,
+        worktreeCreateInput: branch ? { branch } : undefined,
+      })
       .then((x) => x.data)
       .catch((err) => {
         showToast({
@@ -1623,6 +1671,8 @@ export default function Layout(props: ParentProps) {
 
     globalSync.child(created.directory)
     navigateWithSidebarReset(`/${base64Encode(created.directory)}/session`)
+
+    return created
   }
 
   const workspaceSidebarCtx: WorkspaceSidebarContext = {
@@ -1839,7 +1889,12 @@ export default function Layout(props: ParentProps) {
                         keybind={command.keybind("workspace.new")}
                         placement="top"
                       >
-                        <Button size="large" icon="plus-small" class="w-full" onClick={() => createWorkspace(p())}>
+                        <Button
+                          size="large"
+                          icon="plus-small"
+                          class="w-full"
+                          onClick={() => dialog.show(() => <DialogCreateWorkspace project={p()} />)}
+                        >
                           {language.t("workspace.new")}
                         </Button>
                       </TooltipKeybind>

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -139,6 +139,7 @@ const WorkspaceActions = (props: {
   directory: string
   local: Accessor<boolean>
   busy: Accessor<boolean>
+  branch?: Accessor<string | undefined>
   menuOpen: Accessor<boolean>
   pendingRename: Accessor<boolean>
   setMenuOpen: (open: boolean) => void
@@ -156,86 +157,94 @@ const WorkspaceActions = (props: {
   setHoverSession: WorkspaceSidebarContext["setHoverSession"]
   clearHoverProjectSoon: WorkspaceSidebarContext["clearHoverProjectSoon"]
   navigateToNewSession: () => void
-}): JSX.Element => (
-  <div
-    class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 transition-opacity"
-    classList={{
-      "opacity-100 pointer-events-auto": props.menuOpen(),
-      "opacity-0 pointer-events-none": !props.menuOpen(),
-      "group-hover/workspace:opacity-100 group-hover/workspace:pointer-events-auto": true,
-      "group-focus-within/workspace:opacity-100 group-focus-within/workspace:pointer-events-auto": true,
-    }}
-  >
-    <DropdownMenu
-      modal={!props.sidebarHovering()}
-      open={props.menuOpen()}
-      onOpenChange={(open) => props.setMenuOpen(open)}
+}): JSX.Element => {
+  const managed = () => {
+    const branch = props.branch?.()
+    if (!branch) return false
+    return branch.startsWith("opencode/")
+  }
+
+  return (
+    <div
+      class="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5 transition-opacity"
+      classList={{
+        "opacity-100 pointer-events-auto": props.menuOpen(),
+        "opacity-0 pointer-events-none": !props.menuOpen(),
+        "group-hover/workspace:opacity-100 group-hover/workspace:pointer-events-auto": true,
+        "group-focus-within/workspace:opacity-100 group-focus-within/workspace:pointer-events-auto": true,
+      }}
     >
-      <Tooltip value={props.language.t("common.moreOptions")} placement="top">
-        <DropdownMenu.Trigger
-          as={IconButton}
-          icon="dot-grid"
-          variant="ghost"
-          class="size-6 rounded-md"
-          data-action="workspace-menu"
-          data-workspace={base64Encode(props.directory)}
-          aria-label={props.language.t("common.moreOptions")}
-        />
-      </Tooltip>
-      <DropdownMenu.Portal mount={!props.mobile ? props.nav() : undefined}>
-        <DropdownMenu.Content
-          onCloseAutoFocus={(event) => {
-            if (!props.pendingRename()) return
-            event.preventDefault()
-            props.setPendingRename(false)
-            props.openEditor(`workspace:${props.directory}`, props.workspaceValue())
-          }}
-        >
-          <DropdownMenu.Item
-            disabled={props.local()}
-            onSelect={() => {
-              props.setPendingRename(true)
-              props.setMenuOpen(false)
+      <DropdownMenu
+        modal={!props.sidebarHovering()}
+        open={props.menuOpen()}
+        onOpenChange={(open) => props.setMenuOpen(open)}
+      >
+        <Tooltip value={props.language.t("common.moreOptions")} placement="top">
+          <DropdownMenu.Trigger
+            as={IconButton}
+            icon="dot-grid"
+            variant="ghost"
+            class="size-6 rounded-md"
+            data-action="workspace-menu"
+            data-workspace={base64Encode(props.directory)}
+            aria-label={props.language.t("common.moreOptions")}
+          />
+        </Tooltip>
+        <DropdownMenu.Portal mount={!props.mobile ? props.nav() : undefined}>
+          <DropdownMenu.Content
+            onCloseAutoFocus={(event) => {
+              if (!props.pendingRename()) return
+              event.preventDefault()
+              props.setPendingRename(false)
+              props.openEditor(`workspace:${props.directory}`, props.workspaceValue())
             }}
           >
-            <DropdownMenu.ItemLabel>{props.language.t("common.rename")}</DropdownMenu.ItemLabel>
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            disabled={props.local() || props.busy()}
-            onSelect={() => props.showResetWorkspaceDialog(props.root, props.directory)}
-          >
-            <DropdownMenu.ItemLabel>{props.language.t("common.reset")}</DropdownMenu.ItemLabel>
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            disabled={props.local() || props.busy()}
-            onSelect={() => props.showDeleteWorkspaceDialog(props.root, props.directory)}
-          >
-            <DropdownMenu.ItemLabel>{props.language.t("common.delete")}</DropdownMenu.ItemLabel>
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu>
-    <Show when={!props.touch()}>
-      <Tooltip value={props.language.t("command.session.new")} placement="top">
-        <IconButton
-          icon="plus-small"
-          variant="ghost"
-          class="size-6 rounded-md opacity-0 pointer-events-none group-hover/workspace:opacity-100 group-hover/workspace:pointer-events-auto group-focus-within/workspace:opacity-100 group-focus-within/workspace:pointer-events-auto"
-          data-action="workspace-new-session"
-          data-workspace={base64Encode(props.directory)}
-          aria-label={props.language.t("command.session.new")}
-          onClick={(event) => {
-            event.preventDefault()
-            event.stopPropagation()
-            props.setHoverSession(undefined)
-            props.clearHoverProjectSoon()
-            props.navigateToNewSession()
-          }}
-        />
-      </Tooltip>
-    </Show>
-  </div>
-)
+            <DropdownMenu.Item
+              disabled={props.local()}
+              onSelect={() => {
+                props.setPendingRename(true)
+                props.setMenuOpen(false)
+              }}
+            >
+              <DropdownMenu.ItemLabel>{props.language.t("common.rename")}</DropdownMenu.ItemLabel>
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={props.local() || props.busy() || !managed()}
+              onSelect={() => props.showResetWorkspaceDialog(props.root, props.directory)}
+            >
+              <DropdownMenu.ItemLabel>{props.language.t("common.reset")}</DropdownMenu.ItemLabel>
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={props.local() || props.busy()}
+              onSelect={() => props.showDeleteWorkspaceDialog(props.root, props.directory)}
+            >
+              <DropdownMenu.ItemLabel>{props.language.t("common.delete")}</DropdownMenu.ItemLabel>
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu>
+      <Show when={!props.touch()}>
+        <Tooltip value={props.language.t("command.session.new")} placement="top">
+          <IconButton
+            icon="plus-small"
+            variant="ghost"
+            class="size-6 rounded-md opacity-0 pointer-events-none group-hover/workspace:opacity-100 group-hover/workspace:pointer-events-auto group-focus-within/workspace:opacity-100 group-focus-within/workspace:pointer-events-auto"
+            data-action="workspace-new-session"
+            data-workspace={base64Encode(props.directory)}
+            aria-label={props.language.t("command.session.new")}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              props.setHoverSession(undefined)
+              props.clearHoverProjectSoon()
+              props.navigateToNewSession()
+            }}
+          />
+        </Tooltip>
+      </Show>
+    </div>
+  )
+}
 
 const WorkspaceSessionList = (props: {
   slug: Accessor<string>
@@ -421,6 +430,7 @@ export const SortableWorkspace = (props: {
                 directory={props.directory}
                 local={local}
                 busy={busy}
+                branch={() => workspaceStore.vcs?.branch}
                 menuOpen={() => menu.open}
                 pendingRename={() => menu.pendingRename}
                 setMenuOpen={(open) => setMenu("open", open)}

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -48,6 +48,10 @@ export namespace Worktree {
   export const CreateInput = z
     .object({
       name: z.string().optional(),
+      branch: z
+        .string()
+        .optional()
+        .describe("Git branch name to use for this workspace (worktree). If omitted, OpenCode creates a new branch."),
       startCommand: z
         .string()
         .optional()
@@ -265,13 +269,20 @@ export namespace Worktree {
     return process.platform === "win32" ? normalized.toLowerCase() : normalized
   }
 
-  async function candidate(root: string, base?: string) {
+  const MANAGED_PREFIX = "opencode/"
+
+  async function candidate(root: string, base?: string, fixedBranch?: string) {
     for (const attempt of Array.from({ length: 26 }, (_, i) => i)) {
       const name = base ? (attempt === 0 ? base : `${base}-${randomName()}`) : randomName()
-      const branch = `opencode/${name}`
       const directory = path.join(root, name)
 
       if (await exists(directory)) continue
+
+      if (fixedBranch) {
+        return Info.parse({ name, branch: fixedBranch, directory })
+      }
+
+      const branch = `${MANAGED_PREFIX}${name}`
 
       const ref = `refs/heads/${branch}`
       const branchCheck = await $`git show-ref --verify --quiet ${ref}`.quiet().nothrow().cwd(Instance.worktree)
@@ -339,13 +350,77 @@ export namespace Worktree {
     const root = path.join(Global.Path.data, "worktree", Instance.project.id)
     await fs.mkdir(root, { recursive: true })
 
-    const base = input?.name ? slug(input.name) : ""
-    const info = await candidate(root, base || undefined)
+    const branch = input?.branch?.trim() || ""
+    if (branch && branch.startsWith(MANAGED_PREFIX)) {
+      throw new CreateFailedError({
+        message: `Branches under '${MANAGED_PREFIX}' are reserved for auto-generated worktrees`,
+      })
+    }
 
-    const created = await $`git worktree add --no-checkout -b ${info.branch} ${info.directory}`
-      .quiet()
-      .nothrow()
-      .cwd(Instance.worktree)
+    if (branch) {
+      const checked = await $`git check-ref-format --branch ${branch}`.quiet().nothrow().cwd(Instance.worktree)
+      if (checked.exitCode !== 0) {
+        throw new CreateFailedError({ message: `Invalid branch name: ${branch}` })
+      }
+
+      const list = await $`git worktree list --porcelain`.quiet().nothrow().cwd(Instance.worktree)
+      if (list.exitCode !== 0) {
+        throw new CreateFailedError({ message: errorText(list) || "Failed to read git worktrees" })
+      }
+
+      const used = outputText(list.stdout)
+        .split("\n")
+        .map((line) => line.trim())
+        .reduce<{ path?: string; branch?: string }[]>((acc, line) => {
+          if (!line) return acc
+          if (line.startsWith("worktree ")) {
+            acc.push({ path: line.slice("worktree ".length).trim() })
+            return acc
+          }
+          const current = acc[acc.length - 1]
+          if (!current) return acc
+          if (line.startsWith("branch ")) {
+            current.branch = line.slice("branch ".length).trim()
+          }
+          return acc
+        }, [])
+        .map((entry) => ({
+          path: entry.path,
+          branch: entry.branch?.replace(/^refs\/heads\//, ""),
+        }))
+        .find((entry) => entry.branch === branch)
+
+      if (used?.path) {
+        throw new CreateFailedError({ message: `Branch '${branch}' is already checked out at ${used.path}` })
+      }
+    }
+
+    const base = input?.name ? slug(input.name) : branch ? slug(branch) : ""
+    const info = await candidate(root, base || undefined, branch || undefined)
+
+    const ref = branch ? `refs/heads/${branch}` : ""
+    const branchExists = branch
+      ? await $`git show-ref --verify --quiet ${ref}`
+          .quiet()
+          .nothrow()
+          .cwd(Instance.worktree)
+          .then((x) => x.exitCode === 0)
+      : false
+
+    const created = await (async () => {
+      if (!branch) {
+        return $`git worktree add --no-checkout -b ${info.branch} ${info.directory}`
+          .quiet()
+          .nothrow()
+          .cwd(Instance.worktree)
+      }
+
+      if (branchExists) {
+        return $`git worktree add --no-checkout ${info.directory} ${branch}`.quiet().nothrow().cwd(Instance.worktree)
+      }
+
+      return $`git worktree add --no-checkout -b ${branch} ${info.directory}`.quiet().nothrow().cwd(Instance.worktree)
+    })()
     if (created.exitCode !== 0) {
       throw new CreateFailedError({ message: errorText(created) || "Failed to create git worktree" })
     }
@@ -495,7 +570,7 @@ export namespace Worktree {
     await clean(entry.path)
 
     const branch = entry.branch?.replace(/^refs\/heads\//, "")
-    if (branch) {
+    if (branch && branch.startsWith(MANAGED_PREFIX)) {
       const deleted = await $`git branch -D ${branch}`.quiet().nothrow().cwd(Instance.worktree)
       if (deleted.exitCode !== 0) {
         throw new RemoveFailedError({ message: errorText(deleted) || "Failed to delete worktree branch" })
@@ -547,6 +622,14 @@ export namespace Worktree {
     })()
     if (!entry?.path) {
       throw new ResetFailedError({ message: "Worktree not found" })
+    }
+
+    const branch = entry.branch?.replace(/^refs\/heads\//, "")
+    if (!branch) {
+      throw new ResetFailedError({ message: "Worktree branch not found" })
+    }
+    if (!branch.startsWith(MANAGED_PREFIX)) {
+      throw new ResetFailedError({ message: `Cannot reset a workspace on branch '${branch}'` })
     }
 
     const remoteList = await $`git remote`.quiet().nothrow().cwd(Instance.worktree)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2031,6 +2031,10 @@ export type Worktree = {
 export type WorktreeCreateInput = {
   name?: string
   /**
+   * Git branch name to use for this workspace (worktree). If omitted, OpenCode creates a new branch.
+   */
+  branch?: string
+  /**
    * Additional startup script to run after the project's start command
    */
   startCommand?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -10475,6 +10475,10 @@
           "name": {
             "type": "string"
           },
+          "branch": {
+            "description": "Git branch name to use for this workspace (worktree). If omitted, OpenCode creates a new branch.",
+            "type": "string"
+          },
           "startCommand": {
             "description": "Additional startup script to run after the project's start command",
             "type": "string"


### PR DESCRIPTION
### What does this PR do?

Fixes #13723

- Add optional `branch` to worktree create so a workspace can be created/reused on a specific local branch.
- Reserve `opencode/*` for auto-generated worktrees and keep reset/delete behavior limited to managed branches.
- Add a small "Create workspace" dialog in the app to optionally enter a branch name; disable Reset for non-managed branches.

Related: #9965

### How did you verify your code works?

- `./script/generate.ts`
- `bun turbo build --filter=opencode --filter=@opencode-ai/app --filter=@opencode-ai/sdk`
- `bun turbo typecheck` (git hook on push)