### PR TITLE
feat(agent): add optional title field for better display in agent lists

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/dialog-agent.tsx
@@ -3,16 +3,24 @@ import { useLocal } from "@tui/context/local"
 import { DialogSelect } from "@tui/ui/dialog-select"
 import { useDialog } from "@tui/ui/dialog"
 
+function truncate(str: string | undefined, maxLength: number): string {
+  if (!str) return ""
+  if (str.length <= maxLength) return str
+  return str.slice(0, maxLength - 3) + "..."
+}
+
 export function DialogAgent() {
   const local = useLocal()
   const dialog = useDialog()
 
   const options = createMemo(() =>
     local.agent.list().map((item) => {
+      // Use title if available, otherwise truncate description for display
+      const displayTitle = item.title || truncate(item.description, 60) || item.name
       return {
         value: item.name,
         title: item.name,
-        description: item.native ? "native" : item.description,
+        description: item.native ? "native" : displayTitle,
       }
     }),
   )

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -714,6 +714,7 @@ export namespace Config {
         "model",
         "variant",
         "prompt",
+        "title",
         "description",
         "temperature",
         "top_p",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -683,6 +683,7 @@ export namespace Config {
       prompt: z.string().optional(),
       tools: z.record(z.string(), z.boolean()).optional().describe("@deprecated Use 'permission' field instead"),
       disable: z.boolean().optional(),
+      title: z.string().optional().describe("Short title for display in agent lists (recommended: 2-5 words)"),
       description: z.string().optional().describe("Description of when to use the agent"),
       mode: z.enum(["subagent", "primary", "all"]).optional(),
       hidden: z

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2211,6 +2211,7 @@ export type Command = {
 
 export type Agent = {
   name: string
+  title?: string
   description?: string
   mode: "subagent" | "primary" | "all"
   native?: boolean


### PR DESCRIPTION
## Summary

This PR adds an optional `title` field to agent configuration for better display in agent lists, addressing issue #4825 where agent descriptions are too long and unreadable.

## The Problem

When creating agents with `opencode agent create`, the generated description is very extensive. This description is then displayed in the `/agents` command list, making it impossible to read.

## The Solution

**Added optional `title` field** to Agent schema:
- Recommended length: 2-5 words
- Used for display in agent lists
- Falls back to truncated description if not provided
- Full description still used for AI context

**Updated UI logic** with fallback chain:
1. Use `title` if provided
2. Otherwise truncate `description` to 60 characters with "..." suffix
3. Fall back to agent name if neither exists

## Example Usage

```json
{
  "title": "Database Query Expert",
  "description": "This agent specializes in writing and optimizing SQL queries..."
}
```

In the agent list:
- **Before**: Shows full description (unreadable)
- **After**: Shows "Database Query Expert"

## Backward Compatibility

✅ Existing agents work without changes
✅ If `title` is not provided, description is truncated to 60 chars
✅ No breaking changes to existing agent configurations

Fixes #4825

🤖 Generated with [Claude Code](https://claude.com/claude-code)