### PR TITLE
fix(tui): restore worker thread for server/agent/DB operations

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -184,7 +184,7 @@ for (const item of targets) {
       OPENCODE_VERSION: `'${Script.version}'`,
       OPENCODE_MIGRATIONS: JSON.stringify(migrations),
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
-      OPENCODE_WORKER_PATH: workerPath,
+      OPENCODE_WORKER_PATH: `"${bunfsRoot}src/cli/cmd/tui/worker.js"`,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },

--- a/packages/opencode/src/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/cli/cmd/tui/thread.ts
@@ -1,7 +1,5 @@
 import { cmd } from "@/cli/cmd/cmd"
 import { tui } from "./app"
-import { Rpc } from "@/util/rpc"
-import { type rpc } from "./worker"
 import path from "path"
 import { UI } from "@/cli/ui"
 import { iife } from "@/util/iife"
@@ -10,34 +8,45 @@ import { withNetworkOptions, resolveNetworkOptions } from "@/cli/network"
 import type { Event } from "@opencode-ai/sdk/v2"
 import type { EventSource } from "./context/sdk"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
+import { Installation } from "@/installation"
+import { Rpc } from "@/util/rpc"
+import type { WorkerRpc } from "./worker"
 
-declare global {
-  const OPENCODE_WORKER_PATH: string
-}
+declare const OPENCODE_WORKER_PATH: string | undefined
 
-type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
-
-function createWorkerFetch(client: RpcClient): typeof fetch {
-  const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+function createWorkerFetch(client: ReturnType<typeof Rpc.client<WorkerRpc>>): typeof fetch {
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = new Request(input, init)
-    const body = request.body ? await request.text() : undefined
+    const url = new URL(request.url)
     const result = await client.call("fetch", {
-      url: request.url,
-      method: request.method,
-      headers: Object.fromEntries(request.headers.entries()),
-      body,
+      url: url.pathname + url.search,
+      init: {
+        method: request.method,
+        headers: Object.fromEntries(request.headers),
+        body: request.body ? await request.text() : undefined,
+      },
     })
-    return new Response(result.body, {
+    return new Response(result.body ?? null, {
       status: result.status,
       headers: result.headers,
     })
-  }
-  return fn as typeof fetch
+  }) as typeof fetch
 }
 
