### PR TITLE
feat: Add evroc provider

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -589,6 +589,22 @@ export namespace Provider {
         },
       }
     },
+    evroc: async (input) => {
+      const apiKey = await (async () => {
+        const env = Env.all()
+        if (env["EVROC_API_KEY"]) return env["EVROC_API_KEY"]
+        const auth = await Auth.get(input.id)
+        if (auth?.type === "api") return auth.key
+        return undefined
+      })()
+
+      return {
+        autoload: !!apiKey,
+        options: {
+          apiKey,
+        },
+      }
+    },
   }
 
   export const Model = z

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -581,6 +581,33 @@ Cloudflare AI Gateway lets you access models from OpenAI, Anthropic, Workers AI,
 
 ---
 
+### evroc
+
+1. Head over to the [evroc console](https://console.evroc.com/), create an account, and generate a Think Shared Models API key.
+
+2. Run the `/connect` command and search for **evroc**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your evroc API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _Kimi K2.5_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Firmware
 
 1. Head over to the [Firmware dashboard](https://app.firmware.ai/signup), create an account, and generate an API key.


### PR DESCRIPTION
### What does this PR do?

This PR adds evroc as a provider for OpenCode. Fixes: https://github.com/anomalyco/opencode/issues/11940

### How did you verify your code works?
All tests are passing:
```
bun test test/provider/provider.test.ts 2>&1 | tail -10
bun test v1.3.8 (b64edcb4)
 66 pass
 0 fail
 161 expect() calls
Ran 66 tests across 1 file. [828.00ms]
```
