### PR TITLE
fix(attach): default working directory to invoker's cwd

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -32,7 +32,7 @@ export const AttachCommand = cmd({
       win32DisableProcessedInput()
 
       const directory = (() => {
-        if (!args.dir) return undefined
+        if (!args.dir) return process.cwd()
         try {
           process.chdir(args.dir)
           return process.cwd()


### PR DESCRIPTION
## Adding support for server attachments linking to local TUI spawn directory

When running `opencode attach` without `--dir`, the TUI session previously fell back to the server's `process.cwd()` as its working directory. This changes the default to use the attaching client's `process.cwd()` so the session operates in the directory where the attach command was invoked.

## Change

One-line change in `packages/opencode/src/cli/cmd/tui/attach.ts`:

```diff
- if (!args.dir) return undefined
+ if (!args.dir) return process.cwd()
```

When `directory` was `undefined`, the SDK client skipped sending the `x-opencode-directory` header, causing the server middleware to fall back to its own `process.cwd()`. Now it always sends the client's cwd, matching the behavior users would expect.