-function createEventSource(client: RpcClient): EventSource {
+function createEventSource(client: ReturnType<typeof Rpc.client<WorkerRpc>>): EventSource {
+  const handlers = new Set<(event: Event) => void>()
+  const dispatch = (event: Event) => {
+    for (const handler of handlers) handler(event)
+  }
+  client.on("event", dispatch)
+  client.on("global.event", dispatch)
   return {
-    on: (handler) => client.on<Event>("event", handler),
+    on: (handler) => {
+      handlers.add(handler)
+      return () => {
+        handlers.delete(handler)
+      }
+    },
   }
 }
 
@@ -46,44 +55,19 @@ export const TuiThreadCommand = cmd({
   describe: "start opencode tui",
   builder: (yargs) =>
     withNetworkOptions(yargs)
-      .positional("project", {
-        type: "string",
-        describe: "path to start opencode in",
-      })
-      .option("model", {
-        type: "string",
-        alias: ["m"],
-        describe: "model to use in the format of provider/model",
-      })
-      .option("continue", {
-        alias: ["c"],
-        describe: "continue the last session",
-        type: "boolean",
-      })
-      .option("session", {
-        alias: ["s"],
-        type: "string",
-        describe: "session id to continue",
-      })
+      .positional("project", { type: "string", describe: "path to start opencode in" })
+      .option("model", { type: "string", alias: ["m"], describe: "model to use in the format of provider/model" })
+      .option("continue", { alias: ["c"], describe: "continue the last session", type: "boolean" })
+      .option("session", { alias: ["s"], type: "string", describe: "session id to continue" })
       .option("fork", {
         type: "boolean",
         describe: "fork the session when continuing (use with --continue or --session)",
       })
-      .option("prompt", {
-        type: "string",
-        describe: "prompt to use",
-      })
-      .option("agent", {
-        type: "string",
-        describe: "agent to use",
-      }),
+      .option("prompt", { type: "string", describe: "prompt to use" })
+      .option("agent", { type: "string", describe: "agent to use" }),
   handler: async (args) => {
-    // Keep ENABLE_PROCESSED_INPUT cleared even if other code flips it.
-    // (Important when running under `bun run` wrappers on Windows.)
     const unguard = win32InstallCtrlCGuard()
     try {
-      // Must be the very first thing — disables CTRL_C_EVENT before any Worker
-      // spawn or async work so the OS cannot kill the process group.
       win32DisableProcessedInput()
 
       if (args.fork && !args.continue && !args.session) {
@@ -91,41 +75,28 @@ export const TuiThreadCommand = cmd({
         process.exitCode = 1
         return
       }
-
-      // Resolve relative paths against PWD to preserve behavior when using --cwd flag
       const baseCwd = process.env.PWD ?? process.cwd()
       const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
-      const localWorker = new URL("./worker.ts", import.meta.url)
-      const distWorker = new URL("./cli/cmd/tui/worker.js", import.meta.url)
-      const workerPath = await iife(async () => {
-        if (typeof OPENCODE_WORKER_PATH !== "undefined") return OPENCODE_WORKER_PATH
-        if (await Bun.file(distWorker).exists()) return distWorker
-        return localWorker
-      })
       try {
         process.chdir(cwd)
-      } catch (e) {
+      } catch {
         UI.error("Failed to change directory to " + cwd)
         return
       }
 
-      const worker = new Worker(workerPath, {
-        env: Object.fromEntries(
-          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-        ),
+      await Log.init({
+        print: process.argv.includes("--print-logs"),
+        dev: Installation.isLocal(),
+        level: Installation.isLocal() ? "DEBUG" : "INFO",
       })
-      worker.onerror = (e) => {
-        Log.Default.error(e)
-      }
-      const client = Rpc.client<typeof rpc>(worker)
+
+      Log.Default.info("opencode starting", { pid: process.pid })
+
       process.on("uncaughtException", (e) => {
         Log.Default.error(e)
       })
       process.on("unhandledRejection", (e) => {
         Log.Default.error(e)
-      })
-      process.on("SIGUSR2", async () => {
-        await client.call("reload", undefined)
       })
 
       const prompt = await iife(async () => {
@@ -134,7 +105,6 @@ export const TuiThreadCommand = cmd({
         return piped ? piped + "\n" + args.prompt : args.prompt
       })
 
-      // Check if server should be started (port or hostname explicitly set in CLI or config)
       const networkOpts = await resolveNetworkOptions(args)
       const shouldStartServer =
         process.argv.includes("--port") ||
@@ -144,16 +114,32 @@ export const TuiThreadCommand = cmd({
         networkOpts.port !== 0 ||
         networkOpts.hostname !== "127.0.0.1"
 
+      const workerPath =
+        typeof OPENCODE_WORKER_PATH === "string"
+          ? OPENCODE_WORKER_PATH
+          : path.resolve(import.meta.dirname, Installation.isLocal() ? "worker.ts" : "worker.js")
+
+      // Spawn worker thread — all server/agent/DB operations run there
+      const worker = new Worker(workerPath)
+      worker.onerror = (e) => console.error("worker error", e)
+      const transport = Rpc.worker(worker)
+      const client = Rpc.client<WorkerRpc>(transport)
+
       let url: string
       let customFetch: typeof fetch | undefined
       let events: EventSource | undefined
 
       if (shouldStartServer) {
-        // Start HTTP server for external access
-        const server = await client.call("server", networkOpts)
-        url = server.url
+        const result = await client.call("server", {
+          directory: cwd,
+          port: networkOpts.port,
+          hostname: networkOpts.hostname,
+          mdns: networkOpts.mdns,
+        })
+        url = result ?? `http://${networkOpts.hostname}:${networkOpts.port}`
       } else {
-        // Use direct RPC communication (no HTTP)
+        // Start event stream but don't listen on a port
+        await client.call("server", { directory: cwd })
         url = "http://opencode.internal"
         customFetch = createWorkerFetch(client)
         events = createEventSource(client)
@@ -172,10 +158,12 @@ export const TuiThreadCommand = cmd({
           fork: args.fork,
         },
         onExit: async () => {
-          await client.call("shutdown", undefined)
+          await client.call("shutdown", {})
+          worker.terminate()
         },
       })
 
+      // Check for upgrades in background
       setTimeout(() => {
         client.call("checkUpgrade", { directory: cwd }).catch(() => {})
       }, 1000)

--- a/packages/opencode/src/cli/cmd/tui/worker.ts
+++ b/packages/opencode/src/cli/cmd/tui/worker.ts
@@ -1,157 +1,137 @@
-import { Installation } from "@/installation"
 import { Server } from "@/server/server"
-import { Log } from "@/util/log"
 import { Instance } from "@/project/instance"
 import { InstanceBootstrap } from "@/project/bootstrap"
+import { Log } from "@/util/log"
 import { Rpc } from "@/util/rpc"
-import { upgrade } from "@/cli/upgrade"
+import { Installation } from "@/installation"
 import { Config } from "@/config/config"
-import { GlobalBus } from "@/bus/global"
-import { createOpencodeClient, type Event } from "@opencode-ai/sdk/v2"
-import type { BunWebSocketData } from "hono/bun"
 import { Flag } from "@/flag/flag"
+import { upgrade } from "@/cli/upgrade"
+import { GlobalBus } from "@/bus/global"
+import { createOpencodeClient } from "@opencode-ai/sdk/v2"
 
 await Log.init({
   print: process.argv.includes("--print-logs"),
   dev: Installation.isLocal(),
-  level: (() => {
-    if (Installation.isLocal()) return "DEBUG"
-    return "INFO"
-  })(),
-})
-
-process.on("unhandledRejection", (e) => {
-  Log.Default.error("rejection", {
-    e: e instanceof Error ? e.message : e,
-  })
+  level: Installation.isLocal() ? "DEBUG" : "INFO",
 })
 
 process.on("uncaughtException", (e) => {
-  Log.Default.error("exception", {
-    e: e instanceof Error ? e.message : e,
-  })
+  Log.Default.error(e)
+})
+process.on("unhandledRejection", (e) => {
+  Log.Default.error(e)
+})
+process.on("SIGUSR2", async () => {
+  Config.global.reset()
+  await Instance.disposeAll()
 })
 
-// Subscribe to global events and forward them via RPC
-GlobalBus.on("event", (event) => {
-  Rpc.emit("global.event", event)
+const transport = Rpc.self()
+
+GlobalBus.on("event", (data) => {
+  Rpc.emit("global.event", data, transport)
 })
 
-let server: Bun.Server<BunWebSocketData> | undefined
+const BASE_URL = "http://opencode.internal"
 
-const eventStream = {
-  abort: undefined as AbortController | undefined,
+function errmsg(e: unknown) {
+  return e instanceof Error ? e.message : e
 }
 
-const startEventStream = (directory: string) => {
-  if (eventStream.abort) eventStream.abort.abort()
-  const abort = new AbortController()
-  eventStream.abort = abort
-  const signal = abort.signal
+async function appFetch(input: RequestInfo | URL, init?: RequestInit) {
+  const request = new Request(input, init)
+  const password = Flag.OPENCODE_SERVER_PASSWORD
+  if (password) {
+    request.headers.set("Authorization", `Basic ${btoa(`${Flag.OPENCODE_SERVER_USERNAME ?? "opencode"}:${password}`)}`)
+  }
+  return await Server.App().fetch(request)
+}
 
-  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const request = new Request(input, init)
-    const auth = getAuthorizationHeader()
-    if (auth) request.headers.set("Authorization", auth)
-    return Server.App().fetch(request)
-  }) as typeof globalThis.fetch
+function provide<T>(directory: string, fn: () => T) {
+  return Instance.provide({ directory, init: InstanceBootstrap, fn })
+}
 
+const abort = new AbortController()
+let listener: ReturnType<typeof Server.listen> | undefined
+
+function startEventStream(directory: string) {
   const sdk = createOpencodeClient({
-    baseUrl: "http://opencode.internal",
-    directory,
-    fetch: fetchFn,
-    signal,
+    baseUrl: BASE_URL,
+    fetch: appFetch as typeof fetch,
   })
-
   ;(async () => {
-    while (!signal.aborted) {
-      const events = await Promise.resolve(
-        sdk.event.subscribe(
-          {},
-          {
-            signal,
-          },
-        ),
-      ).catch(() => undefined)
-
+    let backoff = 250
+    while (!abort.signal.aborted) {
+      const events = await Promise.resolve(sdk.event.subscribe({})).catch(() => undefined)
       if (!events) {
-        await Bun.sleep(250)
+        await Bun.sleep(backoff)
+        backoff = Math.min(backoff * 1.5, 30000)
         continue
       }
+      backoff = 250
 
       for await (const event of events.stream) {
-        Rpc.emit("event", event as Event)
+        Rpc.emit("event", event, transport)
       }
 
-      if (!signal.aborted) {
-        await Bun.sleep(250)
-      }
+      await Bun.sleep(250)
     }
   })().catch((error) => {
-    Log.Default.error("event stream error", {
-      error: error instanceof Error ? error.message : error,
-    })
+    Log.Default.error("event stream error", { error: errmsg(error) })
   })
 }
 
-startEventStream(process.cwd())
-
-export const rpc = {
-  async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {
-    const headers = { ...input.headers }
-    const auth = getAuthorizationHeader()
-    if (auth && !headers["authorization"] && !headers["Authorization"]) {
-      headers["Authorization"] = auth
-    }
-    const request = new Request(input.url, {
-      method: input.method,
-      headers,
-      body: input.body,
-    })
-    const response = await Server.App().fetch(request)
-    const body = await response.text()
+const rpc = {
+  async fetch(input: { url: string; init: RequestInit & { headers: Record<string, string> } }) {
+    const url = input.url.startsWith("http") ? input.url : `${BASE_URL}${input.url}`
+    const response = await Server.App().fetch(new Request(url, input.init))
     return {
       status: response.status,
+      statusText: response.statusText,
       headers: Object.fromEntries(response.headers.entries()),
-      body,
+      body: await response.text(),
     }
   },
-  async server(input: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
-    if (server) await server.stop(true)
-    server = Server.listen(input)
-    return { url: server.url.toString() }
+  async server(input: {
+    directory: string
+    port?: number
+    hostname?: string
+    mdns?: boolean
+  }): Promise<string | undefined> {
+    startEventStream(input.directory)
+    if (input.port || input.hostname || input.mdns) {
+      listener = Server.listen({
+        port: input.port ?? 0,
+        hostname: input.hostname ?? "127.0.0.1",
+        mdns: input.mdns ?? false,
+      })
+      return listener.url.toString()
+    }
+    return undefined
   },
   async checkUpgrade(input: { directory: string }) {
-    await Instance.provide({
-      directory: input.directory,
-      init: InstanceBootstrap,
-      fn: async () => {
-        await upgrade().catch(() => {})
-      },
-    })
+    return provide(input.directory, async () => {
+      await upgrade().catch(() => {})
+    }).catch(() => {})
   },
-  async reload() {
+  async reload(_input: {}) {
     Config.global.reset()
     await Instance.disposeAll()
   },
-  async shutdown() {
+  async shutdown(_input: {}) {
     Log.Default.info("worker shutting down")
-    if (eventStream.abort) eventStream.abort.abort()
+    abort.abort()
     await Promise.race([
       Instance.disposeAll(),
       new Promise((resolve) => {
         setTimeout(resolve, 5000)
       }),
     ])
-    if (server) server.stop(true)
+    if (listener) listener.stop(true)
   },
 }
 
-Rpc.listen(rpc)
+export type WorkerRpc = typeof rpc
 
-function getAuthorizationHeader(): string | undefined {
-  const password = Flag.OPENCODE_SERVER_PASSWORD
-  if (!password) return undefined
-  const username = Flag.OPENCODE_SERVER_USERNAME ?? "opencode"
-  return `Basic ${btoa(`${username}:${password}`)}`
-}
+Rpc.listen(rpc, transport)

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -3,51 +3,103 @@ export namespace Rpc {
     [method: string]: (input: any) => any
   }
 
-  export function listen(rpc: Definition) {
-    onmessage = async (evt) => {
-      const parsed = JSON.parse(evt.data)
-      if (parsed.type === "rpc.request") {
-        const result = await rpc[parsed.method](parsed.input)
-        postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
-      }
+  export interface Transport {
+    send(msg: any): void
+    receive(handler: (msg: any) => void): void
+  }
+
+  export function process(): Transport {
+    return {
+      send(msg) {
+        globalThis.process.send!(msg)
+      },
+      receive(handler) {
+        globalThis.process.on("message", handler)
+      },
     }
   }
 
-  export function emit(event: string, data: unknown) {
-    postMessage(JSON.stringify({ type: "rpc.event", event, data }))
+  export function worker(w: Worker): Transport {
+    return {
+      send(msg) {
+        w.postMessage(msg)
+      },
+      receive(handler) {
+        w.addEventListener("message", (e: MessageEvent) => handler(e.data))
+      },
+    }
   }
 
-  export function client<T extends Definition>(target: {
-    postMessage: (data: string) => void | null
-    onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
-  }) {
-    const pending = new Map<number, (result: any) => void>()
+  export function self(): Transport {
+    return {
+      send(msg) {
+        postMessage(msg)
+      },
+      receive(handler) {
+        addEventListener("message", (e: MessageEvent) => handler(e.data))
+      },
+    }
+  }
+
+  export function ipc() {
+    const handlers = new Set<(msg: any) => void>()
+    return {
+      transport(send: (msg: any) => void): Transport {
+        return {
+          send,
+          receive(handler) {
+            handlers.add(handler)
+          },
+        }
+      },
+      dispatch(msg: any) {
+        for (const handler of handlers) handler(msg)
+      },
+    }
+  }
+
+  export function listen(rpc: Definition, transport: Transport) {
+    transport.receive(async (msg) => {
+      if (msg.type === "rpc.request") {
+        const result = await rpc[msg.method](msg.input)
+        transport.send({ type: "rpc.result", result, id: msg.id })
+      }
+    })
+  }
+
+  export function emit(event: string, data: unknown, transport: Transport) {
+    transport.send({ type: "rpc.event", event, data })
+  }
+
+  export function client<T extends Definition>(transport: Transport) {
+    const pending = new Map<number, { resolve: (result: any) => void; reject: (error: Error) => void }>()
     const listeners = new Map<string, Set<(data: any) => void>>()
     let id = 0
-    target.onmessage = async (evt) => {
-      const parsed = JSON.parse(evt.data)
-      if (parsed.type === "rpc.result") {
-        const resolve = pending.get(parsed.id)
-        if (resolve) {
-          resolve(parsed.result)
-          pending.delete(parsed.id)
+    let invalidated = false
+    transport.receive((msg) => {
+      if (msg.type === "rpc.result") {
+        const p = pending.get(msg.id)
+        if (p) {
+          p.resolve(msg.result)
+          pending.delete(msg.id)
         }
       }
-      if (parsed.type === "rpc.event") {
-        const handlers = listeners.get(parsed.event)
+      if (msg.type === "rpc.event") {
+        const handlers = listeners.get(msg.event)
         if (handlers) {
           for (const handler of handlers) {
-            handler(parsed.data)
+            handler(msg.data)
           }
         }
       }
-    }
+    })
     return {
       call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
+        if (invalidated) return Promise.reject(new Error("client invalidated"))
         const requestId = id++
-        return new Promise((resolve) => {
-          pending.set(requestId, resolve)
-          target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
+        return new Promise((resolve, reject) => {
+          pending.set(requestId, { resolve, reject })
+          transport.send({ type: "rpc.request", method, input, id: requestId })
         })
       },
       on<Data>(event: string, handler: (data: Data) => void) {
@@ -60,6 +112,15 @@ export namespace Rpc {
         return () => {
           handlers!.delete(handler)
         }
+      },
+      invalidate() {
+        invalidated = true
+        const error = new Error("worker shutting down")
+        for (const [, p] of pending) {
+          p.reject(error)
+        }
+        pending.clear()
+        listeners.clear()
       },
     }
   }


### PR DESCRIPTION
### What does this PR do?

Fixes #14029

SQLite DB access on the main UI thread causes jittery rendering and unresponsive input, especially with long sessions. This moves all server, agent, and database operations into a dedicated Worker thread.

The TUI main thread now only handles rendering. It communicates with the worker via a lightweight RPC transport (`src/util/rpc.ts`):

- `thread.ts` spawns the worker, bridges fetch calls and events through RPC
- `worker.ts` runs `Instance.provide()`, `Server.App().fetch()`, event streaming, and session management
- SDK client requests from the UI are proxied to the worker's `Server.App` via `createWorkerFetch()`

### How did you verify your code works?

- Tested locally on Windows with long sessions — spinner is smooth, input stays responsive
- Type check passes across all packages