### PR TITLE
fix(app): show latest sessions in sidebar

### DIFF
--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -29,7 +29,7 @@ describe("pickDirectoriesToEvict", () => {
 
 describe("loadRootSessionsWithFallback", () => {
   test("uses limited roots query when supported", async () => {
-    const calls: Array<{ directory: string; roots: true; limit?: number }> = []
+    const calls: Array<{ directory: string; limit?: number }> = []
     let fallback = 0
 
     const result = await loadRootSessionsWithFallback({
@@ -46,12 +46,12 @@ describe("loadRootSessionsWithFallback", () => {
 
     expect(result.data).toEqual([])
     expect(result.limited).toBe(true)
-    expect(calls).toEqual([{ directory: "dir", roots: true, limit: 10 }])
+    expect(calls).toEqual([{ directory: "dir", limit: 10 }])
     expect(fallback).toBe(0)
   })
 
   test("falls back to full roots query on limited-query failure", async () => {
-    const calls: Array<{ directory: string; roots: true; limit?: number }> = []
+    const calls: Array<{ directory: string; limit?: number }> = []
     let fallback = 0
 
     const result = await loadRootSessionsWithFallback({
@@ -70,8 +70,8 @@ describe("loadRootSessionsWithFallback", () => {
     expect(result.data).toEqual([])
     expect(result.limited).toBe(false)
     expect(calls).toEqual([
-      { directory: "dir", roots: true, limit: 25 },
-      { directory: "dir", roots: true },
+      { directory: "dir", limit: 25 },
+      { directory: "dir" },
     ])
     expect(fallback).toBe(1)
   })

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -196,10 +196,8 @@ function createGlobalSync() {
         const nonArchived = (x.data ?? [])
           .filter((s) => !!s?.id)
           .filter((s) => !s.time?.archived)
-          .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
         const limit = store.limit
-        const childSessions = store.session.filter((s) => !!s.parentID)
-        const sessions = trimSessions([...nonArchived, ...childSessions], { limit, permission: store.permission })
+        const sessions = trimSessions([...nonArchived, ...store.session], { limit, permission: store.permission })
         setStore(
           "sessionTotal",
           estimateRootSessionTotal({ count: nonArchived.length, limit: x.limit, limited: x.limited }),

--- a/packages/app/src/context/global-sync/event-reducer.ts
+++ b/packages/app/src/context/global-sync/event-reducer.ts
@@ -95,7 +95,7 @@ export function applyDirectoryEvent(input: {
       next.splice(result.index, 0, info)
       const trimmed = trimSessions(next, { limit: input.store.limit, permission: input.store.permission })
       input.setStore("session", reconcile(trimmed, { key: "id" }))
-      if (!info.parentID) input.setStore("sessionTotal", (value) => value + 1)
+      input.setStore("sessionTotal", (value) => value + 1)
       break
     }
     case "session.updated": {
@@ -111,7 +111,6 @@ export function applyDirectoryEvent(input: {
           )
         }
         cleanupSessionCaches(input.store, input.setStore, info.id)
-        if (info.parentID) break
         input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
         break
       }
@@ -137,7 +136,6 @@ export function applyDirectoryEvent(input: {
         )
       }
       cleanupSessionCaches(input.store, input.setStore, info.id)
-      if (info.parentID) break
       input.setStore("sessionTotal", (value) => Math.max(0, value - 1))
       break
     }

--- a/packages/app/src/context/global-sync/session-load.ts
+++ b/packages/app/src/context/global-sync/session-load.ts
@@ -2,7 +2,7 @@ import type { RootLoadArgs } from "./types"
 
 export async function loadRootSessionsWithFallback(input: RootLoadArgs) {
   try {
-    const result = await input.list({ directory: input.directory, roots: true, limit: input.limit })
+    const result = await input.list({ directory: input.directory, limit: input.limit })
     return {
       data: result.data,
       limit: input.limit,
@@ -10,7 +10,7 @@ export async function loadRootSessionsWithFallback(input: RootLoadArgs) {
     } as const
   } catch {
     input.onFallback()
-    const result = await input.list({ directory: input.directory, roots: true })
+    const result = await input.list({ directory: input.directory })
     return {
       data: result.data,
       limit: input.limit,

--- a/packages/app/src/context/global-sync/session-trim.test.ts
+++ b/packages/app/src/context/global-sync/session-trim.test.ts
@@ -14,46 +14,49 @@ const session = (input: { id: string; parentID?: string; created: number; update
   }) as Session
 
 describe("trimSessions", () => {
-  test("keeps base roots and recent roots beyond the limit", () => {
-    const now = 1_000_000
+  test("keeps the most recently updated sessions regardless of parent", () => {
+    const now = 50_000_000
     const list = [
-      session({ id: "a", created: now - 100_000 }),
-      session({ id: "b", created: now - 90_000 }),
-      session({ id: "c", created: now - 80_000 }),
-      session({ id: "d", created: now - 70_000, updated: now - 1_000 }),
-      session({ id: "e", created: now - 60_000, archived: now - 10 }),
+      session({ id: "a-root-old", created: now - 30_000_000 }),
+      session({ id: "b-child-new", parentID: "a-root-old", created: now - 1_000 }),
+      session({ id: "c-root-new", created: now - 2_000 }),
+      session({ id: "d-child-old", parentID: "a-root-old", created: now - 20_000_000 }),
+      session({ id: "e-archived", created: now - 500, archived: now - 10 }),
     ]
 
     const result = trimSessions(list, { limit: 2, permission: {}, now })
-    expect(result.map((x) => x.id)).toEqual(["a", "b", "c", "d"])
+    expect(result.map((x) => x.id)).toEqual(["b-child-new", "c-root-new"])
   })
 
-  test("keeps children when root is kept, permission exists, or child is recent", () => {
-    const now = 1_000_000
+  test("keeps permission-request sessions even when they are outside the recency limit", () => {
+    const now = 50_000_000
     const list = [
-      session({ id: "root-1", created: now - 1000 }),
-      session({ id: "root-2", created: now - 2000 }),
-      session({ id: "z-root", created: now - 30_000_000 }),
-      session({ id: "child-kept-by-root", parentID: "root-1", created: now - 20_000_000 }),
-      session({ id: "child-kept-by-permission", parentID: "z-root", created: now - 20_000_000 }),
-      session({ id: "child-kept-by-recency", parentID: "z-root", created: now - 500 }),
-      session({ id: "child-trimmed", parentID: "z-root", created: now - 20_000_000 }),
+      session({ id: "a-new", created: now - 1_000 }),
+      session({ id: "b-new", created: now - 2_000 }),
+      session({ id: "c-old-permission", created: now - 25_000_000 }),
+      session({ id: "d-old-trimmed", created: now - 26_000_000 }),
     ]
 
     const result = trimSessions(list, {
       limit: 2,
       permission: {
-        "child-kept-by-permission": [{ id: "perm-1" } as PermissionRequest],
+        "c-old-permission": [{ id: "perm-1" } as PermissionRequest],
       },
       now,
     })
 
-    expect(result.map((x) => x.id)).toEqual([
-      "child-kept-by-permission",
-      "child-kept-by-recency",
-      "child-kept-by-root",
-      "root-1",
-      "root-2",
-    ])
+    expect(result.map((x) => x.id)).toEqual(["a-new", "b-new", "c-old-permission"])
+  })
+
+  test("deduplicates sessions by id using the newest copy", () => {
+    const now = 50_000_000
+    const list = [
+      session({ id: "a", created: now - 30_000_000 }),
+      session({ id: "a", created: now - 30_000_000, updated: now - 500 }),
+      session({ id: "b", created: now - 1_000 }),
+    ]
+
+    const result = trimSessions(list, { limit: 2, permission: {}, now })
+    expect(result.map((x) => x.id)).toEqual(["a", "b"])
   })
 })

--- a/packages/app/src/context/global-sync/session-trim.ts
+++ b/packages/app/src/context/global-sync/session-trim.ts
@@ -36,21 +36,36 @@ export function trimSessions(
 ) {
   const limit = Math.max(0, options.limit)
   const cutoff = (options.now ?? Date.now()) - SESSION_RECENT_WINDOW
-  const all = input
-    .filter((s) => !!s?.id)
-    .filter((s) => !s.time?.archived)
-    .sort((a, b) => cmp(a.id, b.id))
-  const roots = all.filter((s) => !s.parentID)
-  const children = all.filter((s) => !!s.parentID)
-  const base = roots.slice(0, limit)
-  const recent = takeRecentSessions(roots.slice(limit), SESSION_RECENT_LIMIT, cutoff)
-  const keepRoots = [...base, ...recent]
-  const keepRootIds = new Set(keepRoots.map((s) => s.id))
-  const keepChildren = children.filter((s) => {
-    if (s.parentID && keepRootIds.has(s.parentID)) return true
-    const perms = options.permission[s.id] ?? []
-    if (perms.length > 0) return true
-    return sessionUpdatedAt(s) > cutoff
+  const deduped = new Map<string, Session>()
+
+  for (const session of input) {
+    if (!session?.id) continue
+    if (session.time?.archived) continue
+    const existing = deduped.get(session.id)
+    if (!existing) {
+      deduped.set(session.id, session)
+      continue
+    }
+    if (compareSessionRecent(session, existing) < 0) {
+      deduped.set(session.id, session)
+    }
+  }
+
+  const sortedByRecent = [...deduped.values()].sort(compareSessionRecent)
+  const base = sortedByRecent.slice(0, limit)
+  const recent = takeRecentSessions(sortedByRecent.slice(limit), SESSION_RECENT_LIMIT, cutoff)
+  const keep = [...base, ...recent]
+  const keepIds = new Set(keep.map((session) => session.id))
+  const keepPermission = sortedByRecent.filter((session) => {
+    if (keepIds.has(session.id)) return false
+    const perms = options.permission[session.id] ?? []
+    return perms.length > 0
   })
-  return [...keepRoots, ...keepChildren].sort((a, b) => cmp(a.id, b.id))
+
+  const merged = new Map<string, Session>()
+  for (const session of [...keep, ...keepPermission]) {
+    merged.set(session.id, session)
+  }
+
+  return [...merged.values()].sort((a, b) => cmp(a.id, b.id))
 }

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -118,7 +118,7 @@ export type DisposeCheck = {
 export type RootLoadArgs = {
   directory: string
   limit: number
-  list: (query: { directory: string; roots: true; limit?: number }) => Promise<{ data?: Session[] }>
+  list: (query: { directory: string; limit?: number }) => Promise<{ data?: Session[] }>
   onFallback: () => void
 }
 

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -23,7 +23,7 @@ export function sortSessions(now: number) {
 }
 
 export const isRootVisibleSession = (session: Session, directory: string) =>
-  workspaceKey(session.directory) === workspaceKey(directory) && !session.parentID && !session.time?.archived
+  workspaceKey(session.directory) === workspaceKey(directory) && !session.time?.archived
 
 export const sortedRootSessions = (store: { session: Session[]; path: { directory: string } }, now: number) =>
   store.session.filter((session) => isRootVisibleSession(session, store.path.directory)).sort(sortSessions(now))


### PR DESCRIPTION
## Summary
- Load sidebar sessions from `session.list` without forcing `roots=true`, so recently updated child sessions are eligible for display.
- Update session trimming to select sessions by recency (with dedupe + permission retention) while still storing by `id` for binary-search event reducers.
- Include non-root sessions in sidebar visibility filtering and keep `sessionTotal` in sync for create/archive/delete events.
- Refresh unit tests for the new query shape and recency-based trimming behavior.

## Verification
- Could not run app tests in this environment: `bun` is not installed (`command not found`).
- Could not run typecheck in this environment: `tsgo` is not installed (`command not found`).