### PR TITLE
fix (tui): Inaccurate tips

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/tips.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/tips.tsx
@@ -2,7 +2,7 @@ import { createMemo, createSignal, For } from "solid-js"
 import { DEFAULT_THEMES, useTheme } from "@tui/context/theme"
 
 const themeCount = Object.keys(DEFAULT_THEMES).length
-const themeTip = `Use {highlight}/theme{/highlight} or {highlight}Ctrl+X T{/highlight} to switch between ${themeCount} built-in themes`
+const themeTip = `Use {highlight}/themes{/highlight} or {highlight}Ctrl+X T{/highlight} to switch between ${themeCount} built-in themes`
 
 type TipPart = { text: string; highlight: boolean }
 
@@ -126,7 +126,7 @@ const TIPS = [
   "Use {highlight}{file:path}{/highlight} to include file contents in config values",
   "Use {highlight}instructions{/highlight} in config to load additional rules files",
   "Set agent {highlight}temperature{/highlight} from 0.0 (focused) to 1.0 (creative)",
-  "Configure {highlight}maxSteps{/highlight} to limit agentic iterations per request",
+  "Configure {highlight}steps{/highlight} to limit agentic iterations per request",
   'Set {highlight}"tools": {"bash": false}{/highlight} to disable specific tools',
   'Set {highlight}"mcp_*": false{/highlight} to disable all tools from an MCP server',
   "Override global tool settings per agent configuration",
@@ -147,7 +147,6 @@ const TIPS = [
   "Commit your project's {highlight}AGENTS.md{/highlight} file to Git for team sharing",
   "Use {highlight}/review{/highlight} to review uncommitted changes, branches, or PRs",
   "Run {highlight}/help{/highlight} or {highlight}Ctrl+X H{/highlight} to show the help dialog",
-  "Use {highlight}/details{/highlight} to toggle tool execution details visibility",
   "Use {highlight}/rename{/highlight} to rename the current session",
   "Press {highlight}Ctrl+Z{/highlight} to suspend the terminal and return to your shell",
 ]


### PR DESCRIPTION

Fixes #13842 

The TUI has a "Tips" component at the bottom that shows random tips. Some of them are outdated/inaccurate.

### Changes

- **`/theme` → `/themes`**: The actual slash command is registered as `"themes"` in `packages/opencode/src/cli/cmd/tui/app.tsx`. Updated the tip to match.
- **`maxSteps` → `steps`**: The `maxSteps` config field is deprecated in favor of `steps` (see `packages/opencode/src/config/config.ts`). Updated the tip to reference the current field name.
- **Removed `/details` tip**: The `/details` slash command does not exist in the OpenCode TUI. Removed the tip to avoid confusing users.

### Testing

Tested by running the app locally and verifying the tips render correctly with the updated text.



(Full disclosure: I'm from Kilo)