### PR TITLE
docs: add oc-mnemoria to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -48,6 +48,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [oc-mnemoria](https://github.com/one-bit/oc-mnemoria)                                                     | Persistent shared memory (hive mind) across sessions, powered by the mnemoria Rust engine         |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [oc-mnemoria](https://github.com/one-bit/oc-mnemoria) to the Plugins table on the ecosystem page.

## What is oc-mnemoria?

**oc-mnemoria** is a persistent shared memory plugin that gives every OpenCode agent a "hive mind" — a single memory store that survives across sessions.

### Why it matters

Every time you start a new OpenCode session, your agents start from scratch. oc-mnemoria fixes this: agents remember decisions, discoveries, bugs, patterns, and solutions from previous sessions — automatically.

### Key highlights

- **Shared hive mind** — All agents (plan, build, ask, review) read and write to one memory store, so the build agent sees what the plan agent decided, and the review agent recalls bugs the build agent fixed
- **Per-agent tagging** — Every memory entry is tagged with the agent that created it, so you can filter by agent or view the full shared timeline
- **Selective forgetting** — Agents can mark outdated memories as forgotten, and compact the store to reclaim space — keeping the memory accurate over time
- **Git-friendly** — The entire memory is a single append-only binary file. Commit it alongside your code to track memory history in version control, or `.gitignore` it — your choice
- **High-performance Rust engine** — Powered by [mnemoria](https://github.com/one-bit/mnemoria), a Rust crate with sub-millisecond hybrid search (BM25 + semantic via Reciprocal Rank Fusion), CRC32 checksum chains, and corruption recovery
- **Automatic context injection** — At session start, the plugin injects relevant memories and past user intents into the system prompt, so agents have context before you say a word
- **Intent capture** — Automatically extracts and stores user intents from chat messages, deduplicating within sessions
- **100% local** — No network calls, no cloud dependencies. Everything stays on your filesystem

### What's included

- 7 agent tools: `remember`, `search_memory`, `ask_memory`, `memory_stats`, `timeline`, `forget`, `compact`
- 6 slash commands: `/mn-ask`, `/mn-search`, `/mn-stats`, `/mn-recent`, `/mn-timeline`, `/mn-forget`, `/mn-compact`
- Full CLI access via the `mnemoria` binary for inspection and management outside OpenCode

### Links

- npm: https://www.npmjs.com/package/oc-mnemoria
- GitHub: https://github.com/one-bit/oc-mnemoria
- Rust engine: https://github.com/one-bit/mnemoria | https://crates.io/crates/mnemoria
- MIT licensed