### PR TITLE
fix: don't fetch models.dev on completion

### DIFF
--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -122,7 +122,7 @@ export namespace ModelsDev {
   }
 }
 
-if (!Flag.OPENCODE_DISABLE_MODELS_FETCH) {
+if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
   ModelsDev.refresh()
   setInterval(
     async () => {


### PR DESCRIPTION
skips refreshing models.dev if cli is invoked to generate completions rather than actually launch the app

### How did you verify your code works?

aliased opencode to newly built version, dissconnected internet, invoked completions, and no error appeared

closes #13994
