### PR TITLE
fix: pre-build custom tools instead of naively import()ing them

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -24,7 +24,7 @@ import { LSPServer } from "../lsp/server"
 import { BunProc } from "@/bun"
 import { Installation } from "@/installation"
 import { ConfigMarkdown } from "./markdown"
-import { constants, existsSync } from "fs"
+import { constants, existsSync, readFileSync } from "fs"
 import { Bus } from "@/bus"
 import { GlobalBus } from "@/bus/global"
 import { Event } from "../server/event"
@@ -247,13 +247,99 @@ export namespace Config {
   })
 
   export async function waitForDependencies() {
-    const deps = await state().then((x) => x.deps)
+    const { deps, directories } = await state()
     await Promise.all(deps)
+    const paths = unique([...directories, Global.Path.cache])
+    for (const dir of paths) {
+      const nm = path.join(dir, "node_modules")
+      if (existsSync(nm)) {
+        const toolDir = path.join(dir, "tools")
+        if (existsSync(toolDir)) {
+          const target = path.join(toolDir, "node_modules")
+          if (!existsSync(target)) {
+            fs.symlink(nm, target, "dir").catch(/* ignore */);
+          }
+        }
+
+        process.env.NODE_PATH = unique([nm, ...(process.env.NODE_PATH?.split(path.delimiter) ?? [])])
+          .filter(Boolean)
+          .join(path.delimiter)
+      }
+    }
+  }
+
+  // Build a tool/plugin file using Bun.build() to bundle all dependencies.
+  // This is needed because compiled Bun binaries can't resolve transitive
+  // dependencies (e.g. zod from @opencode-ai/plugin) at runtime.
+  export async function build(file: string) {
+    const outdir = path.join(Global.Path.cache, "tool-builds")
+    const { directories } = await state()
+    const nmPaths = unique([...directories, Global.Path.cache])
+      .map((dir) => path.join(dir, "node_modules"))
+      .filter(existsSync)
+    const result = await Bun.build({
+      entrypoints: [file],
+      outdir,
+      target: "bun",
+      naming: "[name]-[hash].[ext]",
+      plugins: nmPaths.length
+        ? [
+            {
+              name: "opencode-resolve",
+              setup(builder) {
+                builder.onResolve({ filter: /.*/ }, (args) => {
+                  if (args.path.startsWith(".") || args.path.startsWith("/")) return
+                  for (const nm of nmPaths) {
+                    const parts = args.path.startsWith("@")
+                      ? args.path.split("/").slice(0, 2)
+                      : [args.path.split("/")[0]]
+                    const pkgDir = path.join(nm, ...parts)
+                    if (!existsSync(pkgDir)) continue
+                    const subpath = args.path.startsWith("@")
+                      ? args.path.split("/").slice(2).join("/")
+                      : args.path.split("/").slice(1).join("/")
+                    const pkgJson = path.join(pkgDir, "package.json")
+                    if (!existsSync(pkgJson)) continue
+                    const pkg = JSON.parse(readFileSync(pkgJson, "utf8"))
+                    if (subpath) {
+                      const entry = pkg.exports?.["./" + subpath]
+                      const resolved = entry
+                        ? typeof entry === "string"
+                          ? entry
+                          : entry.import || entry.default || entry.require
+                        : null
+                      if (resolved) return { path: path.join(pkgDir, resolved) }
+                      const direct = path.join(pkgDir, subpath)
+                      for (const ext of ["", ".js", ".mjs", ".ts"]) {
+                        if (existsSync(direct + ext)) return { path: direct + ext }
+                      }
+                      continue
+                    }
+                    const mainExport = pkg.exports?.["."]
+                    const resolved = mainExport
+                      ? typeof mainExport === "string"
+                        ? mainExport
+                        : mainExport.import || mainExport.default || mainExport.require
+                      : pkg.module || pkg.main || "index.js"
+                    if (resolved) return { path: path.join(pkgDir, resolved) }
+                  }
+                })
+              },
+            },
+          ]
+        : [],
+    })
+    if (!result.success) {
+      throw new Error(`Failed to build ${file}: ${result.logs.map(String).join("\n")}`)
+    }
+    return result.outputs[0].path
   }
 
   export async function installDependencies(dir: string) {
     const pkg = path.join(dir, "package.json")
-    const targetVersion = Installation.isLocal() ? "*" : Installation.VERSION
+    const isDev =
+      Installation.VERSION.includes("-dev") || Installation.VERSION.startsWith("0.0.0") || Installation.isLocal()
+    const targetVersion = isDev ? "latest" : Installation.VERSION
 
     const json = await Bun.file(pkg)
       .json()
@@ -263,7 +349,6 @@ export namespace Config {
       "@opencode-ai/plugin": targetVersion,
     }
     await Bun.write(pkg, JSON.stringify(json, null, 2))
-    await new Promise((resolve) => setTimeout(resolve, 3000))
 
     const gitignore = path.join(dir, ".gitignore")
     const hasGitIgnore = await Bun.file(gitignore).exists()
@@ -312,8 +397,11 @@ export namespace Config {
     const depVersion = dependencies["@opencode-ai/plugin"]
     if (!depVersion) return true
 
-    const targetVersion = Installation.isLocal() ? "latest" : Installation.VERSION
+    const isDev =
+      Installation.VERSION.includes("-dev") || Installation.VERSION.startsWith("0.0.0") || Installation.isLocal()
+    const targetVersion = isDev ? "latest" : Installation.VERSION
     if (targetVersion === "latest") {
+      if (depVersion === "latest") return true
       const isOutdated = await PackageRegistry.isOutdated("@opencode-ai/plugin", depVersion, dir)
       if (!isOutdated) return false
       log.info("Cached version is outdated, proceeding with install", {

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -41,7 +41,8 @@ export namespace ToolRegistry {
     if (matches.length) await Config.waitForDependencies()
     for (const match of matches) {
       const namespace = path.basename(match, path.extname(match))
-      const mod = await import(match)
+      const built = await Config.build(match)
+      const mod = await import(built)
       for (const [id, def] of Object.entries<ToolDefinition>(mod)) {
         custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
       }


### PR DESCRIPTION
on first launch, opencode installs @opencode-ai/plugin. but without restarting opencode when it's done, the following error appears:

 error: Cannot find package 'zod' from '/home/demostanis/.config/opencode/node_modules/@opencode-ai/plugin/dist/tool.js'

https://opncd.ai/share/phMT4NGN (seems buggy? my messages don't show correctly)

This is a quick vibe-coded fix with Claude Opus 4.6.

### What does this PR do?

(Fixes #13887)

OpenCode installs @opencode-ai/plugin on first start to ~/.config/opencode/node_modules. However,
when having custom tools in ~/.config/opencode/tools, an error appears on the TUI:
error: Cannot find package 'zod' from '/home/demostanis/.config/opencode/node_modules/@opencode-ai/plugin/dist/tool.js'
(or similar with @opencode-ai/plugin)
A restart is needed for the error to disappear.
This is impactful on temporary systems, where ~/.config/opencode/node_modules will be frequently suppressed (my system runs on a tmpfs)


### How did you verify your code works?

```
rm -rf /home/demostanis/.config/opencode/node_modules && rm -rf /tmp/.opencode && rm -rf /tmp/a && mkdir -p /tmp/a && cd /tmp/a && timeout 120 /tmp/tmp.ILuulrHZEC/opencode/packages/opencode/dist/opencode-linux-x64/bin/opencode run "use the python tool with a hello world program" 2>&
```
(to adapt)