### PR TITLE
fix(github): add null safety for headRepository/baseRepository access

### DIFF
--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -562,7 +562,9 @@ export const GithubRunCommand = cmd({
         ) {
           const prData = await fetchPR()
           // Local PR
-          if (prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner) {
+          const headRepo = prData.headRepository?.nameWithOwner
+          const baseRepo = prData.baseRepository?.nameWithOwner
+          if (headRepo && baseRepo && headRepo === baseRepo) {
             await checkoutLocalBranch(prData)
             const head = (await $`git rev-parse HEAD`).stdout.toString().trim()
             const dataPrompt = buildPromptDataForPR(prData)
@@ -577,7 +579,7 @@ export const GithubRunCommand = cmd({
             await removeReaction(commentType)
           }
           // Fork PR
-          else {
+          else if (headRepo && baseRepo) {
             await checkoutForkBranch(prData)
             const head = (await $`git rev-parse HEAD`).stdout.toString().trim()
             const dataPrompt = buildPromptDataForPR(prData)
@@ -590,6 +592,10 @@ export const GithubRunCommand = cmd({
             const hasShared = prData.comments.nodes.some((c) => c.body.includes(`${shareBaseUrl}/s/${shareId}`))
             await createComment(`${response}${footer({ image: !hasShared })}`)
             await removeReaction(commentType)
+          }
+          // Missing repository data
+          else {
+            throw new Error("PR repository information is missing - unable to process PR")
           }
         }
         // Issue
@@ -1041,7 +1047,13 @@ export const GithubRunCommand = cmd({
         const localBranch = generateBranchName("pr")
         const depth = Math.max(pr.commits.totalCount, 20)
 
-        await $`git remote add fork https://github.com/${pr.headRepository.nameWithOwner}.git`
+        // headRepository is validated before calling this function
+        const headRepoName = pr.headRepository?.nameWithOwner
+        if (!headRepoName) {
+          throw new Error("PR headRepository information is missing")
+        }
+
+        await $`git remote add fork https://github.com/${headRepoName}.git`
         await $`git fetch fork --depth=${depth} ${remoteBranch}`
         await $`git checkout -b ${localBranch} fork/${remoteBranch}`
       }


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when `headRepository` or `baseRepository` are null when processing PRs, particularly in fork PR scenarios.

## The Bug

Error reported in #13812:
```
null is not an object (evaluating 'prData.headRepository.nameWithOwner')
```

This occurs when:
- OpenCode is configured to respond to GitHub Actions events
- A PR from a fork triggers the action
- GitHub API doesn't populate `headRepository` (deleted fork, permissions, etc.)

## The Fix

**Used optional chaining** and early variable extraction:
```typescript
// Before (crashes):
if (prData.headRepository.nameWithOwner === prData.baseRepository.nameWithOwner)

// After (safe):
const headRepo = prData.headRepository?.nameWithOwner
const baseRepo = prData.baseRepository?.nameWithOwner
if (headRepo && baseRepo && headRepo === baseRepo)
```

**Added explicit error handling** for missing repository data:
- Clear error message when repository information is unavailable
- Additional validation in checkoutForkBranch function

## Impact

✅ Fork PRs no longer cause crashes
✅ Safe handling of partial GitHub API responses
✅ Clear error messages for debugging
✅ No changes to type definitions - purely runtime safety

Fixes #13812

🤖 Generated with [Claude Code](https://claude.com/claude-code)