### PR TITLE
fix: treat plugin-handled commands as success to avoid

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1737,6 +1737,33 @@ NOTE: At any point in time through this workflow you should feel free to ask the
    * Does not match when preceded by word characters or backticks (to avoid email addresses and quoted references)
    */
 
+  function isCommandHandledSentinel(err: unknown): boolean {
+    if (err instanceof Error && err.name === "COMMAND_HANDLED") return true
+    return String(err).includes("COMMAND_HANDLED")
+  }
+
+  function handledCommandResponse(
+    input: CommandInput,
+    agentName: string,
+    model: { providerID: string; modelID: string },
+  ): MessageV2.WithParts {
+    const info: MessageV2.Assistant = {
+      id: Identifier.ascending("message"),
+      sessionID: input.sessionID,
+      parentID: input.messageID ?? Identifier.ascending("message"),
+      mode: agentName,
+      agent: agentName,
+      cost: 0,
+      path: { cwd: Instance.directory, root: Instance.worktree },
+      time: { created: Date.now() },
+      role: "assistant",
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: model.modelID,
+      providerID: model.providerID,
+    }
+    return { info, parts: [] }
+  }
+
   export async function command(input: CommandInput) {
     log.info("command", input)
     const command = await Command.get(input.command)
@@ -1852,15 +1879,22 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         : await lastModel(input.sessionID)
       : taskModel
 
-    await Plugin.trigger(
-      "command.execute.before",
-      {
-        command: input.command,
-        sessionID: input.sessionID,
-        arguments: input.arguments,
-      },
-      { parts },
-    )
+    const hookOutput = { parts, handled: false }
+    try {
+      await Plugin.trigger(
+        "command.execute.before",
+        {
+          command: input.command,
+          sessionID: input.sessionID,
+          arguments: input.arguments,
+        },
+        hookOutput,
+      )
+    } catch (err) {
+      if (isCommandHandledSentinel(err)) return handledCommandResponse(input, agentName, taskModel)
+      throw err
+    }
+    if (hookOutput.handled) return handledCommandResponse(input, agentName, taskModel)
 
     const result = (await prompt({
       sessionID: input.sessionID,

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -17,6 +17,13 @@ import { type ToolDefinition } from "./tool"
 
 export * from "./tool"
 
+export class CommandHandledError extends Error {
+  constructor() {
+    super("COMMAND_HANDLED")
+    this.name = "COMMAND_HANDLED"
+  }
+}
+
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"
   info: Provider
@@ -179,7 +186,7 @@ export interface Hooks {
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
-    output: { parts: Part[] },
+    output: { parts: Part[]; handled?: boolean },
   ) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },


### PR DESCRIPTION
fix: #13922

### What does this PR do?

- Issue: Desktop shows an error toast when a plugin handles a slash command; TUI does not.
- Change: Treat plugin-handled commands as success: add handled to the hook output and detect sentinel errors containing COMMAND_HANDLED, then return a success response instead of an error.
- Why: Returning success lets the API resolve normally, so Desktop’s .catch is not triggered and no toast is shown.

### How did you verify your code works?

- Manual check with a plugin that handles commands (e.g. opencode-quota). Typecheck passes.
