### PR TITLE
fix: Homepage video section layout shift

### DIFF
--- a/packages/console/app/src/routes/index.css
+++ b/packages/console/app/src/routes/index.css
@@ -668,6 +668,8 @@ body {
       max-width: none;
       max-height: none;
       display: block;
+      aspect-ratio: 16 / 9;
+      object-fit: cover;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

fixes https://github.com/anomalyco/opencode/issues/13989

Fixes an issue I noticed on the homepage where the video loading was causing layout shift.

### How did you verify your code works?


BEFORE


https://github.com/user-attachments/assets/30dba277-3527-43c7-932b-f054ca1e1331



AFTER


https://github.com/user-attachments/assets/9f564a1f-a1b4-44fe-a349-4197f011ebae


