### PR TITLE
fix(compaction): use neutral text for compaction replay message

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -573,7 +573,7 @@ export namespace MessageV2 {
           if (part.type === "compaction") {
             userMessage.parts.push({
               type: "text",
-              text: "What did we do so far?",
+              text: "[Compacted]",
             })
           }
           if (part.type === "subtask") {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -256,7 +256,7 @@ describe("session.message-v2.toModelMessage", () => {
             filename: "img.png",
             data: "https://example.com/img.png",
           },
-          { type: "text", text: "What did we do so far?" },
+          { type: "text", text: "[Compacted]" },
           { type: "text", text: "The following tool was executed by the user" },
         ],
       },


### PR DESCRIPTION
### What does this PR do?

Closes #13838

Compaction injects `What did we do so far?` as a user message. The model treats this as a real request and sometimes generates an unwanted summary. 

Changed the text to `[Compacted]`. 

### How did you verify your code works?
Updated test in `message-v2.test.ts` and verified manually.