### PR TITLE
fix(app): avoid blocking on large prompt paste

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -35,7 +35,13 @@ import { Persist, persisted } from "@/utils/persist"
 import { usePermission } from "@/context/permission"
 import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
-import { createTextFragment, getCursorPosition, setCursorPosition, setRangeEdge } from "./prompt-input/editor-dom"
+import {
+  createTextFragment,
+  getCursorPosition,
+  getSelectionOffsets,
+  setCursorPosition,
+  setRangeEdge,
+} from "./prompt-input/editor-dom"
 import { createPromptAttachments, ACCEPTED_FILE_TYPES } from "./prompt-input/attachments"
 import {
   canNavigateHistoryAtCursor,
@@ -87,6 +93,35 @@ const EXAMPLES = [
   "prompt.example.25",
 ] as const
 
+const LARGE_PASTE_FAST_PATH = 4 * 1024
+
+const normalizeText = (text: string) => {
+  if (!text.includes("\r") && !text.includes("\u200B")) return text
+
+  let next = text
+  if (next.includes("\r")) {
+    next = next.replace(/\r\n?/g, "\n")
+  }
+  if (next.includes("\u200B")) {
+    next = next.replace(/\u200B/g, "")
+  }
+  return next
+}
+
+const promptText = (parts: Prompt) => {
+  let text = ""
+  for (const part of parts) {
+    if (!("content" in part)) continue
+    text += part.content
+  }
+  return text
+}
+
+const textPrompt = (text: string): Prompt => {
+  if (!text) return [{ type: "text", content: "", start: 0, end: 0 }]
+  return [{ type: "text", content: text, start: 0, end: text.length }]
+}
+
 export const PromptInput: Component<PromptInputProps> = (props) => {
   const sdk = useSDK()
   const sync = useSync()
@@ -108,6 +143,63 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   let slashPopoverRef!: HTMLDivElement
 
   const mirror = { input: false }
+  const paste = {
+    active: false,
+    text: "",
+    source: "",
+    start: 0,
+    end: 0,
+  }
+
+  const clearPlainTextPaste = () => {
+    paste.active = false
+    paste.text = ""
+    paste.source = ""
+    paste.start = 0
+    paste.end = 0
+  }
+
+  const setPlainTextPaste = (value: string | null) => {
+    if (!value || value.length < LARGE_PASTE_FAST_PATH) {
+      clearPlainTextPaste()
+      return false
+    }
+
+    const selection = getSelectionOffsets(editorRef)
+    if (!selection) {
+      clearPlainTextPaste()
+      return false
+    }
+
+    const parts = prompt.current().filter((part) => part.type !== "image")
+    if (parts.some((part) => part.type !== "text")) {
+      clearPlainTextPaste()
+      return false
+    }
+
+    paste.active = true
+    paste.text = value
+    paste.source = promptText(parts)
+    paste.start = selection.start
+    paste.end = selection.end
+    return true
+  }
+
+  const tryFastPlainTextPaste = (value: string) => {
+    if (!setPlainTextPaste(value)) return false
+
+    const source = paste.source
+    const start = Math.max(0, Math.min(source.length, paste.start))
+    const end = Math.max(start, Math.min(source.length, paste.end))
+    const inserted = normalizeText(value)
+    const nextText = source.slice(0, start) + inserted + source.slice(end)
+    const cursorPosition = start + inserted.length
+
+    setEditorText(nextText)
+    setCursorPosition(editorRef, cursorPosition)
+    handleInput()
+    return true
+  }
 
   const scrollCursorIntoView = () => {
     const container = scrollRef
@@ -510,24 +602,40 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return pill
   }
 
-  const isNormalizedEditor = () =>
-    Array.from(editorRef.childNodes).every((node) => {
+  const isNormalizedEditor = () => {
+    let node = editorRef.firstChild
+
+    while (node) {
       if (node.nodeType === Node.TEXT_NODE) {
         const text = node.textContent ?? ""
-        if (!text.includes("\u200B")) return true
+        if (!text.includes("\u200B")) {
+          node = node.nextSibling
+          continue
+        }
+
         if (text !== "\u200B") return false
 
         const prev = node.previousSibling
         const next = node.nextSibling
         const prevIsBr = prev?.nodeType === Node.ELEMENT_NODE && (prev as HTMLElement).tagName === "BR"
-        return !!prevIsBr && !next
+        if (!prevIsBr || !!next) return false
+
+        node = node.nextSibling
+        continue
       }
+
       if (node.nodeType !== Node.ELEMENT_NODE) return false
       const el = node as HTMLElement
-      if (el.dataset.type === "file") return true
-      if (el.dataset.type === "agent") return true
-      return el.tagName === "BR"
-    })
+      if (el.dataset.type === "file" || el.dataset.type === "agent" || el.tagName === "BR") {
+        node = node.nextSibling
+        continue
+      }
+
+      return false
+    }
+
+    return true
+  }
 
   const renderEditor = (parts: Prompt) => {
     clearEditor()
@@ -613,8 +721,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     let buffer = ""
 
     const flushText = () => {
-      const content = buffer.replace(/\r\n?/g, "\n").replace(/\u200B/g, "")
+      let content = buffer
       buffer = ""
+
+      if (content.includes("\r")) {
+        content = content.replace(/\r\n?/g, "\n")
+      }
+
+      if (content.includes("\u200B")) {
+        content = content.replace(/\u200B/g, "")
+      }
+
       if (!content) return
       parts.push({ type: "text", content, start: position, end: position + content.length })
       position += content.length
@@ -667,19 +784,25 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         return
       }
 
-      for (const child of Array.from(el.childNodes)) {
+      let child = el.firstChild
+      while (child) {
         visit(child)
+        child = child.nextSibling
       }
     }
 
-    const children = Array.from(editorRef.childNodes)
-    children.forEach((child, index) => {
-      const isBlock = child.nodeType === Node.ELEMENT_NODE && ["DIV", "P"].includes((child as HTMLElement).tagName)
+    const count = editorRef.childNodes.length
+    for (let index = 0; index < count; index++) {
+      const child = editorRef.childNodes[index]
+      if (!child) continue
+
+      const tag = child.nodeType === Node.ELEMENT_NODE ? (child as HTMLElement).tagName : undefined
+      const isBlock = tag === "DIV" || tag === "P"
       visit(child)
-      if (isBlock && index < children.length - 1) {
+      if (isBlock && index < count - 1) {
         buffer += "\n"
       }
-    })
+    }
 
     flushText()
 
@@ -688,10 +811,27 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   }
 
   const handleInput = () => {
-    const rawParts = parseFromDOM()
     const images = imageAttachments()
-    const cursorPosition = getCursorPosition(editorRef)
-    const rawText = rawParts.map((p) => ("content" in p ? p.content : "")).join("")
+    const fast = (() => {
+      if (!paste.active) return
+
+      const source = paste.source
+      const start = Math.max(0, Math.min(source.length, paste.start))
+      const end = Math.max(start, Math.min(source.length, paste.end))
+      const inserted = normalizeText(paste.text)
+      const rawText = source.slice(0, start) + inserted + source.slice(end)
+      const cursorPosition = start + inserted.length
+      clearPlainTextPaste()
+      return {
+        rawParts: textPrompt(rawText),
+        rawText,
+        cursorPosition,
+      }
+    })()
+
+    const rawParts = fast?.rawParts ?? parseFromDOM()
+    const cursorPosition = fast?.cursorPosition ?? getCursorPosition(editorRef)
+    const rawText = fast?.rawText ?? promptText(rawParts)
     const trimmed = rawText.replace(/\u200B/g, "").trim()
     const hasNonText = rawParts.some((part) => part.type !== "text")
     const shouldReset = trimmed.length === 0 && !hasNonText && images.length === 0
@@ -728,12 +868,21 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     resetHistoryNavigation()
 
+    const nextParts = [...rawParts, ...images]
+    const current = prompt.current()
+    const cursor = prompt.cursor()
+    if (isPromptEqual(nextParts, current) && cursor === cursorPosition) {
+      queueScroll()
+      return
+    }
+
     mirror.input = true
-    prompt.set([...rawParts, ...images], cursorPosition)
+    prompt.set(nextParts, cursorPosition)
     queueScroll()
   }
 
   const addPart = (part: ContentPart) => {
+    clearPlainTextPaste()
     const selection = window.getSelection()
     if (!selection || selection.rangeCount === 0) return
 
@@ -828,6 +977,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     isFocused,
     isDialogActive: () => !!dialog.active,
     setDraggingType: (type) => setStore("draggingType", type),
+    setPlainTextPaste,
+    tryFastPlainTextPaste,
     focusEditor: () => {
       editorRef.focus()
       setCursorPosition(editorRef, promptLength(prompt.current()))

--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -13,6 +13,8 @@ type PromptAttachmentsInput = {
   isFocused: () => boolean
   isDialogActive: () => boolean
   setDraggingType: (type: "image" | "@mention" | null) => void
+  setPlainTextPaste?: (value: string | null) => void
+  tryFastPlainTextPaste?: (value: string) => boolean
   focusEditor: () => void
   addPart: (part: ContentPart) => void
   readClipboardImage?: () => Promise<File | null>
@@ -56,6 +58,7 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
 
     event.preventDefault()
     event.stopPropagation()
+    input.setPlainTextPaste?.(null)
 
     const items = Array.from(clipboardData.items)
     const fileItems = items.filter((item) => item.kind === "file")
@@ -89,8 +92,14 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     }
 
     if (!plainText) return
+    if (input.tryFastPlainTextPaste?.(plainText)) return
+
+    input.setPlainTextPaste?.(plainText)
+
     const inserted = typeof document.execCommand === "function" && document.execCommand("insertText", false, plainText)
     if (inserted) return
+
+    input.setPlainTextPaste?.(null)
 
     input.addPart({ type: "text", content: plainText, start: 0, end: 0 })
   }

--- a/packages/app/src/components/prompt-input/editor-dom.test.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { createTextFragment, getCursorPosition, getNodeLength, getTextLength, setCursorPosition } from "./editor-dom"
+import {
+  createTextFragment,
+  getCursorPosition,
+  getNodeLength,
+  getSelectionOffsets,
+  getTextLength,
+  setCursorPosition,
+} from "./editor-dom"
 
 describe("prompt-input editor dom", () => {
   test("createTextFragment preserves newlines with consecutive br nodes", () => {
@@ -72,6 +79,84 @@ describe("prompt-input editor dom", () => {
     setCursorPosition(container, 3)
     expect(getCursorPosition(container)).toBe(3)
 
+    container.remove()
+  })
+
+  test("getCursorPosition handles element container offsets", () => {
+    const container = document.createElement("div")
+    container.appendChild(document.createTextNode("a"))
+    container.appendChild(document.createElement("br"))
+    container.appendChild(document.createTextNode("b"))
+    document.body.appendChild(container)
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(container, 2)
+    range.collapse(true)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(getCursorPosition(container)).toBe(2)
+
+    container.remove()
+  })
+
+  test("getCursorPosition ignores zero width chars in offset", () => {
+    const container = document.createElement("div")
+    const text = document.createTextNode("a\u200Bb")
+    container.appendChild(text)
+    document.body.appendChild(container)
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(text, 2)
+    range.collapse(true)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(getCursorPosition(container)).toBe(1)
+
+    container.remove()
+  })
+
+  test("getSelectionOffsets reads selection start and end", () => {
+    const container = document.createElement("div")
+    const text = document.createTextNode("abcdef")
+    container.appendChild(text)
+    document.body.appendChild(container)
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(text, 1)
+    range.setEnd(text, 4)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(getSelectionOffsets(container)).toEqual({ start: 1, end: 4 })
+
+    container.remove()
+  })
+
+  test("getSelectionOffsets returns undefined for external selection", () => {
+    const container = document.createElement("div")
+    container.appendChild(document.createTextNode("inside"))
+    document.body.appendChild(container)
+
+    const outside = document.createElement("div")
+    const text = document.createTextNode("outside")
+    outside.appendChild(text)
+    document.body.appendChild(outside)
+
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.setStart(text, 0)
+    range.setEnd(text, 3)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    expect(getSelectionOffsets(container)).toBeUndefined()
+
+    outside.remove()
     container.remove()
   })
 })

--- a/packages/app/src/components/prompt-input/editor-dom.ts
+++ b/packages/app/src/components/prompt-input/editor-dom.ts
@@ -1,30 +1,94 @@
 export function createTextFragment(content: string): DocumentFragment {
   const fragment = document.createDocumentFragment()
-  const segments = content.split("\n")
-  segments.forEach((segment, index) => {
-    if (segment) {
-      fragment.appendChild(document.createTextNode(segment))
+  let start = 0
+
+  for (;;) {
+    const end = content.indexOf("\n", start)
+    if (end === -1) break
+
+    if (end > start) {
+      fragment.appendChild(document.createTextNode(content.slice(start, end)))
     }
-    if (index < segments.length - 1) {
-      fragment.appendChild(document.createElement("br"))
-    }
-  })
+
+    fragment.appendChild(document.createElement("br"))
+    start = end + 1
+  }
+
+  if (start < content.length) {
+    fragment.appendChild(document.createTextNode(content.slice(start)))
+  }
+
   return fragment
+}
+
+function textLength(content: string): number {
+  if (!content.includes("\u200B")) return content.length
+  return content.replace(/\u200B/g, "").length
 }
 
 export function getNodeLength(node: Node): number {
   if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR") return 1
-  return (node.textContent ?? "").replace(/\u200B/g, "").length
+  return textLength(node.textContent ?? "")
 }
 
 export function getTextLength(node: Node): number {
-  if (node.nodeType === Node.TEXT_NODE) return (node.textContent ?? "").replace(/\u200B/g, "").length
+  if (node.nodeType === Node.TEXT_NODE) return textLength(node.textContent ?? "")
   if (node.nodeType === Node.ELEMENT_NODE && (node as HTMLElement).tagName === "BR") return 1
   let length = 0
-  for (const child of Array.from(node.childNodes)) {
+  let child = node.firstChild
+  while (child) {
     length += getTextLength(child)
+    child = child.nextSibling
   }
   return length
+}
+
+function measureUntil(node: Node, target: Node, offset: number): { found: boolean; length: number } {
+  if (node === target) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent ?? ""
+      const max = Math.max(0, Math.min(offset, text.length))
+      return { found: true, length: textLength(text.slice(0, max)) }
+    }
+
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const element = node as HTMLElement
+      if (element.tagName === "BR") return { found: true, length: offset > 0 ? 1 : 0 }
+
+      const max = Math.max(0, Math.min(offset, node.childNodes.length))
+      let length = 0
+      for (let index = 0; index < max; index++) {
+        const child = node.childNodes[index]
+        if (!child) continue
+        length += getTextLength(child)
+      }
+      return { found: true, length }
+    }
+
+    return { found: true, length: 0 }
+  }
+
+  if (node.nodeType === Node.TEXT_NODE) {
+    return { found: false, length: textLength(node.textContent ?? "") }
+  }
+
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as HTMLElement
+    if (element.tagName === "BR") return { found: false, length: 1 }
+
+    let length = 0
+    let child = node.firstChild
+    while (child) {
+      const next = measureUntil(child, target, offset)
+      length += next.length
+      if (next.found) return { found: true, length }
+      child = child.nextSibling
+    }
+
+    return { found: false, length }
+  }
+
+  return { found: false, length: 0 }
 }
 
 export function getCursorPosition(parent: HTMLElement): number {
@@ -32,10 +96,21 @@ export function getCursorPosition(parent: HTMLElement): number {
   if (!selection || selection.rangeCount === 0) return 0
   const range = selection.getRangeAt(0)
   if (!parent.contains(range.startContainer)) return 0
-  const preCaretRange = range.cloneRange()
-  preCaretRange.selectNodeContents(parent)
-  preCaretRange.setEnd(range.startContainer, range.startOffset)
-  return getTextLength(preCaretRange.cloneContents())
+  return measureUntil(parent, range.startContainer, range.startOffset).length
+}
+
+export function getSelectionOffsets(parent: HTMLElement) {
+  const selection = window.getSelection()
+  if (!selection || selection.rangeCount === 0) return
+
+  const range = selection.getRangeAt(0)
+  if (!parent.contains(range.startContainer)) return
+  if (!parent.contains(range.endContainer)) return
+
+  return {
+    start: measureUntil(parent, range.startContainer, range.startOffset).length,
+    end: measureUntil(parent, range.endContainer, range.endOffset).length,
+  }
 }
 
 export function setCursorPosition(parent: HTMLElement, position: number) {

--- a/packages/app/src/context/prompt.tsx
+++ b/packages/app/src/context/prompt.tsx
@@ -1,6 +1,6 @@
 import { createStore, type SetStoreFunction } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
-import { batch, createMemo, createRoot, onCleanup } from "solid-js"
+import { batch, createEffect, createMemo, createRoot, onCleanup } from "solid-js"
 import { useParams } from "@solidjs/router"
 import type { FileSelection } from "@/context/file"
 import { Persist, persisted } from "@/utils/persist"
@@ -116,31 +116,46 @@ function contextItemKey(item: ContextItem) {
   return `${key}:c=${digest.slice(0, 8)}`
 }
 
-function createPromptActions(
-  setStore: SetStoreFunction<{
+function createPromptActions(input: {
+  draft: {
     prompt: Prompt
     cursor?: number
-    context: {
-      items: (ContextItem & { key: string })[]
-    }
-  }>,
-) {
+  }
+  setDraft: SetStoreFunction<{
+    prompt: Prompt
+    cursor?: number
+  }>
+  schedule: VoidFunction
+}) {
   return {
     set(prompt: Prompt, cursorPosition?: number) {
-      const next = clonePrompt(prompt)
+      const samePrompt = isPromptEqual(input.draft.prompt, prompt)
+      const sameCursor = cursorPosition === undefined || input.draft.cursor === cursorPosition
+      if (samePrompt && sameCursor) return
+
+      const next = samePrompt ? input.draft.prompt : clonePrompt(prompt)
       batch(() => {
-        setStore("prompt", next)
-        if (cursorPosition !== undefined) setStore("cursor", cursorPosition)
+        if (!samePrompt) input.setDraft("prompt", next)
+        if (cursorPosition !== undefined && input.draft.cursor !== cursorPosition)
+          input.setDraft("cursor", cursorPosition)
       })
+      input.schedule()
     },
     reset() {
+      const samePrompt = isPromptEqual(input.draft.prompt, DEFAULT_PROMPT)
+      const sameCursor = input.draft.cursor === 0
+      if (samePrompt && sameCursor) return
+
       batch(() => {
-        setStore("prompt", clonePrompt(DEFAULT_PROMPT))
-        setStore("cursor", 0)
+        input.setDraft("prompt", clonePrompt(DEFAULT_PROMPT))
+        input.setDraft("cursor", 0)
       })
+      input.schedule()
     },
   }
 }
+
+const PERSIST_DEBOUNCE_MS = 250
 
 const WORKSPACE_KEY = "__workspace__"
 const MAX_PROMPT_SESSIONS = 20
@@ -172,13 +187,108 @@ function createPromptSession(dir: string, id: string | undefined) {
     }),
   )
 
-  const actions = createPromptActions(setStore)
+  const [draft, setDraft] = createStore<{
+    prompt: Prompt
+    cursor?: number
+  }>({
+    prompt: clonePrompt(store.prompt),
+    cursor: store.cursor,
+  })
+
+  const persistState = {
+    dirty: false,
+    timer: undefined as ReturnType<typeof setTimeout> | undefined,
+    idle: undefined as number | undefined,
+  }
+
+  const flush = () => {
+    const timer = persistState.timer
+    if (timer) {
+      clearTimeout(timer)
+      persistState.timer = undefined
+    }
+
+    const idle = persistState.idle
+    if (idle !== undefined) {
+      if (typeof globalThis.cancelIdleCallback === "function") {
+        globalThis.cancelIdleCallback(idle)
+      }
+      persistState.idle = undefined
+    }
+
+    if (!persistState.dirty) return
+    persistState.dirty = false
+
+    if (isPromptEqual(store.prompt, draft.prompt) && store.cursor === draft.cursor) return
+    const next = clonePrompt(draft.prompt)
+    batch(() => {
+      setStore("prompt", next)
+      setStore("cursor", draft.cursor)
+    })
+  }
+
+  const schedule = () => {
+    persistState.dirty = true
+    if (persistState.timer || persistState.idle !== undefined) return
+
+    persistState.timer = setTimeout(() => {
+      persistState.timer = undefined
+
+      if (typeof globalThis.requestIdleCallback !== "function") {
+        flush()
+        return
+      }
+
+      persistState.idle = globalThis.requestIdleCallback(
+        () => {
+          persistState.idle = undefined
+          flush()
+        },
+        { timeout: PERSIST_DEBOUNCE_MS },
+      )
+    }, PERSIST_DEBOUNCE_MS)
+  }
+
+  createEffect(() => {
+    if (!ready()) return
+    if (persistState.dirty) return
+    if (isPromptEqual(draft.prompt, store.prompt) && draft.cursor === store.cursor) return
+
+    batch(() => {
+      setDraft("prompt", clonePrompt(store.prompt))
+      setDraft("cursor", store.cursor)
+    })
+  })
+
+  if (typeof window !== "undefined" && typeof document !== "undefined") {
+    const handlePagehide = () => flush()
+    const handleVisibility = () => {
+      if (document.visibilityState !== "hidden") return
+      flush()
+    }
+
+    window.addEventListener("pagehide", handlePagehide)
+    document.addEventListener("visibilitychange", handleVisibility)
+
+    onCleanup(() => {
+      window.removeEventListener("pagehide", handlePagehide)
+      document.removeEventListener("visibilitychange", handleVisibility)
+    })
+  }
+
+  onCleanup(() => flush())
+
+  const actions = createPromptActions({
+    draft,
+    setDraft,
+    schedule,
+  })
 
   return {
     ready,
-    current: createMemo(() => store.prompt),
-    cursor: createMemo(() => store.cursor),
-    dirty: createMemo(() => !isPromptEqual(store.prompt, DEFAULT_PROMPT)),
+    current: createMemo(() => draft.prompt),
+    cursor: createMemo(() => draft.cursor),
+    dirty: createMemo(() => !isPromptEqual(draft.prompt, DEFAULT_PROMPT)),
     context: {
       items: createMemo(() => store.context.items),
       add(item: ContextItem) {


### PR DESCRIPTION
Fixes #13995

### What does this PR do?

- adds a large-plain-text paste fast path in the session prompt input to avoid blocking `execCommand("insertText")` for huge payloads
- skips expensive full DOM reparse for that fast path while preserving prompt text/cursor behavior
- moves prompt draft persistence writes off the hot input path with debounced + idle flushes (and flush on hide/cleanup)
- keeps existing file/image paste behavior unchanged

### How did you verify your code works?

- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app test:unit`
- manually tested large plain-text paste in desktop prompt input to confirm the UI no longer blocks for multiple seconds