### PR TITLE
feat(app): add queued follow-up queue/steer controls for web UI

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -6,6 +6,7 @@ import { useLocal } from "@/context/local"
 import { useFile } from "@/context/file"
 import {
   ContentPart,
+  ContextItem,
   DEFAULT_PROMPT,
   isPromptEqual,
   Prompt,
@@ -26,6 +27,7 @@ import type { IconName } from "@opencode-ai/ui/icons/provider"
 import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Select } from "@opencode-ai/ui/select"
+import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { ModelSelectorPopover } from "@/components/dialog-select-model"
 import { DialogSelectModelUnpaid } from "@/components/dialog-select-model-unpaid"
@@ -36,6 +38,7 @@ import { SessionContextUsage } from "@/components/session-context-usage"
 import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
+import { useSettings } from "@/context/settings"
 import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
 import { createPromptAttachments, ACCEPTED_FILE_TYPES } from "./prompt-input/attachments"
 import {
@@ -88,6 +91,13 @@ const EXAMPLES = [
   "prompt.example.25",
 ] as const
 
+type SubmitMode = "queue" | "steer"
+type QueuedFollowup = {
+  id: number
+  prompt: Prompt
+  context: (ContextItem & { key: string })[]
+}
+
 export const PromptInput: Component<PromptInputProps> = (props) => {
   const sdk = useSDK()
   const sync = useSync()
@@ -104,12 +114,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const permission = usePermission()
   const language = useLanguage()
   const platform = usePlatform()
+  const settings = useSettings()
   let editorRef!: HTMLDivElement
   let fileInputRef!: HTMLInputElement
   let scrollRef!: HTMLDivElement
   let slashPopoverRef!: HTMLDivElement
 
   const mirror = { input: false }
+  const ids = { followup: 0 }
 
   const scrollCursorIntoView = () => {
     const container = scrollRef
@@ -214,6 +226,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     draggingType: "image" | "@mention" | null
     mode: "normal" | "shell"
     applyingHistory: boolean
+    followupMode: SubmitMode | undefined
+    queuedFollowups: QueuedFollowup[]
+    sendingQueued: boolean
   }>({
     popover: null,
     historyIndex: -1,
@@ -222,6 +237,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     draggingType: null,
     mode: "normal",
     applyingHistory: false,
+    followupMode: undefined,
+    queuedFollowups: [],
+    sendingQueued: false,
   })
   const placeholder = createMemo(() =>
     promptPlaceholder({
@@ -249,6 +267,99 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       entries: [],
     }),
   )
+  const showFollowupMode = createMemo(() => store.mode === "normal" && store.queuedFollowups.length > 0)
+  const submitMode = createMemo<SubmitMode>(() => {
+    if (!working()) return "queue"
+    if (store.followupMode) return store.followupMode
+    return settings.general.followup()
+  })
+  const clonePrompt = (value: Prompt): Prompt =>
+    value.map((part) => {
+      if (part.type === "file") {
+        return {
+          ...part,
+          selection: part.selection
+            ? {
+                ...part.selection,
+              }
+            : undefined,
+        }
+      }
+      return {
+        ...part,
+      }
+    })
+  const cloneContext = (items: (ContextItem & { key: string })[]) =>
+    items.map((item) => ({
+      ...item,
+      selection: item.selection
+        ? {
+            ...item.selection,
+          }
+        : undefined,
+    }))
+  const setContext = (items: (ContextItem & { key: string })[]) => {
+    prompt.context
+      .items()
+      .forEach((item) => {
+        prompt.context.remove(item.key)
+      })
+    items.forEach((item) => {
+      const { key, ...value } = item
+      void key
+      prompt.context.add(value)
+    })
+  }
+  const followupPreview = (queued: QueuedFollowup) => {
+    const text = queued.prompt
+      .map((part) => ("content" in part ? part.content : ""))
+      .join("")
+      .trim()
+      .replace(/\s+/g, " ")
+    if (text.length > 0) return text
+    if (queued.context.some((item) => !!item.comment?.trim())) return language.t("prompt.followup.commentOnly")
+    return "..."
+  }
+  const focusEditor = () => {
+    requestAnimationFrame(() => {
+      editorRef.focus()
+      setCursorPosition(editorRef, promptLength(prompt.current()))
+      queueScroll()
+    })
+  }
+  const findFollowup = (id: number) => store.queuedFollowups.find((item) => item.id === id)
+  const editFollowup = (id: number) => {
+    const queued = findFollowup(id)
+    if (!queued) return
+    const parts = clonePrompt(queued.prompt)
+    setContext(queued.context)
+    prompt.set(parts, promptLength(parts))
+    setStore("queuedFollowups", (items) => items.filter((item) => item.id !== id))
+    setStore("followupMode", undefined)
+    focusEditor()
+  }
+  const clearFollowup = (id: number) => {
+    setStore("queuedFollowups", (items) => items.filter((item) => item.id !== id))
+    setStore("followupMode", undefined)
+  }
+  const stageFollowup = () => {
+    const queued = {
+      id: ++ids.followup,
+      prompt: clonePrompt(prompt.current()),
+      context: cloneContext(prompt.context.items()),
+    }
+    setStore("queuedFollowups", (items) => [...items, queued])
+    setContext([])
+    prompt.reset()
+    setStore("followupMode", undefined)
+    focusEditor()
+  }
+
+  createEffect(() => {
+    if (working()) return
+    if (!store.followupMode) return
+    setStore("followupMode", undefined)
+  })
 
   const applyHistoryPrompt = (p: Prompt, position: "start" | "end") => {
     const length = position === "start" ? 0 : promptLength(p)
@@ -794,11 +905,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     readClipboardImage: platform.readClipboardImage,
   })
 
-  const { abort, handleSubmit } = createPromptSubmit({
+  const { abort, handleSubmit: submitPrompt } = createPromptSubmit({
     info,
     imageAttachments,
     commentCount,
     mode: () => store.mode,
+    submitMode,
     working,
     editor: () => editorRef,
     queueScroll,
@@ -812,6 +924,40 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     newSessionWorktree: () => props.newSessionWorktree,
     onNewSessionWorktreeReset: props.onNewSessionWorktreeReset,
     onSubmit: props.onSubmit,
+  })
+  const sendQueuedFollowup = async (id: number, mode: SubmitMode) => {
+    const queued = findFollowup(id)
+    if (!queued) return
+    if (store.sendingQueued) return
+    setStore("sendingQueued", true)
+    setStore("queuedFollowups", (items) => items.filter((item) => item.id !== id))
+    setStore("followupMode", mode)
+    const parts = clonePrompt(queued.prompt)
+    setContext(queued.context)
+    prompt.set(parts, promptLength(parts))
+    const event = new Event("submit", { cancelable: true })
+    try {
+      await submitPrompt(event)
+    } finally {
+      setStore("followupMode", undefined)
+      setStore("sendingQueued", false)
+    }
+  }
+  const handleSubmit = async (event: Event) => {
+    event.preventDefault()
+    if (store.mode === "normal" && working() && submitMode() === "queue" && (prompt.dirty() || commentCount() > 0)) {
+      stageFollowup()
+      return
+    }
+    await submitPrompt(event)
+  }
+
+  createEffect(() => {
+    const queued = store.queuedFollowups[0]
+    if (!queued) return
+    if (working()) return
+    if (store.sendingQueued) return
+    void sendQueuedFollowup(queued.id, "queue")
   })
 
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -858,7 +1004,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     // Handle Shift+Enter BEFORE IME check - Shift+Enter is never used for IME input
     // and should always insert a newline regardless of composition state
-    if (event.key === "Enter" && event.shiftKey) {
+    if (event.key === "Enter" && event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
       addPart({ type: "text", content: "\n", start: 0, end: 0 })
       event.preventDefault()
       return
@@ -923,7 +1069,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       return
     }
 
-    // Note: Shift+Enter is handled earlier, before IME check
+    const invertFollowup = event.key === "Enter" && event.shiftKey && !event.altKey && (event.metaKey || event.ctrlKey)
+    if (invertFollowup) {
+      const mode = settings.general.followup() === "queue" ? "steer" : "queue"
+      setStore("followupMode", mode)
+      void handleSubmit(event).finally(() => setStore("followupMode", undefined))
+      return
+    }
+
+    // Note: plain Shift+Enter is handled earlier, before IME check
     if (event.key === "Enter" && !event.shiftKey) {
       handleSubmit(event)
     }
@@ -953,6 +1107,78 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         commandKeybind={command.keybind}
         t={(key) => language.t(key as Parameters<typeof language.t>[0])}
       />
+      <Show when={showFollowupMode()}>
+        <div class="bg-surface-raised-stronger-non-alpha shadow-xs-border rounded-[14px] border border-border-base overflow-clip">
+          <For each={store.queuedFollowups}>
+            {(queued, index) => (
+              <div
+                classList={{
+                  "flex items-center gap-1 px-3 py-2": true,
+                  "border-t border-border-base": index() > 0,
+                }}
+              >
+                <div class="min-w-0 flex flex-1 items-center gap-2">
+                  <Icon name="align-right" size="small" class="shrink-0 text-icon-weak" />
+                  <span class="truncate text-14-regular text-text-base">{followupPreview(queued)}</span>
+                </div>
+                <Button
+                  type="button"
+                  size="small"
+                  variant="ghost"
+                  data-selected
+                  onClick={() => void sendQueuedFollowup(queued.id, "steer")}
+                  disabled={store.sendingQueued}
+                >
+                  {language.t("prompt.submitMode.steer")}
+                </Button>
+                <IconButton
+                  type="button"
+                  icon="trash"
+                  variant="ghost"
+                  class="size-6"
+                  onClick={() => clearFollowup(queued.id)}
+                  disabled={store.sendingQueued}
+                  aria-label={language.t("common.delete")}
+                />
+                <DropdownMenu gutter={6} placement="bottom-end">
+                  <DropdownMenu.Trigger
+                    as={IconButton}
+                    type="button"
+                    icon="dot-grid"
+                    variant="ghost"
+                    class="size-6"
+                    aria-label={language.t("common.moreOptions")}
+                  />
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content>
+                      <DropdownMenu.Item onSelect={() => editFollowup(queued.id)}>
+                        <div class="flex size-4 shrink-0 items-center justify-center">
+                          <Icon name="edit" size="small" class="text-icon-weak" />
+                        </div>
+                        <DropdownMenu.ItemLabel>{language.t("prompt.followup.menu.editMessage")}</DropdownMenu.ItemLabel>
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item
+                        onSelect={() =>
+                          settings.general.setFollowup(settings.general.followup() === "queue" ? "steer" : "queue")
+                        }
+                      >
+                        <div class="flex size-4 shrink-0 items-center justify-center">
+                          <Icon name="align-right" size="small" class="text-icon-weak" />
+                        </div>
+                        <DropdownMenu.ItemLabel>
+                          {settings.general.followup() === "queue"
+                            ? language.t("prompt.followup.menu.turnOffQueueing")
+                            : language.t("prompt.followup.menu.turnOnQueueing")}
+                        </DropdownMenu.ItemLabel>
+                      </DropdownMenu.Item>
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
       <form
         onSubmit={handleSubmit}
         classList={{

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -6,6 +6,8 @@ let createPromptSubmit: typeof import("./submit").createPromptSubmit
 const createdClients: string[] = []
 const createdSessions: string[] = []
 const sentShell: string[] = []
+const sentPrompt: string[] = []
+const sentPromptAsync: string[] = []
 const syncedDirectories: string[] = []
 
 let selected = "/repo/worktree-a"
@@ -22,7 +24,14 @@ const clientFor = (directory: string) => ({
       sentShell.push(directory)
       return { data: undefined }
     },
-    prompt: async () => ({ data: undefined }),
+    prompt: async () => {
+      sentPrompt.push(directory)
+      return { data: undefined }
+    },
+    promptAsync: async () => {
+      sentPromptAsync.push(directory)
+      return { data: undefined }
+    },
     command: async () => ({ data: undefined }),
     abort: async () => ({ data: undefined }),
   },
@@ -137,6 +146,8 @@ beforeEach(() => {
   createdClients.length = 0
   createdSessions.length = 0
   sentShell.length = 0
+  sentPrompt.length = 0
+  sentPromptAsync.length = 0
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
 })
@@ -148,6 +159,7 @@ describe("prompt submit worktree selection", () => {
       imageAttachments: () => [],
       commentCount: () => 0,
       mode: () => "shell",
+      submitMode: () => "queue",
       working: () => false,
       editor: () => undefined,
       queueScroll: () => undefined,
@@ -171,5 +183,59 @@ describe("prompt submit worktree selection", () => {
     expect(createdSessions).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
     expect(sentShell).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
     expect(syncedDirectories).toEqual(["/repo/worktree-a", "/repo/worktree-b"])
+  })
+
+  test("uses queue mode for normal prompts", async () => {
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      mode: () => "normal",
+      submitMode: () => "queue",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+    await submit.handleSubmit(event)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(sentPromptAsync).toEqual(["/repo/main"])
+    expect(sentPrompt).toEqual([])
+  })
+
+  test("uses steer mode for normal prompts", async () => {
+    const submit = createPromptSubmit({
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      mode: () => "normal",
+      submitMode: () => "steer",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+    await submit.handleSubmit(event)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(sentPrompt).toEqual(["/repo/main"])
+    expect(sentPromptAsync).toEqual([])
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -29,6 +29,7 @@ type PromptSubmitInput = {
   imageAttachments: Accessor<ImageAttachmentPart[]>
   commentCount: Accessor<number>
   mode: Accessor<"normal" | "shell">
+  submitMode: Accessor<"queue" | "steer">
   working: Accessor<boolean>
   editor: () => HTMLDivElement | undefined
   queueScroll: () => void
@@ -116,6 +117,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()
     const mode = input.mode()
+    const submitMode = input.submitMode()
 
     if (text.trim().length === 0 && images.length === 0 && input.commentCount() === 0) {
       if (input.working()) abort()
@@ -385,14 +387,19 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const send = async () => {
       const ok = await waitForWorktree()
       if (!ok) return
-      await client.session.promptAsync({
+      const args = {
         sessionID: session.id,
         agent,
         model,
         messageID,
         parts: requestParts,
         variant,
-      })
+      }
+      if (submitMode === "steer") {
+        await client.session.prompt(args)
+        return
+      }
+      await client.session.promptAsync(args)
     }
 
     void send().catch((err) => {

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -114,6 +114,12 @@ export const SettingsGeneral: Component = () => {
       label: language.label(locale),
     })),
   )
+  const followupOptions = createMemo(
+    (): { value: "queue" | "steer"; label: string }[] => [
+      { value: "queue", label: language.t("settings.general.followup.queue") },
+      { value: "steer", label: language.t("settings.general.followup.steer") },
+    ],
+  )
 
   const fontOptions = [
     { value: "ibm-plex-mono", label: "font.option.ibmPlexMono" },
@@ -133,7 +139,6 @@ export const SettingsGeneral: Component = () => {
   const fontOptionsList = [...fontOptions]
 
   const soundOptions = [...SOUND_OPTIONS]
-
   const soundSelectProps = (current: () => string, set: (id: string) => void) => ({
     options: soundOptions,
     current: soundOptions.find((o) => o.id === current()),
@@ -416,6 +421,31 @@ export const SettingsGeneral: Component = () => {
     </div>
   )
 
+  const BehaviorSection = () => (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.general.section.behavior")}</h3>
+
+      <div class="bg-surface-raised-base px-4 rounded-lg">
+        <SettingsRow
+          title={language.t("settings.general.followup.title")}
+          description={language.t("settings.general.followup.description")}
+        >
+          <Select
+            data-action="settings-followup-behavior"
+            options={followupOptions()}
+            current={followupOptions().find((o) => o.value === settings.general.followup())}
+            value={(o) => o.value}
+            label={(o) => o.label}
+            onSelect={(option) => option && settings.general.setFollowup(option.value)}
+            variant="secondary"
+            size="small"
+            triggerVariant="settings"
+          />
+        </SettingsRow>
+      </div>
+    </div>
+  )
+
   return (
     <div class="flex flex-col h-full overflow-y-auto no-scrollbar px-4 pb-10 sm:px-10 sm:pb-10">
       <div class="sticky top-0 z-10 bg-[linear-gradient(to_bottom,var(--surface-raised-stronger-non-alpha)_calc(100%_-_24px),transparent)]">
@@ -426,6 +456,8 @@ export const SettingsGeneral: Component = () => {
 
       <div class="flex flex-col gap-8 w-full">
         <AppearanceSection />
+
+        <BehaviorSection />
 
         <NotificationsSection />
 

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -22,6 +22,7 @@ export interface Settings {
   general: {
     autoSave: boolean
     releaseNotes: boolean
+    followup: "queue" | "steer"
   }
   updates: {
     startup: boolean
@@ -42,6 +43,7 @@ const defaultSettings: Settings = {
   general: {
     autoSave: true,
     releaseNotes: true,
+    followup: "queue",
   },
   updates: {
     startup: true,
@@ -119,6 +121,10 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         releaseNotes: withFallback(() => store.general?.releaseNotes, defaultSettings.general.releaseNotes),
         setReleaseNotes(value: boolean) {
           setStore("general", "releaseNotes", value)
+        },
+        followup: withFallback(() => store.general?.followup, defaultSettings.general.followup),
+        setFollowup(value: "queue" | "steer") {
+          setStore("general", "followup", value)
         },
       },
       updates: {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -228,6 +228,13 @@ export const dict = {
   "prompt.placeholder.summarizeComment": "Summarize comment…",
   "prompt.mode.shell": "Shell",
   "prompt.mode.shell.exit": "esc to exit",
+  "prompt.submitMode.label": "Send mode",
+  "prompt.submitMode.queue": "Queue",
+  "prompt.submitMode.steer": "Steer",
+  "prompt.followup.commentOnly": "Follow-up from comments",
+  "prompt.followup.menu.editMessage": "Edit message",
+  "prompt.followup.menu.turnOffQueueing": "Turn off queueing",
+  "prompt.followup.menu.turnOnQueueing": "Turn on queueing",
 
   "prompt.example.1": "Fix a TODO in the codebase",
   "prompt.example.2": "What is the tech stack of this project?",
@@ -590,6 +597,7 @@ export const dict = {
   "settings.desktop.wsl.description": "Run the OpenCode server inside WSL on Windows.",
 
   "settings.general.section.appearance": "Appearance",
+  "settings.general.section.behavior": "Behavior",
   "settings.general.section.notifications": "System notifications",
   "settings.general.section.updates": "Updates",
   "settings.general.section.sounds": "Sound effects",
@@ -611,6 +619,10 @@ export const dict = {
 
   "settings.general.row.releaseNotes.title": "Release notes",
   "settings.general.row.releaseNotes.description": "Show What's New popups after updates",
+  "settings.general.followup.title": "Follow-up behavior",
+  "settings.general.followup.description": "Queue follow-ups or steer the current run.",
+  "settings.general.followup.queue": "Queue",
+  "settings.general.followup.steer": "Steer",
 
   "settings.updates.row.startup.title": "Check for updates on startup",
   "settings.updates.row.startup.description": "Automatically check for updates when OpenCode launches",


### PR DESCRIPTION
### What does this PR do?

Fixes #5408

UX is inspired by Codex Desktop's queue/steer follow-up flow, adapted to OpenCode's existing app styles.

Adds queued follow-up controls and queue/steer behavior in `packages/app` (web + desktop):
- add a follow-up behavior setting (`Queue` / `Steer`) in General settings
- when a run is active and behavior is `Queue`, submitted follow-ups are staged locally instead of sent immediately
- render staged follow-ups above the composer (supports multiple queued items)
- per queued item actions: `Steer`, `Delete`, and `More` (`Edit message`, `Turn off/on queueing`)
- `Shift+Cmd/Ctrl+Enter` sends one message with the opposite behavior

Related: #12707 #8685 #6942 #4821

### How did you verify your code works?

- `bun run --cwd packages/app typecheck`
- `bun test --preload ./happydom.ts ./src/components/prompt-input/submit.test.ts --cwd packages/app`
- pre-push hook also passed: `bun turbo typecheck`

### Screenshots

1. 1 prompt running + 2 prompts queued
<img width="1396" height="796" alt="image" src="https://github.com/user-attachments/assets/2bef5f49-3258-46f9-ace1-1653a802f12e" />


2. More menu (`Edit message`, `Turn off queueing`)
<img width="481" height="177" alt="image" src="https://github.com/user-attachments/assets/7fb17e94-6860-4e7e-ac02-98533dcf53dd" />


3. Follow-up behavior setting
<img width="796" height="503" alt="image" src="https://github.com/user-attachments/assets/32295978-2338-4202-b601-fc0fa1c19105" />




