### PR TITLE
fix(tui): make use of server dir path for file references in prompts

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/autocomplete.tsx
@@ -247,7 +247,8 @@ export function Autocomplete(props: {
         const width = props.anchor().width - 4
         options.push(
           ...sortedFiles.map((item): AutocompleteOption => {
-            const fullPath = `${process.cwd()}/${item}`
+            const baseDir = (sync.data.path.directory || process.cwd()).replace(/\/+$/, "")
+            const fullPath = `${baseDir}/${item}`
             const urlObj = pathToFileURL(fullPath)
             let filename = item
             if (lineRange && !item.endsWith("/")) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes #13732 

It lets the TUI pass correct file references using the dir of the attached remote instance rather than just the current `process.cwd`

### How did you verify your code works?

Ran a remote server using https://gitterm.dev and attached to it on my local and was able to properly reference files for the model.

Also ran tests on a normal Opencode instance to make sure this update doesnt cause a regression in normal instances

<img width="1128" height="733" alt="Screenshot 2026-02-16 at 01 58 07" src="https://github.com/user-attachments/assets/6f1607d6-da38-477e-9eef-c952cd849afb" />
