### PR TITLE
refactor: simplify redundant ternary in updateMessage

### DIFF
--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -579,7 +579,7 @@ export namespace Session {
   })
 
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
-    const time_created = msg.role === "user" ? msg.time.created : msg.time.created
+    const time_created = msg.time.created
     const { id, sessionID, ...data } = msg
     Database.use((db) => {
       db.insert(MessageTable)


### PR DESCRIPTION
Remove redundant conditional check for msg.time.created in `session/index.ts` as both branches of the ternary returned the same value.


