### PR TITLE
fix(read): skip external directory prompt for global AGENTS.md

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -37,8 +37,12 @@ export const ReadTool = Tool.define("read", {
 
     const stat = Filesystem.stat(filepath)
 
+    const bypassExternal =
+      Boolean(ctx.extra?.["bypassCwdCheck"]) ||
+      (!Instance.containsPath(filepath) && (await InstructionPrompt.systemPaths()).has(filepath))
+
     await assertExternalDirectory(ctx, filepath, {
-      bypass: Boolean(ctx.extra?.["bypassCwdCheck"]),
+      bypass: bypassExternal,
       kind: stat?.isDirectory() ? "directory" : "file",
     })
 

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -158,7 +158,7 @@ describe("tool.read external_directory permission", () => {
         await Bun.write(path.join(dir, "AGENTS.md"), "# Global Instructions")
       },
     })
-    await using tmp = await tmpdir({ git: true })
+    await using tmp = await tmpdir()
 
     const originalConfigDir = process.env["OPENCODE_CONFIG_DIR"]
     process.env["OPENCODE_CONFIG_DIR"] = profileTmp.path

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -151,6 +151,43 @@ describe("tool.read external_directory permission", () => {
       },
     })
   })
+
+  test("does not ask for external_directory permission when reading global AGENTS.md", async () => {
+    await using profileTmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "AGENTS.md"), "# Global Instructions")
+      },
+    })
+    await using tmp = await tmpdir({ git: true })
+
+    const originalConfigDir = process.env["OPENCODE_CONFIG_DIR"]
+    process.env["OPENCODE_CONFIG_DIR"] = profileTmp.path
+
+    try {
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          const read = await ReadTool.init()
+          const requests: Array<Omit<PermissionNext.Request, "id" | "sessionID" | "tool">> = []
+          const testCtx = {
+            ...ctx,
+            ask: async (req: Omit<PermissionNext.Request, "id" | "sessionID" | "tool">) => {
+              requests.push(req)
+            },
+          }
+          await read.execute({ filePath: path.join(profileTmp.path, "AGENTS.md") }, testCtx)
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeUndefined()
+        },
+      })
+    } finally {
+      if (originalConfigDir === undefined) {
+        delete process.env["OPENCODE_CONFIG_DIR"]
+      } else {
+        process.env["OPENCODE_CONFIG_DIR"] = originalConfigDir
+      }
+    }
+  })
 })
 
 describe("tool.read env file permissions", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #13751 by skipping `external_directory` permission prompts when the target file is already part of `InstructionPrompt.systemPaths()` (for example `~/.config/opencode/AGENTS.md`).

This keeps regular external directory protection for unrelated paths, but avoids interrupting instruction-loading flows for OpenCode-owned/global instruction files that are already trusted as system instructions.

I also added a regression test in `test/tool/read.test.ts` to verify that reading global `AGENTS.md` does not request `external_directory` permission.

### How did you verify your code works?

- Ran focused regression test:
  - `bun test test/tool/read.test.ts -t "global AGENTS.md"` (from `packages/opencode`)
- Push hook typecheck also passed during `git push` (`bun turbo typecheck`).