### PR TITLE
ci: fixed Rust cache for 'cargo install' in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -171,13 +171,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}
 
+      - name: Resolve tauri portable SHA
+        if: contains(matrix.settings.host, 'ubuntu')
+        run: echo "TAURI_PORTABLE_SHA=$(git ls-remote https://github.com/tauri-apps/tauri.git refs/heads/feat/truly-portable-appimage | cut -f1)" >> "$GITHUB_ENV"
+
       # Fixes AppImage build issues, can be removed when https://github.com/tauri-apps/tauri/pull/12491 is released
       - name: Install tauri-cli from portable appimage branch
+        uses: taiki-e/cache-cargo-install-action@v3
         if: contains(matrix.settings.host, 'ubuntu')
-        run: |
-          cargo install tauri-cli --git https://github.com/tauri-apps/tauri --branch feat/truly-portable-appimage --force
-          echo "Installed tauri-cli version:"
-          cargo tauri --version
+        with:
+          tool: tauri-cli
+          git: https://github.com/tauri-apps/tauri
+          # branch: feat/truly-portable-appimage
+          rev: ${{ env.TAURI_PORTABLE_SHA }}
+
+      - name: Show tauri-cli version
+        run: cargo tauri --version
 
       - name: Build and upload artifacts
         uses: tauri-apps/tauri-action@390cbe447412ced1303d35abe75287949e43437a


### PR DESCRIPTION
Fixes CI cache for the `cargo install tauri-cli` step in publish.yml

Existing Rust cache setup is caching tauri workspace cargo only. 

Kept the current branch semantics.