### PR TITLE
fix: prevent .gitignore from breaking file glob

### DIFF
--- a/packages/opencode/src/file/ripgrep.ts
+++ b/packages/opencode/src/file/ripgrep.ts
@@ -9,6 +9,7 @@ import { $ } from "bun"
 
 import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 import { Log } from "@/util/log"
+import { FileIgnore } from "./ignore"
 
 export namespace Ripgrep {
   const log = Log.create({ service: "ripgrep" })
@@ -217,10 +218,25 @@ export namespace Ripgrep {
   }) {
     input.signal?.throwIfAborted()
 
-    const args = [await filepath(), "--files", "--glob=!.git/*"]
+    const globs = new Set<string>()
+    globs.add("!.git/**")
+
+    for (const pattern of FileIgnore.PATTERNS) {
+      const hasMeta =
+        pattern.includes("*") || pattern.includes("?") || pattern.includes("[") || pattern.includes("]") || pattern.includes("/")
+      if (hasMeta) {
+        globs.add("!" + pattern)
+        continue
+      }
+      globs.add(`!${pattern}/**`)
+      globs.add(`!**/${pattern}/**`)
+    }
+
+    const args = [await filepath(), "--files", "--no-ignore-vcs"]
     if (input.follow) args.push("--follow")
     if (input.hidden !== false) args.push("--hidden")
     if (input.maxDepth !== undefined) args.push(`--max-depth=${input.maxDepth}`)
+    for (const g of globs) args.push(`--glob=${g}`)
     if (input.glob) {
       for (const g of input.glob) {
         args.push(`--glob=${g}`)

--- a/packages/opencode/test/file/ripgrep.test.ts
+++ b/packages/opencode/test/file/ripgrep.test.ts
@@ -36,4 +36,17 @@ describe("file.ripgrep", () => {
     expect(hasVisible).toBe(true)
     expect(hasHidden).toBe(false)
   })
+
+  test("ignores .gitignore for file discovery", async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "ok.txt"), "ok")
+        await Bun.write(path.join(dir, ".gitignore"), "*\n")
+      },
+    })
+
+    const files = await Array.fromAsync(Ripgrep.files({ cwd: tmp.path }))
+    expect(files.includes("ok.txt")).toBe(true)
+  })
 })


### PR DESCRIPTION
fix: #13959

### what does this PR do?

- prevents .gitignore from breaking file glob/finding by running ripgrep file listing with --no-ignore-vcs and using OpenCode’s ignore patterns.

### how did you verify your code works?

- added a test with .gitignore set to * and confirmed file discovery still returns files.