### PR TITLE
fix: invalidate oauth credentials when the provider says so

### DIFF
--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,8 +1,8 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-xVA4r7Qugw0TSx5wiTI5al93FI4D5LlvQo2ab3cUlmE=",
-    "aarch64-linux": "sha256-EV0U/mXlrnEyCryL9rLlOZvMn6U0+BSgPhTIudVeqTo=",
-    "aarch64-darwin": "sha256-zQvdRyNEHrpJsQMj8PZH0Ub21EREmDetVaJ0yBCgDlE=",
-    "x86_64-darwin": "sha256-Tt5k5KBnrsNVIqPET7OFzClerjdR68XYstyCj3KpvdI="
+    "x86_64-linux": "sha256-xCizgzUsDiGeI3JXj6Z0NoWeQKqznhxY6nrx1CsEMhM=",
+    "aarch64-linux": "sha256-xqr03j6xEcHljm2BAtDn22CJkAr/Tvy7sh+sQTKj09g=",
+    "aarch64-darwin": "sha256-PDu6SSTZJBn8amLc0JwJ0nQF6yICeDWF4a8JUHr6utA=",
+    "x86_64-darwin": "sha256-lEMxdyTvAOO7bAiluzQSqleLx5Cey17iHjM7dab6q/w="
   }
 }

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -149,6 +149,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
     return entry.oauthState
   }
+
+  async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
+    log.info("invalidating credentials", { mcpName: this.mcpName, type })
+    const entry = await McpAuth.get(this.mcpName)
+    if (!entry) {
+      return
+    }
+
+    switch (type) {
+      case "all":
+        await McpAuth.remove(this.mcpName)
+        break
+      case "client":
+        delete entry.clientInfo
+        await McpAuth.set(this.mcpName, entry)
+        break
+      case "tokens":
+        delete entry.tokens
+        await McpAuth.set(this.mcpName, entry)
+        break
+    }
+  }
 }
 
 export { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }


### PR DESCRIPTION
### What does this PR do?

This PR makes opencode's oauth handling respect the oauth provider invalidation callback. This fixes https://github.com/anomalyco/opencode/issues/13998 , and potentially other issues arising from the code persisting invalid credentials, even after the oauth provider deemed them as invalid.

### How did you verify your code works?
 - Logged in and made my MCP server return a refresh token valid for 30m, access tokens valid for 15m.
 - After 16 minutes, ran `opencode mcp auth` and it refreshed my access token automatically (no regression)
 - After 35 minutes, ran `opencode mcp auth` and it kicked my to the login page


<img width="3384" height="634" alt="image" src="https://github.com/user-attachments/assets/e9c67d7d-8adf-4a1e-b3d2-6c63c728d6c9" />
