### PR TITLE
feat(opencode): add defaultModel to GET /config response

### DIFF
--- a/packages/opencode/src/server/routes/config.ts
+++ b/packages/opencode/src/server/routes/config.ts
@@ -23,14 +23,30 @@ export const ConfigRoutes = lazy(() =>
             description: "Get config info",
             content: {
               "application/json": {
-                schema: resolver(Config.Info),
+                schema: resolver(
+                  Config.Info.extend({
+                    defaultModel: z
+                      .object({
+                        providerID: z.string(),
+                        modelID: z.string(),
+                      })
+                      .optional(),
+                  }),
+                ),
               },
             },
           },
         },
       }),
       async (c) => {
-        return c.json(await Config.get())
+        const config = await Config.get()
+        let defaultModel: { providerID: string; modelID: string } | undefined
+        try {
+          defaultModel = await Provider.defaultModel()
+        } catch {
+          // No providers configured
+        }
+        return c.json({ ...config, defaultModel })
       },
     )
     .patch(


### PR DESCRIPTION
Fixes #13727

### What does this PR do?

Adds the resolved default model (`providerID` + `modelID`) to the `GET /config` endpoint response.

**Problem:** When running OpenCode in headless mode (`opencode serve`), external clients have no way to know which model will be used until the first SSE response arrives. This makes it impossible to display "Using model: X" to users before they send their first prompt.

**Solution:** Call `Provider.defaultModel()` in the config route handler and include the result as an optional `defaultModel` field. This reuses the existing model resolution logic (config -> recent models -> fallback).

**Changes:**
- Extended the response schema with optional `defaultModel: { providerID, modelID }`
- Added ~10 lines to call `Provider.defaultModel()` and merge into response
- Wrapped in try/catch to gracefully handle "no providers configured" case

### How did you verify your code works?

1. Started server with `bun dev serve`
2. Verified `curl localhost:4096/config` now includes `defaultModel`
3. Tested with no providers configured - returns config without `defaultModel` (no error)
4. Tested with multiple providers - returns the correct default per existing logic