### PR TITLE
fix: handle null/undefined in titlecase

### DIFF
--- a/packages/opencode/src/util/locale.ts
+++ b/packages/opencode/src/util/locale.ts
@@ -1,5 +1,6 @@
 export namespace Locale {
   export function titlecase(str: string) {
+    if (!str) return str ?? ""
     return str.replace(/\b\w/g, (c) => c.toUpperCase())
   }
 


### PR DESCRIPTION
## Problem

The `Locale.titlecase()` function in `packages/opencode/src/util/locale.ts` does not guard against `undefined`/`null` input, causing crashes when models call the task tool without providing `subagent_type`.

**Error:**
```
TypeError: undefined is not an object (evaluating 'str3.replace')
at titlecase (src/util/locale.ts:3:12)
at task (src/cli/cmd/run.ts:170:24)
```

## Solution

Added a null guard to handle falsy inputs gracefully:
- Returns empty string for `null`/`undefined`/falsy inputs  
- Maintains existing behavior for valid strings
- Prevents session termination in headless mode

## Testing

- Existing tests pass (titlecase functionality preserved)
- Fixes crash scenario described in issue #13933
- Safe fallback prevents task tool errors

Fixes #13933