### PR TITLE
fix: prevent viewport/selection jumping when moving with deletion marked in session_list

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/dialog-select.tsx
@@ -56,6 +56,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     input: "keyboard" as "keyboard" | "mouse",
   })
 
+  let ignoreNextEffect = false
+
   createEffect(
     on(
       () => props.current,
@@ -137,6 +139,10 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   createEffect(
     on([() => store.filter, () => props.current], ([filter, current]) => {
       setTimeout(() => {
+        if (ignoreNextEffect) {
+          ignoreNextEffect = false
+          return
+        }
         if (filter.length > 0) {
           moveTo(0, true)
         } else if (current) {
@@ -159,6 +165,7 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   function moveTo(next: number, center = false) {
     setStore("selected", next)
+    ignoreNextEffect = true
     const option = selected()
     if (option) props.onMove?.(option)
     if (!scroll) return


### PR DESCRIPTION
### What does this PR do?

Add ignoreNextEffect flag to prevent the createEffect from overriding manual navigation when onMove callback triggers prop changes. This prevents unexpected viewport/selection jumps from ocurring. 

Fixes anomalyco#13880

### How did you verify your code works?

Manual A/B testing, `bun typecheck`, `bun test`.