### PR TITLE
fix(web): persist English on unprefixed docs routes

### DIFF
--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -18,6 +18,18 @@ function docsAlias(pathname: string) {
   }
 }
 
+function docsRouteLocale(pathname: string) {
+  if (pathname === "/docs" || pathname === "/docs/") return "root"
+
+  const hit = /^\/docs\/([^/]+)(\/.*)?$/.exec(pathname)
+  if (!hit) return null
+
+  const value = hit[1] ?? ""
+  if (!value || value.startsWith("_") || value.includes(".")) return null
+
+  return exactLocale(value) ?? "root"
+}
+
 function cookie(locale: string) {
   const value = locale === "root" ? "en" : locale
   return `oc_locale=${encodeURIComponent(value)}; Path=/; Max-Age=31536000; SameSite=Lax`
@@ -83,11 +95,16 @@ export const onRequest = defineMiddleware((ctx, next) => {
     return redirect(ctx.url, alias.path, alias.locale)
   }
 
-  if (ctx.url.pathname !== "/docs" && ctx.url.pathname !== "/docs/") return next()
-
   const locale =
     localeFromCookie(ctx.request.headers.get("cookie")) ??
     localeFromAcceptLanguage(ctx.request.headers.get("accept-language"))
+
+  if (ctx.url.pathname !== "/docs" && ctx.url.pathname !== "/docs/") {
+    if (docsRouteLocale(ctx.url.pathname) !== "root") return next()
+    if (!locale || locale === "root") return next()
+    return redirect(ctx.url, ctx.url.pathname, "root")
+  }
+
   if (!locale || locale === "root") return next()
 
   return redirect(ctx.url, `/docs/${locale}/`)


### PR DESCRIPTION
### What does this PR do?

Closes #13606.
Closes #13744.
Duplicate report: #13754 (closed).

Requests to unprefixed docs paths like `/docs/rules/` can still render localized content if a non-root locale cookie is present. This made selecting English in the footer bounce back to Korean content on the same URL. This PR adds middleware handling for unprefixed docs content routes and resets locale to `root` (`oc_locale=en`) when a non-root locale is detected, so `/docs/...` routes consistently render English while keeping locale-prefixed routes (`/docs/ko/...`) unchanged.

### How did you verify your code works?

- Reproduced current production behavior with `oc_locale=ko`: `/docs/rules/` served Korean content at an unprefixed URL.
- Verified middleware logic now treats unprefixed docs content routes as root locale and normalizes cookie state before rendering.
- Ran `lsp_diagnostics` on `packages/web/src/middleware.ts` (clean).
- `bun run astro check` could not run in this worktree because `astro` is not installed in the environment.