### PR TITLE
feat: add "Clean context" option to plan mode exit

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -212,7 +212,9 @@ export function Session() {
 
     if (part.tool === "plan_exit") {
       const meta = part.state.metadata
-      if (!meta?.cleanContext || !meta?.sessionID) {
+      const sessionID = meta?.sessionID as string | undefined
+      const plan = meta?.plan as string | undefined
+      if (!meta?.cleanContext || !sessionID) {
         local.agent.set("build")
         lastSwitch = part.id
         return
@@ -226,7 +228,7 @@ export function Session() {
       local.agent.set("build")
       sdk.client.session
         .prompt({
-          sessionID: meta.sessionID,
+          sessionID,
           ...model,
           messageID: Identifier.ascending("message"),
           agent: "build",
@@ -235,12 +237,12 @@ export function Session() {
             {
               id: Identifier.ascending("part"),
               type: "text" as const,
-              text: `The plan at ${meta.plan} has been approved, you can now edit files. Execute the plan`,
+              text: `The plan at ${plan} has been approved, you can now edit files. Execute the plan`,
             },
           ],
         })
         .catch(() => {})
-      navigate({ type: "session", sessionID: meta.sessionID })
+      navigate({ type: "session", sessionID })
       lastSwitch = part.id
     } else if (part.tool === "plan_enter") {
       local.agent.set("plan")

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -211,34 +211,36 @@ export function Session() {
     if (part.id === lastSwitch) return
 
     if (part.tool === "plan_exit") {
-      const meta = part.state.status === "completed" ? part.state.metadata : undefined
-      if (meta?.cleanContext && meta?.sessionID) {
-        const selectedModel = local.model.current()
-        if (!selectedModel) {
-          toast.show({ variant: "warning", message: "Select a model before switching to clean context", duration: 3000 })
-        } else {
-          local.agent.set("build")
-          sdk.client.session
-            .prompt({
-              sessionID: meta.sessionID as string,
-              ...selectedModel,
-              messageID: Identifier.ascending("message"),
-              agent: "build",
-              model: selectedModel,
-              parts: [
-                {
-                  id: Identifier.ascending("part"),
-                  type: "text" as const,
-                  text: `The plan at ${meta.plan} has been approved, you can now edit files. Execute the plan`,
-                },
-              ],
-            })
-            .catch(() => {})
-          navigate({ type: "session", sessionID: meta.sessionID as string })
-        }
-      } else {
+      const meta = part.state.metadata
+      if (!meta?.cleanContext || !meta?.sessionID) {
         local.agent.set("build")
+        lastSwitch = part.id
+        return
       }
+      const model = local.model.current()
+      if (!model) {
+        toast.show({ variant: "warning", message: "Select a model before switching to clean context", duration: 3000 })
+        lastSwitch = part.id
+        return
+      }
+      local.agent.set("build")
+      sdk.client.session
+        .prompt({
+          sessionID: meta.sessionID,
+          ...model,
+          messageID: Identifier.ascending("message"),
+          agent: "build",
+          model,
+          parts: [
+            {
+              id: Identifier.ascending("part"),
+              type: "text" as const,
+              text: `The plan at ${meta.plan} has been approved, you can now edit files. Execute the plan`,
+            },
+          ],
+        })
+        .catch(() => {})
+      navigate({ type: "session", sessionID: meta.sessionID })
       lastSwitch = part.id
     } else if (part.tool === "plan_enter") {
       local.agent.set("plan")

--- a/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { QuestionPrompt } from "./question"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import { formatTranscript } from "../../util/transcript"
 import { UI } from "@/cli/ui.ts"
+import { Identifier } from "@/id/id"
 
 addDefaultParsers(parsers.parsers)
 
@@ -210,7 +211,34 @@ export function Session() {
     if (part.id === lastSwitch) return
 
     if (part.tool === "plan_exit") {
-      local.agent.set("build")
+      const meta = part.state.status === "completed" ? part.state.metadata : undefined
+      if (meta?.cleanContext && meta?.sessionID) {
+        const selectedModel = local.model.current()
+        if (!selectedModel) {
+          toast.show({ variant: "warning", message: "Select a model before switching to clean context", duration: 3000 })
+        } else {
+          local.agent.set("build")
+          sdk.client.session
+            .prompt({
+              sessionID: meta.sessionID as string,
+              ...selectedModel,
+              messageID: Identifier.ascending("message"),
+              agent: "build",
+              model: selectedModel,
+              parts: [
+                {
+                  id: Identifier.ascending("part"),
+                  type: "text" as const,
+                  text: `The plan at ${meta.plan} has been approved, you can now edit files. Execute the plan`,
+                },
+              ],
+            })
+            .catch(() => {})
+          navigate({ type: "session", sessionID: meta.sessionID as string })
+        }
+      } else {
+        local.agent.set("build")
+      }
       lastSwitch = part.id
     } else if (part.tool === "plan_enter") {
       local.agent.set("plan")

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -7,6 +7,7 @@ import { MessageV2 } from "../session/message-v2"
 import { Identifier } from "../id/id"
 import { Provider } from "../provider/provider"
 import { Instance } from "../project/instance"
+import { Global } from "../global"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 import ENTER_DESCRIPTION from "./plan-enter.txt"
 
@@ -32,6 +33,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
           custom: false,
           options: [
             { label: "Yes", description: "Switch to build agent and start implementing the plan" },
+            { label: "Clean context", description: "Start a new session and implement the plan with a fresh context" },
             { label: "No", description: "Stay with plan agent to continue refining the plan" },
           ],
         },
@@ -41,6 +43,27 @@ export const PlanExitTool = Tool.define("plan_exit", {
 
     const answer = answers[0]?.[0]
     if (answer === "No") throw new Question.RejectedError()
+
+    if (answer === "Clean context") {
+      const newSession = await Session.create({
+        permission: [
+          {
+            permission: "external_directory",
+            pattern: path.join(Global.Path.data, "plans", "*"),
+            action: "allow" as const,
+          },
+        ],
+      })
+      return {
+        title: "Switching to build agent (clean context)",
+        output: "User approved switching to build agent with clean context. A new session has been created.",
+        metadata: {
+          cleanContext: true,
+          sessionID: newSession.id,
+          plan,
+        },
+      }
+    }
 
     const model = await getLastModel(ctx.sessionID)
 
@@ -67,7 +90,11 @@ export const PlanExitTool = Tool.define("plan_exit", {
     return {
       title: "Switching to build agent",
       output: "User approved switching to build agent. Wait for further instructions.",
-      metadata: {},
+      metadata: {
+        cleanContext: false,
+        sessionID: "",
+        plan: "",
+      },
     }
   },
 })


### PR DESCRIPTION
## Summary

- Adds a third option **"Clean context"** to the `plan_exit` dialog
- Creates a new session with empty message history and sends the plan execution prompt there
- Pre-allows the plans directory so the build agent can read the plan without a permission prompt

Closes #13271

## Screenshots
<img width="1732" height="1497" alt="image" src="https://github.com/user-attachments/assets/ba54e662-17c7-4050-8979-00e9350ecea2" />
<img width="1735" height="1501" alt="image" src="https://github.com/user-attachments/assets/5576bc68-1df5-4683-959a-7fa745efe7e1" />

## Test plan

- Enable plan mode (`OPENCODE_EXPERIMENTAL_PLAN_MODE=true`)
- Complete a plan and let the agent call `plan_exit`
- Verify dialog shows 3 options: **Yes**, **Clean context**, **No**
- **Yes**: switches to build in same session (unchanged)
- **Clean context**: navigates to a new session with only the plan execution prompt
- **No**: stays in plan mode (unchanged)
- Build agent can read the plan file without a permission prompt
- If no model is selected, a warning toast appears