### PR TITLE
fix: Invalidate oauth credentials when oauth provider says so

### DIFF
--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -149,6 +149,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
     }
     return entry.oauthState
   }
+
+  async invalidateCredentials(type: "all" | "client" | "tokens"): Promise<void> {
+    log.info("invalidating credentials", { mcpName: this.mcpName, type })
+    const entry = await McpAuth.get(this.mcpName)
+    if (!entry) {
+      return
+    }
+
+    switch (type) {
+      case "all":
+        await McpAuth.remove(this.mcpName)
+        break
+      case "client":
+        delete entry.clientInfo
+        await McpAuth.set(this.mcpName, entry)
+        break
+      case "tokens":
+        delete entry.tokens
+        await McpAuth.set(this.mcpName, entry)
+        break
+    }
+  }
 }
 
 export { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH }


### PR DESCRIPTION
### What does this PR do?

This PR makes opencode's oauth handling respect the oauth provider invalidation callback. This fixes https://github.com/anomalyco/opencode/issues/13998 , and potentially other issues arising from the code persisting invalid credentials, even after the oauth provider deemed them as invalid.

### How did you verify your code works?
 - Logged in and made my MCP server return a refresh token valid for 30m, access tokens valid for 15m.
 - After 16 minutes, ran `opencode mcp auth` and it refreshed my access token automatically (no regression)
 - After 35 minutes, ran `opencode mcp auth` and it kicked my to the login page

<img width="3384" height="634" alt="image" src="https://github.com/user-attachments/assets/8965f293-9a66-49ea-92cf-c20940111ef2" />
