### PR TITLE
docs: add opencode-kilo-auth plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -23,6 +23,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-openai-codex-auth](https://github.com/numman-ali/opencode-openai-codex-auth)                    | Use your ChatGPT Plus/Pro subscription instead of API credits                                     |
 | [opencode-gemini-auth](https://github.com/jenslys/opencode-gemini-auth)                                   | Use your existing Gemini plan instead of API billing                                              |
 | [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth)                       | Use Antigravity's free models instead of API billing                                              |
+| [opencode-kilo-auth](https://github.com/JungHoonGhae/opencode-kilo-auth)                                 | Access 340+ AI models via Kilo Gateway with free tier models support                              |
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                                | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                   |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)          | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling     |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)         | Optimize token usage by pruning obsolete tool outputs                                             |


### PR DESCRIPTION
## Summary

Add opencode-kilo-auth plugin to the ecosystem documentation.

## Description

[opencode-kilo-auth](https://github.com/JungHoonGhae/opencode-kilo-auth) is a plugin that enables OpenCode users to access 340+ AI models via Kilo Gateway, including free tier models like `z-ai/glm-5:free` and `minimax/minimax-m2.5:free`.

### Features
- Access 340+ AI models via Kilo Gateway
- Free tier models support (29 models)
- Device Authorization (OAuth-like flow)
- API Key authentication
- Auto-updating models list

### Links
- GitHub: https://github.com/JungHoonGhae/opencode-kilo-auth
- npm: https://www.npmjs.com/package/opencode-kilo-auth