### PR TITLE
chore: add missing newline

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -18,7 +18,7 @@ export const ExportCommand = cmd({
   handler: async (args) => {
     await bootstrap(process.cwd(), async () => {
       let sessionID = args.sessionID
-      process.stderr.write(`Exporting session: ${sessionID ?? "latest"}`)
+      process.stderr.write(`Exporting session: ${sessionID ?? "latest"}\n`)
 
       if (!sessionID) {
         UI.empty()


### PR DESCRIPTION
A newline is missing in this export log-statement.

The context in which I noticed this was exporting all my sessions;

  opencode session list  --format json \
    | jq -r '.[].id' \
    | xargs -I{} zsh -c 'opencode export {} > sessions/{} .json'

