### PR TITLE
feat(web): Show subagents under parent session, allow intuitive navigation between.

### DIFF
--- a/packages/app/e2e/actions.ts
+++ b/packages/app/e2e/actions.ts
@@ -419,3 +419,20 @@ export async function openWorkspaceMenu(page: Page, workspaceSlug: string) {
   await expect(menu).toBeVisible()
   return menu
 }
+
+export async function seedMessage(sdk: Parameters<typeof withSession>[0], sessionID: string) {
+  await sdk.session.promptAsync({
+    sessionID,
+    noReply: true,
+    parts: [{ type: "text", text: "e2e seed" }],
+  })
+  await expect
+    .poll(
+      async () => {
+        const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+        return messages.length
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0)
+}

--- a/packages/app/e2e/sidebar/session-expansion-persistence.spec.ts
+++ b/packages/app/e2e/sidebar/session-expansion-persistence.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "../fixtures"
+import { openSidebar, withSession } from "../actions"
+import { sessionItemSelector } from "../selectors"
+
+const EXPANDED_SESSIONS_STORAGE_KEY = "opencode.global.dat:expanded-sessions"
+
+type Sdk = Parameters<typeof withSession>[0]
+
+async function getExpandedSessionsFromStorage(page: import("@playwright/test").Page) {
+  const raw = await page.evaluate((key) => localStorage.getItem(key), EXPANDED_SESSIONS_STORAGE_KEY)
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as Record<string, boolean>
+  } catch {
+    return {}
+  }
+}
+
+async function seedMessage(sdk: Sdk, sessionID: string) {
+  await sdk.session.promptAsync({
+    sessionID,
+    noReply: true,
+    parts: [{ type: "text", text: "e2e seed" }],
+  })
+  await expect
+    .poll(
+      async () => {
+        const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+        return messages.length
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0)
+}
+
+test("expanding a session with children persists state to localStorage", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session for expansion test", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await gotoSession(parent.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await expect(parentItem).toBeVisible()
+      await expect(childItem).not.toBeVisible()
+
+      const beforeExpand = await getExpandedSessionsFromStorage(page)
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      const afterExpand = await getExpandedSessionsFromStorage(page)
+      const expandedKeys = Object.keys(afterExpand).filter((k) => afterExpand[k] === true)
+      expect(expandedKeys.length).toBeGreaterThan(
+        beforeExpand.length ? Object.keys(beforeExpand).filter((k) => beforeExpand[k] === true).length : 0,
+      )
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("expanded session state persists after page reload", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session for reload test", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await gotoSession(parent.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await expect(parentItem).toBeVisible()
+      await expect(childItem).not.toBeVisible()
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      await page.reload()
+      await expect(page.locator(sessionItemSelector(parent.id))).toBeVisible()
+
+      await openSidebar(page)
+      await expect(childItem).toBeVisible()
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("collapsing an expanded session updates localStorage", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session for collapse test", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await gotoSession(parent.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      const afterExpand = await getExpandedSessionsFromStorage(page)
+      const expandedKeysAfterExpand = Object.keys(afterExpand).filter((k) => afterExpand[k] === true)
+      expect(expandedKeysAfterExpand.length).toBeGreaterThan(0)
+
+      await chevron.click()
+      await expect(childItem).not.toBeVisible()
+
+      const afterCollapse = await getExpandedSessionsFromStorage(page)
+      const matchingKey = Object.keys(afterExpand).find((k) => k.includes(parent.id))
+      if (matchingKey) {
+        expect(afterCollapse[matchingKey]).toBeFalsy()
+      }
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("multiple sessions can be expanded and all persist", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent 1 for multi-expand test", async (parent1) => {
+    await withSession(sdk, "parent 2 for multi-expand test", async (parent2) => {
+      const child1 = await sdk.session.create({ title: "child 1", parentID: parent1.id }).then((r) => r.data)
+      const child2 = await sdk.session.create({ title: "child 2", parentID: parent2.id }).then((r) => r.data)
+      if (!child1?.id || !child2?.id) throw new Error("Failed to create child sessions")
+
+      try {
+        await gotoSession(parent1.id)
+        await openSidebar(page)
+
+        const parent1Item = page.locator(sessionItemSelector(parent1.id))
+        const parent2Item = page.locator(sessionItemSelector(parent2.id))
+        const child1Item = page.locator(sessionItemSelector(child1.id))
+        const child2Item = page.locator(sessionItemSelector(child2.id))
+
+        const chevron1 = parent1Item.locator('[data-slot="collapsible-trigger"]')
+        const chevron2 = parent2Item.locator('[data-slot="collapsible-trigger"]')
+
+        await chevron1.click()
+        await expect(child1Item).toBeVisible()
+
+        await page.goto(`/${page.url().split("/")[3]}/session/${parent2.id}`)
+        await openSidebar(page)
+        await chevron2.click()
+        await expect(child2Item).toBeVisible()
+
+        const afterExpand = await getExpandedSessionsFromStorage(page)
+        const expandedKeys = Object.keys(afterExpand).filter((k) => afterExpand[k] === true)
+        expect(expandedKeys.length).toBeGreaterThanOrEqual(2)
+      } finally {
+        await sdk.session.delete({ sessionID: child1.id }).catch(() => undefined)
+        await sdk.session.delete({ sessionID: child2.id }).catch(() => undefined)
+      }
+    })
+  })
+})

--- a/packages/app/e2e/sidebar/session-expansion-persistence.spec.ts
+++ b/packages/app/e2e/sidebar/session-expansion-persistence.spec.ts
@@ -1,10 +1,8 @@
 import { test, expect } from "../fixtures"
-import { openSidebar, withSession } from "../actions"
+import { openSidebar, withSession, seedMessage } from "../actions"
 import { sessionItemSelector } from "../selectors"
 
 const EXPANDED_SESSIONS_STORAGE_KEY = "opencode.global.dat:expanded-sessions"
-
-type Sdk = Parameters<typeof withSession>[0]
 
 async function getExpandedSessionsFromStorage(page: import("@playwright/test").Page) {
   const raw = await page.evaluate((key) => localStorage.getItem(key), EXPANDED_SESSIONS_STORAGE_KEY)
@@ -14,23 +12,6 @@ async function getExpandedSessionsFromStorage(page: import("@playwright/test").P
   } catch {
     return {}
   }
-}
-
-async function seedMessage(sdk: Sdk, sessionID: string) {
-  await sdk.session.promptAsync({
-    sessionID,
-    noReply: true,
-    parts: [{ type: "text", text: "e2e seed" }],
-  })
-  await expect
-    .poll(
-      async () => {
-        const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
-        return messages.length
-      },
-      { timeout: 30_000 },
-    )
-    .toBeGreaterThan(0)
 }
 
 test("expanding a session with children persists state to localStorage", async ({ page, sdk, gotoSession }) => {

--- a/packages/app/e2e/sidebar/sidebar.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "../fixtures"
-import { openSidebar, toggleSidebar, withSession } from "../actions"
+import { openSidebar, toggleSidebar, withSession, seedMessage } from "../actions"
 import { sessionItemSelector } from "../selectors"
 
 test("sidebar can be collapsed and expanded", async ({ page, gotoSession }) => {
@@ -109,23 +109,6 @@ test("root session has no back arrow or subagent indicator", async ({ page, sdk,
   })
 })
 
-async function seedMessage(sdk: Parameters<typeof withSession>[0], sessionID: string) {
-  await sdk.session.promptAsync({
-    sessionID,
-    noReply: true,
-    parts: [{ type: "text", text: "e2e seed" }],
-  })
-  await expect
-    .poll(
-      async () => {
-        const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
-        return messages.length
-      },
-      { timeout: 30_000 },
-    )
-    .toBeGreaterThan(0)
-}
-
 test("subagent session shows back arrow and subagent indicator, and navigates to parent", async ({
   page,
   sdk,
@@ -204,6 +187,99 @@ test("navigating to parent session shows background only on parent", async ({ pa
       await expect(parentRow).toHaveClass(/bg-surface-base-active/)
       await expect(childRow).not.toHaveClass(/bg-surface-base-active/)
     } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("deeply nested sessions can be expanded and collapsed at each level", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "grandparent session", async (grandparent) => {
+    const parent = await sdk.session.create({ title: "parent session", parentID: grandparent.id }).then((r) => r.data)
+    if (!parent?.id) throw new Error("Failed to create parent session")
+
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    const grandchild = await sdk.session.create({ title: "grandchild session", parentID: child.id }).then((r) => r.data)
+    if (!grandchild?.id) throw new Error("Failed to create grandchild session")
+
+    try {
+      await gotoSession(grandparent.id)
+      await openSidebar(page)
+
+      const grandparentItem = page.locator(sessionItemSelector(grandparent.id))
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const grandchildItem = page.locator(sessionItemSelector(grandchild.id))
+
+      await expect(grandparentItem).toBeVisible()
+      await expect(parentItem).not.toBeVisible()
+
+      const grandparentChevron = grandparentItem.locator('[data-slot="collapsible-trigger"]').first()
+      await grandparentChevron.click()
+      await expect(parentItem).toBeVisible()
+      await expect(childItem).not.toBeVisible()
+
+      const parentChevron = parentItem.locator('[data-slot="collapsible-trigger"]').first()
+      await parentChevron.click()
+      await expect(childItem).toBeVisible()
+      await expect(grandchildItem).not.toBeVisible()
+
+      const childChevron = childItem.locator('[data-slot="collapsible-trigger"]').first()
+      await childChevron.click()
+      await expect(grandchildItem).toBeVisible()
+
+      await childChevron.click()
+      await expect(grandchildItem).not.toBeVisible()
+
+      await parentChevron.click()
+      await expect(childItem).not.toBeVisible()
+      await expect(grandchildItem).not.toBeVisible()
+
+      await grandparentChevron.click()
+      await expect(parentItem).not.toBeVisible()
+    } finally {
+      await sdk.session.delete({ sessionID: grandchild.id }).catch(() => undefined)
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+      await sdk.session.delete({ sessionID: parent.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("parent with archived child has no chevron", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await seedMessage(sdk, child.id)
+      await gotoSession(parent.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await expect(chevron).toBeVisible()
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      await sdk.session.update({ sessionID: child.id, time: { archived: Date.now() } })
+
+      await page.reload()
+      await openSidebar(page)
+
+      await expect(parentItem).toBeVisible()
+      await expect(chevron).not.toBeVisible()
+
+      await gotoSession(child.id)
+      await expect(page).toHaveURL(new RegExp(`/session/${child.id}`))
+
+      const navigateParent = page.getByTestId("navigate-parent-button")
+      await expect(navigateParent).toBeVisible()
+    } finally {
+      await sdk.session.update({ sessionID: child.id, time: { archived: undefined } }).catch(() => undefined)
       await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
     }
   })

--- a/packages/app/e2e/sidebar/sidebar.spec.ts
+++ b/packages/app/e2e/sidebar/sidebar.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../fixtures"
 import { openSidebar, toggleSidebar, withSession } from "../actions"
+import { sessionItemSelector } from "../selectors"
 
 test("sidebar can be collapsed and expanded", async ({ page, gotoSession }) => {
   await gotoSession()
@@ -33,5 +34,177 @@ test("sidebar collapsed state persists across navigation and reload", async ({ p
       )
       await expect(opened).toBe(false)
     })
+  })
+})
+
+test("session without subagents has no chevron", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "no subagents session", async (session) => {
+    await gotoSession(session.id)
+    await openSidebar(page)
+
+    const sessionItem = page.locator(sessionItemSelector(session.id))
+    await expect(sessionItem).toBeVisible()
+
+    const chevron = sessionItem.locator('[data-slot="collapsible-trigger"]')
+    await expect(chevron).not.toBeVisible()
+  })
+})
+
+test("session with subagents shows chevron", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await gotoSession(parent.id)
+      await openSidebar(page)
+
+      const sessionItem = page.locator(sessionItemSelector(parent.id))
+      await expect(sessionItem).toBeVisible()
+
+      const chevron = sessionItem.locator('[data-slot="collapsible-trigger"]')
+      await expect(chevron).toBeVisible()
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("subagents are hidden until parent session is expanded", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await gotoSession(parent.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await expect(parentItem).toBeVisible()
+      await expect(childItem).not.toBeVisible()
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      await chevron.click()
+      await expect(childItem).not.toBeVisible()
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("root session has no back arrow or subagent indicator", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "root session", async (session) => {
+    await gotoSession(session.id)
+
+    const backButton = page.getByTestId("navigate-parent-button")
+    const subagentIcon = page.getByTestId("subagent-indicator")
+
+    await expect(backButton).not.toBeVisible()
+    await expect(subagentIcon).not.toBeVisible()
+  })
+})
+
+async function seedMessage(sdk: Parameters<typeof withSession>[0], sessionID: string) {
+  await sdk.session.promptAsync({
+    sessionID,
+    noReply: true,
+    parts: [{ type: "text", text: "e2e seed" }],
+  })
+  await expect
+    .poll(
+      async () => {
+        const messages = await sdk.session.messages({ sessionID, limit: 1 }).then((r) => r.data ?? [])
+        return messages.length
+      },
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0)
+}
+
+test("subagent session shows back arrow and subagent indicator, and navigates to parent", async ({
+  page,
+  sdk,
+  gotoSession,
+}) => {
+  await withSession(sdk, "parent session", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await seedMessage(sdk, child.id)
+      await gotoSession(child.id)
+
+      await expect(page.getByTestId("navigate-parent-button")).toBeVisible()
+      await expect(page.getByTestId("subagent-indicator")).toBeVisible()
+
+      await page.getByTestId("navigate-parent-button").click()
+      await expect(page).toHaveURL(new RegExp(`/session/${parent.id}`))
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("subagent session selection shows background only on selected session", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await seedMessage(sdk, child.id)
+      await gotoSession(child.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      const parentRow = parentItem.locator("div.flex.items-center.w-full").first()
+      const childRow = childItem.locator("div.flex.items-center.w-full").first()
+
+      await expect(childRow).toHaveClass(/bg-surface-base-active/)
+      await expect(parentRow).not.toHaveClass(/bg-surface-base-active/)
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
+  })
+})
+
+test("navigating to parent session shows background only on parent", async ({ page, sdk, gotoSession }) => {
+  await withSession(sdk, "parent session", async (parent) => {
+    const child = await sdk.session.create({ title: "child session", parentID: parent.id }).then((r) => r.data)
+    if (!child?.id) throw new Error("Failed to create child session")
+
+    try {
+      await seedMessage(sdk, child.id)
+      await gotoSession(child.id)
+      await openSidebar(page)
+
+      const parentItem = page.locator(sessionItemSelector(parent.id))
+      const childItem = page.locator(sessionItemSelector(child.id))
+      const chevron = parentItem.locator('[data-slot="collapsible-trigger"]')
+
+      await chevron.click()
+      await expect(childItem).toBeVisible()
+
+      await page.getByTestId("navigate-parent-button").click()
+      await expect(page).toHaveURL(new RegExp(`/session/${parent.id}`))
+
+      const parentRow = parentItem.locator("div.flex.items-center.w-full").first()
+      const childRow = childItem.locator("div.flex.items-center.w-full").first()
+
+      await expect(parentRow).toHaveClass(/bg-surface-base-active/)
+      await expect(childRow).not.toHaveClass(/bg-surface-base-active/)
+    } finally {
+      await sdk.session.delete({ sessionID: child.id }).catch(() => undefined)
+    }
   })
 })

--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2/client"
 import {
   canDisposeDirectory,
   estimateRootSessionTotal,
   loadRootSessionsWithFallback,
   pickDirectoriesToEvict,
 } from "./global-sync"
+
+const mockSession = (id: string, overrides?: Partial<Session>): Session => ({
+  id,
+  slug: "",
+  projectID: "",
+  title: "",
+  version: "",
+  directory: "/test",
+  time: { created: Date.now(), updated: Date.now() },
+  ...overrides,
+})
 
 describe("pickDirectoriesToEvict", () => {
   test("keeps pinned stores and evicts idle stores", () => {
@@ -129,5 +141,76 @@ describe("canDisposeDirectory", () => {
         loadingSessions: false,
       }),
     ).toBe(true)
+  })
+})
+
+describe("session deduplication logic", () => {
+  test("deduplicates sessions by id", () => {
+    const sessions: Session[] = [
+      mockSession("a"),
+      mockSession("b"),
+      mockSession("a"),
+      mockSession("c"),
+      mockSession("b"),
+    ]
+
+    const seen = new Set<string>()
+    const deduplicated = sessions.filter((s) => {
+      if (!s.id) return false
+      if (seen.has(s.id)) return false
+      seen.add(s.id)
+      return true
+    })
+
+    expect(deduplicated).toHaveLength(3)
+    expect(deduplicated.map((s) => s.id)).toEqual(["a", "b", "c"])
+  })
+
+  test("combines non-archived and child sessions with deduplication", () => {
+    const fetched: Session[] = [mockSession("root-1"), mockSession("root-2"), mockSession("root-1")]
+    const existingChildren: Session[] = [
+      mockSession("child-1", { parentID: "root-1" }),
+      mockSession("child-2", { parentID: "root-1" }),
+      mockSession("child-1", { parentID: "root-1" }),
+    ]
+
+    const nonArchived = fetched.filter((s) => !s.time?.archived)
+    const childSessions = existingChildren.filter((s) => !!s.parentID)
+
+    const seen = new Set<string>()
+    const deduplicated = [...nonArchived, ...childSessions].filter((s) => {
+      if (!s.id) return false
+      if (seen.has(s.id)) return false
+      seen.add(s.id)
+      return true
+    })
+
+    expect(deduplicated).toHaveLength(4)
+    const ids = deduplicated.map((s) => s.id)
+    expect(ids).toContain("root-1")
+    expect(ids).toContain("root-2")
+    expect(ids).toContain("child-1")
+    expect(ids).toContain("child-2")
+  })
+
+  test("filters out archived sessions before deduplication", () => {
+    const sessions: Session[] = [
+      mockSession("active-1"),
+      mockSession("archived-1", { time: { created: Date.now(), updated: Date.now(), archived: Date.now() } }),
+      mockSession("active-2"),
+      mockSession("archived-1", { time: { created: Date.now(), updated: Date.now(), archived: Date.now() } }),
+    ]
+
+    const nonArchived = sessions.filter((s) => !s.time?.archived)
+    const seen = new Set<string>()
+    const deduplicated = nonArchived.filter((s) => {
+      if (!s.id) return false
+      if (seen.has(s.id)) return false
+      seen.add(s.id)
+      return true
+    })
+
+    expect(deduplicated).toHaveLength(2)
+    expect(deduplicated.map((s) => s.id)).toEqual(["active-1", "active-2"])
   })
 })

--- a/packages/app/src/context/global-sync.test.ts
+++ b/packages/app/src/context/global-sync.test.ts
@@ -29,7 +29,7 @@ describe("pickDirectoriesToEvict", () => {
 
 describe("loadRootSessionsWithFallback", () => {
   test("uses limited roots query when supported", async () => {
-    const calls: Array<{ directory: string; roots: true; limit?: number }> = []
+    const calls: Array<{ directory: string; roots?: boolean; limit?: number }> = []
     let fallback = 0
 
     const result = await loadRootSessionsWithFallback({
@@ -46,12 +46,12 @@ describe("loadRootSessionsWithFallback", () => {
 
     expect(result.data).toEqual([])
     expect(result.limited).toBe(true)
-    expect(calls).toEqual([{ directory: "dir", roots: true, limit: 10 }])
+    expect(calls).toEqual([{ directory: "dir", limit: 10 }])
     expect(fallback).toBe(0)
   })
 
   test("falls back to full roots query on limited-query failure", async () => {
-    const calls: Array<{ directory: string; roots: true; limit?: number }> = []
+    const calls: Array<{ directory: string; roots?: boolean; limit?: number }> = []
     let fallback = 0
 
     const result = await loadRootSessionsWithFallback({
@@ -69,10 +69,7 @@ describe("loadRootSessionsWithFallback", () => {
 
     expect(result.data).toEqual([])
     expect(result.limited).toBe(false)
-    expect(calls).toEqual([
-      { directory: "dir", roots: true, limit: 25 },
-      { directory: "dir", roots: true },
-    ])
+    expect(calls).toEqual([{ directory: "dir", limit: 25 }, { directory: "dir" }])
     expect(fallback).toBe(1)
   })
 })

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -218,7 +218,14 @@ function createGlobalSync() {
           .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
         const limit = store.limit
         const childSessions = store.session.filter((s) => !!s.parentID)
-        const sessions = trimSessions([...nonArchived, ...childSessions], { limit, permission: store.permission })
+        const seen = new Set<string>()
+        const deduplicated = [...nonArchived, ...childSessions].filter((s) => {
+          if (!s.id) return false
+          if (seen.has(s.id)) return false
+          seen.add(s.id)
+          return true
+        })
+        const sessions = trimSessions(deduplicated, { limit, permission: store.permission })
         setStore(
           "sessionTotal",
           estimateRootSessionTotal({ count: nonArchived.length, limit: x.limit, limited: x.limited }),

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -31,6 +31,7 @@ import { createRefreshQueue } from "./global-sync/queue"
 import { createChildStoreManager } from "./global-sync/child-store"
 import { trimSessions } from "./global-sync/session-trim"
 import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
+import { validateParentIDs } from "../pages/layout/helpers"
 import { applyDirectoryEvent, applyGlobalEvent } from "./global-sync/event-reducer"
 import { bootstrapDirectory, bootstrapGlobal } from "./global-sync/bootstrap"
 import { sanitizeProject } from "./global-sync/utils"
@@ -221,11 +222,15 @@ function createGlobalSync() {
         const seen = new Set<string>()
         const deduplicated = [...nonArchived, ...childSessions].filter((s) => {
           if (!s.id) return false
-          if (seen.has(s.id)) return false
+          if (seen.has(s.id)) {
+            console.warn(`[global-sync] Duplicate session ${s.id} detected in directory "${directory}"`)
+            return false
+          }
           seen.add(s.id)
           return true
         })
         const sessions = trimSessions(deduplicated, { limit, permission: store.permission })
+        validateParentIDs(sessions)
         setStore(
           "sessionTotal",
           estimateRootSessionTotal({ count: nonArchived.length, limit: x.limit, limited: x.limited }),

--- a/packages/app/src/context/global-sync/session-load.ts
+++ b/packages/app/src/context/global-sync/session-load.ts
@@ -2,7 +2,7 @@ import type { RootLoadArgs } from "./types"
 
 export async function loadRootSessionsWithFallback(input: RootLoadArgs) {
   try {
-    const result = await input.list({ directory: input.directory, roots: true, limit: input.limit })
+    const result = await input.list({ directory: input.directory, limit: input.limit })
     return {
       data: result.data,
       limit: input.limit,
@@ -10,7 +10,7 @@ export async function loadRootSessionsWithFallback(input: RootLoadArgs) {
     } as const
   } catch {
     input.onFallback()
-    const result = await input.list({ directory: input.directory, roots: true })
+    const result = await input.list({ directory: input.directory })
     return {
       data: result.data,
       limit: input.limit,

--- a/packages/app/src/context/global-sync/types.ts
+++ b/packages/app/src/context/global-sync/types.ts
@@ -118,7 +118,7 @@ export type DisposeCheck = {
 export type RootLoadArgs = {
   directory: string
   limit: number
-  list: (query: { directory: string; roots: true; limit?: number }) => Promise<{ data?: Session[] }>
+  list: (query: { directory: string; roots?: boolean; limit?: number }) => Promise<{ data?: Session[] }>
   onFallback: () => void
 }
 

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -6,6 +6,7 @@ import {
   getChildSessions,
   getDraggableId,
   syncWorkspaceOrder,
+  validateParentIDs,
   workspaceKey,
 } from "./helpers"
 import type { Session } from "@opencode-ai/sdk/v2/client"
@@ -165,5 +166,47 @@ describe("getChildSessions", () => {
     expect(children.map((s) => s.id)).toEqual(expect.arrayContaining(["active-1", "active-2"]))
     expect(children.find((s) => s.id === "archived-1")).toBeUndefined()
     expect(children.find((s) => s.id === "archived-2")).toBeUndefined()
+  })
+})
+
+describe("validateParentIDs", () => {
+  test("returns valid when all parentID references exist", () => {
+    const sessions: Session[] = [
+      mockSession("root"),
+      mockSession("child-1", { parentID: "root" }),
+      mockSession("child-2", { parentID: "root" }),
+      mockSession("grandchild", { parentID: "child-1" }),
+    ]
+
+    const result = validateParentIDs(sessions)
+    expect(result.valid).toBe(true)
+    expect(result.orphaned).toHaveLength(0)
+  })
+
+  test("returns invalid when parentID references are missing", () => {
+    const sessions: Session[] = [
+      mockSession("root"),
+      mockSession("child-1", { parentID: "root" }),
+      mockSession("orphaned-1", { parentID: "non-existent" }),
+      mockSession("orphaned-2", { parentID: "also-missing" }),
+    ]
+
+    const result = validateParentIDs(sessions)
+    expect(result.valid).toBe(false)
+    expect(result.orphaned).toHaveLength(2)
+    expect(result.orphaned).toContain("orphaned-1")
+    expect(result.orphaned).toContain("orphaned-2")
+  })
+
+  test("handles sessions without parentID", () => {
+    const sessions: Session[] = [
+      mockSession("root-1"),
+      mockSession("root-2"),
+      mockSession("child", { parentID: "root-1" }),
+    ]
+
+    const result = validateParentIDs(sessions)
+    expect(result.valid).toBe(true)
+    expect(result.orphaned).toHaveLength(0)
   })
 })

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, test } from "bun:test"
 import { collectOpenProjectDeepLinks, drainPendingDeepLinks, parseDeepLink } from "./deep-links"
-import { displayName, errorMessage, getDraggableId, syncWorkspaceOrder, workspaceKey } from "./helpers"
+import {
+  displayName,
+  errorMessage,
+  getChildSessions,
+  getDraggableId,
+  syncWorkspaceOrder,
+  workspaceKey,
+} from "./helpers"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+const mockSession = (id: string, overrides?: Partial<Session>): Session => ({
+  id,
+  slug: "",
+  projectID: "",
+  title: "",
+  version: "",
+  directory: "/test",
+  time: { created: Date.now(), updated: Date.now() },
+  ...overrides,
+})
 
 describe("layout deep links", () => {
   test("parses open-project deep links", () => {
@@ -88,5 +107,63 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+})
+
+describe("getChildSessions", () => {
+  test("filters by parentID", () => {
+    const sessions: Session[] = [
+      mockSession("child-1", { parentID: "parent-a" }),
+      mockSession("child-2", { parentID: "parent-b" }),
+      mockSession("child-3", { parentID: "parent-a" }),
+      mockSession("root", {}),
+    ]
+
+    const childrenA = getChildSessions(sessions, "parent-a")
+    expect(childrenA.map((s) => s.id)).toEqual(expect.arrayContaining(["child-1", "child-3"]))
+    expect(childrenA).toHaveLength(2)
+
+    const childrenB = getChildSessions(sessions, "parent-b")
+    expect(childrenB).toHaveLength(1)
+    expect(childrenB[0].id).toBe("child-2")
+
+    const childrenNone = getChildSessions(sessions, "non-existent")
+    expect(childrenNone).toHaveLength(0)
+  })
+
+  test("sorts by updated time descending", () => {
+    const now = Date.now()
+    const sessions: Session[] = [
+      mockSession("old", { parentID: "parent", time: { created: now, updated: now - 10000 } }),
+      mockSession("new", { parentID: "parent", time: { created: now, updated: now - 1000 } }),
+      mockSession("mid", { parentID: "parent", time: { created: now, updated: now - 5000 } }),
+    ]
+
+    const children = getChildSessions(sessions, "parent")
+    const ids = children.map((s) => s.id)
+    expect(ids).toContain("mid")
+    expect(ids).toContain("new")
+    expect(ids).toContain("old")
+  })
+
+  test("filters out archived sessions", () => {
+    const sessions: Session[] = [
+      mockSession("active-1", { parentID: "parent" }),
+      mockSession("active-2", { parentID: "parent" }),
+      mockSession("archived-1", {
+        parentID: "parent",
+        time: { created: Date.now(), updated: Date.now(), archived: Date.now() },
+      }),
+      mockSession("archived-2", {
+        parentID: "parent",
+        time: { created: Date.now(), updated: Date.now(), archived: Date.now() },
+      }),
+    ]
+
+    const children = getChildSessions(sessions, "parent")
+    expect(children).toHaveLength(2)
+    expect(children.map((s) => s.id)).toEqual(expect.arrayContaining(["active-1", "active-2"]))
+    expect(children.find((s) => s.id === "archived-1")).toBeUndefined()
+    expect(children.find((s) => s.id === "archived-2")).toBeUndefined()
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -43,7 +43,7 @@ export const childMapByParent = (sessions: Session[]) => {
 }
 
 export const getChildSessions = (sessions: Session[], parentID: string): Session[] => {
-  return sessions.filter((s) => s.parentID === parentID).sort(sortSessions(Date.now()))
+  return sessions.filter((s) => s.parentID === parentID && !s.time?.archived).sort(sortSessions(Date.now()))
 }
 
 export function getDraggableId(event: unknown): string | undefined {

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -46,6 +46,20 @@ export const getChildSessions = (sessions: Session[], parentID: string): Session
   return sessions.filter((s) => s.parentID === parentID && !s.time?.archived).sort(sortSessions(Date.now()))
 }
 
+export const validateParentIDs = (sessions: Session[]): { valid: boolean; orphaned: string[] } => {
+  const sessionIds = new Set(sessions.map((s) => s.id))
+  const orphaned: string[] = []
+
+  for (const session of sessions) {
+    if (session.parentID && !sessionIds.has(session.parentID)) {
+      orphaned.push(session.id)
+      console.warn(`[layout] Session "${session.id}" has missing parentID reference: "${session.parentID}"`)
+    }
+  }
+
+  return { valid: orphaned.length === 0, orphaned }
+}
+
 export function getDraggableId(event: unknown): string | undefined {
   if (typeof event !== "object" || event === null) return undefined
   if (!("draggable" in event)) return undefined

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -42,6 +42,10 @@ export const childMapByParent = (sessions: Session[]) => {
   return map
 }
 
+export const getChildSessions = (sessions: Session[], parentID: string): Session[] => {
+  return sessions.filter((s) => s.parentID === parentID).sort(sortSessions(Date.now()))
+}
+
 export function getDraggableId(event: unknown): string | undefined {
   if (typeof event !== "object" || event === null) return undefined
   if (!("draggable" in event)) return undefined

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -92,7 +92,7 @@ const SessionRow = (props: {
 }): JSX.Element => (
   <A
     href={`/${props.slug}/session/${props.session.id}`}
-    class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 has-[.active]:bg-surface-base-active ${props.dense ? "py-0.5" : "py-1"}`}
+    class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 ${props.dense ? "py-0.5" : "py-1"}`}
     onPointerEnter={props.scheduleHoverPrefetch}
     onPointerLeave={props.cancelHoverPrefetch}
     onMouseEnter={props.scheduleHoverPrefetch}
@@ -296,11 +296,13 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   return (
     <div
       data-session-id={props.session.id}
-      class={`group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-0 group-hover/session:pr-0
-             hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover ${hasChildren() ? "" : "has-[.active]:bg-surface-base-active"}`}
+      class="group/session relative w-full rounded-md cursor-default pl-2 pr-0 group-hover/session:pr-0 [&:has(:focus-visible)]:bg-surface-raised-base-hover"
     >
       <Collapsible open={expanded()} onOpenChange={setExpanded} class="w-full" variant="ghost">
-        <div class="flex items-center">
+        <div
+          class="flex items-center w-full rounded-md transition-colors hover:bg-surface-raised-base-hover"
+          classList={{ "bg-surface-base-active": isActive() }}
+        >
           <Show when={hasChildren()}>
             <Collapsible.Trigger class="flex items-center justify-center w-6 hover:bg-surface-base-hover rounded transition-colors self-center">
               <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -71,6 +71,8 @@ export type SessionItemProps = {
   clearHoverProjectSoon: () => void
   prefetchSession: (session: Session, priority?: "high" | "low") => void
   archiveSession: (session: Session) => Promise<void>
+  isSessionExpanded?: (sessionId: string) => boolean
+  toggleSessionExpanded?: (sessionId: string) => void
 }
 
 const SessionRow = (props: {
@@ -192,7 +194,9 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   const language = useLanguage()
   const notification = useNotification()
   const globalSync = useGlobalSync()
-  const [expanded, setExpanded] = createSignal(false)
+  const isSessionExpanded = props.isSessionExpanded ?? (() => false)
+  const toggleSessionExpanded = props.toggleSessionExpanded ?? (() => {})
+  const expanded = createMemo(() => isSessionExpanded(props.session.id))
   const unseenCount = createMemo(() => notification.session.unseenCount(props.session.id))
   const hasError = createMemo(() => notification.session.unseenHasError(props.session.id))
   const [sessionStore] = globalSync.child(props.session.directory)
@@ -266,7 +270,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()
-        setExpanded((v) => !v)
+        toggleSessionExpanded(props.session.id)
       }}
     >
       <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
@@ -298,7 +302,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
       data-session-id={props.session.id}
       class="group/session relative w-full rounded-md cursor-default pl-2 pr-0 group-hover/session:pr-0 [&:has(:focus-visible)]:bg-surface-raised-base-hover"
     >
-      <Collapsible open={expanded()} onOpenChange={setExpanded} class="w-full" variant="ghost">
+      <Collapsible
+        open={expanded()}
+        onOpenChange={() => toggleSessionExpanded(props.session.id)}
+        class="w-full"
+        variant="ghost"
+      >
         <div
           class="flex items-center w-full rounded-md transition-colors hover:bg-surface-raised-base-hover"
           classList={{ "bg-surface-base-active": isActive() }}
@@ -370,6 +379,8 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
                   clearHoverProjectSoon={props.clearHoverProjectSoon}
                   prefetchSession={props.prefetchSession}
                   archiveSession={props.archiveSession}
+                  isSessionExpanded={props.isSessionExpanded}
+                  toggleSessionExpanded={props.toggleSessionExpanded}
                 />
               )}
             </For>

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -92,7 +92,7 @@ const SessionRow = (props: {
 }): JSX.Element => (
   <A
     href={`/${props.slug}/session/${props.session.id}`}
-    class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 ${props.dense ? "py-0.5" : "py-1"}`}
+    class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 has-[.active]:bg-surface-base-active ${props.dense ? "py-0.5" : "py-1"}`}
     onPointerEnter={props.scheduleHoverPrefetch}
     onPointerLeave={props.cancelHoverPrefetch}
     onMouseEnter={props.scheduleHoverPrefetch}
@@ -296,8 +296,8 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   return (
     <div
       data-session-id={props.session.id}
-      class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-0 group-hover/session:pr-0
-             hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
+      class={`group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-0 group-hover/session:pr-0
+             hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover ${hasChildren() ? "" : "has-[.active]:bg-surface-base-active"}`}
     >
       <Collapsible open={expanded()} onOpenChange={setExpanded} class="w-full" variant="ghost">
         <div class="flex items-center">

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -61,6 +61,7 @@ export type SessionItemProps = {
   mobile?: boolean
   dense?: boolean
   popover?: boolean
+  depth?: number
   children: Map<string, string[]>
   allSessions: Session[]
   sidebarExpanded: Accessor<boolean>
@@ -196,6 +197,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   const globalSync = useGlobalSync()
   const isSessionExpanded = props.isSessionExpanded ?? (() => false)
   const toggleSessionExpanded = props.toggleSessionExpanded ?? (() => {})
+  const depth = props.depth ?? 0
   const expanded = createMemo(() => isSessionExpanded(props.session.id))
   const unseenCount = createMemo(() => notification.session.unseenCount(props.session.id))
   const hasError = createMemo(() => notification.session.unseenHasError(props.session.id))
@@ -263,19 +265,6 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     const text = parts.find((part): part is TextPart => part?.type === "text" && !part.synthetic && !part.ignored)
     return text?.text
   }
-
-  const ExpandButton = () => (
-    <button
-      class="flex items-center justify-center size-5 rounded hover:bg-surface-base-hover transition-colors"
-      onClick={(e) => {
-        e.preventDefault()
-        e.stopPropagation()
-        toggleSessionExpanded(props.session.id)
-      }}
-    >
-      <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
-    </button>
-  )
 
   const item = (
     <SessionRow
@@ -360,7 +349,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
           </div>
         </div>
         <Collapsible.Content>
-          <div class="pl-4 flex flex-col gap-0.5">
+          <div class="flex flex-col gap-0.5" style={{ "padding-left": `${(depth + 1) * 16}px` }}>
             <For each={childSessions()}>
               {(child) => (
                 <SessionItem
@@ -369,6 +358,7 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
                   mobile={props.mobile}
                   dense={props.dense}
                   popover={props.popover}
+                  depth={depth + 1}
                   children={props.children}
                   allSessions={props.allSessions}
                   sidebarExpanded={props.sidebarExpanded}

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -5,6 +5,7 @@ import { useLayout, type LocalProject, getAvatarColors } from "@/context/layout"
 import { useNotification } from "@/context/notification"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { Avatar } from "@opencode-ai/ui/avatar"
+import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { DiffChanges } from "@opencode-ai/ui/diff-changes"
 import { HoverCard } from "@opencode-ai/ui/hover-card"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -14,8 +15,9 @@ import { Spinner } from "@opencode-ai/ui/spinner"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/util/path"
 import { type Message, type Session, type TextPart, type UserMessage } from "@opencode-ai/sdk/v2/client"
-import { For, Match, Show, Switch, createMemo, onCleanup, type Accessor, type JSX } from "solid-js"
+import { For, Match, Show, Switch, createMemo, createSignal, onCleanup, type Accessor, type JSX } from "solid-js"
 import { agentColor } from "@/utils/agent"
+import { getChildSessions } from "./helpers"
 
 const OPENCODE_PROJECT_ID = "4b0ea68d7af9a6031a7ffda7ad66e0cb83315750"
 
@@ -60,6 +62,7 @@ export type SessionItemProps = {
   dense?: boolean
   popover?: boolean
   children: Map<string, string[]>
+  allSessions: Session[]
   sidebarExpanded: Accessor<boolean>
   sidebarHovering: Accessor<boolean>
   nav: Accessor<HTMLElement | undefined>
@@ -102,25 +105,27 @@ const SessionRow = (props: {
     }}
   >
     <div class="flex items-center gap-1 w-full">
-      <div
-        class="shrink-0 size-6 flex items-center justify-center"
-        style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
-      >
-        <Switch fallback={<Icon name="dash" size="small" class="text-icon-weak" />}>
-          <Match when={props.isWorking()}>
-            <Spinner class="size-[15px]" />
-          </Match>
-          <Match when={props.hasPermissions()}>
-            <div class="size-1.5 rounded-full bg-surface-warning-strong" />
-          </Match>
-          <Match when={props.hasError()}>
-            <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
-          </Match>
-          <Match when={props.unseenCount() > 0}>
-            <div class="size-1.5 rounded-full bg-text-interactive-base" />
-          </Match>
-        </Switch>
-      </div>
+      <Show when={props.isWorking() || props.hasPermissions() || props.hasError() || props.unseenCount() > 0}>
+        <div
+          class="shrink-0 size-6 flex items-center justify-center"
+          style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
+        >
+          <Switch>
+            <Match when={props.isWorking()}>
+              <Spinner class="size-[15px]" />
+            </Match>
+            <Match when={props.hasPermissions()}>
+              <div class="size-1.5 rounded-full bg-surface-warning-strong" />
+            </Match>
+            <Match when={props.hasError()}>
+              <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
+            </Match>
+            <Match when={props.unseenCount() > 0}>
+              <div class="size-1.5 rounded-full bg-text-interactive-base" />
+            </Match>
+          </Switch>
+        </div>
+      </Show>
       <span class="text-14-regular text-text-strong grow-1 min-w-0 overflow-hidden text-ellipsis truncate">
         {props.session.title}
       </span>
@@ -187,9 +192,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   const language = useLanguage()
   const notification = useNotification()
   const globalSync = useGlobalSync()
+  const [expanded, setExpanded] = createSignal(false)
   const unseenCount = createMemo(() => notification.session.unseenCount(props.session.id))
   const hasError = createMemo(() => notification.session.unseenHasError(props.session.id))
   const [sessionStore] = globalSync.child(props.session.directory)
+  const childSessions = createMemo(() => getChildSessions(props.allSessions, props.session.id))
+  const hasChildren = createMemo(() => childSessions().length > 0)
   const hasPermissions = createMemo(() => {
     const permissions = sessionStore.permission?.[props.session.id] ?? []
     if (permissions.length > 0) return true
@@ -251,6 +259,20 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
     const text = parts.find((part): part is TextPart => part?.type === "text" && !part.synthetic && !part.ignored)
     return text?.text
   }
+
+  const ExpandButton = () => (
+    <button
+      class="flex items-center justify-center size-5 rounded hover:bg-surface-base-hover transition-colors"
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setExpanded((v) => !v)
+      }}
+    >
+      <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
+    </button>
+  )
+
   const item = (
     <SessionRow
       session={props.session}
@@ -274,42 +296,84 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
   return (
     <div
       data-session-id={props.session.id}
-      class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-3
-             hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[[data-expanded]]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
+      class="group/session relative w-full rounded-md cursor-default transition-colors pl-2 pr-0 group-hover/session:pr-0
+             hover:bg-surface-raised-base-hover [&:has(:focus-visible)]:bg-surface-raised-base-hover has-[.active]:bg-surface-base-active"
     >
-      <Show
-        when={hoverEnabled()}
-        fallback={
-          <Tooltip placement={props.mobile ? "bottom" : "right"} value={props.session.title} gutter={10}>
-            {item}
-          </Tooltip>
-        }
-      >
-        <SessionHoverPreview
-          mobile={props.mobile}
-          nav={props.nav}
-          hoverSession={props.hoverSession}
-          session={props.session}
-          sidebarHovering={props.sidebarHovering}
-          hoverReady={hoverReady}
-          hoverMessages={hoverMessages}
-          language={language}
-          isActive={isActive}
-          slug={props.slug}
-          setHoverSession={props.setHoverSession}
-          messageLabel={messageLabel}
-          onMessageSelect={(message) => {
-            if (!isActive()) {
-              layout.pendingMessage.set(`${base64Encode(props.session.directory)}/${props.session.id}`, message.id)
-              navigate(`${props.slug}/session/${props.session.id}`)
-              return
-            }
-            window.history.replaceState(null, "", `#message-${message.id}`)
-            window.dispatchEvent(new HashChangeEvent("hashchange"))
-          }}
-          trigger={item}
-        />
-      </Show>
+      <Collapsible open={expanded()} onOpenChange={setExpanded} class="w-full" variant="ghost">
+        <div class="flex items-center">
+          <Show when={hasChildren()}>
+            <Collapsible.Trigger class="flex items-center justify-center w-6 hover:bg-surface-base-hover rounded transition-colors self-center">
+              <Icon name={expanded() ? "chevron-down" : "chevron-right"} size="small" />
+            </Collapsible.Trigger>
+          </Show>
+          <Show when={!hasChildren()}>
+            <div class="w-6 self-center" />
+          </Show>
+          <div class="flex-1 min-w-0">
+            <Show
+              when={hoverEnabled()}
+              fallback={
+                <Tooltip placement={props.mobile ? "bottom" : "right"} value={props.session.title} gutter={10}>
+                  {item}
+                </Tooltip>
+              }
+            >
+              <SessionHoverPreview
+                mobile={props.mobile}
+                nav={props.nav}
+                hoverSession={props.hoverSession}
+                session={props.session}
+                sidebarHovering={props.sidebarHovering}
+                hoverReady={hoverReady}
+                hoverMessages={hoverMessages}
+                language={language}
+                isActive={isActive}
+                slug={props.slug}
+                setHoverSession={props.setHoverSession}
+                messageLabel={messageLabel}
+                onMessageSelect={(message) => {
+                  if (!isActive()) {
+                    layout.pendingMessage.set(
+                      `${base64Encode(props.session.directory)}/${props.session.id}`,
+                      message.id,
+                    )
+                    navigate(`${props.slug}/session/${props.session.id}`)
+                    return
+                  }
+                  window.history.replaceState(null, "", `#message-${message.id}`)
+                  window.dispatchEvent(new HashChangeEvent("hashchange"))
+                }}
+                trigger={item}
+              />
+            </Show>
+          </div>
+        </div>
+        <Collapsible.Content>
+          <div class="pl-4 flex flex-col gap-0.5">
+            <For each={childSessions()}>
+              {(child) => (
+                <SessionItem
+                  session={child}
+                  slug={props.slug}
+                  mobile={props.mobile}
+                  dense={props.dense}
+                  popover={props.popover}
+                  children={props.children}
+                  allSessions={props.allSessions}
+                  sidebarExpanded={props.sidebarExpanded}
+                  sidebarHovering={props.sidebarHovering}
+                  nav={props.nav}
+                  hoverSession={props.hoverSession}
+                  setHoverSession={props.setHoverSession}
+                  clearHoverProjectSoon={props.clearHoverProjectSoon}
+                  prefetchSession={props.prefetchSession}
+                  archiveSession={props.archiveSession}
+                />
+              )}
+            </For>
+          </div>
+        </Collapsible.Content>
+      </Collapsible>
       <div
         class={`absolute ${props.dense ? "top-0.5 right-0.5" : "top-1 right-1"} flex items-center gap-0.5 transition-opacity`}
         classList={{

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -92,56 +92,54 @@ const SessionRow = (props: {
   prefetchSession: (session: Session, priority?: "high" | "low") => void
   scheduleHoverPrefetch: () => void
   cancelHoverPrefetch: () => void
-}): JSX.Element => (
-  <A
-    href={`/${props.slug}/session/${props.session.id}`}
-    class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 ${props.dense ? "py-0.5" : "py-1"}`}
-    onPointerEnter={props.scheduleHoverPrefetch}
-    onPointerLeave={props.cancelHoverPrefetch}
-    onMouseEnter={props.scheduleHoverPrefetch}
-    onMouseLeave={props.cancelHoverPrefetch}
-    onFocus={() => props.prefetchSession(props.session, "high")}
-    onClick={() => {
-      props.setHoverSession(undefined)
-      if (props.sidebarOpened()) return
-      props.clearHoverProjectSoon()
-    }}
-  >
-    <div class="flex items-center gap-1 w-full">
-      <Show when={props.isWorking() || props.hasPermissions() || props.hasError() || props.unseenCount() > 0}>
-        <div
-          class="shrink-0 size-6 flex items-center justify-center"
-          style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
-        >
-          <Switch>
-            <Match when={props.isWorking()}>
-              <Spinner class="size-[15px]" />
-            </Match>
-            <Match when={props.hasPermissions()}>
-              <div class="size-1.5 rounded-full bg-surface-warning-strong" />
-            </Match>
-            <Match when={props.hasError()}>
-              <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
-            </Match>
-            <Match when={props.unseenCount() > 0}>
-              <div class="size-1.5 rounded-full bg-text-interactive-base" />
-            </Match>
-          </Switch>
-        </div>
-      </Show>
-      <span class="text-14-regular text-text-strong grow-1 min-w-0 overflow-hidden text-ellipsis truncate">
-        {props.session.title}
-      </span>
-      <Show when={props.session.summary}>
-        {(summary) => (
-          <div class="group-hover/session:hidden group-active/session:hidden group-focus-within/session:hidden">
-            <DiffChanges changes={summary()} />
+}): JSX.Element => {
+  const hasStatus = () => props.isWorking() || props.hasPermissions() || props.hasError() || props.unseenCount() > 0
+
+  const getStatusIcon = () => {
+    if (props.isWorking()) return <Spinner class="size-[15px]" />
+    if (props.hasPermissions()) return <div class="size-1.5 rounded-full bg-surface-warning-strong" />
+    if (props.hasError()) return <div class="size-1.5 rounded-full bg-text-diff-delete-base" />
+    return <div class="size-1.5 rounded-full bg-text-interactive-base" />
+  }
+
+  return (
+    <A
+      href={`/${props.slug}/session/${props.session.id}`}
+      class={`flex items-center justify-between gap-3 min-w-0 text-left w-full focus:outline-none transition-[padding] ${props.mobile ? "pr-7" : ""} group-hover/session:pr-7 group-focus-within/session:pr-7 group-active/session:pr-7 ${props.dense ? "py-0.5" : "py-1"}`}
+      onPointerEnter={props.scheduleHoverPrefetch}
+      onPointerLeave={props.cancelHoverPrefetch}
+      onMouseEnter={props.scheduleHoverPrefetch}
+      onMouseLeave={props.cancelHoverPrefetch}
+      onFocus={() => props.prefetchSession(props.session, "high")}
+      onClick={() => {
+        props.setHoverSession(undefined)
+        if (props.sidebarOpened()) return
+        props.clearHoverProjectSoon()
+      }}
+    >
+      <div class="flex items-center gap-1 w-full">
+        <Show when={hasStatus()}>
+          <div
+            class="shrink-0 size-6 flex items-center justify-center"
+            style={{ color: props.tint() ?? "var(--icon-interactive-base)" }}
+          >
+            {getStatusIcon()}
           </div>
-        )}
-      </Show>
-    </div>
-  </A>
-)
+        </Show>
+        <span class="text-14-regular text-text-strong grow-1 min-w-0 overflow-hidden text-ellipsis truncate">
+          {props.session.title}
+        </span>
+        <Show when={props.session.summary}>
+          {(summary) => (
+            <div class="group-hover/session:hidden group-active/session:hidden group-focus-within/session:hidden">
+              <DiffChanges changes={summary()} />
+            </div>
+          )}
+        </Show>
+      </div>
+    </A>
+  )
+}
 
 const SessionHoverPreview = (props: {
   mobile?: boolean

--- a/packages/app/src/pages/layout/sidebar-project.tsx
+++ b/packages/app/src/pages/layout/sidebar-project.tsx
@@ -14,6 +14,7 @@ import { useNotification } from "@/context/notification"
 import { ProjectIcon, SessionItem, type SessionItemProps } from "./sidebar-items"
 import { childMapByParent, displayName, sortedRootSessions } from "./helpers"
 import { projectSelected, projectTileActive } from "./sidebar-project-helpers"
+import { type Session } from "@opencode-ai/sdk/v2/client"
 
 export type ProjectSidebarContext = {
   currentDir: Accessor<string>
@@ -32,7 +33,7 @@ export type ProjectSidebarContext = {
   workspacesEnabled: (project: LocalProject) => boolean
   workspaceIds: (project: LocalProject) => string[]
   workspaceLabel: (directory: string, branch?: string, projectId?: string) => string
-  sessionProps: Omit<SessionItemProps, "session" | "slug" | "children" | "mobile" | "dense" | "popover">
+  sessionProps: Omit<SessionItemProps, "session" | "slug" | "children" | "mobile" | "dense" | "popover" | "allSessions">
   setHoverSession: (id: string | undefined) => void
 }
 
@@ -169,8 +170,10 @@ const ProjectPreviewPanel = (props: {
   workspaces: Accessor<string[]>
   label: (directory: string) => string
   projectSessions: Accessor<ReturnType<typeof sortedRootSessions>>
+  projectAllSessions: Accessor<Session[]>
   projectChildren: Accessor<Map<string, string[]>>
   workspaceSessions: (directory: string) => ReturnType<typeof sortedRootSessions>
+  workspaceAllSessions: (directory: string) => Session[]
   workspaceChildren: (directory: string) => Map<string, string[]>
   setOpen: (value: boolean) => void
   ctx: ProjectSidebarContext
@@ -210,6 +213,7 @@ const ProjectPreviewPanel = (props: {
                 mobile={props.mobile}
                 popover={false}
                 children={props.projectChildren()}
+                allSessions={props.projectAllSessions()}
               />
             )}
           </For>
@@ -218,6 +222,7 @@ const ProjectPreviewPanel = (props: {
         <For each={props.workspaces()}>
           {(directory) => {
             const sessions = createMemo(() => props.workspaceSessions(directory))
+            const allSessions = createMemo(() => props.workspaceAllSessions(directory))
             const children = createMemo(() => props.workspaceChildren(directory))
             return (
               <div class="flex flex-col gap-1">
@@ -237,6 +242,7 @@ const ProjectPreviewPanel = (props: {
                       mobile={props.mobile}
                       popover={false}
                       children={children()}
+                      allSessions={allSessions()}
                     />
                   )}
                 </For>
@@ -310,10 +316,15 @@ export const SortableProject = (props: {
 
   const projectStore = createMemo(() => globalSync.child(props.project.worktree, { bootstrap: false })[0])
   const projectSessions = createMemo(() => sortedRootSessions(projectStore(), props.sortNow()).slice(0, 2))
+  const projectAllSessions = createMemo(() => projectStore().session)
   const projectChildren = createMemo(() => childMapByParent(projectStore().session))
   const workspaceSessions = (directory: string) => {
     const [data] = globalSync.child(directory, { bootstrap: false })
     return sortedRootSessions(data, props.sortNow()).slice(0, 2)
+  }
+  const workspaceAllSessions = (directory: string) => {
+    const [data] = globalSync.child(directory, { bootstrap: false })
+    return data.session
   }
   const workspaceChildren = (directory: string) => {
     const [data] = globalSync.child(directory, { bootstrap: false })
@@ -368,8 +379,10 @@ export const SortableProject = (props: {
             workspaces={workspaces}
             label={label}
             projectSessions={projectSessions}
+            projectAllSessions={projectAllSessions}
             projectChildren={projectChildren}
             workspaceSessions={workspaceSessions}
+            workspaceAllSessions={workspaceAllSessions}
             workspaceChildren={workspaceChildren}
             setOpen={setOpen}
             ctx={props.ctx}

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -506,7 +506,7 @@ export const LocalWorkspace = (props: {
   return (
     <div
       ref={(el) => props.ctx.setScrollContainerRef(el, props.mobile)}
-      class="size-full flex flex-col py-2 overflow-y-auto no-scrollbar [overflow-anchor:none]"
+      class="size-full flex flex-col py-2 overflow-y-auto no-scrollbar [overflow-anchor:none] pr-2"
     >
       <nav class="flex flex-col gap-1 px-2">
         <Show when={loading()}>

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -244,6 +244,7 @@ const WorkspaceSessionList = (props: {
   showNew: Accessor<boolean>
   loading: Accessor<boolean>
   sessions: Accessor<Session[]>
+  allSessions: Accessor<Session[]>
   children: Accessor<Map<string, string[]>>
   hasMore: Accessor<boolean>
   loadMore: () => Promise<void>
@@ -269,6 +270,7 @@ const WorkspaceSessionList = (props: {
           slug={props.slug()}
           mobile={props.mobile}
           children={props.children()}
+          allSessions={props.allSessions()}
           sidebarExpanded={props.ctx.sidebarExpanded}
           sidebarHovering={props.ctx.sidebarHovering}
           nav={props.ctx.nav}
@@ -451,6 +453,7 @@ export const SortableWorkspace = (props: {
             showNew={showNew}
             loading={loading}
             sessions={sessions}
+            allSessions={() => workspaceStore.session}
             children={children}
             hasMore={hasMore}
             loadMore={loadMore}
@@ -501,6 +504,7 @@ export const LocalWorkspace = (props: {
               slug={slug()}
               mobile={props.mobile}
               children={children()}
+              allSessions={workspace().store.session}
               sidebarExpanded={props.ctx.sidebarExpanded}
               sidebarHovering={props.ctx.sidebarHovering}
               nav={props.ctx.nav}

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -18,6 +18,7 @@ import { useGlobalSync } from "@/context/global-sync"
 import { useLanguage } from "@/context/language"
 import { NewSessionItem, SessionItem, SessionSkeleton } from "./sidebar-items"
 import { childMapByParent, sortedRootSessions } from "./helpers"
+import { useExpandedSessions } from "./use-expanded-sessions"
 
 type InlineEditorComponent = (props: {
   id: string
@@ -249,6 +250,8 @@ const WorkspaceSessionList = (props: {
   hasMore: Accessor<boolean>
   loadMore: () => Promise<void>
   language: ReturnType<typeof useLanguage>
+  isSessionExpanded: (sessionId: string) => boolean
+  toggleSessionExpanded: (sessionId: string) => void
 }): JSX.Element => (
   <nav class="flex flex-col gap-1 px-2">
     <Show when={props.showNew()}>
@@ -279,6 +282,8 @@ const WorkspaceSessionList = (props: {
           clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
           prefetchSession={props.ctx.prefetchSession}
           archiveSession={props.ctx.archiveSession}
+          isSessionExpanded={props.isSessionExpanded}
+          toggleSessionExpanded={props.toggleSessionExpanded}
         />
       )}
     </For>
@@ -319,6 +324,8 @@ export const SortableWorkspace = (props: {
   })
   const slug = createMemo(() => base64Encode(props.directory))
   const sessions = createMemo(() => sortedRootSessions(workspaceStore, props.sortNow()))
+  const allSessions = createMemo(() => Object.values(workspaceStore.session).flat())
+  const expandedSessions = useExpandedSessions(() => props.directory, allSessions)
   const children = createMemo(() => childMapByParent(workspaceStore.session))
   const local = createMemo(() => props.directory === props.project.worktree)
   const active = createMemo(() => props.ctx.currentDir() === props.directory)
@@ -453,11 +460,13 @@ export const SortableWorkspace = (props: {
             showNew={showNew}
             loading={loading}
             sessions={sessions}
-            allSessions={() => workspaceStore.session}
+            allSessions={allSessions}
             children={children}
             hasMore={hasMore}
             loadMore={loadMore}
             language={language}
+            isSessionExpanded={expandedSessions.isExpanded}
+            toggleSessionExpanded={expandedSessions.toggleExpanded}
           />
         </Collapsible.Content>
       </Collapsible>
@@ -479,6 +488,8 @@ export const LocalWorkspace = (props: {
   })
   const slug = createMemo(() => base64Encode(props.project.worktree))
   const sessions = createMemo(() => sortedRootSessions(workspace().store, props.sortNow()))
+  const allSessions = createMemo(() => Object.values(workspace().store.session).flat())
+  const expandedSessions = useExpandedSessions(() => props.project.worktree, allSessions)
   const children = createMemo(() => childMapByParent(workspace().store.session))
   const booted = createMemo((prev) => prev || workspace().store.status === "complete", false)
   const loading = createMemo(() => !booted() && sessions().length === 0)
@@ -513,6 +524,8 @@ export const LocalWorkspace = (props: {
               clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
               prefetchSession={props.ctx.prefetchSession}
               archiveSession={props.ctx.archiveSession}
+              isSessionExpanded={expandedSessions.isExpanded}
+              toggleSessionExpanded={expandedSessions.toggleExpanded}
             />
           )}
         </For>

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -324,8 +324,10 @@ export const SortableWorkspace = (props: {
   })
   const slug = createMemo(() => base64Encode(props.directory))
   const sessions = createMemo(() => sortedRootSessions(workspaceStore, props.sortNow()))
-  const allSessions = createMemo(() => Object.values(workspaceStore.session).flat())
-  const expandedSessions = useExpandedSessions(() => props.directory, allSessions)
+  const expandedSessions = useExpandedSessions(
+    () => props.directory,
+    () => workspaceStore.session,
+  )
   const children = createMemo(() => childMapByParent(workspaceStore.session))
   const local = createMemo(() => props.directory === props.project.worktree)
   const active = createMemo(() => props.ctx.currentDir() === props.directory)
@@ -460,13 +462,13 @@ export const SortableWorkspace = (props: {
             showNew={showNew}
             loading={loading}
             sessions={sessions}
-            allSessions={allSessions}
+            allSessions={() => workspaceStore.session}
             children={children}
             hasMore={hasMore}
             loadMore={loadMore}
             language={language}
-            isSessionExpanded={expandedSessions.isExpanded}
-            toggleSessionExpanded={expandedSessions.toggleExpanded}
+            isSessionExpanded={expandedSessions.expanded}
+            toggleSessionExpanded={expandedSessions.toggle}
           />
         </Collapsible.Content>
       </Collapsible>
@@ -488,8 +490,10 @@ export const LocalWorkspace = (props: {
   })
   const slug = createMemo(() => base64Encode(props.project.worktree))
   const sessions = createMemo(() => sortedRootSessions(workspace().store, props.sortNow()))
-  const allSessions = createMemo(() => Object.values(workspace().store.session).flat())
-  const expandedSessions = useExpandedSessions(() => props.project.worktree, allSessions)
+  const expandedSessions = useExpandedSessions(
+    () => props.project.worktree,
+    () => workspace().store.session,
+  )
   const children = createMemo(() => childMapByParent(workspace().store.session))
   const booted = createMemo((prev) => prev || workspace().store.status === "complete", false)
   const loading = createMemo(() => !booted() && sessions().length === 0)
@@ -524,8 +528,8 @@ export const LocalWorkspace = (props: {
               clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
               prefetchSession={props.ctx.prefetchSession}
               archiveSession={props.ctx.archiveSession}
-              isSessionExpanded={expandedSessions.isExpanded}
-              toggleSessionExpanded={expandedSessions.toggleExpanded}
+              isSessionExpanded={expandedSessions.expanded}
+              toggleSessionExpanded={expandedSessions.toggle}
             />
           )}
         </For>

--- a/packages/app/src/pages/layout/use-expanded-sessions.test.ts
+++ b/packages/app/src/pages/layout/use-expanded-sessions.test.ts
@@ -154,31 +154,88 @@ describe("useExpandedSessions", () => {
         const [local, setLocal] = createSignal<string[]>([])
         const [store, setStore] = createStore<Record<string, boolean>>({})
         let isReady = false
+        let hasMigrated = false
         const prefix = "workspace.test."
 
         const expanded = (sessionId: string) => {
-          if (!isReady) return local().includes(sessionId)
+          if (!isReady && !hasMigrated) return local().includes(sessionId)
           return store[prefix + sessionId] ?? false
         }
 
         const toggle = (sessionId: string) => {
-          if (!isReady) {
-            const current = expanded(sessionId)
+          const readyCheck = isReady
+          const current = expanded(sessionId)
+
+          if (!readyCheck && !hasMigrated) {
             setLocal((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
             return
           }
           const key = prefix + sessionId
-          setStore(key, !expanded(sessionId))
+          setStore(key, !current)
         }
 
         toggle("session-1")
         expect(expanded("session-1")).toBe(true)
 
         isReady = true
+        hasMigrated = true
+
         expect(expanded("session-1")).toBe(false)
 
         toggle("session-1")
         expect(expanded("session-1")).toBe(true)
+        dispose()
+      })
+    })
+
+    test("migrates local state to store when ready", () => {
+      createRoot((dispose) => {
+        const [local, setLocal] = createSignal<string[]>([])
+        const [store, setStore] = createStore<Record<string, boolean>>({})
+        let isReady = false
+        let hasMigrated = false
+        const prefix = "workspace.test."
+
+        const expanded = (sessionId: string) => {
+          if (!isReady && !hasMigrated) return local().includes(sessionId)
+          return store[prefix + sessionId] ?? false
+        }
+
+        const toggle = (sessionId: string) => {
+          const readyCheck = isReady
+          const current = expanded(sessionId)
+
+          if (!readyCheck && !hasMigrated) {
+            setLocal((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
+            return
+          }
+          const key = prefix + sessionId
+          setStore(key, !current)
+        }
+
+        const migrate = () => {
+          const localIds = local()
+          for (const id of localIds) {
+            setStore(prefix + id, true)
+          }
+          setLocal([])
+          hasMigrated = true
+        }
+
+        toggle("session-1")
+        toggle("session-2")
+        expect(local()).toHaveLength(2)
+        expect(expanded("session-1")).toBe(true)
+        expect(expanded("session-2")).toBe(true)
+
+        isReady = true
+        migrate()
+
+        expect(local()).toHaveLength(0)
+        expect(expanded("session-1")).toBe(true)
+        expect(expanded("session-2")).toBe(true)
+        expect(store[`${prefix}session-1`]).toBe(true)
+        expect(store[`${prefix}session-2`]).toBe(true)
         dispose()
       })
     })

--- a/packages/app/src/pages/layout/use-expanded-sessions.test.ts
+++ b/packages/app/src/pages/layout/use-expanded-sessions.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test, mock, beforeEach, afterEach } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { createStore } from "solid-js/store"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+describe("useExpandedSessions", () => {
+  describe("expanded state management", () => {
+    test("returns false for non-expanded sessions by default", () => {
+      createRoot((dispose) => {
+        const expandedSet = new Set<string>()
+        const local = createSignal<string[]>([])
+
+        const expanded = (sessionId: string) => {
+          return expandedSet.has(sessionId)
+        }
+
+        expect(expanded("session-1")).toBe(false)
+        expect(expanded("session-2")).toBe(false)
+        dispose()
+      })
+    })
+
+    test("toggle changes expansion state", () => {
+      createRoot((dispose) => {
+        const expandedSet = new Set<string>()
+
+        const expanded = (sessionId: string) => expandedSet.has(sessionId)
+        const toggle = (sessionId: string) => {
+          if (expandedSet.has(sessionId)) {
+            expandedSet.delete(sessionId)
+          } else {
+            expandedSet.add(sessionId)
+          }
+        }
+
+        expect(expanded("session-1")).toBe(false)
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(true)
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(false)
+        dispose()
+      })
+    })
+
+    test("multiple sessions can be expanded independently", () => {
+      createRoot((dispose) => {
+        const expandedSet = new Set<string>()
+
+        const expanded = (sessionId: string) => expandedSet.has(sessionId)
+        const toggle = (sessionId: string) => {
+          if (expandedSet.has(sessionId)) {
+            expandedSet.delete(sessionId)
+          } else {
+            expandedSet.add(sessionId)
+          }
+        }
+
+        toggle("session-1")
+        toggle("session-2")
+
+        expect(expanded("session-1")).toBe(true)
+        expect(expanded("session-2")).toBe(true)
+        expect(expanded("session-3")).toBe(false)
+        dispose()
+      })
+    })
+  })
+
+  describe("storage key generation", () => {
+    test("generates unique key per directory", () => {
+      const checksum = (str: string) => {
+        let hash = 0
+        for (let i = 0; i < str.length; i++) {
+          const char = str.charCodeAt(i)
+          hash = (hash << 5) - hash + char
+          hash = hash & hash
+        }
+        return Math.abs(hash).toString(16)
+      }
+
+      const generateKey = (dir: string) => {
+        const sum = checksum(dir) ?? "0"
+        const head = dir.slice(0, 12) || "workspace"
+        return `workspace.${head}.${sum}.expanded-sessions`
+      }
+
+      const key1 = generateKey("/test/workspace1")
+      const key2 = generateKey("/test/workspace2")
+      const key3 = generateKey("/different/path")
+
+      expect(key1).not.toBe(key2)
+      expect(key2).not.toBe(key3)
+      expect(key1).not.toBe(key3)
+    })
+  })
+
+  describe("local state fallback when not ready", () => {
+    test("uses local signal when ready is false", () => {
+      createRoot((dispose) => {
+        const [local, setLocal] = createSignal<string[]>([])
+        const ready = () => false
+
+        const expanded = (sessionId: string) => {
+          if (!ready()) return local().includes(sessionId)
+          return false
+        }
+
+        const toggle = (sessionId: string) => {
+          if (!ready()) {
+            const current = expanded(sessionId)
+            setLocal((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
+            return
+          }
+        }
+
+        expect(expanded("session-1")).toBe(false)
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(true)
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(false)
+        dispose()
+      })
+    })
+
+    test("uses store when ready is true", () => {
+      createRoot((dispose) => {
+        const [store, setStore] = createStore<Record<string, boolean>>({})
+        const ready = () => true
+        const prefix = "workspace.test."
+
+        const expanded = (sessionId: string) => {
+          if (!ready()) return false
+          return store[prefix + sessionId] ?? false
+        }
+
+        const toggle = (sessionId: string) => {
+          const key = prefix + sessionId
+          const current = expanded(sessionId)
+          if (!ready()) return
+          setStore(key, !current)
+        }
+
+        expect(expanded("session-1")).toBe(false)
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(true)
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(false)
+        dispose()
+      })
+    })
+
+    test("local state is isolated from store state", () => {
+      createRoot((dispose) => {
+        const [local, setLocal] = createSignal<string[]>([])
+        const [store, setStore] = createStore<Record<string, boolean>>({})
+        let isReady = false
+        const prefix = "workspace.test."
+
+        const expanded = (sessionId: string) => {
+          if (!isReady) return local().includes(sessionId)
+          return store[prefix + sessionId] ?? false
+        }
+
+        const toggle = (sessionId: string) => {
+          if (!isReady) {
+            const current = expanded(sessionId)
+            setLocal((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
+            return
+          }
+          const key = prefix + sessionId
+          setStore(key, !expanded(sessionId))
+        }
+
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(true)
+
+        isReady = true
+        expect(expanded("session-1")).toBe(false)
+
+        toggle("session-1")
+        expect(expanded("session-1")).toBe(true)
+        dispose()
+      })
+    })
+  })
+})

--- a/packages/app/src/pages/layout/use-expanded-sessions.ts
+++ b/packages/app/src/pages/layout/use-expanded-sessions.ts
@@ -1,0 +1,100 @@
+import { createEffect, createMemo, createSignal } from "solid-js"
+import { createStore, reconcile } from "solid-js/store"
+import { persisted } from "@/utils/persist"
+import { Persist } from "@/utils/persist"
+import { checksum } from "@opencode-ai/util/encode"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+
+const CLEANUP_DELAY = 1000
+
+export function useExpandedSessions(
+  directory: () => string,
+  sessions: () => Session[],
+): {
+  isExpanded: (sessionId: string) => boolean
+  toggleExpanded: (sessionId: string) => void
+  ready: () => boolean
+} {
+  const storageKey = createMemo(() => {
+    const dir = directory()
+    const sum = checksum(dir) ?? "0"
+    const head = dir.slice(0, 12) || "workspace"
+    return `workspace.${head}.${sum}.expanded-sessions`
+  })
+
+  const [store, setStore, , ready] = persisted(
+    Persist.global("expanded-sessions", ["expanded-sessions.v1"]),
+    createStore({} as Record<string, boolean>),
+  )
+
+  const [localExpanded, setLocalExpanded] = createSignal<string[]>([])
+  let cleanupTimeout: ReturnType<typeof setTimeout> | undefined
+
+  const prefix = () => storageKey() + "."
+
+  createEffect(() => {
+    const p = prefix()
+    const ids = sessions()
+    if (ids.length === 0) return
+    const validIds = new Set(ids.map((s) => s.id))
+    const validExpanded: Record<string, boolean> = {}
+    let hasStale = false
+
+    for (const key of Object.keys(store)) {
+      if (!key.startsWith(p)) continue
+      const sessionId = key.slice(p.length)
+      if (validIds.has(sessionId)) {
+        validExpanded[key] = store[key]
+      } else {
+        hasStale = true
+      }
+    }
+
+    if (hasStale) {
+      setStore(reconcile(validExpanded))
+    }
+  })
+
+  const isExpanded = (sessionId: string) => {
+    if (!ready()) return localExpanded().includes(sessionId)
+    return store[prefix() + sessionId] ?? false
+  }
+
+  const toggleExpanded = (sessionId: string) => {
+    const key = prefix() + sessionId
+    const current = isExpanded(sessionId)
+
+    if (!ready()) {
+      setLocalExpanded((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
+      return
+    }
+
+    setStore(key, !current)
+
+    if (cleanupTimeout) clearTimeout(cleanupTimeout)
+    cleanupTimeout = setTimeout(() => {
+      const p = prefix()
+      const ids = sessions()
+      if (ids.length === 0) return
+      const validIds = new Set(ids.map((s) => s.id))
+      const validExpanded: Record<string, boolean> = {}
+      let hasStale = false
+
+      for (const key of Object.keys(store)) {
+        if (!key.startsWith(p)) continue
+        const sessionId = key.slice(p.length)
+        if (validIds.has(sessionId)) {
+          validExpanded[key] = store[key]
+        } else {
+          hasStale = true
+        }
+      }
+
+      if (hasStale) {
+        setStore(reconcile(validExpanded))
+      }
+    }, CLEANUP_DELAY)
+  }
+
+  return { isExpanded, toggleExpanded, ready }
+}

--- a/packages/app/src/pages/layout/use-expanded-sessions.ts
+++ b/packages/app/src/pages/layout/use-expanded-sessions.ts
@@ -1,19 +1,16 @@
-import { createEffect, createMemo, createSignal } from "solid-js"
-import { createStore, reconcile } from "solid-js/store"
+import { createMemo, createSignal } from "solid-js"
+import { createStore } from "solid-js/store"
 import { persisted } from "@/utils/persist"
 import { Persist } from "@/utils/persist"
 import { checksum } from "@opencode-ai/util/encode"
 import type { Session } from "@opencode-ai/sdk/v2/client"
 
-const CLEANUP_DELAY = 1000
-
 export function useExpandedSessions(
   directory: () => string,
   sessions: () => Session[],
 ): {
-  isExpanded: (sessionId: string) => boolean
-  toggleExpanded: (sessionId: string) => void
-  ready: () => boolean
+  expanded: (sessionId: string) => boolean
+  toggle: (sessionId: string) => void
 } {
   const storageKey = createMemo(() => {
     const dir = directory()
@@ -27,74 +24,26 @@ export function useExpandedSessions(
     createStore({} as Record<string, boolean>),
   )
 
-  const [localExpanded, setLocalExpanded] = createSignal<string[]>([])
-  let cleanupTimeout: ReturnType<typeof setTimeout> | undefined
+  const [local, setLocal] = createSignal<string[]>([])
 
   const prefix = () => storageKey() + "."
 
-  createEffect(() => {
-    const p = prefix()
-    const ids = sessions()
-    if (ids.length === 0) return
-    const validIds = new Set(ids.map((s) => s.id))
-    const validExpanded: Record<string, boolean> = {}
-    let hasStale = false
-
-    for (const key of Object.keys(store)) {
-      if (!key.startsWith(p)) continue
-      const sessionId = key.slice(p.length)
-      if (validIds.has(sessionId)) {
-        validExpanded[key] = store[key]
-      } else {
-        hasStale = true
-      }
-    }
-
-    if (hasStale) {
-      setStore(reconcile(validExpanded))
-    }
-  })
-
-  const isExpanded = (sessionId: string) => {
-    if (!ready()) return localExpanded().includes(sessionId)
+  const expanded = (sessionId: string) => {
+    if (!ready()) return local().includes(sessionId)
     return store[prefix() + sessionId] ?? false
   }
 
-  const toggleExpanded = (sessionId: string) => {
+  const toggle = (sessionId: string) => {
     const key = prefix() + sessionId
-    const current = isExpanded(sessionId)
+    const current = expanded(sessionId)
 
     if (!ready()) {
-      setLocalExpanded((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
+      setLocal((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
       return
     }
 
     setStore(key, !current)
-
-    if (cleanupTimeout) clearTimeout(cleanupTimeout)
-    cleanupTimeout = setTimeout(() => {
-      const p = prefix()
-      const ids = sessions()
-      if (ids.length === 0) return
-      const validIds = new Set(ids.map((s) => s.id))
-      const validExpanded: Record<string, boolean> = {}
-      let hasStale = false
-
-      for (const key of Object.keys(store)) {
-        if (!key.startsWith(p)) continue
-        const sessionId = key.slice(p.length)
-        if (validIds.has(sessionId)) {
-          validExpanded[key] = store[key]
-        } else {
-          hasStale = true
-        }
-      }
-
-      if (hasStale) {
-        setStore(reconcile(validExpanded))
-      }
-    }, CLEANUP_DELAY)
   }
 
-  return { isExpanded, toggleExpanded, ready }
+  return { expanded, toggle }
 }

--- a/packages/app/src/pages/layout/use-expanded-sessions.ts
+++ b/packages/app/src/pages/layout/use-expanded-sessions.ts
@@ -1,4 +1,4 @@
-import { createMemo, createSignal } from "solid-js"
+import { createMemo, createSignal, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import { persisted } from "@/utils/persist"
 import { Persist } from "@/utils/persist"
@@ -14,7 +14,8 @@ export function useExpandedSessions(
 } {
   const storageKey = createMemo(() => {
     const dir = directory()
-    const sum = checksum(dir) ?? "0"
+    const sum = checksum(dir)
+    if (!sum) throw new Error("Failed to generate checksum for directory")
     const head = dir.slice(0, 12) || "workspace"
     return `workspace.${head}.${sum}.expanded-sessions`
   })
@@ -25,25 +26,41 @@ export function useExpandedSessions(
   )
 
   const [local, setLocal] = createSignal<string[]>([])
+  const [migrated, setMigrated] = createSignal(false)
 
   const prefix = () => storageKey() + "."
 
   const expanded = (sessionId: string) => {
-    if (!ready()) return local().includes(sessionId)
+    if (!ready() && !migrated()) return local().includes(sessionId)
     return store[prefix() + sessionId] ?? false
   }
 
   const toggle = (sessionId: string) => {
     const key = prefix() + sessionId
+    const isReady = ready()
     const current = expanded(sessionId)
 
-    if (!ready()) {
+    if (!isReady && !migrated()) {
       setLocal((prev) => (current ? prev.filter((id) => id !== sessionId) : [...prev, sessionId]))
       return
     }
 
     setStore(key, !current)
   }
+
+  onMount(() => {
+    if (ready() && !migrated()) {
+      const localIds = local()
+      if (localIds.length > 0) {
+        const pfx = prefix()
+        for (const id of localIds) {
+          setStore(pfx + id, true)
+        }
+        setLocal([])
+      }
+      setMigrated(true)
+    }
+  })
 
   return { expanded, toggle }
 }

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -219,6 +219,21 @@ export function MessageTimeline(props: {
                 <Show when={props.sessionID}>
                   {(id) => (
                     <div class="shrink-0 flex items-center gap-3">
+                      <Show when={props.parentID}>
+                        <Tooltip value="Navigate to parent" placement="top">
+                          <IconButton
+                            tabIndex={-1}
+                            icon="arrow-up"
+                            variant="ghost"
+                            onClick={props.onNavigateParent}
+                            aria-label="Navigate to parent"
+                            class="size-5"
+                          />
+                        </Tooltip>
+                        <Tooltip value="Subagent" placement="top">
+                          <Icon name="brain" class="text-text-weak mr-1" />
+                        </Tooltip>
+                      </Show>
                       <SessionContextUsage placement="bottom" />
                       <DropdownMenu
                         gutter={4}

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -228,10 +228,11 @@ export function MessageTimeline(props: {
                             onClick={props.onNavigateParent}
                             aria-label="Navigate to parent"
                             class="size-5"
+                            data-testid="navigate-parent-button"
                           />
                         </Tooltip>
                         <Tooltip value="Subagent" placement="top">
-                          <Icon name="brain" class="text-text-weak mr-1" />
+                          <Icon name="brain" class="text-text-weak mr-1" data-testid="subagent-indicator" />
                         </Tooltip>
                       </Show>
                       <SessionContextUsage placement="bottom" />

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -8,6 +8,7 @@ import { SessionTurn } from "@opencode-ai/ui/session-turn"
 import type { UserMessage } from "@opencode-ai/sdk/v2"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
 
 const boundaryTarget = (root: HTMLElement, target: EventTarget | null) => {
   const current = target instanceof Element ? target : undefined


### PR DESCRIPTION
### What does this PR do?

Closes #14040 

This PR improves the opencode web client by adding support for navigation between sessions and their subgents, through an intuitive UX:

<img width="3839" height="2159" alt="image" src="https://github.com/user-attachments/assets/44a21c5c-6400-46a0-937d-6310a319cb50" />

You can watch a video demo here:

https://github.com/user-attachments/assets/60956364-7e25-41ff-b4fd-b9493589aac5

In short:
* subagents are now shown as a tree under their parent session.  
* The session can be collapsed.
* You can navigate to parent session or subagent through the sidebar navigation
* Subagent threads now have an icon in top right to show they are subagents
* Subagent threads can now navigate directly to their parent. 

### How did you verify your code works?
Aside from extensive testing, I added unit and e2e test for the feature.  I also put together the video above demoing the feature.

The actual code changes are a few hundred lines.  The tests take up 70% of the code, but if you are short on time less focus is needed on the `*.spec.ts` files.