### PR TITLE
fix: sanitize tool schemas for strict JSON Schema validators (#13737)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -856,6 +856,47 @@ export namespace ProviderTransform {
   }
 
   export function schema(model: Provider.Model, schema: JSONSchema.BaseSchema | JSONSchema7): JSONSchema7 {
+    // Universal schema sanitization for strict JSON Schema validators (Codex, Vertex AI, SGLang, etc.)
+    // 1. Remove Zod .meta() injected fields ($schema, ref) that are invalid in function parameter schemas
+    // 2. When additionalProperties is false, ensure all property keys are in required array
+    const sanitizeStrict = (obj: any): any => {
+      if (obj === null || typeof obj !== "object") return obj
+      if (Array.isArray(obj)) return obj.map(sanitizeStrict)
+
+      const result: any = {}
+      for (const [key, value] of Object.entries(obj)) {
+        // Strip Zod meta fields that break strict validators
+        if (key === "$schema" || key === "ref") continue
+        if (typeof value === "object" && value !== null) {
+          result[key] = sanitizeStrict(value)
+        } else {
+          result[key] = value
+        }
+      }
+
+      // Strict mode: additionalProperties=false requires all properties in required
+      if (
+        result.type === "object" &&
+        result.properties &&
+        result.additionalProperties === false
+      ) {
+        const allKeys = Object.keys(result.properties)
+        const existing = new Set(Array.isArray(result.required) ? result.required : [])
+        result.required = allKeys.filter((k) => existing.has(k))
+        // Wrap optional properties with anyOf [..., {type: "null"}] so they can be omitted
+        for (const k of allKeys) {
+          if (!existing.has(k) && result.properties[k]) {
+            result.properties[k] = {
+              anyOf: [result.properties[k], { type: "null" }],
+            }
+            result.required.push(k)
+          }
+        }
+      }
+
+      return result
+    }
+    schema = sanitizeStrict(schema)
     /*
     if (["openai", "azure"].includes(providerID)) {
       if (schema.type === "object" && schema.properties) {


### PR DESCRIPTION
## Problem

Built-in tool schemas (like `question`) break on providers with strict JSON Schema validation — Codex, Vertex AI OpenAI-compatible, SGLang, etc.

Two issues:
1. **Zod `.meta()` pollution**: Injects `$schema` and `ref` keywords that are invalid in OpenAI function parameter schemas
2. **Missing `required` fields**: When `additionalProperties: false` is set, strict validators require ALL property keys to be in the `required` array. Optional fields like `multiple` are missing.

Error from Codex:
```
Invalid schema for function 'question': In context=('properties', 'questions',
'items'), 'required' is required to be supplied and to be an array including
every key in properties. Missing 'multiple'.
```

## Fix

Add universal schema sanitization in `ProviderTransform.schema()` that runs before any provider-specific transforms:

1. **Strip Zod meta fields** (`$schema`, `ref`) recursively from all schemas
2. **Fix strict mode compliance**: When `additionalProperties: false` is set, ensure all property keys are in `required`. Optional properties are wrapped with `anyOf: [original, {type: 'null'}]` so they remain nullable while satisfying strict validators.

## Changes

- `packages/opencode/src/provider/transform.ts`: Add `sanitizeStrict()` pass in `schema()` function

Closes #13737
Related: #13618, #11413, #8184