### PR TITLE
fix: invalidate state cache after auth removal

### DIFF
--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -189,6 +189,7 @@ export namespace Server {
           async (c) => {
             const providerID = c.req.valid("param").providerID
             await Auth.remove(providerID)
+            await Instance.disposeAll()
             return c.json(true)
           },
         )


### PR DESCRIPTION
## Summary

When removing an auth provider via `DELETE /auth/:providerID`, the `Provider.state()` cache was not being invalidated. This caused the provider to still appear as "connected" even after successful removal.

## Fix

Added `await Instance.disposeAll()` after `await Auth.remove(providerID)` to ensure the state cache is cleared and subsequent `/provider` requests return the correct (updated) provider list.

## Testing

Verified that:
1. `DELETE /auth/:providerID` returns `true`
2. Provider still appears as "connected" in `/provider` response (bug)
3. After fix, state cache is invalidated and provider correctly shows as disconnected

---

*Reported by: Digi4Care*
*Found in: opencode embedded server*

Fixes #14010