### PR TITLE
fix(website): fix site in safari 18

### DIFF
--- a/packages/console/app/src/routes/index.css
+++ b/packages/console/app/src/routes/index.css
@@ -174,21 +174,6 @@ body {
     }
   }
 
-  input:-webkit-autofill,
-  input:-webkit-autofill:hover,
-  input:-webkit-autofill:focus,
-  input:-webkit-autofill:active {
-    transition: background-color 5000000s ease-in-out 0s;
-  }
-
-  input:-webkit-autofill {
-    -webkit-text-fill-color: var(--color-text-strong) !important;
-  }
-
-  input:-moz-autofill {
-    -moz-text-fill-color: var(--color-text-strong) !important;
-  }
-
   [data-component="container"] {
     max-width: 67.5rem;
     margin: 0 auto;
@@ -1248,5 +1233,20 @@ body {
       color: var(--color-text);
       text-decoration: underline;
     }
+  }
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    transition: background-color 5000000s ease-in-out 0s;
+  }
+
+  input:-webkit-autofill {
+    -webkit-text-fill-color: var(--color-text-strong) !important;
+  }
+
+  input:-moz-autofill {
+    -moz-text-fill-color: var(--color-text-strong) !important;
   }
 }


### PR DESCRIPTION
### What does this PR do?

The website is broken in Safari 18:

<img width="2224" height="1444" alt="Screenshot 2026-02-16 at 3 18 01 PM" src="https://github.com/user-attachments/assets/40f4fb4c-c7aa-4a78-82aa-ab87d723a4fa" />

Looks like there's a bug in Safari with the `input:-moz-autofill` rule (or any pseudo-selector it doesn't recognize) where it breaks all styles after that. It's like is breaks the parser at that point. Move these styles to the bottom fixes it. (This is fixed in later versions of Safari)

Given that Safari 18 is Sequoia 15 which is only 1 version back from latest (a brief search shows ~1-2% market share) seems like it's worth fixing

### How did you verify your code works?

I loaded it locally, did the fix, and now it works:

<img width="3070" height="1598" alt="Screenshot 2026-02-16 at 4 41 30 PM" src="https://github.com/user-attachments/assets/c8e519ce-6196-44a8-a811-3dc966af19ad" />
