### PR TITLE
core: keep message part order stable when files resolve asynchronously

### DIFF
--- a/packages/opencode/test/session/prompt-missing-file.test.ts
+++ b/packages/opencode/test/session/prompt-missing-file.test.ts
@@ -2,6 +2,7 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Instance } from "../../src/project/instance"
 import { Session } from "../../src/session"
+import { MessageV2 } from "../../src/session/message-v2"
 import { SessionPrompt } from "../../src/session/prompt"
 import { tmpdir } from "../fixture/fixture"
 
@@ -45,6 +46,56 @@ describe("session.prompt missing file", () => {
           (part) => part.type === "text" && part.synthetic && part.text.includes("Read tool failed to read"),
         )
         expect(hasFailure).toBe(true)
+
+        await Session.remove(session.id)
+      },
+    })
+  })
+
+  test("keeps stored part order stable when file resolution is async", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      config: {
+        agent: {
+          build: {
+            model: "openai/gpt-5.2",
+          },
+        },
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const session = await Session.create({})
+
+        const missing = path.join(tmp.path, "still-missing.ts")
+        const msg = await SessionPrompt.prompt({
+          sessionID: session.id,
+          agent: "build",
+          noReply: true,
+          parts: [
+            {
+              type: "file",
+              mime: "text/plain",
+              url: `file://${missing}`,
+              filename: "still-missing.ts",
+            },
+            { type: "text", text: "after-file" },
+          ],
+        })
+
+        if (msg.info.role !== "user") throw new Error("expected user message")
+
+        const stored = await MessageV2.get({
+          sessionID: session.id,
+          messageID: msg.info.id,
+        })
+        const text = stored.parts.filter((part) => part.type === "text").map((part) => part.text)
+
+        expect(text[0]?.startsWith("Called the Read tool with the following input:")).toBe(true)
+        expect(text[1]?.includes("Read tool failed to read")).toBe(true)
+        expect(text[2]).toBe("after-file")
 
         await Session.remove(session.id)
       },


### PR DESCRIPTION
Previously, when multiple files were attached to a message and some resolved asynchronously (like via MCP resources), the order of message parts in the conversation could shift unpredictably. This caused confusing contexts where referenced content appeared out of sequence relative to the text parts.

Now part IDs are assigned centrally after all async operations complete, ensuring the visual order matches the order users specified their attachments.

