### PR TITLE
fix: --prompt submitting the first message before recent model has been loaded

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/home.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/home.tsx
@@ -1,5 +1,5 @@
 import { Prompt, type PromptRef } from "@tui/component/prompt"
-import { createMemo, Match, onMount, Show, Switch } from "solid-js"
+import { createEffect, createMemo, Match, Show, Switch } from "solid-js"
 import { useTheme } from "@tui/context/theme"
 import { useKeybind } from "@tui/context/keybind"
 import { Logo } from "../component/logo"
@@ -14,6 +14,7 @@ import { usePromptRef } from "../context/prompt"
 import { Installation } from "@/installation"
 import { useKV } from "../context/kv"
 import { useCommandDialog } from "../component/dialog-command"
+import { useLocal } from "../context/local"
 
 // TODO: what is the best way to do this?
 let once = false
@@ -25,6 +26,7 @@ export function Home() {
   const route = useRouteData("home")
   const promptRef = usePromptRef()
   const command = useCommandDialog()
+  const local = useLocal()
   const mcp = createMemo(() => Object.keys(sync.data.mcp).length > 0)
   const mcpError = createMemo(() => {
     return Object.values(sync.data.mcp).some((x) => x.status === "failed")
@@ -76,7 +78,8 @@ export function Home() {
 
   let prompt: PromptRef
   const args = useArgs()
-  onMount(() => {
+  createEffect(() => {
+    if (!local.model.ready) return
     if (once) return
     if (route.initialPrompt) {
       prompt.set(route.initialPrompt)


### PR DESCRIPTION
### What does this PR do?

Fixes #8551 

#### Issue
Running opencode normally starts the session with the most recent model.
Running opencode with `--prompt` starts the session with a random(ish) fallback model. Im my case Gemini3.

This happens because the prompt arg is submitted as a message before the model is ready and has loaded the recent model.
The `onMount` already uses `once` to make it idempotent. Adding an additional check that the model is "ready" (has loaded recent models, etc.) ensures that the prompt is submitted with the most recent model like when opencode is opened normally.

### How did you verify your code works?

Using the latest commit from the dev branch:

1. Run `opencode` and pick a model. Send a "hello" message
2. Run `opencode --prompt hello`. The model is different than the one selected in step 1
3. Run `bun dev` and verify that the model from step 1 is selected
4. Run `bun dev --prompt hello` The model is different than step 1 and the same as step 2

Using this fix branch:

1. Run `bun dev` and verify that the model from step 1 is selected
2. Run `bun dev --prompt hello` The model from step 1 should be selected