### PR TITLE
feat(web): fix(web): - Add FPS configuration for terminal to stop busy cycling (Issue #13899)

### DIFF
--- a/packages/app/e2e/selectors.ts
+++ b/packages/app/e2e/selectors.ts
@@ -14,6 +14,7 @@ export const settingsSoundsAgentEnabledSelector = '[data-action="settings-sounds
 export const settingsSoundsPermissionsSelector = '[data-action="settings-sounds-permissions"]'
 export const settingsSoundsPermissionsEnabledSelector = '[data-action="settings-sounds-permissions-enabled"]'
 export const settingsSoundsErrorsSelector = '[data-action="settings-sounds-errors"]'
+export const settingsTerminalFpsSelector = '[data-action="settings-terminal-fps"]'
 export const settingsSoundsErrorsEnabledSelector = '[data-action="settings-sounds-errors-enabled"]'
 export const settingsUpdatesStartupSelector = '[data-action="settings-updates-startup"]'
 export const settingsReleaseNotesSelector = '[data-action="settings-release-notes"]'

--- a/packages/app/e2e/settings/settings.spec.ts
+++ b/packages/app/e2e/settings/settings.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, settingsKey } from "../fixtures"
 import { closeDialog, openSettings } from "../actions"
 import {
+  promptSelector,
   settingsColorSchemeSelector,
   settingsFontSelector,
   settingsLanguageSelectSelector,
@@ -9,12 +10,15 @@ import {
   settingsNotificationsPermissionsSelector,
   settingsReleaseNotesSelector,
   settingsSoundsAgentSelector,
+  settingsTerminalFpsSelector,
   settingsSoundsAgentEnabledSelector,
   settingsSoundsErrorsSelector,
   settingsSoundsPermissionsSelector,
   settingsThemeSelector,
+  terminalSelector,
   settingsUpdatesStartupSelector,
 } from "../selectors"
+import { terminalToggleKey } from "../utils"
 
 test("smoke settings dialog opens, switches tabs, closes", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -476,4 +480,72 @@ test("toggling release notes switch updates localStorage", async ({ page, gotoSe
   }, settingsKey)
 
   expect(stored?.general?.releaseNotes).toBe(false)
+})
+
+test("changing terminal FPS persists in localStorage", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const dialog = await openSettings(page)
+  const input = dialog.locator(settingsTerminalFpsSelector)
+  await expect(input).toBeVisible()
+
+  const initialFps = await input.inputValue()
+  expect(initialFps).toBe("15")
+
+  await input.fill("30")
+  await page.waitForTimeout(100)
+
+  const stored = await page.evaluate((key) => {
+    const raw = localStorage.getItem(key)
+    return raw ? JSON.parse(raw) : null
+  }, settingsKey)
+
+  expect(stored?.appearance?.terminalFps).toBe(30)
+})
+
+test("terminal FPS value is retrieved after page reload", async ({ page, gotoSession }) => {
+  await page.addInitScript(() => {
+    const settings = JSON.parse(localStorage.getItem("settings.v3") || "{}")
+    settings.appearance = { ...(settings.appearance || {}), terminalFps: 60 }
+    localStorage.setItem("settings.v3", JSON.stringify(settings))
+  })
+
+  await gotoSession()
+
+  const dialog = await openSettings(page)
+  const input = dialog.locator(settingsTerminalFpsSelector)
+  await expect(input).toBeVisible()
+
+  const fpsValue = await input.inputValue()
+  expect(fpsValue).toBe("60")
+})
+
+test("changing terminal FPS updates all open terminals", async ({ page, gotoSession }) => {
+  await gotoSession()
+
+  const terminals = page.locator(terminalSelector)
+  const initiallyOpen = await terminals.first().isVisible()
+  if (!initiallyOpen) {
+    await page.keyboard.press(terminalToggleKey)
+  }
+
+  await page.locator(promptSelector).click()
+  await page.keyboard.press("Control+Alt+T")
+
+  await expect(terminals).toHaveCount(2)
+  await expect(terminals.first().locator("textarea")).toHaveCount(1)
+  await expect(terminals.nth(1).locator("textarea")).toHaveCount(1)
+
+  const dialog = await openSettings(page)
+  const input = dialog.locator(settingsTerminalFpsSelector)
+  await expect(input).toBeVisible()
+
+  await input.fill("1")
+  await page.waitForTimeout(100)
+
+  await closeDialog(page, dialog)
+
+  await expect(terminals).toHaveCount(2)
+  await expect(terminals.first().locator("textarea")).toHaveCount(1)
+  await expect(terminals.nth(1).locator("textarea")).toHaveCount(1)
 })

