### PR TITLE
core: add persisted task graph and runtime task metrics

### DIFF
--- a/packages/opencode/migration/20260216002919_task_graph_tables/migration.sql
+++ b/packages/opencode/migration/20260216002919_task_graph_tables/migration.sql
@@ -1,0 +1,77 @@
+CREATE TABLE `dead_letter` (
+	`id` text PRIMARY KEY,
+	`task_id` text NOT NULL,
+	`session_id` text NOT NULL,
+	`error` text NOT NULL,
+	`attempt_count` integer NOT NULL,
+	`last_attempt` integer NOT NULL,
+	`time_created` integer NOT NULL,
+	CONSTRAINT `fk_dead_letter_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE `state_snapshot` (
+	`id` text PRIMARY KEY,
+	`session_id` text NOT NULL,
+	`graph_id` text NOT NULL,
+	`timestamp` integer NOT NULL,
+	`completed_nodes` text,
+	`in_progress_nodes` text,
+	`failed_nodes` text,
+	`metadata` text,
+	`time_created` integer NOT NULL,
+	CONSTRAINT `fk_state_snapshot_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE `task_dependency` (
+	`source_id` text NOT NULL,
+	`target_id` text NOT NULL,
+	CONSTRAINT `fk_task_dependency_source_id_task_node_id_fk` FOREIGN KEY (`source_id`) REFERENCES `task_node`(`id`) ON DELETE CASCADE,
+	CONSTRAINT `fk_task_dependency_target_id_task_node_id_fk` FOREIGN KEY (`target_id`) REFERENCES `task_node`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE `task_metrics` (
+	`id` text PRIMARY KEY,
+	`session_id` text NOT NULL,
+	`task_id` text NOT NULL,
+	`duration` integer NOT NULL,
+	`tokens_used` integer NOT NULL,
+	`attempts` integer NOT NULL,
+	`success` integer NOT NULL,
+	`complexity` text NOT NULL,
+	`skills_used` text,
+	`type` text NOT NULL,
+	`time_created` integer NOT NULL,
+	CONSTRAINT `fk_task_metrics_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE,
+	CONSTRAINT `fk_task_metrics_task_id_task_node_id_fk` FOREIGN KEY (`task_id`) REFERENCES `task_node`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE `task_node` (
+	`id` text PRIMARY KEY,
+	`session_id` text NOT NULL,
+	`version` integer NOT NULL,
+	`type` text NOT NULL,
+	`content` text NOT NULL,
+	`status` text NOT NULL,
+	`priority` text NOT NULL,
+	`duration` integer,
+	`tokens_used` integer,
+	`result` text,
+	`data` text,
+	`time_created` integer NOT NULL,
+	`time_updated` integer NOT NULL,
+	CONSTRAINT `fk_task_node_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `dead_letter_session_idx` ON `dead_letter` (`session_id`);--> statement-breakpoint
+CREATE INDEX `dead_letter_task_idx` ON `dead_letter` (`task_id`);--> statement-breakpoint
+CREATE INDEX `state_snapshot_session_idx` ON `state_snapshot` (`session_id`);--> statement-breakpoint
+CREATE INDEX `state_snapshot_graph_idx` ON `state_snapshot` (`graph_id`);--> statement-breakpoint
+CREATE INDEX `state_snapshot_timestamp_idx` ON `state_snapshot` (`timestamp`);--> statement-breakpoint
+CREATE INDEX `task_dependency_source_idx` ON `task_dependency` (`source_id`);--> statement-breakpoint
+CREATE INDEX `task_dependency_target_idx` ON `task_dependency` (`target_id`);--> statement-breakpoint
+CREATE INDEX `task_metrics_session_idx` ON `task_metrics` (`session_id`);--> statement-breakpoint
+CREATE INDEX `task_metrics_task_idx` ON `task_metrics` (`task_id`);--> statement-breakpoint
+CREATE INDEX `task_metrics_type_idx` ON `task_metrics` (`type`);--> statement-breakpoint
+CREATE INDEX `task_node_session_idx` ON `task_node` (`session_id`);--> statement-breakpoint
+CREATE INDEX `task_node_status_idx` ON `task_node` (`status`);--> statement-breakpoint
+CREATE INDEX `task_node_type_idx` ON `task_node` (`type`);

--- a/packages/opencode/migration/20260216002919_task_graph_tables/snapshot.json
+++ b/packages/opencode/migration/20260216002919_task_graph_tables/snapshot.json
@@ -1,0 +1,1704 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "d9e15db5-0299-464e-9e43-6c73799c5d68",
+  "prevIds": [
+    "d2736e43-700f-4e9e-8151-9f2f0d967bc8"
+  ],
+  "ddl": [
+    {
+      "name": "control_account",
+      "entityType": "tables"
+    },
+    {
+      "name": "dead_letter",
+      "entityType": "tables"
+    },
+    {
+      "name": "state_snapshot",
+      "entityType": "tables"
+    },
+    {
+      "name": "task_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "task_metrics",
+      "entityType": "tables"
+    },
+    {
+      "name": "task_node",
+      "entityType": "tables"
+    },
+    {
+      "name": "project",
+      "entityType": "tables"
+    },
+    {
+      "name": "message",
+      "entityType": "tables"
+    },
+    {
+      "name": "part",
+      "entityType": "tables"
+    },
+    {
+      "name": "permission",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "todo",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_share",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "attempt_count",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_attempt",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "dead_letter"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "graph_id",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "timestamp",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_nodes",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "in_progress_nodes",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failed_nodes",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "state_snapshot"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_id",
+      "entityType": "columns",
+      "table": "task_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "table": "task_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tokens_used",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "attempts",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "success",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "complexity",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "skills_used",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "task_metrics"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tokens_used",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "task_node"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vcs",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_color",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_initialized",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sandboxes",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "commands",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "share_url",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_additions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_deletions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_files",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_diffs",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revert",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_compacting",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_archived",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_dead_letter_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "dead_letter"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_state_snapshot_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "state_snapshot"
+    },
+    {
+      "columns": [
+        "source_id"
+      ],
+      "tableTo": "task_node",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_task_dependency_source_id_task_node_id_fk",
+      "entityType": "fks",
+      "table": "task_dependency"
+    },
+    {
+      "columns": [
+        "target_id"
+      ],
+      "tableTo": "task_node",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_task_dependency_target_id_task_node_id_fk",
+      "entityType": "fks",
+      "table": "task_dependency"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_task_metrics_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "task_metrics"
+    },
+    {
+      "columns": [
+        "task_id"
+      ],
+      "tableTo": "task_node",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_task_metrics_task_id_task_node_id_fk",
+      "entityType": "fks",
+      "table": "task_metrics"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_task_node_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "task_node"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "message"
+    },
+    {
+      "columns": [
+        "message_id"
+      ],
+      "tableTo": "message",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_part_message_id_message_id_fk",
+      "entityType": "fks",
+      "table": "part"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_permission_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "permission"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_todo_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_share_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "email",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "control_account_pk",
+      "entityType": "pks",
+      "table": "control_account"
+    },
+    {
+      "columns": [
+        "session_id",
+        "position"
+      ],
+      "nameExplicit": false,
+      "name": "todo_pk",
+      "entityType": "pks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "dead_letter_pk",
+      "table": "dead_letter",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "state_snapshot_pk",
+      "table": "state_snapshot",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "task_metrics_pk",
+      "table": "task_metrics",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "task_node_pk",
+      "table": "task_node",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pk",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "message_pk",
+      "table": "message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "part_pk",
+      "table": "part",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "nameExplicit": false,
+      "name": "permission_pk",
+      "table": "permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "session_share_pk",
+      "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dead_letter_session_idx",
+      "entityType": "indexes",
+      "table": "dead_letter"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "dead_letter_task_idx",
+      "entityType": "indexes",
+      "table": "dead_letter"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "state_snapshot_session_idx",
+      "entityType": "indexes",
+      "table": "state_snapshot"
+    },
+    {
+      "columns": [
+        {
+          "value": "graph_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "state_snapshot_graph_idx",
+      "entityType": "indexes",
+      "table": "state_snapshot"
+    },
+    {
+      "columns": [
+        {
+          "value": "timestamp",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "state_snapshot_timestamp_idx",
+      "entityType": "indexes",
+      "table": "state_snapshot"
+    },
+    {
+      "columns": [
+        {
+          "value": "source_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_dependency_source_idx",
+      "entityType": "indexes",
+      "table": "task_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "target_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_dependency_target_idx",
+      "entityType": "indexes",
+      "table": "task_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_metrics_session_idx",
+      "entityType": "indexes",
+      "table": "task_metrics"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_metrics_task_idx",
+      "entityType": "indexes",
+      "table": "task_metrics"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_metrics_type_idx",
+      "entityType": "indexes",
+      "table": "task_metrics"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_node_session_idx",
+      "entityType": "indexes",
+      "table": "task_node"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_node_status_idx",
+      "entityType": "indexes",
+      "table": "task_node"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "task_node_type_idx",
+      "entityType": "indexes",
+      "table": "task_node"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "message_session_idx",
+      "entityType": "indexes",
+      "table": "message"
+    },
+    {
+      "columns": [
+        {
+          "value": "message_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_message_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_session_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_project_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "todo_session_idx",
+      "entityType": "indexes",
+      "table": "todo"
+    }
+  ],
+  "renames": []
+}

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1171,27 +1171,37 @@ export namespace Config {
             .describe("Token buffer for compaction. Leaves enough window to avoid overflow during compaction."),
         })
         .optional(),
-      experimental: z
-        .object({
-          disable_paste_summary: z.boolean().optional(),
-          batch_tool: z.boolean().optional().describe("Enable the batch tool"),
-          openTelemetry: z
-            .boolean()
-            .optional()
-            .describe("Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)"),
-          primary_tools: z
-            .array(z.string())
-            .optional()
-            .describe("Tools that should only be available to primary agents."),
-          continue_loop_on_deny: z.boolean().optional().describe("Continue the agent loop when a tool call is denied"),
-          mcp_timeout: z
-            .number()
-            .int()
-            .positive()
-            .optional()
-            .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
-        })
-        .optional(),
+       experimental: z
+         .object({
+           disable_paste_summary: z.boolean().optional(),
+           batch_tool: z.boolean().optional().describe("Enable the batch tool"),
+           openTelemetry: z
+             .boolean()
+             .optional()
+             .describe("Enable OpenTelemetry spans for AI SDK calls (using the 'experimental_telemetry' flag)"),
+           task_metrics: z
+             .boolean()
+             .optional()
+             .describe("Persist task metrics to the database (default: true; set false to disable)"),
+           task_metrics_retention_days: z
+             .number()
+             .int()
+             .positive()
+             .optional()
+             .describe("Retention window for task_metrics cleanup (default: 30 days)"),
+           primary_tools: z
+             .array(z.string())
+             .optional()
+             .describe("Tools that should only be available to primary agents."),
+           continue_loop_on_deny: z.boolean().optional().describe("Continue the agent loop when a tool call is denied"),
+           mcp_timeout: z
+             .number()
+             .int()
+             .positive()
+             .optional()
+             .describe("Timeout in milliseconds for model context protocol (MCP) requests"),
+         })
+         .optional(),
     })
     .strict()
     .meta({

--- a/packages/opencode/src/graph/graph.sql.ts
+++ b/packages/opencode/src/graph/graph.sql.ts
@@ -1,0 +1,123 @@
+// packages/opencode/src/graph/graph.sql.ts
+// Database schema for task graph
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core"
+import { SessionTable } from "../session/session.sql"
+
+export const TaskNodeTable = sqliteTable(
+  "task_node",
+  {
+    id: text().notNull().primaryKey(),
+    session_id: text()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    version: integer().notNull(),
+    type: text().notNull(),
+    content: text().notNull(),
+    status: text().notNull(),
+    priority: text().notNull(),
+    duration: integer(),
+    tokens_used: integer(),
+    result: text(),
+    data: text({ mode: "json" }),
+    time_created: integer()
+      .notNull()
+      .$default(() => Date.now()),
+    time_updated: integer()
+      .notNull()
+      .$onUpdate(() => Date.now()),
+  },
+  (table) => [
+    index("task_node_session_idx").on(table.session_id),
+    index("task_node_status_idx").on(table.status),
+    index("task_node_type_idx").on(table.type),
+  ],
+)
+
+export const TaskDependencyTable = sqliteTable(
+  "task_dependency",
+  {
+    source_id: text()
+      .notNull()
+      .references(() => TaskNodeTable.id, { onDelete: "cascade" }),
+    target_id: text()
+      .notNull()
+      .references(() => TaskNodeTable.id, { onDelete: "cascade" }),
+  },
+  (table) => [
+    index("task_dependency_source_idx").on(table.source_id),
+    index("task_dependency_target_idx").on(table.target_id),
+  ],
+)
+
+export const TaskMetricsTable = sqliteTable(
+  "task_metrics",
+  {
+    id: text().notNull().primaryKey(),
+    session_id: text()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    task_id: text()
+      .notNull()
+      .references(() => TaskNodeTable.id, { onDelete: "cascade" }),
+    duration: integer().notNull(),
+    tokens_used: integer().notNull(),
+    attempts: integer().notNull(),
+    success: integer().notNull(),
+    complexity: text().notNull(),
+    skills_used: text({ mode: "json" }),
+    type: text().notNull(),
+    time_created: integer()
+      .notNull()
+      .$default(() => Date.now()),
+  },
+  (table) => [
+    index("task_metrics_session_idx").on(table.session_id),
+    index("task_metrics_task_idx").on(table.task_id),
+    index("task_metrics_type_idx").on(table.type),
+  ],
+)
+
+export const StateSnapshotTable = sqliteTable(
+  "state_snapshot",
+  {
+    id: text().notNull().primaryKey(),
+    session_id: text()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    graph_id: text().notNull(),
+    timestamp: integer().notNull(),
+    completed_nodes: text({ mode: "json" }),
+    in_progress_nodes: text({ mode: "json" }),
+    failed_nodes: text({ mode: "json" }),
+    metadata: text({ mode: "json" }),
+    time_created: integer()
+      .notNull()
+      .$default(() => Date.now()),
+  },
+  (table) => [
+    index("state_snapshot_session_idx").on(table.session_id),
+    index("state_snapshot_graph_idx").on(table.graph_id),
+    index("state_snapshot_timestamp_idx").on(table.timestamp),
+  ],
+)
+
+export const DeadLetterTable = sqliteTable(
+  "dead_letter",
+  {
+    id: text().notNull().primaryKey(),
+    task_id: text().notNull(),
+    session_id: text()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    error: text().notNull(),
+    attempt_count: integer().notNull(),
+    last_attempt: integer().notNull(),
+    time_created: integer()
+      .notNull()
+      .$default(() => Date.now()),
+  },
+  (table) => [
+    index("dead_letter_session_idx").on(table.session_id),
+    index("dead_letter_task_idx").on(table.task_id),
+  ],
+)

--- a/packages/opencode/src/graph/metrics.ts
+++ b/packages/opencode/src/graph/metrics.ts
@@ -1,0 +1,61 @@
+import z from "zod"
+import { Database, desc, eq, lt } from "@/storage/db"
+import { Config } from "@/config/config"
+import { Scheduler } from "@/scheduler"
+import { TaskMetricsTable } from "./graph.sql"
+
+export namespace TaskMetrics {
+  const DAY_MS = 24 * 60 * 60 * 1000
+
+  export const Row = z
+    .object({
+      id: z.string(),
+      session_id: z.string(),
+      task_id: z.string(),
+      duration: z.number().int(),
+      tokens_used: z.number().int(),
+      attempts: z.number().int(),
+      success: z.number().int(),
+      complexity: z.string(),
+      skills_used: z.array(z.string()).nullable().optional(),
+      type: z.string(),
+      time_created: z.number().int(),
+    })
+    .meta({ ref: "TaskMetrics" })
+
+  export type Row = z.infer<typeof Row>
+
+  export function list(sessionID: string, input?: { limit?: number }) {
+    const limit = input?.limit
+    if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
+      throw new Error("limit must be a positive integer")
+    }
+
+    return Database.use((db) =>
+      db
+        .select()
+        .from(TaskMetricsTable)
+        .where(eq(TaskMetricsTable.session_id, sessionID))
+        .orderBy(desc(TaskMetricsTable.time_created))
+        .limit(limit ?? 1000)
+        .all(),
+    )
+  }
+
+  export function init() {
+    Scheduler.register({
+      id: "task_metrics.cleanup",
+      interval: DAY_MS,
+      run: cleanup,
+      scope: "global",
+    })
+  }
+
+  export async function cleanup() {
+    const cfg = await Config.get()
+    if (cfg.experimental?.task_metrics === false) return
+    const days = cfg.experimental?.task_metrics_retention_days ?? 30
+    const cutoff = Date.now() - days * DAY_MS
+    Database.use((db) => db.delete(TaskMetricsTable).where(lt(TaskMetricsTable.time_created, cutoff)).run())
+  }
+}

--- a/packages/opencode/src/graph/store.ts
+++ b/packages/opencode/src/graph/store.ts
@@ -1,0 +1,160 @@
+import z from "zod"
+import { Database, and, eq, inArray } from "../storage/db"
+import { TaskDependencyTable, TaskNodeTable } from "./graph.sql"
+
+type TodoLike = {
+  content: string
+  status: string
+  priority: string
+}
+
+function todoid(sessionID: string, position: number) {
+  return `todo_${sessionID}_${position}`
+}
+
+function pos(data: unknown) {
+  if (!data) return Number.POSITIVE_INFINITY
+  if (typeof data !== "object") return Number.POSITIVE_INFINITY
+  if (!("position" in data)) return Number.POSITIVE_INFINITY
+  const value = (data as { position?: unknown }).position
+  if (typeof value !== "number") return Number.POSITIVE_INFINITY
+  return value
+}
+
+export namespace TaskGraph {
+  export const Node = z
+    .object({
+      id: z.string(),
+      session_id: z.string(),
+      version: z.number().int(),
+      type: z.string(),
+      content: z.string(),
+      status: z.string(),
+      priority: z.string(),
+      duration: z.number().int().nullable().optional(),
+      tokens_used: z.number().int().nullable().optional(),
+      result: z.string().nullable().optional(),
+      data: z.unknown().nullable().optional(),
+      time_created: z.number().int(),
+      time_updated: z.number().int(),
+    })
+    .meta({ ref: "TaskNode" })
+  export type Node = z.infer<typeof Node>
+
+  export const Dependency = z
+    .object({
+      source_id: z.string(),
+      target_id: z.string(),
+    })
+    .meta({ ref: "TaskDependency" })
+  export type Dependency = z.infer<typeof Dependency>
+
+  export const Info = z
+    .object({
+      nodes: Node.array(),
+      dependencies: Dependency.array(),
+    })
+    .meta({ ref: "TaskGraph" })
+  export type Info = z.infer<typeof Info>
+
+  export function syncTodos(db: Database.TxOrDb, input: { sessionID: string; todos: TodoLike[] }) {
+    const now = Date.now()
+    db.delete(TaskNodeTable)
+      .where(and(eq(TaskNodeTable.session_id, input.sessionID), eq(TaskNodeTable.type, "todo")))
+      .run()
+
+    if (input.todos.length === 0) return
+
+    db.insert(TaskNodeTable)
+      .values(
+        input.todos.map((todo, position) => ({
+          id: todoid(input.sessionID, position),
+          session_id: input.sessionID,
+          version: 1,
+          type: "todo",
+          content: todo.content,
+          status: todo.status,
+          priority: todo.priority,
+          time_created: now,
+          time_updated: now,
+          data: {
+            source: "todo",
+            position,
+          },
+        })),
+      )
+      .run()
+
+    const deps = input.todos
+      .slice(1)
+      .map((_, position) => ({
+        source_id: todoid(input.sessionID, position),
+        target_id: todoid(input.sessionID, position + 1),
+      }))
+
+    if (deps.length === 0) return
+
+    db.insert(TaskDependencyTable).values(deps).run()
+  }
+
+  export function get(sessionID: string): Info {
+    const nodes = Database.use((db) => db.select().from(TaskNodeTable).where(eq(TaskNodeTable.session_id, sessionID)).all())
+
+    const ids = nodes.map((n) => n.id)
+    const dependencies =
+      ids.length === 0
+        ? []
+        : Database.use((db) =>
+            db
+              .select({ source_id: TaskDependencyTable.source_id, target_id: TaskDependencyTable.target_id })
+              .from(TaskDependencyTable)
+              .where(and(inArray(TaskDependencyTable.source_id, ids), inArray(TaskDependencyTable.target_id, ids)))
+              .all(),
+          )
+
+    nodes.sort((a, b) => {
+      const pa = pos(a.data)
+      const pb = pos(b.data)
+      if (pa !== pb) return pa - pb
+      return a.time_created - b.time_created
+    })
+
+    return {
+      nodes,
+      dependencies,
+    }
+  }
+
+  export function render(sessionID: string) {
+    const graph = get(sessionID)
+    const deps = new Map<string, string[]>()
+
+    for (const dep of graph.dependencies) {
+      const list = deps.get(dep.target_id)
+      if (list) {
+        list.push(dep.source_id)
+        continue
+      }
+      deps.set(dep.target_id, [dep.source_id])
+    }
+
+    const lines = graph.nodes.map((node) => {
+      const icon =
+        node.status === "completed"
+          ? "[x]"
+          : node.status === "in_progress"
+            ? "[>]"
+            : node.status === "failed"
+              ? "[!]"
+              : node.status === "cancelled"
+                ? "[-]"
+                : "[ ]"
+
+      const upstream = deps.get(node.id)
+      if (!upstream?.length) return `${icon} (${node.priority}) ${node.content}`
+      return `${icon} (${node.priority}) ${node.content}  <- ${upstream.join(", ")}`
+    })
+
+    return lines.join("\n")
+  }
+}

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -12,6 +12,7 @@ import { Log } from "@/util/log"
 import { ShareNext } from "@/share/share-next"
 import { Snapshot } from "../snapshot"
 import { Truncate } from "../tool/truncation"
+import { TaskMetrics } from "@/graph/metrics"
 
 export async function InstanceBootstrap() {
   Log.Default.info("bootstrapping", { directory: Instance.directory })
@@ -24,6 +25,7 @@ export async function InstanceBootstrap() {
   Vcs.init()
   Snapshot.init()
   Truncate.init()
+  TaskMetrics.init()
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -10,6 +10,8 @@ import { SessionRevert } from "../../session/revert"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
 import { Todo } from "../../session/todo"
+import { TaskGraph } from "../../graph/store"
+import { TaskMetrics } from "../../graph/metrics"
 import { Agent } from "../../agent/agent"
 import { Snapshot } from "@/snapshot"
 import { Log } from "../../util/log"
@@ -180,6 +182,73 @@ export const SessionRoutes = lazy(() =>
         const sessionID = c.req.valid("param").sessionID
         const todos = await Todo.get(sessionID)
         return c.json(todos)
+      },
+    )
+    .get(
+      "/:sessionID/graph",
+      describeRoute({
+        summary: "Get session task graph",
+        description: "Retrieve the task graph associated with a session (nodes and dependencies).",
+        operationId: "session.graph",
+        responses: {
+          200: {
+            description: "Task graph",
+            content: {
+              "application/json": {
+                schema: resolver(TaskGraph.Info),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const graph = TaskGraph.get(sessionID)
+        return c.json(graph)
+      },
+    )
+    .get(
+      "/:sessionID/metrics",
+      describeRoute({
+        summary: "Get session metrics",
+        description: "Retrieve metrics emitted during session processing (LLM steps and tool calls).",
+        operationId: "session.metrics",
+        responses: {
+          200: {
+            description: "Metrics list",
+            content: {
+              "application/json": {
+                schema: resolver(TaskMetrics.Row.array()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          sessionID: z.string().meta({ description: "Session ID" }),
+        }),
+      ),
+      validator(
+        "query",
+        z.object({
+          limit: z.coerce.number().int().positive().optional().meta({ description: "Max rows (default: 1000)" }),
+        }),
+      ),
+      async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const query = c.req.valid("query")
+        const metrics = TaskMetrics.list(sessionID, { limit: query.limit })
+        return c.json(metrics)
       },
     )
     .post(

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -9,6 +9,8 @@ import { Bus } from "@/bus"
 import { SessionRetry } from "./retry"
 import { SessionStatus } from "./status"
 import { Plugin } from "@/plugin"
+import { Database } from "@/storage/db"
+import { TaskMetricsTable, TaskNodeTable } from "@/graph/graph.sql"
 import type { Provider } from "@/provider/provider"
 import { LLM } from "./llm"
 import { Config } from "@/config/config"
@@ -31,9 +33,20 @@ export namespace SessionProcessor {
   }) {
     const toolcalls: Record<string, MessageV2.ToolPart> = {}
     let snapshot: string | undefined
+    let start: number | undefined
     let blocked = false
     let attempt = 0
     let needsCompaction = false
+
+    const write = (fn: (tx: Database.TxOrDb) => void) => {
+      try {
+        Database.transaction(fn)
+      } catch (error) {
+        log.error("task_metrics", {
+          error,
+        })
+      }
+    }
 
     const result = {
       get message() {
@@ -45,7 +58,9 @@ export namespace SessionProcessor {
       async process(streamInput: LLM.StreamInput) {
         log.info("process")
         needsCompaction = false
-        const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
+        const cfg = await Config.get()
+        const shouldBreak = cfg.experimental?.continue_loop_on_deny !== true
+        const metrics = cfg.experimental?.task_metrics !== false
         while (true) {
           try {
             let currentText: MessageV2.TextPart | undefined
@@ -148,6 +163,36 @@ export namespace SessionProcessor {
                     })
                     toolcalls[value.toolCallId] = part as MessageV2.ToolPart
 
+                    if (metrics)
+                      write((db) => {
+                      const now = part.state.time.start
+                      db.insert(TaskNodeTable)
+                        .values({
+                          id: part.id,
+                          session_id: part.sessionID,
+                          version: 1,
+                          type: `tool.${value.toolName}`,
+                          content: value.toolName,
+                          status: "in_progress",
+                          priority: "low",
+                          time_created: now,
+                          time_updated: now,
+                          data: {
+                            kind: "tool",
+                            tool: value.toolName,
+                            call_id: part.callID,
+                          },
+                        })
+                        .onConflictDoUpdate({
+                          target: TaskNodeTable.id,
+                          set: {
+                            status: "in_progress",
+                            time_updated: now,
+                          },
+                        })
+                        .run()
+                      })
+
                     const parts = await MessageV2.parts(input.assistantMessage.id)
                     const lastThree = parts.slice(-DOOM_LOOP_THRESHOLD)
 
@@ -196,6 +241,58 @@ export namespace SessionProcessor {
                       },
                     })
 
+                    if (metrics)
+                      write((db) => {
+                      const end = Date.now()
+                      const dur = Math.max(0, end - match.state.time.start)
+                      db.insert(TaskNodeTable)
+                        .values({
+                          id: match.id,
+                          session_id: match.sessionID,
+                          version: 1,
+                          type: `tool.${match.tool}`,
+                          content: match.tool,
+                          status: "completed",
+                          priority: "low",
+                          duration: dur,
+                          tokens_used: 0,
+                          result: value.output.title,
+                          time_created: match.state.time.start,
+                          time_updated: end,
+                          data: {
+                            kind: "tool",
+                            tool: match.tool,
+                            call_id: match.callID,
+                          },
+                        })
+                        .onConflictDoUpdate({
+                          target: TaskNodeTable.id,
+                          set: {
+                            status: "completed",
+                            duration: dur,
+                            tokens_used: 0,
+                            result: value.output.title,
+                            time_updated: end,
+                          },
+                        })
+                        .run()
+
+                      db.insert(TaskMetricsTable)
+                        .values({
+                          id: Identifier.ascending("tool"),
+                          session_id: match.sessionID,
+                          task_id: match.id,
+                          duration: dur,
+                          tokens_used: 0,
+                          attempts: 1,
+                          success: 1,
+                          complexity: "simple",
+                          skills_used: [match.tool],
+                          type: match.tool,
+                        })
+                        .run()
+                      })
+
                     delete toolcalls[value.toolCallId]
                   }
                   break
@@ -217,6 +314,58 @@ export namespace SessionProcessor {
                       },
                     })
 
+                    if (metrics)
+                      write((db) => {
+                      const end = Date.now()
+                      const dur = Math.max(0, end - match.state.time.start)
+                      db.insert(TaskNodeTable)
+                        .values({
+                          id: match.id,
+                          session_id: match.sessionID,
+                          version: 1,
+                          type: `tool.${match.tool}`,
+                          content: match.tool,
+                          status: "failed",
+                          priority: "low",
+                          duration: dur,
+                          tokens_used: 0,
+                          result: "error",
+                          time_created: match.state.time.start,
+                          time_updated: end,
+                          data: {
+                            kind: "tool",
+                            tool: match.tool,
+                            call_id: match.callID,
+                          },
+                        })
+                        .onConflictDoUpdate({
+                          target: TaskNodeTable.id,
+                          set: {
+                            status: "failed",
+                            duration: dur,
+                            tokens_used: 0,
+                            result: "error",
+                            time_updated: end,
+                          },
+                        })
+                        .run()
+
+                      db.insert(TaskMetricsTable)
+                        .values({
+                          id: Identifier.ascending("tool"),
+                          session_id: match.sessionID,
+                          task_id: match.id,
+                          duration: dur,
+                          tokens_used: 0,
+                          attempts: 1,
+                          success: 0,
+                          complexity: "simple",
+                          skills_used: [match.tool],
+                          type: match.tool,
+                        })
+                        .run()
+                      })
+
                     if (
                       value.error instanceof PermissionNext.RejectedError ||
                       value.error instanceof Question.RejectedError
@@ -231,6 +380,40 @@ export namespace SessionProcessor {
                   throw value.error
 
                 case "start-step":
+                  if (metrics) {
+                    if (!start) start = Date.now()
+                    write((db) => {
+                    const now = Date.now()
+                    db.insert(TaskNodeTable)
+                      .values({
+                        id: input.assistantMessage.id,
+                        session_id: input.assistantMessage.sessionID,
+                        version: 1,
+                        type: "llm.step",
+                        content: "step",
+                        status: "in_progress",
+                        priority: "low",
+                        time_created: now,
+                        time_updated: now,
+                        data: {
+                          kind: "llm",
+                          message_id: input.assistantMessage.id,
+                          parent_id: input.assistantMessage.parentID,
+                          agent: input.assistantMessage.agent,
+                          provider_id: input.model.providerID,
+                          model_id: input.model.id,
+                        },
+                      })
+                      .onConflictDoUpdate({
+                        target: TaskNodeTable.id,
+                        set: {
+                          status: "in_progress",
+                          time_updated: now,
+                        },
+                      })
+                      .run()
+                    })
+                  }
                   snapshot = await Snapshot.track()
                   await Session.updatePart({
                     id: Identifier.ascending("part"),
@@ -250,6 +433,72 @@ export namespace SessionProcessor {
                   input.assistantMessage.finish = value.finishReason
                   input.assistantMessage.cost += usage.cost
                   input.assistantMessage.tokens = usage.tokens
+                  if (metrics)
+                    write((db) => {
+                    const end = Date.now()
+                    const dur = Math.max(0, end - (start ?? end))
+                    db.insert(TaskNodeTable)
+                      .values({
+                        id: input.assistantMessage.id,
+                        session_id: input.assistantMessage.sessionID,
+                        version: 1,
+                        type: "llm.step",
+                        content: "step",
+                        status: "completed",
+                        priority: "low",
+                        duration: dur,
+                        tokens_used: usage.tokens.total,
+                        result: value.finishReason,
+                        time_created: start ?? end,
+                        time_updated: end,
+                        data: {
+                          kind: "llm",
+                          message_id: input.assistantMessage.id,
+                          parent_id: input.assistantMessage.parentID,
+                          agent: input.assistantMessage.agent,
+                          provider_id: input.model.providerID,
+                          model_id: input.model.id,
+                          attempts: attempt + 1,
+                          tokens: usage.tokens,
+                        },
+                      })
+                      .onConflictDoUpdate({
+                        target: TaskNodeTable.id,
+                        set: {
+                          status: "completed",
+                          duration: dur,
+                          tokens_used: usage.tokens.total,
+                          result: value.finishReason,
+                          time_updated: end,
+                          data: {
+                            kind: "llm",
+                            message_id: input.assistantMessage.id,
+                            parent_id: input.assistantMessage.parentID,
+                            agent: input.assistantMessage.agent,
+                            provider_id: input.model.providerID,
+                            model_id: input.model.id,
+                            attempts: attempt + 1,
+                            tokens: usage.tokens,
+                          },
+                        },
+                      })
+                      .run()
+
+                    db.insert(TaskMetricsTable)
+                      .values({
+                        id: Identifier.ascending("tool"),
+                        session_id: input.assistantMessage.sessionID,
+                        task_id: input.assistantMessage.id,
+                        duration: dur,
+                        tokens_used: usage.tokens.total,
+                        attempts: attempt + 1,
+                        success: 1,
+                        complexity: "simple",
+                        skills_used: [],
+                        type: "llm",
+                      })
+                      .run()
+                    })
                   await Session.updatePart({
                     id: Identifier.ascending("part"),
                     reason: value.finishReason,
@@ -260,6 +509,7 @@ export namespace SessionProcessor {
                     tokens: usage.tokens,
                     cost: usage.cost,
                   })
+                  start = undefined
                   await Session.updateMessage(input.assistantMessage)
                   if (snapshot) {
                     const patch = await Snapshot.patch(snapshot)

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -1,6 +1,7 @@
 import { BusEvent } from "@/bus/bus-event"
 import { Bus } from "@/bus"
 import z from "zod"
+import { TaskGraph } from "../graph/store"
 import { Database, eq, asc } from "../storage/db"
 import { TodoTable } from "./session.sql"
 
@@ -27,6 +28,12 @@ export namespace Todo {
   export function update(input: { sessionID: string; todos: Info[] }) {
     Database.transaction((db) => {
       db.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
+
+      TaskGraph.syncTodos(db, {
+        sessionID: input.sessionID,
+        todos: input.todos,
+      })
+
       if (input.todos.length === 0) return
       db.insert(TodoTable)
         .values(

--- a/packages/opencode/src/storage/schema.ts
+++ b/packages/opencode/src/storage/schema.ts
@@ -2,3 +2,10 @@ export { ControlAccountTable } from "../control/control.sql"
 export { SessionTable, MessageTable, PartTable, TodoTable, PermissionTable } from "../session/session.sql"
 export { SessionShareTable } from "../share/share.sql"
 export { ProjectTable } from "../project/project.sql"
+export {
+  DeadLetterTable,
+  StateSnapshotTable,
+  TaskDependencyTable,
+  TaskMetricsTable,
+  TaskNodeTable,
+} from "../graph/graph.sql"


### PR DESCRIPTION
## Summary
- add persisted task-graph schema/tables (`task_node`, `task_dependency`, `task_metrics`, `state_snapshot`, `dead_letter`) and generated migration
- shadow-write session todos into task graph, and expose read APIs for graph/metrics (`GET /session/:sessionID/graph`, `GET /session/:sessionID/metrics`)
- persist runtime metrics from session processor for LLM steps and tool calls; add config flags for enable/disable and retention with scheduled cleanup

## Verification
- `cd packages/opencode && bun test --timeout 30000`