### PR TITLE
fix(app): use computed latest set for model (latest) tag

### DIFF
--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -96,7 +96,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       available().map((m) => ({
         ...m,
         name: m.name.replace("(latest)", "").trim(),
-        latest: m.name.includes("(latest)"),
+        latest: latestSet().has(modelKey({ providerID: m.provider.id, modelID: m.id })),
       })),
     )
 


### PR DESCRIPTION
## Summary
- The "(latest)" tag displayed next to models in the model selection dialog was determined by checking if the models.dev API included `(latest)` in the model name string
- This is stale — e.g. it shows "(latest)" for Claude Opus 4.5 even though Opus 4.6 is now the latest
- Uses the already-computed `latestSet` instead, which correctly picks the newest model per family by `release_date`

## Test plan
- [ ] Open model selection dialog and verify "(latest)" tag appears on the newest model per family (e.g. Opus 4.6, not Opus 4.5)
- [ ] Verify models without a newer sibling still show "(latest)" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)