--- a/packages/app/e2e/settings/settings.spec.ts
+++ b/packages/app/e2e/settings/settings.spec.ts
@@ -542,7 +542,6 @@ test("changing terminal FPS updates all open terminals", async ({ page, gotoSess
 
   await input.fill("1")
   await page.waitForTimeout(100)
-
   await closeDialog(page, dialog)
 
   await expect(terminals).toHaveCount(2)

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -2,6 +2,7 @@ import { Component, Show, createMemo, createResource, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Button } from "@opencode-ai/ui/button"
 import { Icon } from "@opencode-ai/ui/icon"
+import { InlineInput } from "@opencode-ai/ui/inline-input"
 import { Select } from "@opencode-ai/ui/select"
 import { Switch } from "@opencode-ai/ui/switch"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
@@ -249,6 +250,30 @@ export const SettingsGeneral: Component = () => {
               </span>
             )}
           </Select>
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.terminalFps.title")}
+          description={language.t("settings.general.row.terminalFps.description")}
+        >
+          <InlineInput
+            data-action="settings-terminal-fps"
+            type="number"
+            min={0}
+            max={240}
+            value={settings.appearance.terminalFps()}
+            onBlur={(e) => {
+              const value = Math.min(240, Math.max(0, parseInt(e.currentTarget.value, 10) || 0))
+              settings.appearance.setTerminalFps(value)
+            }}
+            onInput={(e) => {
+              const value = parseInt(e.currentTarget.value, 10)
+              if (!isNaN(value) && value >= 0 && value <= 240) {
+                settings.appearance.setTerminalFps(value)
+              }
+            }}
+            class="w-20 text-right"
+          />
         </SettingsRow>
       </div>
     </div>

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -1,5 +1,5 @@
 import type { Ghostty, Terminal as Term, FitAddon } from "ghostty-web"
-import { ComponentProps, createEffect, createSignal, onCleanup, onMount, splitProps } from "solid-js"
+import { ComponentProps, createEffect, createMemo, createSignal, onCleanup, onMount, splitProps } from "solid-js"
 import { usePlatform } from "@/context/platform"
 import { useSDK } from "@/context/sdk"
 import { monoFontFamily, useSettings } from "@/context/settings"
@@ -393,15 +393,19 @@ export const Terminal = (props: TerminalProps) => {
       }
 
       let lastFrameTime = 0
-      const minFrameInterval = 1000 / 15
+      const minFrameInterval = createMemo(() => {
+        const fps = settings.appearance.terminalFps()
+        return fps === 0 ? 0 : 1000 / fps
+      })
 
       termImpl.startRenderLoop = function () {
         const throttledLoop = () => {
           if (termImpl.isDisposed || !termImpl.isOpen) return
 
           const now = performance.now()
-          if (now - lastFrameTime >= minFrameInterval) {
-            lastFrameTime = now
+          const interval = minFrameInterval()
+          if (interval === 0 || now - lastFrameTime >= interval) {
+            if (interval > 0) lastFrameTime = now
             termImpl.renderer.render(termImpl.wasmTerm, false, termImpl.viewportY, termImpl, termImpl.scrollbarOpacity)
             const cursor = termImpl.wasmTerm.getCursor()
             if (cursor.y !== termImpl.lastCursorY) {

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -42,6 +42,20 @@ type TerminalColors = {
   selectionBackground: string
 }
 
+interface GhosttyTerminalImpl {
+  startRenderLoop: () => void
+  isDisposed: boolean
+  isOpen: boolean
+  renderer: {
+    render: (wasmTerm: unknown, force: boolean, viewportY: number, term: unknown, scrollbarOpacity: number) => void
+  }
+  wasmTerm: { getCursor: () => { x: number; y: number } }
+  lastCursorY: number
+  cursorMoveEmitter: { fire: () => void }
+  viewportY: number
+  scrollbarOpacity: number
+}
+
 const DEFAULT_TERMINAL_COLORS: Record<"light" | "dark", TerminalColors> = {
   light: {
     background: "#fcfcfc",
@@ -371,28 +385,13 @@ export const Terminal = (props: TerminalProps) => {
       fitAddon = fit
       serializeAddon = serializer
 
-      const termImpl = t as unknown as {
-        startRenderLoop: () => void
-        isDisposed: boolean
-        isOpen: boolean
-        renderer: {
-          render: (
-            wasmTerm: unknown,
-            force: boolean,
-            viewportY: number,
-            term: unknown,
-            scrollbarOpacity: number,
-          ) => void
-        }
-        wasmTerm: { getCursor: () => { x: number; y: number } }
-        lastCursorY: number
-        cursorMoveEmitter: { fire: () => void }
-        animationFrameId: number | undefined
-        viewportY: number
-        scrollbarOpacity: number
-      }
+      // Monkey-patch the terminal's render loop to throttle FPS for CPU usage
+      // IMPORTANT: This must happen BEFORE t.open(container) so the patched function is used
+      // when the render loop starts
+      const termImpl = t as unknown as GhosttyTerminalImpl
 
       let lastFrameTime = 0
+      let animationFrameId: number | undefined
       const minFrameInterval = createMemo(() => {
         const fps = settings.appearance.terminalFps()
         return fps === 0 ? 0 : 1000 / fps
@@ -413,7 +412,7 @@ export const Terminal = (props: TerminalProps) => {
               termImpl.cursorMoveEmitter.fire()
             }
           }
-          termImpl.animationFrameId = requestAnimationFrame(throttledLoop)
+          animationFrameId = requestAnimationFrame(throttledLoop)
         }
         throttledLoop()
       }
@@ -441,6 +440,13 @@ export const Terminal = (props: TerminalProps) => {
         }
       })
       cleanups.push(() => disposeIfDisposable(onKey))
+
+      cleanups.push(() => {
+        if (animationFrameId !== undefined) {
+          cancelAnimationFrame(animationFrameId)
+        }
+      })
+
 
       const startResize = () => {
         fit.observeResize()

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -371,6 +371,49 @@ export const Terminal = (props: TerminalProps) => {
       fitAddon = fit
       serializeAddon = serializer
 
+      const termImpl = t as unknown as {
+        startRenderLoop: () => void
+        isDisposed: boolean
+        isOpen: boolean
+        renderer: {
+          render: (
+            wasmTerm: unknown,
+            force: boolean,
+            viewportY: number,
+            term: unknown,
+            scrollbarOpacity: number,
+          ) => void
+        }
+        wasmTerm: { getCursor: () => { x: number; y: number } }
+        lastCursorY: number
+        cursorMoveEmitter: { fire: () => void }
+        animationFrameId: number | undefined
+        viewportY: number
+        scrollbarOpacity: number
+      }
+
+      let lastFrameTime = 0
+      const minFrameInterval = 1000 / 15
+
+      termImpl.startRenderLoop = function () {
+        const throttledLoop = () => {
+          if (termImpl.isDisposed || !termImpl.isOpen) return
+
+          const now = performance.now()
+          if (now - lastFrameTime >= minFrameInterval) {
+            lastFrameTime = now
+            termImpl.renderer.render(termImpl.wasmTerm, false, termImpl.viewportY, termImpl, termImpl.scrollbarOpacity)
+            const cursor = termImpl.wasmTerm.getCursor()
+            if (cursor.y !== termImpl.lastCursorY) {
+              termImpl.lastCursorY = cursor.y
+              termImpl.cursorMoveEmitter.fire()
+            }
+          }
+          termImpl.animationFrameId = requestAnimationFrame(throttledLoop)
+        }
+        throttledLoop()
+      }
+
       t.open(container)
       useTerminalUiBindings({ container, term: t, cleanups, handlePointerDown, handleLinkClick })
 

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -385,14 +385,11 @@ export const Terminal = (props: TerminalProps) => {
       fitAddon = fit
       serializeAddon = serializer
 
-      // Monkey-patch the terminal's render loop to throttle FPS for CPU usage
-      // IMPORTANT: This must happen BEFORE t.open(container) so the patched function is used
-      // when the render loop starts
       const termImpl = t as unknown as GhosttyTerminalImpl
 
-      let lastFrameTime = 0
-      let animationFrameId: number | undefined
-      const minFrameInterval = createMemo(() => {
+      let lastFrame = 0
+      let frameId: number | undefined
+      const interval = createMemo(() => {
         const fps = settings.appearance.terminalFps()
         return fps === 0 ? 0 : 1000 / fps
       })
@@ -402,9 +399,9 @@ export const Terminal = (props: TerminalProps) => {
           if (termImpl.isDisposed || !termImpl.isOpen) return
 
           const now = performance.now()
-          const interval = minFrameInterval()
-          if (interval === 0 || now - lastFrameTime >= interval) {
-            if (interval > 0) lastFrameTime = now
+          const ms = interval()
+          if (ms === 0 || now - lastFrame >= ms) {
+            if (ms > 0) lastFrame = now
             termImpl.renderer.render(termImpl.wasmTerm, false, termImpl.viewportY, termImpl, termImpl.scrollbarOpacity)
             const cursor = termImpl.wasmTerm.getCursor()
             if (cursor.y !== termImpl.lastCursorY) {
@@ -412,7 +409,7 @@ export const Terminal = (props: TerminalProps) => {
               termImpl.cursorMoveEmitter.fire()
             }
           }
-          animationFrameId = requestAnimationFrame(throttledLoop)
+          frameId = requestAnimationFrame(throttledLoop)
         }
         throttledLoop()
       }
@@ -442,8 +439,8 @@ export const Terminal = (props: TerminalProps) => {
       cleanups.push(() => disposeIfDisposable(onKey))
 
       cleanups.push(() => {
-        if (animationFrameId !== undefined) {
-          cancelAnimationFrame(animationFrameId)
+        if (frameId !== undefined) {
+          cancelAnimationFrame(frameId)
         }
       })
 

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -29,6 +29,7 @@ export interface Settings {
   appearance: {
     fontSize: number
     font: string
+    terminalFps: number
   }
   keybinds: Record<string, string>
   permissions: {
@@ -49,6 +50,7 @@ const defaultSettings: Settings = {
   appearance: {
     fontSize: 14,
     font: "ibm-plex-mono",
+    terminalFps: 15,
   },
   keybinds: {},
   permissions: {
@@ -135,6 +137,10 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         font: withFallback(() => store.appearance?.font, defaultSettings.appearance.font),
         setFont(value: string) {
           setStore("appearance", "font", value)
+        },
+        terminalFps: createMemo(() => store.appearance?.terminalFps ?? defaultSettings.appearance.terminalFps),
+        setTerminalFps(value: number) {
+          setStore("appearance", "terminalFps", value)
         },
       },
       keybinds: {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -603,6 +603,8 @@ export const dict = {
   "settings.general.row.theme.description": "Customise how OpenCode is themed.",
   "settings.general.row.font.title": "Font",
   "settings.general.row.font.description": "Customise the mono font used in code blocks",
+  "settings.general.row.terminalFps.title": "Terminal FPS",
+  "settings.general.row.terminalFps.description": "Terminal rendering speed. 0 = unlimited (uses more CPU).",
 
   "settings.general.row.wayland.title": "Use native Wayland",
   "settings.general.row.wayland.description": "Disable X11 fallback on Wayland. Requires restart.",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -604,7 +604,7 @@ export const dict = {
   "settings.general.row.font.title": "Font",
   "settings.general.row.font.description": "Customise the mono font used in code blocks",
   "settings.general.row.terminalFps.title": "Terminal FPS",
-  "settings.general.row.terminalFps.description": "Terminal rendering speed. 0 = unlimited (uses more CPU).",
+  "settings.general.row.terminalFps.description": "The maximum terminal framerate. 0 = unlimited (uses more CPU).",
 
   "settings.general.row.wayland.title": "Use native Wayland",
   "settings.general.row.wayland.description": "Disable X11 fallback on Wayland. Requires restart.",


### PR DESCRIPTION
### What does this PR do?

This PR fixes #13899 and fixes #13817

When the terminal is loaded in the opencode web interface, my CPU cycles 100%.  I traced this down to the terminal constantly requesting another animation frame.  My monitor is 240hz so this used up an entire core forcing my computer into a higher power state. 

This PR adds a new configurable setting via the web ux, to limit the max FPS of the terminal.  I've set it to a default of 15 fps which uses negligible CPU.  Setting it 0 uses the maximum frame rate.  Anything else and it targets that frame rate.  

I've added e2e tests to verify the settings are saved and applied to multiple terminals correctly.  

Here is a screen shot of that UX:

<img width="3839" height="2159" alt="image" src="https://github.com/user-attachments/assets/d3a40f39-d214-4a95-93dd-258e0ce65d5d" />

Details of my analysis are in the original issue linked above.

### Testing

1. Goto a fresh opencode web instance without a terminal.  Examine CPU usage in the terminal or use the chrome profiler.
2. Open up the terminal.  It should now be 15fps by default, and CPU usage should be minimal. 
3. Type in the terminal make sure it doesn't look lagy
4. Open the settings and put it to 1fps, notice the terminal is laggy
5. Change the fps to 240 (or 0) on a machine that can support that refresh rate and watch the CPU usage spike to 100%

### How did you verify your code works?

I ran the testing described above, and added tests. 

Profiler before changes:

<img width="3839" height="2159" alt="Screenshot_20260216_142541" src="https://github.com/user-attachments/assets/05499e06-a0df-4ac4-ad28-9b18d76ee5f9" />

Profile after changes at 15 fps:

<img width="3839" height="2159" alt="Screenshot_20260216_142448" src="https://github.com/user-attachments/assets/a16786de-4f00-477c-8df1-6a720bfd8fd9" />
