### PR TITLE
fix(bedrock): route Kimi/Moonshot models via bedrock-mantle OpenAI-compatible endpoint

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -286,7 +286,7 @@ export namespace Provider {
                     accessKeyId: credentials.accessKeyId,
                     secretAccessKey: credentials.secretAccessKey,
                     sessionToken: credentials.sessionToken,
-                    service: "bedrock",
+                    service: "bedrock-mantle",
                   })
                   const signed = await signer.sign()
                   return fetch(input, {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -263,6 +263,38 @@ export namespace Provider {
               }
               if (awsBearerToken) {
                 mantleOptions.apiKey = awsBearerToken
+              } else if (providerOptions.credentialProvider) {
+                // SigV4 signing for IAM credentials — same pattern as @ai-sdk/amazon-bedrock
+                const { AwsV4Signer } = await import("aws4fetch")
+                const credentialProvider = providerOptions.credentialProvider
+                mantleOptions.fetch = async (input: any, init?: any) => {
+                  const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url
+                  const body = typeof init?.body === "string" ? init.body : JSON.stringify(init?.body)
+                  const headers = init?.headers ?? {}
+                  const headerEntries = headers instanceof Headers
+                    ? Array.from(headers.entries())
+                    : Array.isArray(headers)
+                      ? headers
+                      : Object.entries(headers)
+                  const credentials = await credentialProvider()
+                  const signer = new AwsV4Signer({
+                    url,
+                    method: init?.method ?? "POST",
+                    headers: headerEntries,
+                    body,
+                    region,
+                    accessKeyId: credentials.accessKeyId,
+                    secretAccessKey: credentials.secretAccessKey,
+                    sessionToken: credentials.sessionToken,
+                    service: "bedrock",
+                  })
+                  const signed = await signer.sign()
+                  return fetch(input, {
+                    ...init,
+                    body,
+                    headers: Object.fromEntries(signed.headers.entries()),
+                  })
+                }
               }
               mantleSDKCache.set(cacheKey, createOpenAICompatible(mantleOptions))
             }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -241,10 +241,36 @@ export namespace Provider {
         providerOptions.baseURL = endpoint
       }
 
+      // Cache for bedrock-mantle OpenAI-compatible SDK instances (keyed by region)
+      const mantleSDKCache = new Map<string, any>()
+
       return {
         autoload: true,
         options: providerOptions,
         async getModel(sdk: any, modelID: string, options?: Record<string, any>) {
+          // Route Kimi/Moonshot models through Bedrock's OpenAI-compatible endpoint
+          // (bedrock-mantle) instead of the Converse API. The Converse API has known
+          // tool call parsing bugs for these models (see vercel/ai#11409) that cause
+          // premature end_turn and lost tool calls in multi-step agentic workflows.
+          const isMoonshotModel = ["kimi", "moonshot"].some((m) => modelID.toLowerCase().includes(m))
+          if (isMoonshotModel) {
+            const region = options?.region ?? defaultRegion
+            const cacheKey = region
+            if (!mantleSDKCache.has(cacheKey)) {
+              const mantleOptions: Record<string, any> = {
+                baseURL: `https://bedrock-mantle.${region}.api.aws/v1`,
+                name: "amazon-bedrock",
+              }
+              if (awsBearerToken) {
+                mantleOptions.apiKey = awsBearerToken
+              }
+              mantleSDKCache.set(cacheKey, createOpenAICompatible(mantleOptions))
+            }
+            const mantleSDK = mantleSDKCache.get(cacheKey)!
+            log.info("routing moonshot model via bedrock-mantle", { modelID, region })
+            return mantleSDK.languageModel(modelID)
+          }
+
           // Skip region prefixing if model already has a cross-region inference profile prefix
           // Models from models.dev may already include prefixes like us., eu., global., etc.
           const crossRegionPrefixes = ["global.", "us.", "eu.", "jp.", "apac.", "au."]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -260,6 +260,7 @@ export namespace Provider {
               const mantleOptions: Record<string, any> = {
                 baseURL: `https://bedrock-mantle.${region}.api.aws/v1`,
                 name: "amazon-bedrock",
+                includeUsage: true,
               }
               if (awsBearerToken) {
                 mantleOptions.apiKey = awsBearerToken


### PR DESCRIPTION
Fixes #13807

## Summary

- Route Moonshot AI models (Kimi K2.5, Kimi K2 Thinking) through Bedrock's OpenAI-compatible endpoint (`bedrock-mantle.<region>.api.aws`) instead of the Converse API
- Fixes tool call parsing failures that cause premature `end_turn` in multi-step agentic workflows

## Problem

Kimi K2.5 on Bedrock via the Converse API exhibits premature stopping behavior — the model makes 2-3 tool calls then issues `end_turn`, requiring multiple `opencode run` invocations for tasks that should complete in one session. The same model via OpenAI-compatible endpoints chains 14+ tool calls autonomously.

Root cause: Bedrock's Converse API has a known tool call parsing bug for Kimi/Moonshot models ([vercel/ai#11409](https://github.com/vercel/ai/issues/11409)) where internal model tokens leak into text output instead of being parsed as tool calls. Additionally, Moonshot models are not listed in AWS's official Converse API tool calling support table.

## Solution

When a Bedrock model ID contains "kimi" or "moonshot", route through `bedrock-mantle.<region>.api.aws/v1` using `@ai-sdk/openai-compatible` instead of the Converse API. This:

- Bypasses the lossy Converse API translation layer
- Sends requests in OpenAI format (which Kimi was trained on)
- Keeps authentication and billing on Bedrock infrastructure
- Uses the existing bearer token authentication

## Validation

Multi-turn tool calling tests with 5 tools and a 4-step task:

| Route | Steps completed | Tool calls | Premature end_turn? |
|---|---|---|---|
| Converse API | 2-3 then stops | 2-3 per session | Yes |
| bedrock-mantle (this PR) | All steps | 8+ in one session | No |

Tested with both curl (15 rounds, never stopped) and AI SDK generateText (6 steps, 8 tool calls, task fully completed).

## Test plan

- [ ] Run existing Bedrock provider tests
- [ ] Test `amazon-bedrock/moonshotai.kimi-k2.5` with multi-step tool calling task
- [ ] Verify non-Moonshot Bedrock models (Claude, Nova) still use Converse API
- [ ] Test with both bearer token and IAM credential authentication