### PR TITLE
Hide server CLI on windows

### DIFF
--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -317,12 +317,12 @@ pub fn spawn_command(
         cmd
     };
 
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
 
     #[cfg(windows)]
-    cmd.creation_flags(0x08000000);
+    cmd.creation_flags(0x0800_0000);
 
     let mut wrap = CommandWrap::from(cmd);
 

--- a/packages/desktop/src-tauri/src/cli.rs
+++ b/packages/desktop/src-tauri/src/cli.rs
@@ -321,6 +321,9 @@ pub fn spawn_command(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
+    #[cfg(windows)]
+    cmd.creation_flags(0x08000000);
+
     let mut wrap = CommandWrap::from(cmd);
 
     #[cfg(unix)]


### PR DESCRIPTION
Fixes a bug introduced by #13431 where cration_flags weren't being passed to cmd on windows