### PR TITLE
feat: Support individual subagent cancellation

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/component/prompt/index.tsx
@@ -37,6 +37,7 @@ import { useTextareaKeybindings } from "../textarea-keybindings"
 import { DialogSkill } from "../dialog-skill"
 
 export type PromptProps = {
+  parentSessionID?: string
   sessionID?: string
   workspaceID?: string
   visible?: boolean
@@ -50,6 +51,7 @@ export type PromptProps = {
 export type PromptRef = {
   focused: boolean
   current: PromptInfo
+  interrupt: number
   set(prompt: PromptInfo): void
   reset(): void
   blur(): void
@@ -127,6 +129,7 @@ export function Prompt(props: PromptProps) {
     mode: "normal" | "shell"
     extmarkToPartIndex: Map<number, number>
     interrupt: number
+    interruptTimeout: ReturnType<typeof setTimeout> | undefined,
     placeholder: number
   }>({
     placeholder: Math.floor(Math.random() * PLACEHOLDERS.length),
@@ -137,6 +140,7 @@ export function Prompt(props: PromptProps) {
     mode: "normal",
     extmarkToPartIndex: new Map(),
     interrupt: 0,
+    interruptTimeout: undefined,
   })
 
   createEffect(
@@ -144,6 +148,9 @@ export function Prompt(props: PromptProps) {
       () => props.sessionID,
       () => {
         setStore("placeholder", Math.floor(Math.random() * PLACEHOLDERS.length))
+        clearTimeout(store.interruptTimeout)
+        setStore("interrupt", 0)
+        setStore("interruptTimeout", undefined)
       },
       { defer: true },
     ),
@@ -221,7 +228,7 @@ export function Prompt(props: PromptProps) {
         enabled: status().type !== "idle",
         onSelect: (dialog) => {
           if (autocomplete.visible) return
-          if (!input.focused) return
+          if (!input.focused && !props.parentSessionID) return
           // TODO: this should be its own command
           if (store.mode === "shell") {
             setStore("mode", "normal")
@@ -229,18 +236,25 @@ export function Prompt(props: PromptProps) {
           }
           if (!props.sessionID) return
 
-          setStore("interrupt", store.interrupt + 1)
+          if (store.interruptTimeout) {
+            clearTimeout(store.interruptTimeout)
+            setStore("interruptTimeout", undefined)
+          }
 
-          setTimeout(() => {
-            setStore("interrupt", 0)
-          }, 5000)
-
-          if (store.interrupt >= 2) {
+          if (store.interrupt) {
             sdk.client.session.abort({
               sessionID: props.sessionID,
             })
             setStore("interrupt", 0)
+            dialog.clear()
+            return
           }
+
+          setStore("interrupt", store.interrupt + 1)
+          setStore("interruptTimeout", setTimeout(() => {
+            setStore("interrupt", 0)
+            setStore("interruptTimeout", undefined)
+          }, 5000))
           dialog.clear()
         },
       },
@@ -362,6 +376,9 @@ export function Prompt(props: PromptProps) {
     },
     get current() {
       return store.prompt
+    },
+    get interrupt() {
+      return store.interrupt
     },
     focus() {
       input.focus()
@@ -1130,10 +1147,10 @@ export function Prompt(props: PromptProps) {
                   })()}
                 </box>
               </box>
-              <text fg={store.interrupt > 0 ? theme.primary : theme.text}>
-                esc{" "}
-                <span style={{ fg: store.interrupt > 0 ? theme.primary : theme.textMuted }}>
-                  {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+              <text fg={store.interrupt ? theme.primary : theme.text}>
+                {keybind.print("session_interrupt")}{" "}
+                <span style={{ fg: store.interrupt ? theme.primary : theme.textMuted }}>
+                  {store.interrupt ? "again to interrupt" : "interrupt"}
                 </span>
               </text>
             </box>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/header.tsx
@@ -9,6 +9,7 @@ import { useCommandDialog } from "@tui/component/dialog-command"
 import { useKeybind } from "../../context/keybind"
 import { Flag } from "@/flag/flag"
 import { useTerminalDimensions } from "@opentui/solid"
+import { usePromptRef } from "../../context/prompt"
 
 const Title = (props: { session: Accessor<Session> }) => {
   const { theme } = useTheme()
@@ -44,6 +45,7 @@ const WorkspaceInfo = (props: { workspace: Accessor<string | undefined> }) => {
 export function Header() {
   const route = useRouteData("session")
   const sync = useSync()
+  const promptRef = usePromptRef()
   const session = createMemo(() => sync.session.get(route.sessionID)!)
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
 
@@ -82,7 +84,9 @@ export function Header() {
   const { theme } = useTheme()
   const keybind = useKeybind()
   const command = useCommandDialog()
-  const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
+  const status = createMemo(() => sync.data.session_status?.[route.sessionID])
+  const isRunning = createMemo(() => status()?.type !== "idle")
+  const [hover, setHover] = createSignal<"parent" | "prev" | "next" | "cancel" | null>(null)
   const dimensions = useTerminalDimensions()
   const narrow = createMemo(() => dimensions().width < 80)
 
@@ -149,6 +153,19 @@ export function Header() {
                     Next <span style={{ fg: theme.textMuted }}>{keybind.print("session_child_cycle")}</span>
                   </text>
                 </box>
+                <Show when={isRunning()}>
+                  <box
+                    onMouseOver={() => setHover("cancel")}
+                    onMouseOut={() => setHover(null)}
+                    onMouseUp={() => command.trigger("session.interrupt")}
+                    backgroundColor={hover() === "cancel" ? theme.backgroundElement : theme.backgroundPanel}
+                  >
+                    <text fg={theme.text}>
+                      Cancel{" "}
+                      <span style={{ fg: promptRef.current?.interrupt ? theme.primary : theme.textMuted }}>{keybind.print("session_interrupt")}{promptRef.current?.interrupt ? " again to confirm" : ""}</span>
+                    </text>
+                  </box>
+                </Show>
               </box>
             </box>
           </Match>

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -1187,6 +1187,7 @@ export function Session() {
                   toBottom()
                 }}
                 sessionID={route.sessionID}
+                parentSessionID={session()?.parentID}
               />
             </box>
           </Show>

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -144,7 +144,8 @@ export const TaskTool = Tool.define("task", async (ctx) => {
         parts: promptParts,
       })
 
-      const text = result.parts.findLast((x) => x.type === "text")?.text ?? ""
+      const cancelled = result.info.role === "assistant" && result.info.error?.name === "MessageAbortedError"
+      const text = cancelled ? "Task was cancelled by user." : result.parts.findLast((x) => x.type === "text")?.text ?? ""
 
       const output = [
         `task_id: ${session.id} (for resuming to continue this task if needed)`,


### PR DESCRIPTION
### Issue for this PR

Closes #13916

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for interrupting subagent tasks with a clickable button or the `session_interrupt` keybinding in the TUI. The motivation behind this work is twofold:
1. Face-value: Support this feature so that individual subagents can be cancelled when a group of subagents is run without cancelling everything
2. Support this feature as a prerequisite to background subagents. This can give us a way to abort background subagents without creeping the scope of that feature addition too much. See: https://github.com/anomalyco/opencode/issues/5887, https://github.com/anomalyco/opencode/pull/13261


### Screenshots / recordings
#### Screenshot before
<img width="1864" height="479" alt="Screenshot from 2026-02-16 20-15-39" src="https://github.com/user-attachments/assets/bd93169b-73e7-4874-a63f-554cdf0194f3" />

#### Screenshot after:
<img width="1864" height="479" alt="Screenshot from 2026-02-16 20-11-18" src="https://github.com/user-attachments/assets/ad2c0553-c475-41c8-bd6d-4303ecedc1cc" />
<img width="1864" height="479" alt="Screenshot from 2026-02-16 20-11-22" src="https://github.com/user-attachments/assets/f4c0be5c-be88-48b6-ae68-b7c8076307a1" />

### How did you verify your code works?
Ran the following prompt repeatedly:
```
Run 2 general subagents in parallel. Each one should use bash to
sleep for an amount of time and then print out a random number. Have them sleep
for 30 seconds each. Then print out a chart to be
updated as each task notifies you of its completion.
```
And tested interrupt behavior including:
- That interrupt must be re-confirmed after changing session views
- That old interrupt confirmation timeouts don't overlap with the current timeout
- That subagents can be interrupted individually, without affecting the others
- That the primary agent continues as expected when all subagents terminate, via interrupts or successful completion
- That the primary agent can be interrupted
- That the parent agent sees the message that the task was cancelled by the user

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._