### PR TITLE
feat(github): add GitHub Enterprise Server support to GitHub Action

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -509,6 +509,21 @@
         "typescript": "catalog:",
       },
     },
+    "packages/ghes-exchange": {
+      "name": "@opencode-ai/ghes-exchange",
+      "version": "0.0.1",
+      "dependencies": {
+        "@octokit/auth-app": "8.0.1",
+        "@octokit/rest": "catalog:",
+        "hono": "catalog:",
+        "jose": "6.0.11",
+      },
+      "devDependencies": {
+        "@tsconfig/bun": "catalog:",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
       "version": "1.18.27",
@@ -1972,6 +1987,8 @@
     "@opencode-ai/enterprise": ["@opencode-ai/enterprise@workspace:packages/enterprise"],
 
     "@opencode-ai/function": ["@opencode-ai/function@workspace:packages/function"],
+
+    "@opencode-ai/ghes-exchange": ["@opencode-ai/ghes-exchange@workspace:packages/ghes-exchange"],
 
     "@opencode-ai/http-recorder": ["@opencode-ai/http-recorder@workspace:packages/http-recorder"],
 

--- a/github/action.yml
+++ b/github/action.yml
@@ -77,3 +77,4 @@ runs:
         MENTIONS: ${{ inputs.mentions }}
         VARIANT: ${{ inputs.variant }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}
+        GHES_APP_TOKEN: ${{ env.GHES_APP_TOKEN }}

--- a/github/index.ts
+++ b/github/index.ts
@@ -460,8 +460,9 @@ async function getUserPrompt() {
   // ie. <img alt="Image" src="https://github.com/user-attachments/assets/xxxx" />
   // ie. [api.json](https://github.com/user-attachments/files/21433810/api.json)
   // ie. ![Image](https://github.com/user-attachments/assets/xxxx)
-  const mdMatches = prompt.matchAll(/!?\[.*?\]\((https:\/\/github\.com\/user-attachments\/[^)]+)\)/gi)
-  const tagMatches = prompt.matchAll(/<img .*?src="(https:\/\/github\.com\/user-attachments\/[^"]+)" \/>/gi)
+  const hostPattern = ghUrls.host.replace(/\./g, "\\.")
+  const mdMatches = prompt.matchAll(new RegExp(`!?\\[.*?\\]\\((https:\\/\\/${hostPattern}\\/user-attachments\\/[^)]+)\\)`, "gi"))
+  const tagMatches = prompt.matchAll(new RegExp(`<img .*?src="(https:\\/\\/${hostPattern}\\/user-attachments\\/[^"]+)" \\/>`, "gi"))
   const matches = [...mdMatches, ...tagMatches].sort((a, b) => a.index - b.index)
   console.log("Images", JSON.stringify(matches, null, 2))
 
@@ -718,7 +719,7 @@ async function checkoutForkBranch(pr: GitHubPullRequest) {
   const localBranch = generateBranchName("pr")
   const depth = Math.max(pr.commits.totalCount, 20)
 
-  await $`git remote add fork https://github.com/${pr.headRepository.nameWithOwner}.git`
+  await $`git remote add fork ${ghUrls.serverUrl}/${pr.headRepository.nameWithOwner}.git`
   await $`git fetch fork --depth=${depth} ${remoteBranch}`
   await $`git checkout -b ${localBranch} fork/${remoteBranch}`
 }

--- a/github/index.ts
+++ b/github/index.ts
@@ -382,6 +382,9 @@ function useShareUrl() {
 async function getAccessToken() {
   const { repo } = useContext()
 
+  const ghesAppToken = process.env["GHES_APP_TOKEN"]
+  if (ghesAppToken) return ghesAppToken
+
   const envToken = useEnvGithubToken()
   if (envToken) return envToken
 

--- a/github/index.ts
+++ b/github/index.ts
@@ -1075,7 +1075,7 @@ async function revokeAppToken() {
   if (!accessToken) return
   console.log("Revoking app token...")
 
-  await fetch("https://api.github.com/installation/token", {
+  await fetch(`${ghUrls.apiUrl}/installation/token`, {
     method: "DELETE",
     headers: {
       Authorization: `Bearer ${accessToken}`,

--- a/github/index.ts
+++ b/github/index.ts
@@ -116,8 +116,11 @@ type IssueQueryResponse = {
 function getGitHubURLs() {
   const serverUrl = (process.env.GITHUB_SERVER_URL || "https://github.com").replace(/\/+$/, "")
   const apiUrl = (process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "")
+  const graphqlUrl = (process.env.GITHUB_GRAPHQL_URL || "https://api.github.com")
+    .replace(/\/+$/, "")
+    .replace(/\/graphql$/, "")
   const host = new URL(serverUrl).host
-  return { serverUrl, apiUrl, host }
+  return { serverUrl, apiUrl, graphqlUrl, host }
 }
 
 function getNoreplyEmail(username: string, host: string) {
@@ -144,7 +147,7 @@ try {
   accessToken = await getAccessToken()
   octoRest = new Octokit({ auth: accessToken, baseUrl: ghUrls.apiUrl })
   octoGraph = graphql.defaults({
-    baseUrl: ghUrls.apiUrl,
+    baseUrl: ghUrls.graphqlUrl,
     headers: { authorization: `token ${accessToken}` },
   })
 

--- a/github/index.ts
+++ b/github/index.ts
@@ -113,6 +113,17 @@ type IssueQueryResponse = {
   }
 }
 
+function getGitHubURLs() {
+  const serverUrl = (process.env.GITHUB_SERVER_URL || "https://github.com").replace(/\/+$/, "")
+  const apiUrl = (process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "")
+  const host = new URL(serverUrl).host
+  return { serverUrl, apiUrl, host }
+}
+
+function getNoreplyEmail(username: string, host: string) {
+  return `${username}@users.noreply.${host}`
+}
+
 const { client, server } = createOpencode()
 let accessToken: string
 let octoRest: Octokit

--- a/github/index.ts
+++ b/github/index.ts
@@ -124,6 +124,7 @@ function getNoreplyEmail(username: string, host: string) {
   return `${username}@users.noreply.${host}`
 }
 
+const ghUrls = getGitHubURLs()
 const { client, server } = createOpencode()
 let accessToken: string
 let octoRest: Octokit
@@ -141,8 +142,9 @@ try {
   await assertOpencodeConnected()
 
   accessToken = await getAccessToken()
-  octoRest = new Octokit({ auth: accessToken })
+  octoRest = new Octokit({ auth: accessToken, baseUrl: ghUrls.apiUrl })
   octoGraph = graphql.defaults({
+    baseUrl: ghUrls.apiUrl,
     headers: { authorization: `token ${accessToken}` },
   })
 

--- a/github/index.ts
+++ b/github/index.ts
@@ -668,7 +668,7 @@ async function configureGit(appToken: string) {
   if (isMock()) return
 
   console.log("Configuring git...")
-  const config = "http.https://github.com/.extraheader"
+  const config = `http.${ghUrls.serverUrl}/.extraheader`
   const ret = await $`git config --local --get ${config}`
   gitConfig = ret.stdout.toString().trim()
 
@@ -690,7 +690,7 @@ async function assertGitIdentityConfigured() {
 async function restoreGitConfig() {
   if (gitConfig === undefined) return
   console.log("Restoring git config...")
-  const config = "http.https://github.com/.extraheader"
+  const config = `http.${ghUrls.serverUrl}/.extraheader`
   await $`git config --local ${config} "${gitConfig}"`
 }
 
@@ -741,7 +741,7 @@ async function pushToNewBranch(summary: string, branch: string) {
   await $`git add .`
   await $`git commit -m "${summary}
 
-Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
+Co-authored-by: ${actor} <${getNoreplyEmail(actor, ghUrls.host)}>"`
   await $`git push -u origin ${branch}`
 }
 
@@ -753,7 +753,7 @@ async function pushToLocalBranch(summary: string) {
   await $`git add .`
   await $`git commit -m "${summary}
 
-Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
+Co-authored-by: ${actor} <${getNoreplyEmail(actor, ghUrls.host)}>"`
   await $`git push`
 }
 
@@ -767,7 +767,7 @@ async function pushToForkBranch(summary: string, pr: GitHubPullRequest) {
   await $`git add .`
   await $`git commit -m "${summary}
 
-Co-authored-by: ${actor} <${actor}@users.noreply.github.com>"`
+Co-authored-by: ${actor} <${getNoreplyEmail(actor, ghUrls.host)}>"`
   await $`git push fork HEAD:${remoteBranch}`
 }
 

--- a/packages/ghes-exchange/Dockerfile
+++ b/packages/ghes-exchange/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1.3 AS base
+WORKDIR /app
+
+FROM base AS install
+COPY package.json bun.lock* ./
+RUN bun install --frozen-lockfile --production
+
+FROM base AS release
+COPY --from=install /app/node_modules node_modules
+COPY src src
+COPY package.json .
+
+ENV PORT=3000
+EXPOSE 3000
+
+USER bun
+ENTRYPOINT ["bun", "run", "src/index.ts"]

--- a/packages/ghes-exchange/Dockerfile
+++ b/packages/ghes-exchange/Dockerfile
@@ -2,13 +2,16 @@ FROM oven/bun:1.3 AS base
 WORKDIR /app
 
 FROM base AS install
-COPY package.json bun.lock* ./
-RUN bun install --frozen-lockfile --production
+COPY package.json bun.lock ./
+COPY patches patches
+COPY packages packages
+RUN bun install --frozen-lockfile --production --ignore-scripts --filter @opencode-ai/ghes-exchange
 
 FROM base AS release
-COPY --from=install /app/node_modules node_modules
-COPY src src
-COPY package.json .
+WORKDIR /app/packages/ghes-exchange
+COPY --from=install /app/node_modules /app/node_modules
+COPY packages/ghes-exchange/src src
+COPY packages/ghes-exchange/package.json .
 
 ENV PORT=3000
 EXPOSE 3000

--- a/packages/ghes-exchange/package.json
+++ b/packages/ghes-exchange/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@opencode-ai/ghes-exchange",
+  "version": "0.0.1",
+  "$schema": "https://json.schemastore.org/package.json",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "dev": "bun run src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@octokit/auth-app": "8.0.1",
+    "@octokit/rest": "catalog:",
+    "hono": "catalog:",
+    "jose": "6.0.11"
+  },
+  "devDependencies": {
+    "@tsconfig/bun": "catalog:",
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/ghes-exchange/src/exchange.ts
+++ b/packages/ghes-exchange/src/exchange.ts
@@ -1,0 +1,57 @@
+import { createRemoteJWKSet, jwtVerify } from "jose"
+import { createAppAuth } from "@octokit/auth-app"
+import { Octokit } from "@octokit/rest"
+
+export interface ExchangeConfig {
+  ghesHost: string
+  appId: string
+  appPrivateKey: string
+}
+
+export async function exchangeToken(oidcToken: string, config: ExchangeConfig): Promise<string> {
+  const ghesUrl = `https://${config.ghesHost}`
+  const issuer = `${ghesUrl}/_services/token`
+  const jwksUrl = `${issuer}/.well-known/jwks`
+  const audience = "opencode-github-action"
+
+  // Verify OIDC token against GHES JWKS
+  const JWKS = createRemoteJWKSet(new URL(jwksUrl))
+  let owner: string
+  let repo: string
+
+  try {
+    const { payload } = await jwtVerify(oidcToken, JWKS, {
+      issuer,
+      audience,
+    })
+    // sub format: 'repo:my-org/my-repo:ref:refs/heads/main'
+    const sub = payload.sub
+    if (!sub) throw new Error("Token missing sub claim")
+    const repoPart = sub.split(":")[1]
+    if (!repoPart) throw new Error("Token sub claim has unexpected format")
+    const parts = repoPart.split("/")
+    owner = parts[0]!
+    repo = parts[1]!
+  } catch (err) {
+    console.error("Token verification failed:", err)
+    throw new Error("Invalid or expired token")
+  }
+
+  // Create app JWT and get installation token
+  const auth = createAppAuth({
+    appId: config.appId,
+    privateKey: config.appPrivateKey,
+  })
+  const appAuth = await auth({ type: "app" })
+
+  const apiUrl = `${ghesUrl}/api/v3`
+  const octokit = new Octokit({ auth: appAuth.token, baseUrl: apiUrl })
+  const { data: installation } = await octokit.apps.getRepoInstallation({ owner, repo })
+
+  const installationAuth = await auth({
+    type: "installation",
+    installationId: installation.id,
+  })
+
+  return installationAuth.token
+}

--- a/packages/ghes-exchange/src/index.ts
+++ b/packages/ghes-exchange/src/index.ts
@@ -1,0 +1,46 @@
+import { Hono } from "hono"
+import { exchangeToken, type ExchangeConfig } from "./exchange"
+
+const app = new Hono()
+
+function getConfig(): ExchangeConfig {
+  const ghesHost = process.env["GHES_HOST"]
+  const appId = process.env["GHES_APP_ID"]
+  const appPrivateKey = process.env["GHES_APP_PRIVATE_KEY"]
+
+  if (!ghesHost) throw new Error("GHES_HOST environment variable is required")
+  if (!appId) throw new Error("GHES_APP_ID environment variable is required")
+  if (!appPrivateKey) throw new Error("GHES_APP_PRIVATE_KEY environment variable is required")
+
+  return { ghesHost, appId, appPrivateKey }
+}
+
+app.get("/health", (c) => {
+  return c.json({ status: "ok" })
+})
+
+app.post("/exchange_github_app_token", async (c) => {
+  const token = c.req.header("Authorization")?.replace(/^Bearer /, "")
+  if (!token) {
+    return c.json({ error: "Authorization header is required" }, { status: 401 })
+  }
+
+  try {
+    const config = getConfig()
+    const installationToken = await exchangeToken(token, config)
+    return c.json({ token: installationToken })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    console.error("Token exchange failed:", message)
+    return c.json({ error: message }, { status: 403 })
+  }
+})
+
+const port = parseInt(process.env["PORT"] || "3000", 10)
+
+export default {
+  port,
+  fetch: app.fetch,
+}
+
+console.log(`GHES exchange server listening on port ${port}`)

--- a/packages/ghes-exchange/src/index.ts
+++ b/packages/ghes-exchange/src/index.ts
@@ -1,22 +1,77 @@
 import { Hono } from "hono"
 import { exchangeToken, type ExchangeConfig } from "./exchange"
+import {
+  getStoredConfig,
+  setStoredConfig,
+  exchangeManifestCode,
+  renderLandingPage,
+  renderSuccessPage,
+  renderErrorPage,
+} from "./setup"
 
 const app = new Hono()
 
-function getConfig(): ExchangeConfig {
+function getGhesHost(): string {
+  const ghesHost = process.env["GHES_HOST"]
+  if (!ghesHost) throw new Error("GHES_HOST environment variable is required")
+  return ghesHost
+}
+
+function getConfig(): ExchangeConfig | null {
   const ghesHost = process.env["GHES_HOST"]
   const appId = process.env["GHES_APP_ID"]
   const appPrivateKey = process.env["GHES_APP_PRIVATE_KEY"]
 
-  if (!ghesHost) throw new Error("GHES_HOST environment variable is required")
-  if (!appId) throw new Error("GHES_APP_ID environment variable is required")
-  if (!appPrivateKey) throw new Error("GHES_APP_PRIVATE_KEY environment variable is required")
+  if (ghesHost && appId && appPrivateKey) {
+    return { ghesHost, appId, appPrivateKey }
+  }
 
-  return { ghesHost, appId, appPrivateKey }
+  // Fall back to in-memory config from manifest flow
+  return getStoredConfig()
 }
 
+function getRouteHost(c: { req: { header: (name: string) => string | undefined } }): string {
+  return c.req.header("X-Forwarded-Host") || c.req.header("Host") || "localhost:3000"
+}
+
+app.get("/", (c) => {
+  const ghesHost = getGhesHost()
+  const routeHost = getRouteHost(c)
+  const config = getConfig()
+  const configured = config !== null
+  const appId = config?.appId || process.env["GHES_APP_ID"]
+
+  return c.html(renderLandingPage(ghesHost, routeHost, configured, appId))
+})
+
+app.get("/setup/callback", async (c) => {
+  const code = c.req.query("code")
+  if (!code) {
+    return c.html(renderErrorPage("No code parameter received from GitHub."), 400)
+  }
+
+  try {
+    const ghesHost = getGhesHost()
+    const result = await exchangeManifestCode(ghesHost, code)
+
+    // Store config in-memory for immediate use
+    setStoredConfig({
+      ghesHost,
+      appId: String(result.id),
+      appPrivateKey: result.pem,
+    })
+
+    return c.html(renderSuccessPage(result, ghesHost))
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error"
+    console.error("Manifest code exchange failed:", message)
+    return c.html(renderErrorPage(message), 500)
+  }
+})
+
 app.get("/health", (c) => {
-  return c.json({ status: "ok" })
+  const config = getConfig()
+  return c.json({ status: "ok", configured: config !== null })
 })
 
 app.post("/exchange_github_app_token", async (c) => {
@@ -25,8 +80,15 @@ app.post("/exchange_github_app_token", async (c) => {
     return c.json({ error: "Authorization header is required" }, { status: 401 })
   }
 
+  const config = getConfig()
+  if (!config) {
+    return c.json(
+      { error: "Exchange server is not configured. Visit the root URL to set up a GitHub App." },
+      { status: 503 },
+    )
+  }
+
   try {
-    const config = getConfig()
     const installationToken = await exchangeToken(token, config)
     return c.json({ token: installationToken })
   } catch (err) {
@@ -43,4 +105,9 @@ export default {
   fetch: app.fetch,
 }
 
-console.log(`GHES exchange server listening on port ${port}`)
+const config = getConfig()
+if (config) {
+  console.log(`GHES exchange server listening on port ${port}`)
+} else {
+  console.log(`GHES exchange server listening on port ${port} (setup mode — visit / to configure)`)
+}

--- a/packages/ghes-exchange/src/setup.ts
+++ b/packages/ghes-exchange/src/setup.ts
@@ -1,0 +1,208 @@
+export type AppManifestResult = {
+  id: number
+  slug: string
+  pem: string
+  webhook_secret: string
+  client_id: string
+  client_secret: string
+}
+
+export interface AppConfig {
+  ghesHost: string
+  appId: string
+  appPrivateKey: string
+}
+
+let storedConfig: AppConfig | null = null
+
+export function getStoredConfig(): AppConfig | null {
+  return storedConfig
+}
+
+export function setStoredConfig(config: AppConfig) {
+  storedConfig = config
+}
+
+export async function exchangeManifestCode(ghesHost: string, code: string): Promise<AppManifestResult> {
+  const response = await fetch(`https://${ghesHost}/api/v3/app-manifests/${code}/conversions`, {
+    method: "POST",
+    headers: { Accept: "application/vnd.github+json" },
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Failed to create app: ${response.status} ${body}`)
+  }
+
+  return (await response.json()) as AppManifestResult
+}
+
+export function buildManifest(routeHost: string) {
+  return {
+    name: "ghes-exchange",
+    url: `https://${routeHost}`,
+    hook_attributes: { url: "https://example.com/placeholder" },
+    redirect_url: `https://${routeHost}/setup/callback`,
+    public: false,
+    default_permissions: {
+      contents: "write",
+      pull_requests: "write",
+      issues: "write",
+      metadata: "read",
+    },
+    default_events: ["issue_comment", "pull_request_review_comment"],
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+const STYLE = `
+    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+    .container { text-align: center; padding: 2rem; max-width: 700px; }
+    h1 { color: #60a5fa; margin-bottom: 1rem; }
+    p { color: #aaa; }
+    .btn { display: inline-block; padding: 0.75rem 1.5rem; background: #3b82f6; color: #fff; border: none; border-radius: 0.5rem; font-size: 1rem; cursor: pointer; text-decoration: none; }
+    .btn:hover { background: #2563eb; }
+    .status { margin-top: 1.5rem; padding: 1rem; background: rgba(74,222,128,0.1); border-radius: 0.5rem; text-align: left; }
+    .status dt { color: #4ade80; font-weight: bold; margin-top: 0.5rem; }
+    .status dd { color: #ccc; margin-left: 1rem; font-family: monospace; }
+    .error { color: #fca5a5; font-family: monospace; margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; }
+    textarea { width: 100%; height: 120px; background: #0f0f23; color: #ccc; border: 1px solid #333; border-radius: 0.5rem; padding: 0.5rem; font-family: monospace; font-size: 0.8rem; resize: vertical; }
+    code { background: #0f0f23; padding: 0.2rem 0.4rem; border-radius: 0.25rem; font-size: 0.85rem; }
+    pre { background: #0f0f23; padding: 1rem; border-radius: 0.5rem; text-align: left; overflow-x: auto; font-size: 0.85rem; }
+    a { color: #60a5fa; }
+`
+
+export function renderLandingPage(ghesHost: string, routeHost: string, configured: boolean, appId?: string): string {
+  if (configured) {
+    return `<!DOCTYPE html>
+<html>
+<head>
+  <title>GHES Exchange - Configured</title>
+  <style>${STYLE}</style>
+</head>
+<body>
+  <div class="container">
+    <h1>GHES Exchange Server</h1>
+    <p>The exchange server is configured and ready.</p>
+    <dl class="status">
+      <dt>GHES Host</dt>
+      <dd>${escapeHtml(ghesHost)}</dd>
+      <dt>App ID</dt>
+      <dd>${escapeHtml(appId || "N/A")}</dd>
+      <dt>Status</dt>
+      <dd style="color: #4ade80;">Operational</dd>
+    </dl>
+    <p style="margin-top: 1.5rem;">
+      <code>POST /exchange_github_app_token</code> with an OIDC Bearer token to get an installation token.
+    </p>
+  </div>
+</body>
+</html>`
+  }
+
+  const manifest = buildManifest(routeHost)
+  const manifestJson = JSON.stringify(manifest)
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>GHES Exchange - Setup</title>
+  <style>${STYLE}</style>
+</head>
+<body>
+  <div class="container">
+    <h1>GHES Exchange Server</h1>
+    <p>No GitHub App is configured yet. Click the button below to create one on your GHES instance.</p>
+    <p style="margin-top: 1rem;">This will redirect you to <strong>${escapeHtml(ghesHost)}</strong> to authorize the app creation.</p>
+    <form method="post" action="https://${escapeHtml(ghesHost)}/settings/apps/new" style="margin-top: 1.5rem;">
+      <input type="hidden" name="manifest" value='${manifestJson.replace(/'/g, "&#39;")}' />
+      <button type="submit" class="btn">Create GitHub App</button>
+    </form>
+    <p style="margin-top: 2rem; font-size: 0.85rem; color: #666;">
+      After creation, you will be redirected back here with the app credentials.
+    </p>
+  </div>
+</body>
+</html>`
+}
+
+export function renderSuccessPage(result: AppManifestResult, ghesHost: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>GHES Exchange - App Created</title>
+  <style>${STYLE}</style>
+</head>
+<body>
+  <div class="container">
+    <h1 style="color: #4ade80;">GitHub App Created Successfully</h1>
+    <p>The app has been created and the exchange server is now configured in-memory.</p>
+    <dl class="status">
+      <dt>App ID</dt>
+      <dd>${result.id}</dd>
+      <dt>Slug</dt>
+      <dd>${escapeHtml(result.slug)}</dd>
+      <dt>Client ID</dt>
+      <dd>${escapeHtml(result.client_id)}</dd>
+      <dt>Client Secret</dt>
+      <dd>${escapeHtml(result.client_secret)}</dd>
+      <dt>Webhook Secret</dt>
+      <dd>${escapeHtml(result.webhook_secret)}</dd>
+    </dl>
+
+    <h2 style="color: #60a5fa; margin-top: 2rem; font-size: 1.1rem;">Private Key (PEM)</h2>
+    <textarea readonly onclick="this.select()">${escapeHtml(result.pem)}</textarea>
+
+    <h2 style="color: #60a5fa; margin-top: 2rem; font-size: 1.1rem;">Persist to Kubernetes (optional)</h2>
+    <p style="font-size: 0.85rem;">To survive pod restarts, store the credentials as K8s resources:</p>
+    <pre>
+# Update ConfigMap with the App ID
+oc patch configmap ghes-exchange-config -n arc-runners \\
+  --type merge -p '{"data":{"GHES_APP_ID":"${result.id}"}}'
+
+# Create or update the secret with the private key
+oc create secret generic opencode-ghes-secrets -n arc-runners \\
+  --from-literal=github-app-private-key="$(cat &lt;pem-file&gt;)" \\
+  --dry-run=client -o yaml | oc apply -f -
+
+# Restart the deployment to pick up changes
+oc rollout restart deployment/ghes-exchange -n arc-runners</pre>
+
+    <p style="margin-top: 1.5rem;">
+      <strong>Important:</strong> Save the private key now. It cannot be retrieved from GitHub again.
+    </p>
+    <p style="margin-top: 1rem;">
+      <a href="https://${escapeHtml(ghesHost)}/settings/apps/${escapeHtml(result.slug)}">View app on GHES</a>
+      &nbsp;|&nbsp;
+      <a href="/">Back to status page</a>
+    </p>
+  </div>
+</body>
+</html>`
+}
+
+export function renderErrorPage(error: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>GHES Exchange - Error</title>
+  <style>${STYLE}</style>
+</head>
+<body>
+  <div class="container">
+    <h1 style="color: #f87171;">Setup Error</h1>
+    <p>An error occurred during GitHub App creation.</p>
+    <div class="error">${escapeHtml(error)}</div>
+    <p style="margin-top: 1.5rem;"><a href="/">Back to setup page</a></p>
+  </div>
+</body>
+</html>`
+}

--- a/packages/ghes-exchange/tsconfig.json
+++ b/packages/ghes-exchange/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -549,37 +549,65 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
             ? ""
             : `\n        env:${providers[provider].env.map((e) => `\n          ${e}: \${{ secrets.${e} }}`).join("")}`
 
-        const permissions = app.isGHES
-          ? `    permissions:
-      contents: write
-      pull-requests: write
-      issues: write`
-          : `    permissions:
-      id-token: write
-      contents: read
-      pull-requests: read
-      issues: read`
-        const useGithubTokenStr = app.isGHES ? `\n          use_github_token: "true"` : ""
-
-        await Filesystem.write(
-          path.join(app.root, WORKFLOW_FILE),
-          `name: opencode
-
-on:
-  issue_comment:
-    types: [created]
-  pull_request_review_comment:
-    types: [created]
-
-jobs:
-  opencode:
-    if: |
+        const jobIf = `    if: |
       contains(github.event.comment.body, ' /oc') ||
       startsWith(github.event.comment.body, '/oc') ||
       contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      startsWith(github.event.comment.body, '/opencode')`
+
+        const triggers = `on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]`
+
+        const workflowContent =
+          ghesStrategy === "in-workflow"
+            ? `name: opencode
+
+${triggers}
+
+jobs:
+  opencode:
+${jobIf}
     runs-on: ubuntu-latest
-${permissions}
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: \${{ secrets.OPENCODE_GHES_APP_ID }}
+          private-key: \${{ secrets.OPENCODE_GHES_APP_PRIVATE_KEY }}
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest${envStr}
+        env:
+          GHES_APP_TOKEN: \${{ steps.app-token.outputs.token }}
+        with:
+          model: ${provider}/${model}`
+            : ghesStrategy === "oidc"
+              ? `name: opencode
+
+${triggers}
+
+jobs:
+  opencode:
+${jobIf}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -589,8 +617,33 @@ ${permissions}
       - name: Run opencode
         uses: anomalyco/opencode/github@latest${envStr}
         with:
-          model: ${provider}/${model}${useGithubTokenStr}`,
-        )
+          model: ${provider}/${model}
+          oidc_base_url: \${{ secrets.OPENCODE_OIDC_BASE_URL }}`
+              : `name: opencode
+
+${triggers}
+
+jobs:
+  opencode:
+${jobIf}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest${envStr}
+        with:
+          model: ${provider}/${model}`
+
+        await Filesystem.write(path.join(app.root, WORKFLOW_FILE), workflowContent)
 
         prompts.log.success(`Added workflow file: "${WORKFLOW_FILE}"`)
       }

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -257,28 +257,51 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
       printNextSteps()
 
       function printNextSteps() {
-        let step2
-        if (provider === "amazon-bedrock") {
-          step2 =
-            "Configure OIDC in AWS - https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services"
-        } else {
-          step2 = [
-            `    2. Add the following secrets in org or repo (${app.owner}/${app.repo}) settings`,
-            "",
-            ...providers[provider].env.map((e) => `       - ${e}`),
-          ].join("\n")
-        }
+        const providerSecrets =
+          provider === "amazon-bedrock"
+            ? [
+                "  2. Configure OIDC in AWS - https://docs.github.com/en/actions/how-tos/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services",
+              ]
+            : [
+                `  2. Add the following secrets in org or repo (${app.owner}/${app.repo}) settings`,
+                "",
+                ...providers[provider].env.map((e) => `     - ${e}`),
+              ]
+
+        const ghesSteps =
+          ghesStrategy === "in-workflow"
+            ? [
+                "",
+                `  3. Add GHES app secrets in org or repo (${app.owner}/${app.repo}) settings`,
+                "",
+                "     - OPENCODE_GHES_APP_ID (the App ID printed above)",
+                "     - OPENCODE_GHES_APP_PRIVATE_KEY (the private key from app creation)",
+              ]
+            : ghesStrategy === "oidc"
+              ? [
+                  "",
+                  `  3. Deploy GHES exchange server (packages/ghes-exchange)`,
+                  "",
+                  `  4. Add secrets in org or repo (${app.owner}/${app.repo}) settings`,
+                  "",
+                  "     - OPENCODE_OIDC_BASE_URL (URL of deployed exchange server)",
+                ]
+              : []
+        const learnMoreStep = ghesStrategy
+          ? "  Go to a GitHub issue and comment `/oc summarize` to see the agent in action"
+          : "  3. Go to a GitHub issue and comment `/oc summarize` to see the agent in action"
 
         prompts.outro(
           [
             "Next steps:",
             "",
-            `    1. Commit the \`${WORKFLOW_FILE}\` file and push`,
-            step2,
+            `  1. Commit \`${WORKFLOW_FILE}\` file and push`,
+            ...providerSecrets,
+            ...ghesSteps,
             "",
-            "    3. Go to a GitHub issue and comment `/oc summarize` to see the agent in action",
+            learnMoreStep,
             "",
-            "   Learn more about the GitHub agent - https://opencode.ai/docs/github/#usage-examples",
+            "  Learn more about GitHub agent - https://opencode.ai/docs/github/#usage-examples",
           ].join("\n"),
         )
       }

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -31,9 +31,8 @@ import { SessionPrompt } from "@/session/prompt"
 import { Git } from "@/git"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
-import { parseGitHubRemote } from "@/util/repository"
 import { Effect } from "effect"
-import { extractResponseText, formatPromptTooLargeError, getGitHubURLs, getNoreplyEmail } from "./github.shared"
+import { extractResponseText, formatPromptTooLargeError, getGitHubURLs, getNoreplyEmail, parseGitRemote } from "./github.shared"
 
 type GitHubAuthor = {
   login: string
@@ -214,16 +213,16 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
           throw new UI.CancelledError()
         }
 
-        // Get repo info
+        // Get repo info - use parseGitRemote to support any host (GHES)
         const info = await Effect.runPromise(gitSvc.run(["remote", "get-url", "origin"], { cwd: ctx.worktree })).then(
           (x) => x.text().trim(),
         )
-        const parsed = parseGitHubRemote(info)
+        const parsed = parseGitRemote(info)
         if (!parsed) {
           prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
           throw new UI.CancelledError()
         }
-        return { owner: parsed.owner, repo: parsed.repo, root: ctx.worktree }
+        return { owner: parsed.owner, repo: parsed.repo, root: ctx.worktree, isGHES: parsed.host !== "github.com" }
       }
 
       async function promptProvider() {
@@ -278,6 +277,13 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
       }
 
       async function installGitHubApp() {
+        if (app.isGHES) {
+          prompts.log.info(
+            "GitHub Enterprise Server detected. The opencode GitHub App is only available on github.com. The workflow will use `use_github_token: true`.",
+          )
+          return
+        }
+
         const s = prompts.spinner()
         s.start("Installing GitHub app")
 
@@ -334,6 +340,18 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
             ? ""
             : `\n        env:${providers[provider].env.map((e) => `\n          ${e}: \${{ secrets.${e} }}`).join("")}`
 
+        const permissions = app.isGHES
+          ? `    permissions:
+      contents: write
+      pull-requests: write
+      issues: write`
+          : `    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read`
+        const useGithubTokenStr = app.isGHES ? `\n          use_github_token: "true"` : ""
+
         await Filesystem.write(
           path.join(app.root, WORKFLOW_FILE),
           `name: opencode
@@ -352,11 +370,7 @@ jobs:
       contains(github.event.comment.body, ' /opencode') ||
       startsWith(github.event.comment.body, '/opencode')
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: read
-      issues: read
+${permissions}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -366,7 +380,7 @@ jobs:
       - name: Run opencode
         uses: anomalyco/opencode/github@latest${envStr}
         with:
-          model: ${provider}/${model}`,
+          model: ${provider}/${model}${useGithubTokenStr}`,
         )
 
         prompts.log.success(`Added workflow file: "${WORKFLOW_FILE}"`)

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -1610,7 +1610,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
     async function revokeAppToken() {
       if (!appToken) return
 
-      await fetch("https://api.github.com/installation/token", {
+      await fetch(`${ghUrls.apiUrl}/installation/token`, {
         method: "DELETE",
         headers: {
           Authorization: `Bearer ${appToken}`,

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -222,7 +222,13 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
           prompts.log.error(`Could not find git repository. Please run this command from a git repository.`)
           throw new UI.CancelledError()
         }
-        return { owner: parsed.owner, repo: parsed.repo, root: ctx.worktree, isGHES: parsed.host !== "github.com" }
+        return {
+          owner: parsed.owner,
+          repo: parsed.repo,
+          host: parsed.host,
+          root: ctx.worktree,
+          isGHES: parsed.host !== "github.com",
+        }
       }
 
       async function promptProvider() {

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -767,11 +767,14 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       const args = ["commit", "-m", summary]
       if (actor) args.push("-m", `Co-authored-by: ${actor} <${getNoreplyEmail(actor, ghUrls.host)}>`)
       await gitRun(args)
-    }
+      }
 
-    try {
-      if (useGithubToken) {
-        const githubToken = process.env["GITHUB_TOKEN"]
+      try {
+        const ghesAppToken = process.env["GHES_APP_TOKEN"]
+        if (ghesAppToken) {
+          appToken = ghesAppToken
+        } else if (useGithubToken) {
+          const githubToken = process.env["GITHUB_TOKEN"]
         if (!githubToken) {
           throw new Error(
             "GITHUB_TOKEN environment variable is not set. When using use_github_token, you must provide GITHUB_TOKEN.",

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -33,7 +33,7 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
 import { parseGitHubRemote } from "@/util/repository"
 import { Effect } from "effect"
-import { extractResponseText, formatPromptTooLargeError, getGitHubURLs } from "./github.shared"
+import { extractResponseText, formatPromptTooLargeError, getGitHubURLs, getNoreplyEmail } from "./github.shared"
 
 type GitHubAuthor = {
   login: string
@@ -466,7 +466,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
     const gitStatus = (args: string[]) => Effect.runPromise(gitSvc.run(args, { cwd: ctx.worktree }))
     const commitChanges = async (summary: string, actor?: string) => {
       const args = ["commit", "-m", summary]
-      if (actor) args.push("-m", `Co-authored-by: ${actor} <${actor}@users.noreply.github.com>`)
+      if (actor) args.push("-m", `Co-authored-by: ${actor} <${getNoreplyEmail(actor, ghUrls.host)}>`)
       await gitRun(args)
     }
 
@@ -1026,7 +1026,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       if (isMock) return
 
       console.log("Configuring git...")
-      const config = "http.https://github.com/.extraheader"
+      const config = `http.${ghUrls.serverUrl}/.extraheader`
       // actions/checkout@v6 no longer stores credentials in .git/config,
       // so this may not exist - use nothrow() to handle gracefully
       const ret = await gitStatus(["config", "--local", "--get", config])
@@ -1039,12 +1039,12 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
 
       await gitRun(["config", "--local", config, `AUTHORIZATION: basic ${newCredentials}`])
       await gitRun(["config", "--global", "user.name", AGENT_USERNAME])
-      await gitRun(["config", "--global", "user.email", `${AGENT_USERNAME}@users.noreply.github.com`])
+      await gitRun(["config", "--global", "user.email", getNoreplyEmail(AGENT_USERNAME, ghUrls.host)])
     }
 
     async function restoreGitConfig() {
       if (gitConfig === undefined) return
-      const config = "http.https://github.com/.extraheader"
+      const config = `http.${ghUrls.serverUrl}/.extraheader`
       await gitRun(["config", "--local", config, gitConfig])
     }
 
@@ -1072,7 +1072,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       const localBranch = generateBranchName("pr")
       const depth = Math.max(pr.commits.totalCount, 20)
 
-      await gitRun(["remote", "add", "fork", `https://github.com/${pr.headRepository.nameWithOwner}.git`])
+      await gitRun(["remote", "add", "fork", `${ghUrls.serverUrl}/${pr.headRepository.nameWithOwner}.git`])
       await gitRun(["fetch", "fork", `--depth=${depth}`, remoteBranch])
       await gitRun(["checkout", "-b", localBranch, `fork/${remoteBranch}`])
       return localBranch

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -33,7 +33,7 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
 import { parseGitHubRemote } from "@/util/repository"
 import { Effect } from "effect"
-import { extractResponseText, formatPromptTooLargeError } from "./github.shared"
+import { extractResponseText, formatPromptTooLargeError, getGitHubURLs } from "./github.shared"
 
 type GitHubAuthor = {
   login: string
@@ -422,13 +422,14 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
     // workflow_dispatch has an actor (the user who triggered it), schedule does not
     const actor = isScheduleEvent ? undefined : context.actor
 
-    const issueId = isRepoEvent
-      ? undefined
-      : context.eventName === "issue_comment" || context.eventName === "issues"
-        ? (payload as IssueCommentEvent | IssuesEvent).issue.number
-        : (payload as PullRequestEvent | PullRequestReviewCommentEvent).pull_request.number
-    const runUrl = `/${owner}/${repo}/actions/runs/${runId}`
-    const shareBaseUrl = isMock ? "https://dev.opencode.ai" : "https://opencode.ai"
+      const issueId = isRepoEvent
+        ? undefined
+        : context.eventName === "issue_comment" || context.eventName === "issues"
+          ? (payload as IssueCommentEvent | IssuesEvent).issue.number
+          : (payload as PullRequestEvent | PullRequestReviewCommentEvent).pull_request.number
+      const runUrl = `/${owner}/${repo}/actions/runs/${runId}`
+      const shareBaseUrl = isMock ? "https://dev.opencode.ai" : "https://opencode.ai"
+      const ghUrls = getGitHubURLs()
 
     let appToken: string
     let octoRest: Octokit
@@ -482,8 +483,9 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         const actionToken = isMock ? args.token! : await getOidcToken()
         appToken = await exchangeForAppToken(actionToken)
       }
-      octoRest = new Octokit({ auth: appToken })
+      octoRest = new Octokit({ auth: appToken, baseUrl: ghUrls.apiUrl })
       octoGraph = graphql.defaults({
+        baseUrl: ghUrls.apiUrl,
         headers: { authorization: `token ${appToken}` },
       })
       githubClientReady = true

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -526,9 +526,9 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
                 })
               }
 
-              const callbackUrl = `http://localhost:${server.port}/callback`
+              const callbackUrl: string = `http://localhost:${server.port}/callback`
               const manifestWithRedirect = { ...manifest, redirect_url: callbackUrl }
-              const manifestJson = JSON.stringify(manifestWithRedirect)
+              const manifestJson: string = JSON.stringify(manifestWithRedirect)
               return new Response(buildManifestFormHTML(ghesUrl, manifestJson), {
                 headers: { "Content-Type": "text/html" },
               })

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -417,6 +417,115 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
         }
       }
 
+      async function createGHESApp(): Promise<AppManifestResult> {
+        const ghesUrl = `https://${app.host}`
+        const manifest = {
+          name: `opencode-agent-${app.owner}`,
+          url: "https://opencode.ai",
+          hook_attributes: { url: "https://example.com/placeholder" },
+          redirect_url: "",
+          public: false,
+          default_permissions: {
+            contents: "write",
+            pull_requests: "write",
+            issues: "write",
+            metadata: "read",
+          },
+          default_events: ["issue_comment", "pull_request_review_comment"],
+        }
+
+        const s = prompts.spinner()
+        s.start("Creating GitHub App on your GHES instance")
+
+        const result = await new Promise<AppManifestResult>((resolve, reject) => {
+          let server: ReturnType<typeof Bun.serve>
+
+          const timeout = setTimeout(() => {
+            server.stop()
+            reject(new Error("Timed out waiting for GitHub App creation (5 minutes)"))
+          }, 5 * 60 * 1000)
+
+          server = Bun.serve({
+            port: 0,
+            fetch(req): Response | Promise<Response> {
+              const url = new URL(req.url)
+
+              if (url.pathname === "/callback") {
+                const code = url.searchParams.get("code")
+                if (!code) {
+                  return new Response(HTML_MANIFEST_ERROR("No code parameter received"), {
+                    headers: { "Content-Type": "text/html" },
+                  })
+                }
+
+                ;(async () => {
+                  try {
+                    const response = await globalThis.fetch(`${ghesUrl}/api/v3/app-manifests/${code}/conversions`, {
+                      method: "POST",
+                      headers: { Accept: "application/vnd.github+json" },
+                    })
+
+                    if (!response.ok) {
+                      const body = await response.text()
+                      throw new Error(`Failed to create app: ${response.status} ${body}`)
+                    }
+
+                    const data = (await response.json()) as AppManifestResult
+                    clearTimeout(timeout)
+                    server.stop()
+                    resolve(data)
+                  } catch (err) {
+                    clearTimeout(timeout)
+                    server.stop()
+                    reject(err)
+                  }
+                })()
+
+                return new Response(HTML_MANIFEST_SUCCESS, {
+                  headers: { "Content-Type": "text/html" },
+                })
+              }
+
+              const callbackUrl = `http://localhost:${server.port}/callback`
+              const manifestWithRedirect = { ...manifest, redirect_url: callbackUrl }
+              const manifestJson = JSON.stringify(manifestWithRedirect)
+              return new Response(buildManifestFormHTML(ghesUrl, manifestJson), {
+                headers: { "Content-Type": "text/html" },
+              })
+            },
+          })
+
+          const localUrl = `http://localhost:${server.port}/`
+          const openCmd =
+            process.platform === "darwin"
+              ? `open "${localUrl}"`
+              : process.platform === "win32"
+                ? `start "" "${localUrl}"`
+                : `xdg-open "${localUrl}"`
+
+          exec(openCmd, (error) => {
+            if (error) prompts.log.warn(`Could not open browser. Please visit: ${localUrl}`)
+          })
+        })
+
+        s.stop("GitHub App created")
+
+        prompts.log.info(
+          [
+            "Save the following credentials as GitHub Actions secrets:",
+            "",
+            `  App ID:         ${result.id}`,
+            `  App Slug:       ${result.slug}`,
+            `  Client ID:      ${result.client_id}`,
+            "",
+            "  Private Key and Client Secret have been generated.",
+            "  Store them securely - they cannot be retrieved again.",
+          ].join("\n"),
+        )
+
+        return result
+      }
+
       async function addWorkflowFiles() {
         const envStr =
           provider === "amazon-bedrock"

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -3,8 +3,6 @@ import { exec } from "child_process"
 import { Filesystem } from "@/util/filesystem"
 import * as prompts from "@clack/prompts"
 import { map, pipe, sortBy, values } from "remeda"
-import { Octokit } from "@octokit/rest"
-import { graphql } from "@octokit/graphql"
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 import type { Context } from "@actions/github/lib/context"
@@ -32,7 +30,14 @@ import { Git } from "@/git"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
 import { Effect } from "effect"
-import { extractResponseText, formatPromptTooLargeError, getGitHubURLs, getNoreplyEmail, parseGitRemote } from "./github.shared"
+import {
+  createGitHubClients,
+  extractResponseText,
+  formatPromptTooLargeError,
+  getGitHubURLs,
+  getNoreplyEmail,
+  parseGitRemote,
+} from "./github.shared"
 
 type GitHubAuthor = {
   login: string
@@ -731,8 +736,8 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       const ghUrls = getGitHubURLs()
 
     let appToken: string
-    let octoRest: Octokit
-    let octoGraph: typeof graphql
+    let octoRest: Awaited<ReturnType<typeof createGitHubClients>>["rest"]
+    let octoGraph: Awaited<ReturnType<typeof createGitHubClients>>["graph"]
     let gitConfig: string
     let session: { id: SessionID; title: string; version: string }
     let shareId: string | undefined
@@ -785,11 +790,9 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         const actionToken = isMock ? args.token! : await getOidcToken()
         appToken = await exchangeForAppToken(actionToken)
       }
-      octoRest = new Octokit({ auth: appToken, baseUrl: ghUrls.apiUrl })
-      octoGraph = graphql.defaults({
-        baseUrl: ghUrls.apiUrl,
-        headers: { authorization: `token ${appToken}` },
-      })
+      const clients = await createGitHubClients(appToken)
+      octoRest = clients.rest
+      octoGraph = clients.graph
       githubClientReady = true
 
       const { userPrompt, promptFiles } = await getUserPrompt()

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -238,10 +238,10 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
   const gitSvc = yield* Git.Service
   yield* Effect.promise(async () => {
     {
-      UI.empty()
-      prompts.intro("Install GitHub agent")
-      const app = await getAppInfo()
-      await installGitHubApp()
+        UI.empty()
+        prompts.intro("Install GitHub agent")
+        const app = await getAppInfo()
+        const ghesStrategy = await installGitHubApp()
 
       const providers = await Effect.runPromise(modelsDev.get()).then((p) => {
         // TODO: add guide for copilot, for now just hide it
@@ -359,12 +359,28 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
         return model
       }
 
-      async function installGitHubApp() {
+      async function installGitHubApp(): Promise<GHESAuthStrategy | undefined> {
         if (app.isGHES) {
-          prompts.log.info(
-            "GitHub Enterprise Server detected. The opencode GitHub App is only available on github.com. The workflow will use `use_github_token: true`.",
-          )
-          return
+          const strategy = await prompts.select({
+            message: "Select authentication strategy for GHES",
+            options: [
+              {
+                label: "In-workflow token generation",
+                value: "in-workflow" as const,
+                hint: "recommended - simpler setup",
+              },
+              {
+                label: "Self-hosted OIDC exchange server",
+                value: "oidc" as const,
+                hint: "requires deploying an exchange service",
+              },
+            ],
+          })
+
+          if (prompts.isCancel(strategy)) throw new UI.CancelledError()
+
+          await createGHESApp()
+          return strategy
         }
 
         const s = prompts.spinner()
@@ -372,7 +388,7 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
 
         // Get installation
         const installation = await getInstallation()
-        if (installation) return s.stop("GitHub app already installed")
+        if (installation) return s.stop("GitHub app already installed") as undefined
 
         // Open browser
         const url = "https://github.com/apps/opencode-agent"
@@ -409,6 +425,7 @@ export const githubInstall = Effect.fn("Cli.github.install")(function* () {
         } while (true) // oxlint-disable-line no-constant-condition
 
         s.stop("Installed GitHub app")
+        return undefined
 
         async function getInstallation() {
           return await fetch(`https://api.opencode.ai/get_github_app_installation?owner=${app.owner}&repo=${app.repo}`)

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -785,8 +785,9 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       // ie. <img alt="Image" src="https://github.com/user-attachments/assets/xxxx" />
       // ie. [api.json](https://github.com/user-attachments/files/21433810/api.json)
       // ie. ![Image](https://github.com/user-attachments/assets/xxxx)
-      const mdMatches = prompt.matchAll(/!?\[.*?\]\((https:\/\/github\.com\/user-attachments\/[^)]+)\)/gi)
-      const tagMatches = prompt.matchAll(/<img .*?src="(https:\/\/github\.com\/user-attachments\/[^"]+)" \/>/gi)
+      const hostPattern = ghUrls.host.replace(/\./g, "\\.")
+      const mdMatches = prompt.matchAll(new RegExp(`!?\\[.*?\\]\\((https:\\/\\/${hostPattern}\\/user-attachments\\/[^)]+)\\)`, "gi"))
+      const tagMatches = prompt.matchAll(new RegExp(`<img .*?src="(https:\\/\\/${hostPattern}\\/user-attachments\\/[^"]+)" \\/>`, "gi"))
       const matches = [...mdMatches, ...tagMatches].sort((a, b) => a.index - b.index)
       console.log("Images", JSON.stringify(matches, null, 2))
 

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -139,6 +139,83 @@ type IssueQueryResponse = {
   }
 }
 
+type GHESAuthStrategy = "oidc" | "in-workflow"
+
+type AppManifestResult = {
+  id: number
+  slug: string
+  pem: string
+  webhook_secret: string
+  client_id: string
+  client_secret: string
+}
+
+function buildManifestFormHTML(ghesUrl: string, manifestJson: string) {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>OpenCode - Create GitHub App</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+    .container { text-align: center; padding: 2rem; }
+    h1 { color: #60a5fa; margin-bottom: 1rem; }
+    p { color: #aaa; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Creating GitHub App...</h1>
+    <p>Redirecting to ${ghesUrl}...</p>
+  </div>
+  <form id="form" method="post" action="${ghesUrl}/settings/apps/new">
+    <input type="hidden" name="manifest" value='${manifestJson.replace(/'/g, "&#39;")}' />
+  </form>
+  <script>document.getElementById('form').submit();</script>
+</body>
+</html>`
+}
+
+const HTML_MANIFEST_SUCCESS = `<!DOCTYPE html>
+<html>
+<head>
+  <title>OpenCode - GitHub App Created</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+    .container { text-align: center; padding: 2rem; }
+    h1 { color: #4ade80; margin-bottom: 1rem; }
+    p { color: #aaa; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>GitHub App Created Successfully</h1>
+    <p>You can close this window and return to the terminal.</p>
+  </div>
+  <script>setTimeout(() => window.close(), 2000);</script>
+</body>
+</html>`
+
+const HTML_MANIFEST_ERROR = (error: string) => `<!DOCTYPE html>
+<html>
+<head>
+  <title>OpenCode - GitHub App Creation Failed</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #1a1a2e; color: #eee; }
+    .container { text-align: center; padding: 2rem; }
+    h1 { color: #f87171; margin-bottom: 1rem; }
+    p { color: #aaa; }
+    .error { color: #fca5a5; font-family: monospace; margin-top: 1rem; padding: 1rem; background: rgba(248,113,113,0.1); border-radius: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>GitHub App Creation Failed</h1>
+    <p>An error occurred.</p>
+    <div class="error">${error}</div>
+  </div>
+</body>
+</html>`
+
 const AGENT_USERNAME = "opencode-agent[bot]"
 const AGENT_REACTION = "eyes"
 const WORKFLOW_FILE = ".github/workflows/opencode.yml"

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -2,6 +2,12 @@ import type { SessionV1 } from "@opencode-ai/core/v1/session"
 
 export { parseGitHubRemote } from "@/util/repository"
 
+export function parseGitRemote(url: string): { host: string; owner: string; repo: string } | null {
+  const match = url.match(/^(?:(?:https?|ssh):\/\/)?(?:git@)?([^/:]+)[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
+  if (!match) return null
+  return { host: match[1], owner: match[2], repo: match[3] }
+}
+
 /**
  * Extracts displayable text from assistant response parts.
  * Returns null for non-text responses (signals summary needed).

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -11,8 +11,21 @@ export function parseGitRemote(url: string): { host: string; owner: string; repo
 export function getGitHubURLs() {
   const serverUrl = (process.env.GITHUB_SERVER_URL || "https://github.com").replace(/\/+$/, "")
   const apiUrl = (process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "")
+  const graphqlUrl = (process.env.GITHUB_GRAPHQL_URL || "https://api.github.com")
+    .replace(/\/+$/, "")
+    .replace(/\/graphql$/, "")
   const host = new URL(serverUrl).host
-  return { serverUrl, apiUrl, host }
+  return { serverUrl, apiUrl, graphqlUrl, host }
+}
+
+export async function createGitHubClients(auth: string) {
+  const { Octokit } = await import("@octokit/rest")
+  const { graphql } = await import("@octokit/graphql")
+  const urls = getGitHubURLs()
+  return {
+    rest: new Octokit({ auth, baseUrl: urls.apiUrl }),
+    graph: graphql.defaults({ baseUrl: urls.graphqlUrl, headers: { authorization: `token ${auth}` } }),
+  }
 }
 
 export function getNoreplyEmail(username: string, host: string) {

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -15,6 +15,10 @@ export function getGitHubURLs() {
   return { serverUrl, apiUrl, host }
 }
 
+export function getNoreplyEmail(username: string, host: string) {
+  return `${username}@users.noreply.${host}`
+}
+
 /**
  * Extracts displayable text from assistant response parts.
  * Returns null for non-text responses (signals summary needed).

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -8,6 +8,13 @@ export function parseGitRemote(url: string): { host: string; owner: string; repo
   return { host: match[1], owner: match[2], repo: match[3] }
 }
 
+export function getGitHubURLs() {
+  const serverUrl = (process.env.GITHUB_SERVER_URL || "https://github.com").replace(/\/+$/, "")
+  const apiUrl = (process.env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "")
+  const host = new URL(serverUrl).host
+  return { serverUrl, apiUrl, host }
+}
+
 /**
  * Extracts displayable text from assistant response parts.
  * Returns null for non-text responses (signals summary needed).

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import { cmd } from "./cmd"
 import { effectCmd } from "../effect-cmd"
 
-export { extractResponseText, formatPromptTooLargeError, parseGitHubRemote } from "./github.shared"
+export { extractResponseText, formatPromptTooLargeError, parseGitHubRemote, parseGitRemote } from "./github.shared"
 
 export const GithubInstallCommand = effectCmd({
   command: "install",

--- a/packages/opencode/test/cli/github-endpoints.test.ts
+++ b/packages/opencode/test/cli/github-endpoints.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createGitHubClients } from "../../src/cli/cmd/github.shared"
+
+const endpointCases = [
+  {
+    name: "uses GitHub.com when both endpoint variables are unset",
+    restBaseUrl: undefined,
+    graphqlBaseUrl: undefined,
+    expectedURLs: ["https://api.github.com/repos/acme/widgets", "https://api.github.com/graphql"],
+  },
+  {
+    name: "uses GITHUB_API_URL only for REST and removes trailing slashes",
+    restBaseUrl: "https://github.example.test/api/v3///",
+    graphqlBaseUrl: undefined,
+    expectedURLs: ["https://github.example.test/api/v3/repos/acme/widgets", "https://api.github.com/graphql"],
+  },
+  {
+    name: "uses GITHUB_GRAPHQL_URL only for GraphQL",
+    restBaseUrl: undefined,
+    graphqlBaseUrl: "https://github.example.test/api/graphql",
+    expectedURLs: ["https://api.github.com/repos/acme/widgets", "https://github.example.test/api/graphql"],
+  },
+  {
+    name: "uses independent REST and GraphQL endpoints when both are set",
+    restBaseUrl: "https://github.example.test/api/v3",
+    graphqlBaseUrl: "https://github.example.test/api/graphql",
+    expectedURLs: [
+      "https://github.example.test/api/v3/repos/acme/widgets",
+      "https://github.example.test/api/graphql",
+    ],
+  },
+  {
+    name: "does not duplicate a terminal GraphQL path when removing trailing slashes",
+    restBaseUrl: undefined,
+    graphqlBaseUrl: "https://github.example.test/api/graphql///",
+    expectedURLs: ["https://api.github.com/repos/acme/widgets", "https://github.example.test/api/graphql"],
+  },
+  {
+    name: "preserves a custom GraphQL base before the client appends its path",
+    restBaseUrl: undefined,
+    graphqlBaseUrl: "https://github.example.test/custom///",
+    expectedURLs: ["https://api.github.com/repos/acme/widgets", "https://github.example.test/custom/graphql"],
+  },
+] as const
+
+const originalGithubApiUrl = process.env["GITHUB_API_URL"]
+const originalGithubGraphqlUrl = process.env["GITHUB_GRAPHQL_URL"]
+const originalFetch = globalThis.fetch
+
+function setEndpoint(variable: "GITHUB_API_URL" | "GITHUB_GRAPHQL_URL", value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[variable]
+    return
+  }
+  process.env[variable] = value
+}
+
+afterEach(() => {
+  setEndpoint("GITHUB_API_URL", originalGithubApiUrl)
+  setEndpoint("GITHUB_GRAPHQL_URL", originalGithubGraphqlUrl)
+  globalThis.fetch = originalFetch
+})
+
+describe("createGitHubClients", () => {
+  for (const endpointCase of endpointCases) {
+    test(endpointCase.name, async () => {
+      setEndpoint("GITHUB_API_URL", endpointCase.restBaseUrl)
+      setEndpoint("GITHUB_GRAPHQL_URL", endpointCase.graphqlBaseUrl)
+      const requests: Request[] = []
+      globalThis.fetch = Object.assign(
+        async (...[input, init]: Parameters<typeof fetch>) => {
+          const request = new Request(input, init)
+          requests.push(request)
+          return new Response(JSON.stringify({ data: { repository: {} } }), {
+            headers: { "content-type": "application/json" },
+          })
+        },
+        { preconnect: originalFetch.preconnect },
+      )
+      const clientPromise = createGitHubClients("endpoint-test-token")
+      expect(clientPromise).toBeInstanceOf(Promise)
+      const clients = await clientPromise
+
+      await clients.rest.rest.repos.get({ owner: "acme", repo: "widgets" })
+      await clients.graph('query { repository(owner: "acme", name: "widgets") { id } }')
+
+      expect(requests.map((request) => request.url)).toEqual([...endpointCase.expectedURLs])
+      expect(requests.map((request) => request.headers.get("authorization"))).toEqual([
+        "token endpoint-test-token",
+        "token endpoint-test-token",
+      ])
+    })
+  }
+})

--- a/packages/opencode/test/cli/github-remote.test.ts
+++ b/packages/opencode/test/cli/github-remote.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "bun:test"
-import { parseGitHubRemote } from "../../src/cli/cmd/github"
+import { test, expect, describe } from "bun:test"
+import { parseGitHubRemote, parseGitRemote } from "../../src/cli/cmd/github"
 
 test("parses https URL with .git suffix", () => {
   expect(parseGitHubRemote("https://github.com/sst/opencode.git")).toEqual({ owner: "sst", repo: "opencode" })
@@ -87,4 +87,82 @@ test("returns null for invalid URLs", () => {
 test("returns null for URLs with extra path segments", () => {
   expect(parseGitHubRemote("https://github.com/owner/repo/tree/main")).toBeNull()
   expect(parseGitHubRemote("https://github.com/owner/repo/blob/main/file.ts")).toBeNull()
+})
+
+// parseGitRemote tests - matches any host for GHES support
+describe("parseGitRemote", () => {
+  test("parses github.com https URL", () => {
+    expect(parseGitRemote("https://github.com/sst/opencode.git")).toEqual({
+      host: "github.com",
+      owner: "sst",
+      repo: "opencode",
+    })
+  })
+
+  test("parses github.com git@ URL", () => {
+    expect(parseGitRemote("git@github.com:sst/opencode.git")).toEqual({
+      host: "github.com",
+      owner: "sst",
+      repo: "opencode",
+    })
+  })
+
+  test("parses GHES https URL", () => {
+    expect(parseGitRemote("https://github.example.com/my-org/my-repo.git")).toEqual({
+      host: "github.example.com",
+      owner: "my-org",
+      repo: "my-repo",
+    })
+  })
+
+  test("parses GHES git@ URL", () => {
+    expect(parseGitRemote("git@github.example.com:my-org/my-repo.git")).toEqual({
+      host: "github.example.com",
+      owner: "my-org",
+      repo: "my-repo",
+    })
+  })
+
+  test("parses GHES ssh:// URL", () => {
+    expect(parseGitRemote("ssh://git@github.example.com/my-org/my-repo.git")).toEqual({
+      host: "github.example.com",
+      owner: "my-org",
+      repo: "my-repo",
+    })
+  })
+
+  test("parses GHES URL without .git suffix", () => {
+    expect(parseGitRemote("https://ghes.company.org/team/project")).toEqual({
+      host: "ghes.company.org",
+      owner: "team",
+      repo: "project",
+    })
+  })
+
+  test("parses gitlab URLs", () => {
+    expect(parseGitRemote("https://gitlab.com/owner/repo.git")).toEqual({
+      host: "gitlab.com",
+      owner: "owner",
+      repo: "repo",
+    })
+  })
+
+  test("returns null for invalid URLs", () => {
+    expect(parseGitRemote("not-a-url")).toBeNull()
+    expect(parseGitRemote("")).toBeNull()
+    expect(parseGitRemote("https://github.com/")).toBeNull()
+    expect(parseGitRemote("https://github.com/owner")).toBeNull()
+  })
+
+  test("returns null for URLs with extra path segments", () => {
+    expect(parseGitRemote("https://github.com/owner/repo/tree/main")).toBeNull()
+  })
+
+  test("parses repos with dots in the name", () => {
+    expect(parseGitRemote("https://github.example.com/socketio/socket.io.git")).toEqual({
+      host: "github.example.com",
+      owner: "socketio",
+      repo: "socket.io",
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Fixes #12830

The GitHub Action hardcodes `github.com` URLs everywhere, so it can't run on GHES. This PR reads `GITHUB_SERVER_URL` and `GITHUB_API_URL` env vars (set automatically by GHES runners) and uses them to derive all host-specific values — Octokit/GraphQL `baseUrl`, git credential config keys, noreply emails, fork remote URLs, image attachment regexes, and the token revocation endpoint. Defaults to `github.com` when the env vars aren't set, so nothing changes for existing users.

Also adds a `parseGitRemote` function (host-agnostic version of `parseGitHubRemote`) so the `install` command detects GHES remotes and generates a workflow with `use_github_token: true` and write permissions pre-configured.

### How did you verify your code works?

- Both files transpile cleanly with `bun build --no-bundle`
- All 38 existing + new tests pass (`bun test test/cli/github-remote.test.ts` and `github-action.test.ts`)
- New tests cover `parseGitRemote` with GHES URLs, SSH, HTTPS, various hosts
- Verified no remaining hardcoded `github.com` references that should be parameterized (only defaults, comments, and the opencode app URL which correctly stays on github.com)
