### PR TITLE
ci: fix aur apt cache as well

### DIFF
--- a/.github/actions/setup-apt/action.yml
+++ b/.github/actions/setup-apt/action.yml
@@ -1,0 +1,47 @@
+name: "Setup Apt"
+description: "Cache apt archives and install packages"
+inputs:
+  archives-dir:
+    description: "Directory used for apt archives cache"
+    required: true
+  cache-key:
+    description: "Cache key for apt archives"
+    required: true
+  cache-restore-keys:
+    description: "Optional restore keys for apt archives cache"
+    required: false
+    default: ""
+  packages:
+    description: "Space-separated apt packages to install"
+    required: true
+  install-options:
+    description: "Additional apt-get install options"
+    required: false
+    default: "--no-install-recommends"
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare apt archives dir
+      run: |
+        mkdir -p "${{ inputs.archives-dir }}"
+        chmod -R a+rw "${{ inputs.archives-dir }}"
+      shell: bash
+
+    - name: Cache apt archives
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.archives-dir }}
+        key: ${{ inputs.cache-key }}
+        restore-keys: ${{ inputs.cache-restore-keys }}
+
+    - name: Install apt packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ inputs.install-options }} -o dir::cache::archives="${{ inputs.archives-dir }}" ${{ inputs.packages }}
+      shell: bash
+
+    - name: Restore apt archives permissions
+      if: ${{ always() }}
+      run: |
+        sudo chmod -R a+rw "${{ inputs.archives-dir }}"
+      shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,22 +152,15 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
-      - name: Cache apt packages
+      - name: Setup apt dependencies
         if: contains(matrix.settings.host, 'ubuntu')
-        uses: actions/cache@v4
+        uses: ./.github/actions/setup-apt
         with:
-          path: ~/apt-cache
-          key: ${{ runner.os }}-${{ matrix.settings.target }}-apt-${{ hashFiles('.github/workflows/publish.yml') }}
-          restore-keys: |
+          archives-dir: ${{ runner.temp }}/apt-cache
+          cache-key: ${{ runner.os }}-${{ matrix.settings.target }}-apt-${{ hashFiles('.github/workflows/publish.yml', '.github/actions/setup-apt/action.yml') }}
+          cache-restore-keys: |
             ${{ runner.os }}-${{ matrix.settings.target }}-apt-
-
-      - name: install dependencies (ubuntu only)
-        if: contains(matrix.settings.host, 'ubuntu')
-        run: |
-          mkdir -p ~/apt-cache && chmod -R a+rw ~/apt-cache
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends -o dir::cache::archives="$HOME/apt-cache" libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-          sudo chmod -R a+rw ~/apt-cache
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -283,18 +276,18 @@ jobs:
           name: opencode-cli
           path: packages/opencode/dist
 
-      - name: Cache apt packages (AUR)
-        uses: actions/cache@v4
+      - name: Setup apt dependencies (AUR)
+        uses: ./.github/actions/setup-apt
         with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-aur-${{ hashFiles('.github/workflows/publish.yml') }}
-          restore-keys: |
+          archives-dir: ${{ runner.temp }}/apt-cache
+          cache-key: ${{ runner.os }}-apt-aur-${{ hashFiles('.github/workflows/publish.yml', '.github/actions/setup-apt/action.yml') }}
+          cache-restore-keys: |
             ${{ runner.os }}-apt-aur-
+          # makepkg is a recommended dep of pacman-package-manager, not included with --no-install-recommends
+          packages: pacman-package-manager makepkg
 
       - name: Setup SSH for AUR
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pacman-package-manager
           mkdir -p ~/.ssh
           echo "${{ secrets.AUR_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa


### PR DESCRIPTION
Followup PR https://github.com/anomalyco/opencode/pull/13897

This PR extracts the fixes for APT cache to a reusable action and applies it to the AUR packages as well.