### PR TITLE
fix(opencode): include partial bash output on abort

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -17,6 +17,9 @@ import { type SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 
 export namespace MessageV2 {
+  const BASH_ABORT = "Tool execution aborted"
+  const BASH_PARTIAL_LIMIT = 8_000
+
   export const OutputLengthError = NamedError.create("MessageOutputLengthError", z.object({}))
   export const AbortedError = NamedError.create("MessageAbortedError", z.object({ message: z.string() }))
   export const StructuredOutputError = NamedError.create(
@@ -545,6 +548,40 @@ export namespace MessageV2 {
       return { type: "json", value: output as never }
     }
 
+    const clip = (text: string) => {
+      if (text.length <= BASH_PARTIAL_LIMIT) {
+        return {
+          text,
+          truncated: false,
+        }
+      }
+      return {
+        text: text.slice(-BASH_PARTIAL_LIMIT),
+        truncated: true,
+      }
+    }
+
+    const errorText = (tool: string, state: ToolStateError) => {
+      if (tool !== "bash") return state.error
+      if (state.error !== BASH_ABORT) return state.error
+      if (typeof state.metadata?.output !== "string") return state.error
+      if (state.metadata.output.length === 0) return state.error
+      const output = clip(state.metadata.output)
+      return [
+        state.error,
+        "",
+        "<bash_partial_output>",
+        output.text,
+        "</bash_partial_output>",
+        "",
+        "<bash_partial_output_metadata>",
+        "interrupted=true",
+        "complete=false",
+        `truncated=${output.truncated}`,
+        "</bash_partial_output_metadata>",
+      ].join("\n")
+    }
+
     for (const msg of input) {
       if (msg.parts.length === 0) continue
 
@@ -654,7 +691,7 @@ export namespace MessageV2 {
                 state: "output-error",
                 toolCallId: part.callID,
                 input: part.state.input,
-                errorText: part.state.error,
+                errorText: errorText(part.tool, part.state),
                 ...(differentModel ? {} : { callProviderMetadata: part.metadata }),
               })
             // Handle pending/running tool calls to prevent dangling tool_use blocks

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -566,6 +566,172 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("includes partial bash output in aborted tool errors", () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+    const output = "step 1\nstep 2"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "error",
+              input: { cmd: "ls" },
+              error: "Tool execution aborted",
+              metadata: {
+                output,
+              },
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const error = [
+      "Tool execution aborted",
+      "",
+      "<bash_partial_output>",
+      output,
+      "</bash_partial_output>",
+      "",
+      "<bash_partial_output_metadata>",
+      "interrupted=true",
+      "complete=false",
+      "truncated=false",
+      "</bash_partial_output_metadata>",
+    ].join("\n")
+
+    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            output: { type: "error-text", value: error },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("includes whitespace-only partial bash output in aborted tool errors", () => {
+    const userID = "m-user"
+    const assistantID = "m-assistant"
+    const output = " \n\t"
+
+    const input: MessageV2.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1"),
+            type: "text",
+            text: "run tool",
+          },
+        ] as MessageV2.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1"),
+            type: "tool",
+            callID: "call-1",
+            tool: "bash",
+            state: {
+              status: "error",
+              input: { cmd: "ls" },
+              error: "Tool execution aborted",
+              metadata: {
+                output,
+              },
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as MessageV2.Part[],
+      },
+    ]
+
+    const error = [
+      "Tool execution aborted",
+      "",
+      "<bash_partial_output>",
+      output,
+      "</bash_partial_output>",
+      "",
+      "<bash_partial_output_metadata>",
+      "interrupted=true",
+      "complete=false",
+      "truncated=false",
+      "</bash_partial_output_metadata>",
+    ].join("\n")
+
+    expect(MessageV2.toModelMessages(input, model)).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "run tool" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "bash",
+            input: { cmd: "ls" },
+            providerExecuted: undefined,
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-1",
+            toolName: "bash",
+            output: { type: "error-text", value: error },
+          },
+        ],
+      },
+    ])
+  })
+
   test("filters assistant messages with non-abort errors", () => {
     const assistantID = "m-assistant"
 


### PR DESCRIPTION
## Summary

- Include bounded partial `bash` output in tool error text when execution is aborted, so the model can reason from already-produced logs.
- Keep existing behavior unchanged for non-`bash` tools and non-abort errors.
- Add tests for both normal partial output and whitespace-only partial output on abort.

Fixes #13809

## Verification

- `bun test test/session/message-v2.test.ts`
- `bun run typecheck`
