### PR TITLE
fix(tui): add signal handlers to prevent orphaned processes on terminal close

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -128,6 +128,28 @@ export const TuiThreadCommand = cmd({
         await client.call("reload", undefined)
       })
 
+      // Ensure the process exits when receiving termination signals.
+      // Without this, @opentui/core's exitHandler swallows SIGTERM/SIGINT/etc.
+      // (it calls destroy() but never process.exit()), and SIGHUP has no handler
+      // at all. When a terminal tab is closed the bun binary survives as an
+      // orphan (PPID=1) with revoked file descriptors, leaking memory forever.
+      let exiting = false
+      for (const signal of ["SIGHUP", "SIGTERM", "SIGINT"] as const) {
+        process.on(signal, () => {
+          if (exiting) return
+          exiting = true
+          const code = signal === "SIGHUP" ? 129 : signal === "SIGINT" ? 130 : 143
+          const timeout = setTimeout(() => process.exit(code), 5000)
+          client
+            .call("shutdown", undefined)
+            .catch(() => {})
+            .finally(() => {
+              clearTimeout(timeout)
+              process.exit(code)
+            })
+        })
+      }
+
       const prompt = await iife(async () => {
         const piped = !process.stdin.isTTY ? await Bun.stdin.text() : undefined
         if (!args.prompt) return piped


### PR DESCRIPTION
### What does this PR do?

Fixes #12767, relates to #11527, #10563

When a terminal tab is closed, `@opentui/core`'s `exitHandler` catches SIGTERM/SIGINT/SIGQUIT/SIGABRT but only calls `destroy()` without calling `process.exit()` or re-raising the signal -- silently swallowing them. SIGHUP has no handler at all. The Worker thread keeps the event loop alive, so the bun binary survives as an orphan (PPID=1) with revoked file descriptors, leaking memory indefinitely.

On my machine this accumulated **152 orphaned processes** over 10 days.

<img width="391" height="259" alt="b1affa4d177d89e62b7fbfcccc0248ca" src="https://github.com/user-attachments/assets/af2a0370-1571-4720-81fc-ca422644f15e" />
<img width="690" height="815" alt="52c4ac4bf5515ac18ef0b3781a2a5c65" src="https://github.com/user-attachments/assets/e4843edd-637e-4111-a77c-adcb155982fb" />


The fix adds signal handlers in `thread.ts` that gracefully shut down the worker (disposes instances, stops servers) before calling `process.exit()` with the correct exit code (128 + signum). A 5s timeout ensures exit even if shutdown hangs. A reentrancy guard prevents double-shutdown from multiple signals.

### How did you verify your code works?

- `tsc --noEmit` passes (0 errors in `opencode` package)
- Verified SIGHUP/SIGTERM kill orphaned processes: `kill -HUP <pid>` and `kill -TERM <pid>` both cause clean exit
- Confirmed normal Ctrl+C / Ctrl+D exit path is unaffected (raw mode means SIGINT is not generated by the terminal driver; the app handles `^C` as a keypress)