### PR TITLE
fix: sanitize lone surrogates in API request body to prevent JSON parse errors

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -5,6 +5,7 @@ import { Config } from "../config/config"
 import { mapValues, mergeDeep, omit, pickBy, sortBy } from "remeda"
 import { NoSuchModelError, type Provider as SDK } from "ai"
 import { Log } from "../util/log"
+import { sanitizeSurrogates } from "../util/sanitize-surrogates"
 import { BunProc } from "../bun"
 import { Plugin } from "../plugin"
 import { ModelsDev } from "./models"
@@ -1091,6 +1092,10 @@ export namespace Provider {
             }
             opts.body = JSON.stringify(body)
           }
+        }
+
+        if (typeof opts.body === "string") {
+          opts.body = sanitizeSurrogates(opts.body)
         }
 
         return fetchFn(input, {

--- a/packages/opencode/src/util/sanitize-surrogates.test.ts
+++ b/packages/opencode/src/util/sanitize-surrogates.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from "bun:test"
+import { sanitizeSurrogates } from "./sanitize-surrogates"
+
+describe("sanitizeSurrogates", () => {
+  test("replaces lone high surrogate", () => {
+    expect(sanitizeSurrogates("\uD800")).toBe("\uFFFD")
+  })
+
+  test("replaces lone low surrogate", () => {
+    expect(sanitizeSurrogates("\uDC00")).toBe("\uFFFD")
+  })
+
+  test("preserves valid surrogate pair", () => {
+    const emoji = "\uD83D\uDE00"
+    expect(sanitizeSurrogates(emoji)).toBe(emoji)
+  })
+
+  test("preserves normal text", () => {
+    expect(sanitizeSurrogates("hello world")).toBe("hello world")
+  })
+
+  test("preserves Korean text", () => {
+    expect(sanitizeSurrogates("안녕하세요")).toBe("안녕하세요")
+  })
+
+  test("preserves empty string", () => {
+    expect(sanitizeSurrogates("")).toBe("")
+  })
+
+  test("replaces surrogate in middle", () => {
+    expect(sanitizeSurrogates("hello\uD800world")).toBe("hello\uFFFDworld")
+  })
+
+  test("result is well-formed", () => {
+    const result = sanitizeSurrogates("test\uD800\uDBFF\uDC00data\uDFFF")
+    expect(result.isWellFormed()).toBe(true)
+  })
+})

--- a/packages/opencode/src/util/sanitize-surrogates.ts
+++ b/packages/opencode/src/util/sanitize-surrogates.ts
@@ -1,0 +1,6 @@
+export function sanitizeSurrogates(s: string): string {
+  if (typeof s !== "string" || s.length === 0) return s
+  if (typeof s.isWellFormed === "function" && s.isWellFormed()) return s
+  if (typeof s.toWellFormed === "function") return s.toWellFormed()
+  return s.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
+}


### PR DESCRIPTION
Fixes #13988

## Summary
- Adds lone surrogate sanitization in the custom fetch wrapper (`provider.ts`)
- Prevents `no low surrogate in string` API errors from Anthropic's strict JSON parser
- Uses `String.prototype.toWellFormed()` (ES2024) with regex fallback

## Problem
When tools read non-UTF-8 files or capture terminal output with invalid Unicode, lone surrogate characters (U+D800-U+DFFF) enter the conversation. JavaScript's `JSON.stringify()` permits lone surrogates (per ECMA-262), but Anthropic's API uses Rust `serde_json` which strictly enforces RFC 8259, rejecting these as invalid JSON:

```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error",
"message":"The request body is not valid JSON: no low surrogate in string: ..."}}
```

This is a well-known issue across the ecosystem:
- anthropics/claude-code#1709 (original report)
- anthropics/claude-code#1832, #1939, #2108, #5440, #7175 (duplicates)

## Solution
Add a single sanitization point in the custom fetch wrapper that sanitizes the request body string before sending. This:
- Catches ALL tool outputs (file reads, bash, MCP) in one place
- Follows the existing body post-processing pattern (similar to OpenAI itemId removal)
- Uses the industry-standard approach (same as Microsoft Playwright)

## Testing
- New unit tests for the sanitizer function
- Verified with Bun 1.3.9 — `toWellFormed()` fully supported