### PR TITLE
fix(docs): correct reversed meaning in Korean plugins logging section

### DIFF
--- a/packages/web/src/content/docs/ko/plugins.mdx
+++ b/packages/web/src/content/docs/ko/plugins.mdx
@@ -312,7 +312,7 @@ export const CustomToolsPlugin: Plugin = async (ctx) => {
 
 ### 로깅
 
-구조화된 로깅을 위한 `client.app.log()` 대신에 `console.log`를 사용하십시오:
+구조화된 로깅을 위해 `console.log` 대신 `client.app.log()`를 사용하십시오:
 
 ```ts title=".opencode/plugins/my-plugin.ts"
 export const MyPlugin = async ({ client }) => {


### PR DESCRIPTION
Fix #13943

### What does this PR do?
The Korean translation of the logging section in the plugins doc had `console.log` and `client.app.log()` swapped, telling users to do the exact opposite of what the English original says.
Swapped the two references so the Korean sentence matches the original meaning: use `client.app.log()` instead of `console.log` for structured logging.

### How did you verify your code works?
Compared the corrected Korean sentence with the English original in `plugins.mdx` line 315 to confirm the meaning matches.