### PR TITLE
feat(opencode): add LINE Messaging API integration

### DIFF
--- a/packages/line/.env.example
+++ b/packages/line/.env.example
@@ -1,0 +1,3 @@
+LINE_CHANNEL_ACCESS_TOKEN=your-channel-access-token
+LINE_CHANNEL_SECRET=your-channel-secret
+PORT=3000

--- a/packages/line/.gitignore
+++ b/packages/line/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/packages/line/README.md
+++ b/packages/line/README.md
@@ -1,0 +1,44 @@
+# @opencode-ai/line
+
+LINE Messaging API integration for OpenCode. Send coding prompts to OpenCode through LINE chat.
+
+## Setup
+
+1. Create a LINE Messaging API channel at https://developers.line.biz/console/
+2. In the channel settings:
+   - Enable "Use webhook"
+   - Issue a "Channel access token (long-lived)"
+   - Note the "Channel secret"
+3. Set environment variables in `.env`:
+   - `LINE_CHANNEL_ACCESS_TOKEN` - Channel access token
+   - `LINE_CHANNEL_SECRET` - Channel secret
+   - `PORT` - Webhook port (default: 3000)
+
+## Usage
+
+```bash
+# Copy and edit env file
+cp .env.example .env
+
+# Start the bot
+bun dev
+```
+
+The bot starts an OpenCode server internally and listens for LINE webhook events.
+
+### Webhook URL
+
+Set the webhook URL in LINE Developer Console:
+- Local development: Use ngrok (`ngrok http 3000`) and set `https://xxx.ngrok.io/webhook`
+- Production: `https://your-domain.com/webhook`
+
+### Commands
+
+- Send any text message to start coding
+- `/new` - Start a new coding session
+- `/abort` - Cancel the current prompt
+- `/sessions` - Show active session info
+
+### How it works
+
+Each LINE user gets their own OpenCode session. Messages are forwarded to the AI coding agent, and responses are sent back through LINE. Tool updates (file edits, bash commands) are sent as real-time notifications.

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -12,6 +12,7 @@
     "@line/bot-sdk": "^9.6.0"
   },
   "devDependencies": {
+    "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "@typescript/native-preview": "catalog:"

--- a/packages/line/package.json
+++ b/packages/line/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@opencode-ai/line",
+  "version": "1.0.0",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@opencode-ai/sdk": "workspace:*",
+    "@line/bot-sdk": "^9.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  }
+}

