### PR TITLE
fix: add timeout and retry recovery for subagent LLM streams

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1065,10 +1065,13 @@ export namespace Provider {
         const fetchFn = customFetch ?? fetch
         const opts = init ?? {}
 
-        if (options["timeout"] !== undefined && options["timeout"] !== null) {
+        // Apply timeout: use configured value, fall back to 300s default.
+        // Only skip when explicitly set to `false`.
+        const timeout = options["timeout"] ?? 300_000
+        if (timeout !== false) {
           const signals: AbortSignal[] = []
           if (opts.signal) signals.push(opts.signal)
-          if (options["timeout"] !== false) signals.push(AbortSignal.timeout(options["timeout"]))
+          signals.push(AbortSignal.timeout(timeout))
 
           const combined = signals.length > 1 ? AbortSignal.any(signals) : signals[0]
 

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -840,6 +840,14 @@ export namespace MessageV2 {
           },
           { cause: e },
         ).toObject()
+      case e instanceof Error && e.name === "StreamIdleTimeoutError":
+        return new MessageV2.APIError(
+          {
+            message: e.message,
+            isRetryable: true,
+          },
+          { cause: e },
+        ).toObject()
       case APICallError.isInstance(e):
         const parsed = ProviderError.parseAPICallError({
           providerID: ctx.providerID,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -18,7 +18,39 @@ import { Question } from "@/question"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
+  const MAX_RETRY_ATTEMPTS = 10
+  const STREAM_IDLE_TIMEOUT_MS = 120_000 // 2 minutes with no stream chunk
   const log = Log.create({ service: "session.processor" })
+
+  class StreamIdleTimeoutError extends Error {
+    readonly isRetryable = true
+    constructor(ms: number) {
+      super(`Stream idle for ${ms}ms with no data received`)
+      this.name = "StreamIdleTimeoutError"
+    }
+  }
+
+  async function* withIdleTimeout<T>(stream: AsyncIterable<T>, ms: number, signal: AbortSignal): AsyncGenerator<T> {
+    const iterator = stream[Symbol.asyncIterator]()
+    while (true) {
+      const result = await Promise.race([
+        iterator.next(),
+        new Promise<never>((_, reject) => {
+          const timer = setTimeout(() => reject(new StreamIdleTimeoutError(ms)), ms)
+          signal.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer)
+              reject(signal.reason ?? new DOMException("Aborted", "AbortError"))
+            },
+            { once: true },
+          )
+        }),
+      ])
+      if (result.done) return
+      yield result.value
+    }
+  }
 
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
@@ -52,7 +84,7 @@ export namespace SessionProcessor {
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
             const stream = await LLM.stream(streamInput)
 
-            for await (const value of stream.fullStream) {
+            for await (const value of withIdleTimeout(stream.fullStream, STREAM_IDLE_TIMEOUT_MS, input.abort)) {
               input.abort.throwIfAborted()
               switch (value.type) {
                 case "start":
@@ -357,7 +389,7 @@ export namespace SessionProcessor {
               // TODO: Handle context overflow error
             }
             const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
+            if (retry !== undefined && attempt < MAX_RETRY_ATTEMPTS) {
               attempt++
               const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
               SessionStatus.set(input.sessionID, {
@@ -368,6 +400,9 @@ export namespace SessionProcessor {
               })
               await SessionRetry.sleep(delay, input.abort).catch(() => {})
               continue
+            }
+            if (retry !== undefined) {
+              log.error("max retries exceeded", { attempt, message: retry })
             }
             input.assistantMessage.error = error
             Bus.publish(Session.Event.Error, {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { iife } from "@/util/iife"
 import { defer } from "@/util/defer"
 import { Config } from "../config/config"
 import { PermissionNext } from "@/permission/next"
+import { abortAfterAny } from "@/util/abort"
 
 const parameters = z.object({
   description: z.string().describe("A short (3-5 words) description of the task"),
@@ -118,11 +119,17 @@ export const TaskTool = Tool.define("task", async (ctx) => {
 
       const messageID = Identifier.ascending("message")
 
+      // Subagent timeout: 10 minutes default to prevent indefinite hangs
+      const SUBAGENT_TIMEOUT_MS = 10 * 60 * 1000
+      const timeout = abortAfterAny(SUBAGENT_TIMEOUT_MS, ctx.abort)
       function cancel() {
         SessionPrompt.cancel(session.id)
       }
-      ctx.abort.addEventListener("abort", cancel)
-      using _ = defer(() => ctx.abort.removeEventListener("abort", cancel))
+      timeout.signal.addEventListener("abort", cancel)
+      using _ = defer(() => {
+        timeout.signal.removeEventListener("abort", cancel)
+        timeout.clearTimeout()
+      })
       const promptParts = await SessionPrompt.resolvePromptParts(params.prompt)
 
       const result = await SessionPrompt.prompt({


### PR DESCRIPTION
## Summary

Fixes #13841 — Explore subagent hangs indefinitely with Anthropic Claude Opus 4.6 (and other providers) due to four compounding gaps in timeout/retry handling.

## Changes

### 1. Default 300s fetch timeout (`provider.ts`)
The config schema documented a 300s default, but the field was `.optional()` with no enforced default. When unconfigured, `options["timeout"]` was `undefined` and the `AbortSignal.timeout()` guard was skipped entirely. Combined with Bun's socket timeout being explicitly disabled (`timeout: false`), there was **no fallback timeout of any kind**.

Now: `const timeout = options["timeout"] ?? 300_000` — always applies the documented default unless explicitly set to `false`.

### 2. Stream-idle watchdog (`processor.ts`)
A connection that stays open but stops delivering SSE chunks was never detected. The `LLM.stream()` call only passed the session's `AbortSignal` with no idle detection.

Now: `withIdleTimeout()` async generator wraps `stream.fullStream` with a 2-minute idle timer that resets on each received chunk. On timeout, throws a `StreamIdleTimeoutError` (marked retryable via `message-v2.ts`).

### 3. Session-level retry cap (`processor.ts`)
The retry loop had no maximum attempt count — `attempt++` with no ceiling. If errors stayed retryable (e.g. rate limits, overloaded), it looped forever.

Now: `MAX_RETRY_ATTEMPTS = 10` — after exceeding the cap, the error is surfaced to the user instead of retrying.

### 4. Subagent timeout (`task.ts`)
The Task tool awaited `SessionPrompt.prompt()` with no timeout wrapper. Cancellation only happened when the parent session was manually aborted.

Now: wraps the prompt call with `abortAfterAny(10 * 60 * 1000, ctx.abort)` — 10-minute hard ceiling that also cascades to `SessionPrompt.cancel()`.

## Testing

- All 980 existing tests pass (0 failures)
- Changes are minimal and surgical — 59 lines added, 6 removed across 4 files

## Related Issues

- #11865 — Same symptom with Codex/OpenAI
- #13395 — Subagent API errors silently swallowed
- #9003 — Main agent hangs because of subagent (explore)
- #12234 — Infinite retry loop on StreamIdleTimeoutError