### PR TITLE
ci: use `useblacksmith/stickydisk` on linux runners only

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -4,6 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Mount Bun Cache
+      if: ${{ runner.os == 'Linux' }}
       uses: useblacksmith/stickydisk@v1
       with:
         key: ${{ github.repository }}-bun-cache-${{ runner.os }}


### PR DESCRIPTION
Fixes timeout issues on non Linux CI runs that use `setup-bun` action.

The `useblacksmith/stickydisk` action used works on Linux only and was not conditioned.

This fix should reduce the macOS and Windows builds by 1m ~ 

<img width="377" height="335" alt="image" src="https://github.com/user-attachments/assets/172cb9de-4c9e-42dc-bb99-f95fbd3e6907" />


<img width="524" height="589" alt="image" src="https://github.com/user-attachments/assets/1193842d-12fa-429a-9bd4-bbc78a6e9167" />