--- a/packages/line/src/index.ts
+++ b/packages/line/src/index.ts
@@ -226,14 +226,12 @@ async function handleTextMessage(
 
   const response = result.data
 
-  // Build response text
+  // Build response text from parts
   const responseText =
-    response.info?.content ||
     response.parts
-      ?.filter((p: any) => p.type === "text")
-      .map((p: any) => p.text)
-      .join("\n") ||
-    "I received your message but didn't have a response."
+      ?.filter((p) => p.type === "text")
+      .map((p) => (p as { type: "text"; text: string }).text)
+      .join("\n") || "I received your message but didn't have a response."
 
   console.log(`Response length: ${responseText.length} chars`)
   await sendMessage(userId, responseText)

--- a/packages/line/src/index.ts
+++ b/packages/line/src/index.ts
@@ -1,0 +1,294 @@
+import { createOpencode, type ToolPart } from "@opencode-ai/sdk"
+import { messagingApi } from "@line/bot-sdk"
+import { createHmac } from "node:crypto"
+
+// --- Config ---
+const channelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN
+const channelSecret = process.env.LINE_CHANNEL_SECRET
+const port = Number(process.env.PORT ?? 3000)
+
+if (!channelAccessToken || !channelSecret) {
+  console.error("Missing LINE_CHANNEL_ACCESS_TOKEN or LINE_CHANNEL_SECRET")
+  process.exit(1)
+}
+
+console.log("LINE bot configuration:")
+console.log("- Channel access token present:", !!channelAccessToken)
+console.log("- Channel secret present:", !!channelSecret)
+console.log("- Webhook port:", port)
+
+// --- LINE Client ---
+const lineClient = new messagingApi.MessagingApiClient({ channelAccessToken })
+
+// --- Start OpenCode server ---
+console.log("Starting opencode server...")
+const opencode = await createOpencode({ port: 0 })
+console.log("Opencode server ready")
+
+// --- Session Management ---
+// LINE userId → { sessionId, userId }
+const sessions = new Map<
+  string,
+  { sessionId: string; userId: string }
+>()
+
+// --- Subscribe to OpenCode events (tool updates) ---
+;(async () => {
+  const events = await opencode.client.event.subscribe()
+  for await (const event of events.stream) {
+    if (event.type === "message.part.updated") {
+      const part = event.properties.part
+      if (part.type === "tool") {
+        for (const [userId, session] of sessions) {
+          if (session.sessionId === part.sessionID) {
+            handleToolUpdate(part, userId)
+            break
+          }
+        }
+      }
+    }
+  }
+})()
+
+async function handleToolUpdate(part: ToolPart, userId: string) {
+  if (part.state.status !== "completed") return
+  const toolMessage = `*${part.tool}* - ${part.state.title}`
+  await lineClient
+    .pushMessage({
+      to: userId,
+      messages: [{ type: "text", text: toolMessage }],
+    })
+    .catch(() => {})
+}
+
+// --- LINE Signature Validation ---
+function validateSignature(body: string, signature: string): boolean {
+  const hash = createHmac("SHA256", channelSecret!)
+    .update(body)
+    .digest("base64")
+  return hash === signature
+}
+
+// --- Chunk long messages for LINE (max 5000 chars) ---
+const LINE_MAX_TEXT = 5000
+
+function chunkText(text: string, limit: number = LINE_MAX_TEXT): string[] {
+  if (text.length <= limit) return [text]
+
+  const chunks: string[] = []
+  let remaining = text
+
+  while (remaining.length > 0) {
+    if (remaining.length <= limit) {
+      chunks.push(remaining)
+      break
+    }
+
+    let breakAt = remaining.lastIndexOf("\n", limit)
+    if (breakAt < limit * 0.3) {
+      breakAt = remaining.lastIndexOf(" ", limit)
+    }
+    if (breakAt < limit * 0.3) {
+      breakAt = limit
+    }
+
+    const chunk = remaining.slice(0, breakAt)
+    remaining = remaining.slice(breakAt).trimStart()
+
+    // Handle unclosed code blocks
+    const backtickCount = (chunk.match(/```/g) || []).length
+    if (backtickCount % 2 !== 0) {
+      chunks.push(chunk + "\n```")
+      remaining = "```\n" + remaining
+    } else {
+      chunks.push(chunk)
+    }
+  }
+
+  return chunks
+}
+
+// --- Send long message via Push API ---
+async function sendMessage(userId: string, text: string): Promise<void> {
+  const chunks = chunkText(text)
+  for (const chunk of chunks) {
+    await lineClient
+      .pushMessage({
+        to: userId,
+        messages: [{ type: "text", text: chunk }],
+      })
+      .catch((err: any) => {
+        console.error("Failed to send LINE message:", err?.message ?? err)
+      })
+  }
+}
+
+// --- Handle incoming LINE message ---
+async function handleTextMessage(
+  userId: string,
+  text: string,
+  replyToken: string,
+): Promise<void> {
+  console.log(`Message from ${userId}: ${text}`)
+
+  // Special commands
+  if (text.toLowerCase() === "/new") {
+    sessions.delete(userId)
+    await lineClient.replyMessage({
+      replyToken,
+      messages: [
+        {
+          type: "text",
+          text: "Session cleared. Next message starts a new session.",
+        },
+      ],
+    })
+    return
+  }
+
+  if (text.toLowerCase() === "/abort") {
+    const session = sessions.get(userId)
+    if (session) {
+      await opencode.client.session
+        .abort({ path: { id: session.sessionId } })
+        .catch(() => {})
+      await lineClient.replyMessage({
+        replyToken,
+        messages: [{ type: "text", text: "Prompt cancelled." }],
+      })
+    } else {
+      await lineClient.replyMessage({
+        replyToken,
+        messages: [{ type: "text", text: "No active session." }],
+      })
+    }
+    return
+  }
+
+  if (text.toLowerCase() === "/sessions") {
+    const session = sessions.get(userId)
+    const msg = session
+      ? `Active session: ${session.sessionId}`
+      : "No active session. Send a message to start one."
+    await lineClient.replyMessage({
+      replyToken,
+      messages: [{ type: "text", text: msg }],
+    })
+    return
+  }
+
+  // Get or create OpenCode session
+  let session = sessions.get(userId)
+
+  if (!session) {
+    console.log("Creating new opencode session...")
+    const createResult = await opencode.client.session.create({
+      body: { title: `LINE: ${userId.slice(-8)}` },
+    })
+
+    if (createResult.error) {
+      console.error("Failed to create session:", createResult.error)
+      await sendMessage(
+        userId,
+        "Failed to create coding session. Please try again.",
+      )
+      return
+    }
+
+    console.log("Created opencode session:", createResult.data.id)
+    session = { sessionId: createResult.data.id, userId }
+    sessions.set(userId, session)
+  }
+
+  // Send prompt to OpenCode
+  console.log("Sending to opencode:", text)
+  const result = await opencode.client.session.prompt({
+    path: { id: session.sessionId },
+    body: { parts: [{ type: "text", text }] },
+  })
+
+  if (result.error) {
+    console.error("Failed to send message:", result.error)
+
+    // If session not found, clear and retry
+    const errorStr = JSON.stringify(result.error)
+    if (errorStr.includes("404") || errorStr.includes("not found")) {
+      sessions.delete(userId)
+      await sendMessage(userId, "Session expired. Please send your message again.")
+    } else {
+      await sendMessage(
+        userId,
+        "Sorry, I had trouble processing your message. Please try again.",
+      )
+    }
+    return
+  }
+
+  const response = result.data
+
+  // Build response text
+  const responseText =
+    response.info?.content ||
+    response.parts
+      ?.filter((p: any) => p.type === "text")
+      .map((p: any) => p.text)
+      .join("\n") ||
+    "I received your message but didn't have a response."
+
+  console.log(`Response length: ${responseText.length} chars`)
+  await sendMessage(userId, responseText)
+}
+
+// --- HTTP Server for LINE Webhook ---
+Bun.serve({
+  port,
+  async fetch(req) {
+    const url = new URL(req.url)
+
+    // Health check
+    if (req.method === "GET" && url.pathname === "/") {
+      return new Response("OpenCode LINE Bot is running")
+    }
+
+    // LINE Webhook
+    if (req.method === "POST" && url.pathname === "/webhook") {
+      const body = await req.text()
+      const signature = req.headers.get("x-line-signature") || ""
+
+      if (!validateSignature(body, signature)) {
+        console.error("Invalid LINE signature")
+        return new Response("Invalid signature", { status: 403 })
+      }
+
+      let parsed: { events: any[] }
+      try {
+        parsed = JSON.parse(body)
+      } catch {
+        return new Response("Invalid JSON", { status: 400 })
+      }
+
+      // Process events async (return 200 immediately so LINE doesn't retry)
+      for (const event of parsed.events) {
+        if (
+          event.type === "message" &&
+          event.message?.type === "text" &&
+          event.source?.userId
+        ) {
+          handleTextMessage(
+            event.source.userId,
+            event.message.text,
+            event.replyToken,
+          ).catch((err) => {
+            console.error("Error handling message:", err)
+          })
+        }
+      }
+
+      return new Response("OK")
+    }
+
+    return new Response("Not Found", { status: 404 })
+  },
+})
+
+console.log(`LINE bot webhook listening on http://localhost:${port}/webhook`)

--- a/packages/line/tsconfig.json
+++ b/packages/line/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "noUncheckedIndexedAccess": false
+  }
+}


