### PR TITLE
docs: add chat-history-logger plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                           | Native OS notifications for OpenCode – know when tasks complete                                   |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                                     | Bundled multi-agent orchestration harness – 16 components, one install                            |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                       | Zero-friction git worktrees for OpenCode                                                          |
+| [chat-history-logger](https://github.com/ru4871SG/chat-history-logger-opencode-claudecode)                | Logs opencode chat history instantly as local markdown files with cloud sync options              |
 
 ---
 


### PR DESCRIPTION
Add [chat-history-logger](https://github.com/ru4871SG/chat-history-logger-opencode-claudecode) to the Plugins list.

chat-history-logger is a plugin for OpenCode where your chat history (doesn't matter what mode you are in) will be instantly stored as markdown files locally, and the plugin can also append the chat history from Claude Code to the same files. For now, it has sync capabilities to MongoDB and Supabase, in case you want to sync the chat history memory across devices.

### What does this PR do?

This PR is only to add a plugin that I made to the ecosystem page. 

### How did you verify your code works?

You can use the npx command that I provided in my plugin's repository README file. It will install the plugin, and you can use it right away (for local markdown files). Also it will allow you to use slash command like `/chat-history-cloud-config` that will allow you to set up cloud sync for the chat history, if you wish to do so. The slash command is associated with the prompts that are available in the repository.