### PR TITLE
fix: ignore vertex_event SSE error from vertex antro proxy

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -163,6 +163,17 @@ export namespace ProviderError {
         metadata?: Record<string, string>
       }
 
+  export function isUnknownSseEventError(e: unknown): boolean {
+    if (!APICallError.isInstance(e)) return false
+    const msg = e.message ?? ""
+    const body = e.responseBody ?? ""
+    const combined = `${msg} ${body}`
+    return (
+      combined.includes("vertex_event") &&
+      (combined.includes("No matching discriminator") || combined.includes("Type validation failed"))
+    )
+  }
+
   export function parseAPICallError(input: { providerID: string; error: APICallError }): ParsedAPICallError {
     const m = message(input.providerID, input.error)
     if (isOverflow(m)) {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -15,6 +15,7 @@ import { Config } from "@/config/config"
 import { SessionCompaction } from "./compaction"
 import { PermissionNext } from "@/permission/next"
 import { Question } from "@/question"
+import { ProviderError } from "@/provider/error"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
@@ -348,33 +349,36 @@ export namespace SessionProcessor {
               if (needsCompaction) break
             }
           } catch (e: any) {
-            log.error("process", {
-              error: e,
-              stack: JSON.stringify(e.stack),
-            })
-            const error = MessageV2.fromError(e, { providerID: input.model.providerID })
-            if (MessageV2.ContextOverflowError.isInstance(error)) {
-              // TODO: Handle context overflow error
-            }
-            const retry = SessionRetry.retryable(error)
-            if (retry !== undefined) {
-              attempt++
-              const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
-              SessionStatus.set(input.sessionID, {
-                type: "retry",
-                attempt,
-                message: retry,
-                next: Date.now() + delay,
+            if (ProviderError.isUnknownSseEventError(e)) {
+               } else {
+              log.error("process", {
+                error: e,
+                stack: JSON.stringify(e.stack),
               })
-              await SessionRetry.sleep(delay, input.abort).catch(() => {})
-              continue
+              const error = MessageV2.fromError(e, { providerID: input.model.providerID })
+              if (MessageV2.ContextOverflowError.isInstance(error)) {
+                // TODO: Handle context overflow error
+              }
+              const retry = SessionRetry.retryable(error)
+              if (retry !== undefined) {
+                attempt++
+                const delay = SessionRetry.delay(attempt, error.name === "APIError" ? error : undefined)
+                SessionStatus.set(input.sessionID, {
+                  type: "retry",
+                  attempt,
+                  message: retry,
+                  next: Date.now() + delay,
+                })
+                await SessionRetry.sleep(delay, input.abort).catch(() => {})
+                continue
+              }
+              input.assistantMessage.error = error
+              Bus.publish(Session.Event.Error, {
+                sessionID: input.assistantMessage.sessionID,
+                error: input.assistantMessage.error,
+              })
+              SessionStatus.set(input.sessionID, { type: "idle" })
             }
-            input.assistantMessage.error = error
-            Bus.publish(Session.Event.Error, {
-              sessionID: input.assistantMessage.sessionID,
-              error: input.assistantMessage.error,
-            })
-            SessionStatus.set(input.sessionID, { type: "idle" })
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)


### PR DESCRIPTION
fix: #13914

### what this PR does

- stops the stream from crashing when a Vertex Anthropic proxy sends a vertex_event SSE event.

- detects that specific validation error and treats it as “stream ended” so the turn finishes normally instead of erroring.