### PR DESCRIPTION
Closes #13801

## Summary

- Add `packages/line/` - LINE Messaging API integration for OpenCode, following the same pattern as the existing Slack integration (`packages/slack/`)
- Each LINE user gets their own OpenCode session via `createOpencode()` from `@opencode-ai/sdk`
- Messages are forwarded to the AI coding agent, and responses are sent back through LINE
- Real-time tool update notifications via event subscription
- Handles LINE's 5000 char message limit with smart chunking (respects code blocks)

## How it works

```
User (LINE app)
  ↕  LINE Messaging API webhook
packages/line/ (Bun HTTP server)
  ↕  @opencode-ai/sdk
OpenCode Server (auto-started)
  ↕
Project Filesystem
```

## Commands

- Send any text message → forwarded to OpenCode as a coding prompt
- `/new` - Start a new coding session
- `/abort` - Cancel the current prompt
- `/sessions` - Show active session info

## Files

| File | Description |
|------|-------------|
| `packages/line/package.json` | Dependencies: `@opencode-ai/sdk`, `@line/bot-sdk` |
| `packages/line/src/index.ts` | Main entry - LINE webhook + OpenCode bridge (~290 lines) |
| `packages/line/.env.example` | Required env vars |
| `packages/line/tsconfig.json` | TypeScript config (same as Slack) |
| `packages/line/README.md` | Setup instructions |

## Test plan

- [ ] Create LINE Messaging API channel at https://developers.line.biz
- [ ] Set `.env` with LINE credentials
- [ ] Run `cd packages/line && bun dev`
- [ ] Expose webhook via ngrok or cloudflare tunnel
- [ ] Send text message in LINE → verify OpenCode processes and responds
- [ ] Send `/new` → verify new session created
- [ ] Send `/abort` → verify prompt cancelled
- [ ] Send long prompt → verify chunked response

> Tested locally with Docker setup and real LINE channel - working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)